### PR TITLE
Add safeguard against a decompression bomb

### DIFF
--- a/models/remote_provider.go
+++ b/models/remote_provider.go
@@ -2365,7 +2365,8 @@ func TarXZ(gzipStream io.Reader, destination string) error {
 				return err
 			}
 			defer outFile.Close()
-			if _, err := io.Copy(outFile, tarReader); err != nil {
+			// Sets a limit of 1 GB on an outfile
+			if _, err := io.CopyN(outFile, tarReader, 1073741824); err != nil {
 				return err
 			}
 		default:


### PR DESCRIPTION
**Description**

This PR fixes this [potential vulnerability](https://lift.sonatype.com/result/bhamail/meshery/01FHG29F0QRMPRZJ80530Q7K22?t=CustomTool%20%22Semgrep%22%7Copt.semgrep.go.lang.security.decompression_bomb.potential-dos-via-decompression-bomb) reported by Sonatype Lift.

**Notes for Reviewers**
- The limit for each `outFile` in [line 2369](https://github.com/meshery/meshery/pull/4415/files#diff-66629ba7c556c1082a79ffd13b84f88049d8d2e1fa6fb1ffa6be31358fc6acafR2369) is 1 GB. Should this be increased/dereased?

**[Signed commits](https://github.com/meshery/meshery/blob/master/CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [x] Yes, I signed my commits.
 

<!--
Thank you for contributing to Meshery! 

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. Sign your commits

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.
-->
