### PR TITLE
[Logs] Add docker-compose availability check before log streaming

### DIFF
--- a/mesheryctl/internal/cli/root/system/logs.go
+++ b/mesheryctl/internal/cli/root/system/logs.go
@@ -141,11 +141,11 @@ mesheryctl system logs meshery-istio
 				return nil
 			} 
 
-			if _, err := exec.LookPath("docker-compose"); err != nil {
-	                       log.Error("docker-compose is not installed or not available in your PATH.")
-	                       log.Info("Please install docker-compose: https://docs.docker.com/compose/install/")
-	                       return nil
-                       }
+				if _, err := exec.LookPath("docker-compose"); err != nil {
+					log.Error("docker-compose is not installed or not available in your PATH.")
+					log.Info("Please install docker-compose: https://docs.docker.com/compose/install/")
+					return nil
+				}
 
 			cmdlog := exec.Command("docker-compose", "-f", utils.DockerComposeFile, "logs", "-f")
 


### PR DESCRIPTION
This PR improves the reliability and user experience of the mesheryctl system logs command when using Docker as the platform.

Changes Made:
Added a check to verify if docker-compose is installed and available in the system's PATH before attempting to run it.

If docker-compose is not found, a helpful error message is printed and execution is gracefully halted.


Previously, if docker-compose was not installed, running mesheryctl system logs would result in a vague or misleading error. This enhancement ensures:

Clear feedback to the user about the missing dependency.

Instructions for installing docker-compose.

Prevents command failure due to an unhandled missing binary.

Test Plan:
Verified that the command now exits gracefully with a message when docker-compose is not installed.

Ensured that existing functionality remains unchanged when docker-compose is available.

**Notes for Reviewers**

- This PR fixes #6543

**[Signed commits](https://github.com/meshery/meshery/blob/master/CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [ ] Yes, I signed my commits.

<!--
Thank you for contributing to Meshery! 

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. Sign your commits.
4. Include before and after screenshots/terminal output.

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.
-->
