### PR TITLE
fix publish and unpublish action trigger

### DIFF
--- a/ui/components/MesheryPatterns.js
+++ b/ui/components/MesheryPatterns.js
@@ -225,10 +225,12 @@ const styles = (theme) => ({
   },
 });
 
-function TooltipIcon({ children, onClick, title, placement }) {
+function TooltipIcon({ children, onClick, title, placement, disabled }) {
   return (
     <CustomTooltip title={title} placement={placement} interactive>
-      <IconButton onClick={onClick}>{children}</IconButton>
+      <IconButton disabled={disabled} onClick={onClick}>
+        {children}
+      </IconButton>
     </CustomTooltip>
   );
 }
@@ -521,8 +523,8 @@ function MesheryPatterns({
       error_msg: 'Failed to publish catalog',
     },
     UNPUBLISH_CATALOG: {
-      name: 'PUBLISH_CATALOG',
-      error_msg: 'Failed to publish catalog',
+      name: 'UNPUBLISH_CATALOG',
+      error_msg: 'Failed to unpublish catalog',
     },
     SCHEMA_FETCH: {
       name: 'SCHEMA_FETCH',
@@ -795,48 +797,45 @@ function MesheryPatterns({
     });
   };
 
-  const handlePublishModal = (ev, pattern) => {
-    if (canPublishPattern) {
-      ev.stopPropagation();
-      setPublishModal({
-        open: true,
-        pattern: pattern,
-        name: '',
-      });
-    }
-  };
+  // const handlePublishModal = (ev, pattern) => {
+  //   if (canPublishPattern) {
+  //     ev.stopPropagation();
+  //     setPublishModal({
+  //       open: true,
+  //       pattern: pattern,
+  //       name: '',
+  //     });
+  //   }
+  // };
 
   const handleUnpublishModal = (ev, pattern) => {
-    if (canPublishPattern) {
-      ev.stopPropagation();
-      return async () => {
-        let response = await modalRef.current.show({
-          title: `Unpublish Catalog item?`,
-          subtitle: `Are you sure you want to unpublish ${pattern?.name}?`,
-          options: ['Yes', 'No'],
-          showInfoIcon:
-            "Unpublishing a catolog item removes the item from the public-facing catalog (a public website accessible to anonymous visitors at meshery.io/catalog). The catalog item's visibility will change to either public (or private with a subscription). The ability to for other users to continue to access, edit, clone and collaborate on your content depends upon the assigned visibility level (public or private). Prior collaborators (users with whom you have shared your catalog item) will retain access. However, you can always republish it whenever you want. Remember: unpublished catalog items can still be available to other users if that item is set to public visibility. For detailed information, please refer to the [documentation](https://docs.meshery.io/concepts/designs).",
-        });
-        if (response === 'Yes') {
-          updateProgress({ showProgress: true });
-          unpublishCatalog({
-            unpublishBody: JSON.stringify({ id: pattern?.id }),
-          })
-            .unwrap()
-            .then(() => {
-              updateProgress({ showProgress: false });
-              notify({
-                message: `Design Unpublished`,
-                event_type: EVENT_TYPES.SUCCESS,
-              });
-            })
-            .catch(() => {
-              updateProgress({ showProgress: false });
-              handleError(ACTION_TYPES.UNPUBLISH_CATALOG);
+    return async () => {
+      let response = await modalRef.current.show({
+        title: `Unpublish Catalog item?`,
+        subtitle: `Are you sure you want to unpublish ${pattern?.name}?`,
+        options: ['Yes', 'No'],
+        showInfoIcon:
+          "Unpublishing a catolog item removes the item from the public-facing catalog (a public website accessible to anonymous visitors at meshery.io/catalog). The catalog item's visibility will change to either public (or private with a subscription). The ability to for other users to continue to access, edit, clone and collaborate on your content depends upon the assigned visibility level (public or private). Prior collaborators (users with whom you have shared your catalog item) will retain access. However, you can always republish it whenever you want. Remember: unpublished catalog items can still be available to other users if that item is set to public visibility. For detailed information, please refer to the [documentation](https://docs.meshery.io/concepts/designs).",
+      });
+      if (response === 'Yes') {
+        updateProgress({ showProgress: true });
+        unpublishCatalog({
+          unpublishBody: JSON.stringify({ id: pattern?.id }),
+        })
+          .unwrap()
+          .then(() => {
+            updateProgress({ showProgress: false });
+            notify({
+              message: `Design Unpublished`,
+              event_type: EVENT_TYPES.SUCCESS,
             });
-        }
-      };
-    }
+          })
+          .catch(() => {
+            updateProgress({ showProgress: false });
+            handleError(ACTION_TYPES.UNPUBLISH_CATALOG);
+          });
+      }
+    };
   };
 
   const handlePublishModalClose = () => {
@@ -1247,7 +1246,8 @@ function MesheryPatterns({
                 <InfoOutlinedIcon data-cy="information-button" />
               </TooltipIcon>
 
-              {canPublishPattern && visibility !== VISIBILITY.PUBLISHED ? (
+              {/* Publish action can be done through Info modal so we might not need separate publish action */}
+              {/* {canPublishPattern && visibility !== VISIBILITY.PUBLISHED && (
                 <TooltipIcon
                   placement="bottom"
                   title="Publish"
@@ -1256,7 +1256,9 @@ function MesheryPatterns({
                 >
                   <PublicIcon fill="#F91313" data-cy="publish-button" />
                 </TooltipIcon>
-              ) : (
+              )} */}
+
+              {visibility === VISIBILITY.PUBLISHED && (
                 <TooltipIcon
                   title="Unpublish"
                   disabled={!CAN(keys.UNPUBLISH_DESIGN.action, keys.UNPUBLISH_DESIGN.subject)}
@@ -1359,7 +1361,8 @@ function MesheryPatterns({
       },
     },
 
-    onCellClick: (_, meta) => meta.colIndex !== 3 && setSelectedRowData(patterns[meta.rowIndex]),
+    onCellClick: (_, meta) =>
+      meta.colIndex !== 3 && meta.colIndex !== 4 && setSelectedRowData(patterns[meta.rowIndex]),
 
     onRowsDelete: async function handleDelete(row) {
       const toBeDeleted = Object.keys(row.lookup).map((idx) => ({

--- a/ui/components/MesheryPatterns/MesheryPatternCard.js
+++ b/ui/components/MesheryPatterns/MesheryPatternCard.js
@@ -53,7 +53,6 @@ function MesheryPatternCard_({
   setYaml,
   description = {},
   visibility,
-  canPublishPattern = false,
   user,
   pattern,
   handleInfoModal,
@@ -163,7 +162,7 @@ function MesheryPatternCard_({
           </div>
           <div className={classes.bottomPart}>
             <div className={classes.cardButtons}>
-              {canPublishPattern && visibility === VISIBILITY.PUBLISHED && (
+              {visibility === VISIBILITY.PUBLISHED && (
                 <TooltipButton
                   variant="contained"
                   title="Unpublish"

--- a/ui/components/MesheryPatterns/MesheryPatternGridView.js
+++ b/ui/components/MesheryPatterns/MesheryPatternGridView.js
@@ -31,7 +31,6 @@ function PatternCardGridItem({
   handleSubmit,
   handleDownload,
   setSelectedPatterns,
-  canPublishPattern = false,
   user,
   handleInfoModal,
   hideVisibility = false,
@@ -45,7 +44,6 @@ function PatternCardGridItem({
       <MesheryPatternCard
         id={pattern.id}
         user={user}
-        canPublishPattern={canPublishPattern}
         name={pattern.name}
         updated_at={pattern.updated_at}
         created_at={pattern.created_at}
@@ -213,7 +211,6 @@ function MesheryPatternGrid({
               key={pattern.id}
               user={user}
               pattern={pattern}
-              canPublishPattern={canPublishPattern}
               handleClone={() => handleClone(pattern.id, pattern.name)}
               handleDeploy={(e) => {
                 openDeployModal(e, pattern.pattern_file, pattern.name, pattern.id);


### PR DESCRIPTION
**Notes for Reviewers**

- This PR fixes #

- The publish and unpublish action trigger issues. Unpublish action was not triggering due to event propogation issue and was delayed to display because we were using a check called `canPublishPattern` which is not needed for unpublish action and this prop was taking time to render.
- Remove publish action from design table since we use info modal to publish.

**[Signed commits](https://github.com/meshery/meshery/blob/master/CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [x] Yes, I signed my commits.
 

<!--
Thank you for contributing to Meshery! 

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. Sign your commits

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.
-->
