### PR TITLE
Fix bad end alignment

### DIFF
--- a/docs/lib/tasks/helper.rb
+++ b/docs/lib/tasks/helper.rb
@@ -347,7 +347,7 @@ module Graphql
                   "The connection type for [`#{base}`](##{base.downcase})."
                 else
                   object[:description]&.strip
-                end
+               end
 
         return if desc.blank?
 


### PR DESCRIPTION
Signed-off-by: Soumik Majumder <soumikm@vmware.com>

**Description**

This PR fixes `EndAlignment` warning produced by [Sonatype Lift](https://lift.sonatype.com/result/bhamail/meshery/01FHG29F0QRMPRZJ80530Q7K22?t=CustomTool%20%22Rubocop%22%7CLayout%2FEndAlignment)


**[Signed commits](https://github.com/meshery/meshery/blob/master/CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [ ] Yes, I signed my commits.
 

<!--
Thank you for contributing to Meshery! 

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. Sign your commits

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.
-->
