### PR TITLE
Fix failing queries in case of custom telemetry deployment

### DIFF
--- a/server/models/grafana_helper.go
+++ b/server/models/grafana_helper.go
@@ -73,7 +73,7 @@ func (g *GrafanaClient) makeRequest(ctx context.Context, queryURL, APIKey string
 		return nil, err
 	}
 	if !g.promMode {
-		req.Header.Set("Authorization", APIKey)
+		req.Header.Set("Authorization", "Bearer " + APIKey)
 	}
 	req.Header.Set("Accept", "application/json")
 	req.Header.Set("Content-Type", "application/json")


### PR DESCRIPTION
Signed-off-by: MUzairS15 <muzair.shaikh810@gmail.com>

**Notes for Reviewers**
In custom deployment of Grafana, the queries were failing with status code as `401`.
This PR fixes failing Grafana queries when it is deployed manually.


**[Signed commits](https://github.com/meshery/meshery/blob/master/CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [x] Yes, I signed my commits.
 

<!--
Thank you for contributing to Meshery! 

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. Sign your commits

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.
-->
