### PR TITLE
[UI] Add a formatter for `academy_quiz_evaluation`.

### DIFF
--- a/ui/components/NotificationCenter/constants.js
+++ b/ui/components/NotificationCenter/constants.js
@@ -78,4 +78,8 @@ export const EVENT_TYPE = {
     category: 'entity',
     action: 'get_summary',
   },
+  ACADEMY_QUIZ_EVALUATION: {
+    category: 'academy',
+    action: 'academy_quiz_evaluation',
+  },
 };

--- a/ui/components/NotificationCenter/formatters/academy_events.js
+++ b/ui/components/NotificationCenter/formatters/academy_events.js
@@ -1,0 +1,95 @@
+import React from 'react';
+import {
+  Box,
+  Divider,
+  Link,
+  List,
+  ListItem,
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableRow,
+  Typography,
+} from '@sistent/sistent';
+
+export const AcademyEventsFormatter = ({ event }) => {
+  const result = event.metadata.result;
+  const quiz = result.quiz;
+  if (!result || !quiz || !quiz.parent) {
+    return (
+      <Typography variant="body1" color="error">
+        Could not load quiz results. The event data is incomplete.
+      </Typography>
+    );
+  }
+
+  const quizDetails = [
+    { label: 'Chapter', value: quiz.parent.title },
+    { label: 'Description', value: quiz.description },
+    { label: 'Time limit', value: quiz.time_limit },
+    { label: 'Attempted at', value: new Date(result.attempted_at).toLocaleString() },
+  ];
+
+  return (
+    <Box>
+      <Typography variant="h6">Quiz details</Typography>
+      <List disablePadding>
+        <ListItem sx={{ py: 0.5 }}>
+          <Link variant="body1" target="_blank" rel="noopener noreferrer" href={quiz.permalink}>
+            Go to quiz
+          </Link>
+        </ListItem>
+        {quizDetails.map(({ label, value }) => (
+          <ListItem key={label} sx={{ py: 0.5 }}>
+            <Typography variant="body1">
+              <Box component="span" fontWeight="bold">
+                {label}:
+              </Box>{' '}
+              {value || (
+                <Box component="span" fontStyle="italic">
+                  none
+                </Box>
+              )}
+            </Typography>
+          </ListItem>
+        ))}
+      </List>
+
+      <Divider sx={{ my: 2 }} />
+
+      <Typography variant="h6">Result</Typography>
+
+      <List disablePadding>
+        <ListItem sx={{ py: 0.5 }} divider>
+          <Box>
+            <Typography variant="body1">
+              {`Score: ${Number(result.percentage_scored).toFixed(2)}% (Pass mark: ${result.pass_percentage}%)`}
+            </Typography>
+            <Typography variant="body1" color={result.passed ? 'green' : 'red'}>
+              {result.passed ? '✅ Passed' : '❌ Not passed'}
+            </Typography>
+          </Box>
+        </ListItem>
+        <ListItem sx={{ display: 'block', py: 0.5 }}>
+          <Table size="small">
+            <TableHead>
+              <TableRow>
+                <TableCell>Question</TableCell>
+                <TableCell>Result</TableCell>
+              </TableRow>
+            </TableHead>
+            <TableBody>
+              {Object.entries(result.correct_submissions).map(([question, isCorrect]) => (
+                <TableRow key={question}>
+                  <TableCell>{question}</TableCell>
+                  <TableCell>{isCorrect ? '✅' : '❌'}</TableCell>
+                </TableRow>
+              ))}
+            </TableBody>
+          </Table>
+        </ListItem>
+      </List>
+    </Box>
+  );
+};

--- a/ui/components/NotificationCenter/metadata.js
+++ b/ui/components/NotificationCenter/metadata.js
@@ -12,6 +12,7 @@ import { RelationshipEvaluationEventFormatter } from './formatters/relationship_
 import { useTheme, DownloadIcon, InfoIcon } from '@sistent/sistent';
 import _ from 'lodash';
 import { ChipWrapper } from '../connections/styles';
