### PR TITLE
chore(mesheryctl): use schema driven development on workspace create subcommand

### DIFF
--- a/mesheryctl/internal/cli/root/workspaces/testdata/create.workspace.success.output.golden
+++ b/mesheryctl/internal/cli/root/workspaces/testdata/create.workspace.success.output.golden
@@ -1,1 +1,1 @@
-Workspace workspace-test created
+Workspace workspace-test created in organization 2d2c0b60-076a-4f0a-8a63-de538570a553


### PR DESCRIPTION
**Notes for Reviewers**

- This PR fixes try to implement schema driven dev for workspace create subcommand

**[Signed commits](https://github.com/meshery/meshery/blob/master/CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [x] Yes, I signed my commits.

<!--
Thank you for contributing to Meshery! 

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. Sign your commits.
4. Include before and after screenshots/terminal output.

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.
-->
