### PR TITLE
[mesheryctl] chore: fix model build and model init failing tests

### DIFF
--- a/docs/_includes/test-report.md
+++ b/docs/_includes/test-report.md
@@ -1,15 +1,15 @@
 ### END-TO-END TESTS
 
-- Testing started at: August 17th 2025, 11:48:35 pm
+- Testing started at: August 18th 2025, 8:56:51 pm
 
 **📦 Test Result Summary**
 
-- ✅ 70 passed
+- ✅ 74 passed
 - ❌ 0 failed
-- ⚠️ 0 flaked
+- ⚠️ 2 flaked
 - ⏩ 0 skipped
 
-⌛ _Duration: 4 minutes and 54 seconds_
+⌛ _Duration: 6 minutes and 8 seconds_
 
 **Overall Result**: 👍 All tests passed.
 
@@ -21,6 +21,8 @@
 
 | Test | Browser | Test Case | Tags | Result |
 | :---: | :---: | :--- | :---: | :---: |
+| 1 | chromium-meshery-provider | Import a Model via CSV Import |  | ⚠️ |
+| 2 | chromium-local-provider | Transition to disconnected state and then back to connected state |  | ⚠️ |
 
 </div>
 </details>

--- a/server/handlers/k8sconfig_handler.go
+++ b/server/handlers/k8sconfig_handler.go
@@ -30,6 +30,12 @@ import (
 )
 
 const MeshsyncDeploymentModeFormKey = "meshsync_deployment_mode"
