### PR TITLE
Fix Rubecop errors

### DIFF
--- a/docs/lib/tasks/helper.rb
+++ b/docs/lib/tasks/helper.rb
@@ -127,7 +127,7 @@ module Graphql
           render_input_type(field),
           render_connection_note(field),
           render_argument_table(heading_level, args, arg_owner),
-          render_return_fields(field, owner: owner)
+          render_return_fields(field)
         ]
 
         join(:block, chunks)
@@ -291,7 +291,7 @@ module Graphql
         )
       end
 
-      def render_return_fields(mutation, owner:)
+      def render_return_fields(mutation)
         fields = mutation[:return_fields]
         return if fields.blank?
 
@@ -347,7 +347,7 @@ module Graphql
                   "The connection type for [`#{base}`](##{base.downcase})."
                 else
                   object[:description]&.strip
-                end
+               end
 
         return if desc.blank?
 


### PR DESCRIPTION
Signed-off-by: Soumik Majumder <soumikm@vmware.com>

**Description**

This PR fixes Rubecop [lint errors](https://lift.sonatype.com/result/bhamail/meshery/01FHG29F0QRMPRZJ80530Q7K22?t=CustomTool%20%22Rubocop%22%7CLayout%2FEndAlignment&t=CustomTool%20%22Rubocop%22%7CLint%2FUnusedMethodArgument).

**[Signed commits](https://github.com/meshery/meshery/blob/master/CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [x] Yes, I signed my commits.
 

<!--
Thank you for contributing to Meshery! 

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. Sign your commits

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.
-->
