### PR TITLE
Fix missing `Secure` paramater in cookies

### DIFF
--- a/handlers/common_handlers.go
+++ b/handlers/common_handlers.go
@@ -43,6 +43,7 @@ func (h *Handler) LogoutHandler(w http.ResponseWriter, req *http.Request, p mode
 		Expires:  time.Now().Add(-time.Hour),
 		Path:     "/",
 		HttpOnly: true,
+		Secure:   true,
 	})
 	p.Logout(w, req)
 }

--- a/handlers/provider_handler.go
+++ b/handlers/provider_handler.go
@@ -27,6 +27,7 @@ func (h *Handler) ProviderHandler(w http.ResponseWriter, r *http.Request) {
 				Expires:  time.Now().Add(h.config.ProviderCookieDuration),
 				Path:     "/",
 				HttpOnly: true,
+				Secure:   true,
 			})
 			http.Redirect(w, r, "/", http.StatusFound)
 			return

--- a/mesheryctl/pkg/utils/auth.go
+++ b/mesheryctl/pkg/utils/auth.go
@@ -40,11 +40,13 @@ func AddAuthDetails(req *http.Request, filepath string) error {
 		Name:     tokenName,
 		Value:    tokenObj[tokenName],
 		HttpOnly: true,
+		Secure:   true,
 	})
 	req.AddCookie(&http.Cookie{
 		Name:     providerName,
 		Value:    tokenObj[providerName],
 		HttpOnly: true,
+		Secure:   true,
 	})
 	return nil
 }
@@ -269,11 +271,13 @@ func getTokenObjFromMesheryServer(mctl *config.MesheryCtlConfig, provider, token
 		Name:     tokenName,
 		Value:    token,
 		HttpOnly: true,
+		Secure:   true,
 	})
 	req.AddCookie(&http.Cookie{
 		Name:     "meshery-provider",
 		Value:    provider,
 		HttpOnly: true,
+		Secure:   true,
 	})
 
 	cli := &http.Client{}

--- a/models/remote_provider.go
+++ b/models/remote_provider.go
@@ -259,6 +259,7 @@ func (l *RemoteProvider) InitiateLogin(w http.ResponseWriter, r *http.Request, _
 			Expires:  time.Now().Add(l.LoginCookieDuration),
 			Path:     "/",
 			HttpOnly: true,
+			Secure:   true,
 		})
 		http.Redirect(w, r, l.RemoteProviderURL+"?source="+base64.RawURLEncoding.EncodeToString([]byte(tu))+"&provider_version="+l.ProviderVersion, http.StatusFound)
 		return
@@ -2057,6 +2058,7 @@ func (l *RemoteProvider) TokenHandler(w http.ResponseWriter, r *http.Request, fr
 		Value:    string(tokenString),
 		Path:     "/",
 		HttpOnly: true,
+		Secure:   true,
 	}
 	http.SetCookie(w, ck)
 
@@ -2086,6 +2088,7 @@ func (l *RemoteProvider) UpdateToken(w http.ResponseWriter, r *http.Request) str
 			Value:    newts,
 			Path:     "/",
 			HttpOnly: true,
+			Secure:   true,
 		})
 		return newts
 	}


### PR DESCRIPTION
**Description**

This PR fixes bugs observed by Sonatype Lift over [here](https://lift.sonatype.com/result/bhamail/meshery/01FHG29F0QRMPRZJ80530Q7K22?t=CustomTool%20%22Semgrep%22%7Copt.semgrep.cookie-missing-secure)


**[Signed commits](https://github.com/meshery/meshery/blob/master/CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [x] Yes, I signed my commits.
 

<!--
Thank you for contributing to Meshery! 

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. Sign your commits

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.
-->
