### PR TITLE
[server] chore: fix add k8sconfig logic when context already persisted

### DIFF
--- a/server/handlers/k8sconfig_handler.go
+++ b/server/handlers/k8sconfig_handler.go
@@ -117,7 +117,7 @@ func (h *Handler) addK8SConfig(user *models.User, _ *models.Preference, w http.R
 		metadata["description"] = fmt.Sprintf("Connection established with context \"%s\" at %s", ctx.Name, ctx.Server)
 
 		connection, err := provider.SaveK8sContext(token, *ctx, k8sContextsMetadata)
-		if err != nil {
+		if err != nil && !errors.Is(err, models.ErrContextAlreadyPersisted) {
 			saveK8sContextResponse.ErroredContexts = append(saveK8sContextResponse.ErroredContexts, *ctx)
 			metadata["description"] = fmt.Sprintf("Unable to establish connection with context \"%s\" at %s", ctx.Name, ctx.Server)
 			metadata["error"] = err


### PR DESCRIPTION
**Notes for Reviewers**

After merging this pr: https://github.com/meshery/meshery/pull/15568

now if user submits context which already been submitted it returned as errored context, while should be returned as connected.

And pr https://github.com/meshery/meshery/pull/15568 fails integration test with meshsync :cry: 

**[Signed commits](https://github.com/meshery/meshery/blob/master/CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [ ] Yes, I signed my commits.

<!--
Thank you for contributing to Meshery! 

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. Sign your commits.
4. Include before and after screenshots/terminal output.

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.
-->
