### PR TITLE
Fixed Typos in architecture.md 

### DIFF
--- a/docs/pages/concepts/architecture/architecture.md
+++ b/docs/pages/concepts/architecture/architecture.md
@@ -28,7 +28,7 @@ Meshery and its components are written using the following languages and technol
 
 ## Deployments
 
-Meshery deploys as a set of containers. Meshery's containers can be deployed to either Docker or Kubernetes. Meshery components connect to one another via gRPC requests. Meshery Server stores the location of the other components and connects with those components as needed. Typically, a connection from Meshery Server to Meshery Aapters is initiated from a client request (usually either `mesheryctl` or Meshery UI) to gather information from the Adapter or invoke an Adapter's operation.
+Meshery deploys as a set of containers. Meshery's containers can be deployed to either Docker or Kubernetes. Meshery components connect to one another via gRPC requests. Meshery Server stores the location of the other components and connects with those components as needed. Typically, a connection from Meshery Server to Meshery Adapters is initiated from a client request (usually either `mesheryctl` or Meshery UI) to gather information from the Adapter or invoke an Adapter's operation.
 
 ### Adapters
 


### PR DESCRIPTION
Signed-off-by: Bishal Das <70086051+bishal7679@users.noreply.github.com>

**Description**
`Aapters` is changed into `Adapters`

This PR fixes #5788 

**[Signed commits](https://github.com/meshery/meshery/blob/master/CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [x] Yes, I signed my commits.
 

<!--
Thank you for contributing to Meshery ! 