### PR TITLE
design: add Devtron Operator design

### DIFF
--- a/hacktoberfest_contributions/devtron-operator/design.yml
+++ b/hacktoberfest_contributions/devtron-operator/design.yml
@@ -1,0 +1,9048 @@
+id: b11a2691-4884-4142-904a-822371f0a60b
+name: devtron-operator
+schemaVersion: designs.meshery.io/v1beta1
+version: 0.0.3
+metadata:
+  resolvedAliases:
+    7992b206-6d7c-43e5-b208-e0cc64cca312:
+      alias_component_id: 7992b206-6d7c-43e5-b208-e0cc64cca312
+      immediate_parent_id: 09ae7182-3f78-4fe8-8b76-db4b1e9ed46a
+      immediate_ref_field_path:
+        - configuration
+        - spec
+        - template
+        - spec
+        - containers
+        - "0"
+      relationship_id: f9c9654f-aa03-40c1-be8c-789c02b3f0cc
+      resolved_parent_id: 09ae7182-3f78-4fe8-8b76-db4b1e9ed46a
+      resolved_ref_field_path:
+        - configuration
+        - spec
+        - template
+        - spec
+        - containers
+        - "0"
+    96b6e2bf-d53c-4404-a696-94eb9a5c4b3d:
+      alias_component_id: 96b6e2bf-d53c-4404-a696-94eb9a5c4b3d
+      immediate_parent_id: 0851ce28-0a59-4a30-85a8-36488ecb3762
+      immediate_ref_field_path:
+        - configuration
+        - spec
+        - template
+        - spec
+        - containers
+        - "0"
+      relationship_id: f2932caf-aadb-4d94-a3fd-17af207c906d
+      resolved_parent_id: 0851ce28-0a59-4a30-85a8-36488ecb3762
+      resolved_ref_field_path:
+        - configuration
+        - spec
+        - template
+        - spec
+        - containers
+        - "0"
+    e00b8605-ecbf-4049-b0a9-d0a904b8b124:
+      alias_component_id: e00b8605-ecbf-4049-b0a9-d0a904b8b124
+      immediate_parent_id: 575c9682-8b50-4ea5-8307-9ce2e77e65b0
+      immediate_ref_field_path:
+        - configuration
+        - spec
+        - template
+        - spec
+        - containers
+        - "0"
+      relationship_id: 8324f480-334e-4f6a-bc49-621d636f6aaa
+      resolved_parent_id: 575c9682-8b50-4ea5-8307-9ce2e77e65b0
+      resolved_ref_field_path:
+        - configuration
+        - spec
+        - template
+        - spec
+        - containers
+        - "0"
+    f8aea98b-ba7d-4cc1-8b1a-9ca729e34db1:
+      alias_component_id: f8aea98b-ba7d-4cc1-8b1a-9ca729e34db1
+      immediate_parent_id: ce42bd94-2fb6-451e-bba2-e88a6c83fa6b
+      immediate_ref_field_path:
+        - configuration
+        - spec
+        - template
+        - spec
+        - containers
+        - "0"
+      relationship_id: bc28eaf5-4619-4cf5-95af-7fea3e08fb38
+      resolved_parent_id: ce42bd94-2fb6-451e-bba2-e88a6c83fa6b
+      resolved_ref_field_path:
+        - configuration
+        - spec
+        - template
+        - spec
+        - containers
+        - "0"
+components:
+  - id: c1e55e88-394c-45bc-948e-d9472c1240d6
+    schemaVersion: components.meshery.io/v1beta1
+    version: v1.0.0
+    displayName: devtron
+    description: ""
+    format: ""
+    model:
+      id: b3f5bc0d-30f7-607d-6c73-784ddde6cad8
+      schemaVersion: models.meshery.io/v1beta1
+      version: v1.0.0
+      name: kubernetes
+      displayName: Kubernetes
+      status: enabled
+      registrant:
+        id: 5bc80e3c-5d43-9eb4-d16c-78a2769247a6
+        name: Github
+        credential_id: 00000000-0000-0000-0000-000000000000
+        type: registry
+        sub_type: ""
+        kind: github
+        status: registered
+        user_id: 00000000-0000-0000-0000-000000000000
+        created_at: "2025-10-12T14:26:03.160654794Z"
+        updated_at: "2025-10-12T14:26:03.160654794Z"
+        deleted_at: "0001-01-01T00:00:00Z"
+        schemaVersion: ""
+      connection_id: 5bc80e3c-5d43-9eb4-d16c-78a2769247a6
+      category:
+        id: 9ca27d0d-66ce-42a9-8c85-6236563f2ddb
+        name: Orchestration & Management
+      subCategory: Scheduling & Orchestration
+      metadata:
+        isAnnotation: false
+        primaryColor: '#326CE5'
+        secondaryColor: '#7aa1f0'
+        shape: circle
+        styleOverrides: ""
+        svgColor: ui/public/static/img/meshmodels/kubernetes/color/kubernetes-color.svg
+        svgComplete: ""
+        svgWhite: ui/public/static/img/meshmodels/kubernetes/white/kubernetes-white.svg
+      model:
+        version: v1.32.0-alpha.3
+      components_count: 0
+      relationships_count: 0
+      components: null
+      relationships: null
+    styles:
+      height: 22
+      position:
+        x: 1236.49609375
+        y: 179.0048828125
+      primaryColor: '#326CE5'
+      secondaryColor: '#7aa1f0'
+      shape: round-rectangle
+      svgColor: ui/public/static/img/meshmodels/kubernetes/color/clusterrole-color.svg
+      svgComplete: ""
+      svgWhite: ui/public/static/img/meshmodels/kubernetes/white/clusterrole-white.svg
+      width: 22
+      x: 8.5
+      y: 7.5
+      z-index: 22
+    capabilities: []
+    status: enabled
+    metadata:
+      configurationUISchema: ""
+      genealogy: ""
+      instanceDetails: null
+      isAnnotation: false
+      isNamespaced: false
+      published: false
+      source_uri: git://github.com/kubernetes/kubernetes/master/api/openapi-spec/v3
+    configuration:
+      metadata:
+        annotations:
+          helm.sh/resource-policy: keep
+        labels:
+          app.kubernetes.io/instance: devtron
+        name: devtron
+      rules:
+        - apiGroups:
+            - '*'
+          resources:
+            - '*'
+          verbs:
+            - '*'
+        - nonResourceURLs:
+            - '*'
+          verbs:
+            - '*'
+    component:
+      version: rbac.authorization.k8s.io/v1
+      kind: ClusterRole
+      schema: ""
+  - id: 4fdaa688-5699-49db-8d24-a01507099802
+    schemaVersion: components.meshery.io/v1beta1
+    version: v1.0.0
+    displayName: devtron
+    description: ""
+    format: ""
+    model:
+      id: b3f5bc0d-30f7-607d-6c73-784ddde6cad8
+      schemaVersion: models.meshery.io/v1beta1
+      version: v1.0.0
+      name: kubernetes
+      displayName: Kubernetes
+      status: enabled
+      registrant:
+        id: 5bc80e3c-5d43-9eb4-d16c-78a2769247a6
+        name: Github
+        credential_id: 00000000-0000-0000-0000-000000000000
+        type: registry
+        sub_type: ""
+        kind: github
+        status: registered
+        user_id: 00000000-0000-0000-0000-000000000000
+        created_at: "2025-10-12T14:26:03.160654794Z"
+        updated_at: "2025-10-12T14:26:03.160654794Z"
+        deleted_at: "0001-01-01T00:00:00Z"
+        schemaVersion: ""
+      connection_id: 5bc80e3c-5d43-9eb4-d16c-78a2769247a6
+      category:
+        id: 9ca27d0d-66ce-42a9-8c85-6236563f2ddb
+        name: Orchestration & Management
+      subCategory: Scheduling & Orchestration
+      metadata:
+        isAnnotation: false
+        primaryColor: '#326CE5'
+        secondaryColor: '#7aa1f0'
+        shape: circle
+        styleOverrides: ""
+        svgColor: ui/public/static/img/meshmodels/kubernetes/color/kubernetes-color.svg
+        svgComplete: ""
+        svgWhite: ui/public/static/img/meshmodels/kubernetes/white/kubernetes-white.svg
+      model:
+        version: v1.32.0-alpha.3
+      components_count: 0
+      relationships_count: 0
+      components: null
+      relationships: null
+    styles:
+      height: 25
+      position:
+        x: 1039.49609375
+        y: 310.0048828125
+      primaryColor: '#326CE5'
+      secondaryColor: '#7aa1f0'
+      shape: round-rectangle
+      svgColor: ui/public/static/img/meshmodels/kubernetes/color/clusterrolebinding-color.svg
+      svgComplete: ""
+      svgWhite: ui/public/static/img/meshmodels/kubernetes/white/clusterrolebinding-white.svg
+      width: 25
+      x: 7
+      y: 7
+      z-index: 23
+    capabilities: []
+    status: enabled
+    metadata:
+      configurationUISchema: ""
+      genealogy: ""
+      instanceDetails: null
+      isAnnotation: false
+      isNamespaced: false
+      published: false
+      source_uri: git://github.com/kubernetes/kubernetes/master/api/openapi-spec/v3
+    configuration:
+      metadata:
+        annotations:
+          helm.sh/resource-policy: keep
+        name: devtron
+      roleRef:
+        apiGroup: rbac.authorization.k8s.io
+        kind: ClusterRole
+        name: devtron
+      subjects:
+        - kind: ServiceAccount
+          name: devtron
+          namespace: devtroncd
+    component:
+      version: rbac.authorization.k8s.io/v1
+      kind: ClusterRoleBinding
+      schema: ""
+  - id: c58c6c35-098c-4b95-9d88-778499239d03
+    schemaVersion: components.meshery.io/v1beta1
+    version: v1.0.0
+    displayName: devtron-common-cm
+    description: ""
+    format: ""
+    model:
+      id: b3f5bc0d-30f7-607d-6c73-784ddde6cad8
+      schemaVersion: models.meshery.io/v1beta1
+      version: v1.0.0
+      name: kubernetes
+      displayName: Kubernetes
+      status: enabled
+      registrant:
+        id: 5bc80e3c-5d43-9eb4-d16c-78a2769247a6
+        name: Github
+        credential_id: 00000000-0000-0000-0000-000000000000
+        type: registry
+        sub_type: ""
+        kind: github
+        status: registered
+        user_id: 00000000-0000-0000-0000-000000000000
+        created_at: "2025-10-12T14:26:03.160654794Z"
+        updated_at: "2025-10-12T14:26:03.160654794Z"
+        deleted_at: "0001-01-01T00:00:00Z"
+        schemaVersion: ""
+      connection_id: 5bc80e3c-5d43-9eb4-d16c-78a2769247a6
+      category:
+        id: 9ca27d0d-66ce-42a9-8c85-6236563f2ddb
+        name: Orchestration & Management
+      subCategory: Scheduling & Orchestration
+      metadata:
+        isAnnotation: false
+        primaryColor: '#326CE5'
+        secondaryColor: '#7aa1f0'
+        shape: circle
+        styleOverrides: ""
+        svgColor: ui/public/static/img/meshmodels/kubernetes/color/kubernetes-color.svg
+        svgComplete: ""
+        svgWhite: ui/public/static/img/meshmodels/kubernetes/white/kubernetes-white.svg
+      model:
+        version: v1.32.0-alpha.3
+      components_count: 0
+      relationships_count: 0
+      components: null
+      relationships: null
+    styles:
+      position:
+        x: 1180.49609375
+        y: 565.0048828125
+      primaryColor: '#326CE5'
+      secondaryColor: '#7aa1f0'
+      shape: bottom-round-rectangle
+      svgColor: ui/public/static/img/meshmodels/kubernetes/color/configmap-color.svg
+      svgComplete: ""
+      svgWhite: ui/public/static/img/meshmodels/kubernetes/white/configmap-white.svg
+      z-index: 16
+    capabilities: []
+    status: enabled
+    metadata:
+      configurationUISchema: ""
+      genealogy: ""
+      instanceDetails: null
+      isAnnotation: false
+      isNamespaced: true
+      published: false
+      source_uri: git://github.com/kubernetes/kubernetes/master/api/openapi-spec/v3
+    configuration:
+      data: null
+      metadata:
+        annotations:
+          helm.sh/resource-policy: keep
+        labels:
+          release: devtron
+        name: devtron-common-cm
+        namespace: argo
+    component:
+      version: v1
+      kind: ConfigMap
+      schema: ""
+  - id: 6d4ad9d9-af51-4569-9abe-a5197e75affb
+    schemaVersion: components.meshery.io/v1beta1
+    version: v1.0.0
+    displayName: devtron-common-cm
+    description: ""
+    format: ""
+    model:
+      id: b3f5bc0d-30f7-607d-6c73-784ddde6cad8
+      schemaVersion: models.meshery.io/v1beta1
+      version: v1.0.0
+      name: kubernetes
+      displayName: Kubernetes
+      status: enabled
+      registrant:
+        id: 5bc80e3c-5d43-9eb4-d16c-78a2769247a6
+        name: Github
+        credential_id: 00000000-0000-0000-0000-000000000000
+        type: registry
+        sub_type: ""
+        kind: github
+        status: registered
+        user_id: 00000000-0000-0000-0000-000000000000
+        created_at: "2025-10-12T14:26:03.160654794Z"
+        updated_at: "2025-10-12T14:26:03.160654794Z"
+        deleted_at: "0001-01-01T00:00:00Z"
+        schemaVersion: ""
+      connection_id: 5bc80e3c-5d43-9eb4-d16c-78a2769247a6
+      category:
+        id: 9ca27d0d-66ce-42a9-8c85-6236563f2ddb
+        name: Orchestration & Management
+      subCategory: Scheduling & Orchestration
+      metadata:
+        isAnnotation: false
+        primaryColor: '#326CE5'
+        secondaryColor: '#7aa1f0'
+        shape: circle
+        styleOverrides: ""
+        svgColor: ui/public/static/img/meshmodels/kubernetes/color/kubernetes-color.svg
+        svgComplete: ""
+        svgWhite: ui/public/static/img/meshmodels/kubernetes/white/kubernetes-white.svg
+      model:
+        version: v1.32.0-alpha.3
+      components_count: 0
+      relationships_count: 0
+      components: null
+      relationships: null
+    styles:
+      position:
+        x: 1146.49609375
+        y: 181.0048828125
+      primaryColor: '#326CE5'
+      secondaryColor: '#7aa1f0'
+      shape: bottom-round-rectangle
+      svgColor: ui/public/static/img/meshmodels/kubernetes/color/configmap-color.svg
+      svgComplete: ""
+      svgWhite: ui/public/static/img/meshmodels/kubernetes/white/configmap-white.svg
+      z-index: 15
+    capabilities: []
+    status: enabled
+    metadata:
+      configurationUISchema: ""
+      genealogy: ""
+      instanceDetails: null
+      isAnnotation: false
+      isNamespaced: true
+      published: false
+      source_uri: git://github.com/kubernetes/kubernetes/master/api/openapi-spec/v3
+    configuration:
+      data: null
+      metadata:
+        annotations:
+          helm.sh/resource-policy: keep
+        labels:
+          release: devtron
+        name: devtron-common-cm
+        namespace: devtroncd
+    component:
+      version: v1
+      kind: ConfigMap
+      schema: ""
+  - id: 595b7cae-0cd8-476a-9ec9-ace3f5ef7a04
+    schemaVersion: components.meshery.io/v1beta1
+    version: v1.0.0
+    displayName: postgresql-postgresql-scripts
+    description: ""
+    format: ""
+    model:
+      id: b3f5bc0d-30f7-607d-6c73-784ddde6cad8
+      schemaVersion: models.meshery.io/v1beta1
+      version: v1.0.0
+      name: kubernetes
+      displayName: Kubernetes
+      status: enabled
+      registrant:
+        id: 5bc80e3c-5d43-9eb4-d16c-78a2769247a6
+        name: Github
+        credential_id: 00000000-0000-0000-0000-000000000000
+        type: registry
+        sub_type: ""
+        kind: github
+        status: registered
+        user_id: 00000000-0000-0000-0000-000000000000
+        created_at: "2025-10-12T14:26:03.160654794Z"
+        updated_at: "2025-10-12T14:26:03.160654794Z"
+        deleted_at: "0001-01-01T00:00:00Z"
+        schemaVersion: ""
+      connection_id: 5bc80e3c-5d43-9eb4-d16c-78a2769247a6
+      category:
+        id: 9ca27d0d-66ce-42a9-8c85-6236563f2ddb
+        name: Orchestration & Management
+      subCategory: Scheduling & Orchestration
+      metadata:
+        isAnnotation: false
+        primaryColor: '#326CE5'
+        secondaryColor: '#7aa1f0'
+        shape: circle
+        styleOverrides: ""
+        svgColor: ui/public/static/img/meshmodels/kubernetes/color/kubernetes-color.svg
+        svgComplete: ""
+        svgWhite: ui/public/static/img/meshmodels/kubernetes/white/kubernetes-white.svg
+      model:
+        version: v1.32.0-alpha.3
+      components_count: 0
+      relationships_count: 0
+      components: null
+      relationships: null
+    styles:
+      position:
+        x: 1114.49609375
+        y: 765.0048828125
+      primaryColor: '#326CE5'
+      secondaryColor: '#7aa1f0'
+      shape: bottom-round-rectangle
+      svgColor: ui/public/static/img/meshmodels/kubernetes/color/configmap-color.svg
+      svgComplete: ""
+      svgWhite: ui/public/static/img/meshmodels/kubernetes/white/configmap-white.svg
+      z-index: 46
+    capabilities: []
+    status: enabled
+    metadata:
+      configurationUISchema: ""
+      genealogy: ""
+      instanceDetails: null
+      isAnnotation: false
+      isNamespaced: true
+      published: false
+      source_uri: git://github.com/kubernetes/kubernetes/master/api/openapi-spec/v3
+    configuration:
+      data:
+        01-init-userdb.sh: |
+          #!/bin/sh
+          create_user()
+          {
+          psql -v ON_ERROR_STOP=1 --username "$POSTGRES_USER" -v USERDBNAME="$POSTGRES_DB" -v USERDBUSER="$USERDB_USER" -v USERDBPASSWORD="'$USERDB_PASSWORD'" <<-EOSQL
+            CREATE USER :USERDBUSER WITH PASSWORD :USERDBPASSWORD;
+            GRANT ALL PRIVILEGES ON DATABASE :USERDBNAME TO :USERDBUSER;
+          EOSQL
+          }
+          set -e
+          if [ ! -z "$POSTGRES_DB" ] && [ ! -z "$USERDB_USER" ] && [ ! -z "$USERDB_PASSWORD" ]; then
+            create_user
+          fi
+        init.sh: |
+          #!/bin/sh
+          echo "Start initialization"
+          echo "Copy init-userdb script"
+          cp /initscripts/01-init-userdb.sh /scripts
+          if [ -d /extrascripts ]; then
+            echo "Copy extra scripts"
+            cp /extrascripts/* /scripts
+          fi
+          if [ -d /customscripts ]; then
+            echo "Copy custom scripts"
+            cp /customscripts/* /scripts
+          fi
+          if [ -d /customconfig ]; then
+            echo "Create postgres config"
+            cat /customconfig/* >>/configs/postgresql.conf
+          fi
+          if [ -d /extraconfigs ]; then
+            echo "Add extra configs to postgres config"
+            cat /extraconfigs/* >>/configs/postgresql.conf
+          fi
+          echo "Initialization done."
+      metadata:
+        annotations:
+          helm.sh/hook: pre-install
+          helm.sh/hook-weight: "-2"
+          helm.sh/resource-policy: keep
+          meta.helm.sh/release-name: devtron
+          meta.helm.sh/release-namespace: devtroncd
+        labels:
+          app.kubernetes.io/instance: devtron
+          app.kubernetes.io/managed-by: Helm
+          app.kubernetes.io/name: postgres
+          app.kubernetes.io/version: "14.5"
+          helm.sh/chart: postgres-0.4.0
+        name: postgresql-postgresql-scripts
+        namespace: devtroncd
+    component:
+      version: v1
+      kind: ConfigMap
+      schema: ""
+  - id: 4ec90688-30ce-4526-8c9e-d523bf3459ae
+    schemaVersion: components.meshery.io/v1beta1
+    version: v1.0.0
+    displayName: dashboard-cm
+    description: ""
+    format: ""
+    model:
+      id: b3f5bc0d-30f7-607d-6c73-784ddde6cad8
+      schemaVersion: models.meshery.io/v1beta1
+      version: v1.0.0
+      name: kubernetes
+      displayName: Kubernetes
+      status: enabled
+      registrant:
+        id: 5bc80e3c-5d43-9eb4-d16c-78a2769247a6
+        name: Github
+        credential_id: 00000000-0000-0000-0000-000000000000
+        type: registry
+        sub_type: ""
+        kind: github
+        status: registered
+        user_id: 00000000-0000-0000-0000-000000000000
+        created_at: "2025-10-12T14:26:03.160654794Z"
+        updated_at: "2025-10-12T14:26:03.160654794Z"
+        deleted_at: "0001-01-01T00:00:00Z"
+        schemaVersion: ""
+      connection_id: 5bc80e3c-5d43-9eb4-d16c-78a2769247a6
+      category:
+        id: 9ca27d0d-66ce-42a9-8c85-6236563f2ddb
+        name: Orchestration & Management
+      subCategory: Scheduling & Orchestration
+      metadata:
+        isAnnotation: false
+        primaryColor: '#326CE5'
+        secondaryColor: '#7aa1f0'
+        shape: circle
+        styleOverrides: ""
+        svgColor: ui/public/static/img/meshmodels/kubernetes/color/kubernetes-color.svg
+        svgComplete: ""
+        svgWhite: ui/public/static/img/meshmodels/kubernetes/white/kubernetes-white.svg
+      model:
+        version: v1.32.0-alpha.3
+      components_count: 0
+      relationships_count: 0
+      components: null
+      relationships: null
+    styles:
+      position:
+        x: 1206.49609375
+        y: 673.0048828125
+      primaryColor: '#326CE5'
+      secondaryColor: '#7aa1f0'
+      shape: bottom-round-rectangle
+      svgColor: ui/public/static/img/meshmodels/kubernetes/color/configmap-color.svg
+      svgComplete: ""
+      svgWhite: ui/public/static/img/meshmodels/kubernetes/white/configmap-white.svg
+      z-index: 17
+    capabilities: []
+    status: enabled
+    metadata:
+      configurationUISchema: ""
+      genealogy: ""
+      instanceDetails: null
+      isAnnotation: false
+      isNamespaced: true
+      published: false
+      source_uri: git://github.com/kubernetes/kubernetes/master/api/openapi-spec/v3
+    configuration:
+      data:
+        API_BATCH_SIZE: "30"
+        APPLICATION_METRICS_ENABLED: "true"
+        ENABLE_BUILD_CONTEXT: "true"
+        ENABLE_CI_JOB: "true"
+        ENABLE_EXTERNAL_ARGO_CD: "true"
+        ENABLE_RESOURCE_SCAN: "true"
+        ENABLE_RESTART_WORKLOAD: "true"
+        ENABLE_SCOPED_VARIABLES: "true"
+        FEATURE_CODE_MIRROR_ENABLE: "true"
+        FEATURE_EXTERNAL_FLUX_CD_ENABLE: "true"
+        FEATURE_GROUPED_APP_LIST_FILTERS_ENABLE: "true"
+        FEATURE_STEP_WISE_LOGS_ENABLE: "true"
+        FEATURE_USER_DEFINED_GITOPS_REPO_ENABLE: "true"
+        GA_ENABLED: "false"
+        GLOBAL_API_TIMEOUT: "60000"
+        HIDE_APPLICATION_GROUPS: "false"
+        HIDE_EXCLUDE_INCLUDE_GIT_COMMITS: "false"
+        HOTJAR_ENABLED: "false"
+        SENTRY_ENABLED: "false"
+        SENTRY_ENV: PRODUCTION
+        SERVICE_WORKER_TIMEOUT: "1"
+        TRIGGER_API_TIMEOUT: "60000"
+        USE_V2: "true"
+      metadata:
+        annotations:
+          helm.sh/resource-policy: keep
+        labels:
+          release: devtron
+        name: dashboard-cm
+    component:
+      version: v1
+      kind: ConfigMap
+      schema: ""
+  - id: a6fbb851-a6ef-45d1-b20f-695aab006792
+    schemaVersion: components.meshery.io/v1beta1
+    version: v1.0.0
+    displayName: devtron-cm
+    description: ""
+    format: ""
+    model:
+      id: b3f5bc0d-30f7-607d-6c73-784ddde6cad8
+      schemaVersion: models.meshery.io/v1beta1
+      version: v1.0.0
+      name: kubernetes
+      displayName: Kubernetes
+      status: enabled
+      registrant:
+        id: 5bc80e3c-5d43-9eb4-d16c-78a2769247a6
+        name: Github
+        credential_id: 00000000-0000-0000-0000-000000000000
+        type: registry
+        sub_type: ""
+        kind: github
+        status: registered
+        user_id: 00000000-0000-0000-0000-000000000000
+        created_at: "2025-10-12T14:26:03.160654794Z"
+        updated_at: "2025-10-12T14:26:03.160654794Z"
+        deleted_at: "0001-01-01T00:00:00Z"
+        schemaVersion: ""
+      connection_id: 5bc80e3c-5d43-9eb4-d16c-78a2769247a6
+      category:
+        id: 9ca27d0d-66ce-42a9-8c85-6236563f2ddb
+        name: Orchestration & Management
+      subCategory: Scheduling & Orchestration
+      metadata:
+        isAnnotation: false
+        primaryColor: '#326CE5'
+        secondaryColor: '#7aa1f0'
+        shape: circle
+        styleOverrides: ""
+        svgColor: ui/public/static/img/meshmodels/kubernetes/color/kubernetes-color.svg
+        svgComplete: ""
+        svgWhite: ui/public/static/img/meshmodels/kubernetes/white/kubernetes-white.svg
+      model:
+        version: v1.32.0-alpha.3
+      components_count: 0
+      relationships_count: 0
+      components: null
+      relationships: null
+    styles:
+      position:
+        x: 654.49609375
+        y: 765.0048828125
+      primaryColor: '#326CE5'
+      secondaryColor: '#7aa1f0'
+      shape: bottom-round-rectangle
+      svgColor: ui/public/static/img/meshmodels/kubernetes/color/configmap-color.svg
+      svgComplete: ""
+      svgWhite: ui/public/static/img/meshmodels/kubernetes/white/configmap-white.svg
+      z-index: 18
+    capabilities: []
+    status: enabled
+    metadata:
+      configurationUISchema: ""
+      genealogy: ""
+      instanceDetails: null
+      isAnnotation: false
+      isNamespaced: true
+      published: false
+      source_uri: git://github.com/kubernetes/kubernetes/master/api/openapi-spec/v3
+    configuration:
+      data:
+        APP_SYNC_IMAGE: quay.io/devtron/chart-sync:880420ac-836-36037
+        DASHBOARD_HOST: dashboard-service.devtroncd
+        DASHBOARD_PORT: "80"
+        DEVTRON_HELM_RELEASE_NAME: devtron-operator
+        DEVTRON_HELM_RELEASE_NAMESPACE: default
+        DEX_HOST: http://argocd-dex-server.devtroncd
+        DEX_PORT: "5556"
+        FEATURE_MIGRATE_ARGOCD_APPLICATION_ENABLE: "true"
+        GRPC_ENFORCE_ALPN_ENABLED: "false"
+        HELM_CLIENT_URL: kubelink-service-headless:50051
+        PG_ADDR: postgresql-postgresql.devtroncd
+        PG_DATABASE: orchestrator
+        PG_PORT: "5432"
+        PG_USER: postgres
+      metadata:
+        annotations:
+          helm.sh/resource-policy: keep
+        labels:
+          release: devtron
+        name: devtron-cm
+    component:
+      version: v1
+      kind: ConfigMap
+      schema: ""
+  - id: b61ca361-222f-48c2-a4ca-943ec7d69633
+    schemaVersion: components.meshery.io/v1beta1
+    version: v1.0.0
+    displayName: devtron-custom-cm
+    description: ""
+    format: ""
+    model:
+      id: b3f5bc0d-30f7-607d-6c73-784ddde6cad8
+      schemaVersion: models.meshery.io/v1beta1
+      version: v1.0.0
+      name: kubernetes
+      displayName: Kubernetes
+      status: enabled
+      registrant:
+        id: 5bc80e3c-5d43-9eb4-d16c-78a2769247a6
+        name: Github
+        credential_id: 00000000-0000-0000-0000-000000000000
+        type: registry
+        sub_type: ""
+        kind: github
+        status: registered
+        user_id: 00000000-0000-0000-0000-000000000000
+        created_at: "2025-10-12T14:26:03.160654794Z"
+        updated_at: "2025-10-12T14:26:03.160654794Z"
+        deleted_at: "0001-01-01T00:00:00Z"
+        schemaVersion: ""
+      connection_id: 5bc80e3c-5d43-9eb4-d16c-78a2769247a6
+      category:
+        id: 9ca27d0d-66ce-42a9-8c85-6236563f2ddb
+        name: Orchestration & Management
+      subCategory: Scheduling & Orchestration
+      metadata:
+        isAnnotation: false
+        primaryColor: '#326CE5'
+        secondaryColor: '#7aa1f0'
+        shape: circle
+        styleOverrides: ""
+        svgColor: ui/public/static/img/meshmodels/kubernetes/color/kubernetes-color.svg
+        svgComplete: ""
+        svgWhite: ui/public/static/img/meshmodels/kubernetes/white/kubernetes-white.svg
+      model:
+        version: v1.32.0-alpha.3
+      components_count: 0
+      relationships_count: 0
+      components: null
+      relationships: null
+    styles:
+      position:
+        x: 746.49609375
+        y: 765.0048828125
+      primaryColor: '#326CE5'
+      secondaryColor: '#7aa1f0'
+      shape: bottom-round-rectangle
+      svgColor: ui/public/static/img/meshmodels/kubernetes/color/configmap-color.svg
+      svgComplete: ""
+      svgWhite: ui/public/static/img/meshmodels/kubernetes/white/configmap-white.svg
+      z-index: 19
+    capabilities: []
+    status: enabled
+    metadata:
+      configurationUISchema: ""
+      genealogy: ""
+      instanceDetails: null
+      isAnnotation: false
+      isNamespaced: true
+      published: false
+      source_uri: git://github.com/kubernetes/kubernetes/master/api/openapi-spec/v3
+    configuration:
+      data:
+        DEFAULT_CI_IMAGE: quay.io/devtron/ci-runner:880420ac-138-36030
+        INSTALLED_MODULES: ""
+        POSTGRES_MIGRATED: "14"
+      metadata:
+        annotations:
+          helm.sh/resource-policy: keep
+        labels:
+          release: devtron
+        name: devtron-custom-cm
+    component:
+      version: v1
+      kind: ConfigMap
+      schema: ""
+  - id: 9829e694-b211-45ee-a4b5-77a0fe4dc286
+    schemaVersion: components.meshery.io/v1beta1
+    version: v1.0.0
+    displayName: kubelink-cm
+    description: ""
+    format: ""
+    model:
+      id: b3f5bc0d-30f7-607d-6c73-784ddde6cad8
+      schemaVersion: models.meshery.io/v1beta1
+      version: v1.0.0
+      name: kubernetes
+      displayName: Kubernetes
+      status: enabled
+      registrant:
+        id: 5bc80e3c-5d43-9eb4-d16c-78a2769247a6
+        name: Github
+        credential_id: 00000000-0000-0000-0000-000000000000
+        type: registry
+        sub_type: ""
+        kind: github
+        status: registered
+        user_id: 00000000-0000-0000-0000-000000000000
+        created_at: "2025-10-12T14:26:03.160654794Z"
+        updated_at: "2025-10-12T14:26:03.160654794Z"
+        deleted_at: "0001-01-01T00:00:00Z"
+        schemaVersion: ""
+      connection_id: 5bc80e3c-5d43-9eb4-d16c-78a2769247a6
+      category:
+        id: 9ca27d0d-66ce-42a9-8c85-6236563f2ddb
+        name: Orchestration & Management
+      subCategory: Scheduling & Orchestration
+      metadata:
+        isAnnotation: false
+        primaryColor: '#326CE5'
+        secondaryColor: '#7aa1f0'
+        shape: circle
+        styleOverrides: ""
+        svgColor: ui/public/static/img/meshmodels/kubernetes/color/kubernetes-color.svg
+        svgComplete: ""
+        svgWhite: ui/public/static/img/meshmodels/kubernetes/white/kubernetes-white.svg
+      model:
+        version: v1.32.0-alpha.3
+      components_count: 0
+      relationships_count: 0
+      components: null
+      relationships: null
+    styles:
+      position:
+        x: 930.49609375
+        y: 765.0048828125
+      primaryColor: '#326CE5'
+      secondaryColor: '#7aa1f0'
+      shape: bottom-round-rectangle
+      svgColor: ui/public/static/img/meshmodels/kubernetes/color/configmap-color.svg
+      svgComplete: ""
+      svgWhite: ui/public/static/img/meshmodels/kubernetes/white/configmap-white.svg
+      z-index: 21
+    capabilities: []
+    status: enabled
+    metadata:
+      configurationUISchema: ""
+      genealogy: ""
+      instanceDetails: null
+      isAnnotation: false
+      isNamespaced: true
+      published: false
+      source_uri: git://github.com/kubernetes/kubernetes/master/api/openapi-spec/v3
+    configuration:
+      data:
+        ENABLE_HELM_RELEASE_CACHE: "true"
+        MANIFEST_FETCH_BATCH_SIZE: "2"
+        NATS_MSG_PROCESSING_BATCH_SIZE: "1"
+        NATS_SERVER_HOST: nats://devtron-nats.devtroncd:4222
+        PG_ADDR: postgresql-postgresql.devtroncd
+        PG_DATABASE: orchestrator
+        PG_LOG_QUERY: "true"
+        PG_PORT: "5432"
+        PG_USER: postgres
+        USE_CUSTOM_HTTP_TRANSPORT: "true"
+      metadata:
+        annotations:
+          helm.sh/resource-policy: keep
+        labels:
+          app: kubelink
+          release: devtron
+        name: kubelink-cm
+    component:
+      version: v1
+      kind: ConfigMap
+      schema: ""
+  - id: 17a56b56-6952-483d-8f74-e727410c5378
+    schemaVersion: components.meshery.io/v1beta1
+    version: v1.0.0
+    displayName: app-sync-cm
+    description: ""
+    format: ""
+    model:
+      id: b3f5bc0d-30f7-607d-6c73-784ddde6cad8
+      schemaVersion: models.meshery.io/v1beta1
+      version: v1.0.0
+      name: kubernetes
+      displayName: Kubernetes
+      status: enabled
+      registrant:
+        id: 5bc80e3c-5d43-9eb4-d16c-78a2769247a6
+        name: Github
+        credential_id: 00000000-0000-0000-0000-000000000000
+        type: registry
+        sub_type: ""
+        kind: github
+        status: registered
+        user_id: 00000000-0000-0000-0000-000000000000
+        created_at: "2025-10-12T14:26:03.160654794Z"
+        updated_at: "2025-10-12T14:26:03.160654794Z"
+        deleted_at: "0001-01-01T00:00:00Z"
+        schemaVersion: ""
+      connection_id: 5bc80e3c-5d43-9eb4-d16c-78a2769247a6
+      category:
+        id: 9ca27d0d-66ce-42a9-8c85-6236563f2ddb
+        name: Orchestration & Management
+      subCategory: Scheduling & Orchestration
+      metadata:
+        isAnnotation: false
+        primaryColor: '#326CE5'
+        secondaryColor: '#7aa1f0'
+        shape: circle
+        styleOverrides: ""
+        svgColor: ui/public/static/img/meshmodels/kubernetes/color/kubernetes-color.svg
+        svgComplete: ""
+        svgWhite: ui/public/static/img/meshmodels/kubernetes/white/kubernetes-white.svg
+      model:
+        version: v1.32.0-alpha.3
+      components_count: 0
+      relationships_count: 0
+      components: null
+      relationships: null
+    styles:
+      position:
+        x: 1022.49609375
+        y: 673.0048828125
+      primaryColor: '#326CE5'
+      secondaryColor: '#7aa1f0'
+      shape: bottom-round-rectangle
+      svgColor: ui/public/static/img/meshmodels/kubernetes/color/configmap-color.svg
+      svgComplete: ""
+      svgWhite: ui/public/static/img/meshmodels/kubernetes/white/configmap-white.svg
+      z-index: 12
+    capabilities: []
+    status: enabled
+    metadata:
+      configurationUISchema: ""
+      genealogy: ""
+      instanceDetails: null
+      isAnnotation: false
+      isNamespaced: true
+      published: false
+      source_uri: git://github.com/kubernetes/kubernetes/master/api/openapi-spec/v3
+    configuration:
+      data:
+        PG_ADDR: postgresql-postgresql.devtroncd
+        PG_DATABASE: orchestrator
+        PG_PORT: "5432"
+        PG_USER: postgres
+      metadata:
+        labels:
+          app: app-sync-cronjob
+          release: devtron
+        name: app-sync-cm
+    component:
+      version: v1
+      kind: ConfigMap
+      schema: ""
+  - id: 51757207-7663-4caa-94e5-41e6b41e4082
+    schemaVersion: components.meshery.io/v1beta1
+    version: v1.0.0
+    displayName: postgresql-postgresql-customscripts
+    description: ""
+    format: ""
+    model:
+      id: b3f5bc0d-30f7-607d-6c73-784ddde6cad8
+      schemaVersion: models.meshery.io/v1beta1
+      version: v1.0.0
+      name: kubernetes
+      displayName: Kubernetes
+      status: enabled
+      registrant:
+        id: 5bc80e3c-5d43-9eb4-d16c-78a2769247a6
+        name: Github
+        credential_id: 00000000-0000-0000-0000-000000000000
+        type: registry
+        sub_type: ""
+        kind: github
+        status: registered
+        user_id: 00000000-0000-0000-0000-000000000000
+        created_at: "2025-10-12T14:26:03.160654794Z"
+        updated_at: "2025-10-12T14:26:03.160654794Z"
+        deleted_at: "0001-01-01T00:00:00Z"
+        schemaVersion: ""
+      connection_id: 5bc80e3c-5d43-9eb4-d16c-78a2769247a6
+      category:
+        id: 9ca27d0d-66ce-42a9-8c85-6236563f2ddb
+        name: Orchestration & Management
+      subCategory: Scheduling & Orchestration
+      metadata:
+        isAnnotation: false
+        primaryColor: '#326CE5'
+        secondaryColor: '#7aa1f0'
+        shape: circle
+        styleOverrides: ""
+        svgColor: ui/public/static/img/meshmodels/kubernetes/color/kubernetes-color.svg
+        svgComplete: ""
+        svgWhite: ui/public/static/img/meshmodels/kubernetes/white/kubernetes-white.svg
+      model:
+        version: v1.32.0-alpha.3
+      components_count: 0
+      relationships_count: 0
+      components: null
+      relationships: null
+    styles:
+      position:
+        x: 1022.49609375
+        y: 765.0048828125
+      primaryColor: '#326CE5'
+      secondaryColor: '#7aa1f0'
+      shape: bottom-round-rectangle
+      svgColor: ui/public/static/img/meshmodels/kubernetes/color/configmap-color.svg
+      svgComplete: ""
+      svgWhite: ui/public/static/img/meshmodels/kubernetes/white/configmap-white.svg
+      z-index: 45
+    capabilities: []
+    status: enabled
+    metadata:
+      configurationUISchema: ""
+      genealogy: ""
+      instanceDetails: null
+      isAnnotation: false
+      isNamespaced: true
+      published: false
+      source_uri: git://github.com/kubernetes/kubernetes/master/api/openapi-spec/v3
+    configuration:
+      data:
+        db_create.sql: |
+          create database casbin;
+          create database git_sensor;
+          create database lens;
+          create database clairv4;
+      metadata:
+        annotations:
+          helm.sh/hook: pre-install
+          helm.sh/hook-weight: "-2"
+          helm.sh/resource-policy: keep
+          meta.helm.sh/release-name: devtron
+          meta.helm.sh/release-namespace: devtroncd
+        labels:
+          app.kubernetes.io/instance: devtron
+          app.kubernetes.io/managed-by: Helm
+          app.kubernetes.io/name: postgres
+        name: postgresql-postgresql-customscripts
+        namespace: devtroncd
+    component:
+      version: v1
+      kind: ConfigMap
+      schema: ""
+  - id: f8994b85-2b32-4cd9-921a-dfbc8fd3ca7f
+    schemaVersion: components.meshery.io/v1beta1
+    version: v1.0.0
+    displayName: migrator-override-cm
+    description: ""
+    format: ""
+    model:
+      id: b3f5bc0d-30f7-607d-6c73-784ddde6cad8
+      schemaVersion: models.meshery.io/v1beta1
+      version: v1.0.0
+      name: kubernetes
+      displayName: Kubernetes
+      status: enabled
+      registrant:
+        id: 5bc80e3c-5d43-9eb4-d16c-78a2769247a6
+        name: Github
+        credential_id: 00000000-0000-0000-0000-000000000000
+        type: registry
+        sub_type: ""
+        kind: github
+        status: registered
+        user_id: 00000000-0000-0000-0000-000000000000
+        created_at: "2025-10-12T14:26:03.160654794Z"
+        updated_at: "2025-10-12T14:26:03.160654794Z"
+        deleted_at: "0001-01-01T00:00:00Z"
+        schemaVersion: ""
+      connection_id: 5bc80e3c-5d43-9eb4-d16c-78a2769247a6
+      category:
+        id: 9ca27d0d-66ce-42a9-8c85-6236563f2ddb
+        name: Orchestration & Management
+      subCategory: Scheduling & Orchestration
+      metadata:
+        isAnnotation: false
+        primaryColor: '#326CE5'
+        secondaryColor: '#7aa1f0'
+        shape: circle
+        styleOverrides: ""
+        svgColor: ui/public/static/img/meshmodels/kubernetes/color/kubernetes-color.svg
+        svgComplete: ""
+        svgWhite: ui/public/static/img/meshmodels/kubernetes/white/kubernetes-white.svg
+      model:
+        version: v1.32.0-alpha.3
+      components_count: 0
+      relationships_count: 0
+      components: null
+      relationships: null
+    styles:
+      position:
+        x: 1132.49609375
+        y: 309.0048828125
+      primaryColor: '#326CE5'
+      secondaryColor: '#7aa1f0'
+      shape: bottom-round-rectangle
+      svgColor: ui/public/static/img/meshmodels/kubernetes/color/configmap-color.svg
+      svgComplete: ""
+      svgWhite: ui/public/static/img/meshmodels/kubernetes/white/configmap-white.svg
+      z-index: 14
+    capabilities: []
+    status: enabled
+    metadata:
+      configurationUISchema: ""
+      genealogy: ""
+      instanceDetails: null
+      isAnnotation: false
+      isNamespaced: true
+      published: false
+      source_uri: git://github.com/kubernetes/kubernetes/master/api/openapi-spec/v3
+    configuration:
+      data:
+        override: ""
+      metadata:
+        name: migrator-override-cm
+        namespace: devtroncd
+    component:
+      version: v1
+      kind: ConfigMap
+      schema: ""
+  - id: ed70a4f0-95c0-44e7-926b-ddde78bcc1c5
+    schemaVersion: components.meshery.io/v1beta1
+    version: v1.0.0
+    displayName: argocd-cm
+    description: ""
+    format: ""
+    model:
+      id: b3f5bc0d-30f7-607d-6c73-784ddde6cad8
+      schemaVersion: models.meshery.io/v1beta1
+      version: v1.0.0
+      name: kubernetes
+      displayName: Kubernetes
+      status: enabled
+      registrant:
+        id: 5bc80e3c-5d43-9eb4-d16c-78a2769247a6
+        name: Github
+        credential_id: 00000000-0000-0000-0000-000000000000
+        type: registry
+        sub_type: ""
+        kind: github
+        status: registered
+        user_id: 00000000-0000-0000-0000-000000000000
+        created_at: "2025-10-12T14:26:03.160654794Z"
+        updated_at: "2025-10-12T14:26:03.160654794Z"
+        deleted_at: "0001-01-01T00:00:00Z"
+        schemaVersion: ""
+      connection_id: 5bc80e3c-5d43-9eb4-d16c-78a2769247a6
+      category:
+        id: 9ca27d0d-66ce-42a9-8c85-6236563f2ddb
+        name: Orchestration & Management
+      subCategory: Scheduling & Orchestration
+      metadata:
+        isAnnotation: false
+        primaryColor: '#326CE5'
+        secondaryColor: '#7aa1f0'
+        shape: circle
+        styleOverrides: ""
+        svgColor: ui/public/static/img/meshmodels/kubernetes/color/kubernetes-color.svg
+        svgComplete: ""
+        svgWhite: ui/public/static/img/meshmodels/kubernetes/white/kubernetes-white.svg
+      model:
+        version: v1.32.0-alpha.3
+      components_count: 0
+      relationships_count: 0
+      components: null
+      relationships: null
+    styles:
+      position:
+        x: 1114.49609375
+        y: 673.0048828125
+      primaryColor: '#326CE5'
+      secondaryColor: '#7aa1f0'
+      shape: bottom-round-rectangle
+      svgColor: ui/public/static/img/meshmodels/kubernetes/color/configmap-color.svg
+      svgComplete: ""
+      svgWhite: ui/public/static/img/meshmodels/kubernetes/white/configmap-white.svg
+      z-index: 13
+    capabilities: []
+    status: enabled
+    metadata:
+      configurationUISchema: ""
+      genealogy: ""
+      instanceDetails: null
+      isAnnotation: false
+      isNamespaced: true
+      published: false
+      source_uri: git://github.com/kubernetes/kubernetes/master/api/openapi-spec/v3
+    configuration:
+      data:
+        repositories: |-
+          - name: devtron
+            type: helm
+            url: https://helm.devtron.ai
+          - name: fluent
+            type: helm
+            url: https://fluent.github.io/helm-charts
+          - name: nginx-ingress
+            type: helm
+            url: https://kubernetes.github.io/ingress-nginx
+          - name: elastic
+            type: helm
+            url: https://helm.elastic.co
+          - name: bitnami
+            type: helm
+            url: https://charts.bitnami.com/bitnami
+          - name: prometheus-community
+            type: helm
+            url:  https://prometheus-community.github.io/helm-charts
+          - name: jetstack
+            type: helm
+            url:  https://charts.jetstack.io
+          - name: metrics-server
+            type: helm
+            url:  https://kubernetes-sigs.github.io/metrics-server
+          - name: autoscaler
+            type: helm
+            url:  https://kubernetes.github.io/autoscaler
+          - name: external-secrets
+            type: helm
+            url:  https://charts.external-secrets.io
+          - name: kedacore
+            type: helm
+            url:  https://kedacore.github.io/charts
+        resource.customizations: "kubernetes-client.io/ExternalSecret:\n  health.lua: |\n    hs = {}\n    if obj.status ~= nil then\n        if obj.status.status ~= nil then\n            hs.status = \"Degraded\"\n            hs.message = obj.status.status\n        else\n        hs.status = \"Healthy\"\n        end\n    else\n        hs.status = \"Healthy\"\n    end\n    return hs\nargoproj.io/Rollout:\n  health.lua: |\n    function getNumberValueOrDefault(field)\n        if field ~= nil then\n            return field\n        end\n        return 0\n    end          \n    function checkPaused(obj)\n        hs = {}\n        local paused = false\n        if obj.status.verifyingPreview ~= nil then\n        paused = obj.status.verifyingPreview\n        elseif obj.spec.paused ~= nil then\n        paused = obj.spec.paused\n        end\n\n        if paused then\n        hs.status = \"Suspended\"\n        hs.message = \"Rollout is paused\"\n        return hs\n        end\n        return nil\n    end    \n    function checkReplicasStatus(obj)\n        hs = {}\n        replicasCount = getNumberValueOrDefault(obj.spec.replicas)\n        replicasStatus = getNumberValueOrDefault(obj.status.replicas)\n        updatedReplicas = getNumberValueOrDefault(obj.status.updatedReplicas)\n        availableReplicas = getNumberValueOrDefault(obj.status.availableReplicas)\n\n        if updatedReplicas < replicasCount then\n        hs.status = \"Progressing\"\n        hs.message = \"Waiting for roll out to finish: More replicas need to be updated\"\n        return hs\n        end\n        -- Since the scale down delay can be very high, BlueGreen does not wait for all the old replicas to scale\n        -- down before marking itself healthy. As a result, only evaluate this condition if the strategy is canary.\n        if obj.spec.strategy.canary ~= nil and replicasStatus > updatedReplicas then\n        hs.status = \"Progressing\"\n        hs.message = \"Waiting for roll out to finish: old replicas are pending termination\"\n        return hs\n        end\n        if availableReplicas < updatedReplicas then\n        hs.status = \"Progressing\"\n        hs.message = \"Waiting for roll out to finish: updated replicas are still becoming available\"\n        return hs\n        end\n        return nil\n    end    \n\n    function statusfromcondition(obj)  \n        local hs={}\n        for _, condition in ipairs(obj.status.conditions) do\n            if condition.type == \"InvalidSpec\" then\n                hs.status = \"Degraded\"\n                hs.message = condition.message\n            return hs\n            end\n            if condition.type == \"Progressing\" and condition.reason == \"RolloutAborted\" then\n                hs.status = \"Degraded\"\n                hs.message = condition.message\n            return hs\n            end\n            if condition.type == \"Progressing\" and condition.reason == \"ProgressDeadlineExceeded\" then\n                hs.status = \"Degraded\"\n                hs.message = condition.message\n            return hs\n            end\n        end\n        return nil\n    end    \n\n    function statusfrompodhash(obj)    \n        local hs={}\n        if obj.spec.strategy.blueGreen ~= nil then\n            isPaused = checkPaused(obj)\n            if isPaused ~= nil then\n                return isPaused\n            end\n            replicasHS = checkReplicasStatus(obj)\n            if replicasHS ~= nil then\n                return replicasHS\n            end\n            if obj.status.blueGreen ~= nil and obj.status.blueGreen.activeSelector ~= nil and obj.status.blueGreen.activeSelector == obj.status.currentPodHash then\n                hs.status = \"Healthy\"\n                hs.message = \"The active Service is serving traffic to the current pod spec\"\n                return hs\n            end\n            hs.status = \"Progressing\"\n            hs.message = \"The current pod spec is not receiving traffic from the active service\"\n            return hs\n        end\n        if obj.spec.strategy.recreate ~= nil then\n            isPaused = checkPaused(obj)\n            if isPaused ~= nil then\n                return isPaused\n            end\n            replicasHS = checkReplicasStatus(obj)\n            if replicasHS ~= nil then\n                return replicasHS\n            end\n            if obj.status.recreate ~= nil and obj.status.recreate.currentRS ~= nil and obj.status.recreate.currentRS == obj.status.currentPodHash then\n                hs.status = \"Healthy\"\n                hs.message = \"Rollout is successful\"\n                return hs\n            end\n            hs.status = \"Progressing\"\n            hs.message = \"Rollout is in progress\"\n            return hs\n        end\n        if obj.spec.strategy.canary ~= nil then\n            if obj.status.stableRS ~= nil then\n            currentRSIsStable = obj.status.stableRS == obj.status.currentPodHash\n            end\n            if obj.status.canary.stableRS ~= nil then\n            currentRSIsStable = obj.status.canary.stableRS == obj.status.currentPodHash\n            end                \n            if obj.spec.strategy.canary.steps ~= nil and table.getn(obj.spec.strategy.canary.steps) > 0 then\n            stepCount = table.getn(obj.spec.strategy.canary.steps)\n            if obj.status.currentStepIndex ~= nil then\n                currentStepIndex = obj.status.currentStepIndex\n                isPaused = checkPaused(obj)\n                if isPaused ~= nil then\n                return isPaused\n                end\n            \n                if paused then\n                hs.status = \"Suspended\"\n                hs.message = \"Rollout is paused\"\n                return hs\n                end\n                if currentRSIsStable and stepCount == currentStepIndex then\n                replicasHS = checkReplicasStatus(obj)\n                if replicasHS ~= nil then\n                    return replicasHS\n                end\n                hs.status = \"Healthy\"\n                hs.message = \"The rollout has completed all steps\"\n                return hs\n                end\n            end\n            hs.status = \"Progressing\"\n            hs.message = \"Waiting for rollout to finish steps\"\n            return hs\n            end\n\n            -- The detecting the health of the Canary deployment when there are no steps\n            replicasHS = checkReplicasStatus(obj)\n            if replicasHS ~= nil then\n            return replicasHS\n            end\n            if currentRSIsStable then\n            hs.status = \"Healthy\"\n            hs.message = \"The rollout has completed canary deployment\"\n            return hs\n            end\n            hs.status = \"Progressing\"\n            hs.message = \"Waiting for rollout to finish canary deployment\"\n        end\n\n\n        return hs\n    end   \n\n    -- Main Code\n    hs = {}\n    if obj.status.phase ~= nil then\n        if obj.status.phase == \"Paused\" then\n            hs.status = \"Progressing\"\n            hs.message = \"Rollout is paused\"    \n        elseif obj.status.phase == \"Progressing\" then\n            hs=statusfromcondition(obj) or hs\n            hs=statusfrompodhash(obj) or hs   \n        elseif obj.status.phase == \"Healthy\" then\n            hs=statusfromcondition(obj) or hs\n            hs=statusfrompodhash(obj) or hs                  \n        else\n            hs.status = obj.status.phase\n            hs.message = obj.status.message\n        end   \n    else\n        if obj.status ~= nil then\n            if obj.status.conditions ~= nil then\n                hs=statusfromcondition(obj)\n            end\n            if obj.status.currentPodHash ~= nil then\n                hs=statusfrompodhash(obj)   \n            end        \n        end\n    end        \n    return hs\n"
+        timeout.hard.reconciliation: "0"
+        timeout.reconciliation: 60s
+      metadata:
+        annotations:
+          helm.sh/resource-policy: keep
+        labels:
+          app.kubernetes.io/name: argocd-cm
+          app.kubernetes.io/part-of: argocd
+        name: argocd-cm
+    component:
+      version: v1
+      kind: ConfigMap
+      schema: ""
+  - id: 2e025543-635c-4b1a-8304-3129927643ee
+    schemaVersion: components.meshery.io/v1beta1
+    version: v1.0.0
+    displayName: devtron-cluster-components
+    description: ""
+    format: ""
+    model:
+      id: b3f5bc0d-30f7-607d-6c73-784ddde6cad8
+      schemaVersion: models.meshery.io/v1beta1
+      version: v1.0.0
+      name: kubernetes
+      displayName: Kubernetes
+      status: enabled
+      registrant:
+        id: 5bc80e3c-5d43-9eb4-d16c-78a2769247a6
+        name: Github
+        credential_id: 00000000-0000-0000-0000-000000000000
+        type: registry
+        sub_type: ""
+        kind: github
+        status: registered
+        user_id: 00000000-0000-0000-0000-000000000000
+        created_at: "2025-10-12T14:26:03.160654794Z"
+        updated_at: "2025-10-12T14:26:03.160654794Z"
+        deleted_at: "0001-01-01T00:00:00Z"
+        schemaVersion: ""
+      connection_id: 5bc80e3c-5d43-9eb4-d16c-78a2769247a6
+      category:
+        id: 9ca27d0d-66ce-42a9-8c85-6236563f2ddb
+        name: Orchestration & Management
+      subCategory: Scheduling & Orchestration
+      metadata:
+        isAnnotation: false
+        primaryColor: '#326CE5'
+        secondaryColor: '#7aa1f0'
+        shape: circle
+        styleOverrides: ""
+        svgColor: ui/public/static/img/meshmodels/kubernetes/color/kubernetes-color.svg
+        svgComplete: ""
+        svgWhite: ui/public/static/img/meshmodels/kubernetes/white/kubernetes-white.svg
+      model:
+        version: v1.32.0-alpha.3
+      components_count: 0
+      relationships_count: 0
+      components: null
+      relationships: null
+    styles:
+      position:
+        x: 838.49609375
+        y: 765.0048828125
+      primaryColor: '#326CE5'
+      secondaryColor: '#7aa1f0'
+      shape: bottom-round-rectangle
+      svgColor: ui/public/static/img/meshmodels/kubernetes/color/configmap-color.svg
+      svgComplete: ""
+      svgWhite: ui/public/static/img/meshmodels/kubernetes/white/configmap-white.svg
+      z-index: 20
+    capabilities: []
+    status: enabled
+    metadata:
+      configurationUISchema: ""
+      genealogy: ""
+      instanceDetails: null
+      isAnnotation: false
+      isNamespaced: true
+      published: false
+      source_uri: git://github.com/kubernetes/kubernetes/master/api/openapi-spec/v3
+    configuration:
+      data:
+        rollout.yaml: |-
+          rollout:
+            resources:
+              limits:
+                cpu: 250m
+                memory: 200Mi
+              requests:
+                cpu: 50m
+                memory: 100Mi
+      metadata:
+        labels:
+          release: devtron
+        name: devtron-cluster-components
+    component:
+      version: v1
+      kind: ConfigMap
+      schema: ""
+  - id: 7992b206-6d7c-43e5-b208-e0cc64cca312
+    schemaVersion: components.meshery.io/v1beta1
+    version: v1.0.0
+    displayName: containers.0
+    description: ""
+    format: JSON
+    model:
+      id: 6b49e0cc-6d83-f917-b2bd-30b69792bb20
+      schemaVersion: models.meshery.io/v1beta1
+      version: v1.0.0
+      name: meshery-core
+      displayName: Meshery Core
+      status: enabled
+      registrant:
+        id: 13df38ce-edc0-8c01-ed9f-0414912a43fd
+        name: meshery
+        type: registry
+        sub_type: ""
+        kind: meshery
+        status: registered
+        created_at: "2025-10-12T14:26:00.149008876Z"
+        updated_at: "2025-10-12T14:26:00.149008876Z"
+        deleted_at: null
+        schemaVersion: ""
+      connection_id: 13df38ce-edc0-8c01-ed9f-0414912a43fd
+      category:
+        id: 9ca27d0d-66ce-42a9-8c85-6236563f2ddb
+        name: Orchestration & Management
+      subCategory: Application Definition & Image Build
+      metadata:
+        isAnnotation: false
+        primaryColor: '#00B39F'
+        secondaryColor: '#00D3A9'
+        shape: circle
+        styleOverrides: ""
+        svgColor: ui/public/static/img/meshmodels/meshery-core/color/meshery-core-color.svg
+        svgComplete: ""
+        svgWhite: ui/public/static/img/meshmodels/meshery-core/white/meshery-core-white.svg
+      model:
+        version: 0.7.2
+      components_count: 0
+      relationships_count: 0
+      components: null
+      relationships: null
+    styles:
+      primaryColor: '#326CE5'
+      secondaryColor: '#00D3A9'
+      shape: circle
+      svgColor: ui/public/static/img/meshmodels/meshery-core/color/container-color.svg
+      svgComplete: ""
+      svgWhite: ui/public/static/img/meshmodels/meshery-core/white/container-white.svg
+    capabilities: []
+    status: enabled
+    metadata:
+      configurationUISchema: ""
+      genealogy: ""
+      hasInvalidSchema: true
+      instanceDetails: null
+      isAnnotation: true
+      isNamespaced: false
+      published: false
+    configuration: null
+    component:
+      version: core.meshery.io/v1alpha1
+      kind: Container
+      schema: ""
+  - id: 96b6e2bf-d53c-4404-a696-94eb9a5c4b3d
+    schemaVersion: components.meshery.io/v1beta1
+    version: v1.0.0
+    displayName: containers.0
+    description: ""
+    format: JSON
+    model:
+      id: 6b49e0cc-6d83-f917-b2bd-30b69792bb20
+      schemaVersion: models.meshery.io/v1beta1
+      version: v1.0.0
+      name: meshery-core
+      displayName: Meshery Core
+      status: enabled
+      registrant:
+        id: 13df38ce-edc0-8c01-ed9f-0414912a43fd
+        name: meshery
+        type: registry
+        sub_type: ""
+        kind: meshery
+        status: registered
+        created_at: "2025-10-12T14:26:00.149008876Z"
+        updated_at: "2025-10-12T14:26:00.149008876Z"
+        deleted_at: null
+        schemaVersion: ""
+      connection_id: 13df38ce-edc0-8c01-ed9f-0414912a43fd
+      category:
+        id: 9ca27d0d-66ce-42a9-8c85-6236563f2ddb
+        name: Orchestration & Management
+      subCategory: Application Definition & Image Build
+      metadata:
+        isAnnotation: false
+        primaryColor: '#00B39F'
+        secondaryColor: '#00D3A9'
+        shape: circle
+        styleOverrides: ""
+        svgColor: ui/public/static/img/meshmodels/meshery-core/color/meshery-core-color.svg
+        svgComplete: ""
+        svgWhite: ui/public/static/img/meshmodels/meshery-core/white/meshery-core-white.svg
+      model:
+        version: 0.7.2
+      components_count: 0
+      relationships_count: 0
+      components: null
+      relationships: null
+    styles:
+      primaryColor: '#326CE5'
+      secondaryColor: '#00D3A9'
+      shape: circle
+      svgColor: ui/public/static/img/meshmodels/meshery-core/color/container-color.svg
+      svgComplete: ""
+      svgWhite: ui/public/static/img/meshmodels/meshery-core/white/container-white.svg
+    capabilities: []
+    status: enabled
+    metadata:
+      configurationUISchema: ""
+      genealogy: ""
+      hasInvalidSchema: true
+      instanceDetails: null
+      isAnnotation: true
+      isNamespaced: false
+      published: false
+    configuration: null
+    component:
+      version: core.meshery.io/v1alpha1
+      kind: Container
+      schema: ""
+  - id: e00b8605-ecbf-4049-b0a9-d0a904b8b124
+    schemaVersion: components.meshery.io/v1beta1
+    version: v1.0.0
+    displayName: containers.0
+    description: ""
+    format: JSON
+    model:
+      id: 6b49e0cc-6d83-f917-b2bd-30b69792bb20
+      schemaVersion: models.meshery.io/v1beta1
+      version: v1.0.0
+      name: meshery-core
+      displayName: Meshery Core
+      status: enabled
+      registrant:
+        id: 13df38ce-edc0-8c01-ed9f-0414912a43fd
+        name: meshery
+        type: registry
+        sub_type: ""
+        kind: meshery
+        status: registered
+        created_at: "2025-10-12T14:26:00.149008876Z"
+        updated_at: "2025-10-12T14:26:00.149008876Z"
+        deleted_at: null
+        schemaVersion: ""
+      connection_id: 13df38ce-edc0-8c01-ed9f-0414912a43fd
+      category:
+        id: 9ca27d0d-66ce-42a9-8c85-6236563f2ddb
+        name: Orchestration & Management
+      subCategory: Application Definition & Image Build
+      metadata:
+        isAnnotation: false
+        primaryColor: '#00B39F'
+        secondaryColor: '#00D3A9'
+        shape: circle
+        styleOverrides: ""
+        svgColor: ui/public/static/img/meshmodels/meshery-core/color/meshery-core-color.svg
+        svgComplete: ""
+        svgWhite: ui/public/static/img/meshmodels/meshery-core/white/meshery-core-white.svg
+      model:
+        version: 0.7.2
+      components_count: 0
+      relationships_count: 0
+      components: null
+      relationships: null
+    styles:
+      primaryColor: '#326CE5'
+      secondaryColor: '#00D3A9'
+      shape: circle
+      svgColor: ui/public/static/img/meshmodels/meshery-core/color/container-color.svg
+      svgComplete: ""
+      svgWhite: ui/public/static/img/meshmodels/meshery-core/white/container-white.svg
+    capabilities: []
+    status: enabled
+    metadata:
+      configurationUISchema: ""
+      genealogy: ""
+      hasInvalidSchema: true
+      instanceDetails: null
+      isAnnotation: true
+      isNamespaced: false
+      published: false
+    configuration: null
+    component:
+      version: core.meshery.io/v1alpha1
+      kind: Container
+      schema: ""
+  - id: f8aea98b-ba7d-4cc1-8b1a-9ca729e34db1
+    schemaVersion: components.meshery.io/v1beta1
+    version: v1.0.0
+    displayName: containers.0
+    description: ""
+    format: JSON
+    model:
+      id: 6b49e0cc-6d83-f917-b2bd-30b69792bb20
+      schemaVersion: models.meshery.io/v1beta1
+      version: v1.0.0
+      name: meshery-core
+      displayName: Meshery Core
+      status: enabled
+      registrant:
+        id: 13df38ce-edc0-8c01-ed9f-0414912a43fd
+        name: meshery
+        type: registry
+        sub_type: ""
+        kind: meshery
+        status: registered
+        created_at: "2025-10-12T14:26:00.149008876Z"
+        updated_at: "2025-10-12T14:26:00.149008876Z"
+        deleted_at: null
+        schemaVersion: ""
+      connection_id: 13df38ce-edc0-8c01-ed9f-0414912a43fd
+      category:
+        id: 9ca27d0d-66ce-42a9-8c85-6236563f2ddb
+        name: Orchestration & Management
+      subCategory: Application Definition & Image Build
+      metadata:
+        isAnnotation: false
+        primaryColor: '#00B39F'
+        secondaryColor: '#00D3A9'
+        shape: circle
+        styleOverrides: ""
+        svgColor: ui/public/static/img/meshmodels/meshery-core/color/meshery-core-color.svg
+        svgComplete: ""
+        svgWhite: ui/public/static/img/meshmodels/meshery-core/white/meshery-core-white.svg
+      model:
+        version: 0.7.2
+      components_count: 0
+      relationships_count: 0
+      components: null
+      relationships: null
+    styles:
+      primaryColor: '#326CE5'
+      secondaryColor: '#00D3A9'
+      shape: circle
+      svgColor: ui/public/static/img/meshmodels/meshery-core/color/container-color.svg
+      svgComplete: ""
+      svgWhite: ui/public/static/img/meshmodels/meshery-core/white/container-white.svg
+    capabilities: []
+    status: enabled
+    metadata:
+      configurationUISchema: ""
+      genealogy: ""
+      hasInvalidSchema: true
+      instanceDetails: null
+      isAnnotation: true
+      isNamespaced: false
+      published: false
+    configuration: null
+    component:
+      version: core.meshery.io/v1alpha1
+      kind: Container
+      schema: ""
+  - id: 504e4bb7-88e8-4d2c-a587-865a20c974d2
+    schemaVersion: components.meshery.io/v1beta1
+    version: v1.0.0
+    displayName: installers.installer.devtron.ai
+    description: ""
+    format: ""
+    model:
+      id: b3f5bc0d-30f7-607d-6c73-784ddde6cad8
+      schemaVersion: models.meshery.io/v1beta1
+      version: v1.0.0
+      name: kubernetes
+      displayName: Kubernetes
+      status: enabled
+      registrant:
+        id: 5bc80e3c-5d43-9eb4-d16c-78a2769247a6
+        name: Github
+        credential_id: 00000000-0000-0000-0000-000000000000
+        type: registry
+        sub_type: ""
+        kind: github
+        status: registered
+        user_id: 00000000-0000-0000-0000-000000000000
+        created_at: "2025-10-12T14:26:03.160654794Z"
+        updated_at: "2025-10-12T14:26:03.160654794Z"
+        deleted_at: "0001-01-01T00:00:00Z"
+        schemaVersion: ""
+      connection_id: 5bc80e3c-5d43-9eb4-d16c-78a2769247a6
+      category:
+        id: 9ca27d0d-66ce-42a9-8c85-6236563f2ddb
+        name: Orchestration & Management
+      subCategory: Scheduling & Orchestration
+      metadata:
+        isAnnotation: false
+        primaryColor: '#326CE5'
+        secondaryColor: '#7aa1f0'
+        shape: circle
+        styleOverrides: ""
+        svgColor: ui/public/static/img/meshmodels/kubernetes/color/kubernetes-color.svg
+        svgComplete: ""
+        svgWhite: ui/public/static/img/meshmodels/kubernetes/white/kubernetes-white.svg
+      model:
+        version: v1.32.0-alpha.3
+      components_count: 0
+      relationships_count: 0
+      components: null
+      relationships: null
+    styles:
+      position:
+        x: 1126.49609375
+        y: 437.0048828125
+      primaryColor: '#326CE5'
+      secondaryColor: '#7aa1f0'
+      shape: circle
+      svgColor: ui/public/static/img/meshmodels/kubernetes/color/customresourcedefinition-color.svg
+      svgComplete: ""
+      svgWhite: ui/public/static/img/meshmodels/kubernetes/white/customresourcedefinition-white.svg
+    capabilities: []
+    status: enabled
+    metadata:
+      configurationUISchema: ""
+      genealogy: ""
+      instanceDetails: null
+      isAnnotation: false
+      isNamespaced: false
+      published: false
+      source_uri: git://github.com/kubernetes/kubernetes/master/api/openapi-spec/v3
+    configuration:
+      metadata:
+        annotations:
+          controller-gen.kubebuilder.io/version: v0.3.0
+        creationTimestamp: null
+        name: installers.installer.devtron.ai
+      spec:
+        group: installer.devtron.ai
+        names:
+          kind: Installer
+          listKind: InstallerList
+          plural: installers
+          singular: installer
+        scope: Namespaced
+        versions:
+          - name: v1alpha1
+            schema:
+              openAPIV3Schema:
+                description: Installer is the Schema for the installers API
+                properties:
+                  apiVersion:
+                    description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+                    type: string
+                  kind:
+                    description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                    type: string
+                  metadata:
+                    type: object
+                  spec:
+                    description: InstallerSpec defines the desired state of Installer
+                    properties:
+                      reSync:
+                        description: Rerun the installation script
+                        type: boolean
+                      url:
+                        description: URL of the BOM version to be installed
+                        type: string
+                    type: object
+                  status:
+                    description: InstallerStatus defines the observed state of Installer
+                    properties:
+                      current_spec_hash:
+                        type: string
+                      sync:
+                        description: SyncStatus is a comparison result of application spec and deployed application.
+                        properties:
+                          conditions:
+                            items:
+                              description: InstallerCondition contains details about current application condition
+                              properties:
+                                lastTransitionTime:
+                                  description: LastTransitionTime is the time the condition was first observed.
+                                  format: date-time
+                                  type: string
+                                message:
+                                  description: Message contains human-readable message indicating details about condition
+                                  type: string
+                                type:
+                                  description: Type is an application condition type
+                                  type: string
+                              required:
+                                - message
+                                - type
+                              type: object
+                            type: array
+                          data:
+                            type: string
+                          health:
+                            properties:
+                              message:
+                                type: string
+                              status:
+                                description: Represents resource health status
+                                type: string
+                            type: object
+                          history:
+                            description: RevisionHistories is a array of history, oldest first and newest last
+                            items:
+                              description: RevisionHistory contains information relevant to an application deployment
+                              properties:
+                                deployStartedAt:
+                                  description: DeployStartedAt holds the time the deployment started
+                                  format: date-time
+                                  type: string
+                                deployedAt:
+                                  description: DeployedAt holds the time the deployment completed
+                                  format: date-time
+                                  type: string
+                                id:
+                                  description: ID is an auto incrementing identifier of the RevisionHistory
+                                  format: int64
+                                  type: integer
+                                revision:
+                                  description: Revision holds the revision of the sync
+                                  type: string
+                                source:
+                                  description: ApplicationSource contains information about github repository, path within repository and target application environment.
+                                  properties:
+                                    url:
+                                      type: string
+                                  type: object
+                              required:
+                                - deployedAt
+                                - id
+                                - revision
+                              type: object
+                            type: array
+                          resources:
+                            items:
+                              description: ResourceStatus holds the current sync and health status of a resource
+                              properties:
+                                group:
+                                  type: string
+                                health:
+                                  properties:
+                                    message:
+                                      type: string
+                                    status:
+                                      description: Represents resource health status
+                                      type: string
+                                  type: object
+                                kind:
+                                  type: string
+                                name:
+                                  type: string
+                                namespace:
+                                  type: string
+                                operation:
+                                  type: string
+                                status:
+                                  type: string
+                                version:
+                                  type: string
+                              type: object
+                            type: array
+                          status:
+                            type: string
+                          url:
+                            description: URL of the BOM version pulled
+                            type: string
+                        required:
+                          - status
+                        type: object
+                    required:
+                      - current_spec_hash
+                      - sync
+                    type: object
+                type: object
+            served: true
+            storage: true
+    component:
+      version: apiextensions.k8s.io/v1
+      kind: CustomResourceDefinition
+      schema: ""
+  - id: 575c9682-8b50-4ea5-8307-9ce2e77e65b0
+    schemaVersion: components.meshery.io/v1beta1
+    version: v1.0.0
+    displayName: dashboard
+    description: ""
+    format: ""
+    model:
+      id: b3f5bc0d-30f7-607d-6c73-784ddde6cad8
+      schemaVersion: models.meshery.io/v1beta1
+      version: v1.0.0
+      name: kubernetes
+      displayName: Kubernetes
+      status: enabled
+      registrant:
+        id: 5bc80e3c-5d43-9eb4-d16c-78a2769247a6
+        name: Github
+        credential_id: 00000000-0000-0000-0000-000000000000
+        type: registry
+        sub_type: ""
+        kind: github
+        status: registered
+        user_id: 00000000-0000-0000-0000-000000000000
+        created_at: "2025-10-12T14:26:03.160654794Z"
+        updated_at: "2025-10-12T14:26:03.160654794Z"
+        deleted_at: "0001-01-01T00:00:00Z"
+        schemaVersion: ""
+      connection_id: 5bc80e3c-5d43-9eb4-d16c-78a2769247a6
+      category:
+        id: 9ca27d0d-66ce-42a9-8c85-6236563f2ddb
+        name: Orchestration & Management
+      subCategory: Scheduling & Orchestration
+      metadata:
+        isAnnotation: false
+        primaryColor: '#326CE5'
+        secondaryColor: '#7aa1f0'
+        shape: circle
+        styleOverrides: ""
+        svgColor: ui/public/static/img/meshmodels/kubernetes/color/kubernetes-color.svg
+        svgComplete: ""
+        svgWhite: ui/public/static/img/meshmodels/kubernetes/white/kubernetes-white.svg
+      model:
+        version: v1.32.0-alpha.3
+      components_count: 0
+      relationships_count: 0
+      components: null
+      relationships: null
+    styles:
+      background-image: none
+      background-opacity: 0.5
+      border-width: 2
+      position:
+        x: 672.49609375
+        y: 199.0048828125
+      primaryColor: '#326CE5'
+      secondaryColor: '#7aa1f0'
+      shape: round-rectangle
+      svgColor: ui/public/static/img/meshmodels/kubernetes/color/deployment-color.svg
+      svgComplete: ui/public/static/img/meshmodels/kubernetes/complete/deployment-complete.svg
+      svgWhite: ui/public/static/img/meshmodels/kubernetes/white/deployment-white.svg
+      z-index: 32
+    capabilities: []
+    status: enabled
+    metadata:
+      configurationUISchema: ""
+      genealogy: parent
+      instanceDetails: null
+      isAnnotation: false
+      isNamespaced: true
+      published: false
+      source_uri: git://github.com/kubernetes/kubernetes/master/api/openapi-spec/v3
+    configuration:
+      metadata:
+        annotations:
+          helm.sh/resource-policy: keep
+        labels:
+          app: dashboard
+          release: devtron
+        name: dashboard
+      spec:
+        minReadySeconds: 60
+        replicas: 1
+        revisionHistoryLimit: 3
+        selector:
+          matchLabels:
+            app: dashboard
+        template:
+          metadata:
+            labels:
+              app: dashboard
+              release: devtron
+          spec:
+            containers:
+              - env:
+                  - name: DEVTRON_APP_NAME
+                    value: dashboard
+                  - name: POD_NAME
+                    valueFrom:
+                      fieldRef:
+                        fieldPath: metadata.name
+                envFrom:
+                  - configMapRef:
+                      name: dashboard-cm
+                  - secretRef:
+                      name: devtron-dashboard-secret
+                  - configMapRef:
+                      name: devtron-common-cm
+                image: quay.io/devtron/dashboard:b00aa204-690-36533
+                imagePullPolicy: IfNotPresent
+                livenessProbe:
+                  failureThreshold: 3
+                  httpGet:
+                    path: /
+                    port: 8080
+                    scheme: HTTP
+                  initialDelaySeconds: 20
+                  periodSeconds: 10
+                  successThreshold: 1
+                  timeoutSeconds: 5
+                name: dashboard
+                ports:
+                  - containerPort: 8080
+                    name: app
+                    protocol: TCP
+                readinessProbe:
+                  failureThreshold: 3
+                  httpGet:
+                    path: /
+                    port: 8080
+                    scheme: HTTP
+                  initialDelaySeconds: 20
+                  periodSeconds: 10
+                  successThreshold: 1
+                  timeoutSeconds: 5
+                securityContext:
+                  allowPrivilegeEscalation: false
+                  runAsNonRoot: true
+                  runAsUser: 1000
+                volumeMounts: []
+            restartPolicy: Always
+            securityContext:
+              fsGroup: 1000
+              runAsGroup: 1000
+              runAsUser: 1000
+            serviceAccountName: devtron-default-sa
+            terminationGracePeriodSeconds: 30
+    component:
+      version: apps/v1
+      kind: Deployment
+      schema: ""
+  - id: 0851ce28-0a59-4a30-85a8-36488ecb3762
+    schemaVersion: components.meshery.io/v1beta1
+    version: v1.0.0
+    displayName: devtron
+    description: ""
+    format: ""
+    model:
+      id: b3f5bc0d-30f7-607d-6c73-784ddde6cad8
+      schemaVersion: models.meshery.io/v1beta1
+      version: v1.0.0
+      name: kubernetes
+      displayName: Kubernetes
+      status: enabled
+      registrant:
+        id: 5bc80e3c-5d43-9eb4-d16c-78a2769247a6
+        name: Github
+        credential_id: 00000000-0000-0000-0000-000000000000
+        type: registry
+        sub_type: ""
+        kind: github
+        status: registered
+        user_id: 00000000-0000-0000-0000-000000000000
+        created_at: "2025-10-12T14:26:03.160654794Z"
+        updated_at: "2025-10-12T14:26:03.160654794Z"
+        deleted_at: "0001-01-01T00:00:00Z"
+        schemaVersion: ""
+      connection_id: 5bc80e3c-5d43-9eb4-d16c-78a2769247a6
+      category:
+        id: 9ca27d0d-66ce-42a9-8c85-6236563f2ddb
+        name: Orchestration & Management
+      subCategory: Scheduling & Orchestration
+      metadata:
+        isAnnotation: false
+        primaryColor: '#326CE5'
+        secondaryColor: '#7aa1f0'
+        shape: circle
+        styleOverrides: ""
+        svgColor: ui/public/static/img/meshmodels/kubernetes/color/kubernetes-color.svg
+        svgComplete: ""
+        svgWhite: ui/public/static/img/meshmodels/kubernetes/white/kubernetes-white.svg
+      model:
+        version: v1.32.0-alpha.3
+      components_count: 0
+      relationships_count: 0
+      components: null
+      relationships: null
+    styles:
+      background-image: none
+      background-opacity: 0.5
+      border-width: 2
+      position:
+        x: 800.49609375
+        y: 199.0048828125
+      primaryColor: '#326CE5'
+      secondaryColor: '#7aa1f0'
+      shape: round-rectangle
+      svgColor: ui/public/static/img/meshmodels/kubernetes/color/deployment-color.svg
+      svgComplete: ui/public/static/img/meshmodels/kubernetes/complete/deployment-complete.svg
+      svgWhite: ui/public/static/img/meshmodels/kubernetes/white/deployment-white.svg
+      z-index: 33
+    capabilities: []
+    status: enabled
+    metadata:
+      configurationUISchema: ""
+      genealogy: parent
+      instanceDetails: null
+      isAnnotation: false
+      isNamespaced: true
+      published: false
+      source_uri: git://github.com/kubernetes/kubernetes/master/api/openapi-spec/v3
+    configuration:
+      metadata:
+        annotations:
+          helm.sh/resource-policy: keep
+        labels:
+          app: devtron
+          release: devtron
+        name: devtron
+      spec:
+        minReadySeconds: 60
+        replicas: 1
+        revisionHistoryLimit: 3
+        selector:
+          matchLabels:
+            app: devtron
+        template:
+          metadata:
+            labels:
+              app: devtron
+              release: devtron
+          spec:
+            containers:
+              - env:
+                  - name: DEVTRON_APP_NAME
+                    value: devtron
+                  - name: POD_NAME
+                    valueFrom:
+                      fieldRef:
+                        fieldPath: metadata.name
+                envFrom:
+                  - configMapRef:
+                      name: devtron-cm
+                  - secretRef:
+                      name: devtron-secret
+                  - configMapRef:
+                      name: devtron-custom-cm
+                  - secretRef:
+                      name: devtron-custom-secret
+                  - configMapRef:
+                      name: devtron-common-cm
+                image: quay.io/devtron/hyperion:261df88d-280-36531
+                imagePullPolicy: IfNotPresent
+                lifecycle:
+                  preStop:
+                    exec:
+                      command:
+                        - /bin/sh
+                        - -c
+                        - ' curl -X POST -H "Content-Type: application/json" -d ''{"eventType": "SIG_TERM"}'' localhost:8080/orchestrator/telemetry/summary'
+                livenessProbe:
+                  failureThreshold: 3
+                  httpGet:
+                    path: /health
+                    port: 8080
+                    scheme: HTTP
+                  initialDelaySeconds: 20
+                  periodSeconds: 10
+                  successThreshold: 1
+                  timeoutSeconds: 5
+                name: devtron
+                ports:
+                  - containerPort: 8080
+                    name: devtron
+                    protocol: TCP
+                readinessProbe:
+                  failureThreshold: 3
+                  httpGet:
+                    path: /health
+                    port: 8080
+                    scheme: HTTP
+                  initialDelaySeconds: 20
+                  periodSeconds: 10
+                  successThreshold: 1
+                  timeoutSeconds: 5
+                securityContext:
+                  allowPrivilegeEscalation: false
+                  runAsNonRoot: true
+                  runAsUser: 1001
+                volumeMounts:
+                  - mountPath: /cluster/component
+                    name: devtron-cluster-components-vol
+            restartPolicy: Always
+            securityContext:
+              fsGroup: 1001
+              runAsGroup: 1001
+              runAsUser: 1001
+            serviceAccountName: devtron
+            terminationGracePeriodSeconds: 30
+            volumes:
+              - configMap:
+                  name: devtron-cluster-components
+                name: devtron-cluster-components-vol
+    component:
+      version: apps/v1
+      kind: Deployment
+      schema: ""
+  - id: 09ae7182-3f78-4fe8-8b76-db4b1e9ed46a
+    schemaVersion: components.meshery.io/v1beta1
+    version: v1.0.0
+    displayName: kubelink
+    description: ""
+    format: ""
+    model:
+      id: b3f5bc0d-30f7-607d-6c73-784ddde6cad8
+      schemaVersion: models.meshery.io/v1beta1
+      version: v1.0.0
+      name: kubernetes
+      displayName: Kubernetes
+      status: enabled
+      registrant:
+        id: 5bc80e3c-5d43-9eb4-d16c-78a2769247a6
+        name: Github
+        credential_id: 00000000-0000-0000-0000-000000000000
+        type: registry
+        sub_type: ""
+        kind: github
+        status: registered
+        user_id: 00000000-0000-0000-0000-000000000000
+        created_at: "2025-10-12T14:26:03.160654794Z"
+        updated_at: "2025-10-12T14:26:03.160654794Z"
+        deleted_at: "0001-01-01T00:00:00Z"
+        schemaVersion: ""
+      connection_id: 5bc80e3c-5d43-9eb4-d16c-78a2769247a6
+      category:
+        id: 9ca27d0d-66ce-42a9-8c85-6236563f2ddb
+        name: Orchestration & Management
+      subCategory: Scheduling & Orchestration
+      metadata:
+        isAnnotation: false
+        primaryColor: '#326CE5'
+        secondaryColor: '#7aa1f0'
+        shape: circle
+        styleOverrides: ""
+        svgColor: ui/public/static/img/meshmodels/kubernetes/color/kubernetes-color.svg
+        svgComplete: ""
+        svgWhite: ui/public/static/img/meshmodels/kubernetes/white/kubernetes-white.svg
+      model:
+        version: v1.32.0-alpha.3
+      components_count: 0
+      relationships_count: 0
+      components: null
+      relationships: null
+    styles:
+      background-image: none
+      background-opacity: 0.5
+      border-width: 2
+      position:
+        x: 800.49609375
+        y: 327.0048828125
+      primaryColor: '#326CE5'
+      secondaryColor: '#7aa1f0'
+      shape: round-rectangle
+      svgColor: ui/public/static/img/meshmodels/kubernetes/color/deployment-color.svg
+      svgComplete: ui/public/static/img/meshmodels/kubernetes/complete/deployment-complete.svg
+      svgWhite: ui/public/static/img/meshmodels/kubernetes/white/deployment-white.svg
+      z-index: 35
+    capabilities: []
+    status: enabled
+    metadata:
+      configurationUISchema: ""
+      genealogy: parent
+      instanceDetails: null
+      isAnnotation: false
+      isNamespaced: true
+      published: false
+      source_uri: git://github.com/kubernetes/kubernetes/master/api/openapi-spec/v3
+    configuration:
+      metadata:
+        annotations:
+          helm.sh/resource-policy: keep
+        labels:
+          app: kubelink
+          chart: kubelink-4.11.1
+        name: kubelink
+      spec:
+        minReadySeconds: 60
+        replicas: 1
+        revisionHistoryLimit: 3
+        selector:
+          matchLabels:
+            app: kubelink
+        template:
+          metadata:
+            labels:
+              app: kubelink
+          spec:
+            containers:
+              - env:
+                  - name: DEVTRON_APP_NAME
+                    value: kubelink
+                  - name: POD_NAME
+                    valueFrom:
+                      fieldRef:
+                        fieldPath: metadata.name
+                  - name: PG_PASSWORD
+                    valueFrom:
+                      secretKeyRef:
+                        key: postgresql-password
+                        name: postgresql-postgresql
+                envFrom:
+                  - configMapRef:
+                      name: kubelink-cm
+                  - secretRef:
+                      name: kubelink-secret
+                  - configMapRef:
+                      name: devtron-common-cm
+                image: quay.io/devtron/kubelink:880420ac-564-36036
+                imagePullPolicy: IfNotPresent
+                livenessProbe:
+                  failureThreshold: 3
+                  httpGet:
+                    path: /health
+                    port: 50052
+                    scheme: HTTP
+                  initialDelaySeconds: 20
+                  periodSeconds: 10
+                  successThreshold: 1
+                  timeoutSeconds: 5
+                name: kubelink
+                ports:
+                  - containerPort: 50051
+                    name: app
+                    protocol: TCP
+                readinessProbe:
+                  failureThreshold: 3
+                  httpGet:
+                    path: /health
+                    port: 50052
+                    scheme: HTTP
+                  initialDelaySeconds: 20
+                  periodSeconds: 10
+                  successThreshold: 1
+                  timeoutSeconds: 5
+                securityContext:
+                  allowPrivilegeEscalation: false
+                  runAsNonRoot: true
+                  runAsUser: 1001
+            restartPolicy: Always
+            securityContext:
+              fsGroup: 1001
+              runAsGroup: 1001
+              runAsUser: 1001
+            serviceAccount: devtron
+            terminationGracePeriodSeconds: 30
+    component:
+      version: apps/v1
+      kind: Deployment
+      schema: ""
+  - id: ce42bd94-2fb6-451e-bba2-e88a6c83fa6b
+    schemaVersion: components.meshery.io/v1beta1
+    version: v1.0.0
+    displayName: argocd-dex-server
+    description: ""
+    format: ""
+    model:
+      id: b3f5bc0d-30f7-607d-6c73-784ddde6cad8
+      schemaVersion: models.meshery.io/v1beta1
+      version: v1.0.0
+      name: kubernetes
+      displayName: Kubernetes
+      status: enabled
+      registrant:
+        id: 5bc80e3c-5d43-9eb4-d16c-78a2769247a6
+        name: Github
+        credential_id: 00000000-0000-0000-0000-000000000000
+        type: registry
+        sub_type: ""
+        kind: github
+        status: registered
+        user_id: 00000000-0000-0000-0000-000000000000
+        created_at: "2025-10-12T14:26:03.160654794Z"
+        updated_at: "2025-10-12T14:26:03.160654794Z"
+        deleted_at: "0001-01-01T00:00:00Z"
+        schemaVersion: ""
+      connection_id: 5bc80e3c-5d43-9eb4-d16c-78a2769247a6
+      category:
+        id: 9ca27d0d-66ce-42a9-8c85-6236563f2ddb
+        name: Orchestration & Management
+      subCategory: Scheduling & Orchestration
+      metadata:
+        isAnnotation: false
+        primaryColor: '#326CE5'
+        secondaryColor: '#7aa1f0'
+        shape: circle
+        styleOverrides: ""
+        svgColor: ui/public/static/img/meshmodels/kubernetes/color/kubernetes-color.svg
+        svgComplete: ""
+        svgWhite: ui/public/static/img/meshmodels/kubernetes/white/kubernetes-white.svg
+      model:
+        version: v1.32.0-alpha.3
+      components_count: 0
+      relationships_count: 0
+      components: null
+      relationships: null
+    styles:
+      background-image: none
+      background-opacity: 0.5
+      border-width: 2
+      position:
+        x: 672.49609375
+        y: 327.0048828125
+      primaryColor: '#326CE5'
+      secondaryColor: '#7aa1f0'
+      shape: round-rectangle
+      svgColor: ui/public/static/img/meshmodels/kubernetes/color/deployment-color.svg
+      svgComplete: ui/public/static/img/meshmodels/kubernetes/complete/deployment-complete.svg
+      svgWhite: ui/public/static/img/meshmodels/kubernetes/white/deployment-white.svg
+      z-index: 34
+    capabilities: []
+    status: enabled
+    metadata:
+      configurationUISchema: ""
+      genealogy: parent
+      instanceDetails: null
+      isAnnotation: false
+      isNamespaced: true
+      published: false
+      source_uri: git://github.com/kubernetes/kubernetes/master/api/openapi-spec/v3
+    configuration:
+      metadata:
+        annotations:
+          helm.sh/resource-policy: keep
+          meta.helm.sh/release-name: devtron-operator
+          meta.helm.sh/release-namespace: default
+        labels:
+          app.kubernetes.io/component: dex-server
+          app.kubernetes.io/managed-by: Helm
+          app.kubernetes.io/name: argocd-dex-server
+          app.kubernetes.io/part-of: argocd
+        name: argocd-dex-server
+      spec:
+        minReadySeconds: 60
+        selector:
+          matchLabels:
+            app.kubernetes.io/name: argocd-dex-server
+        template:
+          metadata:
+            labels:
+              app.kubernetes.io/name: argocd-dex-server
+          spec:
+            affinity:
+              podAntiAffinity:
+                preferredDuringSchedulingIgnoredDuringExecution:
+                  - podAffinityTerm:
+                      labelSelector:
+                        matchLabels:
+                          app.kubernetes.io/part-of: argocd
+                      topologyKey: kubernetes.io/hostname
+                    weight: 5
+            containers:
+              - command:
+                  - /shared/authenticator
+                  - rundex
+                envFrom:
+                  - configMapRef:
+                      name: devtron-common-cm
+                image: quay.io/devtron/dex:v2.30.2
+                imagePullPolicy: IfNotPresent
+                name: dex
+                ports:
+                  - containerPort: 5556
+                  - containerPort: 5557
+                  - containerPort: 5558
+                securityContext:
+                  allowPrivilegeEscalation: false
+                  runAsNonRoot: true
+                  runAsUser: 1000
+                volumeMounts:
+                  - mountPath: /shared
+                    name: static-files
+            initContainers:
+              - command:
+                  - cp
+                  - -n
+                  - /authenticator
+                  - /shared
+                envFrom:
+                  - configMapRef:
+                      name: devtron-common-cm
+                image: quay.io/devtron/authenticator:e414faff-393-13273
+                imagePullPolicy: IfNotPresent
+                name: copyutil
+                securityContext:
+                  allowPrivilegeEscalation: false
+                  runAsNonRoot: true
+                  runAsUser: 1000
+                volumeMounts:
+                  - mountPath: /shared
+                    name: static-files
+            securityContext:
+              fsGroup: 1000
+              runAsGroup: 1000
+              runAsUser: 1000
+            serviceAccountName: argocd-dex-server
+            volumes:
+              - emptyDir: {}
+                name: static-files
+    component:
+      version: apps/v1
+      kind: Deployment
+      schema: ""
+  - id: 86c08e70-5da8-4970-a779-81a0ce712463
+    schemaVersion: components.meshery.io/v1beta1
+    version: v1.0.0
+    displayName: devtroncd
+    description: ""
+    format: JSON
+    model:
+      id: b3f5bc0d-30f7-607d-6c73-784ddde6cad8
+      schemaVersion: models.meshery.io/v1beta1
+      version: v1.0.0
+      name: kubernetes
+      displayName: Kubernetes
+      status: enabled
+      registrant:
+        id: 5bc80e3c-5d43-9eb4-d16c-78a2769247a6
+        name: Github
+        credential_id: 00000000-0000-0000-0000-000000000000
+        type: registry
+        sub_type: ""
+        kind: github
+        status: registered
+        user_id: 00000000-0000-0000-0000-000000000000
+        created_at: "2025-10-12T14:26:03.160654794Z"
+        updated_at: "2025-10-12T14:26:03.160654794Z"
+        deleted_at: "0001-01-01T00:00:00Z"
+        schemaVersion: ""
+      connection_id: 5bc80e3c-5d43-9eb4-d16c-78a2769247a6
+      category:
+        id: 9ca27d0d-66ce-42a9-8c85-6236563f2ddb
+        name: Orchestration & Management
+      subCategory: Scheduling & Orchestration
+      metadata:
+        isAnnotation: false
+        primaryColor: '#326CE5'
+        secondaryColor: '#7aa1f0'
+        shape: circle
+        styleOverrides: ""
+        svgColor: ui/public/static/img/meshmodels/kubernetes/color/kubernetes-color.svg
+        svgComplete: ""
+        svgWhite: ui/public/static/img/meshmodels/kubernetes/white/kubernetes-white.svg
+      model:
+        version: v1.32.0-alpha.3
+      components_count: 0
+      relationships_count: 0
+      components: null
+      relationships: null
+    styles:
+      background-image: none
+      background-opacity: 0.5
+      border-style: dashed
+      border-width: 2
+      primaryColor: '#326CE5'
+      secondaryColor: '#7aa1f0'
+      shape: rectangle
+      svgColor: ui/public/static/img/meshmodels/kubernetes/color/namespace-color.svg
+      svgComplete: ui/public/static/img/meshmodels/kubernetes/complete/namespace-complete.svg
+      svgWhite: ui/public/static/img/meshmodels/kubernetes/white/namespace-white.svg
+    capabilities: []
+    status: enabled
+    metadata:
+      configurationUISchema: ""
+      genealogy: parent
+      instanceDetails: null
+      isAnnotation: false
+      isNamespaced: false
+      published: false
+      source_uri: git://github.com/kubernetes/kubernetes/master/api/openapi-spec/v3
+    configuration: null
+    component:
+      version: v1
+      kind: Namespace
+      schema: ""
+  - id: 59cfb0c1-50f3-4f7c-895f-b06144e58c93
+    schemaVersion: components.meshery.io/v1beta1
+    version: v1.0.0
+    displayName: argo
+    description: ""
+    format: ""
+    model:
+      id: b3f5bc0d-30f7-607d-6c73-784ddde6cad8
+      schemaVersion: models.meshery.io/v1beta1
+      version: v1.0.0
+      name: kubernetes
+      displayName: Kubernetes
+      status: enabled
+      registrant:
+        id: 5bc80e3c-5d43-9eb4-d16c-78a2769247a6
+        name: Github
+        credential_id: 00000000-0000-0000-0000-000000000000
+        type: registry
+        sub_type: ""
+        kind: github
+        status: registered
+        user_id: 00000000-0000-0000-0000-000000000000
+        created_at: "2025-10-12T14:26:03.160654794Z"
+        updated_at: "2025-10-12T14:26:03.160654794Z"
+        deleted_at: "0001-01-01T00:00:00Z"
+        schemaVersion: ""
+      connection_id: 5bc80e3c-5d43-9eb4-d16c-78a2769247a6
+      category:
+        id: 9ca27d0d-66ce-42a9-8c85-6236563f2ddb
+        name: Orchestration & Management
+      subCategory: Scheduling & Orchestration
+      metadata:
+        isAnnotation: false
+        primaryColor: '#326CE5'
+        secondaryColor: '#7aa1f0'
+        shape: circle
+        styleOverrides: ""
+        svgColor: ui/public/static/img/meshmodels/kubernetes/color/kubernetes-color.svg
+        svgComplete: ""
+        svgWhite: ui/public/static/img/meshmodels/kubernetes/white/kubernetes-white.svg
+      model:
+        version: v1.32.0-alpha.3
+      components_count: 0
+      relationships_count: 0
+      components: null
+      relationships: null
+    styles:
+      background-image: none
+      background-opacity: 0.5
+      border-style: dashed
+      border-width: 2
+      position:
+        x: 928.49609375
+        y: 199.0048828125
+      primaryColor: '#326CE5'
+      secondaryColor: '#7aa1f0'
+      shape: rectangle
+      svgColor: ui/public/static/img/meshmodels/kubernetes/color/namespace-color.svg
+      svgComplete: ui/public/static/img/meshmodels/kubernetes/complete/namespace-complete.svg
+      svgWhite: ui/public/static/img/meshmodels/kubernetes/white/namespace-white.svg
+      z-index: 37
+    capabilities: []
+    status: enabled
+    metadata:
+      configurationUISchema: ""
+      genealogy: parent
+      instanceDetails: null
+      isAnnotation: false
+      isNamespaced: false
+      published: false
+      source_uri: git://github.com/kubernetes/kubernetes/master/api/openapi-spec/v3
+    configuration:
+      metadata:
+        annotations:
+          helm.sh/hook: pre-install
+          helm.sh/resource-policy: keep
+        labels:
+          name: devtron
+        name: argo
+    component:
+      version: v1
+      kind: Namespace
+      schema: ""
+  - id: 4fd98d6e-0b3f-40b1-9c31-fdd820d574f3
+    schemaVersion: components.meshery.io/v1beta1
+    version: v1.0.0
+    displayName: devtron-cd
+    description: ""
+    format: ""
+    model:
+      id: b3f5bc0d-30f7-607d-6c73-784ddde6cad8
+      schemaVersion: models.meshery.io/v1beta1
+      version: v1.0.0
+      name: kubernetes
+      displayName: Kubernetes
+      status: enabled
+      registrant:
+        id: 5bc80e3c-5d43-9eb4-d16c-78a2769247a6
+        name: Github
+        credential_id: 00000000-0000-0000-0000-000000000000
+        type: registry
+        sub_type: ""
+        kind: github
+        status: registered
+        user_id: 00000000-0000-0000-0000-000000000000
+        created_at: "2025-10-12T14:26:03.160654794Z"
+        updated_at: "2025-10-12T14:26:03.160654794Z"
+        deleted_at: "0001-01-01T00:00:00Z"
+        schemaVersion: ""
+      connection_id: 5bc80e3c-5d43-9eb4-d16c-78a2769247a6
+      category:
+        id: 9ca27d0d-66ce-42a9-8c85-6236563f2ddb
+        name: Orchestration & Management
+      subCategory: Scheduling & Orchestration
+      metadata:
+        isAnnotation: false
+        primaryColor: '#326CE5'
+        secondaryColor: '#7aa1f0'
+        shape: circle
+        styleOverrides: ""
+        svgColor: ui/public/static/img/meshmodels/kubernetes/color/kubernetes-color.svg
+        svgComplete: ""
+        svgWhite: ui/public/static/img/meshmodels/kubernetes/white/kubernetes-white.svg
+      model:
+        version: v1.32.0-alpha.3
+      components_count: 0
+      relationships_count: 0
+      components: null
+      relationships: null
+    styles:
+      background-image: none
+      background-opacity: 0.5
+      border-style: dashed
+      border-width: 2
+      position:
+        x: 800.49609375
+        y: 455.0048828125
+      primaryColor: '#326CE5'
+      secondaryColor: '#7aa1f0'
+      shape: rectangle
+      svgColor: ui/public/static/img/meshmodels/kubernetes/color/namespace-color.svg
+      svgComplete: ui/public/static/img/meshmodels/kubernetes/complete/namespace-complete.svg
+      svgWhite: ui/public/static/img/meshmodels/kubernetes/white/namespace-white.svg
+      z-index: 40
+    capabilities: []
+    status: enabled
+    metadata:
+      configurationUISchema: ""
+      genealogy: parent
+      instanceDetails: null
+      isAnnotation: false
+      isNamespaced: false
+      published: false
+      source_uri: git://github.com/kubernetes/kubernetes/master/api/openapi-spec/v3
+    configuration:
+      metadata:
+        annotations:
+          helm.sh/hook: pre-install
+          helm.sh/resource-policy: keep
+        labels:
+          name: devtron
+        name: devtron-cd
+    component:
+      version: v1
+      kind: Namespace
+      schema: ""
+  - id: 94cda2f1-e9a0-43e8-a50f-c9b462886cad
+    schemaVersion: components.meshery.io/v1beta1
+    version: v1.0.0
+    displayName: devtron-ci
+    description: ""
+    format: ""
+    model:
+      id: b3f5bc0d-30f7-607d-6c73-784ddde6cad8
+      schemaVersion: models.meshery.io/v1beta1
+      version: v1.0.0
+      name: kubernetes
+      displayName: Kubernetes
+      status: enabled
+      registrant:
+        id: 5bc80e3c-5d43-9eb4-d16c-78a2769247a6
+        name: Github
+        credential_id: 00000000-0000-0000-0000-000000000000
+        type: registry
+        sub_type: ""
+        kind: github
+        status: registered
+        user_id: 00000000-0000-0000-0000-000000000000
+        created_at: "2025-10-12T14:26:03.160654794Z"
+        updated_at: "2025-10-12T14:26:03.160654794Z"
+        deleted_at: "0001-01-01T00:00:00Z"
+        schemaVersion: ""
+      connection_id: 5bc80e3c-5d43-9eb4-d16c-78a2769247a6
+      category:
+        id: 9ca27d0d-66ce-42a9-8c85-6236563f2ddb
+        name: Orchestration & Management
+      subCategory: Scheduling & Orchestration
+      metadata:
+        isAnnotation: false
+        primaryColor: '#326CE5'
+        secondaryColor: '#7aa1f0'
+        shape: circle
+        styleOverrides: ""
+        svgColor: ui/public/static/img/meshmodels/kubernetes/color/kubernetes-color.svg
+        svgComplete: ""
+        svgWhite: ui/public/static/img/meshmodels/kubernetes/white/kubernetes-white.svg
+      model:
+        version: v1.32.0-alpha.3
+      components_count: 0
+      relationships_count: 0
+      components: null
+      relationships: null
+    styles:
+      background-image: none
+      background-opacity: 0.5
+      border-style: dashed
+      border-width: 2
+      position:
+        x: 928.49609375
+        y: 327.0048828125
+      primaryColor: '#326CE5'
+      secondaryColor: '#7aa1f0'
+      shape: rectangle
+      svgColor: ui/public/static/img/meshmodels/kubernetes/color/namespace-color.svg
+      svgComplete: ui/public/static/img/meshmodels/kubernetes/complete/namespace-complete.svg
+      svgWhite: ui/public/static/img/meshmodels/kubernetes/white/namespace-white.svg
+      z-index: 38
+    capabilities: []
+    status: enabled
+    metadata:
+      configurationUISchema: ""
+      genealogy: parent
+      instanceDetails: null
+      isAnnotation: false
+      isNamespaced: false
+      published: false
+      source_uri: git://github.com/kubernetes/kubernetes/master/api/openapi-spec/v3
+    configuration:
+      metadata:
+        annotations:
+          helm.sh/hook: pre-install
+          helm.sh/resource-policy: keep
+        labels:
+          name: devtron
+        name: devtron-ci
+    component:
+      version: v1
+      kind: Namespace
+      schema: ""
+  - id: d868026a-01d4-4b4b-bcbb-030eb15906ba
+    schemaVersion: components.meshery.io/v1beta1
+    version: v1.0.0
+    displayName: devtron-demo
+    description: ""
+    format: ""
+    model:
+      id: b3f5bc0d-30f7-607d-6c73-784ddde6cad8
+      schemaVersion: models.meshery.io/v1beta1
+      version: v1.0.0
+      name: kubernetes
+      displayName: Kubernetes
+      status: enabled
+      registrant:
+        id: 5bc80e3c-5d43-9eb4-d16c-78a2769247a6
+        name: Github
+        credential_id: 00000000-0000-0000-0000-000000000000
+        type: registry
+        sub_type: ""
+        kind: github
+        status: registered
+        user_id: 00000000-0000-0000-0000-000000000000
+        created_at: "2025-10-12T14:26:03.160654794Z"
+        updated_at: "2025-10-12T14:26:03.160654794Z"
+        deleted_at: "0001-01-01T00:00:00Z"
+        schemaVersion: ""
+      connection_id: 5bc80e3c-5d43-9eb4-d16c-78a2769247a6
+      category:
+        id: 9ca27d0d-66ce-42a9-8c85-6236563f2ddb
+        name: Orchestration & Management
+      subCategory: Scheduling & Orchestration
+      metadata:
+        isAnnotation: false
+        primaryColor: '#326CE5'
+        secondaryColor: '#7aa1f0'
+        shape: circle
+        styleOverrides: ""
+        svgColor: ui/public/static/img/meshmodels/kubernetes/color/kubernetes-color.svg
+        svgComplete: ""
+        svgWhite: ui/public/static/img/meshmodels/kubernetes/white/kubernetes-white.svg
+      model:
+        version: v1.32.0-alpha.3
+      components_count: 0
+      relationships_count: 0
+      components: null
+      relationships: null
+    styles:
+      background-image: none
+      background-opacity: 0.5
+      border-style: dashed
+      border-width: 2
+      position:
+        x: 672.49609375
+        y: 455.0048828125
+      primaryColor: '#326CE5'
+      secondaryColor: '#7aa1f0'
+      shape: rectangle
+      svgColor: ui/public/static/img/meshmodels/kubernetes/color/namespace-color.svg
+      svgComplete: ui/public/static/img/meshmodels/kubernetes/complete/namespace-complete.svg
+      svgWhite: ui/public/static/img/meshmodels/kubernetes/white/namespace-white.svg
+      z-index: 39
+    capabilities: []
+    status: enabled
+    metadata:
+      configurationUISchema: ""
+      genealogy: parent
+      instanceDetails: null
+      isAnnotation: false
+      isNamespaced: false
+      published: false
+      source_uri: git://github.com/kubernetes/kubernetes/master/api/openapi-spec/v3
+    configuration:
+      metadata:
+        annotations:
+          helm.sh/hook: pre-install
+          helm.sh/resource-policy: keep
+        labels:
+          name: devtron
+        name: devtron-demo
+    component:
+      version: v1
+      kind: Namespace
+      schema: ""
+  - id: 6db433b8-9b87-464e-a57d-32e1dc22c567
+    schemaVersion: components.meshery.io/v1beta1
+    version: v1.0.0
+    displayName: argocd-dex-server
+    description: ""
+    format: ""
+    model:
+      id: b3f5bc0d-30f7-607d-6c73-784ddde6cad8
+      schemaVersion: models.meshery.io/v1beta1
+      version: v1.0.0
+      name: kubernetes
+      displayName: Kubernetes
+      status: enabled
+      registrant:
+        id: 5bc80e3c-5d43-9eb4-d16c-78a2769247a6
+        name: Github
+        credential_id: 00000000-0000-0000-0000-000000000000
+        type: registry
+        sub_type: ""
+        kind: github
+        status: registered
+        user_id: 00000000-0000-0000-0000-000000000000
+        created_at: "2025-10-12T14:26:03.160654794Z"
+        updated_at: "2025-10-12T14:26:03.160654794Z"
+        deleted_at: "0001-01-01T00:00:00Z"
+        schemaVersion: ""
+      connection_id: 5bc80e3c-5d43-9eb4-d16c-78a2769247a6
+      category:
+        id: 9ca27d0d-66ce-42a9-8c85-6236563f2ddb
+        name: Orchestration & Management
+      subCategory: Scheduling & Orchestration
+      metadata:
+        isAnnotation: false
+        primaryColor: '#326CE5'
+        secondaryColor: '#7aa1f0'
+        shape: circle
+        styleOverrides: ""
+        svgColor: ui/public/static/img/meshmodels/kubernetes/color/kubernetes-color.svg
+        svgComplete: ""
+        svgWhite: ui/public/static/img/meshmodels/kubernetes/white/kubernetes-white.svg
+      model:
+        version: v1.32.0-alpha.3
+      components_count: 0
+      relationships_count: 0
+      components: null
+      relationships: null
+    styles:
+      height: 22
+      position:
+        x: 1270.49609375
+        y: 563.0048828125
+      primaryColor: '#326CE5'
+      secondaryColor: '#7aa1f0'
+      shape: round-rectangle
+      svgColor: ui/public/static/img/meshmodels/kubernetes/color/role-color.svg
+      svgComplete: ""
+      svgWhite: ui/public/static/img/meshmodels/kubernetes/white/role-white.svg
+      width: 22
+      x: 8.5
+      y: 7.5
+      z-index: 4
+    capabilities: []
+    status: enabled
+    metadata:
+      configurationUISchema: ""
+      genealogy: ""
+      instanceDetails: null
+      isAnnotation: false
+      isNamespaced: true
+      published: false
+      source_uri: git://github.com/kubernetes/kubernetes/master/api/openapi-spec/v3
+    configuration:
+      metadata:
+        annotations:
+          helm.sh/resource-policy: keep
+          meta.helm.sh/release-name: devtron-operator
+          meta.helm.sh/release-namespace: default
+        labels:
+          app.kubernetes.io/component: dex-server
+          app.kubernetes.io/managed-by: Helm
+          app.kubernetes.io/name: argocd-dex-server
+          app.kubernetes.io/part-of: argocd
+        name: argocd-dex-server
+      rules:
+        - apiGroups:
+            - ""
+          resources:
+            - secrets
+            - configmaps
+          verbs:
+            - get
+            - list
+            - watch
+            - create
+            - update
+            - patch
+    component:
+      version: rbac.authorization.k8s.io/v1
+      kind: Role
+      schema: ""
+  - id: 2decfb32-83eb-433a-9292-5ed81abb45b8
+    schemaVersion: components.meshery.io/v1beta1
+    version: v1.0.0
+    displayName: argocd-dex-server
+    description: ""
+    format: ""
+    model:
+      id: b3f5bc0d-30f7-607d-6c73-784ddde6cad8
+      schemaVersion: models.meshery.io/v1beta1
+      version: v1.0.0
+      name: kubernetes
+      displayName: Kubernetes
+      status: enabled
+      registrant:
+        id: 5bc80e3c-5d43-9eb4-d16c-78a2769247a6
+        name: Github
+        credential_id: 00000000-0000-0000-0000-000000000000
+        type: registry
+        sub_type: ""
+        kind: github
+        status: registered
+        user_id: 00000000-0000-0000-0000-000000000000
+        created_at: "2025-10-12T14:26:03.160654794Z"
+        updated_at: "2025-10-12T14:26:03.160654794Z"
+        deleted_at: "0001-01-01T00:00:00Z"
+        schemaVersion: ""
+      connection_id: 5bc80e3c-5d43-9eb4-d16c-78a2769247a6
+      category:
+        id: 9ca27d0d-66ce-42a9-8c85-6236563f2ddb
+        name: Orchestration & Management
+      subCategory: Scheduling & Orchestration
+      metadata:
+        isAnnotation: false
+        primaryColor: '#326CE5'
+        secondaryColor: '#7aa1f0'
+        shape: circle
+        styleOverrides: ""
+        svgColor: ui/public/static/img/meshmodels/kubernetes/color/kubernetes-color.svg
+        svgComplete: ""
+        svgWhite: ui/public/static/img/meshmodels/kubernetes/white/kubernetes-white.svg
+      model:
+        version: v1.32.0-alpha.3
+      components_count: 0
+      relationships_count: 0
+      components: null
+      relationships: null
+    styles:
+      height: 25
+      position:
+        x: 1087.49609375
+        y: 566.0048828125
+      primaryColor: '#326CE5'
+      secondaryColor: '#7aa1f0'
+      shape: round-rectangle
+      svgColor: ui/public/static/img/meshmodels/kubernetes/color/rolebinding-color.svg
+      svgComplete: ""
+      svgWhite: ui/public/static/img/meshmodels/kubernetes/white/rolebinding-white.svg
+      width: 25
+      x: 7
+      y: 7
+      z-index: 24
+    capabilities: []
+    status: enabled
+    metadata:
+      configurationUISchema: ""
+      genealogy: ""
+      instanceDetails: null
+      isAnnotation: false
+      isNamespaced: true
+      published: false
+      source_uri: git://github.com/kubernetes/kubernetes/master/api/openapi-spec/v3
+    configuration:
+      metadata:
+        annotations:
+          helm.sh/resource-policy: keep
+          meta.helm.sh/release-name: devtron-operator
+          meta.helm.sh/release-namespace: default
+        labels:
+          app.kubernetes.io/component: dex-server
+          app.kubernetes.io/managed-by: Helm
+          app.kubernetes.io/name: argocd-dex-server
+          app.kubernetes.io/part-of: argocd
+        name: argocd-dex-server
+      roleRef:
+        apiGroup: rbac.authorization.k8s.io
+        kind: Role
+        name: argocd-dex-server
+      subjects:
+        - kind: ServiceAccount
+          name: argocd-dex-server
+    component:
+      version: rbac.authorization.k8s.io/v1
+      kind: RoleBinding
+      schema: ""
+  - id: d63f76a6-1268-4f25-9ce1-ca796f27e88a
+    schemaVersion: components.meshery.io/v1beta1
+    version: v1.0.0
+    displayName: postgresql-migrator
+    description: ""
+    format: ""
+    model:
+      id: b3f5bc0d-30f7-607d-6c73-784ddde6cad8
+      schemaVersion: models.meshery.io/v1beta1
+      version: v1.0.0
+      name: kubernetes
+      displayName: Kubernetes
+      status: enabled
+      registrant:
+        id: 5bc80e3c-5d43-9eb4-d16c-78a2769247a6
+        name: Github
+        credential_id: 00000000-0000-0000-0000-000000000000
+        type: registry
+        sub_type: ""
+        kind: github
+        status: registered
+        user_id: 00000000-0000-0000-0000-000000000000
+        created_at: "2025-10-12T14:26:03.160654794Z"
+        updated_at: "2025-10-12T14:26:03.160654794Z"
+        deleted_at: "0001-01-01T00:00:00Z"
+        schemaVersion: ""
+      connection_id: 5bc80e3c-5d43-9eb4-d16c-78a2769247a6
+      category:
+        id: 9ca27d0d-66ce-42a9-8c85-6236563f2ddb
+        name: Orchestration & Management
+      subCategory: Scheduling & Orchestration
+      metadata:
+        isAnnotation: false
+        primaryColor: '#326CE5'
+        secondaryColor: '#7aa1f0'
+        shape: circle
+        styleOverrides: ""
+        svgColor: ui/public/static/img/meshmodels/kubernetes/color/kubernetes-color.svg
+        svgComplete: ""
+        svgWhite: ui/public/static/img/meshmodels/kubernetes/white/kubernetes-white.svg
+      model:
+        version: v1.32.0-alpha.3
+      components_count: 0
+      relationships_count: 0
+      components: null
+      relationships: null
+    styles:
+      background-clip: node
+      background-image-containment: over
+      background-opacity: 0
+      height: 32
+      padding: 1
+      position:
+        x: 652.49609375
+        y: 855.0048828125
+      primaryColor: '#326CE5'
+      secondaryColor: '#7aa1f0'
+      shape: shield
+      svgColor: ui/public/static/img/meshmodels/kubernetes/color/secret-color.svg
+      svgComplete: ui/public/static/img/meshmodels/kubernetes/complete/secret-complete.svg
+      svgWhite: ui/public/static/img/meshmodels/kubernetes/white/secret-white.svg
+      width: 32
+      z-index: 42
+    capabilities: []
+    status: enabled
+    metadata:
+      configurationUISchema: ""
+      genealogy: ""
+      instanceDetails: null
+      isAnnotation: false
+      isNamespaced: true
+      published: false
+      source_uri: git://github.com/kubernetes/kubernetes/master/api/openapi-spec/v3
+    configuration:
+      data:
+        DB_PASSWORD: WTNyajNwOXpnMm5pQ3ptNHNneGlYWU52Q2RpRkVJT2Q=
+      metadata:
+        annotations:
+          helm.sh/hook: pre-install
+          helm.sh/hook-weight: "-4"
+          helm.sh/resource-policy: keep
+        labels:
+          app: postgresql
+          chart: postgresql-8.6.4
+          release: devtron
+        name: postgresql-migrator
+      type: Opaque
+    component:
+      version: v1
+      kind: Secret
+      schema: ""
+  - id: 3534f973-0af4-403c-9f63-ec02dc92c36b
+    schemaVersion: components.meshery.io/v1beta1
+    version: v1.0.0
+    displayName: devtron-custom-secret
+    description: ""
+    format: ""
+    model:
+      id: b3f5bc0d-30f7-607d-6c73-784ddde6cad8
+      schemaVersion: models.meshery.io/v1beta1
+      version: v1.0.0
+      name: kubernetes
+      displayName: Kubernetes
+      status: enabled
+      registrant:
+        id: 5bc80e3c-5d43-9eb4-d16c-78a2769247a6
+        name: Github
+        credential_id: 00000000-0000-0000-0000-000000000000
+        type: registry
+        sub_type: ""
+        kind: github
+        status: registered
+        user_id: 00000000-0000-0000-0000-000000000000
+        created_at: "2025-10-12T14:26:03.160654794Z"
+        updated_at: "2025-10-12T14:26:03.160654794Z"
+        deleted_at: "0001-01-01T00:00:00Z"
+        schemaVersion: ""
+      connection_id: 5bc80e3c-5d43-9eb4-d16c-78a2769247a6
+      category:
+        id: 9ca27d0d-66ce-42a9-8c85-6236563f2ddb
+        name: Orchestration & Management
+      subCategory: Scheduling & Orchestration
+      metadata:
+        isAnnotation: false
+        primaryColor: '#326CE5'
+        secondaryColor: '#7aa1f0'
+        shape: circle
+        styleOverrides: ""
+        svgColor: ui/public/static/img/meshmodels/kubernetes/color/kubernetes-color.svg
+        svgComplete: ""
+        svgWhite: ui/public/static/img/meshmodels/kubernetes/white/kubernetes-white.svg
+      model:
+        version: v1.32.0-alpha.3
+      components_count: 0
+      relationships_count: 0
+      components: null
+      relationships: null
+    styles:
+      background-clip: node
+      background-image-containment: over
+      background-opacity: 0
+      height: 32
+      padding: 1
+      position:
+        x: 828.49609375
+        y: 855.0048828125
+      primaryColor: '#326CE5'
+      secondaryColor: '#7aa1f0'
+      shape: shield
+      svgColor: ui/public/static/img/meshmodels/kubernetes/color/secret-color.svg
+      svgComplete: ui/public/static/img/meshmodels/kubernetes/complete/secret-complete.svg
+      svgWhite: ui/public/static/img/meshmodels/kubernetes/white/secret-white.svg
+      width: 32
+      z-index: 44
+    capabilities: []
+    status: enabled
+    metadata:
+      configurationUISchema: ""
+      genealogy: ""
+      instanceDetails: null
+      isAnnotation: false
+      isNamespaced: true
+      published: false
+      source_uri: git://github.com/kubernetes/kubernetes/master/api/openapi-spec/v3
+    configuration:
+      data:
+        ORCH_TOKEN: akFiM2s5RG1kYm5lZ3pSM28xR1lwekxMT2ZkNzRZc04=
+      metadata:
+        annotations:
+          helm.sh/hook: pre-install, pre-upgrade
+        labels:
+          release: devtron
+        name: devtron-custom-secret
+      type: Opaque
+    component:
+      version: v1
+      kind: Secret
+      schema: ""
+  - id: 46c0e6d2-67b4-47fd-a9f5-e7828ddedc63
+    schemaVersion: components.meshery.io/v1beta1
+    version: v1.0.0
+    displayName: devtron-secret
+    description: ""
+    format: ""
+    model:
+      id: b3f5bc0d-30f7-607d-6c73-784ddde6cad8
+      schemaVersion: models.meshery.io/v1beta1
+      version: v1.0.0
+      name: kubernetes
+      displayName: Kubernetes
+      status: enabled
+      registrant:
+        id: 5bc80e3c-5d43-9eb4-d16c-78a2769247a6
+        name: Github
+        credential_id: 00000000-0000-0000-0000-000000000000
+        type: registry
+        sub_type: ""
+        kind: github
+        status: registered
+        user_id: 00000000-0000-0000-0000-000000000000
+        created_at: "2025-10-12T14:26:03.160654794Z"
+        updated_at: "2025-10-12T14:26:03.160654794Z"
+        deleted_at: "0001-01-01T00:00:00Z"
+        schemaVersion: ""
+      connection_id: 5bc80e3c-5d43-9eb4-d16c-78a2769247a6
+      category:
+        id: 9ca27d0d-66ce-42a9-8c85-6236563f2ddb
+        name: Orchestration & Management
+      subCategory: Scheduling & Orchestration
+      metadata:
+        isAnnotation: false
+        primaryColor: '#326CE5'
+        secondaryColor: '#7aa1f0'
+        shape: circle
+        styleOverrides: ""
+        svgColor: ui/public/static/img/meshmodels/kubernetes/color/kubernetes-color.svg
+        svgComplete: ""
+        svgWhite: ui/public/static/img/meshmodels/kubernetes/white/kubernetes-white.svg
+      model:
+        version: v1.32.0-alpha.3
+      components_count: 0
+      relationships_count: 0
+      components: null
+      relationships: null
+    styles:
+      background-clip: node
+      background-image-containment: over
+      background-opacity: 0
+      height: 32
+      padding: 1
+      position:
+        x: 740.49609375
+        y: 855.0048828125
+      primaryColor: '#326CE5'
+      secondaryColor: '#7aa1f0'
+      shape: shield
+      svgColor: ui/public/static/img/meshmodels/kubernetes/color/secret-color.svg
+      svgComplete: ui/public/static/img/meshmodels/kubernetes/complete/secret-complete.svg
+      svgWhite: ui/public/static/img/meshmodels/kubernetes/white/secret-white.svg
+      width: 32
+      z-index: 43
+    capabilities: []
+    status: enabled
+    metadata:
+      configurationUISchema: ""
+      genealogy: ""
+      instanceDetails: null
+      isAnnotation: false
+      isNamespaced: true
+      published: false
+      source_uri: git://github.com/kubernetes/kubernetes/master/api/openapi-spec/v3
+    configuration:
+      data:
+        PG_PASSWORD: WTNyajNwOXpnMm5pQ3ptNHNneGlYWU52Q2RpRkVJT2Q=
+      metadata:
+        annotations:
+          helm.sh/hook: pre-install
+          helm.sh/hook-weight: "-3"
+          helm.sh/resource-policy: keep
+        labels:
+          release: devtron
+        name: devtron-secret
+      type: Opaque
+    component:
+      version: v1
+      kind: Secret
+      schema: ""
+  - id: be26258e-320e-4551-86ba-d933ecb99339
+    schemaVersion: components.meshery.io/v1beta1
+    version: v1.0.0
+    displayName: postgresql-postgresql
+    description: ""
+    format: ""
+    model:
+      id: b3f5bc0d-30f7-607d-6c73-784ddde6cad8
+      schemaVersion: models.meshery.io/v1beta1
+      version: v1.0.0
+      name: kubernetes
+      displayName: Kubernetes
+      status: enabled
+      registrant:
+        id: 5bc80e3c-5d43-9eb4-d16c-78a2769247a6
+        name: Github
+        credential_id: 00000000-0000-0000-0000-000000000000
+        type: registry
+        sub_type: ""
+        kind: github
+        status: registered
+        user_id: 00000000-0000-0000-0000-000000000000
+        created_at: "2025-10-12T14:26:03.160654794Z"
+        updated_at: "2025-10-12T14:26:03.160654794Z"
+        deleted_at: "0001-01-01T00:00:00Z"
+        schemaVersion: ""
+      connection_id: 5bc80e3c-5d43-9eb4-d16c-78a2769247a6
+      category:
+        id: 9ca27d0d-66ce-42a9-8c85-6236563f2ddb
+        name: Orchestration & Management
+      subCategory: Scheduling & Orchestration
+      metadata:
+        isAnnotation: false
+        primaryColor: '#326CE5'
+        secondaryColor: '#7aa1f0'
+        shape: circle
+        styleOverrides: ""
+        svgColor: ui/public/static/img/meshmodels/kubernetes/color/kubernetes-color.svg
+        svgComplete: ""
+        svgWhite: ui/public/static/img/meshmodels/kubernetes/white/kubernetes-white.svg
+      model:
+        version: v1.32.0-alpha.3
+      components_count: 0
+      relationships_count: 0
+      components: null
+      relationships: null
+    styles:
+      background-clip: node
+      background-image-containment: over
+      background-opacity: 0
+      height: 32
+      padding: 1
+      position:
+        x: 1292.49609375
+        y: 763.0048828125
+      primaryColor: '#326CE5'
+      secondaryColor: '#7aa1f0'
+      shape: shield
+      svgColor: ui/public/static/img/meshmodels/kubernetes/color/secret-color.svg
+      svgComplete: ui/public/static/img/meshmodels/kubernetes/complete/secret-complete.svg
+      svgWhite: ui/public/static/img/meshmodels/kubernetes/white/secret-white.svg
+      width: 32
+      z-index: 41
+    capabilities: []
+    status: enabled
+    metadata:
+      configurationUISchema: ""
+      genealogy: ""
+      instanceDetails: null
+      isAnnotation: false
+      isNamespaced: true
+      published: false
+      source_uri: git://github.com/kubernetes/kubernetes/master/api/openapi-spec/v3
+    configuration:
+      data:
+        POSTGRES_DB: b3JjaGVzdHJhdG9y
+        POSTGRES_USER: cG9zdGdyZXM=
+        postgresql-password: WTNyajNwOXpnMm5pQ3ptNHNneGlYWU52Q2RpRkVJT2Q=
+      metadata:
+        annotations:
+          helm.sh/hook: pre-install
+          helm.sh/hook-weight: "-5"
+          helm.sh/resource-policy: keep
+        labels:
+          app: postgresql
+          chart: postgresql-8.6.4
+          release: devtron
+        name: postgresql-postgresql
+      type: Opaque
+    component:
+      version: v1
+      kind: Secret
+      schema: ""
+  - id: 5d430702-48f4-4b67-8012-ca0603c9e5fe
+    schemaVersion: components.meshery.io/v1beta1
+    version: v1.0.0
+    displayName: kubelink-secret
+    description: ""
+    format: ""
+    model:
+      id: b3f5bc0d-30f7-607d-6c73-784ddde6cad8
+      schemaVersion: models.meshery.io/v1beta1
+      version: v1.0.0
+      name: kubernetes
+      displayName: Kubernetes
+      status: enabled
+      registrant:
+        id: 5bc80e3c-5d43-9eb4-d16c-78a2769247a6
+        name: Github
+        credential_id: 00000000-0000-0000-0000-000000000000
+        type: registry
+        sub_type: ""
+        kind: github
+        status: registered
+        user_id: 00000000-0000-0000-0000-000000000000
+        created_at: "2025-10-12T14:26:03.160654794Z"
+        updated_at: "2025-10-12T14:26:03.160654794Z"
+        deleted_at: "0001-01-01T00:00:00Z"
+        schemaVersion: ""
+      connection_id: 5bc80e3c-5d43-9eb4-d16c-78a2769247a6
+      category:
+        id: 9ca27d0d-66ce-42a9-8c85-6236563f2ddb
+        name: Orchestration & Management
+      subCategory: Scheduling & Orchestration
+      metadata:
+        isAnnotation: false
+        primaryColor: '#326CE5'
+        secondaryColor: '#7aa1f0'
+        shape: circle
+        styleOverrides: ""
+        svgColor: ui/public/static/img/meshmodels/kubernetes/color/kubernetes-color.svg
+        svgComplete: ""
+        svgWhite: ui/public/static/img/meshmodels/kubernetes/white/kubernetes-white.svg
+      model:
+        version: v1.32.0-alpha.3
+      components_count: 0
+      relationships_count: 0
+      components: null
+      relationships: null
+    styles:
+      background-clip: node
+      background-image-containment: over
+      background-opacity: 0
+      height: 32
+      padding: 1
+      position:
+        x: 1222.49609375
+        y: 307.0048828125
+      primaryColor: '#326CE5'
+      secondaryColor: '#7aa1f0'
+      shape: shield
+      svgColor: ui/public/static/img/meshmodels/kubernetes/color/secret-color.svg
+      svgComplete: ui/public/static/img/meshmodels/kubernetes/complete/secret-complete.svg
+      svgWhite: ui/public/static/img/meshmodels/kubernetes/white/secret-white.svg
+      width: 32
+      z-index: 11
+    capabilities: []
+    status: enabled
+    metadata:
+      configurationUISchema: ""
+      genealogy: ""
+      instanceDetails: null
+      isAnnotation: false
+      isNamespaced: true
+      published: false
+      source_uri: git://github.com/kubernetes/kubernetes/master/api/openapi-spec/v3
+    configuration:
+      metadata:
+        annotations:
+          helm.sh/resource-policy: keep
+        labels:
+          app: kubelink
+          release: devtron
+        name: kubelink-secret
+      type: Opaque
+    component:
+      version: v1
+      kind: Secret
+      schema: ""
+  - id: 735a7537-ca88-4bfb-a3a4-ce811825b0f9
+    schemaVersion: components.meshery.io/v1beta1
+    version: v1.0.0
+    displayName: argocd-secret
+    description: ""
+    format: ""
+    model:
+      id: b3f5bc0d-30f7-607d-6c73-784ddde6cad8
+      schemaVersion: models.meshery.io/v1beta1
+      version: v1.0.0
+      name: kubernetes
+      displayName: Kubernetes
+      status: enabled
+      registrant:
+        id: 5bc80e3c-5d43-9eb4-d16c-78a2769247a6
+        name: Github
+        credential_id: 00000000-0000-0000-0000-000000000000
+        type: registry
+        sub_type: ""
+        kind: github
+        status: registered
+        user_id: 00000000-0000-0000-0000-000000000000
+        created_at: "2025-10-12T14:26:03.160654794Z"
+        updated_at: "2025-10-12T14:26:03.160654794Z"
+        deleted_at: "0001-01-01T00:00:00Z"
+        schemaVersion: ""
+      connection_id: 5bc80e3c-5d43-9eb4-d16c-78a2769247a6
+      category:
+        id: 9ca27d0d-66ce-42a9-8c85-6236563f2ddb
+        name: Orchestration & Management
+      subCategory: Scheduling & Orchestration
+      metadata:
+        isAnnotation: false
+        primaryColor: '#326CE5'
+        secondaryColor: '#7aa1f0'
+        shape: circle
+        styleOverrides: ""
+        svgColor: ui/public/static/img/meshmodels/kubernetes/color/kubernetes-color.svg
+        svgComplete: ""
+        svgWhite: ui/public/static/img/meshmodels/kubernetes/white/kubernetes-white.svg
+      model:
+        version: v1.32.0-alpha.3
+      components_count: 0
+      relationships_count: 0
+      components: null
+      relationships: null
+    styles:
+      background-clip: node
+      background-image-containment: over
+      background-opacity: 0
+      height: 32
+      padding: 1
+      position:
+        x: 1204.49609375
+        y: 763.0048828125
+      primaryColor: '#326CE5'
+      secondaryColor: '#7aa1f0'
+      shape: shield
+      svgColor: ui/public/static/img/meshmodels/kubernetes/color/secret-color.svg
+      svgComplete: ui/public/static/img/meshmodels/kubernetes/complete/secret-complete.svg
+      svgWhite: ui/public/static/img/meshmodels/kubernetes/white/secret-white.svg
+      width: 32
+      z-index: 9
+    capabilities: []
+    status: enabled
+    metadata:
+      configurationUISchema: ""
+      genealogy: ""
+      instanceDetails: null
+      isAnnotation: false
+      isNamespaced: true
+      published: false
+      source_uri: git://github.com/kubernetes/kubernetes/master/api/openapi-spec/v3
+    configuration:
+      metadata:
+        annotations:
+          helm.sh/resource-policy: keep
+        labels:
+          app.kubernetes.io/name: argocd-secret
+          app.kubernetes.io/part-of: argocd
+        name: argocd-secret
+        namespace: devtroncd
+      type: Opaque
+    component:
+      version: v1
+      kind: Secret
+      schema: ""
+  - id: 4744d086-e8f4-42e0-afcd-350d58eb3b41
+    schemaVersion: components.meshery.io/v1beta1
+    version: v1.0.0
+    displayName: devtron-dashboard-secret
+    description: ""
+    format: ""
+    model:
+      id: b3f5bc0d-30f7-607d-6c73-784ddde6cad8
+      schemaVersion: models.meshery.io/v1beta1
+      version: v1.0.0
+      name: kubernetes
+      displayName: Kubernetes
+      status: enabled
+      registrant:
+        id: 5bc80e3c-5d43-9eb4-d16c-78a2769247a6
+        name: Github
+        credential_id: 00000000-0000-0000-0000-000000000000
+        type: registry
+        sub_type: ""
+        kind: github
+        status: registered
+        user_id: 00000000-0000-0000-0000-000000000000
+        created_at: "2025-10-12T14:26:03.160654794Z"
+        updated_at: "2025-10-12T14:26:03.160654794Z"
+        deleted_at: "0001-01-01T00:00:00Z"
+        schemaVersion: ""
+      connection_id: 5bc80e3c-5d43-9eb4-d16c-78a2769247a6
+      category:
+        id: 9ca27d0d-66ce-42a9-8c85-6236563f2ddb
+        name: Orchestration & Management
+      subCategory: Scheduling & Orchestration
+      metadata:
+        isAnnotation: false
+        primaryColor: '#326CE5'
+        secondaryColor: '#7aa1f0'
+        shape: circle
+        styleOverrides: ""
+        svgColor: ui/public/static/img/meshmodels/kubernetes/color/kubernetes-color.svg
+        svgComplete: ""
+        svgWhite: ui/public/static/img/meshmodels/kubernetes/white/kubernetes-white.svg
+      model:
+        version: v1.32.0-alpha.3
+      components_count: 0
+      relationships_count: 0
+      components: null
+      relationships: null
+    styles:
+      background-clip: node
+      background-image-containment: over
+      background-opacity: 0
+      height: 32
+      padding: 1
+      position:
+        x: 1216.49609375
+        y: 435.0048828125
+      primaryColor: '#326CE5'
+      secondaryColor: '#7aa1f0'
+      shape: shield
+      svgColor: ui/public/static/img/meshmodels/kubernetes/color/secret-color.svg
+      svgComplete: ui/public/static/img/meshmodels/kubernetes/complete/secret-complete.svg
+      svgWhite: ui/public/static/img/meshmodels/kubernetes/white/secret-white.svg
+      width: 32
+      z-index: 10
+    capabilities: []
+    status: enabled
+    metadata:
+      configurationUISchema: ""
+      genealogy: ""
+      instanceDetails: null
+      isAnnotation: false
+      isNamespaced: true
+      published: false
+      source_uri: git://github.com/kubernetes/kubernetes/master/api/openapi-spec/v3
+    configuration:
+      metadata:
+        annotations:
+          helm.sh/resource-policy: keep
+        labels:
+          release: devtron
+        name: devtron-dashboard-secret
+      type: Opaque
+    component:
+      version: v1
+      kind: Secret
+      schema: ""
+  - id: 1a927054-cc7e-4435-bb00-f0e47647724b
+    schemaVersion: components.meshery.io/v1beta1
+    version: v1.0.0
+    displayName: dashboard-service
+    description: ""
+    format: ""
+    model:
+      id: b3f5bc0d-30f7-607d-6c73-784ddde6cad8
+      schemaVersion: models.meshery.io/v1beta1
+      version: v1.0.0
+      name: kubernetes
+      displayName: Kubernetes
+      status: enabled
+      registrant:
+        id: 5bc80e3c-5d43-9eb4-d16c-78a2769247a6
+        name: Github
+        credential_id: 00000000-0000-0000-0000-000000000000
+        type: registry
+        sub_type: ""
+        kind: github
+        status: registered
+        user_id: 00000000-0000-0000-0000-000000000000
+        created_at: "2025-10-12T14:26:03.160654794Z"
+        updated_at: "2025-10-12T14:26:03.160654794Z"
+        deleted_at: "0001-01-01T00:00:00Z"
+        schemaVersion: ""
+      connection_id: 5bc80e3c-5d43-9eb4-d16c-78a2769247a6
+      category:
+        id: 9ca27d0d-66ce-42a9-8c85-6236563f2ddb
+        name: Orchestration & Management
+      subCategory: Scheduling & Orchestration
+      metadata:
+        isAnnotation: false
+        primaryColor: '#326CE5'
+        secondaryColor: '#7aa1f0'
+        shape: circle
+        styleOverrides: ""
+        svgColor: ui/public/static/img/meshmodels/kubernetes/color/kubernetes-color.svg
+        svgComplete: ""
+        svgWhite: ui/public/static/img/meshmodels/kubernetes/white/kubernetes-white.svg
+      model:
+        version: v1.32.0-alpha.3
+      components_count: 0
+      relationships_count: 0
+      components: null
+      relationships: null
+    styles:
+      background-position-y: "4.5"
+      height: 20
+      padding: 12
+      position:
+        x: 918.49609375
+        y: 445.0048828125
+      primaryColor: '#326CE5'
+      secondaryColor: '#7aa1f0'
+      shape: round-triangle
+      svgColor: ui/public/static/img/meshmodels/kubernetes/color/service-color.svg
+      svgComplete: ""
+      svgWhite: ui/public/static/img/meshmodels/kubernetes/white/service-white.svg
+      width: 20
+      z-index: 25
+    capabilities: []
+    status: enabled
+    metadata:
+      configurationUISchema: ""
+      genealogy: ""
+      instanceDetails: null
+      isAnnotation: false
+      isNamespaced: true
+      published: false
+      source_uri: git://github.com/kubernetes/kubernetes/master/api/openapi-spec/v3
+    configuration:
+      metadata:
+        annotations:
+          helm.sh/resource-policy: keep
+        labels:
+          app: dashboard
+          release: devtron
+        name: dashboard-service
+      spec:
+        ports:
+          - name: app
+            port: 80
+            protocol: TCP
+            targetPort: app
+        selector:
+          app: dashboard
+        type: ClusterIP
+    component:
+      version: v1
+      kind: Service
+      schema: ""
+  - id: dba874a7-f162-4580-b604-2bce367624f4
+    schemaVersion: components.meshery.io/v1beta1
+    version: v1.0.0
+    displayName: devtron-service
+    description: ""
+    format: ""
+    model:
+      id: b3f5bc0d-30f7-607d-6c73-784ddde6cad8
+      schemaVersion: models.meshery.io/v1beta1
+      version: v1.0.0
+      name: kubernetes
+      displayName: Kubernetes
+      status: enabled
+      registrant:
+        id: 5bc80e3c-5d43-9eb4-d16c-78a2769247a6
+        name: Github
+        credential_id: 00000000-0000-0000-0000-000000000000
+        type: registry
+        sub_type: ""
+        kind: github
+        status: registered
+        user_id: 00000000-0000-0000-0000-000000000000
+        created_at: "2025-10-12T14:26:03.160654794Z"
+        updated_at: "2025-10-12T14:26:03.160654794Z"
+        deleted_at: "0001-01-01T00:00:00Z"
+        schemaVersion: ""
+      connection_id: 5bc80e3c-5d43-9eb4-d16c-78a2769247a6
+      category:
+        id: 9ca27d0d-66ce-42a9-8c85-6236563f2ddb
+        name: Orchestration & Management
+      subCategory: Scheduling & Orchestration
+      metadata:
+        isAnnotation: false
+        primaryColor: '#326CE5'
+        secondaryColor: '#7aa1f0'
+        shape: circle
+        styleOverrides: ""
+        svgColor: ui/public/static/img/meshmodels/kubernetes/color/kubernetes-color.svg
+        svgComplete: ""
+        svgWhite: ui/public/static/img/meshmodels/kubernetes/white/kubernetes-white.svg
+      model:
+        version: v1.32.0-alpha.3
+      components_count: 0
+      relationships_count: 0
+      components: null
+      relationships: null
+    styles:
+      background-position-y: "4.5"
+      height: 20
+      padding: 12
+      position:
+        x: 1026.49609375
+        y: 445.0048828125
+      primaryColor: '#326CE5'
+      secondaryColor: '#7aa1f0'
+      shape: round-triangle
+      svgColor: ui/public/static/img/meshmodels/kubernetes/color/service-color.svg
+      svgComplete: ""
+      svgWhite: ui/public/static/img/meshmodels/kubernetes/white/service-white.svg
+      width: 20
+      z-index: 26
+    capabilities: []
+    status: enabled
+    metadata:
+      configurationUISchema: ""
+      genealogy: ""
+      instanceDetails: null
+      isAnnotation: false
+      isNamespaced: true
+      published: false
+      source_uri: git://github.com/kubernetes/kubernetes/master/api/openapi-spec/v3
+    configuration:
+      metadata:
+        annotations:
+          helm.sh/resource-policy: keep
+        labels:
+          app: devtron
+          release: devtron
+        name: devtron-service
+        namespace: devtroncd
+      spec:
+        ports:
+          - name: devtron
+            port: 80
+            protocol: TCP
+            targetPort: devtron
+        selector:
+          app: devtron
+        sessionAffinity: None
+        type: LoadBalancer
+    component:
+      version: v1
+      kind: Service
+      schema: ""
+  - id: 868ab99a-9d42-45b7-86e7-935d91f1986d
+    schemaVersion: components.meshery.io/v1beta1
+    version: v1.0.0
+    displayName: kubelink-service-headless
+    description: ""
+    format: ""
+    model:
+      id: b3f5bc0d-30f7-607d-6c73-784ddde6cad8
+      schemaVersion: models.meshery.io/v1beta1
+      version: v1.0.0
+      name: kubernetes
+      displayName: Kubernetes
+      status: enabled
+      registrant:
+        id: 5bc80e3c-5d43-9eb4-d16c-78a2769247a6
+        name: Github
+        credential_id: 00000000-0000-0000-0000-000000000000
+        type: registry
+        sub_type: ""
+        kind: github
+        status: registered
+        user_id: 00000000-0000-0000-0000-000000000000
+        created_at: "2025-10-12T14:26:03.160654794Z"
+        updated_at: "2025-10-12T14:26:03.160654794Z"
+        deleted_at: "0001-01-01T00:00:00Z"
+        schemaVersion: ""
+      connection_id: 5bc80e3c-5d43-9eb4-d16c-78a2769247a6
+      category:
+        id: 9ca27d0d-66ce-42a9-8c85-6236563f2ddb
+        name: Orchestration & Management
+      subCategory: Scheduling & Orchestration
+      metadata:
+        isAnnotation: false
+        primaryColor: '#326CE5'
+        secondaryColor: '#7aa1f0'
+        shape: circle
+        styleOverrides: ""
+        svgColor: ui/public/static/img/meshmodels/kubernetes/color/kubernetes-color.svg
+        svgComplete: ""
+        svgWhite: ui/public/static/img/meshmodels/kubernetes/white/kubernetes-white.svg
+      model:
+        version: v1.32.0-alpha.3
+      components_count: 0
+      relationships_count: 0
+      components: null
+      relationships: null
+    styles:
+      background-position-y: "4.5"
+      height: 20
+      padding: 12
+      position:
+        x: 770.49609375
+        y: 573.0048828125
+      primaryColor: '#326CE5'
+      secondaryColor: '#7aa1f0'
+      shape: round-triangle
+      svgColor: ui/public/static/img/meshmodels/kubernetes/color/service-color.svg
+      svgComplete: ""
+      svgWhite: ui/public/static/img/meshmodels/kubernetes/white/service-white.svg
+      width: 20
+      z-index: 28
+    capabilities: []
+    status: enabled
+    metadata:
+      configurationUISchema: ""
+      genealogy: ""
+      instanceDetails: null
+      isAnnotation: false
+      isNamespaced: true
+      published: false
+      source_uri: git://github.com/kubernetes/kubernetes/master/api/openapi-spec/v3
+    configuration:
+      metadata:
+        annotations:
+          helm.sh/resource-policy: keep
+        labels:
+          app: kubelink
+        name: kubelink-service-headless
+        namespace: devtroncd
+      spec:
+        clusterIP: None
+        ports:
+          - name: app
+            port: 50051
+            protocol: TCP
+            targetPort: app
+        selector:
+          app: kubelink
+        sessionAffinity: None
+        type: ClusterIP
+    component:
+      version: v1
+      kind: Service
+      schema: ""
+  - id: 7ca7b376-0963-4846-8303-1e5962b870c5
+    schemaVersion: components.meshery.io/v1beta1
+    version: v1.0.0
+    displayName: postgresql-postgresql
+    description: ""
+    format: ""
+    model:
+      id: b3f5bc0d-30f7-607d-6c73-784ddde6cad8
+      schemaVersion: models.meshery.io/v1beta1
+      version: v1.0.0
+      name: kubernetes
+      displayName: Kubernetes
+      status: enabled
+      registrant:
+        id: 5bc80e3c-5d43-9eb4-d16c-78a2769247a6
+        name: Github
+        credential_id: 00000000-0000-0000-0000-000000000000
+        type: registry
+        sub_type: ""
+        kind: github
+        status: registered
+        user_id: 00000000-0000-0000-0000-000000000000
+        created_at: "2025-10-12T14:26:03.160654794Z"
+        updated_at: "2025-10-12T14:26:03.160654794Z"
+        deleted_at: "0001-01-01T00:00:00Z"
+        schemaVersion: ""
+      connection_id: 5bc80e3c-5d43-9eb4-d16c-78a2769247a6
+      category:
+        id: 9ca27d0d-66ce-42a9-8c85-6236563f2ddb
+        name: Orchestration & Management
+      subCategory: Scheduling & Orchestration
+      metadata:
+        isAnnotation: false
+        primaryColor: '#326CE5'
+        secondaryColor: '#7aa1f0'
+        shape: circle
+        styleOverrides: ""
+        svgColor: ui/public/static/img/meshmodels/kubernetes/color/kubernetes-color.svg
+        svgComplete: ""
+        svgWhite: ui/public/static/img/meshmodels/kubernetes/white/kubernetes-white.svg
+      model:
+        version: v1.32.0-alpha.3
+      components_count: 0
+      relationships_count: 0
+      components: null
+      relationships: null
+    styles:
+      background-position-y: "4.5"
+      height: 20
+      padding: 12
+      position:
+        x: 878.49609375
+        y: 573.0048828125
+      primaryColor: '#326CE5'
+      secondaryColor: '#7aa1f0'
+      shape: round-triangle
+      svgColor: ui/public/static/img/meshmodels/kubernetes/color/service-color.svg
+      svgComplete: ""
+      svgWhite: ui/public/static/img/meshmodels/kubernetes/white/service-white.svg
+      width: 20
+      z-index: 29
+    capabilities: []
+    status: enabled
+    metadata:
+      configurationUISchema: ""
+      genealogy: ""
+      instanceDetails: null
+      isAnnotation: false
+      isNamespaced: true
+      published: false
+      source_uri: git://github.com/kubernetes/kubernetes/master/api/openapi-spec/v3
+    configuration:
+      metadata:
+        annotations:
+          helm.sh/resource-policy: keep
+        labels:
+          app: postgresql
+          app.kubernetes.io/managed-by: Helm
+          release: devtron
+        name: postgresql-postgresql
+        namespace: devtroncd
+      spec:
+        ports:
+          - name: postgres
+            port: 5432
+            protocol: TCP
+            targetPort: postgres
+        selector:
+          app.kubernetes.io/instance: devtron
+          app.kubernetes.io/name: postgres
+        type: ClusterIP
+    component:
+      version: v1
+      kind: Service
+      schema: ""
+  - id: 42ed44fe-19b0-4da1-a880-13a51dbaaf82
+    schemaVersion: components.meshery.io/v1beta1
+    version: v1.0.0
+    displayName: postgresql-postgresql-headless
+    description: ""
+    format: ""
+    model:
+      id: b3f5bc0d-30f7-607d-6c73-784ddde6cad8
+      schemaVersion: models.meshery.io/v1beta1
+      version: v1.0.0
+      name: kubernetes
+      displayName: Kubernetes
+      status: enabled
+      registrant:
+        id: 5bc80e3c-5d43-9eb4-d16c-78a2769247a6
+        name: Github
+        credential_id: 00000000-0000-0000-0000-000000000000
+        type: registry
+        sub_type: ""
+        kind: github
+        status: registered
+        user_id: 00000000-0000-0000-0000-000000000000
+        created_at: "2025-10-12T14:26:03.160654794Z"
+        updated_at: "2025-10-12T14:26:03.160654794Z"
+        deleted_at: "0001-01-01T00:00:00Z"
+        schemaVersion: ""
+      connection_id: 5bc80e3c-5d43-9eb4-d16c-78a2769247a6
+      category:
+        id: 9ca27d0d-66ce-42a9-8c85-6236563f2ddb
+        name: Orchestration & Management
+      subCategory: Scheduling & Orchestration
+      metadata:
+        isAnnotation: false
+        primaryColor: '#326CE5'
+        secondaryColor: '#7aa1f0'
+        shape: circle
+        styleOverrides: ""
+        svgColor: ui/public/static/img/meshmodels/kubernetes/color/kubernetes-color.svg
+        svgComplete: ""
+        svgWhite: ui/public/static/img/meshmodels/kubernetes/white/kubernetes-white.svg
+      model:
+        version: v1.32.0-alpha.3
+      components_count: 0
+      relationships_count: 0
+      components: null
+      relationships: null
+    styles:
+      background-position-y: "4.5"
+      height: 20
+      padding: 12
+      position:
+        x: 986.49609375
+        y: 573.0048828125
+      primaryColor: '#326CE5'
+      secondaryColor: '#7aa1f0'
+      shape: round-triangle
+      svgColor: ui/public/static/img/meshmodels/kubernetes/color/service-color.svg
+      svgComplete: ""
+      svgWhite: ui/public/static/img/meshmodels/kubernetes/white/service-white.svg
+      width: 20
+      z-index: 30
+    capabilities: []
+    status: enabled
+    metadata:
+      configurationUISchema: ""
+      genealogy: ""
+      instanceDetails: null
+      isAnnotation: false
+      isNamespaced: true
+      published: false
+      source_uri: git://github.com/kubernetes/kubernetes/master/api/openapi-spec/v3
+    configuration:
+      metadata:
+        annotations:
+          helm.sh/resource-policy: keep
+        labels:
+          app: postgresql
+          app.kubernetes.io/managed-by: Helm
+          release: devtron
+        name: postgresql-postgresql-headless
+        namespace: devtroncd
+      spec:
+        clusterIP: None
+        ports:
+          - name: postgres
+            port: 5432
+            protocol: TCP
+            targetPort: postgres
+        selector:
+          app.kubernetes.io/instance: devtron
+          app.kubernetes.io/name: postgres
+        type: ClusterIP
+    component:
+      version: v1
+      kind: Service
+      schema: ""
+  - id: 515ec42b-5c9e-4361-83c1-f4092d7d24ae
+    schemaVersion: components.meshery.io/v1beta1
+    version: v1.0.0
+    displayName: argocd-dex-server
+    description: ""
+    format: ""
+    model:
+      id: b3f5bc0d-30f7-607d-6c73-784ddde6cad8
+      schemaVersion: models.meshery.io/v1beta1
+      version: v1.0.0
+      name: kubernetes
+      displayName: Kubernetes
+      status: enabled
+      registrant:
+        id: 5bc80e3c-5d43-9eb4-d16c-78a2769247a6
+        name: Github
+        credential_id: 00000000-0000-0000-0000-000000000000
+        type: registry
+        sub_type: ""
+        kind: github
+        status: registered
+        user_id: 00000000-0000-0000-0000-000000000000
+        created_at: "2025-10-12T14:26:03.160654794Z"
+        updated_at: "2025-10-12T14:26:03.160654794Z"
+        deleted_at: "0001-01-01T00:00:00Z"
+        schemaVersion: ""
+      connection_id: 5bc80e3c-5d43-9eb4-d16c-78a2769247a6
+      category:
+        id: 9ca27d0d-66ce-42a9-8c85-6236563f2ddb
+        name: Orchestration & Management
+      subCategory: Scheduling & Orchestration
+      metadata:
+        isAnnotation: false
+        primaryColor: '#326CE5'
+        secondaryColor: '#7aa1f0'
+        shape: circle
+        styleOverrides: ""
+        svgColor: ui/public/static/img/meshmodels/kubernetes/color/kubernetes-color.svg
+        svgComplete: ""
+        svgWhite: ui/public/static/img/meshmodels/kubernetes/white/kubernetes-white.svg
+      model:
+        version: v1.32.0-alpha.3
+      components_count: 0
+      relationships_count: 0
+      components: null
+      relationships: null
+    styles:
+      background-position-y: "4.5"
+      height: 20
+      padding: 12
+      position:
+        x: 662.49609375
+        y: 573.0048828125
+      primaryColor: '#326CE5'
+      secondaryColor: '#7aa1f0'
+      shape: round-triangle
+      svgColor: ui/public/static/img/meshmodels/kubernetes/color/service-color.svg
+      svgComplete: ""
+      svgWhite: ui/public/static/img/meshmodels/kubernetes/white/service-white.svg
+      width: 20
+      z-index: 27
+    capabilities: []
+    status: enabled
+    metadata:
+      configurationUISchema: ""
+      genealogy: ""
+      instanceDetails: null
+      isAnnotation: false
+      isNamespaced: true
+      published: false
+      source_uri: git://github.com/kubernetes/kubernetes/master/api/openapi-spec/v3
+    configuration:
+      metadata:
+        annotations:
+          helm.sh/resource-policy: keep
+          meta.helm.sh/release-name: devtron-operator
+          meta.helm.sh/release-namespace: default
+        labels:
+          app.kubernetes.io/component: dex-server
+          app.kubernetes.io/managed-by: Helm
+          app.kubernetes.io/name: argocd-dex-server
+          app.kubernetes.io/part-of: argocd
+        name: argocd-dex-server
+      spec:
+        ports:
+          - name: http
+            port: 5556
+            protocol: TCP
+            targetPort: 5556
+          - name: grpc
+            port: 5557
+            protocol: TCP
+            targetPort: 5557
+          - name: metrics
+            port: 5558
+            protocol: TCP
+            targetPort: 5558
+        selector:
+          app.kubernetes.io/name: argocd-dex-server
+    component:
+      version: v1
+      kind: Service
+      schema: ""
+  - id: 5cdf33dc-8060-4140-a5ca-17e7f3c1c3be
+    schemaVersion: components.meshery.io/v1beta1
+    version: v1.0.0
+    displayName: postgresql-postgresql-metrics
+    description: ""
+    format: ""
+    model:
+      id: b3f5bc0d-30f7-607d-6c73-784ddde6cad8
+      schemaVersion: models.meshery.io/v1beta1
+      version: v1.0.0
+      name: kubernetes
+      displayName: Kubernetes
+      status: enabled
+      registrant:
+        id: 5bc80e3c-5d43-9eb4-d16c-78a2769247a6
+        name: Github
+        credential_id: 00000000-0000-0000-0000-000000000000
+        type: registry
+        sub_type: ""
+        kind: github
+        status: registered
+        user_id: 00000000-0000-0000-0000-000000000000
+        created_at: "2025-10-12T14:26:03.160654794Z"
+        updated_at: "2025-10-12T14:26:03.160654794Z"
+        deleted_at: "0001-01-01T00:00:00Z"
+        schemaVersion: ""
+      connection_id: 5bc80e3c-5d43-9eb4-d16c-78a2769247a6
+      category:
+        id: 9ca27d0d-66ce-42a9-8c85-6236563f2ddb
+        name: Orchestration & Management
+      subCategory: Scheduling & Orchestration
+      metadata:
+        isAnnotation: false
+        primaryColor: '#326CE5'
+        secondaryColor: '#7aa1f0'
+        shape: circle
+        styleOverrides: ""
+        svgColor: ui/public/static/img/meshmodels/kubernetes/color/kubernetes-color.svg
+        svgComplete: ""
+        svgWhite: ui/public/static/img/meshmodels/kubernetes/white/kubernetes-white.svg
+      model:
+        version: v1.32.0-alpha.3
+      components_count: 0
+      relationships_count: 0
+      components: null
+      relationships: null
+    styles:
+      background-position-y: "4.5"
+      height: 20
+      padding: 12
+      position:
+        x: 1046.49609375
+        y: 189.0048828125
+      primaryColor: '#326CE5'
+      secondaryColor: '#7aa1f0'
+      shape: round-triangle
+      svgColor: ui/public/static/img/meshmodels/kubernetes/color/service-color.svg
+      svgComplete: ""
+      svgWhite: ui/public/static/img/meshmodels/kubernetes/white/service-white.svg
+      width: 20
+      z-index: 31
+    capabilities: []
+    status: enabled
+    metadata:
+      configurationUISchema: ""
+      genealogy: ""
+      instanceDetails: null
+      isAnnotation: false
+      isNamespaced: true
+      published: false
+      source_uri: git://github.com/kubernetes/kubernetes/master/api/openapi-spec/v3
+    configuration:
+      metadata:
+        annotations:
+          helm.sh/resource-policy: keep
+          prometheus.io/port: "9187"
+          prometheus.io/scrape: "true"
+        labels:
+          app: postgresql
+          app.kubernetes.io/managed-by: Helm
+          release: devtron
+        name: postgresql-postgresql-metrics
+        namespace: devtroncd
+      spec:
+        ports:
+          - name: http-metrics
+            port: 9187
+            targetPort: http-metrics
+        selector:
+          app.kubernetes.io/instance: devtron
+          app.kubernetes.io/name: postgres
+        type: ClusterIP
+    component:
+      version: v1
+      kind: Service
+      schema: ""
+  - id: 1586c53d-e6a0-49db-81f2-662533d65ffa
+    schemaVersion: components.meshery.io/v1beta1
+    version: v1.0.0
+    displayName: devtron
+    description: ""
+    format: ""
+    model:
+      id: b3f5bc0d-30f7-607d-6c73-784ddde6cad8
+      schemaVersion: models.meshery.io/v1beta1
+      version: v1.0.0
+      name: kubernetes
+      displayName: Kubernetes
+      status: enabled
+      registrant:
+        id: 5bc80e3c-5d43-9eb4-d16c-78a2769247a6
+        name: Github
+        credential_id: 00000000-0000-0000-0000-000000000000
+        type: registry
+        sub_type: ""
+        kind: github
+        status: registered
+        user_id: 00000000-0000-0000-0000-000000000000
+        created_at: "2025-10-12T14:26:03.160654794Z"
+        updated_at: "2025-10-12T14:26:03.160654794Z"
+        deleted_at: "0001-01-01T00:00:00Z"
+        schemaVersion: ""
+      connection_id: 5bc80e3c-5d43-9eb4-d16c-78a2769247a6
+      category:
+        id: 9ca27d0d-66ce-42a9-8c85-6236563f2ddb
+        name: Orchestration & Management
+      subCategory: Scheduling & Orchestration
+      metadata:
+        isAnnotation: false
+        primaryColor: '#326CE5'
+        secondaryColor: '#7aa1f0'
+        shape: circle
+        styleOverrides: ""
+        svgColor: ui/public/static/img/meshmodels/kubernetes/color/kubernetes-color.svg
+        svgComplete: ""
+        svgWhite: ui/public/static/img/meshmodels/kubernetes/white/kubernetes-white.svg
+      model:
+        version: v1.32.0-alpha.3
+      components_count: 0
+      relationships_count: 0
+      components: null
+      relationships: null
+    styles:
+      position:
+        x: 746.49609375
+        y: 673.0048828125
+      primaryColor: '#326CE5'
+      secondaryColor: '#7aa1f0'
+      shape: bottom-round-rectangle
+      svgColor: ui/public/static/img/meshmodels/kubernetes/color/serviceaccount-color.svg
+      svgComplete: ""
+      svgWhite: ui/public/static/img/meshmodels/kubernetes/white/serviceaccount-white.svg
+      z-index: 6
+    capabilities: []
+    status: enabled
+    metadata:
+      configurationUISchema: ""
+      genealogy: ""
+      instanceDetails: null
+      isAnnotation: false
+      isNamespaced: true
+      published: false
+      source_uri: git://github.com/kubernetes/kubernetes/master/api/openapi-spec/v3
+    configuration:
+      metadata:
+        annotations:
+          helm.sh/resource-policy: keep
+        labels:
+          release: devtron
+        name: devtron
+        namespace: devtroncd
+    component:
+      version: v1
+      kind: ServiceAccount
+      schema: ""
+  - id: 12d59f52-0e0b-4767-9222-968edd4be8b3
+    schemaVersion: components.meshery.io/v1beta1
+    version: v1.0.0
+    displayName: argocd-dex-server
+    description: ""
+    format: ""
+    model:
+      id: b3f5bc0d-30f7-607d-6c73-784ddde6cad8
+      schemaVersion: models.meshery.io/v1beta1
+      version: v1.0.0
+      name: kubernetes
+      displayName: Kubernetes
+      status: enabled
+      registrant:
+        id: 5bc80e3c-5d43-9eb4-d16c-78a2769247a6
+        name: Github
+        credential_id: 00000000-0000-0000-0000-000000000000
+        type: registry
+        sub_type: ""
+        kind: github
+        status: registered
+        user_id: 00000000-0000-0000-0000-000000000000
+        created_at: "2025-10-12T14:26:03.160654794Z"
+        updated_at: "2025-10-12T14:26:03.160654794Z"
+        deleted_at: "0001-01-01T00:00:00Z"
+        schemaVersion: ""
+      connection_id: 5bc80e3c-5d43-9eb4-d16c-78a2769247a6
+      category:
+        id: 9ca27d0d-66ce-42a9-8c85-6236563f2ddb
+        name: Orchestration & Management
+      subCategory: Scheduling & Orchestration
+      metadata:
+        isAnnotation: false
+        primaryColor: '#326CE5'
+        secondaryColor: '#7aa1f0'
+        shape: circle
+        styleOverrides: ""
+        svgColor: ui/public/static/img/meshmodels/kubernetes/color/kubernetes-color.svg
+        svgComplete: ""
+        svgWhite: ui/public/static/img/meshmodels/kubernetes/white/kubernetes-white.svg
+      model:
+        version: v1.32.0-alpha.3
+      components_count: 0
+      relationships_count: 0
+      components: null
+      relationships: null
+    styles:
+      position:
+        x: 654.49609375
+        y: 673.0048828125
+      primaryColor: '#326CE5'
+      secondaryColor: '#7aa1f0'
+      shape: bottom-round-rectangle
+      svgColor: ui/public/static/img/meshmodels/kubernetes/color/serviceaccount-color.svg
+      svgComplete: ""
+      svgWhite: ui/public/static/img/meshmodels/kubernetes/white/serviceaccount-white.svg
+      z-index: 5
+    capabilities: []
+    status: enabled
+    metadata:
+      configurationUISchema: ""
+      genealogy: ""
+      instanceDetails: null
+      isAnnotation: false
+      isNamespaced: true
+      published: false
+      source_uri: git://github.com/kubernetes/kubernetes/master/api/openapi-spec/v3
+    configuration:
+      metadata:
+        annotations:
+          helm.sh/resource-policy: keep
+          meta.helm.sh/release-name: devtron-operator
+          meta.helm.sh/release-namespace: default
+        labels:
+          app.kubernetes.io/component: dex-server
+          app.kubernetes.io/managed-by: Helm
+          app.kubernetes.io/name: argocd-dex-server
+          app.kubernetes.io/part-of: argocd
+        name: argocd-dex-server
+    component:
+      version: v1
+      kind: ServiceAccount
+      schema: ""
+  - id: aea7e6fe-fa70-4d75-9c52-da3ec3536955
+    schemaVersion: components.meshery.io/v1beta1
+    version: v1.0.0
+    displayName: chart-sync
+    description: ""
+    format: ""
+    model:
+      id: b3f5bc0d-30f7-607d-6c73-784ddde6cad8
+      schemaVersion: models.meshery.io/v1beta1
+      version: v1.0.0
+      name: kubernetes
+      displayName: Kubernetes
+      status: enabled
+      registrant:
+        id: 5bc80e3c-5d43-9eb4-d16c-78a2769247a6
+        name: Github
+        credential_id: 00000000-0000-0000-0000-000000000000
+        type: registry
+        sub_type: ""
+        kind: github
+        status: registered
+        user_id: 00000000-0000-0000-0000-000000000000
+        created_at: "2025-10-12T14:26:03.160654794Z"
+        updated_at: "2025-10-12T14:26:03.160654794Z"
+        deleted_at: "0001-01-01T00:00:00Z"
+        schemaVersion: ""
+      connection_id: 5bc80e3c-5d43-9eb4-d16c-78a2769247a6
+      category:
+        id: 9ca27d0d-66ce-42a9-8c85-6236563f2ddb
+        name: Orchestration & Management
+      subCategory: Scheduling & Orchestration
+      metadata:
+        isAnnotation: false
+        primaryColor: '#326CE5'
+        secondaryColor: '#7aa1f0'
+        shape: circle
+        styleOverrides: ""
+        svgColor: ui/public/static/img/meshmodels/kubernetes/color/kubernetes-color.svg
+        svgComplete: ""
+        svgWhite: ui/public/static/img/meshmodels/kubernetes/white/kubernetes-white.svg
+      model:
+        version: v1.32.0-alpha.3
+      components_count: 0
+      relationships_count: 0
+      components: null
+      relationships: null
+    styles:
+      position:
+        x: 838.49609375
+        y: 673.0048828125
+      primaryColor: '#326CE5'
+      secondaryColor: '#7aa1f0'
+      shape: bottom-round-rectangle
+      svgColor: ui/public/static/img/meshmodels/kubernetes/color/serviceaccount-color.svg
+      svgComplete: ""
+      svgWhite: ui/public/static/img/meshmodels/kubernetes/white/serviceaccount-white.svg
+      z-index: 7
+    capabilities: []
+    status: enabled
+    metadata:
+      configurationUISchema: ""
+      genealogy: ""
+      instanceDetails: null
+      isAnnotation: false
+      isNamespaced: true
+      published: false
+      source_uri: git://github.com/kubernetes/kubernetes/master/api/openapi-spec/v3
+    configuration:
+      metadata:
+        labels:
+          release: devtron
+        name: chart-sync
+        namespace: devtroncd
+    component:
+      version: v1
+      kind: ServiceAccount
+      schema: ""
+  - id: dc7ffec0-613f-4324-af65-aa72574b8746
+    schemaVersion: components.meshery.io/v1beta1
+    version: v1.0.0
+    displayName: devtron-default-sa
+    description: ""
+    format: ""
+    model:
+      id: b3f5bc0d-30f7-607d-6c73-784ddde6cad8
+      schemaVersion: models.meshery.io/v1beta1
+      version: v1.0.0
+      name: kubernetes
+      displayName: Kubernetes
+      status: enabled
+      registrant:
+        id: 5bc80e3c-5d43-9eb4-d16c-78a2769247a6
+        name: Github
+        credential_id: 00000000-0000-0000-0000-000000000000
+        type: registry
+        sub_type: ""
+        kind: github
+        status: registered
+        user_id: 00000000-0000-0000-0000-000000000000
+        created_at: "2025-10-12T14:26:03.160654794Z"
+        updated_at: "2025-10-12T14:26:03.160654794Z"
+        deleted_at: "0001-01-01T00:00:00Z"
+        schemaVersion: ""
+      connection_id: 5bc80e3c-5d43-9eb4-d16c-78a2769247a6
+      category:
+        id: 9ca27d0d-66ce-42a9-8c85-6236563f2ddb
+        name: Orchestration & Management
+      subCategory: Scheduling & Orchestration
+      metadata:
+        isAnnotation: false
+        primaryColor: '#326CE5'
+        secondaryColor: '#7aa1f0'
+        shape: circle
+        styleOverrides: ""
+        svgColor: ui/public/static/img/meshmodels/kubernetes/color/kubernetes-color.svg
+        svgComplete: ""
+        svgWhite: ui/public/static/img/meshmodels/kubernetes/white/kubernetes-white.svg
+      model:
+        version: v1.32.0-alpha.3
+      components_count: 0
+      relationships_count: 0
+      components: null
+      relationships: null
+    styles:
+      position:
+        x: 930.49609375
+        y: 673.0048828125
+      primaryColor: '#326CE5'
+      secondaryColor: '#7aa1f0'
+      shape: bottom-round-rectangle
+      svgColor: ui/public/static/img/meshmodels/kubernetes/color/serviceaccount-color.svg
+      svgComplete: ""
+      svgWhite: ui/public/static/img/meshmodels/kubernetes/white/serviceaccount-white.svg
+      z-index: 8
+    capabilities: []
+    status: enabled
+    metadata:
+      configurationUISchema: ""
+      genealogy: ""
+      instanceDetails: null
+      isAnnotation: false
+      isNamespaced: true
+      published: false
+      source_uri: git://github.com/kubernetes/kubernetes/master/api/openapi-spec/v3
+    configuration:
+      metadata:
+        labels:
+          release: devtron
+        name: devtron-default-sa
+        namespace: devtroncd
+    component:
+      version: v1
+      kind: ServiceAccount
+      schema: ""
+  - id: 41cd3364-b405-46ad-b3fe-6f544f3fdf91
+    schemaVersion: components.meshery.io/v1beta1
+    version: v1.0.0
+    displayName: postgresql-postgresql
+    description: ""
+    format: ""
+    model:
+      id: b3f5bc0d-30f7-607d-6c73-784ddde6cad8
+      schemaVersion: models.meshery.io/v1beta1
+      version: v1.0.0
+      name: kubernetes
+      displayName: Kubernetes
+      status: enabled
+      registrant:
+        id: 5bc80e3c-5d43-9eb4-d16c-78a2769247a6
+        name: Github
+        credential_id: 00000000-0000-0000-0000-000000000000
+        type: registry
+        sub_type: ""
+        kind: github
+        status: registered
+        user_id: 00000000-0000-0000-0000-000000000000
+        created_at: "2025-10-12T14:26:03.160654794Z"
+        updated_at: "2025-10-12T14:26:03.160654794Z"
+        deleted_at: "0001-01-01T00:00:00Z"
+        schemaVersion: ""
+      connection_id: 5bc80e3c-5d43-9eb4-d16c-78a2769247a6
+      category:
+        id: 9ca27d0d-66ce-42a9-8c85-6236563f2ddb
+        name: Orchestration & Management
+      subCategory: Scheduling & Orchestration
+      metadata:
+        isAnnotation: false
+        primaryColor: '#326CE5'
+        secondaryColor: '#7aa1f0'
+        shape: circle
+        styleOverrides: ""
+        svgColor: ui/public/static/img/meshmodels/kubernetes/color/kubernetes-color.svg
+        svgComplete: ""
+        svgWhite: ui/public/static/img/meshmodels/kubernetes/white/kubernetes-white.svg
+      model:
+        version: v1.32.0-alpha.3
+      components_count: 0
+      relationships_count: 0
+      components: null
+      relationships: null
+    styles:
+      background-opacity: 0.2
+      height: 15
+      position:
+        x: 911.49609375
+        y: 850.0048828125
+      primaryColor: '#326CE5'
+      secondaryColor: '#7aa1f0'
+      shape: round-rectangle
+      svgColor: ui/public/static/img/meshmodels/kubernetes/color/statefulset-color.svg
+      svgComplete: ui/public/static/img/meshmodels/kubernetes/complete/statefulset-complete.svg
+      svgWhite: ui/public/static/img/meshmodels/kubernetes/white/statefulset-white.svg
+      width: 15
+      x: 12
+      y: 20
+      z-index: 36
+    capabilities: []
+    status: enabled
+    metadata:
+      configurationUISchema: ""
+      genealogy: parent
+      instanceDetails: null
+      isAnnotation: false
+      isNamespaced: true
+      published: false
+      source_uri: git://github.com/kubernetes/kubernetes/master/api/openapi-spec/v3
+    configuration:
+      metadata:
+        annotations:
+          helm.sh/resource-policy: keep
+        labels:
+          app.kubernetes.io/instance: devtron
+          app.kubernetes.io/managed-by: Helm
+          app.kubernetes.io/name: postgres
+          app.kubernetes.io/version: "14.5"
+          helm.sh/chart: postgres-0.4.0
+        name: postgresql-postgresql
+      spec:
+        podManagementPolicy: OrderedReady
+        replicas: 1
+        selector:
+          matchLabels:
+            app.kubernetes.io/instance: devtron
+            app.kubernetes.io/name: postgres
+        serviceName: postgresql-postgresql
+        template:
+          metadata:
+            labels:
+              app.kubernetes.io/instance: devtron
+              app.kubernetes.io/name: postgres
+          spec:
+            containers:
+              - env:
+                  - name: PGDATA
+                    value: /var/lib/postgresql/data/pg
+                  - name: POSTGRES_PASSWORD
+                    valueFrom:
+                      secretKeyRef:
+                        key: postgresql-password
+                        name: postgresql-postgresql
+                  - name: POSTGRES_HOST_AUTH_METHOD
+                    value: md5
+                  - name: POSTGRES_INITDB_ARGS
+                    value: --auth-local=md5
+                envFrom:
+                  - secretRef:
+                      name: postgresql-postgresql
+                  - configMapRef:
+                      name: devtron-common-cm
+                image: quay.io/devtron/postgres:14.9
+                imagePullPolicy: IfNotPresent
+                livenessProbe:
+                  exec:
+                    command:
+                      - sh
+                      - -c
+                      - pg_isready -h localhost
+                  failureThreshold: 3
+                  initialDelaySeconds: 10
+                  periodSeconds: 10
+                  successThreshold: 1
+                  timeoutSeconds: 5
+                name: postgres
+                ports:
+                  - containerPort: 5432
+                    name: postgres
+                    protocol: TCP
+                readinessProbe:
+                  exec:
+                    command:
+                      - sh
+                      - -c
+                      - pg_isready -h localhost
+                  failureThreshold: 3
+                  initialDelaySeconds: 10
+                  periodSeconds: 10
+                  successThreshold: 1
+                  timeoutSeconds: 5
+                securityContext:
+                  allowPrivilegeEscalation: false
+                  privileged: false
+                  readOnlyRootFilesystem: true
+                  runAsGroup: 999
+                  runAsNonRoot: true
+                  runAsUser: 999
+                startupProbe:
+                  exec:
+                    command:
+                      - sh
+                      - -c
+                      - pg_isready -h localhost
+                  failureThreshold: 30
+                  initialDelaySeconds: 10
+                  periodSeconds: 10
+                  successThreshold: 1
+                  timeoutSeconds: 5
+                volumeMounts:
+                  - mountPath: /var/run
+                    name: run
+                  - mountPath: /tmp
+                    name: tmp
+                  - mountPath: /var/lib/postgresql/data
+                    name: data
+                  - mountPath: /docker-entrypoint-initdb.d
+                    name: scripts
+                  - mountPath: /etc/postgresql
+                    name: configs
+              - env:
+                  - name: DATA_SOURCE_URI
+                    value: 127.0.0.1:5432/orchestrator?sslmode=disable
+                  - name: DATA_SOURCE_PASS
+                    valueFrom:
+                      secretKeyRef:
+                        key: postgresql-password
+                        name: postgresql-postgresql
+                  - name: DATA_SOURCE_USER
+                    value: postgres
+                envFrom:
+                  - configMapRef:
+                      name: devtron-common-cm
+                image: quay.io/devtron/postgres_exporter:v0.10.1
+                imagePullPolicy: IfNotPresent
+                livenessProbe:
+                  failureThreshold: 6
+                  httpGet:
+                    path: /
+                    port: http-metrics
+                  initialDelaySeconds: 5
+                  periodSeconds: 10
+                  successThreshold: 1
+                  timeoutSeconds: 5
+                name: metrics
+                ports:
+                  - containerPort: 9187
+                    name: http-metrics
+                readinessProbe:
+                  failureThreshold: 6
+                  httpGet:
+                    path: /
+                    port: http-metrics
+                  initialDelaySeconds: 5
+                  periodSeconds: 10
+                  successThreshold: 1
+                  timeoutSeconds: 5
+                volumeMounts: null
+            initContainers:
+              - command:
+                  - /initscripts/init.sh
+                envFrom:
+                  - configMapRef:
+                      name: devtron-common-cm
+                image: quay.io/devtron/postgres:14.9
+                imagePullPolicy: IfNotPresent
+                name: postgres-init
+                securityContext:
+                  allowPrivilegeEscalation: false
+                  privileged: false
+                  readOnlyRootFilesystem: true
+                  runAsGroup: 999
+                  runAsNonRoot: true
+                  runAsUser: 999
+                volumeMounts:
+                  - mountPath: /customscripts
+                    name: customscripts-volume
+                  - mountPath: /initscripts
+                    name: initscripts
+                  - mountPath: /scripts
+                    name: scripts
+                  - mountPath: /configs
+                    name: configs
+            securityContext:
+              fsGroup: 999
+            serviceAccountName: devtron-default-sa
+            volumes:
+              - emptyDir: {}
+                name: run
+              - emptyDir: {}
+                name: tmp
+              - emptyDir: {}
+                name: scripts
+              - emptyDir: {}
+                name: configs
+              - configMap:
+                  defaultMode: 365
+                  name: postgresql-postgresql-scripts
+                name: initscripts
+              - configMap:
+                  defaultMode: 365
+                  name: postgresql-postgresql-customscripts
+                name: customscripts-volume
+        updateStrategy:
+          type: RollingUpdate
+        volumeClaimTemplates:
+          - metadata:
+              name: data
+            spec:
+              accessModes:
+                - ReadWriteOnce
+              resources:
+                requests:
+                  storage: 20Gi
+    component:
+      version: apps/v1
+      kind: StatefulSet
+      schema: ""
+preferences:
+  layers:
+    relationships:
+      hierarchical-sibling-matchlabels: false
+relationships:
+  - id: 2cb59809-11a3-43c2-b986-d2a4994edc26
+    evaluationQuery: ""
+    kind: hierarchical
+    metadata:
+      description: Namespace to namespaced components
+      styles:
+        primaryColor: ""
+        svgColor: ""
+        svgWhite: ""
+      isAnnotation: false
+    model:
+      id: b3f5bc0d-30f7-607d-6c73-784ddde6cad8
+      schemaVersion: models.meshery.io/v1beta1
+      version: v1.0.0
+      name: kubernetes
+      displayName: Kubernetes
+      status: enabled
+      registrant:
+        id: 00000000-0000-0000-0000-000000000000
+        name: ""
+        type: ""
+        sub_type: ""
+        kind: ""
+        status: ""
+        created_at: "0001-01-01T00:00:00Z"
+        updated_at: "0001-01-01T00:00:00Z"
+        deleted_at: null
+        schemaVersion: ""
+      connection_id: 5bc80e3c-5d43-9eb4-d16c-78a2769247a6
+      category:
+        id: 9ca27d0d-66ce-42a9-8c85-6236563f2ddb
+        name: Orchestration & Management
+      subCategory: Scheduling & Orchestration
+      metadata:
+        isAnnotation: false
+        primaryColor: '#326CE5'
+        secondaryColor: '#7aa1f0'
+        shape: circle
+        styleOverrides: ""
+        svgColor: ui/public/static/img/meshmodels/kubernetes/color/kubernetes-color.svg
+        svgComplete: ""
+        svgWhite: ui/public/static/img/meshmodels/kubernetes/white/kubernetes-white.svg
+      model:
+        version: v1.32.0-alpha.3
+      components_count: 0
+      relationships_count: 0
+      components: null
+      relationships: null
+    schemaVersion: relationships.meshery.io/v1alpha3
+    selectors:
+      - allow:
+          from:
+            - id: c58c6c35-098c-4b95-9d88-778499239d03
+              kind: '*'
+              match: {}
+              match_strategy_matrix: null
+              model:
+                id: 00000000-0000-0000-0000-000000000000
+                schemaVersion: ""
+                version: ""
+                name: '*'
+                displayName: ""
+                status: ""
+                registrant:
+                  id: 00000000-0000-0000-0000-000000000000
+                  name: ""
+                  type: ""
+                  sub_type: ""
+                  kind: ""
+                  status: ""
+                  created_at: "0001-01-01T00:00:00Z"
+                  updated_at: "0001-01-01T00:00:00Z"
+                  deleted_at: null
+                  schemaVersion: ""
+                connection_id: 00000000-0000-0000-0000-000000000000
+                category:
+                  id: 00000000-0000-0000-0000-000000000000
+                  name: ""
+                subCategory: ""
+                metadata: null
+                model:
+                  version: ""
+                components_count: 0
+                relationships_count: 0
+                components: null
+                relationships: null
+              patch:
+                patchStrategy: replace
+                mutatedRef:
+                  - - configuration
+                    - metadata
+                    - namespace
+          to:
+            - id: 59cfb0c1-50f3-4f7c-895f-b06144e58c93
+              kind: Namespace
+              match: {}
+              match_strategy_matrix: null
+              model:
+                id: 00000000-0000-0000-0000-000000000000
+                schemaVersion: ""
+                version: ""
+                name: kubernetes
+                displayName: ""
+                status: ""
+                registrant:
+                  id: 00000000-0000-0000-0000-000000000000
+                  name: ""
+                  type: ""
+                  sub_type: ""
+                  kind: github
+                  status: ""
+                  created_at: "0001-01-01T00:00:00Z"
+                  updated_at: "0001-01-01T00:00:00Z"
+                  deleted_at: null
+                  schemaVersion: ""
+                connection_id: 00000000-0000-0000-0000-000000000000
+                category:
+                  id: 00000000-0000-0000-0000-000000000000
+                  name: ""
+                subCategory: ""
+                metadata: null
+                model:
+                  version: ""
+                components_count: 0
+                relationships_count: 0
+                components: null
+                relationships: null
+              patch:
+                patchStrategy: replace
+                mutatorRef:
+                  - - displayName
+    subType: inventory
+    status: approved
+    type: parent
+    version: v1.0.0
+  - id: 3023a233-bc5f-42f4-a5c2-7c675758546d
+    evaluationQuery: ""
+    kind: edge
+    metadata:
+      description: In Kubernetes, ConfigMaps are a versatile resource that can be referenced by various other resources to provide configuration data to applications or other Kubnernetes resources.\n\nBy referencing ConfigMaps in these various contexts, you can centralize and manage configuration data more efficiently, allowing for easier updates, versioning, and maintenance of configurations in a Kubernetes environment.
+      styles:
+        primaryColor: ""
+        svgColor: ""
+        svgWhite: ""
+      isAnnotation: false
+    model:
+      id: b3f5bc0d-30f7-607d-6c73-784ddde6cad8
+      schemaVersion: models.meshery.io/v1beta1
+      version: v1.0.0
+      name: kubernetes
+      displayName: Kubernetes
+      status: enabled
+      registrant:
+        id: 00000000-0000-0000-0000-000000000000
+        name: ""
+        type: ""
+        sub_type: ""
+        kind: ""
+        status: ""
+        created_at: "0001-01-01T00:00:00Z"
+        updated_at: "0001-01-01T00:00:00Z"
+        deleted_at: null
+        schemaVersion: ""
+      connection_id: 5bc80e3c-5d43-9eb4-d16c-78a2769247a6
+      category:
+        id: 9ca27d0d-66ce-42a9-8c85-6236563f2ddb
+        name: Orchestration & Management
+      subCategory: Scheduling & Orchestration
+      metadata:
+        isAnnotation: false
+        primaryColor: '#326CE5'
+        secondaryColor: '#7aa1f0'
+        shape: circle
+        styleOverrides: ""
+        svgColor: ui/public/static/img/meshmodels/kubernetes/color/kubernetes-color.svg
+        svgComplete: ""
+        svgWhite: ui/public/static/img/meshmodels/kubernetes/white/kubernetes-white.svg
+      model:
+        version: v1.32.0-alpha.3
+      components_count: 0
+      relationships_count: 0
+      components: null
+      relationships: null
+    schemaVersion: relationships.meshery.io/v1alpha3
+    selectors:
+      - allow:
+          from:
+            - id: 6d4ad9d9-af51-4569-9abe-a5197e75affb
+              kind: ConfigMap
+              match: {}
+              match_strategy_matrix: null
+              model:
+                id: 00000000-0000-0000-0000-000000000000
+                schemaVersion: ""
+                version: ""
+                name: kubernetes
+                displayName: ""
+                status: ""
+                registrant:
+                  id: 00000000-0000-0000-0000-000000000000
+                  name: ""
+                  type: ""
+                  sub_type: ""
+                  kind: github
+                  status: ""
+                  created_at: "0001-01-01T00:00:00Z"
+                  updated_at: "0001-01-01T00:00:00Z"
+                  deleted_at: null
+                  schemaVersion: ""
+                connection_id: 00000000-0000-0000-0000-000000000000
+                category:
+                  id: 00000000-0000-0000-0000-000000000000
+                  name: ""
+                subCategory: ""
+                metadata: null
+                model:
+                  version: ""
+                components_count: 0
+                relationships_count: 0
+                components: null
+                relationships: null
+              patch:
+                patchStrategy: replace
+                mutatorRef:
+                  - - displayName
+          to:
+            - id: ce42bd94-2fb6-451e-bba2-e88a6c83fa6b
+              kind: Deployment
+              match: {}
+              match_strategy_matrix: null
+              model:
+                id: 00000000-0000-0000-0000-000000000000
+                schemaVersion: ""
+                version: ""
+                name: kubernetes
+                displayName: ""
+                status: ""
+                registrant:
+                  id: 00000000-0000-0000-0000-000000000000
+                  name: ""
+                  type: ""
+                  sub_type: ""
+                  kind: github
+                  status: ""
+                  created_at: "0001-01-01T00:00:00Z"
+                  updated_at: "0001-01-01T00:00:00Z"
+                  deleted_at: null
+                  schemaVersion: ""
+                connection_id: 00000000-0000-0000-0000-000000000000
+                category:
+                  id: 00000000-0000-0000-0000-000000000000
+                  name: ""
+                subCategory: ""
+                metadata: null
+                model:
+                  version: ""
+                components_count: 0
+                relationships_count: 0
+                components: null
+                relationships: null
+              patch:
+                patchStrategy: replace
+                mutatedRef:
+                  - - configuration
+                    - spec
+                    - template
+                    - spec
+                    - containers
+                    - "0"
+                    - envFrom
+                    - "0"
+                    - configMapRef
+                    - name
+        deny:
+          from: null
+          to: null
+    subType: reference
+    status: approved
+    type: non-binding
+    version: v1.0.0
+  - id: 3b295b2c-b76a-4401-ad19-fa7c82571f85
+    evaluationQuery: ""
+    kind: hierarchical
+    metadata:
+      description: Namespace to namespaced components
+      styles:
+        primaryColor: ""
+        svgColor: ""
+        svgWhite: ""
+      isAnnotation: false
+    model:
+      id: b3f5bc0d-30f7-607d-6c73-784ddde6cad8
+      schemaVersion: models.meshery.io/v1beta1
+      version: v1.0.0
+      name: kubernetes
+      displayName: Kubernetes
+      status: enabled
+      registrant:
+        id: 00000000-0000-0000-0000-000000000000
+        name: ""
+        type: ""
+        sub_type: ""
+        kind: ""
+        status: ""
+        created_at: "0001-01-01T00:00:00Z"
+        updated_at: "0001-01-01T00:00:00Z"
+        deleted_at: null
+        schemaVersion: ""
+      connection_id: 5bc80e3c-5d43-9eb4-d16c-78a2769247a6
+      category:
+        id: 9ca27d0d-66ce-42a9-8c85-6236563f2ddb
+        name: Orchestration & Management
+      subCategory: Scheduling & Orchestration
+      metadata:
+        isAnnotation: false
+        primaryColor: '#326CE5'
+        secondaryColor: '#7aa1f0'
+        shape: circle
+        styleOverrides: ""
+        svgColor: ui/public/static/img/meshmodels/kubernetes/color/kubernetes-color.svg
+        svgComplete: ""
+        svgWhite: ui/public/static/img/meshmodels/kubernetes/white/kubernetes-white.svg
+      model:
+        version: v1.32.0-alpha.3
+      components_count: 0
+      relationships_count: 0
+      components: null
+      relationships: null
+    schemaVersion: relationships.meshery.io/v1alpha3
+    selectors:
+      - allow:
+          from:
+            - id: 7ca7b376-0963-4846-8303-1e5962b870c5
+              kind: '*'
+              match: {}
+              match_strategy_matrix: null
+              model:
+                id: 00000000-0000-0000-0000-000000000000
+                schemaVersion: ""
+                version: ""
+                name: '*'
+                displayName: ""
+                status: ""
+                registrant:
+                  id: 00000000-0000-0000-0000-000000000000
+                  name: ""
+                  type: ""
+                  sub_type: ""
+                  kind: ""
+                  status: ""
+                  created_at: "0001-01-01T00:00:00Z"
+                  updated_at: "0001-01-01T00:00:00Z"
+                  deleted_at: null
+                  schemaVersion: ""
+                connection_id: 00000000-0000-0000-0000-000000000000
+                category:
+                  id: 00000000-0000-0000-0000-000000000000
+                  name: ""
+                subCategory: ""
+                metadata: null
+                model:
+                  version: ""
+                components_count: 0
+                relationships_count: 0
+                components: null
+                relationships: null
+              patch:
+                patchStrategy: replace
+                mutatedRef:
+                  - - configuration
+                    - metadata
+                    - namespace
+          to:
+            - id: 86c08e70-5da8-4970-a779-81a0ce712463
+              kind: Namespace
+              match: {}
+              match_strategy_matrix: null
+              model:
+                id: 00000000-0000-0000-0000-000000000000
+                schemaVersion: ""
+                version: ""
+                name: kubernetes
+                displayName: ""
+                status: ""
+                registrant:
+                  id: 00000000-0000-0000-0000-000000000000
+                  name: ""
+                  type: ""
+                  sub_type: ""
+                  kind: github
+                  status: ""
+                  created_at: "0001-01-01T00:00:00Z"
+                  updated_at: "0001-01-01T00:00:00Z"
+                  deleted_at: null
+                  schemaVersion: ""
+                connection_id: 00000000-0000-0000-0000-000000000000
+                category:
+                  id: 00000000-0000-0000-0000-000000000000
+                  name: ""
+                subCategory: ""
+                metadata: null
+                model:
+                  version: ""
+                components_count: 0
+                relationships_count: 0
+                components: null
+                relationships: null
+              patch:
+                patchStrategy: replace
+                mutatorRef:
+                  - - displayName
+    subType: inventory
+    status: approved
+    type: parent
+    version: v1.0.0
+  - id: 442002ad-b137-4cb6-9ad1-b66ea970101a
+    evaluationQuery: ""
+    kind: hierarchical
+    metadata:
+      description: Namespace to namespaced components
+      styles:
+        primaryColor: ""
+        svgColor: ""
+        svgWhite: ""
+      isAnnotation: false
+    model:
+      id: b3f5bc0d-30f7-607d-6c73-784ddde6cad8
+      schemaVersion: models.meshery.io/v1beta1
+      version: v1.0.0
+      name: kubernetes
+      displayName: Kubernetes
+      status: enabled
+      registrant:
+        id: 00000000-0000-0000-0000-000000000000
+        name: ""
+        type: ""
+        sub_type: ""
+        kind: ""
+        status: ""
+        created_at: "0001-01-01T00:00:00Z"
+        updated_at: "0001-01-01T00:00:00Z"
+        deleted_at: null
+        schemaVersion: ""
+      connection_id: 5bc80e3c-5d43-9eb4-d16c-78a2769247a6
+      category:
+        id: 9ca27d0d-66ce-42a9-8c85-6236563f2ddb
+        name: Orchestration & Management
+      subCategory: Scheduling & Orchestration
+      metadata:
+        isAnnotation: false
+        primaryColor: '#326CE5'
+        secondaryColor: '#7aa1f0'
+        shape: circle
+        styleOverrides: ""
+        svgColor: ui/public/static/img/meshmodels/kubernetes/color/kubernetes-color.svg
+        svgComplete: ""
+        svgWhite: ui/public/static/img/meshmodels/kubernetes/white/kubernetes-white.svg
+      model:
+        version: v1.32.0-alpha.3
+      components_count: 0
+      relationships_count: 0
+      components: null
+      relationships: null
+    schemaVersion: relationships.meshery.io/v1alpha3
+    selectors:
+      - allow:
+          from:
+            - id: 5cdf33dc-8060-4140-a5ca-17e7f3c1c3be
+              kind: '*'
+              match: {}
+              match_strategy_matrix: null
+              model:
+                id: 00000000-0000-0000-0000-000000000000
+                schemaVersion: ""
+                version: ""
+                name: '*'
+                displayName: ""
+                status: ""
+                registrant:
+                  id: 00000000-0000-0000-0000-000000000000
+                  name: ""
+                  type: ""
+                  sub_type: ""
+                  kind: ""
+                  status: ""
+                  created_at: "0001-01-01T00:00:00Z"
+                  updated_at: "0001-01-01T00:00:00Z"
+                  deleted_at: null
+                  schemaVersion: ""
+                connection_id: 00000000-0000-0000-0000-000000000000
+                category:
+                  id: 00000000-0000-0000-0000-000000000000
+                  name: ""
+                subCategory: ""
+                metadata: null
+                model:
+                  version: ""
+                components_count: 0
+                relationships_count: 0
+                components: null
+                relationships: null
+              patch:
+                patchStrategy: replace
+                mutatedRef:
+                  - - configuration
+                    - metadata
+                    - namespace
+          to:
+            - id: 86c08e70-5da8-4970-a779-81a0ce712463
+              kind: Namespace
+              match: {}
+              match_strategy_matrix: null
+              model:
+                id: 00000000-0000-0000-0000-000000000000
+                schemaVersion: ""
+                version: ""
+                name: kubernetes
+                displayName: ""
+                status: ""
+                registrant:
+                  id: 00000000-0000-0000-0000-000000000000
+                  name: ""
+                  type: ""
+                  sub_type: ""
+                  kind: github
+                  status: ""
+                  created_at: "0001-01-01T00:00:00Z"
+                  updated_at: "0001-01-01T00:00:00Z"
+                  deleted_at: null
+                  schemaVersion: ""
+                connection_id: 00000000-0000-0000-0000-000000000000
+                category:
+                  id: 00000000-0000-0000-0000-000000000000
+                  name: ""
+                subCategory: ""
+                metadata: null
+                model:
+                  version: ""
+                components_count: 0
+                relationships_count: 0
+                components: null
+                relationships: null
+              patch:
+                patchStrategy: replace
+                mutatorRef:
+                  - - displayName
+    subType: inventory
+    status: approved
+    type: parent
+    version: v1.0.0
+  - id: 44297448-29be-46ad-8532-ce3d6d5c0f1a
+    evaluationQuery: ""
+    kind: hierarchical
+    metadata:
+      description: Namespace to namespaced components
+      styles:
+        primaryColor: ""
+        svgColor: ""
+        svgWhite: ""
+      isAnnotation: false
+    model:
+      id: b3f5bc0d-30f7-607d-6c73-784ddde6cad8
+      schemaVersion: models.meshery.io/v1beta1
+      version: v1.0.0
+      name: kubernetes
+      displayName: Kubernetes
+      status: enabled
+      registrant:
+        id: 00000000-0000-0000-0000-000000000000
+        name: ""
+        type: ""
+        sub_type: ""
+        kind: ""
+        status: ""
+        created_at: "0001-01-01T00:00:00Z"
+        updated_at: "0001-01-01T00:00:00Z"
+        deleted_at: null
+        schemaVersion: ""
+      connection_id: 5bc80e3c-5d43-9eb4-d16c-78a2769247a6
+      category:
+        id: 9ca27d0d-66ce-42a9-8c85-6236563f2ddb
+        name: Orchestration & Management
+      subCategory: Scheduling & Orchestration
+      metadata:
+        isAnnotation: false
+        primaryColor: '#326CE5'
+        secondaryColor: '#7aa1f0'
+        shape: circle
+        styleOverrides: ""
+        svgColor: ui/public/static/img/meshmodels/kubernetes/color/kubernetes-color.svg
+        svgComplete: ""
+        svgWhite: ui/public/static/img/meshmodels/kubernetes/white/kubernetes-white.svg
+      model:
+        version: v1.32.0-alpha.3
+      components_count: 0
+      relationships_count: 0
+      components: null
+      relationships: null
+    schemaVersion: relationships.meshery.io/v1alpha3
+    selectors:
+      - allow:
+          from:
+            - id: f8994b85-2b32-4cd9-921a-dfbc8fd3ca7f
+              kind: '*'
+              match: {}
+              match_strategy_matrix: null
+              model:
+                id: 00000000-0000-0000-0000-000000000000
+                schemaVersion: ""
+                version: ""
+                name: '*'
+                displayName: ""
+                status: ""
+                registrant:
+                  id: 00000000-0000-0000-0000-000000000000
+                  name: ""
+                  type: ""
+                  sub_type: ""
+                  kind: ""
+                  status: ""
+                  created_at: "0001-01-01T00:00:00Z"
+                  updated_at: "0001-01-01T00:00:00Z"
+                  deleted_at: null
+                  schemaVersion: ""
+                connection_id: 00000000-0000-0000-0000-000000000000
+                category:
+                  id: 00000000-0000-0000-0000-000000000000
+                  name: ""
+                subCategory: ""
+                metadata: null
+                model:
+                  version: ""
+                components_count: 0
+                relationships_count: 0
+                components: null
+                relationships: null
+              patch:
+                patchStrategy: replace
+                mutatedRef:
+                  - - configuration
+                    - metadata
+                    - namespace
+          to:
+            - id: 86c08e70-5da8-4970-a779-81a0ce712463
+              kind: Namespace
+              match: {}
+              match_strategy_matrix: null
+              model:
+                id: 00000000-0000-0000-0000-000000000000
+                schemaVersion: ""
+                version: ""
+                name: kubernetes
+                displayName: ""
+                status: ""
+                registrant:
+                  id: 00000000-0000-0000-0000-000000000000
+                  name: ""
+                  type: ""
+                  sub_type: ""
+                  kind: github
+                  status: ""
+                  created_at: "0001-01-01T00:00:00Z"
+                  updated_at: "0001-01-01T00:00:00Z"
+                  deleted_at: null
+                  schemaVersion: ""
+                connection_id: 00000000-0000-0000-0000-000000000000
+                category:
+                  id: 00000000-0000-0000-0000-000000000000
+                  name: ""
+                subCategory: ""
+                metadata: null
+                model:
+                  version: ""
+                components_count: 0
+                relationships_count: 0
+                components: null
+                relationships: null
+              patch:
+                patchStrategy: replace
+                mutatorRef:
+                  - - displayName
+    subType: inventory
+    status: approved
+    type: parent
+    version: v1.0.0
+  - id: 44c4fbbb-bf95-48d8-be1e-4175ec4cfd5a
+    evaluationQuery: ""
+    kind: hierarchical
+    metadata:
+      description: Namespace to namespaced components
+      styles:
+        primaryColor: ""
+        svgColor: ""
+        svgWhite: ""
+      isAnnotation: false
+    model:
+      id: b3f5bc0d-30f7-607d-6c73-784ddde6cad8
+      schemaVersion: models.meshery.io/v1beta1
+      version: v1.0.0
+      name: kubernetes
+      displayName: Kubernetes
+      status: enabled
+      registrant:
+        id: 00000000-0000-0000-0000-000000000000
+        name: ""
+        type: ""
+        sub_type: ""
+        kind: ""
+        status: ""
+        created_at: "0001-01-01T00:00:00Z"
+        updated_at: "0001-01-01T00:00:00Z"
+        deleted_at: null
+        schemaVersion: ""
+      connection_id: 5bc80e3c-5d43-9eb4-d16c-78a2769247a6
+      category:
+        id: 9ca27d0d-66ce-42a9-8c85-6236563f2ddb
+        name: Orchestration & Management
+      subCategory: Scheduling & Orchestration
+      metadata:
+        isAnnotation: false
+        primaryColor: '#326CE5'
+        secondaryColor: '#7aa1f0'
+        shape: circle
+        styleOverrides: ""
+        svgColor: ui/public/static/img/meshmodels/kubernetes/color/kubernetes-color.svg
+        svgComplete: ""
+        svgWhite: ui/public/static/img/meshmodels/kubernetes/white/kubernetes-white.svg
+      model:
+        version: v1.32.0-alpha.3
+      components_count: 0
+      relationships_count: 0
+      components: null
+      relationships: null
+    schemaVersion: relationships.meshery.io/v1alpha3
+    selectors:
+      - allow:
+          from:
+            - id: dba874a7-f162-4580-b604-2bce367624f4
+              kind: '*'
+              match: {}
+              match_strategy_matrix: null
+              model:
+                id: 00000000-0000-0000-0000-000000000000
+                schemaVersion: ""
+                version: ""
+                name: '*'
+                displayName: ""
+                status: ""
+                registrant:
+                  id: 00000000-0000-0000-0000-000000000000
+                  name: ""
+                  type: ""
+                  sub_type: ""
+                  kind: ""
+                  status: ""
+                  created_at: "0001-01-01T00:00:00Z"
+                  updated_at: "0001-01-01T00:00:00Z"
+                  deleted_at: null
+                  schemaVersion: ""
+                connection_id: 00000000-0000-0000-0000-000000000000
+                category:
+                  id: 00000000-0000-0000-0000-000000000000
+                  name: ""
+                subCategory: ""
+                metadata: null
+                model:
+                  version: ""
+                components_count: 0
+                relationships_count: 0
+                components: null
+                relationships: null
+              patch:
+                patchStrategy: replace
+                mutatedRef:
+                  - - configuration
+                    - metadata
+                    - namespace
+          to:
+            - id: 86c08e70-5da8-4970-a779-81a0ce712463
+              kind: Namespace
+              match: {}
+              match_strategy_matrix: null
+              model:
+                id: 00000000-0000-0000-0000-000000000000
+                schemaVersion: ""
+                version: ""
+                name: kubernetes
+                displayName: ""
+                status: ""
+                registrant:
+                  id: 00000000-0000-0000-0000-000000000000
+                  name: ""
+                  type: ""
+                  sub_type: ""
+                  kind: github
+                  status: ""
+                  created_at: "0001-01-01T00:00:00Z"
+                  updated_at: "0001-01-01T00:00:00Z"
+                  deleted_at: null
+                  schemaVersion: ""
+                connection_id: 00000000-0000-0000-0000-000000000000
+                category:
+                  id: 00000000-0000-0000-0000-000000000000
+                  name: ""
+                subCategory: ""
+                metadata: null
+                model:
+                  version: ""
+                components_count: 0
+                relationships_count: 0
+                components: null
+                relationships: null
+              patch:
+                patchStrategy: replace
+                mutatorRef:
+                  - - displayName
+    subType: inventory
+    status: approved
+    type: parent
+    version: v1.0.0
+  - id: 47213352-8a13-4672-b300-9fafb2623a50
+    evaluationQuery: ""
+    kind: hierarchical
+    metadata:
+      description: Namespace to namespaced components
+      styles:
+        primaryColor: ""
+        svgColor: ""
+        svgWhite: ""
+      isAnnotation: false
+    model:
+      id: b3f5bc0d-30f7-607d-6c73-784ddde6cad8
+      schemaVersion: models.meshery.io/v1beta1
+      version: v1.0.0
+      name: kubernetes
+      displayName: Kubernetes
+      status: enabled
+      registrant:
+        id: 00000000-0000-0000-0000-000000000000
+        name: ""
+        type: ""
+        sub_type: ""
+        kind: ""
+        status: ""
+        created_at: "0001-01-01T00:00:00Z"
+        updated_at: "0001-01-01T00:00:00Z"
+        deleted_at: null
+        schemaVersion: ""
+      connection_id: 5bc80e3c-5d43-9eb4-d16c-78a2769247a6
+      category:
+        id: 9ca27d0d-66ce-42a9-8c85-6236563f2ddb
+        name: Orchestration & Management
+      subCategory: Scheduling & Orchestration
+      metadata:
+        isAnnotation: false
+        primaryColor: '#326CE5'
+        secondaryColor: '#7aa1f0'
+        shape: circle
+        styleOverrides: ""
+        svgColor: ui/public/static/img/meshmodels/kubernetes/color/kubernetes-color.svg
+        svgComplete: ""
+        svgWhite: ui/public/static/img/meshmodels/kubernetes/white/kubernetes-white.svg
+      model:
+        version: v1.32.0-alpha.3
+      components_count: 0
+      relationships_count: 0
+      components: null
+      relationships: null
+    schemaVersion: relationships.meshery.io/v1alpha3
+    selectors:
+      - allow:
+          from:
+            - id: dc7ffec0-613f-4324-af65-aa72574b8746
+              kind: '*'
+              match: {}
+              match_strategy_matrix: null
+              model:
+                id: 00000000-0000-0000-0000-000000000000
+                schemaVersion: ""
+                version: ""
+                name: '*'
+                displayName: ""
+                status: ""
+                registrant:
+                  id: 00000000-0000-0000-0000-000000000000
+                  name: ""
+                  type: ""
+                  sub_type: ""
+                  kind: ""
+                  status: ""
+                  created_at: "0001-01-01T00:00:00Z"
+                  updated_at: "0001-01-01T00:00:00Z"
+                  deleted_at: null
+                  schemaVersion: ""
+                connection_id: 00000000-0000-0000-0000-000000000000
+                category:
+                  id: 00000000-0000-0000-0000-000000000000
+                  name: ""
+                subCategory: ""
+                metadata: null
+                model:
+                  version: ""
+                components_count: 0
+                relationships_count: 0
+                components: null
+                relationships: null
+              patch:
+                patchStrategy: replace
+                mutatedRef:
+                  - - configuration
+                    - metadata
+                    - namespace
+          to:
+            - id: 86c08e70-5da8-4970-a779-81a0ce712463
+              kind: Namespace
+              match: {}
+              match_strategy_matrix: null
+              model:
+                id: 00000000-0000-0000-0000-000000000000
+                schemaVersion: ""
+                version: ""
+                name: kubernetes
+                displayName: ""
+                status: ""
+                registrant:
+                  id: 00000000-0000-0000-0000-000000000000
+                  name: ""
+                  type: ""
+                  sub_type: ""
+                  kind: github
+                  status: ""
+                  created_at: "0001-01-01T00:00:00Z"
+                  updated_at: "0001-01-01T00:00:00Z"
+                  deleted_at: null
+                  schemaVersion: ""
+                connection_id: 00000000-0000-0000-0000-000000000000
+                category:
+                  id: 00000000-0000-0000-0000-000000000000
+                  name: ""
+                subCategory: ""
+                metadata: null
+                model:
+                  version: ""
+                components_count: 0
+                relationships_count: 0
+                components: null
+                relationships: null
+              patch:
+                patchStrategy: replace
+                mutatorRef:
+                  - - displayName
+    subType: inventory
+    status: approved
+    type: parent
+    version: v1.0.0
+  - id: 52ba395b-38ba-471b-b740-396bd4ef5c04
+    evaluationQuery: ""
+    kind: edge
+    metadata:
+      description: In Kubernetes, ConfigMaps are a versatile resource that can be referenced by various other resources to provide configuration data to applications or other Kubnernetes resources.\n\nBy referencing ConfigMaps in these various contexts, you can centralize and manage configuration data more efficiently, allowing for easier updates, versioning, and maintenance of configurations in a Kubernetes environment.
+      styles:
+        primaryColor: ""
+        svgColor: ""
+        svgWhite: ""
+      isAnnotation: false
+    model:
+      id: b3f5bc0d-30f7-607d-6c73-784ddde6cad8
+      schemaVersion: models.meshery.io/v1beta1
+      version: v1.0.0
+      name: kubernetes
+      displayName: Kubernetes
+      status: enabled
+      registrant:
+        id: 00000000-0000-0000-0000-000000000000
+        name: ""
+        type: ""
+        sub_type: ""
+        kind: ""
+        status: ""
+        created_at: "0001-01-01T00:00:00Z"
+        updated_at: "0001-01-01T00:00:00Z"
+        deleted_at: null
+        schemaVersion: ""
+      connection_id: 5bc80e3c-5d43-9eb4-d16c-78a2769247a6
+      category:
+        id: 9ca27d0d-66ce-42a9-8c85-6236563f2ddb
+        name: Orchestration & Management
+      subCategory: Scheduling & Orchestration
+      metadata:
+        isAnnotation: false
+        primaryColor: '#326CE5'
+        secondaryColor: '#7aa1f0'
+        shape: circle
+        styleOverrides: ""
+        svgColor: ui/public/static/img/meshmodels/kubernetes/color/kubernetes-color.svg
+        svgComplete: ""
+        svgWhite: ui/public/static/img/meshmodels/kubernetes/white/kubernetes-white.svg
+      model:
+        version: v1.32.0-alpha.3
+      components_count: 0
+      relationships_count: 0
+      components: null
+      relationships: null
+    schemaVersion: relationships.meshery.io/v1alpha3
+    selectors:
+      - allow:
+          from:
+            - id: c58c6c35-098c-4b95-9d88-778499239d03
+              kind: ConfigMap
+              match: {}
+              match_strategy_matrix: null
+              model:
+                id: 00000000-0000-0000-0000-000000000000
+                schemaVersion: ""
+                version: ""
+                name: kubernetes
+                displayName: ""
+                status: ""
+                registrant:
+                  id: 00000000-0000-0000-0000-000000000000
+                  name: ""
+                  type: ""
+                  sub_type: ""
+                  kind: github
+                  status: ""
+                  created_at: "0001-01-01T00:00:00Z"
+                  updated_at: "0001-01-01T00:00:00Z"
+                  deleted_at: null
+                  schemaVersion: ""
+                connection_id: 00000000-0000-0000-0000-000000000000
+                category:
+                  id: 00000000-0000-0000-0000-000000000000
+                  name: ""
+                subCategory: ""
+                metadata: null
+                model:
+                  version: ""
+                components_count: 0
+                relationships_count: 0
+                components: null
+                relationships: null
+              patch:
+                patchStrategy: replace
+                mutatorRef:
+                  - - displayName
+          to:
+            - id: ce42bd94-2fb6-451e-bba2-e88a6c83fa6b
+              kind: Deployment
+              match: {}
+              match_strategy_matrix: null
+              model:
+                id: 00000000-0000-0000-0000-000000000000
+                schemaVersion: ""
+                version: ""
+                name: kubernetes
+                displayName: ""
+                status: ""
+                registrant:
+                  id: 00000000-0000-0000-0000-000000000000
+                  name: ""
+                  type: ""
+                  sub_type: ""
+                  kind: github
+                  status: ""
+                  created_at: "0001-01-01T00:00:00Z"
+                  updated_at: "0001-01-01T00:00:00Z"
+                  deleted_at: null
+                  schemaVersion: ""
+                connection_id: 00000000-0000-0000-0000-000000000000
+                category:
+                  id: 00000000-0000-0000-0000-000000000000
+                  name: ""
+                subCategory: ""
+                metadata: null
+                model:
+                  version: ""
+                components_count: 0
+                relationships_count: 0
+                components: null
+                relationships: null
+              patch:
+                patchStrategy: replace
+                mutatedRef:
+                  - - configuration
+                    - spec
+                    - template
+                    - spec
+                    - containers
+                    - "0"
+                    - envFrom
+                    - "0"
+                    - configMapRef
+                    - name
+        deny:
+          from: null
+          to: null
+    subType: reference
+    status: approved
+    type: non-binding
+    version: v1.0.0
+  - id: 5915edcf-bd43-4ab4-aa77-f3369524b6b8
+    evaluationQuery: ""
+    kind: hierarchical
+    metadata:
+      description: Namespace to namespaced components
+      styles:
+        primaryColor: ""
+        svgColor: ""
+        svgWhite: ""
+      isAnnotation: false
+    model:
+      id: b3f5bc0d-30f7-607d-6c73-784ddde6cad8
+      schemaVersion: models.meshery.io/v1beta1
+      version: v1.0.0
+      name: kubernetes
+      displayName: Kubernetes
+      status: enabled
+      registrant:
+        id: 00000000-0000-0000-0000-000000000000
+        name: ""
+        type: ""
+        sub_type: ""
+        kind: ""
+        status: ""
+        created_at: "0001-01-01T00:00:00Z"
+        updated_at: "0001-01-01T00:00:00Z"
+        deleted_at: null
+        schemaVersion: ""
+      connection_id: 5bc80e3c-5d43-9eb4-d16c-78a2769247a6
+      category:
+        id: 9ca27d0d-66ce-42a9-8c85-6236563f2ddb
+        name: Orchestration & Management
+      subCategory: Scheduling & Orchestration
+      metadata:
+        isAnnotation: false
+        primaryColor: '#326CE5'
+        secondaryColor: '#7aa1f0'
+        shape: circle
+        styleOverrides: ""
+        svgColor: ui/public/static/img/meshmodels/kubernetes/color/kubernetes-color.svg
+        svgComplete: ""
+        svgWhite: ui/public/static/img/meshmodels/kubernetes/white/kubernetes-white.svg
+      model:
+        version: v1.32.0-alpha.3
+      components_count: 0
+      relationships_count: 0
+      components: null
+      relationships: null
+    schemaVersion: relationships.meshery.io/v1alpha3
+    selectors:
+      - allow:
+          from:
+            - id: 1586c53d-e6a0-49db-81f2-662533d65ffa
+              kind: '*'
+              match: {}
+              match_strategy_matrix: null
+              model:
+                id: 00000000-0000-0000-0000-000000000000
+                schemaVersion: ""
+                version: ""
+                name: '*'
+                displayName: ""
+                status: ""
+                registrant:
+                  id: 00000000-0000-0000-0000-000000000000
+                  name: ""
+                  type: ""
+                  sub_type: ""
+                  kind: ""
+                  status: ""
+                  created_at: "0001-01-01T00:00:00Z"
+                  updated_at: "0001-01-01T00:00:00Z"
+                  deleted_at: null
+                  schemaVersion: ""
+                connection_id: 00000000-0000-0000-0000-000000000000
+                category:
+                  id: 00000000-0000-0000-0000-000000000000
+                  name: ""
+                subCategory: ""
+                metadata: null
+                model:
+                  version: ""
+                components_count: 0
+                relationships_count: 0
+                components: null
+                relationships: null
+              patch:
+                patchStrategy: replace
+                mutatedRef:
+                  - - configuration
+                    - metadata
+                    - namespace
+          to:
+            - id: 86c08e70-5da8-4970-a779-81a0ce712463
+              kind: Namespace
+              match: {}
+              match_strategy_matrix: null
+              model:
+                id: 00000000-0000-0000-0000-000000000000
+                schemaVersion: ""
+                version: ""
+                name: kubernetes
+                displayName: ""
+                status: ""
+                registrant:
+                  id: 00000000-0000-0000-0000-000000000000
+                  name: ""
+                  type: ""
+                  sub_type: ""
+                  kind: github
+                  status: ""
+                  created_at: "0001-01-01T00:00:00Z"
+                  updated_at: "0001-01-01T00:00:00Z"
+                  deleted_at: null
+                  schemaVersion: ""
+                connection_id: 00000000-0000-0000-0000-000000000000
+                category:
+                  id: 00000000-0000-0000-0000-000000000000
+                  name: ""
+                subCategory: ""
+                metadata: null
+                model:
+                  version: ""
+                components_count: 0
+                relationships_count: 0
+                components: null
+                relationships: null
+              patch:
+                patchStrategy: replace
+                mutatorRef:
+                  - - displayName
+    subType: inventory
+    status: approved
+    type: parent
+    version: v1.0.0
+  - id: 6fce0723-cde0-4dea-ad5c-253596de23cb
+    evaluationQuery: ""
+    kind: hierarchical
+    metadata:
+      description: Namespace to namespaced components
+      styles:
+        primaryColor: ""
+        svgColor: ""
+        svgWhite: ""
+      isAnnotation: false
+    model:
+      id: b3f5bc0d-30f7-607d-6c73-784ddde6cad8
+      schemaVersion: models.meshery.io/v1beta1
+      version: v1.0.0
+      name: kubernetes
+      displayName: Kubernetes
+      status: enabled
+      registrant:
+        id: 00000000-0000-0000-0000-000000000000
+        name: ""
+        type: ""
+        sub_type: ""
+        kind: ""
+        status: ""
+        created_at: "0001-01-01T00:00:00Z"
+        updated_at: "0001-01-01T00:00:00Z"
+        deleted_at: null
+        schemaVersion: ""
+      connection_id: 5bc80e3c-5d43-9eb4-d16c-78a2769247a6
+      category:
+        id: 9ca27d0d-66ce-42a9-8c85-6236563f2ddb
+        name: Orchestration & Management
+      subCategory: Scheduling & Orchestration
+      metadata:
+        isAnnotation: false
+        primaryColor: '#326CE5'
+        secondaryColor: '#7aa1f0'
+        shape: circle
+        styleOverrides: ""
+        svgColor: ui/public/static/img/meshmodels/kubernetes/color/kubernetes-color.svg
+        svgComplete: ""
+        svgWhite: ui/public/static/img/meshmodels/kubernetes/white/kubernetes-white.svg
+      model:
+        version: v1.32.0-alpha.3
+      components_count: 0
+      relationships_count: 0
+      components: null
+      relationships: null
+    schemaVersion: relationships.meshery.io/v1alpha3
+    selectors:
+      - allow:
+          from:
+            - id: aea7e6fe-fa70-4d75-9c52-da3ec3536955
+              kind: '*'
+              match: {}
+              match_strategy_matrix: null
+              model:
+                id: 00000000-0000-0000-0000-000000000000
+                schemaVersion: ""
+                version: ""
+                name: '*'
+                displayName: ""
+                status: ""
+                registrant:
+                  id: 00000000-0000-0000-0000-000000000000
+                  name: ""
+                  type: ""
+                  sub_type: ""
+                  kind: ""
+                  status: ""
+                  created_at: "0001-01-01T00:00:00Z"
+                  updated_at: "0001-01-01T00:00:00Z"
+                  deleted_at: null
+                  schemaVersion: ""
+                connection_id: 00000000-0000-0000-0000-000000000000
+                category:
+                  id: 00000000-0000-0000-0000-000000000000
+                  name: ""
+                subCategory: ""
+                metadata: null
+                model:
+                  version: ""
+                components_count: 0
+                relationships_count: 0
+                components: null
+                relationships: null
+              patch:
+                patchStrategy: replace
+                mutatedRef:
+                  - - configuration
+                    - metadata
+                    - namespace
+          to:
+            - id: 86c08e70-5da8-4970-a779-81a0ce712463
+              kind: Namespace
+              match: {}
+              match_strategy_matrix: null
+              model:
+                id: 00000000-0000-0000-0000-000000000000
+                schemaVersion: ""
+                version: ""
+                name: kubernetes
+                displayName: ""
+                status: ""
+                registrant:
+                  id: 00000000-0000-0000-0000-000000000000
+                  name: ""
+                  type: ""
+                  sub_type: ""
+                  kind: github
+                  status: ""
+                  created_at: "0001-01-01T00:00:00Z"
+                  updated_at: "0001-01-01T00:00:00Z"
+                  deleted_at: null
+                  schemaVersion: ""
+                connection_id: 00000000-0000-0000-0000-000000000000
+                category:
+                  id: 00000000-0000-0000-0000-000000000000
+                  name: ""
+                subCategory: ""
+                metadata: null
+                model:
+                  version: ""
+                components_count: 0
+                relationships_count: 0
+                components: null
+                relationships: null
+              patch:
+                patchStrategy: replace
+                mutatorRef:
+                  - - displayName
+    subType: inventory
+    status: approved
+    type: parent
+    version: v1.0.0
+  - id: 700b6937-25f0-41c0-ac41-f5d9696ef8cc
+    evaluationQuery: ""
+    kind: edge
+    metadata:
+      description: In Kubernetes, ConfigMaps are a versatile resource that can be referenced by various other resources to provide configuration data to applications or other Kubnernetes resources.\n\nBy referencing ConfigMaps in these various contexts, you can centralize and manage configuration data more efficiently, allowing for easier updates, versioning, and maintenance of configurations in a Kubernetes environment.
+      styles:
+        primaryColor: ""
+        svgColor: ""
+        svgWhite: ""
+      isAnnotation: false
+    model:
+      id: b3f5bc0d-30f7-607d-6c73-784ddde6cad8
+      schemaVersion: models.meshery.io/v1beta1
+      version: v1.0.0
+      name: kubernetes
+      displayName: Kubernetes
+      status: enabled
+      registrant:
+        id: 00000000-0000-0000-0000-000000000000
+        name: ""
+        type: ""
+        sub_type: ""
+        kind: ""
+        status: ""
+        created_at: "0001-01-01T00:00:00Z"
+        updated_at: "0001-01-01T00:00:00Z"
+        deleted_at: null
+        schemaVersion: ""
+      connection_id: 5bc80e3c-5d43-9eb4-d16c-78a2769247a6
+      category:
+        id: 9ca27d0d-66ce-42a9-8c85-6236563f2ddb
+        name: Orchestration & Management
+      subCategory: Scheduling & Orchestration
+      metadata:
+        isAnnotation: false
+        primaryColor: '#326CE5'
+        secondaryColor: '#7aa1f0'
+        shape: circle
+        styleOverrides: ""
+        svgColor: ui/public/static/img/meshmodels/kubernetes/color/kubernetes-color.svg
+        svgComplete: ""
+        svgWhite: ui/public/static/img/meshmodels/kubernetes/white/kubernetes-white.svg
+      model:
+        version: v1.32.0-alpha.3
+      components_count: 0
+      relationships_count: 0
+      components: null
+      relationships: null
+    schemaVersion: relationships.meshery.io/v1alpha3
+    selectors:
+      - allow:
+          from:
+            - id: 4ec90688-30ce-4526-8c9e-d523bf3459ae
+              kind: ConfigMap
+              match: {}
+              match_strategy_matrix: null
+              model:
+                id: 00000000-0000-0000-0000-000000000000
+                schemaVersion: ""
+                version: ""
+                name: kubernetes
+                displayName: ""
+                status: ""
+                registrant:
+                  id: 00000000-0000-0000-0000-000000000000
+                  name: ""
+                  type: ""
+                  sub_type: ""
+                  kind: github
+                  status: ""
+                  created_at: "0001-01-01T00:00:00Z"
+                  updated_at: "0001-01-01T00:00:00Z"
+                  deleted_at: null
+                  schemaVersion: ""
+                connection_id: 00000000-0000-0000-0000-000000000000
+                category:
+                  id: 00000000-0000-0000-0000-000000000000
+                  name: ""
+                subCategory: ""
+                metadata: null
+                model:
+                  version: ""
+                components_count: 0
+                relationships_count: 0
+                components: null
+                relationships: null
+              patch:
+                patchStrategy: replace
+                mutatorRef:
+                  - - displayName
+          to:
+            - id: 575c9682-8b50-4ea5-8307-9ce2e77e65b0
+              kind: Deployment
+              match: {}
+              match_strategy_matrix: null
+              model:
+                id: 00000000-0000-0000-0000-000000000000
+                schemaVersion: ""
+                version: ""
+                name: kubernetes
+                displayName: ""
+                status: ""
+                registrant:
+                  id: 00000000-0000-0000-0000-000000000000
+                  name: ""
+                  type: ""
+                  sub_type: ""
+                  kind: github
+                  status: ""
+                  created_at: "0001-01-01T00:00:00Z"
+                  updated_at: "0001-01-01T00:00:00Z"
+                  deleted_at: null
+                  schemaVersion: ""
+                connection_id: 00000000-0000-0000-0000-000000000000
+                category:
+                  id: 00000000-0000-0000-0000-000000000000
+                  name: ""
+                subCategory: ""
+                metadata: null
+                model:
+                  version: ""
+                components_count: 0
+                relationships_count: 0
+                components: null
+                relationships: null
+              patch:
+                patchStrategy: replace
+                mutatedRef:
+                  - - configuration
+                    - spec
+                    - template
+                    - spec
+                    - containers
+                    - "0"
+                    - envFrom
+                    - "0"
+                    - configMapRef
+                    - name
+        deny:
+          from: null
+          to: null
+    subType: reference
+    status: approved
+    type: non-binding
+    version: v1.0.0
+  - id: 826ba4d5-b92f-465b-9b09-2052054a4c95
+    evaluationQuery: ""
+    kind: edge
+    metadata:
+      description: A relationship that defines network edges between components
+      styles:
+        primaryColor: ""
+        svgColor: ""
+        svgWhite: ""
+      isAnnotation: false
+    model:
+      id: b3f5bc0d-30f7-607d-6c73-784ddde6cad8
+      schemaVersion: models.meshery.io/v1beta1
+      version: v1.0.0
+      name: kubernetes
+      displayName: Kubernetes
+      status: enabled
+      registrant:
+        id: 00000000-0000-0000-0000-000000000000
+        name: ""
+        type: ""
+        sub_type: ""
+        kind: ""
+        status: ""
+        created_at: "0001-01-01T00:00:00Z"
+        updated_at: "0001-01-01T00:00:00Z"
+        deleted_at: null
+        schemaVersion: ""
+      connection_id: 5bc80e3c-5d43-9eb4-d16c-78a2769247a6
+      category:
+        id: 9ca27d0d-66ce-42a9-8c85-6236563f2ddb
+        name: Orchestration & Management
+      subCategory: Scheduling & Orchestration
+      metadata:
+        isAnnotation: false
+        primaryColor: '#326CE5'
+        secondaryColor: '#7aa1f0'
+        shape: circle
+        styleOverrides: ""
+        svgColor: ui/public/static/img/meshmodels/kubernetes/color/kubernetes-color.svg
+        svgComplete: ""
+        svgWhite: ui/public/static/img/meshmodels/kubernetes/white/kubernetes-white.svg
+      model:
+        version: v1.32.0-alpha.3
+      components_count: 0
+      relationships_count: 0
+      components: null
+      relationships: null
+    schemaVersion: relationships.meshery.io/v1alpha3
+    selectors:
+      - allow:
+          from:
+            - id: dba874a7-f162-4580-b604-2bce367624f4
+              kind: Service
+              match: {}
+              match_strategy_matrix:
+                - - to_contains_from
+                  - not_null
+                - - equal_as_strings
+                  - not_null
+                - - equal
+              model:
+                id: 00000000-0000-0000-0000-000000000000
+                schemaVersion: ""
+                version: ""
+                name: kubernetes
+                displayName: ""
+                status: ""
+                registrant:
+                  id: 00000000-0000-0000-0000-000000000000
+                  name: ""
+                  type: ""
+                  sub_type: ""
+                  kind: github
+                  status: ""
+                  created_at: "0001-01-01T00:00:00Z"
+                  updated_at: "0001-01-01T00:00:00Z"
+                  deleted_at: null
+                  schemaVersion: ""
+                connection_id: 00000000-0000-0000-0000-000000000000
+                category:
+                  id: 00000000-0000-0000-0000-000000000000
+                  name: ""
+                subCategory: ""
+                metadata: null
+                model:
+                  version: ""
+                components_count: 0
+                relationships_count: 0
+                components: null
+                relationships: null
+              patch:
+                patchStrategy: replace
+                mutatorRef:
+                  - - configuration
+                    - spec
+                    - selector
+                  - - configuration
+                    - spec
+                    - ports
+                    - "0"
+                    - targetPort
+                  - - configuration
+                    - spec
+                    - ports
+                    - "0"
+                    - protocol
+          to:
+            - id: 0851ce28-0a59-4a30-85a8-36488ecb3762
+              kind: Deployment
+              match: {}
+              match_strategy_matrix: null
+              model:
+                id: 00000000-0000-0000-0000-000000000000
+                schemaVersion: ""
+                version: ""
+                name: kubernetes
+                displayName: ""
+                status: ""
+                registrant:
+                  id: 00000000-0000-0000-0000-000000000000
+                  name: ""
+                  type: ""
+                  sub_type: ""
+                  kind: github
+                  status: ""
+                  created_at: "0001-01-01T00:00:00Z"
+                  updated_at: "0001-01-01T00:00:00Z"
+                  deleted_at: null
+                  schemaVersion: ""
+                connection_id: 00000000-0000-0000-0000-000000000000
+                category:
+                  id: 00000000-0000-0000-0000-000000000000
+                  name: ""
+                subCategory: ""
+                metadata: null
+                model:
+                  version: ""
+                components_count: 0
+                relationships_count: 0
+                components: null
+                relationships: null
+              patch:
+                patchStrategy: replace
+                mutatedRef:
+                  - - configuration
+                    - spec
+                    - selector
+                    - matchLabels
+                  - - configuration
+                    - spec
+                    - template
+                    - spec
+                    - containers
+                    - "0"
+                    - ports
+                    - "0"
+                    - name
+                  - - configuration
+                    - spec
+                    - template
+                    - spec
+                    - containers
+                    - "0"
+                    - ports
+                    - "0"
+                    - protocol
+        deny:
+          from: null
+          to: null
+    subType: network
+    status: approved
+    type: non-binding
+    version: v1.0.0
+  - id: 8324f480-334e-4f6a-bc49-621d636f6aaa
+    evaluationQuery: ""
+    kind: hierarchical
+    metadata:
+      description: 'A hierarchical inventory relationship in which the configuration of (parent) component is patched with the configuration of other (child) component. Eg: The configuration of the EnvoyFilter (parent) component is patched with the configuration as received from WASMFilter (child) component.'
+      styles:
+        primaryColor: ""
+        svgColor: ""
+        svgWhite: ""
+      isAnnotation: false
+    model:
+      id: b3f5bc0d-30f7-607d-6c73-784ddde6cad8
+      schemaVersion: models.meshery.io/v1beta1
+      version: v1.0.0
+      name: kubernetes
+      displayName: Kubernetes
+      status: enabled
+      registrant:
+        id: 00000000-0000-0000-0000-000000000000
+        name: ""
+        type: ""
+        sub_type: ""
+        kind: ""
+        status: ""
+        created_at: "0001-01-01T00:00:00Z"
+        updated_at: "0001-01-01T00:00:00Z"
+        deleted_at: null
+        schemaVersion: ""
+      connection_id: 5bc80e3c-5d43-9eb4-d16c-78a2769247a6
+      category:
+        id: 9ca27d0d-66ce-42a9-8c85-6236563f2ddb
+        name: Orchestration & Management
+      subCategory: Scheduling & Orchestration
+      metadata:
+        isAnnotation: false
+        primaryColor: '#326CE5'
+        secondaryColor: '#7aa1f0'
+        shape: circle
+        styleOverrides: ""
+        svgColor: ui/public/static/img/meshmodels/kubernetes/color/kubernetes-color.svg
+        svgComplete: ""
+        svgWhite: ui/public/static/img/meshmodels/kubernetes/white/kubernetes-white.svg
+      model:
+        version: v1.32.0-alpha.3
+      components_count: 0
+      relationships_count: 0
+      components: null
+      relationships: null
+    schemaVersion: relationships.meshery.io/v1alpha3
+    selectors:
+      - allow:
+          from:
+            - id: e00b8605-ecbf-4049-b0a9-d0a904b8b124
+              kind: Container
+              match: {}
+              match_strategy_matrix: null
+              model:
+                id: 00000000-0000-0000-0000-000000000000
+                schemaVersion: ""
+                version: ""
+                name: meshery-core
+                displayName: ""
+                status: ""
+                registrant:
+                  id: 00000000-0000-0000-0000-000000000000
+                  name: ""
+                  type: ""
+                  sub_type: ""
+                  kind: github
+                  status: ""
+                  created_at: "0001-01-01T00:00:00Z"
+                  updated_at: "0001-01-01T00:00:00Z"
+                  deleted_at: null
+                  schemaVersion: ""
+                connection_id: 00000000-0000-0000-0000-000000000000
+                category:
+                  id: 00000000-0000-0000-0000-000000000000
+                  name: ""
+                subCategory: ""
+                metadata: null
+                model:
+                  version: ""
+                components_count: 0
+                relationships_count: 0
+                components: null
+                relationships: null
+              patch:
+                patchStrategy: replace
+                mutatorRef:
+                  - - configuration
+                    - spec
+                    - template
+                    - spec
+                    - containers
+                    - "0"
+                mutatedRef:
+                  - - configuration
+                    - spec
+                    - template
+                    - spec
+                    - containers
+                    - "0"
+          to:
+            - id: 575c9682-8b50-4ea5-8307-9ce2e77e65b0
+              kind: Deployment
+              match: {}
+              match_strategy_matrix: null
+              model:
+                id: 00000000-0000-0000-0000-000000000000
+                schemaVersion: ""
+                version: ""
+                name: kubernetes
+                displayName: ""
+                status: ""
+                registrant:
+                  id: 00000000-0000-0000-0000-000000000000
+                  name: ""
+                  type: ""
+                  sub_type: ""
+                  kind: github
+                  status: ""
+                  created_at: "0001-01-01T00:00:00Z"
+                  updated_at: "0001-01-01T00:00:00Z"
+                  deleted_at: null
+                  schemaVersion: ""
+                connection_id: 00000000-0000-0000-0000-000000000000
+                category:
+                  id: 00000000-0000-0000-0000-000000000000
+                  name: ""
+                subCategory: ""
+                metadata: null
+                model:
+                  version: ""
+                components_count: 0
+                relationships_count: 0
+                components: null
+                relationships: null
+              patch:
+                patchStrategy: replace
+                mutatorRef:
+                  - - configuration
+                    - spec
+                    - template
+                    - spec
+                    - containers
+                    - "0"
+                mutatedRef:
+                  - - configuration
+                    - spec
+                    - template
+                    - spec
+                    - containers
+                    - "0"
+        deny:
+          from: null
+          to: null
+    subType: alias
+    status: approved
+    type: parent
+    version: v1.0.0
+  - id: 88e1e0a7-f361-4ae2-979d-f189bc3455fc
+    evaluationQuery: ""
+    kind: edge
+    metadata:
+      description: A relationship that defines network edges between components
+      styles:
+        primaryColor: ""
+        svgColor: ""
+        svgWhite: ""
+      isAnnotation: false
+    model:
+      id: b3f5bc0d-30f7-607d-6c73-784ddde6cad8
+      schemaVersion: models.meshery.io/v1beta1
+      version: v1.0.0
+      name: kubernetes
+      displayName: Kubernetes
+      status: enabled
+      registrant:
+        id: 00000000-0000-0000-0000-000000000000
+        name: ""
+        type: ""
+        sub_type: ""
+        kind: ""
+        status: ""
+        created_at: "0001-01-01T00:00:00Z"
+        updated_at: "0001-01-01T00:00:00Z"
+        deleted_at: null
+        schemaVersion: ""
+      connection_id: 5bc80e3c-5d43-9eb4-d16c-78a2769247a6
+      category:
+        id: 9ca27d0d-66ce-42a9-8c85-6236563f2ddb
+        name: Orchestration & Management
+      subCategory: Scheduling & Orchestration
+      metadata:
+        isAnnotation: false
+        primaryColor: '#326CE5'
+        secondaryColor: '#7aa1f0'
+        shape: circle
+        styleOverrides: ""
+        svgColor: ui/public/static/img/meshmodels/kubernetes/color/kubernetes-color.svg
+        svgComplete: ""
+        svgWhite: ui/public/static/img/meshmodels/kubernetes/white/kubernetes-white.svg
+      model:
+        version: v1.32.0-alpha.3
+      components_count: 0
+      relationships_count: 0
+      components: null
+      relationships: null
+    schemaVersion: relationships.meshery.io/v1alpha3
+    selectors:
+      - allow:
+          from:
+            - id: 868ab99a-9d42-45b7-86e7-935d91f1986d
+              kind: Service
+              match: {}
+              match_strategy_matrix:
+                - - to_contains_from
+                  - not_null
+                - - equal_as_strings
+                  - not_null
+                - - equal
+              model:
+                id: 00000000-0000-0000-0000-000000000000
+                schemaVersion: ""
+                version: ""
+                name: kubernetes
+                displayName: ""
+                status: ""
+                registrant:
+                  id: 00000000-0000-0000-0000-000000000000
+                  name: ""
+                  type: ""
+                  sub_type: ""
+                  kind: github
+                  status: ""
+                  created_at: "0001-01-01T00:00:00Z"
+                  updated_at: "0001-01-01T00:00:00Z"
+                  deleted_at: null
+                  schemaVersion: ""
+                connection_id: 00000000-0000-0000-0000-000000000000
+                category:
+                  id: 00000000-0000-0000-0000-000000000000
+                  name: ""
+                subCategory: ""
+                metadata: null
+                model:
+                  version: ""
+                components_count: 0
+                relationships_count: 0
+                components: null
+                relationships: null
+              patch:
+                patchStrategy: replace
+                mutatorRef:
+                  - - configuration
+                    - spec
+                    - selector
+                  - - configuration
+                    - spec
+                    - ports
+                    - "0"
+                    - targetPort
+                  - - configuration
+                    - spec
+                    - ports
+                    - "0"
+                    - protocol
+          to:
+            - id: 09ae7182-3f78-4fe8-8b76-db4b1e9ed46a
+              kind: Deployment
+              match: {}
+              match_strategy_matrix: null
+              model:
+                id: 00000000-0000-0000-0000-000000000000
+                schemaVersion: ""
+                version: ""
+                name: kubernetes
+                displayName: ""
+                status: ""
+                registrant:
+                  id: 00000000-0000-0000-0000-000000000000
+                  name: ""
+                  type: ""
+                  sub_type: ""
+                  kind: github
+                  status: ""
+                  created_at: "0001-01-01T00:00:00Z"
+                  updated_at: "0001-01-01T00:00:00Z"
+                  deleted_at: null
+                  schemaVersion: ""
+                connection_id: 00000000-0000-0000-0000-000000000000
+                category:
+                  id: 00000000-0000-0000-0000-000000000000
+                  name: ""
+                subCategory: ""
+                metadata: null
+                model:
+                  version: ""
+                components_count: 0
+                relationships_count: 0
+                components: null
+                relationships: null
+              patch:
+                patchStrategy: replace
+                mutatedRef:
+                  - - configuration
+                    - spec
+                    - selector
+                    - matchLabels
+                  - - configuration
+                    - spec
+                    - template
+                    - spec
+                    - containers
+                    - "0"
+                    - ports
+                    - "0"
+                    - name
+                  - - configuration
+                    - spec
+                    - template
+                    - spec
+                    - containers
+                    - "0"
+                    - ports
+                    - "0"
+                    - protocol
+        deny:
+          from: null
+          to: null
+    subType: network
+    status: approved
+    type: non-binding
+    version: v1.0.0
+  - id: 9a04ca01-0298-46c5-b941-323797ca5e55
+    evaluationQuery: ""
+    kind: edge
+    metadata:
+      description: A relationship that represents a set of permissions
+      styles:
+        primaryColor: ""
+        svgColor: ""
+        svgWhite: ""
+      isAnnotation: false
+    model:
+      id: b3f5bc0d-30f7-607d-6c73-784ddde6cad8
+      schemaVersion: models.meshery.io/v1beta1
+      version: v1.0.0
+      name: kubernetes
+      displayName: Kubernetes
+      status: enabled
+      registrant:
+        id: 00000000-0000-0000-0000-000000000000
+        name: ""
+        type: ""
+        sub_type: ""
+        kind: ""
+        status: ""
+        created_at: "0001-01-01T00:00:00Z"
+        updated_at: "0001-01-01T00:00:00Z"
+        deleted_at: null
+        schemaVersion: ""
+      connection_id: 5bc80e3c-5d43-9eb4-d16c-78a2769247a6
+      category:
+        id: 9ca27d0d-66ce-42a9-8c85-6236563f2ddb
+        name: Orchestration & Management
+      subCategory: Scheduling & Orchestration
+      metadata:
+        isAnnotation: false
+        primaryColor: '#326CE5'
+        secondaryColor: '#7aa1f0'
+        shape: circle
+        styleOverrides: ""
+        svgColor: ui/public/static/img/meshmodels/kubernetes/color/kubernetes-color.svg
+        svgComplete: ""
+        svgWhite: ui/public/static/img/meshmodels/kubernetes/white/kubernetes-white.svg
+      model:
+        version: v1.32.0-alpha.3
+      components_count: 0
+      relationships_count: 0
+      components: null
+      relationships: null
+    schemaVersion: relationships.meshery.io/v1alpha3
+    selectors:
+      - allow:
+          from:
+            - id: 6db433b8-9b87-464e-a57d-32e1dc22c567
+              kind: Role
+              match:
+                from:
+                  - id: 6db433b8-9b87-464e-a57d-32e1dc22c567
+                    kind: self
+                    mutatorRef:
+                      - - component
+                        - kind
+                      - - displayName
+                to:
+                  - id: 2decfb32-83eb-433a-9292-5ed81abb45b8
+                    kind: RoleBinding
+                    mutatedRef:
+                      - - configuration
+                        - roleRef
+                        - kind
+                      - - configuration
+                        - roleRef
+                        - name
+              match_strategy_matrix: null
+              model:
+                id: 00000000-0000-0000-0000-000000000000
+                schemaVersion: ""
+                version: ""
+                name: kubernetes
+                displayName: ""
+                status: ""
+                registrant:
+                  id: 00000000-0000-0000-0000-000000000000
+                  name: ""
+                  credential_id: 00000000-0000-0000-0000-000000000000
+                  type: ""
+                  sub_type: ""
+                  kind: github
+                  status: ""
+                  user_id: 00000000-0000-0000-0000-000000000000
+                  created_at: "0001-01-01T00:00:00Z"
+                  updated_at: "0001-01-01T00:00:00Z"
+                  deleted_at: "0001-01-01T00:00:00Z"
+                  schemaVersion: ""
+                connection_id: 00000000-0000-0000-0000-000000000000
+                category:
+                  id: 00000000-0000-0000-0000-000000000000
+                  name: ""
+                subCategory: ""
+                metadata: null
+                model:
+                  version: ""
+                components_count: 0
+                relationships_count: 0
+                components: null
+                relationships: null
+              patch: null
+          to:
+            - id: 12d59f52-0e0b-4767-9222-968edd4be8b3
+              kind: ServiceAccount
+              match:
+                from:
+                  - id: 2decfb32-83eb-433a-9292-5ed81abb45b8
+                    kind: RoleBinding
+                    mutatedRef:
+                      - - configuration
+                        - subjects
+                        - _
+                        - name
+                to:
+                  - id: 12d59f52-0e0b-4767-9222-968edd4be8b3
+                    kind: self
+                    mutatorRef:
+                      - - displayName
+              match_strategy_matrix: null
+              model:
+                id: 00000000-0000-0000-0000-000000000000
+                schemaVersion: ""
+                version: ""
+                name: kubernetes
+                displayName: ""
+                status: ""
+                registrant:
+                  id: 00000000-0000-0000-0000-000000000000
+                  name: ""
+                  credential_id: 00000000-0000-0000-0000-000000000000
+                  type: ""
+                  sub_type: ""
+                  kind: github
+                  status: ""
+                  user_id: 00000000-0000-0000-0000-000000000000
+                  created_at: "0001-01-01T00:00:00Z"
+                  updated_at: "0001-01-01T00:00:00Z"
+                  deleted_at: "0001-01-01T00:00:00Z"
+                  schemaVersion: ""
+                connection_id: 00000000-0000-0000-0000-000000000000
+                category:
+                  id: 00000000-0000-0000-0000-000000000000
+                  name: ""
+                subCategory: ""
+                metadata: null
+                model:
+                  version: ""
+                components_count: 0
+                relationships_count: 0
+                components: null
+                relationships: null
+              patch: null
+    subType: permission
+    status: approved
+    type: binding
+    version: v1.0.0
+  - id: 9f591f24-3043-42be-9ef8-0952c2a5dc83
+    evaluationQuery: ""
+    kind: edge
+    metadata:
+      description: A relationship that represents a set of permissions
+      styles:
+        primaryColor: ""
+        svgColor: ""
+        svgWhite: ""
+      isAnnotation: false
+    model:
+      id: b3f5bc0d-30f7-607d-6c73-784ddde6cad8
+      schemaVersion: models.meshery.io/v1beta1
+      version: v1.0.0
+      name: kubernetes
+      displayName: Kubernetes
+      status: enabled
+      registrant:
+        id: 00000000-0000-0000-0000-000000000000
+        name: ""
+        type: ""
+        sub_type: ""
+        kind: ""
+        status: ""
+        created_at: "0001-01-01T00:00:00Z"
+        updated_at: "0001-01-01T00:00:00Z"
+        deleted_at: null
+        schemaVersion: ""
+      connection_id: 5bc80e3c-5d43-9eb4-d16c-78a2769247a6
+      category:
+        id: 9ca27d0d-66ce-42a9-8c85-6236563f2ddb
+        name: Orchestration & Management
+      subCategory: Scheduling & Orchestration
+      metadata:
+        isAnnotation: false
+        primaryColor: '#326CE5'
+        secondaryColor: '#7aa1f0'
+        shape: circle
+        styleOverrides: ""
+        svgColor: ui/public/static/img/meshmodels/kubernetes/color/kubernetes-color.svg
+        svgComplete: ""
+        svgWhite: ui/public/static/img/meshmodels/kubernetes/white/kubernetes-white.svg
+      model:
+        version: v1.32.0-alpha.3
+      components_count: 0
+      relationships_count: 0
+      components: null
+      relationships: null
+    schemaVersion: relationships.meshery.io/v1alpha3
+    selectors:
+      - allow:
+          from:
+            - id: c1e55e88-394c-45bc-948e-d9472c1240d6
+              kind: ClusterRole
+              match:
+                from:
+                  - id: c1e55e88-394c-45bc-948e-d9472c1240d6
+                    kind: self
+                    mutatorRef:
+                      - - component
+                        - kind
+                      - - displayName
+                to:
+                  - id: 4fdaa688-5699-49db-8d24-a01507099802
+                    kind: ClusterRoleBinding
+                    mutatedRef:
+                      - - configuration
+                        - roleRef
+                        - kind
+                      - - configuration
+                        - roleRef
+                        - name
+              match_strategy_matrix: null
+              model:
+                id: 00000000-0000-0000-0000-000000000000
+                schemaVersion: ""
+                version: ""
+                name: kubernetes
+                displayName: ""
+                status: ""
+                registrant:
+                  id: 00000000-0000-0000-0000-000000000000
+                  name: ""
+                  credential_id: 00000000-0000-0000-0000-000000000000
+                  type: ""
+                  sub_type: ""
+                  kind: github
+                  status: ""
+                  user_id: 00000000-0000-0000-0000-000000000000
+                  created_at: "0001-01-01T00:00:00Z"
+                  updated_at: "0001-01-01T00:00:00Z"
+                  deleted_at: "0001-01-01T00:00:00Z"
+                  schemaVersion: ""
+                connection_id: 00000000-0000-0000-0000-000000000000
+                category:
+                  id: 00000000-0000-0000-0000-000000000000
+                  name: ""
+                subCategory: ""
+                metadata: null
+                model:
+                  version: ""
+                components_count: 0
+                relationships_count: 0
+                components: null
+                relationships: null
+              patch: null
+          to:
+            - id: 1586c53d-e6a0-49db-81f2-662533d65ffa
+              kind: ServiceAccount
+              match:
+                from:
+                  - id: 4fdaa688-5699-49db-8d24-a01507099802
+                    kind: ClusterRoleBinding
+                    mutatedRef:
+                      - - configuration
+                        - subjects
+                        - _
+                        - name
+                to:
+                  - id: 1586c53d-e6a0-49db-81f2-662533d65ffa
+                    kind: self
+                    mutatorRef:
+                      - - displayName
+              match_strategy_matrix: null
+              model:
+                id: 00000000-0000-0000-0000-000000000000
+                schemaVersion: ""
+                version: ""
+                name: kubernetes
+                displayName: ""
+                status: ""
+                registrant:
+                  id: 00000000-0000-0000-0000-000000000000
+                  name: ""
+                  credential_id: 00000000-0000-0000-0000-000000000000
+                  type: ""
+                  sub_type: ""
+                  kind: github
+                  status: ""
+                  user_id: 00000000-0000-0000-0000-000000000000
+                  created_at: "0001-01-01T00:00:00Z"
+                  updated_at: "0001-01-01T00:00:00Z"
+                  deleted_at: "0001-01-01T00:00:00Z"
+                  schemaVersion: ""
+                connection_id: 00000000-0000-0000-0000-000000000000
+                category:
+                  id: 00000000-0000-0000-0000-000000000000
+                  name: ""
+                subCategory: ""
+                metadata: null
+                model:
+                  version: ""
+                components_count: 0
+                relationships_count: 0
+                components: null
+                relationships: null
+              patch: null
+    subType: permission
+    status: approved
+    type: binding
+    version: v1.0.0
+  - id: bc28eaf5-4619-4cf5-95af-7fea3e08fb38
+    evaluationQuery: ""
+    kind: hierarchical
+    metadata:
+      description: 'A hierarchical inventory relationship in which the configuration of (parent) component is patched with the configuration of other (child) component. Eg: The configuration of the EnvoyFilter (parent) component is patched with the configuration as received from WASMFilter (child) component.'
+      styles:
+        primaryColor: ""
+        svgColor: ""
+        svgWhite: ""
+      isAnnotation: false
+    model:
+      id: b3f5bc0d-30f7-607d-6c73-784ddde6cad8
+      schemaVersion: models.meshery.io/v1beta1
+      version: v1.0.0
+      name: kubernetes
+      displayName: Kubernetes
+      status: enabled
+      registrant:
+        id: 00000000-0000-0000-0000-000000000000
+        name: ""
+        type: ""
+        sub_type: ""
+        kind: ""
+        status: ""
+        created_at: "0001-01-01T00:00:00Z"
+        updated_at: "0001-01-01T00:00:00Z"
+        deleted_at: null
+        schemaVersion: ""
+      connection_id: 5bc80e3c-5d43-9eb4-d16c-78a2769247a6
+      category:
+        id: 9ca27d0d-66ce-42a9-8c85-6236563f2ddb
+        name: Orchestration & Management
+      subCategory: Scheduling & Orchestration
+      metadata:
+        isAnnotation: false
+        primaryColor: '#326CE5'
+        secondaryColor: '#7aa1f0'
+        shape: circle
+        styleOverrides: ""
+        svgColor: ui/public/static/img/meshmodels/kubernetes/color/kubernetes-color.svg
+        svgComplete: ""
+        svgWhite: ui/public/static/img/meshmodels/kubernetes/white/kubernetes-white.svg
+      model:
+        version: v1.32.0-alpha.3
+      components_count: 0
+      relationships_count: 0
+      components: null
+      relationships: null
+    schemaVersion: relationships.meshery.io/v1alpha3
+    selectors:
+      - allow:
+          from:
+            - id: f8aea98b-ba7d-4cc1-8b1a-9ca729e34db1
+              kind: Container
+              match: {}
+              match_strategy_matrix: null
+              model:
+                id: 00000000-0000-0000-0000-000000000000
+                schemaVersion: ""
+                version: ""
+                name: meshery-core
+                displayName: ""
+                status: ""
+                registrant:
+                  id: 00000000-0000-0000-0000-000000000000
+                  name: ""
+                  type: ""
+                  sub_type: ""
+                  kind: github
+                  status: ""
+                  created_at: "0001-01-01T00:00:00Z"
+                  updated_at: "0001-01-01T00:00:00Z"
+                  deleted_at: null
+                  schemaVersion: ""
+                connection_id: 00000000-0000-0000-0000-000000000000
+                category:
+                  id: 00000000-0000-0000-0000-000000000000
+                  name: ""
+                subCategory: ""
+                metadata: null
+                model:
+                  version: ""
+                components_count: 0
+                relationships_count: 0
+                components: null
+                relationships: null
+              patch:
+                patchStrategy: replace
+                mutatorRef:
+                  - - configuration
+                    - spec
+                    - template
+                    - spec
+                    - containers
+                    - "0"
+                mutatedRef:
+                  - - configuration
+                    - spec
+                    - template
+                    - spec
+                    - containers
+                    - "0"
+          to:
+            - id: ce42bd94-2fb6-451e-bba2-e88a6c83fa6b
+              kind: Deployment
+              match: {}
+              match_strategy_matrix: null
+              model:
+                id: 00000000-0000-0000-0000-000000000000
+                schemaVersion: ""
+                version: ""
+                name: kubernetes
+                displayName: ""
+                status: ""
+                registrant:
+                  id: 00000000-0000-0000-0000-000000000000
+                  name: ""
+                  type: ""
+                  sub_type: ""
+                  kind: github
+                  status: ""
+                  created_at: "0001-01-01T00:00:00Z"
+                  updated_at: "0001-01-01T00:00:00Z"
+                  deleted_at: null
+                  schemaVersion: ""
+                connection_id: 00000000-0000-0000-0000-000000000000
+                category:
+                  id: 00000000-0000-0000-0000-000000000000
+                  name: ""
+                subCategory: ""
+                metadata: null
+                model:
+                  version: ""
+                components_count: 0
+                relationships_count: 0
+                components: null
+                relationships: null
+              patch:
+                patchStrategy: replace
+                mutatorRef:
+                  - - configuration
+                    - spec
+                    - template
+                    - spec
+                    - containers
+                    - "0"
+                mutatedRef:
+                  - - configuration
+                    - spec
+                    - template
+                    - spec
+                    - containers
+                    - "0"
+        deny:
+          from: null
+          to: null
+    subType: alias
+    status: approved
+    type: parent
+    version: v1.0.0
+  - id: c2f1d5dd-9c24-4ae9-a94f-753861be09f8
+    evaluationQuery: ""
+    kind: hierarchical
+    metadata:
+      description: Namespace to namespaced components
+      styles:
+        primaryColor: ""
+        svgColor: ""
+        svgWhite: ""
+      isAnnotation: false
+    model:
+      id: b3f5bc0d-30f7-607d-6c73-784ddde6cad8
+      schemaVersion: models.meshery.io/v1beta1
+      version: v1.0.0
+      name: kubernetes
+      displayName: Kubernetes
+      status: enabled
+      registrant:
+        id: 00000000-0000-0000-0000-000000000000
+        name: ""
+        type: ""
+        sub_type: ""
+        kind: ""
+        status: ""
+        created_at: "0001-01-01T00:00:00Z"
+        updated_at: "0001-01-01T00:00:00Z"
+        deleted_at: null
+        schemaVersion: ""
+      connection_id: 5bc80e3c-5d43-9eb4-d16c-78a2769247a6
+      category:
+        id: 9ca27d0d-66ce-42a9-8c85-6236563f2ddb
+        name: Orchestration & Management
+      subCategory: Scheduling & Orchestration
+      metadata:
+        isAnnotation: false
+        primaryColor: '#326CE5'
+        secondaryColor: '#7aa1f0'
+        shape: circle
+        styleOverrides: ""
+        svgColor: ui/public/static/img/meshmodels/kubernetes/color/kubernetes-color.svg
+        svgComplete: ""
+        svgWhite: ui/public/static/img/meshmodels/kubernetes/white/kubernetes-white.svg
+      model:
+        version: v1.32.0-alpha.3
+      components_count: 0
+      relationships_count: 0
+      components: null
+      relationships: null
+    schemaVersion: relationships.meshery.io/v1alpha3
+    selectors:
+      - allow:
+          from:
+            - id: 51757207-7663-4caa-94e5-41e6b41e4082
+              kind: '*'
+              match: {}
+              match_strategy_matrix: null
+              model:
+                id: 00000000-0000-0000-0000-000000000000
+                schemaVersion: ""
+                version: ""
+                name: '*'
+                displayName: ""
+                status: ""
+                registrant:
+                  id: 00000000-0000-0000-0000-000000000000
+                  name: ""
+                  type: ""
+                  sub_type: ""
+                  kind: ""
+                  status: ""
+                  created_at: "0001-01-01T00:00:00Z"
+                  updated_at: "0001-01-01T00:00:00Z"
+                  deleted_at: null
+                  schemaVersion: ""
+                connection_id: 00000000-0000-0000-0000-000000000000
+                category:
+                  id: 00000000-0000-0000-0000-000000000000
+                  name: ""
+                subCategory: ""
+                metadata: null
+                model:
+                  version: ""
+                components_count: 0
+                relationships_count: 0
+                components: null
+                relationships: null
+              patch:
+                patchStrategy: replace
+                mutatedRef:
+                  - - configuration
+                    - metadata
+                    - namespace
+          to:
+            - id: 86c08e70-5da8-4970-a779-81a0ce712463
+              kind: Namespace
+              match: {}
+              match_strategy_matrix: null
+              model:
+                id: 00000000-0000-0000-0000-000000000000
+                schemaVersion: ""
+                version: ""
+                name: kubernetes
+                displayName: ""
+                status: ""
+                registrant:
+                  id: 00000000-0000-0000-0000-000000000000
+                  name: ""
+                  type: ""
+                  sub_type: ""
+                  kind: github
+                  status: ""
+                  created_at: "0001-01-01T00:00:00Z"
+                  updated_at: "0001-01-01T00:00:00Z"
+                  deleted_at: null
+                  schemaVersion: ""
+                connection_id: 00000000-0000-0000-0000-000000000000
+                category:
+                  id: 00000000-0000-0000-0000-000000000000
+                  name: ""
+                subCategory: ""
+                metadata: null
+                model:
+                  version: ""
+                components_count: 0
+                relationships_count: 0
+                components: null
+                relationships: null
+              patch:
+                patchStrategy: replace
+                mutatorRef:
+                  - - displayName
+    subType: inventory
+    status: approved
+    type: parent
+    version: v1.0.0
+  - id: d10489e2-6893-4604-9ea5-d238b0b3a591
+    evaluationQuery: ""
+    kind: edge
+    metadata:
+      description: In Kubernetes, ConfigMaps are a versatile resource that can be referenced by various other resources to provide configuration data to applications or other Kubnernetes resources.\n\nBy referencing ConfigMaps in these various contexts, you can centralize and manage configuration data more efficiently, allowing for easier updates, versioning, and maintenance of configurations in a Kubernetes environment.
+      styles:
+        primaryColor: ""
+        svgColor: ""
+        svgWhite: ""
+      isAnnotation: false
+    model:
+      id: b3f5bc0d-30f7-607d-6c73-784ddde6cad8
+      schemaVersion: models.meshery.io/v1beta1
+      version: v1.0.0
+      name: kubernetes
+      displayName: Kubernetes
+      status: enabled
+      registrant:
+        id: 00000000-0000-0000-0000-000000000000
+        name: ""
+        type: ""
+        sub_type: ""
+        kind: ""
+        status: ""
+        created_at: "0001-01-01T00:00:00Z"
+        updated_at: "0001-01-01T00:00:00Z"
+        deleted_at: null
+        schemaVersion: ""
+      connection_id: 5bc80e3c-5d43-9eb4-d16c-78a2769247a6
+      category:
+        id: 9ca27d0d-66ce-42a9-8c85-6236563f2ddb
+        name: Orchestration & Management
+      subCategory: Scheduling & Orchestration
+      metadata:
+        isAnnotation: false
+        primaryColor: '#326CE5'
+        secondaryColor: '#7aa1f0'
+        shape: circle
+        styleOverrides: ""
+        svgColor: ui/public/static/img/meshmodels/kubernetes/color/kubernetes-color.svg
+        svgComplete: ""
+        svgWhite: ui/public/static/img/meshmodels/kubernetes/white/kubernetes-white.svg
+      model:
+        version: v1.32.0-alpha.3
+      components_count: 0
+      relationships_count: 0
+      components: null
+      relationships: null
+    schemaVersion: relationships.meshery.io/v1alpha3
+    selectors:
+      - allow:
+          from:
+            - id: a6fbb851-a6ef-45d1-b20f-695aab006792
+              kind: ConfigMap
+              match: {}
+              match_strategy_matrix: null
+              model:
+                id: 00000000-0000-0000-0000-000000000000
+                schemaVersion: ""
+                version: ""
+                name: kubernetes
+                displayName: ""
+                status: ""
+                registrant:
+                  id: 00000000-0000-0000-0000-000000000000
+                  name: ""
+                  type: ""
+                  sub_type: ""
+                  kind: github
+                  status: ""
+                  created_at: "0001-01-01T00:00:00Z"
+                  updated_at: "0001-01-01T00:00:00Z"
+                  deleted_at: null
+                  schemaVersion: ""
+                connection_id: 00000000-0000-0000-0000-000000000000
+                category:
+                  id: 00000000-0000-0000-0000-000000000000
+                  name: ""
+                subCategory: ""
+                metadata: null
+                model:
+                  version: ""
+                components_count: 0
+                relationships_count: 0
+                components: null
+                relationships: null
+              patch:
+                patchStrategy: replace
+                mutatorRef:
+                  - - displayName
+          to:
+            - id: 0851ce28-0a59-4a30-85a8-36488ecb3762
+              kind: Deployment
+              match: {}
+              match_strategy_matrix: null
+              model:
+                id: 00000000-0000-0000-0000-000000000000
+                schemaVersion: ""
+                version: ""
+                name: kubernetes
+                displayName: ""
+                status: ""
+                registrant:
+                  id: 00000000-0000-0000-0000-000000000000
+                  name: ""
+                  type: ""
+                  sub_type: ""
+                  kind: github
+                  status: ""
+                  created_at: "0001-01-01T00:00:00Z"
+                  updated_at: "0001-01-01T00:00:00Z"
+                  deleted_at: null
+                  schemaVersion: ""
+                connection_id: 00000000-0000-0000-0000-000000000000
+                category:
+                  id: 00000000-0000-0000-0000-000000000000
+                  name: ""
+                subCategory: ""
+                metadata: null
+                model:
+                  version: ""
+                components_count: 0
+                relationships_count: 0
+                components: null
+                relationships: null
+              patch:
+                patchStrategy: replace
+                mutatedRef:
+                  - - configuration
+                    - spec
+                    - template
+                    - spec
+                    - containers
+                    - "0"
+                    - envFrom
+                    - "0"
+                    - configMapRef
+                    - name
+        deny:
+          from: null
+          to: null
+    subType: reference
+    status: approved
+    type: non-binding
+    version: v1.0.0
+  - id: d6eca4eb-4623-4e17-9153-57841a834743
+    evaluationQuery: ""
+    kind: edge
+    metadata:
+      description: A relationship that defines network edges between components
+      styles:
+        primaryColor: ""
+        svgColor: ""
+        svgWhite: ""
+      isAnnotation: false
+    model:
+      id: b3f5bc0d-30f7-607d-6c73-784ddde6cad8
+      schemaVersion: models.meshery.io/v1beta1
+      version: v1.0.0
+      name: kubernetes
+      displayName: Kubernetes
+      status: enabled
+      registrant:
+        id: 00000000-0000-0000-0000-000000000000
+        name: ""
+        type: ""
+        sub_type: ""
+        kind: ""
+        status: ""
+        created_at: "0001-01-01T00:00:00Z"
+        updated_at: "0001-01-01T00:00:00Z"
+        deleted_at: null
+        schemaVersion: ""
+      connection_id: 5bc80e3c-5d43-9eb4-d16c-78a2769247a6
+      category:
+        id: 9ca27d0d-66ce-42a9-8c85-6236563f2ddb
+        name: Orchestration & Management
+      subCategory: Scheduling & Orchestration
+      metadata:
+        isAnnotation: false
+        primaryColor: '#326CE5'
+        secondaryColor: '#7aa1f0'
+        shape: circle
+        styleOverrides: ""
+        svgColor: ui/public/static/img/meshmodels/kubernetes/color/kubernetes-color.svg
+        svgComplete: ""
+        svgWhite: ui/public/static/img/meshmodels/kubernetes/white/kubernetes-white.svg
+      model:
+        version: v1.32.0-alpha.3
+      components_count: 0
+      relationships_count: 0
+      components: null
+      relationships: null
+    schemaVersion: relationships.meshery.io/v1alpha3
+    selectors:
+      - allow:
+          from:
+            - id: 1a927054-cc7e-4435-bb00-f0e47647724b
+              kind: Service
+              match: {}
+              match_strategy_matrix:
+                - - to_contains_from
+                  - not_null
+                - - equal_as_strings
+                  - not_null
+                - - equal
+              model:
+                id: 00000000-0000-0000-0000-000000000000
+                schemaVersion: ""
+                version: ""
+                name: kubernetes
+                displayName: ""
+                status: ""
+                registrant:
+                  id: 00000000-0000-0000-0000-000000000000
+                  name: ""
+                  type: ""
+                  sub_type: ""
+                  kind: github
+                  status: ""
+                  created_at: "0001-01-01T00:00:00Z"
+                  updated_at: "0001-01-01T00:00:00Z"
+                  deleted_at: null
+                  schemaVersion: ""
+                connection_id: 00000000-0000-0000-0000-000000000000
+                category:
+                  id: 00000000-0000-0000-0000-000000000000
+                  name: ""
+                subCategory: ""
+                metadata: null
+                model:
+                  version: ""
+                components_count: 0
+                relationships_count: 0
+                components: null
+                relationships: null
+              patch:
+                patchStrategy: replace
+                mutatorRef:
+                  - - configuration
+                    - spec
+                    - selector
+                  - - configuration
+                    - spec
+                    - ports
+                    - "0"
+                    - targetPort
+                  - - configuration
+                    - spec
+                    - ports
+                    - "0"
+                    - protocol
+          to:
+            - id: 575c9682-8b50-4ea5-8307-9ce2e77e65b0
+              kind: Deployment
+              match: {}
+              match_strategy_matrix: null
+              model:
+                id: 00000000-0000-0000-0000-000000000000
+                schemaVersion: ""
+                version: ""
+                name: kubernetes
+                displayName: ""
+                status: ""
+                registrant:
+                  id: 00000000-0000-0000-0000-000000000000
+                  name: ""
+                  type: ""
+                  sub_type: ""
+                  kind: github
+                  status: ""
+                  created_at: "0001-01-01T00:00:00Z"
+                  updated_at: "0001-01-01T00:00:00Z"
+                  deleted_at: null
+                  schemaVersion: ""
+                connection_id: 00000000-0000-0000-0000-000000000000
+                category:
+                  id: 00000000-0000-0000-0000-000000000000
+                  name: ""
+                subCategory: ""
+                metadata: null
+                model:
+                  version: ""
+                components_count: 0
+                relationships_count: 0
+                components: null
+                relationships: null
+              patch:
+                patchStrategy: replace
+                mutatedRef:
+                  - - configuration
+                    - spec
+                    - selector
+                    - matchLabels
+                  - - configuration
+                    - spec
+                    - template
+                    - spec
+                    - containers
+                    - "0"
+                    - ports
+                    - "0"
+                    - name
+                  - - configuration
+                    - spec
+                    - template
+                    - spec
+                    - containers
+                    - "0"
+                    - ports
+                    - "0"
+                    - protocol
+        deny:
+          from: null
+          to: null
+    subType: network
+    status: approved
+    type: non-binding
+    version: v1.0.0
+  - id: d896e55f-5c0b-45ff-92d9-0fd02878a45a
+    evaluationQuery: ""
+    kind: hierarchical
+    metadata:
+      description: Namespace to namespaced components
+      styles:
+        primaryColor: ""
+        svgColor: ""
+        svgWhite: ""
+      isAnnotation: false
+    model:
+      id: b3f5bc0d-30f7-607d-6c73-784ddde6cad8
+      schemaVersion: models.meshery.io/v1beta1
+      version: v1.0.0
+      name: kubernetes
+      displayName: Kubernetes
+      status: enabled
+      registrant:
+        id: 00000000-0000-0000-0000-000000000000
+        name: ""
+        type: ""
+        sub_type: ""
+        kind: ""
+        status: ""
+        created_at: "0001-01-01T00:00:00Z"
+        updated_at: "0001-01-01T00:00:00Z"
+        deleted_at: null
+        schemaVersion: ""
+      connection_id: 5bc80e3c-5d43-9eb4-d16c-78a2769247a6
+      category:
+        id: 9ca27d0d-66ce-42a9-8c85-6236563f2ddb
+        name: Orchestration & Management
+      subCategory: Scheduling & Orchestration
+      metadata:
+        isAnnotation: false
+        primaryColor: '#326CE5'
+        secondaryColor: '#7aa1f0'
+        shape: circle
+        styleOverrides: ""
+        svgColor: ui/public/static/img/meshmodels/kubernetes/color/kubernetes-color.svg
+        svgComplete: ""
+        svgWhite: ui/public/static/img/meshmodels/kubernetes/white/kubernetes-white.svg
+      model:
+        version: v1.32.0-alpha.3
+      components_count: 0
+      relationships_count: 0
+      components: null
+      relationships: null
+    schemaVersion: relationships.meshery.io/v1alpha3
+    selectors:
+      - allow:
+          from:
+            - id: 42ed44fe-19b0-4da1-a880-13a51dbaaf82
+              kind: '*'
+              match: {}
+              match_strategy_matrix: null
+              model:
+                id: 00000000-0000-0000-0000-000000000000
+                schemaVersion: ""
+                version: ""
+                name: '*'
+                displayName: ""
+                status: ""
+                registrant:
+                  id: 00000000-0000-0000-0000-000000000000
+                  name: ""
+                  type: ""
+                  sub_type: ""
+                  kind: ""
+                  status: ""
+                  created_at: "0001-01-01T00:00:00Z"
+                  updated_at: "0001-01-01T00:00:00Z"
+                  deleted_at: null
+                  schemaVersion: ""
+                connection_id: 00000000-0000-0000-0000-000000000000
+                category:
+                  id: 00000000-0000-0000-0000-000000000000
+                  name: ""
+                subCategory: ""
+                metadata: null
+                model:
+                  version: ""
+                components_count: 0
+                relationships_count: 0
+                components: null
+                relationships: null
+              patch:
+                patchStrategy: replace
+                mutatedRef:
+                  - - configuration
+                    - metadata
+                    - namespace
+          to:
+            - id: 86c08e70-5da8-4970-a779-81a0ce712463
+              kind: Namespace
+              match: {}
+              match_strategy_matrix: null
+              model:
+                id: 00000000-0000-0000-0000-000000000000
+                schemaVersion: ""
+                version: ""
+                name: kubernetes
+                displayName: ""
+                status: ""
+                registrant:
+                  id: 00000000-0000-0000-0000-000000000000
+                  name: ""
+                  type: ""
+                  sub_type: ""
+                  kind: github
+                  status: ""
+                  created_at: "0001-01-01T00:00:00Z"
+                  updated_at: "0001-01-01T00:00:00Z"
+                  deleted_at: null
+                  schemaVersion: ""
+                connection_id: 00000000-0000-0000-0000-000000000000
+                category:
+                  id: 00000000-0000-0000-0000-000000000000
+                  name: ""
+                subCategory: ""
+                metadata: null
+                model:
+                  version: ""
+                components_count: 0
+                relationships_count: 0
+                components: null
+                relationships: null
+              patch:
+                patchStrategy: replace
+                mutatorRef:
+                  - - displayName
+    subType: inventory
+    status: approved
+    type: parent
+    version: v1.0.0
+  - id: e4285dba-5ec8-4418-ba67-f131ccb299b8
+    evaluationQuery: ""
+    kind: edge
+    metadata:
+      description: In Kubernetes, ConfigMaps are a versatile resource that can be referenced by various other resources to provide configuration data to applications or other Kubnernetes resources.\n\nBy referencing ConfigMaps in these various contexts, you can centralize and manage configuration data more efficiently, allowing for easier updates, versioning, and maintenance of configurations in a Kubernetes environment.
+      styles:
+        primaryColor: ""
+        svgColor: ""
+        svgWhite: ""
+      isAnnotation: false
+    model:
+      id: b3f5bc0d-30f7-607d-6c73-784ddde6cad8
+      schemaVersion: models.meshery.io/v1beta1
+      version: v1.0.0
+      name: kubernetes
+      displayName: Kubernetes
+      status: enabled
+      registrant:
+        id: 00000000-0000-0000-0000-000000000000
+        name: ""
+        type: ""
+        sub_type: ""
+        kind: ""
+        status: ""
+        created_at: "0001-01-01T00:00:00Z"
+        updated_at: "0001-01-01T00:00:00Z"
+        deleted_at: null
+        schemaVersion: ""
+      connection_id: 5bc80e3c-5d43-9eb4-d16c-78a2769247a6
+      category:
+        id: 9ca27d0d-66ce-42a9-8c85-6236563f2ddb
+        name: Orchestration & Management
+      subCategory: Scheduling & Orchestration
+      metadata:
+        isAnnotation: false
+        primaryColor: '#326CE5'
+        secondaryColor: '#7aa1f0'
+        shape: circle
+        styleOverrides: ""
+        svgColor: ui/public/static/img/meshmodels/kubernetes/color/kubernetes-color.svg
+        svgComplete: ""
+        svgWhite: ui/public/static/img/meshmodels/kubernetes/white/kubernetes-white.svg
+      model:
+        version: v1.32.0-alpha.3
+      components_count: 0
+      relationships_count: 0
+      components: null
+      relationships: null
+    schemaVersion: relationships.meshery.io/v1alpha3
+    selectors:
+      - allow:
+          from:
+            - id: 9829e694-b211-45ee-a4b5-77a0fe4dc286
+              kind: ConfigMap
+              match: {}
+              match_strategy_matrix: null
+              model:
+                id: 00000000-0000-0000-0000-000000000000
+                schemaVersion: ""
+                version: ""
+                name: kubernetes
+                displayName: ""
+                status: ""
+                registrant:
+                  id: 00000000-0000-0000-0000-000000000000
+                  name: ""
+                  type: ""
+                  sub_type: ""
+                  kind: github
+                  status: ""
+                  created_at: "0001-01-01T00:00:00Z"
+                  updated_at: "0001-01-01T00:00:00Z"
+                  deleted_at: null
+                  schemaVersion: ""
+                connection_id: 00000000-0000-0000-0000-000000000000
+                category:
+                  id: 00000000-0000-0000-0000-000000000000
+                  name: ""
+                subCategory: ""
+                metadata: null
+                model:
+                  version: ""
+                components_count: 0
+                relationships_count: 0
+                components: null
+                relationships: null
+              patch:
+                patchStrategy: replace
+                mutatorRef:
+                  - - displayName
+          to:
+            - id: 09ae7182-3f78-4fe8-8b76-db4b1e9ed46a
+              kind: Deployment
+              match: {}
+              match_strategy_matrix: null
+              model:
+                id: 00000000-0000-0000-0000-000000000000
+                schemaVersion: ""
+                version: ""
+                name: kubernetes
+                displayName: ""
+                status: ""
+                registrant:
+                  id: 00000000-0000-0000-0000-000000000000
+                  name: ""
+                  type: ""
+                  sub_type: ""
+                  kind: github
+                  status: ""
+                  created_at: "0001-01-01T00:00:00Z"
+                  updated_at: "0001-01-01T00:00:00Z"
+                  deleted_at: null
+                  schemaVersion: ""
+                connection_id: 00000000-0000-0000-0000-000000000000
+                category:
+                  id: 00000000-0000-0000-0000-000000000000
+                  name: ""
+                subCategory: ""
+                metadata: null
+                model:
+                  version: ""
+                components_count: 0
+                relationships_count: 0
+                components: null
+                relationships: null
+              patch:
+                patchStrategy: replace
+                mutatedRef:
+                  - - configuration
+                    - spec
+                    - template
+                    - spec
+                    - containers
+                    - "0"
+                    - envFrom
+                    - "0"
+                    - configMapRef
+                    - name
+        deny:
+          from: null
+          to: null
+    subType: reference
+    status: approved
+    type: non-binding
+    version: v1.0.0
+  - id: ebd3edd6-f650-4e48-8e05-db663811e639
+    evaluationQuery: ""
+    kind: hierarchical
+    metadata:
+      description: Namespace to namespaced components
+      styles:
+        primaryColor: ""
+        svgColor: ""
+        svgWhite: ""
+      isAnnotation: false
+    model:
+      id: b3f5bc0d-30f7-607d-6c73-784ddde6cad8
+      schemaVersion: models.meshery.io/v1beta1
+      version: v1.0.0
+      name: kubernetes
+      displayName: Kubernetes
+      status: enabled
+      registrant:
+        id: 00000000-0000-0000-0000-000000000000
+        name: ""
+        type: ""
+        sub_type: ""
+        kind: ""
+        status: ""
+        created_at: "0001-01-01T00:00:00Z"
+        updated_at: "0001-01-01T00:00:00Z"
+        deleted_at: null
+        schemaVersion: ""
+      connection_id: 5bc80e3c-5d43-9eb4-d16c-78a2769247a6
+      category:
+        id: 9ca27d0d-66ce-42a9-8c85-6236563f2ddb
+        name: Orchestration & Management
+      subCategory: Scheduling & Orchestration
+      metadata:
+        isAnnotation: false
+        primaryColor: '#326CE5'
+        secondaryColor: '#7aa1f0'
+        shape: circle
+        styleOverrides: ""
+        svgColor: ui/public/static/img/meshmodels/kubernetes/color/kubernetes-color.svg
+        svgComplete: ""
+        svgWhite: ui/public/static/img/meshmodels/kubernetes/white/kubernetes-white.svg
+      model:
+        version: v1.32.0-alpha.3
+      components_count: 0
+      relationships_count: 0
+      components: null
+      relationships: null
+    schemaVersion: relationships.meshery.io/v1alpha3
+    selectors:
+      - allow:
+          from:
+            - id: 868ab99a-9d42-45b7-86e7-935d91f1986d
+              kind: '*'
+              match: {}
+              match_strategy_matrix: null
+              model:
+                id: 00000000-0000-0000-0000-000000000000
+                schemaVersion: ""
+                version: ""
+                name: '*'
+                displayName: ""
+                status: ""
+                registrant:
+                  id: 00000000-0000-0000-0000-000000000000
+                  name: ""
+                  type: ""
+                  sub_type: ""
+                  kind: ""
+                  status: ""
+                  created_at: "0001-01-01T00:00:00Z"
+                  updated_at: "0001-01-01T00:00:00Z"
+                  deleted_at: null
+                  schemaVersion: ""
+                connection_id: 00000000-0000-0000-0000-000000000000
+                category:
+                  id: 00000000-0000-0000-0000-000000000000
+                  name: ""
+                subCategory: ""
+                metadata: null
+                model:
+                  version: ""
+                components_count: 0
+                relationships_count: 0
+                components: null
+                relationships: null
+              patch:
+                patchStrategy: replace
+                mutatedRef:
+                  - - configuration
+                    - metadata
+                    - namespace
+          to:
+            - id: 86c08e70-5da8-4970-a779-81a0ce712463
+              kind: Namespace
+              match: {}
+              match_strategy_matrix: null
+              model:
+                id: 00000000-0000-0000-0000-000000000000
+                schemaVersion: ""
+                version: ""
+                name: kubernetes
+                displayName: ""
+                status: ""
+                registrant:
+                  id: 00000000-0000-0000-0000-000000000000
+                  name: ""
+                  type: ""
+                  sub_type: ""
+                  kind: github
+                  status: ""
+                  created_at: "0001-01-01T00:00:00Z"
+                  updated_at: "0001-01-01T00:00:00Z"
+                  deleted_at: null
+                  schemaVersion: ""
+                connection_id: 00000000-0000-0000-0000-000000000000
+                category:
+                  id: 00000000-0000-0000-0000-000000000000
+                  name: ""
+                subCategory: ""
+                metadata: null
+                model:
+                  version: ""
+                components_count: 0
+                relationships_count: 0
+                components: null
+                relationships: null
+              patch:
+                patchStrategy: replace
+                mutatorRef:
+                  - - displayName
+    subType: inventory
+    status: approved
+    type: parent
+    version: v1.0.0
+  - id: f04817cd-8a88-412e-908f-5f7641874d6c
+    evaluationQuery: ""
+    kind: hierarchical
+    metadata:
+      description: Namespace to namespaced components
+      styles:
+        primaryColor: ""
+        svgColor: ""
+        svgWhite: ""
+      isAnnotation: false
+    model:
+      id: b3f5bc0d-30f7-607d-6c73-784ddde6cad8
+      schemaVersion: models.meshery.io/v1beta1
+      version: v1.0.0
+      name: kubernetes
+      displayName: Kubernetes
+      status: enabled
+      registrant:
+        id: 00000000-0000-0000-0000-000000000000
+        name: ""
+        type: ""
+        sub_type: ""
+        kind: ""
+        status: ""
+        created_at: "0001-01-01T00:00:00Z"
+        updated_at: "0001-01-01T00:00:00Z"
+        deleted_at: null
+        schemaVersion: ""
+      connection_id: 5bc80e3c-5d43-9eb4-d16c-78a2769247a6
+      category:
+        id: 9ca27d0d-66ce-42a9-8c85-6236563f2ddb
+        name: Orchestration & Management
+      subCategory: Scheduling & Orchestration
+      metadata:
+        isAnnotation: false
+        primaryColor: '#326CE5'
+        secondaryColor: '#7aa1f0'
+        shape: circle
+        styleOverrides: ""
+        svgColor: ui/public/static/img/meshmodels/kubernetes/color/kubernetes-color.svg
+        svgComplete: ""
+        svgWhite: ui/public/static/img/meshmodels/kubernetes/white/kubernetes-white.svg
+      model:
+        version: v1.32.0-alpha.3
+      components_count: 0
+      relationships_count: 0
+      components: null
+      relationships: null
+    schemaVersion: relationships.meshery.io/v1alpha3
+    selectors:
+      - allow:
+          from:
+            - id: 735a7537-ca88-4bfb-a3a4-ce811825b0f9
+              kind: '*'
+              match: {}
+              match_strategy_matrix: null
+              model:
+                id: 00000000-0000-0000-0000-000000000000
+                schemaVersion: ""
+                version: ""
+                name: '*'
+                displayName: ""
+                status: ""
+                registrant:
+                  id: 00000000-0000-0000-0000-000000000000
+                  name: ""
+                  type: ""
+                  sub_type: ""
+                  kind: ""
+                  status: ""
+                  created_at: "0001-01-01T00:00:00Z"
+                  updated_at: "0001-01-01T00:00:00Z"
+                  deleted_at: null
+                  schemaVersion: ""
+                connection_id: 00000000-0000-0000-0000-000000000000
+                category:
+                  id: 00000000-0000-0000-0000-000000000000
+                  name: ""
+                subCategory: ""
+                metadata: null
+                model:
+                  version: ""
+                components_count: 0
+                relationships_count: 0
+                components: null
+                relationships: null
+              patch:
+                patchStrategy: replace
+                mutatedRef:
+                  - - configuration
+                    - metadata
+                    - namespace
+          to:
+            - id: 86c08e70-5da8-4970-a779-81a0ce712463
+              kind: Namespace
+              match: {}
+              match_strategy_matrix: null
+              model:
+                id: 00000000-0000-0000-0000-000000000000
+                schemaVersion: ""
+                version: ""
+                name: kubernetes
+                displayName: ""
+                status: ""
+                registrant:
+                  id: 00000000-0000-0000-0000-000000000000
+                  name: ""
+                  type: ""
+                  sub_type: ""
+                  kind: github
+                  status: ""
+                  created_at: "0001-01-01T00:00:00Z"
+                  updated_at: "0001-01-01T00:00:00Z"
+                  deleted_at: null
+                  schemaVersion: ""
+                connection_id: 00000000-0000-0000-0000-000000000000
+                category:
+                  id: 00000000-0000-0000-0000-000000000000
+                  name: ""
+                subCategory: ""
+                metadata: null
+                model:
+                  version: ""
+                components_count: 0
+                relationships_count: 0
+                components: null
+                relationships: null
+              patch:
+                patchStrategy: replace
+                mutatorRef:
+                  - - displayName
+    subType: inventory
+    status: approved
+    type: parent
+    version: v1.0.0
+  - id: f0b39221-9af8-4911-9b73-97c45d28b628
+    evaluationQuery: ""
+    kind: hierarchical
+    metadata:
+      description: Namespace to namespaced components
+      styles:
+        primaryColor: ""
+        svgColor: ""
+        svgWhite: ""
+      isAnnotation: false
+    model:
+      id: b3f5bc0d-30f7-607d-6c73-784ddde6cad8
+      schemaVersion: models.meshery.io/v1beta1
+      version: v1.0.0
+      name: kubernetes
+      displayName: Kubernetes
+      status: enabled
+      registrant:
+        id: 00000000-0000-0000-0000-000000000000
+        name: ""
+        type: ""
+        sub_type: ""
+        kind: ""
+        status: ""
+        created_at: "0001-01-01T00:00:00Z"
+        updated_at: "0001-01-01T00:00:00Z"
+        deleted_at: null
+        schemaVersion: ""
+      connection_id: 5bc80e3c-5d43-9eb4-d16c-78a2769247a6
+      category:
+        id: 9ca27d0d-66ce-42a9-8c85-6236563f2ddb
+        name: Orchestration & Management
+      subCategory: Scheduling & Orchestration
+      metadata:
+        isAnnotation: false
+        primaryColor: '#326CE5'
+        secondaryColor: '#7aa1f0'
+        shape: circle
+        styleOverrides: ""
+        svgColor: ui/public/static/img/meshmodels/kubernetes/color/kubernetes-color.svg
+        svgComplete: ""
+        svgWhite: ui/public/static/img/meshmodels/kubernetes/white/kubernetes-white.svg
+      model:
+        version: v1.32.0-alpha.3
+      components_count: 0
+      relationships_count: 0
+      components: null
+      relationships: null
+    schemaVersion: relationships.meshery.io/v1alpha3
+    selectors:
+      - allow:
+          from:
+            - id: 595b7cae-0cd8-476a-9ec9-ace3f5ef7a04
+              kind: '*'
+              match: {}
+              match_strategy_matrix: null
+              model:
+                id: 00000000-0000-0000-0000-000000000000
+                schemaVersion: ""
+                version: ""
+                name: '*'
+                displayName: ""
+                status: ""
+                registrant:
+                  id: 00000000-0000-0000-0000-000000000000
+                  name: ""
+                  type: ""
+                  sub_type: ""
+                  kind: ""
+                  status: ""
+                  created_at: "0001-01-01T00:00:00Z"
+                  updated_at: "0001-01-01T00:00:00Z"
+                  deleted_at: null
+                  schemaVersion: ""
+                connection_id: 00000000-0000-0000-0000-000000000000
+                category:
+                  id: 00000000-0000-0000-0000-000000000000
+                  name: ""
+                subCategory: ""
+                metadata: null
+                model:
+                  version: ""
+                components_count: 0
+                relationships_count: 0
+                components: null
+                relationships: null
+              patch:
+                patchStrategy: replace
+                mutatedRef:
+                  - - configuration
+                    - metadata
+                    - namespace
+          to:
+            - id: 86c08e70-5da8-4970-a779-81a0ce712463
+              kind: Namespace
+              match: {}
+              match_strategy_matrix: null
+              model:
+                id: 00000000-0000-0000-0000-000000000000
+                schemaVersion: ""
+                version: ""
+                name: kubernetes
+                displayName: ""
+                status: ""
+                registrant:
+                  id: 00000000-0000-0000-0000-000000000000
+                  name: ""
+                  type: ""
+                  sub_type: ""
+                  kind: github
+                  status: ""
+                  created_at: "0001-01-01T00:00:00Z"
+                  updated_at: "0001-01-01T00:00:00Z"
+                  deleted_at: null
+                  schemaVersion: ""
+                connection_id: 00000000-0000-0000-0000-000000000000
+                category:
+                  id: 00000000-0000-0000-0000-000000000000
+                  name: ""
+                subCategory: ""
+                metadata: null
+                model:
+                  version: ""
+                components_count: 0
+                relationships_count: 0
+                components: null
+                relationships: null
+              patch:
+                patchStrategy: replace
+                mutatorRef:
+                  - - displayName
+    subType: inventory
+    status: approved
+    type: parent
+    version: v1.0.0
+  - id: f2932caf-aadb-4d94-a3fd-17af207c906d
+    evaluationQuery: ""
+    kind: hierarchical
+    metadata:
+      description: 'A hierarchical inventory relationship in which the configuration of (parent) component is patched with the configuration of other (child) component. Eg: The configuration of the EnvoyFilter (parent) component is patched with the configuration as received from WASMFilter (child) component.'
+      styles:
+        primaryColor: ""
+        svgColor: ""
+        svgWhite: ""
+      isAnnotation: false
+    model:
+      id: b3f5bc0d-30f7-607d-6c73-784ddde6cad8
+      schemaVersion: models.meshery.io/v1beta1
+      version: v1.0.0
+      name: kubernetes
+      displayName: Kubernetes
+      status: enabled
+      registrant:
+        id: 00000000-0000-0000-0000-000000000000
+        name: ""
+        type: ""
+        sub_type: ""
+        kind: ""
+        status: ""
+        created_at: "0001-01-01T00:00:00Z"
+        updated_at: "0001-01-01T00:00:00Z"
+        deleted_at: null
+        schemaVersion: ""
+      connection_id: 5bc80e3c-5d43-9eb4-d16c-78a2769247a6
+      category:
+        id: 9ca27d0d-66ce-42a9-8c85-6236563f2ddb
+        name: Orchestration & Management
+      subCategory: Scheduling & Orchestration
+      metadata:
+        isAnnotation: false
+        primaryColor: '#326CE5'
+        secondaryColor: '#7aa1f0'
+        shape: circle
+        styleOverrides: ""
+        svgColor: ui/public/static/img/meshmodels/kubernetes/color/kubernetes-color.svg
+        svgComplete: ""
+        svgWhite: ui/public/static/img/meshmodels/kubernetes/white/kubernetes-white.svg
+      model:
+        version: v1.32.0-alpha.3
+      components_count: 0
+      relationships_count: 0
+      components: null
+      relationships: null
+    schemaVersion: relationships.meshery.io/v1alpha3
+    selectors:
+      - allow:
+          from:
+            - id: 96b6e2bf-d53c-4404-a696-94eb9a5c4b3d
+              kind: Container
+              match: {}
+              match_strategy_matrix: null
+              model:
+                id: 00000000-0000-0000-0000-000000000000
+                schemaVersion: ""
+                version: ""
+                name: meshery-core
+                displayName: ""
+                status: ""
+                registrant:
+                  id: 00000000-0000-0000-0000-000000000000
+                  name: ""
+                  type: ""
+                  sub_type: ""
+                  kind: github
+                  status: ""
+                  created_at: "0001-01-01T00:00:00Z"
+                  updated_at: "0001-01-01T00:00:00Z"
+                  deleted_at: null
+                  schemaVersion: ""
+                connection_id: 00000000-0000-0000-0000-000000000000
+                category:
+                  id: 00000000-0000-0000-0000-000000000000
+                  name: ""
+                subCategory: ""
+                metadata: null
+                model:
+                  version: ""
+                components_count: 0
+                relationships_count: 0
+                components: null
+                relationships: null
+              patch:
+                patchStrategy: replace
+                mutatorRef:
+                  - - configuration
+                    - spec
+                    - template
+                    - spec
+                    - containers
+                    - "0"
+                mutatedRef:
+                  - - configuration
+                    - spec
+                    - template
+                    - spec
+                    - containers
+                    - "0"
+          to:
+            - id: 0851ce28-0a59-4a30-85a8-36488ecb3762
+              kind: Deployment
+              match: {}
+              match_strategy_matrix: null
+              model:
+                id: 00000000-0000-0000-0000-000000000000
+                schemaVersion: ""
+                version: ""
+                name: kubernetes
+                displayName: ""
+                status: ""
+                registrant:
+                  id: 00000000-0000-0000-0000-000000000000
+                  name: ""
+                  type: ""
+                  sub_type: ""
+                  kind: github
+                  status: ""
+                  created_at: "0001-01-01T00:00:00Z"
+                  updated_at: "0001-01-01T00:00:00Z"
+                  deleted_at: null
+                  schemaVersion: ""
+                connection_id: 00000000-0000-0000-0000-000000000000
+                category:
+                  id: 00000000-0000-0000-0000-000000000000
+                  name: ""
+                subCategory: ""
+                metadata: null
+                model:
+                  version: ""
+                components_count: 0
+                relationships_count: 0
+                components: null
+                relationships: null
+              patch:
+                patchStrategy: replace
+                mutatorRef:
+                  - - configuration
+                    - spec
+                    - template
+                    - spec
+                    - containers
+                    - "0"
+                mutatedRef:
+                  - - configuration
+                    - spec
+                    - template
+                    - spec
+                    - containers
+                    - "0"
+        deny:
+          from: null
+          to: null
+    subType: alias
+    status: approved
+    type: parent
+    version: v1.0.0
+  - id: f833e77a-cd11-414f-bcfc-3aceffcda1d5
+    evaluationQuery: ""
+    kind: hierarchical
+    metadata:
+      description: Namespace to namespaced components
+      styles:
+        primaryColor: ""
+        svgColor: ""
+        svgWhite: ""
+      isAnnotation: false
+    model:
+      id: b3f5bc0d-30f7-607d-6c73-784ddde6cad8
+      schemaVersion: models.meshery.io/v1beta1
+      version: v1.0.0
+      name: kubernetes
+      displayName: Kubernetes
+      status: enabled
+      registrant:
+        id: 00000000-0000-0000-0000-000000000000
+        name: ""
+        type: ""
+        sub_type: ""
+        kind: ""
+        status: ""
+        created_at: "0001-01-01T00:00:00Z"
+        updated_at: "0001-01-01T00:00:00Z"
+        deleted_at: null
+        schemaVersion: ""
+      connection_id: 5bc80e3c-5d43-9eb4-d16c-78a2769247a6
+      category:
+        id: 9ca27d0d-66ce-42a9-8c85-6236563f2ddb
+        name: Orchestration & Management
+      subCategory: Scheduling & Orchestration
+      metadata:
+        isAnnotation: false
+        primaryColor: '#326CE5'
+        secondaryColor: '#7aa1f0'
+        shape: circle
+        styleOverrides: ""
+        svgColor: ui/public/static/img/meshmodels/kubernetes/color/kubernetes-color.svg
+        svgComplete: ""
+        svgWhite: ui/public/static/img/meshmodels/kubernetes/white/kubernetes-white.svg
+      model:
+        version: v1.32.0-alpha.3
+      components_count: 0
+      relationships_count: 0
+      components: null
+      relationships: null
+    schemaVersion: relationships.meshery.io/v1alpha3
+    selectors:
+      - allow:
+          from:
+            - id: 6d4ad9d9-af51-4569-9abe-a5197e75affb
+              kind: '*'
+              match: {}
+              match_strategy_matrix: null
+              model:
+                id: 00000000-0000-0000-0000-000000000000
+                schemaVersion: ""
+                version: ""
+                name: '*'
+                displayName: ""
+                status: ""
+                registrant:
+                  id: 00000000-0000-0000-0000-000000000000
+                  name: ""
+                  type: ""
+                  sub_type: ""
+                  kind: ""
+                  status: ""
+                  created_at: "0001-01-01T00:00:00Z"
+                  updated_at: "0001-01-01T00:00:00Z"
+                  deleted_at: null
+                  schemaVersion: ""
+                connection_id: 00000000-0000-0000-0000-000000000000
+                category:
+                  id: 00000000-0000-0000-0000-000000000000
+                  name: ""
+                subCategory: ""
+                metadata: null
+                model:
+                  version: ""
+                components_count: 0
+                relationships_count: 0
+                components: null
+                relationships: null
+              patch:
+                patchStrategy: replace
+                mutatedRef:
+                  - - configuration
+                    - metadata
+                    - namespace
+          to:
+            - id: 86c08e70-5da8-4970-a779-81a0ce712463
+              kind: Namespace
+              match: {}
+              match_strategy_matrix: null
+              model:
+                id: 00000000-0000-0000-0000-000000000000
+                schemaVersion: ""
+                version: ""
+                name: kubernetes
+                displayName: ""
+                status: ""
+                registrant:
+                  id: 00000000-0000-0000-0000-000000000000
+                  name: ""
+                  type: ""
+                  sub_type: ""
+                  kind: github
+                  status: ""
+                  created_at: "0001-01-01T00:00:00Z"
+                  updated_at: "0001-01-01T00:00:00Z"
+                  deleted_at: null
+                  schemaVersion: ""
+                connection_id: 00000000-0000-0000-0000-000000000000
+                category:
+                  id: 00000000-0000-0000-0000-000000000000
+                  name: ""
+                subCategory: ""
+                metadata: null
+                model:
+                  version: ""
+                components_count: 0
+                relationships_count: 0
+                components: null
+                relationships: null
+              patch:
+                patchStrategy: replace
+                mutatorRef:
+                  - - displayName
+    subType: inventory
+    status: approved
+    type: parent
+    version: v1.0.0
+  - id: f9c9654f-aa03-40c1-be8c-789c02b3f0cc
+    evaluationQuery: ""
+    kind: hierarchical
+    metadata:
+      description: 'A hierarchical inventory relationship in which the configuration of (parent) component is patched with the configuration of other (child) component. Eg: The configuration of the EnvoyFilter (parent) component is patched with the configuration as received from WASMFilter (child) component.'
+      styles:
+        primaryColor: ""
+        svgColor: ""
+        svgWhite: ""
+      isAnnotation: false
+    model:
+      id: b3f5bc0d-30f7-607d-6c73-784ddde6cad8
+      schemaVersion: models.meshery.io/v1beta1
+      version: v1.0.0
+      name: kubernetes
+      displayName: Kubernetes
+      status: enabled
+      registrant:
+        id: 00000000-0000-0000-0000-000000000000
+        name: ""
+        type: ""
+        sub_type: ""
+        kind: ""
+        status: ""
+        created_at: "0001-01-01T00:00:00Z"
+        updated_at: "0001-01-01T00:00:00Z"
+        deleted_at: null
+        schemaVersion: ""
+      connection_id: 5bc80e3c-5d43-9eb4-d16c-78a2769247a6
+      category:
+        id: 9ca27d0d-66ce-42a9-8c85-6236563f2ddb
+        name: Orchestration & Management
+      subCategory: Scheduling & Orchestration
+      metadata:
+        isAnnotation: false
+        primaryColor: '#326CE5'
+        secondaryColor: '#7aa1f0'
+        shape: circle
+        styleOverrides: ""
+        svgColor: ui/public/static/img/meshmodels/kubernetes/color/kubernetes-color.svg
+        svgComplete: ""
+        svgWhite: ui/public/static/img/meshmodels/kubernetes/white/kubernetes-white.svg
+      model:
+        version: v1.32.0-alpha.3
+      components_count: 0
+      relationships_count: 0
+      components: null
+      relationships: null
+    schemaVersion: relationships.meshery.io/v1alpha3
+    selectors:
+      - allow:
+          from:
+            - id: 7992b206-6d7c-43e5-b208-e0cc64cca312
+              kind: Container
+              match: {}
+              match_strategy_matrix: null
+              model:
+                id: 00000000-0000-0000-0000-000000000000
+                schemaVersion: ""
+                version: ""
+                name: meshery-core
+                displayName: ""
+                status: ""
+                registrant:
+                  id: 00000000-0000-0000-0000-000000000000
+                  name: ""
+                  type: ""
+                  sub_type: ""
+                  kind: github
+                  status: ""
+                  created_at: "0001-01-01T00:00:00Z"
+                  updated_at: "0001-01-01T00:00:00Z"
+                  deleted_at: null
+                  schemaVersion: ""
+                connection_id: 00000000-0000-0000-0000-000000000000
+                category:
+                  id: 00000000-0000-0000-0000-000000000000
+                  name: ""
+                subCategory: ""
+                metadata: null
+                model:
+                  version: ""
+                components_count: 0
+                relationships_count: 0
+                components: null
+                relationships: null
+              patch:
+                patchStrategy: replace
+                mutatorRef:
+                  - - configuration
+                    - spec
+                    - template
+                    - spec
+                    - containers
+                    - "0"
+                mutatedRef:
+                  - - configuration
+                    - spec
+                    - template
+                    - spec
+                    - containers
+                    - "0"
+          to:
+            - id: 09ae7182-3f78-4fe8-8b76-db4b1e9ed46a
+              kind: Deployment
+              match: {}
+              match_strategy_matrix: null
+              model:
+                id: 00000000-0000-0000-0000-000000000000
+                schemaVersion: ""
+                version: ""
+                name: kubernetes
+                displayName: ""
+                status: ""
+                registrant:
+                  id: 00000000-0000-0000-0000-000000000000
+                  name: ""
+                  type: ""
+                  sub_type: ""
+                  kind: github
+                  status: ""
+                  created_at: "0001-01-01T00:00:00Z"
+                  updated_at: "0001-01-01T00:00:00Z"
+                  deleted_at: null
+                  schemaVersion: ""
+                connection_id: 00000000-0000-0000-0000-000000000000
+                category:
+                  id: 00000000-0000-0000-0000-000000000000
+                  name: ""
+                subCategory: ""
+                metadata: null
+                model:
+                  version: ""
+                components_count: 0
+                relationships_count: 0
+                components: null
+                relationships: null
+              patch:
+                patchStrategy: replace
+                mutatorRef:
+                  - - configuration
+                    - spec
+                    - template
+                    - spec
+                    - containers
+                    - "0"
+                mutatedRef:
+                  - - configuration
+                    - spec
+                    - template
+                    - spec
+                    - containers
+                    - "0"
+        deny:
+          from: null
+          to: null
+    subType: alias
+    status: approved
+    type: parent
+    version: v1.0.0


### PR DESCRIPTION
# [Design] Add devtron-operator to Meshery Catalog

## Summary
Adds a Meshery **Design** for the Devtron Operator (CRDs only). The design consolidates the Devtron Operator CRD and Argo CD CRDs (Application, AppProject, ApplicationSet) into a single reusable design named `devtron-operator`.

## What’s included
- `hacktoberfest_contributions/devtron-operator/devtron-operator.design.yaml`
- Design scope: **CRDs only** (no controller Deployment).

## How this was produced
```bash
# Render the Helm chart (includes CRDs)
helm template devtron-operator ./devtron-operator --include-crds > devtron-operator.rendered.yaml

# Import into a single design
mesheryctl design import -n devtron-operator -f devtron-operator.rendered.yaml
```
#15945 