### PR TITLE
[docs] Event Verification: View & Update

### DIFF
--- a/hacktoberfest_contributions/verify-event/view_update_results.md
+++ b/hacktoberfest_contributions/verify-event/view_update_results.md
@@ -1,0 +1,44 @@
+# Event Parity Verification — View & Update
+
+**Contributor:** [@KatalKavya96](https://github.com/KatalKavya96) 
+**Goal:** Verify that “View” and “Update” events are generated consistently across Meshery clients.
+
+---
+
+## Results Table
+
+| Event Type | Meshery Cloud Catalog | Meshery UI | Meshery.io Catalog | mesheryctl |
+|-------------|----------------------|-------------|--------------------|-------------|
+| View | ✅ | ✅ | ✅ | ✅ |
+| Update | ✅ | ✅ | N/A | N/A |
+
+✅ = Event generated ❌ = Not generated N/A = Not available
+
+---
+
+### Meshery Cloud Catalog
+**Design tested:** `Kibana-Helm-Design-Fixed`  
+- **View:** Opened design details page → page loaded correctly ✅  
+- **Update:** Clicked *Edit*, renamed to `Kibana-Helm-Design-Fixed-test`, saved → toast appeared and “Updated At” changed ✅  
+
+---
+
+### Meshery UI (Local)
+**Design tested:** `test-design-ui`  
+- **View:** Clicking **Info** triggered `GET /api/meshmodels/models` with **200 OK** ✅  
+- **Update:** Edited YAML (changed `replicas`) → save request **200 OK** ✅  
+
+---
+
+### Meshery.io Catalog
+**Design tested:** Public design (e.g., `Kubernetes Deployment`)  
+- **View:** Opened public design page on meshery.io → rendered successfully ✅  
+- **Update:** Not supported for public users → N/A  
+
+---
+
+### mesheryctl
+**Design tested:** `c3957bda` (`Online Boutique`)  
+- **View:** `mesheryctl design view c3957bda` → details printed ✅  
+- **Update:** N/A — no direct `design update` subcommand in this build (updates typically via apply/onboard).
+


### PR DESCRIPTION
### Adds results for event parity verification of **View** and **Update** across clients.

| Event Type | Meshery Cloud Catalog | Meshery UI | Meshery.io Catalog | mesheryctl |
|------------|------------------------|------------|--------------------|------------|
| View       | ✅                     | ✅         | ✅                 | ✅         |
| Update     | ✅                     | ✅         | N/A                | N/A        |

### Notes:
- Cloud: View + Update confirmed (toast + Updated At).
- UI (local): View + Update confirmed via Network 200s.
- meshery.io: View ✅, Update N/A (public read-only).
- mesheryctl: `design view` works; no direct `design update` in this build → N/A.

Closes #15993 
Signed-off-by: Kavya Katal <kavyakatal09@gmail.com>