### PR TITLE
fix cutoff styles of checkboxes

### DIFF
--- a/ui/themes/rjsf.js
+++ b/ui/themes/rjsf.js
@@ -63,6 +63,7 @@ export const rjsfTheme = createTheme({
     MuiFormControlLabel: {
       root: {
         textTransform: 'capitalize',
+        marginLeft: 'auto',
       },
     },
     MuiBox: {
@@ -262,6 +263,7 @@ const darkRjsfTheme = createTheme({
     MuiFormControlLabel: {
       root: {
         textTransform: 'capitalize',
+        marginLeft: 'auto',
       },
     },
     MuiInputLabel: {


### PR DESCRIPTION
**Notes for Reviewers**

This PR fixes the margin of formlabel which was causing the issue of cutting off checkbox.



**[Signed commits](https://github.com/meshery/meshery/blob/master/CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [x] Yes, I signed my commits.
 

<!--
Thank you for contributing to Meshery! 

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. Sign your commits

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.
-->
