### PR TITLE
chore: add padding to `select-all box` in components/ui/NotificationCenter`

### DIFF
--- a/ui/components/Header.js
+++ b/ui/components/Header.js
@@ -137,8 +137,8 @@ export const K8sContextConnectionChip = K8sContextConnectionChip_;
 function K8sContextMenu({
   contexts = {},
   activeContexts = [],
-  setActiveContexts = () => { },
-  searchContexts = () => { },
+  setActiveContexts = () => {},
+  searchContexts = () => {},
 }) {
   const [anchorEl, setAnchorEl] = useState(false);
   const [showFullContextMenu, setShowFullContextMenu] = useState(false);
@@ -262,7 +262,7 @@ function K8sContextMenu({
                 className="k8s-image"
                 src={
                   connectionMetadataState &&
-                    connectionMetadataState[CONNECTION_KINDS.KUBERNETES]?.icon
+                  connectionMetadataState[CONNECTION_KINDS.KUBERNETES]?.icon
                     ? `/${connectionMetadataState[CONNECTION_KINDS.KUBERNETES]?.icon}`
                     : '/static/img/kubernetes.svg'
                 }


### PR DESCRIPTION
**Notes for Reviewers**

add padding to `select-all box` 1rem is good by my side.
- This PR fixes #15041 

**[Signed commits](https://github.com/meshery/meshery/blob/master/CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [x] Yes, I signed my commits.

## before padding  ##
![Screenshot from 2025-06-14 20-43-27](https://github.com/user-attachments/assets/295c3c2d-0416-49d8-a5ef-09cfc9625945)
 
## after padding  ##

![Screenshot from 2025-06-14 21-10-37](https://github.com/user-attachments/assets/1eb1dc56-3ade-4b04-8478-e02bff14f8af)


<!--
Thank you for contributing to Meshery! 

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. Sign your commits.
4. Include before and after screenshots/terminal output.

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.
-->
