### PR TITLE
fix(mesheryctl-generate): Fix error not handled properly in model generate subcommand

### DIFF
--- a/mesheryctl/internal/cli/root/model/generate.go
+++ b/mesheryctl/internal/cli/root/model/generate.go
@@ -136,18 +136,25 @@ func (u *UrlModelGenerator) Generate() error {
 func (c *CsvModelGenerator) Generate() error {
 	utils.Log.Info("Generating model from CSV files")
 
-	modelData, err := os.ReadFile(c.ModelFile)
-	if err != nil {
-		return utils.ErrFileRead(err)
+	var modelData, componentData, relationshipData []byte
+	var err error
+
+	filePaths := []struct {
+		path string
+		data *[]byte
+	}{
+		{c.ModelFile, &modelData},
+		{c.ComponentFile, &componentData},
+		{c.RelationshipFile, &relationshipData},
 	}
-	componentData, err := os.ReadFile(c.ComponentFile)
-	if err != nil {
-		return utils.ErrFileRead(err)
+
+	for _, f := range filePaths {
+		*f.data, err = os.ReadFile(f.path)
+		if err != nil {
+			return utils.ErrFileRead(err)
+		}
 	}
-	relationshipData, err := os.ReadFile(c.RelationshipFile)
-	if err != nil {
-		return utils.ErrFileRead(err)
-	}
+
 	err = registerModel(modelData, componentData, relationshipData, "model.csv", "csv", "", !c.SkipRegister)
 	if err != nil {
 		return err


### PR DESCRIPTION
**Notes for Reviewers**

- This PR fixes #15665 

**[Signed commits](https://github.com/meshery/meshery/blob/master/CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [x] Yes, I signed my commits.


New behavior

```bash
~$ ./mesheryctl model generate -f tests/e2e/002-model/fixtures/model-import/valid-model
Error: inside the directory tests/e2e/002-model/fixtures/model-import/valid-model either the model csv or component csv is missing or they are not of write format
```


<!--
Thank you for contributing to Meshery! 

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. Sign your commits.
4. Include before and after screenshots/terminal output.

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.
-->