+const ContextsFormKey = "contexts"
+
+// ContextOptions represents the configuration options for a specific context
+type ContextOptions struct {
+	MeshsyncDeploymentMode string `json:"meshsync_deployment_mode"`
+}
 
 // SaveK8sContextResponse - struct used as (json marshaled) response to requests for saving k8s contexts
 type SaveK8sContextResponse struct {
@@ -100,21 +106,51 @@ func (h *Handler) addK8SConfig(user *models.User, _ *models.Preference, w http.R
 		WithDescription("Kubernetes config uploaded.").WithSeverity(events.Informational)
 	eventMetadata := map[string]interface{}{}
 	contexts := models.K8sContextsFromKubeconfig(provider, user.ID, h.config.EventBroadcaster, *k8sConfigBytes, h.SystemID, eventMetadata, h.log)
-	len := len(contexts)
+	contextsLen := len(contexts)
 
-	k8sContextsMetadata := make(map[string]any, 1)
-	schemasConnection.SetMeshsyncDeploymentModeToMetadata(
-		k8sContextsMetadata,
-		schemasConnection.MeshsyncDeploymentModeFromString(
-			req.FormValue(MeshsyncDeploymentModeFormKey),
-		),
-	)
+	// Parse contexts configuration if provided
+	var contextsConfig map[string]ContextOptions
+	if contextsJSON := req.FormValue(ContextsFormKey); contextsJSON != "" {
+		if err := json.Unmarshal([]byte(contextsJSON), &contextsConfig); err != nil {
+			h.log.Error(fmt.Errorf("failed to parse contexts configuration: %w", err))
+			http.Error(w, fmt.Sprintf("Invalid contexts configuration: %v", err), http.StatusBadRequest)
+			return
+		}
+	}
+
+	// Helper function to get meshsync deployment mode for a context
+	// Uses closure pattern to call req.FormValue only once while keeping globalMeshsyncMode scoped
+	getMeshsyncModeForContext := func() func(*models.K8sContext) string {
+		// Get global meshsync deployment mode for backward compatibility
+		globalMeshsyncMode := req.FormValue(MeshsyncDeploymentModeFormKey)
+		return func(ctx *models.K8sContext) string {
+			// If contexts config is provided and contains this context, use context-specific setting
+			if contextOpts, exists := contextsConfig[ctx.ID]; exists {
+				if contextOpts.MeshsyncDeploymentMode != "" {
+					return contextOpts.MeshsyncDeploymentMode
+				}
+			}
+			// Fall back to global setting
+			return globalMeshsyncMode
+		}
+	}()
 
 	smInstanceTracker := h.ConnectionToStateMachineInstanceTracker
+	// TODO:
+	// when new api with param "contexts" will be addopted,
+	// only take into account contexts from that param
 	for idx, ctx := range contexts {
 		metadata := map[string]interface{}{}
 		metadata["context"] = models.RedactCredentialsForContext(ctx)
 		metadata["description"] = fmt.Sprintf("Connection established with context \"%s\" at %s", ctx.Name, ctx.Server)
+
+		// Create context-specific metadata with appropriate meshsync deployment mode
+		k8sContextsMetadata := make(map[string]any, 1)
+		meshsyncMode := getMeshsyncModeForContext(ctx)
+		schemasConnection.SetMeshsyncDeploymentModeToMetadata(
+			k8sContextsMetadata,
+			schemasConnection.MeshsyncDeploymentModeFromString(meshsyncMode),
+		)
 
 		connection, err := provider.SaveK8sContext(token, *ctx, k8sContextsMetadata)
 		if err != nil {
@@ -173,7 +209,7 @@ func (h *Handler) addK8SConfig(user *models.User, _ *models.Preference, w http.R
 
 		eventMetadata[ctx.Name] = metadata
 
-		if idx == len-1 {
+		if idx == contextsLen-1 {
 			h.config.K8scontextChannel.PublishContext()
 		}
 	}


### PR DESCRIPTION
**Notes for Reviewers**

I have just noticed that model build test are failing, f.e. in https://github.com/meshery/meshery/actions/runs/17051771904/job/48341158012?pr=15617 

<details>
Error: Usage:
mesheryctl model build [model-name]
or
mesheryctl model build [model-name]/[model-version]

Run 'mesheryctl model build --help' to see detailed help message

folder test-case-model-build-aws-dynamodb-controller does not exist
build_test.go:187:

	exp: "Usage:\nmesheryctl model build [model-name]\nor\nmesheryctl model build [model-name]/[model-version]\n\nRun 'mesheryctl model build --help' to see detailed help message"

	got: "Usage:\nmesheryctl model build [model-name]\nor\nmesheryctl model build [model-name]/[model-version]\n\nRun 'mesheryctl model build --help' to see detailed help message\n\nfolder test-case-model-build-aws-dynamodb-controller does not exist"

Error: Usage:
mesheryctl model build [model-name]
or
mesheryctl model build [model-name]/[model-version]

Run 'mesheryctl model build --help' to see detailed help message
Error: Usage:
mesheryctl model build [model-name]
or
mesheryctl model build [model-name]/[model-version]

Run 'mesheryctl model build --help' to see detailed help message

Command does not support multiple versions build under one image
Error: Usage:
mesheryctl model build [model-name]
or
mesheryctl model build [model-name]/[model-version]

Run 'mesheryctl model build --help' to see detailed help message

folder not_existing_folder/aws-ec2-controller/v0.1.0 does not exist
--- FAIL: TestModelBuild (0.09s)
    build_test.go:60: removed created dirs and files
    build_test.go:60: removed created dirs and files
    build_test.go:60: removed created dirs and files
    --- FAIL: TestModelBuild/model_build_no_params (0.00s)
    build_test.go:60: removed created dirs and files
Error: folder test-case-aws-ec2-controller/v1.0.0 exists, please specify different model name or version
Error: version must follow a semver format, f.e. v1.2.3
Error: [ json, yaml ] are the only format supported
Error: must provide only one argument: model name
Error: must provide only one argument: model name
Error: invalid model name: name must match pattern ^[a-z0-9-]+$
</details>

The issue is that the same object of cobra command is using in different test cases, and there are some interference between them. Like if run each test case separately it is passing OK. 

Added some factoring to ensure each test case is run on a fresh instance of sub command object.

model tests are passing now :white_check_mark: 

<img width="1095" height="163" alt="image" src="https://github.com/user-attachments/assets/55dc51a2-bd84-42ca-84b2-43c2bb869293" />


**[Signed commits](https://github.com/meshery/meshery/blob/master/CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [x] Yes, I signed my commits.

<!--
Thank you for contributing to Meshery! 

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. Sign your commits.
4. Include before and after screenshots/terminal output.

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.
-->
