### PR TITLE
feat(ui): add ArgoCD Workflow Template icons (colored & white)

### DIFF
--- a/ui/public/static/img/new-icon/argocd-workflow-template-colored.svg
+++ b/ui/public/static/img/new-icon/argocd-workflow-template-colored.svg
@@ -1,0 +1,9 @@
+<svg width="24" height="24" viewBox="0 0 24 24" role="img" aria-label="ArgoCD Workflow Template icon (colored)" xmlns="http://www.w3.org/2000/svg">
+  <rect x="3" y="3" width="18" height="18" rx="3" fill="none" stroke="#6B7280" stroke-width="1.5"/>
+  <rect x="3" y="3" width="18" height="4" fill="#9CA3AF" opacity="0.3"/>
+  <circle cx="8" cy="11" r="2" fill="#EF7B4D"/>
+  <circle cx="16" cy="11" r="2" fill="#EF7B4D"/>
+  <circle cx="12" cy="16.5" r="2" fill="#EF7B4D"/>
+  <path d="M10 11 H14" stroke="#374151" stroke-width="1.5" stroke-linecap="round"/>
+  <path d="M12 13 V14.5" stroke="#374151" stroke-width="1.5" stroke-linecap="round"/>
+</svg>

--- a/ui/public/static/img/new-icon/argocd-workflow-template-white.svg
+++ b/ui/public/static/img/new-icon/argocd-workflow-template-white.svg
@@ -1,0 +1,9 @@
+<svg width="24" height="24" viewBox="0 0 24 24" role="img" aria-label="ArgoCD Workflow Template icon (white)" xmlns="http://www.w3.org/2000/svg">
+  <rect x="3" y="3" width="18" height="18" rx="3" fill="none" stroke="#FFFFFF" stroke-width="1.5"/>
+  <rect x="3" y="3" width="18" height="4" fill="#FFFFFF" opacity="0.35"/>
+  <circle cx="8" cy="11" r="2" fill="#FFFFFF"/>
+  <circle cx="16" cy="11" r="2" fill="#FFFFFF"/>
+  <circle cx="12" cy="16.5" r="2" fill="#FFFFFF"/>
+  <path d="M10 11 H14" stroke="#FFFFFF" stroke-width="1.5" stroke-linecap="round"/>
+  <path d="M12 13 V14.5" stroke="#FFFFFF" stroke-width="1.5" stroke-linecap="round"/>
+</svg>


### PR DESCRIPTION
### Description
Adds two new SVG icons (colored & white) for the ArgoCD Workflow Template component.

### Details
- Icons placed under `ui/public/static/img/new-icon/`
- Accessible (role="img", aria-label)
- Optimized and consistent 24x24 viewBox

### Related Issue
Closes #10418

### Checklist
- [x] Two new icons added
- [x] DCO signed commit