+import { AcademyEventsFormatter } from './formatters/academy_events';
 
 const DesignFormatter = ({ value }) => {
   const theme = useTheme();
@@ -96,6 +97,7 @@ const EventTypeFormatters = {
   [eventDetailFormatterKey(EVENT_TYPE.DEPLOY_DESIGN)]: DeploymentSummaryFormatter,
   [eventDetailFormatterKey(EVENT_TYPE.UNDEPLOY_DESIGN)]: DeploymentSummaryFormatter,
   [eventDetailFormatterKey(EVENT_TYPE.EVALUATE_DESIGN)]: RelationshipEvaluationEventFormatter,
+  [eventDetailFormatterKey(EVENT_TYPE.ACADEMY_QUIZ_EVALUATION)]: AcademyEventsFormatter,
   // [eventDetailFormatterKey(EVENT_TYPE.REGISTRANT_SUMMARY)]: RegistrantSummaryFormatter,
 };
 


### PR DESCRIPTION
Since we recently introduced enhanced version of academy, we now need of an event formatter for these events coming from academy.


**Notes for Reviewers**
- I took the liberty of using ✅ and ❌ to indicate boolean values in the rendered metadata.
- This PR fixes #15722
- We show only some relevant attributes from the events. I need suggestions on what other fields of the event to include. Here is what the event object looks like:

<details>

```
{
			"acted_upon": "00000000-0000-0000-0000-000000000000",
			"action": "academy_quiz_evaluation",
			"category": "academy",
			"created_at": "2025-09-16T08:52:44.03199Z",
			"description": "User  submitted quiz learning-paths/11111111-1111-1111-1111-111111111111/mastering-meshery/introduction-to-meshery/creating-designs/quiz.md",
			"id": "54b92e29-f0eb-49ad-8bb7-3ea8650ddbca",
			"metadata": {
				"org_id": "11111111-1111-1111-1111-111111111111",
				"result": {
					"attempted_at": "2025-09-16T08:52:44.032709117Z",
					"attempts": 0,
					"correct_submissions": {
						"q1": true,
						"q2": false,
						"q3": true
					},
					"pass_percentage": 70,
					"passed": false,
					"percentage_scored": 66.66667,
					"quiz": {
						"date": "0001-01-01",
						"description": "",
						"draft": false,
						"file_path": "learning-paths/11111111-1111-1111-1111-111111111111/mastering-meshery/introduction-to-meshery/creating-designs/quiz.md",
						"final": true,
						"id": "ce9d2b1a48e536255a3534e8640c15fe",
						"lastmod": "0001-01-01",
						"layout": "",
						"org_id": "11111111-1111-1111-1111-111111111111",
						"parent": {
							"id": "creating-designs",
							"relPermalink": "/learning-paths/11111111-1111-1111-1111-111111111111/mastering-meshery/introduction-to-meshery/creating-designs/",
							"title": "Creating Designs",
							"type": "module"
						},
						"pass_percentage": 70,
						"permalink": "https://cloud.layer5.io/academy/learning-paths/11111111-1111-1111-1111-111111111111/mastering-meshery/introduction-to-meshery/creating-designs/quiz/",
						"prerequisites": [],
						"questions": [],
						"relPermalink": "/learning-paths/11111111-1111-1111-1111-111111111111/mastering-meshery/introduction-to-meshery/creating-designs/quiz/",
						"section": "learning-paths",
						"slug": "",
						"time_limit": "infinite",
						"title": "Quiz",
						"total_marks": 6,
						"total_questions": 3,
						"type": "test"
					},
					"score": 4,
					"total_marks": 6
				}
			},
			"operation_id": "0faf6c45-d719-492e-92f4-ba0f34140021",
			"severity": "informational",
			"status": "unread",
			"system_id": "00000000-0000-0000-0000-000000000000",
			"updated_at": "2025-09-16T08:52:44.033575Z",
			"user_id": "e5e2f455-d8d5-4304-88e3-96904d4a2685"
		}
```
</details>

**[Signed commits](https://github.com/meshery/meshery/blob/master/CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [x] Yes, I signed my commits.



| Before | After |
|--------|-------|
| <img width="691" height="913" alt="image" src="https://github.com/user-attachments/assets/0c0d1106-d683-4f5f-8965-8ee968a386c8" /> | <img width="703" height="608" alt="image" src="https://github.com/user-attachments/assets/1d5bb710-8560-4592-91b8-47ad6116ac7e" /> |


<!--
Thank you for contributing to Meshery! 

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. Sign your commits.
4. Include before and after screenshots/terminal output.

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.
-->
