### PR TITLE
Fix rubecop constants-in-block

### DIFF
--- a/docs/Rakefile
+++ b/docs/Rakefile
@@ -4,10 +4,11 @@ require './lib/tasks/renderer.rb'
 require 'rails'
 require 'graphql/rake_task'
 
+OUTPUT_DIR = File.expand_path("pages/reference", __dir__)
+SCHEMA_DIR = File.expand_path("../internal/graphql/schema/schema.graphql", __dir__)
+TEMPLATES_DIR = File.expand_path("lib/tasks/templates/default.md.haml", __dir__)
+
 namespace :graphql do
-  OUTPUT_DIR = File.expand_path("pages/reference", __dir__)
-  SCHEMA_DIR = File.expand_path("../internal/graphql/schema/schema.graphql", __dir__)
-  TEMPLATES_DIR = File.expand_path("lib/tasks/templates/default.md.haml", __dir__)
 
   GraphQL::RakeTask.new(
     schema_name: 'MesherySchema',


### PR DESCRIPTION
**Description**

This PR fixes Rubecop listing error caught by Sonatype Lift [here](https://lift.sonatype.com/result/bhamail/meshery/01FHG29F0QRMPRZJ80530Q7K22?t=CustomTool%20%22Rubocop%22%7CLint%2FConstantDefinitionInBlock).

**Notes for Reviewers**


**[Signed commits](https://github.com/meshery/meshery/blob/master/CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [ ] Yes, I signed my commits.
 

<!--
Thank you for contributing to Meshery! 

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. Sign your commits

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.
-->
