### PR TITLE
fix: settings css responsiveness fix

### DIFF
--- a/ui/components/Settings/MesherySettings.js
+++ b/ui/components/Settings/MesherySettings.js
@@ -247,7 +247,7 @@ const MesherySettings = () => {
               <Tabs
                 value={tabVal}
                 onChange={handleChange('tabVal')}
-                variant='fullWidth'
+                variant="fullWidth"
                 scrollButtons="on"
                 indicatorColor="primary"
                 textColor="primary"

--- a/ui/components/Settings/MesherySettings.js
+++ b/ui/components/Settings/MesherySettings.js
@@ -247,7 +247,7 @@ const MesherySettings = () => {
               <Tabs
                 value={tabVal}
                 onChange={handleChange('tabVal')}
-                variant={window.innerWidth < 900 ? 'scrollable' : 'fullWidth'}
+                variant='fullWidth'
                 scrollButtons="on"
                 indicatorColor="primary"
                 textColor="primary"


### PR DESCRIPTION
**Notes for Reviewers**

Small fix for the tabs on the settings page. When the screen goes below 900 width the tab items remain left aligned when the screen is expanded agaiN

### Before
Full screen
<img width="1188" height="934" alt="Screenshot 2025-09-23 at 5 59 25 AM" src="https://github.com/user-attachments/assets/06227cfc-f9e5-40f7-948d-57b40ecdfa7d" />
Small screen
<img width="541" height="899" alt="Screenshot 2025-09-23 at 5 59 53 AM" src="https://github.com/user-attachments/assets/2ad5e616-1e4a-44e4-ba3b-0150cd729f4e" />
Return to full screen 
<img width="1164" height="880" alt="Screenshot 2025-09-23 at 6 00 02 AM" src="https://github.com/user-attachments/assets/dade901e-c659-4d56-9e1c-b88b06387ace" />


Fix

https://github.com/user-attachments/assets/f0329292-6657-4810-be43-aa982a5b30f4



**[Signed commits](https://github.com/meshery/meshery/blob/master/CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [ ] Yes, I signed my commits.

<!--
Thank you for contributing to Meshery! 

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. Sign your commits.
4. Include before and after screenshots/terminal output.

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.
-->
