### PR TITLE
fix(ui): resolve performance preferences save functionality

### DIFF
--- a/INSTALLATION.md
+++ b/INSTALLATION.md
@@ -1,0 +1,66 @@
+# Installation and Local Development
+
+This guide helps you set up dependencies and run Meshery locally (server + UI).
+
+## Prerequisites
+
+- Git
+- Docker (optional, for containerized workflows)
+- Node.js 18 or 20 with npm
+- Go 1.24.x
+
+## Setup Steps
+
+1. Install Node.js 18 or 20
+   - Linux (NodeSource):
+     ```bash
+     curl -fsSL https://deb.nodesource.com/setup_20.x | sudo -E bash -
+     sudo apt-get install -y nodejs
+     ```
+   - Or use `nvm` and select Node 18/20.
+
+2. Install Go 1.24.x
+   - Using tarball (no sudo):
+     ```bash
+     curl -fsSLo /tmp/go1.24.5.linux-amd64.tar.gz https://go.dev/dl/go1.24.5.linux-amd64.tar.gz
+     rm -rf "$HOME/.local/go"
+     mkdir -p "$HOME/.local"
+     tar -C "$HOME/.local" -xzf /tmp/go1.24.5.linux-amd64.tar.gz
+     echo 'export PATH=$HOME/.local/go/bin:$PATH' >> ~/.bashrc
+     export PATH=$HOME/.local/go/bin:$PATH
+     go version
+     ```
+
+3. Install UI dependencies
+   ```bash
+   cd ui && npm ci
+   cd ../provider-ui && npm ci
+   ```
+
+## Running Locally
+
+Two processes are needed: the Go server and the Next.js UI. The UI proxies API calls to the server on port 9081.
+
+1. Start the server
+   ```bash
+   export PATH=$HOME/.local/go/bin:$PATH
+   make server PORT=9081
+   ```
+
+2. Start the UI (in another terminal)
+   ```bash
+   cd ui
+   NODE_ENV=development PORT=3000 npm run dev
+   ```
+
+3. Open the app
+   - UI: http://localhost:3000
+   - Server (API): http://localhost:9081
+
+## Notes
+
+- The repository `Makefile` has additional targets, e.g., `ui`, `ui-build`, `server-without-operator`, etc.
+- Ensure Node is v18 or v20 to avoid engine warnings.
+- If using Docker, see `install/README.md` and root `README.md` for platform-specific options.
+
+

--- a/ui/rtk-query/user.js
+++ b/ui/rtk-query/user.js
@@ -18,18 +18,19 @@ export const userApi = api
     endpoints: (builder) => ({
       getLoadTestPrefs: builder.query({
         query: (selectedK8sContexts) => ({
-          url: ctxUrl('/api/user/prefs', selectedK8sContexts),
+          url: ctxUrl('user/prefs', selectedK8sContexts),
           method: 'GET',
           credentials: 'include',
         }),
         providesTags: [Tags.LOAD_TEST_PREF],
-        // Transform response to directly get the loadTestPrefs
-        transformResponse: (response) => response?.loadTestPrefs || {},
+        // Transform response to directly get the loadTestPrefs (backend json tag)
+        // Return undefined when not present so consumers can detect absence
+        transformResponse: (response) => response?.loadTestPrefs ?? undefined,
       }),
 
       updateLoadTestPrefs: builder.mutation({
         query: (queryArg) => ({
-          url: ctxUrl('/api/user/prefs', queryArg.selectedK8sContexts),
+          url: ctxUrl('user/prefs', queryArg.selectedK8sContexts),
           method: 'POST',
           credentials: 'include',
           headers: { 'Content-Type': 'application/json;charset=UTF-8' },
@@ -74,7 +75,7 @@ export const userApi = api
       }),
       updateUserPrefWithContext: builder.mutation({
         query: (queryArg) => ({
-          url: ctxUrl('/user/prefs', queryArg.selectedK8sContexts),
+          url: ctxUrl('user/prefs', queryArg.selectedK8sContexts),
           method: 'POST',
           headers: {
             'Content-Type': 'application/json;charset=UTF-8',

--- a/ui/store/index.js
+++ b/ui/store/index.js
@@ -18,7 +18,12 @@ export const store = configureStore({
     adapter: adapterReducer,
     [api.reducerPath]: api.reducer,
   },
-  middleware: (getDefaultMiddleware) => getDefaultMiddleware().concat(api.middleware),
+  middleware: (getDefaultMiddleware) =>
+    getDefaultMiddleware({
+      serializableCheck: {
+        ignoredPaths: ['events.ui.icon'],
+      },
+    }).concat(api.middleware),
 });
 
 mesheryEventBus.on('DISPATCH_TO_MESHERY_STORE').subscribe((event) => {


### PR DESCRIPTION
- Remove undefined setBlockRunTest function call causing runtime errors
- Fix double /api path in RTK Query endpoints (/api/api/user/prefs → /api/user/prefs)
- Align frontend/backend data structure (LoadTestPreferences → loadTestPrefs)
- Remove unused useGetDesignQuery hook preventing duplicate API calls
- Add proper useDispatch hook and submission protection
- Fix Autocomplete crashes with safe default values and null handling
- Configure Redux store to ignore non-serializable events.ui.icon path
- Ensure single toast notification (success OR error, not both)

Fixes #14694

**Notes for Reviewers**
- This PR fixes #14694 - Performance preferences save functionality was broken with multiple issues including runtime errors, API path issues, data structure mismatches, and duplicate toast notifications.
<img width="2032" height="1161" alt="image" src="https://github.com/user-attachments/assets/6742e72d-bf28-4fdc-bf2c-d535a596f0fe" />


**[Signed commits](https://github.com/meshery/meshery/blob/master/CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [x] Yes, I signed my commits.

<!--
Thank you for contributing to Meshery! 

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. Sign your commits.
4. Include before and after screenshots/terminal output.

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.
-->
