### PR TITLE
changed the FromStringorNill to FromString and did error handeling in…

### DIFF
--- a/server/handlers/component_generation.go
+++ b/server/handlers/component_generation.go
@@ -9,7 +9,7 @@ import (
 	"github.com/meshery/meshery/server/helpers"
 	"github.com/meshery/meshery/server/helpers/utils"
 	"github.com/meshery/meshery/server/models"
-	"github.com/meshery/meshkit/generators/artifacthub"
+	"github.com/meshery/meshkit/generators/artifacthub" 
 
 	meshkitmodels "github.com/meshery/meshkit/generators/models"
 	"github.com/meshery/schemas/models/v1beta1/component"

--- a/server/handlers/credentials_handlers.go
+++ b/server/handlers/credentials_handlers.go
@@ -23,7 +23,7 @@ func (h *Handler) SaveUserCredential(w http.ResponseWriter, req *http.Request, _
 
 	userUUID,err := uuid.FromString(user.ID)
 	if err != nil {
-	       http.Error(w, models.ErrInvalidUUID(nil).Error(), http.StatusBadRequest)
+	       http.Error(w, models.ErrInvalidUUID(err).Error(), http.StatusBadRequest)
 	       return
 	}
 

--- a/server/handlers/credentials_handlers.go
+++ b/server/handlers/credentials_handlers.go
@@ -21,7 +21,12 @@ func (h *Handler) SaveUserCredential(w http.ResponseWriter, req *http.Request, _
 		return
 	}
 
-	userUUID := uuid.FromStringOrNil(user.ID)
+	userUUID,err := uuid.FromString(user.ID)
+	if err != nil {
+	       http.Error(w, models.ErrInvalidUUID(nil).Error(), http.StatusBadRequest)
+	       return
+	}
+
 	credential := models.Credential{
 		UserID: &userUUID,
 		Secret: map[string]interface{}{},

--- a/server/models/error.go
+++ b/server/models/error.go
@@ -138,6 +138,7 @@ const (
 	ErrMarshallingDesignIntoYAMLCode      = "meshery-server-1135"
 	ErrStatusCodeCode                     = "meshery-server-1368"
 	ErrMeshsyncDataHandlerCode            = "meshery-server-1370"
+	ErrInvalidUUIDCode					  = "meshery-server-1371"
 )
 
 var (
@@ -180,6 +181,9 @@ func ErrCloseIoReader(err error) error {
 }
 func ErrGetPackage(err error) error {
 	return errors.New(ErrGetPackageCode, errors.Alert, []string{"Could not get the package"}, []string{"", err.Error()}, []string{""}, []string{"Make sure the configurations are correct"})
+}
+func ErrInvalidUUID(err error) error {
+	return errors.New(ErrInvalidUUIDCode, errors.Alert, []string{"Invalid UUID format"}, []string{err.Error()}, []string{}, []string{})
 }
 func ErrUrlParse(err error) error {
 	return errors.New(ErrUrlParseCode, errors.Alert, []string{"Error parsing the URL"}, []string{"", err.Error()}, []string{""}, []string{"Make sure the URL is correct"})


### PR DESCRIPTION
- This PR fixes #15508 

Replace uuid.FromStringOrNil with uuid.FromString for user ID parsing in SaveUserCredential.
Return meshery-friendly error on invalid UUID: http.Error(w, models.ErrInvalidUUID(nil).Error(), http.StatusBadRequest).
No other logic changes. 

This PR is raised based on the feedbacks by @leecalcote and @n2h9 to check for any other use of uuid.FromStringOrNil  function in the repo and to break down the pr into modular changes for easy debugging.

**[Signed commits](https://github.com/meshery/meshery/blob/master/CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [ ] Yes, I signed my commits.