### PR TITLE
[mesheryctl] Remove redundant error guard clause.

### DIFF
--- a/mesheryctl/internal/cli/root/config/config.go
+++ b/mesheryctl/internal/cli/root/config/config.go
@@ -250,7 +250,7 @@ func (ctx *Context) ValidateVersion() error {
 	client := &http.Client{}
 	resp, err := client.Do(req)
 	if err != nil {
-		return err
+		return errors.Wrapf(err, "failed to make GET request to %s", url)
 	}
 
 	defer func() {
@@ -265,10 +265,6 @@ func (ctx *Context) ValidateVersion() error {
 
 	if resp.StatusCode != http.StatusOK {
 		log.Fatal("failed to validate Meshery release version " + ctx.Version)
-	}
-
-	if err != nil {
-		return errors.Wrapf(err, "failed to make GET request to %s", url)
 	}
 
 	return nil


### PR DESCRIPTION
We're already checking for `err` to be `nil` a little earlier. This was discovered through the static analyzer.

<img width="678" height="52" alt="image" src="https://github.com/user-attachments/assets/33f0f1c8-6375-4804-a3a2-7a995a6692b6" />


**[Signed commits](https://github.com/meshery/meshery/blob/master/CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [x] Yes, I signed my commits.

<!--
Thank you for contributing to Meshery! 

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. Sign your commits.
4. Include before and after screenshots/terminal output.

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.
-->
