### PR TITLE
Fix semgrep cookie-missing-httponly error

### DIFF
--- a/mesheryctl/pkg/utils/auth.go
+++ b/mesheryctl/pkg/utils/auth.go
@@ -266,12 +266,14 @@ func getTokenObjFromMesheryServer(mctl *config.MesheryCtlConfig, provider, token
 	}
 
 	req.AddCookie(&http.Cookie{
-		Name:  tokenName,
-		Value: token,
+		Name:     tokenName,
+		Value:    token,
+		HttpOnly: true,
 	})
 	req.AddCookie(&http.Cookie{
-		Name:  "meshery-provider",
-		Value: provider,
+		Name:     "meshery-provider",
+		Value:    provider,
+		HttpOnly: true,
 	})
 
 	cli := &http.Client{}


### PR DESCRIPTION
Signed-off-by: Soumik Majumder <soumikm@vmware.com>

**Description**

This PR fixes [semgrep errors](https://lift.sonatype.com/result/bhamail/meshery/01FHG29F0QRMPRZJ80530Q7K22?t=CustomTool%20%22Semgrep%22%7Copt.semgrep.cookie-missing-httponly).

**[Signed commits](https://github.com/meshery/meshery/blob/master/CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [x] Yes, I signed my commits.
 

<!--
Thank you for contributing to Meshery! 

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. Sign your commits

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.
-->
