### PR TITLE
[mesheryctl] Added version validation in channel command

### DIFF
--- a/mesheryctl/internal/cli/root/system/channel.go
+++ b/mesheryctl/internal/cli/root/system/channel.go
@@ -132,6 +132,11 @@ var setCmd = &cobra.Command{
 		ContextContent.Version = version
 		ContextContent.Channel = channelNameSeperated[0]
 
+		err = ContextContent.ValidateVersion()
+		if err != nil {
+			return err
+		}
+
 		mctlCfg.Contexts[focusedContext] = ContextContent
 		viper.Set("contexts", mctlCfg.Contexts)
 		err = viper.WriteConfig()


### PR DESCRIPTION
Signed-off-by: sayantan1413 <sayantanbose2001@gmail.com>

**Description**

Added the version validation in the channel command

This PR fixes #4443 

**Notes for Reviewers**

Command used : mesheryctl system channel set stable-v1.0.0

Output : 

<img width="572" alt="Screenshot 2021-10-19 at 11 22 52 PM" src="https://user-images.githubusercontent.com/64970095/137964421-aad61b07-34b1-4417-8265-643ab823cb36.png">

**[Signed commits](https://github.com/meshery/meshery/blob/master/CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [x] Yes, I signed my commits.
 

<!--
Thank you for contributing to Meshery! 

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. Sign your commits

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.
-->
