### PR TITLE
 [UI] Count displayed when deleted in bulk

### DIFF
--- a/ui/components/MesheryPatterns.js
+++ b/ui/components/MesheryPatterns.js
@@ -539,11 +539,11 @@ function MesheryPatterns({
     }
   });
 
-  async function showModal() {
+  async function showModal(count) {
     let response = await modalRef.current.show({
-      title : "Delete Pattern?",
+      title : `Delete ${count ? count : ""} Pattern${count > 1 ? "s" : '' }?`,
 
-      subtitle : "Are you sure you want to delete this pattern?",
+      subtitle : `Are you sure you want to delete ${count > 1 ? "these" : 'this' }  ${count ? count : ""}  pattern${count > 1 ? "s" : '' }?`,
 
       options : ["Yes", "No"],
     })
@@ -597,7 +597,7 @@ function MesheryPatterns({
     onCellClick : (_, meta) => meta.colIndex !== 3 && setSelectedRowData(patterns[meta.rowIndex]),
 
     onRowsDelete : async function handleDelete(row) {
-      let response = await showModal()
+      let response = await showModal(Object.keys(row.lookup).length)
       console.log(response)
       if (response === "Yes") {
         const fid = Object.keys(row.lookup).map(idx => patterns[idx]?.id)


### PR DESCRIPTION
Signed-off-by: Meghana Varanasi <meghana.cosmos@gmail.com>

**Description**
Count displayed in Patterns when content is deleted in bulk. Handles both the case (count == 1 and count > 1). 
<img width="638" alt="Screenshot 2021-10-16 at 12 17 21 AM" src="https://user-images.githubusercontent.com/44519203/137537673-b55c8614-bfd8-4ae3-b839-a6d6a6724de4.png">
<img width="531" alt="Screenshot 2021-10-16 at 12 17 31 AM" src="https://user-images.githubusercontent.com/44519203/137537681-5f9eab3e-ef41-4e36-86ff-e5eb89c1418b.png">


This PR fixes #4341

**Notes for Reviewers**


**[Signed commits](https://github.com/meshery/meshery/blob/master/CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [x] Yes, I signed my commits.
 

<!--
Thank you for contributing to Meshery! 

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. Sign your commits

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.
-->
