### PR TITLE
Added error states in Grafana metrices

### DIFF
--- a/ui/components/GrafanaCustomChart.js
+++ b/ui/components/GrafanaCustomChart.js
@@ -3,15 +3,15 @@ import PropTypes from 'prop-types';
 import { withStyles } from '@material-ui/core/styles';
 import {
   NoSsr, IconButton, Card, CardContent, CardHeader,
+  Tooltip, LinearProgress, Box
 } from '@material-ui/core';
 import { connect } from 'react-redux';
 import { bindActionCreators } from 'redux';
 import { withSnackbar } from 'notistack';
 import moment from 'moment';
 import OpenInNewIcon from '@material-ui/icons/OpenInNewOutlined';
+import WarningIcon from '@material-ui/icons/Warning';
 import CachedIcon from '@material-ui/icons/Cached';
-import LinearProgress from '@material-ui/core/LinearProgress';
-import Box from '@material-ui/core/Box';
 import dataFetch from '../lib/data-fetch';
 import { updateProgress } from '../lib/store';
 import GrafanaCustomGaugeChart from './GrafanaCustomGaugeChart';
@@ -40,14 +40,7 @@ const grafanaStyles = (theme) => ({
     gap : ' 0.5rem', },
   cardContent : { height : '100%',
     width : "100%" },
-  error : {
-    color : '#D32F2F',
-    width : '100%',
-    textAlign : 'center',
-    fontSize : '12px',
-    // fontFamily: 'Helvetica Nueue',
-    fontWeight : 'bold',
-  },
+  error : { color : '#D32F2F', },
 });
 
 const grafanaDateRangeToDate = (dt, startDate) => {
@@ -736,7 +729,6 @@ class GrafanaCustomChart extends Component {
 
       let loadingBar;
       let reloadButton;
-      let errorMessage;
 
       if (error){
         self.createOptions([], [], []); // add empty data to charts
@@ -745,12 +737,10 @@ class GrafanaCustomChart extends Component {
             <LinearProgress />
           </Box>
         );
-        errorMessage = 'Trying to reconnect to the Server';
       }
 
       if (errorCount > 3*panel.targets.length && typeof self.interval !== 'undefined') {
         clearInterval(self.interval); // clearing the interval to prevent further calls to get chart data
-        errorMessage = 'There was an error communicating with the server';
         loadingBar = null;
         reloadButton = (
           <IconButton
@@ -790,7 +780,6 @@ class GrafanaCustomChart extends Component {
       } else {
         mainChart = (
           <div>
-            <div className={classes.error}>{error && errorMessage}</div>
             <div ref={(ch) => self.chartRef = ch} className={classes.root} />
           </div>
         );
@@ -814,6 +803,12 @@ class GrafanaCustomChart extends Component {
             {!inDialog && (
               <CardHeader
                 disableTypography
+                avatar={
+                  error &&
+                  <Tooltip title="There was an error communicating with the server" placement="top">
+                    <WarningIcon className={classes.error}/>
+                  </Tooltip>
+                }
                 title={panel.title}
                 action={iconComponent}
                 className={classes.cardHeader}


### PR DESCRIPTION
Signed-off-by: manav1403 <manavavni@gmail.com>

**Description**

This PR fixes #4186 

**Notes for Reviewers**

There are two stages of lost connection (shown as error):-

1.  Try to reconnect (we make request trying to reconnect to grafana)

     https://user-images.githubusercontent.com/51405571/136497011-af1af304-6be6-4e50-9b4b-d5ab63379445.mp4

     This will enable the user to see the interactive status not just paused graph with an error

2.  Connection failed (after three failed requests no more request is made)

     ![image](https://user-images.githubusercontent.com/51405571/136497160-737bb4fd-eeb4-49f3-bd73-e7d3ab1faae2.png)

      The user could retry to connect using the refresh button in the card actions.

**[Signed commits](https://github.com/meshery/meshery/blob/master/CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [x] Yes, I signed my commits.
 

<!--
Thank you for contributing to Meshery! 

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. Sign your commits

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.
-->
