### PR TITLE
[server] chore: return ErrContextAlreadyPersisted if k8scontext already exists

### DIFF
--- a/server/helpers/component_info.json
+++ b/server/helpers/component_info.json
@@ -1,5 +1,5 @@
 {
   "name": "meshery-server",
   "type": "component",
-  "next_error_code": 1374
+  "next_error_code": 1375
 }

--- a/server/models/connection_persister.go
+++ b/server/models/connection_persister.go
@@ -85,7 +85,7 @@ func (cp *ConnectionPersister) SaveConnection(connection *connections.Connection
 
 		// Check if there is already an entry for this context
 		if err := tx.First(&existingConnection, "id = ?", connection.ID).Error; err == nil {
-			return ErrContextAlreadyPersisted
+			return ErrConnectionAlreadyExist
 		}
 
 		return tx.Save(&connection).Error

--- a/server/models/default_local_provider.go
+++ b/server/models/default_local_provider.go
@@ -296,6 +296,10 @@ func (l *DefaultLocalProvider) SaveK8sContext(_ string, k8sContext K8sContext, a
 	}
 	connectionCreated, err := l.SaveConnection(conn, "", true)
 	if err != nil {
+		// if connection already exists,return in chain that context is already persisted
+		if errors.Is(err, ErrConnectionAlreadyExist) {
+			err = fmt.Errorf("%v: %v", err, ErrContextAlreadyPersisted)
+		}
 		return connections.Connection{}, fmt.Errorf("error in saving k8s context %v", err)
 	}
 

--- a/server/models/error.go
+++ b/server/models/error.go
@@ -138,6 +138,7 @@ const (
 	ErrMarshallingDesignIntoYAMLCode      = "meshery-server-1135"
 	ErrStatusCodeCode                     = "meshery-server-1368"
 	ErrMeshsyncDataHandlerCode            = "meshery-server-1370"
+	ErrConnectionAlreadyExistCode         = "meshery-server-1374"
 )
 
 var (
@@ -169,6 +170,7 @@ var (
 	ErrTokenRetry              = errors.New(ErrTokenRetryCode, errors.Alert, []string{"Error occurred, retrying after refresh to fetch token"}, []string{}, []string{}, []string{})
 	ErrOperationNotAvaibale    = errors.New(ErrOperationNotAvaibaleCode, errors.Alert, []string{"Operation not available"}, []string{}, []string{}, []string{})
 	ErrEmptySession            = errors.New(ErrEmptySessionCode, errors.Alert, []string{"No session found in the request"}, []string{"Unable to find \"token\" cookie in the request."}, []string{"User is not authenticated with the selected Provider.", "Browser might be restricting use of cookies."}, []string{"Choose a Provider and login to establish an active session (receive a new token and cookie). Optionally, try using a private/incognito browser window.", "Verify that your browser settings allow cookies."})
+	ErrConnectionAlreadyExist  = errors.New(ErrConnectionAlreadyExistCode, errors.Alert, []string{"connection already exists"}, []string{"connection already exists"}, []string{}, []string{})
 )
 
 func ErrCloseIoReader(err error) error {


### PR DESCRIPTION

**Notes for Reviewers**

- This PR fixes small miss in logic in connection persister

Right now connection persisted does not save context if it is already exists, but it does not return error, as err in code below  is nil. 

And this prevents loging in machines discovery state [line 52](https://github.com/meshery/meshery/blob/master/server/machines/kubernetes/discover.go#L52)

Here on screenshot and logs output confirmation that the chain is working and error is logged when connection already exists: https://github.com/meshery/meshery/pull/15568#discussion_r2265373705 

**[Signed commits](https://github.com/meshery/meshery/blob/master/CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [ ] Yes, I signed my commits.

<!--
Thank you for contributing to Meshery! 

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. Sign your commits.
4. Include before and after screenshots/terminal output.

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.
-->
