### PR TITLE
feat: Added --component command for mesheryctl system start

### DIFF
--- a/mesheryctl/internal/cli/root/system/check.go
+++ b/mesheryctl/internal/cli/root/system/check.go
@@ -667,6 +667,24 @@ func mesheryReadinessHealthCheck() (bool, error) {
 	return true, nil
 }
 
+func operatorReadinessHealthCheck() (bool, error) {
+	kubeClient, err := initializeKubernetesClient()
+	if err != nil {
+		return false, err
+	}
+
+	// Operator-related components to check
+	resources := []string{"meshery-operator", "meshery-meshsync", "meshery-broker"}
+
+	for _, comp := range resources {
+		if err := utils.WaitForPodRunning(kubeClient, comp, utils.MesheryNamespace, 300); err != nil {
+			return false, fmt.Errorf("resource %s is not ready: %w", comp, err)
+		}
+	}
+
+	return true, nil
+}
+
 func init() {
 	checkCmd.Flags().BoolVarP(&preflight, "preflight", "", false, "Verify environment readiness to deploy Meshery")
 	checkCmd.Flags().BoolVarP(&pre, "pre", "", false, "Verify environment readiness to deploy Meshery")

--- a/mesheryctl/internal/cli/root/system/start.go
+++ b/mesheryctl/internal/cli/root/system/start.go
@@ -449,7 +449,9 @@ func start() error {
 
 		time.Sleep(20 * time.Second) // sleeping 20 seconds to countermeasure time to apply helm charts
 
-		readinessHealthCheck()
+		if err = readinessHealthCheck(); err != nil {
+			return err
+		}
 
 		spinner.Stop()
 

--- a/mesheryctl/internal/cli/root/system/start.go
+++ b/mesheryctl/internal/cli/root/system/start.go
@@ -522,7 +522,7 @@ func applyHelmCharts(kubeClient *meshkitkube.Client, currCtx *config.Context, me
 		})
 	}
 
-	var errOperator error = nil
+	var errOperator error
 	if isKubernetesComponentFlagsSet("operator") {
 		errOperator = kubeClient.ApplyHelmChart(meshkitkube.ApplyHelmChartConfig{
 			Namespace:       utils.MesheryNamespace,


### PR DESCRIPTION
**Notes for Reviewers**

This PR introduces the --components flag for mesheryctl system start -p kubernetes, allowing users to selectively deploy Meshery server, operator, or both.

Adds validation to ensure only valid values (meshery, operator) are accepted.

Updates help text for clarity on multiple flag usage.

Fixes issue where invalid component names or extra spaces could cause unexpected errors.

- This PR fixes #15876 

**[Signed commits](https://github.com/meshery/meshery/blob/master/CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [✓ ] Yes, I signed my commits.

<!--
Thank you for contributing to Meshery! 

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. Sign your commits.
4. Include before and after screenshots/terminal output.

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.
-->
