### PR TITLE
add meshery registry update bats e2e test with sign-off

### DIFF
--- a/mesheryctl/tests/e2e/006-registry/01-registry-update.bats
+++ b/mesheryctl/tests/e2e/006-registry/01-registry-update.bats
@@ -1,0 +1,78 @@
+#!/usr/bin/env bats
+
+setup() {
+	load "$E2E_HELPERS_PATH/bats_libraries"
+	_load_bats_libraries
+
+	load "$E2E_HELPERS_PATH/constants"
+	export FIXTURES_DIR="$BATS_TEST_DIRNAME/fixtures/registry-update"
+	export TEMP_DATA_DIR="$BATS_TEST_DIRNAME/fixtures/registry-update/temp"
+	export LOG_PATH="$HOME/.meshery/logs/registry"
+}
+
+teardown() {
+    rm -rf "$TEMP_DATA_DIR"
+    rm -f "$LOG_PATH/registry-update"
+}
+
+@test "mesheryctl registry update with only spreadsheet-id fails" {
+	run $MESHERYCTL_BIN registry update --spreadsheet-id "$SHEET_ID"
+	assert_failure
+	assert_output --partial "Error: if any flags in the group [spreadsheet-id spreadsheet-cred] are set they must all be set; missing [spreadsheet-cred]"
+}
+
+@test "mesheryctl registry update with only spreadsheet-cred fails" {
+	run $MESHERYCTL_BIN registry update --spreadsheet-cred "$VALID_CRED"
+	assert_failure
+	assert_output --partial "Error: if any flags in the group [spreadsheet-id spreadsheet-cred] are set they must all be set; missing [spreadsheet-id]"
+}
+
+@test "mesheryctl registry update with invalid spreadsheet-id fails" {
+	run $MESHERYCTL_BIN registry update --spreadsheet-id "INVALID_SHEET" --spreadsheet-cred "$VALID_CRED"
+	assert_failure
+	assert_output --partial "googleapi: Error 404: Requested entity was not found., notFound"
+}
+
+@test "mesheryctl registry update with invalid spreadsheet-cred fails" {
+	run $MESHERYCTL_BIN registry update --spreadsheet-id "$SHEET_ID" --spreadsheet-cred "$INVALID_CRED"
+	assert_failure
+	assert_output --partial "invalid character '\u008a' looking for beginning of value"
+}
+
+@test "mesheryctl registry update with valid spreadsheet-id and cred succeeds" {
+	run $MESHERYCTL_BIN registry update --spreadsheet-id $SHEET_ID --spreadsheet-cred $VALID_CRED
+	assert_success
+	assert_output --partial "Downloaded CSV from:" || assert_output --partial "Downloading CSV from:"
+	assert_output --partial "Parsing Components..."
+	assert_output --regexp "Updated [0-9]+ models and [0-9]+ components"
+	assert_output --partial "refer $LOG_PATH for detailed registry update logs"
+}
+
+@test "mesheryctl registry update with --model flag for a specific model succeeds" {
+	run $MESHERYCTL_BIN registry update --spreadsheet-id "$SHEET_ID" --spreadsheet-cred "$VALID_CRED" --model "test-model"
+	assert_success
+	assert_output --partial "Downloaded CSV from:" || assert_output --partial "Downloading CSV from:"
+	assert_output --partial "Parsing Components..."
+	assert_output --regexp "Updated [0-1]+ models and [0-9]+ components"
+	assert_output --partial "refer $LOG_PATH for detailed registry update logs"
+}
+
+@test "mesheryctl registry update with invalid model name" {
+	run $MESHERYCTL_BIN registry update --spreadsheet-id "$SHEET_ID" --spreadsheet-cred "$VALID_CRED" --model "nonexistent-model"
+	assert_success
+	assert_output --partial "Downloaded CSV from:" || assert_output --partial "Downloading CSV from:"
+	assert_output --partial "Parsing Components..."
+	assert_output --regexp "Updated 0 models and 0 components"
+	assert_output --partial "refer $LOG_PATH for detailed registry update logs"
+}
+
+@test "mesheryctl registry update with --input flag uses custom models directory" {
+    mkdir -p "$TEMP_DATA_DIR/custom-models"
+
+    run $MESHERYCTL_BIN registry update --spreadsheet-id "$SHEET_ID" --spreadsheet-cred "$VALID_CRED" --input "$TEMP_DATA_DIR/custom-models"
+	assert_success
+    assert_output --partial "Downloaded CSV from:" || assert_output --partial "Downloading CSV from:"
+	assert_output --partial "Parsing Components..."
+	assert_output --regexp "Updated [0-9]+ models and [0-9]+ components"
+	assert_output --partial "refer $LOG_PATH for detailed registry update logs"
+}

