### PR TITLE
Fix: Change Kubernetes event action from 'registering' to 'register'

### DIFF
--- a/server/models/k8s_components_registration.go
+++ b/server/models/k8s_components_registration.go
@@ -45,7 +45,7 @@ func (rs RegistrationStatus) String() string {
 	case NotRegistered:
 		return "not_registered"
 	case Registering:
-		return "registering"
+		return "register"
 	default:
 		return ""
 	}


### PR DESCRIPTION
## Description
This PR fixes issue #16186 by changing the Kubernetes connection event action from "registering" to "register" for consistency.

## Changes Made
- Updated `RegistrationStatus.String()` method in `server/models/k8s_components_registration.go`
- Changed `Registering` case to return "register" instead of "registering" on line 46
- Ensures consistency with other connection event actions throughout the codebase

## Issue
Resolves: #16186

## Impact
- UI filters will show consistent `action: register` 
- Event logs will use uniform "register" action terminology  
- API responses will have consistent event action naming

## Testing
- [x] Code change applied and verified
- [x] Single line modification confirmed
- [ ] UI testing needed to verify "register" action appears instead of "registering"