### PR TITLE
[Bug] Fix Panic on Hard Reset

### DIFF
--- a/internal/graphql/resolver/meshsync.go
+++ b/internal/graphql/resolver/meshsync.go
@@ -118,7 +118,7 @@ func (r *Resolver) getMeshSyncStatus(k8sctx models.K8sContext) model.OperatorCon
 func (r *Resolver) resyncCluster(ctx context.Context, provider models.Provider, actions *model.ReSyncActions, k8scontextID string) (model.Status, error) {
 	if actions.ClearDb == "true" {
 		// copies the contents .meshery/config/mesherydb.sql to .meshery/config/.archive/mesherydb.sql
-		// then drops all the DB table and then migrate/create tables, missing foreign keys, constraints, columns and indexes. 
+		// then drops all the DB table and then migrate/create tables, missing foreign keys, constraints, columns and indexes.
 		if actions.HardReset == "true" {
 			mesherydbPath := path.Join(utils.GetHome(), ".meshery/config")
 			err := os.Mkdir(path.Join(mesherydbPath, ".archive"), os.ModePerm)
@@ -127,11 +127,11 @@ func (r *Resolver) resyncCluster(ctx context.Context, provider models.Provider, 
 			}
 
 			src := path.Join(mesherydbPath, "mesherydb.sql")
-    	dst := path.Join(mesherydbPath, ".archive/mesherydb.sql")
+			dst := path.Join(mesherydbPath, ".archive/mesherydb.sql")
 
 			fin, err := os.Open(src)
 			if err != nil {
-					return "", err
+				return "", err
 			}
 			defer fin.Close()
 


### PR DESCRIPTION
**Description**

Problem:
- There was some odd behaviour during hard reset, which occurs after [reinitialisation of DBHandler](https://github.com/meshery/meshery/blob/master/internal/graphql/resolver/meshsync.go#L139). Like, sometimes the reset was failing and leading to panic (as shown in issue description), and in some scenarios reset was successful but the [resyncDiscovery operation](https://github.com/meshery/meshery/blob/master/internal/graphql/resolver/meshsync.go#L184) was leading to an error: `sql: database is closed` (error coming from [here](https://github.com/meshery/meshery/blob/master/models/meshsync_events.go#L144) and [here](https://github.com/meshery/meshery/blob/master/models/meshsync_events.go#L169)). 
-  This was because, when Meshery starts for the first time, after [initialising DbHandler var](https://github.com/meshery/meshery/blob/master/cmd/main.go#L146) we pass it to all other initialising operations/structs ([DefaultLocalProvider](https://github.com/meshery/meshery/blob/master/cmd/main.go#L175), [RemoteProvider](https://github.com/meshery/meshery/blob/master/cmd/main.go#L200), [NewHandlerInstance](https://github.com/meshery/meshery/blob/master/cmd/main.go#L242), [mesheryController](https://github.com/meshery/meshery/blob/master/cmd/main.go#L239)) and then that is used by the their child operations or as GenericPersister(). But after reinitialising by Hard Reset, the new instance of DBHandler was not being passed to all those initialisation processes which occurs during Meshery start. Hence, those operations still refer to the older DBHandler instance that was closed during Hard Reset.

Solution:
- Instead of creating a new instance of gorm, we can use the existing one but Drop() all DB tables and then AutoMigrate() them so that we have fresh tables to load MeshSync and other user data. 
- We can stick with the reinitialisation of gorm as we do on first load but we need to refactor the other initialisations we perform on first load into a function that dynamically updates the handler passed to each initialising operation after Hard Reset or on first load. This approach might have some other side affects so this PR implements the first approach.

**Though, we still keep an archive of existing records at `.archive/mesherydb.sql` before dropping the tables.**

This PR fixes #5800 

**Notes for Reviewers**

https://user-images.githubusercontent.com/73700530/178936236-4caaeda6-0fdc-417c-a5a2-554574b2ab69.mov



**[Signed commits](https://github.com/meshery/meshery/blob/master/CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [x] Yes, I signed my commits.
 

<!--
Thank you for contributing to Meshery! 

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. Sign your commits

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.
-->
