### PR TITLE
Fixed toc.yml URL entries

### DIFF
--- a/docs/_data/toc.yml
+++ b/docs/_data/toc.yml
@@ -10,19 +10,19 @@
       url: project/contributing
       children:
         - title: Design and Code Conventions
-          url: project/contributing-guide
+          url: project/contributing/contributing-guide
         - title: Meshery Adapters
-          url: project/contributing-adapters
+          url: project/contributing/contributing-adapters
         - title: Meshery CLI
-          url: project/contributing-cli
+          url: project/contributing/contributing-cli
         - title: Meshery Docs
-          url: project/contributing-docs
+          url: project/contributing/contributing-docs
         - title: Meshery Errors
-          url: project/contributing-error
+          url: project/contributing/contributing-error
         - title: Meshery Server
-          url: project/contributing-server
+          url: project/contributing/contributing-server
         - title: Meshery UI
-          url: project/contributing-ui
+          url: project/contributing/contributing-ui
     - title: Releases
       url: project/releases
     - title: Build & Release (CI)


### PR DESCRIPTION
Signed-off-by: Vedant Kakde <69970950+vedant-kakde@users.noreply.github.com>

**Description**
Fixed toc.yml entries and now pages are routed correctly.

**Notes for Reviewers**


**[Signed commits](https://github.com/meshery/meshery/blob/master/CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [x] Yes, I signed my commits.
 

<!--
Thank you for contributing to Meshery! 

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. Sign your commits

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.
-->