--- a/mesheryctl/tests/e2e/006-registry/01-registry-update.bats
+++ b/mesheryctl/tests/e2e/006-registry/01-registry-update.bats
@@ -16,7 +16,7 @@ teardown() {
 }
 
 @test "mesheryctl registry update with only spreadsheet-id fails" {
-	run $MESHERYCTL_BIN registry update --spreadsheet-id "$SHEET_ID"
+	run $MESHERYCTL_BIN registry update --spreadsheet-id "$GOOGLE_SHEET_VALID_ID"
 	assert_failure
 	assert_output --partial "Error: if any flags in the group [spreadsheet-id spreadsheet-cred] are set they must all be set; missing [spreadsheet-cred]"
 }
@@ -28,19 +28,19 @@ teardown() {
 }
 
 @test "mesheryctl registry update with invalid spreadsheet-id fails" {
-	run $MESHERYCTL_BIN registry update --spreadsheet-id "INVALID_SHEET" --spreadsheet-cred "$VALID_CRED"
+	run $MESHERYCTL_BIN registry update --spreadsheet-id "GOOGLE_SHEET_INVALID_ID" --spreadsheet-cred "$VALID_CRED"
 	assert_failure
 	assert_output --partial "googleapi: Error 404: Requested entity was not found., notFound"
 }
 
 @test "mesheryctl registry update with invalid spreadsheet-cred fails" {
-	run $MESHERYCTL_BIN registry update --spreadsheet-id "$SHEET_ID" --spreadsheet-cred "$INVALID_CRED"
+	run $MESHERYCTL_BIN registry update --spreadsheet-id "$GOOGLE_SHEET_VALID_ID" --spreadsheet-cred "$GOOGLE_SHEET_INVALID_CRED"
 	assert_failure
 	assert_output --partial "invalid character '\u008a' looking for beginning of value"
 }
 
 @test "mesheryctl registry update with valid spreadsheet-id and cred succeeds" {
-	run $MESHERYCTL_BIN registry update --spreadsheet-id $SHEET_ID --spreadsheet-cred $VALID_CRED
+	run $MESHERYCTL_BIN registry update --spreadsheet-id "$GOOGLE_SHEET_VALID_ID" --spreadsheet-cred "$VALID_CRED"
 	assert_success
 	assert_output --partial "Downloaded CSV from:" || assert_output --partial "Downloading CSV from:"
 	assert_output --partial "Parsing Components..."
@@ -49,16 +49,16 @@ teardown() {
 }
 
 @test "mesheryctl registry update with --model flag for a specific model succeeds" {
-	run $MESHERYCTL_BIN registry update --spreadsheet-id "$SHEET_ID" --spreadsheet-cred "$VALID_CRED" --model "test-model"
+	run $MESHERYCTL_BIN registry update --spreadsheet-id "$GOOGLE_SHEET_VALID_ID" --spreadsheet-cred "$VALID_CRED" --model "test-model"
 	assert_success
 	assert_output --partial "Downloaded CSV from:" || assert_output --partial "Downloading CSV from:"
 	assert_output --partial "Parsing Components..."
-	assert_output --regexp "Updated [0-1]+ models and [0-9]+ components"
+	assert_output --regexp "Updated [0-1] models and [0-9]+ components"
 	assert_output --partial "refer $LOG_PATH for detailed registry update logs"
 }
 
 @test "mesheryctl registry update with invalid model name" {
-	run $MESHERYCTL_BIN registry update --spreadsheet-id "$SHEET_ID" --spreadsheet-cred "$VALID_CRED" --model "nonexistent-model"
+	run $MESHERYCTL_BIN registry update --spreadsheet-id "$GOOGLE_SHEET_VALID_ID" --spreadsheet-cred "$VALID_CRED" --model "nonexistent-model"
 	assert_success
 	assert_output --partial "Downloaded CSV from:" || assert_output --partial "Downloading CSV from:"
 	assert_output --partial "Parsing Components..."
@@ -69,9 +69,9 @@ teardown() {
 @test "mesheryctl registry update with --input flag uses custom models directory" {
     mkdir -p "$TEMP_DATA_DIR/custom-models"
 
-    run $MESHERYCTL_BIN registry update --spreadsheet-id "$SHEET_ID" --spreadsheet-cred "$VALID_CRED" --input "$TEMP_DATA_DIR/custom-models"
+    run $MESHERYCTL_BIN registry update --spreadsheet-id "$GOOGLE_SHEET_VALID_ID" --spreadsheet-cred "$VALID_CRED" --input "$TEMP_DATA_DIR/custom-models"
 	assert_success
-    assert_output --partial "Downloaded CSV from:" || assert_output --partial "Downloading CSV from:"
+	assert_output --partial "Downloaded CSV from:" || assert_output --partial "Downloading CSV from:"
 	assert_output --partial "Parsing Components..."
 	assert_output --regexp "Updated [0-9]+ models and [0-9]+ components"
 	assert_output --partial "refer $LOG_PATH for detailed registry update logs"

--- a/mesheryctl/tests/e2e/helpers/constants.bash
+++ b/mesheryctl/tests/e2e/helpers/constants.bash
@@ -3,3 +3,6 @@
 # Description: Centralization of constants for all tests
 
 LIST_COMMAND_OUTPUT_REGEX_PATTERN="^Total number of [a-z]+s: [0-9]+$"
+SHEET_ID="1kldsrMSwItkvlcazw8HEMmSrgsHPJsTsKY7f1hvJNAc"
+INVALID_CRED="1234567890"
+INVALID_SHEET="1kldsrMSwItkvlcazw8HEMmSrgsHPJsTsKY7f1hvJNA"

--- a/mesheryctl/tests/e2e/helpers/constants.bash
+++ b/mesheryctl/tests/e2e/helpers/constants.bash
@@ -3,6 +3,6 @@
 # Description: Centralization of constants for all tests
 
 LIST_COMMAND_OUTPUT_REGEX_PATTERN="^Total number of [a-z]+s: [0-9]+$"
-SHEET_ID="1kldsrMSwItkvlcazw8HEMmSrgsHPJsTsKY7f1hvJNAc"
-INVALID_CRED="1234567890"
-INVALID_SHEET="1kldsrMSwItkvlcazw8HEMmSrgsHPJsTsKY7f1hvJNA"
+GOOGLE_SHEET_VALID_ID="1kldsrMSwItkvlcazw8HEMmSrgsHPJsTsKY7f1hvJNAc"
+GOOGLE_SHEET_INVALID_ID="invald-sheet-id"
+GOOGLE_SHEET_INVALID_CRED="1234567890"


### PR DESCRIPTION
**Notes for Reviewers**

- This PR fixes #
[mesheryctl] add e2e test for mesheryctl registry update command [#14080](https://github.com/meshery/meshery/issues/14080)
<img width="719" alt="image" src="https://github.com/user-attachments/assets/26147ec4-2149-4fc8-8b4d-1e90984ceeb0" />

- Similar to mesheryctl registry publish, This pr also expects a CRED env value, and will update after that one is sorted
- That also goes for valid SHEET_ID or to use meshery integration sheet

**[Signed commits](https://github.com/meshery/meshery/blob/master/CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [x] Yes, I signed my commits.

<!--
Thank you for contributing to Meshery! 

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. Sign your commits.
4. Include before and after screenshots/terminal output.

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.
-->
