### PR TITLE
feat(ui): add Event Bus component icons

### DIFF
--- a/ui/public/static/img/new-icon/eventbus-color.svg
+++ b/ui/public/static/img/new-icon/eventbus-color.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" role="img" aria-label="Event Bus Icon">
+  <title>Event Bus Icon</title>
+  <path d="..." />
+</svg>

--- a/ui/public/static/img/new-icon/eventbus-color.svg
+++ b/ui/public/static/img/new-icon/eventbus-color.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" role="img" aria-label="Event Bus Icon">
-  <title>Event Bus Icon</title>
+<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" role="img" aria-labelledby="eventBusIconTitle">
+  <title id="eventBusIconTitle">Event Bus Icon</title>
   <path d="..." />
 </svg>

--- a/ui/public/static/img/new-icon/eventbus-white.svg
+++ b/ui/public/static/img/new-icon/eventbus-white.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" role="img" aria-label="Event Bus Icon (White)">
+  <title>Event Bus Icon (White)</title>
+  <path d="..." />
+</svg>

--- a/ui/public/static/img/new-icon/eventbus-white.svg
+++ b/ui/public/static/img/new-icon/eventbus-white.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" role="img" aria-label="Event Bus Icon (White)">
-  <title>Event Bus Icon (White)</title>
+<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" role="img" aria-labelledby="eventBusIconWhiteTitle">
+  <title id="eventBusIconWhiteTitle">Event Bus Icon (White)</title>
   <path d="..." />
 </svg>


### PR DESCRIPTION
Summary
This PR adds dedicated icons for the Event Bus component in the Meshery UI.

Changes Introduced
Added eventbus-color.svg
Added eventbus-white.svg

Closes ##10297

Motivation
The Event Bus component in Meshery’s architecture needs proper representation in the UI. These new icons ensure consistent design and better visual identification of the Event Bus component across the interface.

Checklist
Added new icons to ui/public/static/img/new-icon/
Verified DCO sign-off
