### PR TITLE
Design : Add dremio helm design

### DIFF
--- a/hacktoberfest_contributions/dremio-helm/design.yaml
+++ b/hacktoberfest_contributions/dremio-helm/design.yaml
@@ -1,0 +1,1944 @@
+id: 00000000-0000-0000-0000-000000000000
+name: dremio-helm
+schemaVersion: designs.meshery.io/v1beta1
+version: 0.0.1
+components:
+  - id: a8054945-9a3a-4f75-b048-d4e2d5358329
+    schemaVersion: components.meshery.io/v1beta1
+    version: v1.0.0
+    displayName: zk-pdb
+    description: ""
+    format: ""
+    model:
+      id: b3f5bc0d-30f7-607d-6c73-784ddde6cad8
+      schemaVersion: models.meshery.io/v1beta1
+      version: v1.0.0
+      name: kubernetes
+      displayName: Kubernetes
+      status: enabled
+      registrant:
+        id: 5bc80e3c-5d43-9eb4-d16c-78a2769247a6
+        name: Github
+        credential_id: 00000000-0000-0000-0000-000000000000
+        type: registry
+        sub_type: ""
+        kind: github
+        status: registered
+        user_id: 00000000-0000-0000-0000-000000000000
+        created_at: "2025-10-12T14:26:03.160654794Z"
+        updated_at: "2025-10-12T14:26:03.160654794Z"
+        deleted_at: "0001-01-01T00:00:00Z"
+        schemaVersion: ""
+      connection_id: 5bc80e3c-5d43-9eb4-d16c-78a2769247a6
+      category:
+        id: 9ca27d0d-66ce-42a9-8c85-6236563f2ddb
+        name: Orchestration & Management
+      subCategory: Scheduling & Orchestration
+      metadata:
+        isAnnotation: false
+        primaryColor: '#326CE5'
+        secondaryColor: '#7aa1f0'
+        shape: circle
+        styleOverrides: ""
+        svgColor: ui/public/static/img/meshmodels/kubernetes/color/kubernetes-color.svg
+        svgComplete: ""
+        svgWhite: ui/public/static/img/meshmodels/kubernetes/white/kubernetes-white.svg
+      model:
+        version: v1.32.0-alpha.3
+      components_count: 0
+      relationships_count: 0
+      components: null
+      relationships: null
+    styles:
+      primaryColor: '#326CE5'
+      secondaryColor: '#7aa1f0'
+      shape: concave-hexagon
+      svgColor: ui/public/static/img/meshmodels/kubernetes/color/poddisruptionbudget-color.svg
+      svgComplete: ""
+      svgWhite: ui/public/static/img/meshmodels/kubernetes/white/poddisruptionbudget-white.svg
+    capabilities: []
+    status: enabled
+    metadata:
+      configurationUISchema: ""
+      genealogy: ""
+      instanceDetails: null
+      isAnnotation: false
+      isNamespaced: true
+      published: false
+      source_uri: git://github.com/kubernetes/kubernetes/master/api/openapi-spec/v3
+    configuration:
+      metadata:
+        name: zk-pdb
+      spec:
+        maxUnavailable: 1
+        selector:
+          matchLabels:
+            app: zk
+    component:
+      version: policy/v1
+      kind: PodDisruptionBudget
+      schema: ""
+  - id: e338d4d9-050e-4900-bc9d-dfea0fc4f7c4
+    schemaVersion: components.meshery.io/v1beta1
+    version: v1.0.0
+    displayName: dremio-config
+    description: ""
+    format: ""
+    model:
+      id: b3f5bc0d-30f7-607d-6c73-784ddde6cad8
+      schemaVersion: models.meshery.io/v1beta1
+      version: v1.0.0
+      name: kubernetes
+      displayName: Kubernetes
+      status: enabled
+      registrant:
+        id: 5bc80e3c-5d43-9eb4-d16c-78a2769247a6
+        name: Github
+        credential_id: 00000000-0000-0000-0000-000000000000
+        type: registry
+        sub_type: ""
+        kind: github
+        status: registered
+        user_id: 00000000-0000-0000-0000-000000000000
+        created_at: "2025-10-12T14:26:03.160654794Z"
+        updated_at: "2025-10-12T14:26:03.160654794Z"
+        deleted_at: "0001-01-01T00:00:00Z"
+        schemaVersion: ""
+      connection_id: 5bc80e3c-5d43-9eb4-d16c-78a2769247a6
+      category:
+        id: 9ca27d0d-66ce-42a9-8c85-6236563f2ddb
+        name: Orchestration & Management
+      subCategory: Scheduling & Orchestration
+      metadata:
+        isAnnotation: false
+        primaryColor: '#326CE5'
+        secondaryColor: '#7aa1f0'
+        shape: circle
+        styleOverrides: ""
+        svgColor: ui/public/static/img/meshmodels/kubernetes/color/kubernetes-color.svg
+        svgComplete: ""
+        svgWhite: ui/public/static/img/meshmodels/kubernetes/white/kubernetes-white.svg
+      model:
+        version: v1.32.0-alpha.3
+      components_count: 0
+      relationships_count: 0
+      components: null
+      relationships: null
+    styles:
+      primaryColor: '#326CE5'
+      secondaryColor: '#7aa1f0'
+      shape: bottom-round-rectangle
+      svgColor: ui/public/static/img/meshmodels/kubernetes/color/configmap-color.svg
+      svgComplete: ""
+      svgWhite: ui/public/static/img/meshmodels/kubernetes/white/configmap-white.svg
+    capabilities: []
+    status: enabled
+    metadata:
+      configurationUISchema: ""
+      genealogy: ""
+      instanceDetails: null
+      isAnnotation: false
+      isNamespaced: true
+      published: false
+      source_uri: git://github.com/kubernetes/kubernetes/master/api/openapi-spec/v3
+    configuration:
+      data:
+        core-site.xml: "<?xml version=\"1.0\"?>\n<configuration>\n  <!-- If you are editing any content in this file, please remove lines with double curly braces around them -->\n  <!-- S3 Configuration Section -->\n  <property>\n    <name>fs.dremioS3.impl</name>\n    <description>The FileSystem implementation. Must be set to com.dremio.plugins.s3.store.S3FileSystem</description>\n    <value>com.dremio.plugins.s3.store.S3FileSystem</value>\n  </property>\n  <property>\n    <name>fs.s3a.aws.credentials.provider</name>\n    <description>The credential provider type.</description>\n    <value>com.amazonaws.auth.InstanceProfileCredentialsProvider</value>\n  </property>\n  \n</configuration>"
+        dremio-env: |
+          #
+          # Copyright (C) 2017-2018 Dremio Corporation
+          #
+          # Licensed under the Apache License, Version 2.0 (the "License");
+          # you may not use this file except in compliance with the License.
+          # You may obtain a copy of the License at
+          #
+          #     http://www.apache.org/licenses/LICENSE-2.0
+          #
+          # Unless required by applicable law or agreed to in writing, software
+          # distributed under the License is distributed on an "AS IS" BASIS,
+          # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+          # See the License for the specific language governing permissions and
+          # limitations under the License.
+          #
+
+          #
+          # Dremio environment variables used by Dremio daemon
+          #
+
+          #
+          # Directory where Dremio logs are written
+          # Default to $DREMIO_HOME/log
+          #
+          #DREMIO_LOG_DIR=${DREMIO_HOME}/log
+
+          #
+          # Send logs to console and not to log files. The DREMIO_LOG_DIR is ignored if set.
+          #
+          #DREMIO_LOG_TO_CONSOLE=1
+
+          #
+          # Directory where Dremio pidfiles are written
+          # Default to $DREMIO_HOME/run
+          #
+          #DREMIO_PID_DIR=${DREMIO_HOME}/run
+
+          #
+          # Max total memory size (in MB) for the Dremio process
+          #
+          # If not set, default to using max heap and max direct.
+          #
+          # If both max heap and max direct are set, this is not used
+          # If one is set, the other is calculated as difference
+          # of max memory and the one that is set.
+          #
+          #DREMIO_MAX_MEMORY_SIZE_MB=
+
+          #
+          # Max heap memory size (in MB) for the Dremio process
+          #
+          # Default to 4096 for server
+          #
+          #DREMIO_MAX_HEAP_MEMORY_SIZE_MB=4096
+
+          #
+          # Max direct memory size (in MB) for the Dremio process
+          #
+          # Default to 8192 for server
+          #
+          #DREMIO_MAX_DIRECT_MEMORY_SIZE_MB=8192
+
+          #
+          # Max permanent generation memory size (in MB) for the Dremio process
+          # (Only used for Java 7)
+          #
+          # Default to 512 for server
+          #
+          #DREMIO_MAX_PERMGEN_MEMORY_SIZE_MB=512
+
+          #
+          # Garbage collection logging is enabled by default. Set the following
+          # parameter to "no" to disable garbage collection logging.
+          #
+          #DREMIO_GC_LOGS_ENABLED="yes"
+
+          #
+          # The scheduling priority for the server
+          #
+          # Default to 0
+          #
+          # DREMIO_NICENESS=0
+          #
+
+          #
+          # Number of seconds after which the server is killed forcibly it it hasn't stopped
+          #
+          # Default to 120
+          #
+          #DREMIO_STOP_TIMEOUT=120
+
+          # Extra Java options - shared between dremio and dremio-admin commands
+          #
+          #DREMIO_JAVA_EXTRA_OPTS=
+
+          # Extra Java options - client only (dremio-admin command)
+          #
+          #DREMIO_JAVA_CLIENT_EXTRA_OPTS=
+
+          # Warning: Do not set DREMIO_JAVA_SERVER_EXTRA_OPTS in dremio-env.
+          # Please see the values.yaml extraStartParams for setting additional options for Dremio process startup.
+        dremio.conf: "#\n# Copyright (C) 2017-2018 Dremio Corporation\n#\n# Licensed under the Apache License, Version 2.0 (the \"License\");\n# you may not use this file except in compliance with the License.\n# You may obtain a copy of the License at\n#\n#     http://www.apache.org/licenses/LICENSE-2.0\n#\n# Unless required by applicable law or agreed to in writing, software\n# distributed under the License is distributed on an \"AS IS\" BASIS,\n# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.\n# See the License for the specific language governing permissions and\n# limitations under the License.\n#\n\npaths: {\n  # Local path for dremio to store data.\n  local: ${DREMIO_HOME}\"/data\"\n  # Distributed path Dremio data including job results, downloads,\n  # uploads, etc\n  results: \"pdfs://\"${paths.local}\"/results\"\n  dist: \"dremioS3:///AWS Bucket Name/\"\n}\n\nservices: {\n  # The services running are controlled via command line options passed in\n  # while starting the services via kubernetes. Updating the values listed below will not\n  # impact what is running:\n  # - coordinator.enabled\n  # - coordinator.master.enabled\n  # - coordinator.master.embedded-zookeeper.enabled\n  # - executor.enabled\n  #\n  # Other service parameters can be customized via this file.\n  executor: {\n    cache: {\n      path.db: \"/opt/dremio/cloudcache/c0\"\n      pctquota.db: 100\n\n      path.fs: [\"/opt/dremio/cloudcache/c0\"]\n      pctquota.fs: [100]\n      ensurefreespace.fs: [0]\n      \n    }\n  }\n}\ndebug: {\n  # Enable caching for distributed storage, it is turned off by default\n  dist.caching.enabled: true,\n  # Max percent of total available cache space to use when possible for distributed storage\n  dist.max.cache.space.percent: 100\n}\n"
+        logback-access.xml: |
+          <?xml version="1.0" encoding="UTF-8" ?>
+          <!--
+
+              Copyright (C) 2017-2018 Dremio Corporation
+
+              Licensed under the Apache License, Version 2.0 (the "License");
+              you may not use this file except in compliance with the License.
+              You may obtain a copy of the License at
+
+                  http://www.apache.org/licenses/LICENSE-2.0
+
+              Unless required by applicable law or agreed to in writing, software
+              distributed under the License is distributed on an "AS IS" BASIS,
+              WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+              See the License for the specific language governing permissions and
+              limitations under the License.
+
+          -->
+          <configuration>
+
+            <!-- The following appender is only available if dremio.log.path is defined -->
+            <if condition='isDefined("dremio.log.path")'>
+              <then>
+                <appender name="access-text" class="ch.qos.logback.core.rolling.RollingFileAppender">
+                  <file>${dremio.log.path}/access.log</file>
+                  <rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
+                    <fileNamePattern>${dremio.log.path}/archive/access.%d{yyyy-MM-dd}.%i.log.gz</fileNamePattern>
+                    <maxHistory>30</maxHistory>
+                    <timeBasedFileNamingAndTriggeringPolicy class="ch.qos.logback.core.rolling.SizeAndTimeBasedFNATP">
+                      <maxFileSize>100MB</maxFileSize>
+                    </timeBasedFileNamingAndTriggeringPolicy>
+                  </rollingPolicy>
+
+                  <encoder>
+                    <pattern>combined</pattern>
+                  </encoder>
+                </appender>
+
+                <appender-ref ref="access-text" />
+              </then>
+              <else>
+                <appender name="console" class="ch.qos.logback.core.ConsoleAppender">
+                  <encoder>
+                    <pattern>combined</pattern>
+                  </encoder>
+                </appender>
+
+                <appender-ref ref="console"/>
+              </else>
+            </if>
+          </configuration>
+        logback-admin.xml: |
+          <?xml version="1.0" encoding="UTF-8" ?>
+          <!--
+
+              Copyright (C) 2017-2018 Dremio Corporation
+
+              Licensed under the Apache License, Version 2.0 (the "License");
+              you may not use this file except in compliance with the License.
+              You may obtain a copy of the License at
+
+                  http://www.apache.org/licenses/LICENSE-2.0
+
+              Unless required by applicable law or agreed to in writing, software
+              distributed under the License is distributed on an "AS IS" BASIS,
+              WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+              See the License for the specific language governing permissions and
+              limitations under the License.
+
+          -->
+          <configuration>
+            <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+              <encoder>
+                <pattern>%msg%n%ex{0}%n</pattern>
+              </encoder>
+            </appender>
+
+
+            <appender name="CONSOLE" class="ch.qos.logback.core.ConsoleAppender">
+              <filter class="ch.qos.logback.classic.filter.ThresholdFilter">
+                <level>${dremio.admin.log.verbosity:-OFF}</level>
+              </filter>
+              <encoder>
+                <pattern>%date{ISO8601} [%thread] %-5level %logger{30} - %msg%n</pattern>
+              </encoder>
+            </appender>
+
+
+            <if condition='isDefined("dremio.admin.log.path")'>
+              <then>
+                <appender name="ADMINLOG" class="ch.qos.logback.core.FileAppender">
+                  <filter class="ch.qos.logback.classic.filter.ThresholdFilter">
+                    <level>${dremio.admin.log.verbosity:-OFF}</level>
+                  </filter>
+                  <file>${dremio.admin.log.path}</file>
+                  <encoder>
+                    <pattern>%date{ISO8601} [%thread] %-5level %logger{36} - %msg%n</pattern>
+                  </encoder>
+                </appender>
+              </then>
+            </if>
+
+            <logger name="admin" level="INFO" additivity="true">
+              <appender-ref ref="STDOUT"/>
+            </logger>
+
+            <root>
+              <level value="${dremio.admin.log.verbosity:-OFF}"/>
+              <if condition='isDefined("dremio.admin.log.path")'>
+                <then>
+                  <appender-ref ref="ADMINLOG"/>
+                </then>
+                <else>
+                  <appender-ref ref="CONSOLE"/>
+                </else>
+              </if>
+            </root>
+
+          </configuration>
+        logback.xml: |
+          <?xml version="1.0" encoding="UTF-8" ?>
+          <!--
+
+              Copyright (C) 2017-2018 Dremio Corporation
+
+              Licensed under the Apache License, Version 2.0 (the "License");
+              you may not use this file except in compliance with the License.
+              You may obtain a copy of the License at
+
+                  http://www.apache.org/licenses/LICENSE-2.0
+
+              Unless required by applicable law or agreed to in writing, software
+              distributed under the License is distributed on an "AS IS" BASIS,
+              WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+              See the License for the specific language governing permissions and
+              limitations under the License.
+
+          -->
+          <configuration scan="true" scanPeriod="30 seconds">
+            <contextListener class="ch.qos.logback.classic.jul.LevelChangePropagator"/>
+            <appender name="console" class="ch.qos.logback.core.ConsoleAppender">
+              <encoder>
+                <pattern>%date{ISO8601} [%thread] %-5level %logger{36} - %msg%n</pattern>
+              </encoder>
+            </appender>
+
+            <!-- The following appenders are only available if dremio.log.path is defined -->
+            <if condition='isDefined("dremio.log.path")'>
+              <then>
+                <appender name="text" class="ch.qos.logback.core.rolling.RollingFileAppender">
+                  <file>${dremio.log.path}/server.log</file>
+                  <rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
+                    <fileNamePattern>${dremio.log.path}/archive/server.%d{yyyy-MM-dd}.%i.log.gz</fileNamePattern>
+                    <maxHistory>30</maxHistory>
+                    <timeBasedFileNamingAndTriggeringPolicy class="ch.qos.logback.core.rolling.SizeAndTimeBasedFNATP">
+                      <maxFileSize>100MB</maxFileSize>
+                    </timeBasedFileNamingAndTriggeringPolicy>
+                  </rollingPolicy>
+
+                  <encoder>
+                    <pattern>%date{ISO8601} [%thread] %-5level %logger{36} - %msg%n</pattern>
+                  </encoder>
+                </appender>
+
+                <appender name="metadata_refresh" class="ch.qos.logback.core.rolling.RollingFileAppender">
+                  <file>${dremio.log.path}/metadata_refresh.log</file>
+                  <rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
+                    <fileNamePattern>${dremio.log.path}/archive/metadata_refresh.%d{yyyy-MM-dd}.log.gz</fileNamePattern>
+                    <maxHistory>30</maxHistory>
+                  </rollingPolicy>
+
+                  <encoder>
+                    <pattern>%date{ISO8601} [%thread] %-5level %logger{36} - %msg%n</pattern>
+                  </encoder>
+                </appender>
+
+                <appender name="json" class="ch.qos.logback.core.rolling.RollingFileAppender">
+                  <file>${dremio.log.path}/json/server.json</file>
+                  <rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
+                    <fileNamePattern>${dremio.log.path}/json/archive/server.%d{yyyy-MM-dd}.%i.json.gz</fileNamePattern>
+                    <maxHistory>30</maxHistory>
+                    <timeBasedFileNamingAndTriggeringPolicy class="ch.qos.logback.core.rolling.SizeAndTimeBasedFNATP">
+                      <maxFileSize>100MB</maxFileSize>
+                    </timeBasedFileNamingAndTriggeringPolicy>
+                  </rollingPolicy>
+
+                  <encoder class="net.logstash.logback.encoder.LoggingEventCompositeJsonEncoder">
+                    <providers>
+                      <pattern><pattern>{"timestamp": "%date{ISO8601}", "host":"${HOSTNAME}" }</pattern></pattern>
+                      <threadName><fieldName>thread</fieldName></threadName>
+                      <logLevel><fieldName>levelName</fieldName></logLevel>
+                      <logLevelValue><fieldName>levelValue</fieldName></logLevelValue>
+                      <loggerName><fieldName>logger</fieldName></loggerName>
+                      <message><fieldName>message</fieldName></message>
+                      <arguments />
+                      <stackTrace />
+                    </providers>
+                  </encoder>
+                </appender>
+
+                <appender name="query" class="ch.qos.logback.core.rolling.RollingFileAppender">
+                  <file>${dremio.log.path}/queries.json</file>
+                  <rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
+                    <fileNamePattern>${dremio.log.path}/archive/queries.%d{yyyy-MM-dd}.%i.json.gz</fileNamePattern>
+                    <maxHistory>30</maxHistory>
+                    <timeBasedFileNamingAndTriggeringPolicy class="ch.qos.logback.core.rolling.SizeAndTimeBasedFNATP">
+                      <maxFileSize>100MB</maxFileSize>
+                    </timeBasedFileNamingAndTriggeringPolicy>
+                  </rollingPolicy>
+
+                  <encoder class="net.logstash.logback.encoder.LoggingEventCompositeJsonEncoder">
+                    <providers>
+                      <arguments />
+                    </providers>
+                  </encoder>
+                </appender>
+
+                <appender name="audit" class="ch.qos.logback.core.rolling.RollingFileAppender">
+                  <file>${dremio.log.path}/audit.json</file>
+                  <rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
+                    <fileNamePattern>${dremio.log.path}/archive/audit.%d{yyyy-MM-dd}.%i.json.gz</fileNamePattern>
+                    <maxHistory>30</maxHistory>
+                    <timeBasedFileNamingAndTriggeringPolicy class="ch.qos.logback.core.rolling.SizeAndTimeBasedFNATP">
+                      <maxFileSize>100MB</maxFileSize>
+                    </timeBasedFileNamingAndTriggeringPolicy>
+                  </rollingPolicy>
+
+                  <encoder class="net.logstash.logback.encoder.LoggingEventCompositeJsonEncoder">
+                    <providers>
+                      <pattern><pattern>{"timestamp": "%date{ISO8601}"}</pattern></pattern>
+                      <arguments />
+                    </providers>
+                  </encoder>
+                </appender>
+
+                <appender name="tracker" class="ch.qos.logback.core.rolling.RollingFileAppender">
+                  <file>${dremio.log.path}/tracker.json</file>
+                  <rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
+                    <fileNamePattern>${dremio.log.path}/archive/tracker.%d{yyyy-MM-dd}.%i.json.gz</fileNamePattern>
+                    <maxHistory>30</maxHistory>
+                    <timeBasedFileNamingAndTriggeringPolicy class="ch.qos.logback.core.rolling.SizeAndTimeBasedFNATP">
+                        <maxFileSize>100MB</maxFileSize>
+                    </timeBasedFileNamingAndTriggeringPolicy>
+                  </rollingPolicy>
+
+                  <encoder>
+                    <pattern>%date{ISO8601} [%thread] %-5level %logger{36} - %msg%n</pattern>
+                  </encoder>
+                </appender>
+
+                <appender name="vacuum" class="ch.qos.logback.core.rolling.RollingFileAppender">
+                  <file>${dremio.log.path}/vacuum.json</file>
+                  <rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
+                    <fileNamePattern>${dremio.log.path}/archive/vacuum.%d{yyyy-MM-dd}.%i.json.gz</fileNamePattern>
+                    <maxHistory>30</maxHistory>
+                    <timeBasedFileNamingAndTriggeringPolicy class="ch.qos.logback.core.rolling.SizeAndTimeBasedFNATP">
+                      <maxFileSize>100MB</maxFileSize>
+                    </timeBasedFileNamingAndTriggeringPolicy>
+                  </rollingPolicy>
+
+                  <encoder class="net.logstash.logback.encoder.LoggingEventCompositeJsonEncoder">
+                    <providers>
+                      <pattern><pattern>{"timestamp": "%date{ISO8601}"}</pattern></pattern>
+                      <arguments />
+                    </providers>
+                  </encoder>
+                </appender>
+
+              </then>
+            </if>
+
+            <logger name="com.dremio">
+              <level value="${dremio.log.level:-info}"/>
+            </logger>
+
+            <logger name="query.logger">
+              <level value="${dremio.log.level:-info}"/>
+              <if condition='isDefined("dremio.log.path")'>
+                <then>
+                  <appender-ref ref="query"/>
+                </then>
+              </if>
+            </logger>
+
+            <logger name="audit.logger">
+              <level value="${dremio.log.level:-info}"/>
+              <if condition='isDefined("dremio.log.path")'>
+                <then>
+                  <appender-ref ref="audit"/>
+                </then>
+              </if>
+            </logger>
+
+            <logger name="tracker.logger">
+                <level value="{dremio.log.level: -info}"/>
+                <if condition='isDefined("dremio.log.path")'>
+                    <then>
+                        <additivity value ="false"/>
+                        <appender-ref ref="tracker"/>
+                    </then>
+                </if>
+            </logger>
+
+            <logger name="com.dremio.exec.catalog.SourceMetadataManager" additivity="false">
+              <level value="${dremio.log.level:-info}"/>
+              <if condition='isDefined("dremio.log.path")'>
+                <then>
+                  <appender-ref ref="metadata_refresh"/>
+                </then>
+              </if>
+            </logger>
+
+            <logger name="com.dremio.exec.store.hive.HiveClient" additivity="false">
+              <level value="${dremio.log.level:-info}"/>
+              <if condition='isDefined("dremio.log.path")'>
+                <then>
+                  <appender-ref ref="metadata_refresh"/>
+                </then>
+              </if>
+            </logger>
+
+            <logger name="VacuumLogger" additivity="false">
+              <level value="${dremio.log.level:-info}"/>
+              <if condition='isDefined("dremio.log.path")'>
+                <then>
+                  <appender-ref ref="vacuum"/>
+                </then>
+              </if>
+            </logger>
+
+            <logger name="hive.deprecated.function.warning.logger" level="warn">
+              <if condition='isDefined("dremio.log.path")'>
+                <then>
+                  <additivity value ="false"/>
+                  <appender name="text" class="ch.qos.logback.core.rolling.RollingFileAppender">
+                    <file>${dremio.log.path}/hive.deprecated.function.warning.log</file>
+                    <rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
+                      <fileNamePattern>${dremio.log.path}/archive/hive.deprecated.function.warning.%d{yyyy-MM-dd}.%i.log.gz</fileNamePattern>
+                      <maxHistory>30</maxHistory>
+                      <timeBasedFileNamingAndTriggeringPolicy class="ch.qos.logback.core.rolling.SizeAndTimeBasedFNATP">
+                        <maxFileSize>100MB</maxFileSize>
+                      </timeBasedFileNamingAndTriggeringPolicy>
+                    </rollingPolicy>
+
+                    <encoder>
+                      <pattern>%date{ISO8601} [%thread] %-5level %logger{36} - %msg%n</pattern>
+                    </encoder>
+                  </appender>
+                </then>
+              </if>
+            </logger>
+
+            <logger name="org.apache.hadoop.hdfs.DFSClient">
+              <level value="warn"/>
+            </logger>
+
+            <root>
+              <level value="${dremio.log.root.level:-error}"/>
+              <if condition='isDefined("dremio.log.path")'>
+                <then>
+                  <appender-ref ref="text"/>
+                  <appender-ref ref="json"/>
+                  <appender-ref ref="console"/>
+                </then>
+                <else>
+                  <appender-ref ref="console"/>
+                </else>
+              </if>
+            </root>
+
+          </configuration>
+      metadata:
+        name: dremio-config
+    component:
+      version: v1
+      kind: ConfigMap
+      schema: ""
+  - id: ec5b4ecf-1656-44fc-b08f-87545e662c53
+    schemaVersion: components.meshery.io/v1beta1
+    version: v1.0.0
+    displayName: dremio-hive2-config
+    description: ""
+    format: ""
+    model:
+      id: b3f5bc0d-30f7-607d-6c73-784ddde6cad8
+      schemaVersion: models.meshery.io/v1beta1
+      version: v1.0.0
+      name: kubernetes
+      displayName: Kubernetes
+      status: enabled
+      registrant:
+        id: 5bc80e3c-5d43-9eb4-d16c-78a2769247a6
+        name: Github
+        credential_id: 00000000-0000-0000-0000-000000000000
+        type: registry
+        sub_type: ""
+        kind: github
+        status: registered
+        user_id: 00000000-0000-0000-0000-000000000000
+        created_at: "2025-10-12T14:26:03.160654794Z"
+        updated_at: "2025-10-12T14:26:03.160654794Z"
+        deleted_at: "0001-01-01T00:00:00Z"
+        schemaVersion: ""
+      connection_id: 5bc80e3c-5d43-9eb4-d16c-78a2769247a6
+      category:
+        id: 9ca27d0d-66ce-42a9-8c85-6236563f2ddb
+        name: Orchestration & Management
+      subCategory: Scheduling & Orchestration
+      metadata:
+        isAnnotation: false
+        primaryColor: '#326CE5'
+        secondaryColor: '#7aa1f0'
+        shape: circle
+        styleOverrides: ""
+        svgColor: ui/public/static/img/meshmodels/kubernetes/color/kubernetes-color.svg
+        svgComplete: ""
+        svgWhite: ui/public/static/img/meshmodels/kubernetes/white/kubernetes-white.svg
+      model:
+        version: v1.32.0-alpha.3
+      components_count: 0
+      relationships_count: 0
+      components: null
+      relationships: null
+    styles:
+      primaryColor: '#326CE5'
+      secondaryColor: '#7aa1f0'
+      shape: bottom-round-rectangle
+      svgColor: ui/public/static/img/meshmodels/kubernetes/color/configmap-color.svg
+      svgComplete: ""
+      svgWhite: ui/public/static/img/meshmodels/kubernetes/white/configmap-white.svg
+    capabilities: []
+    status: enabled
+    metadata:
+      configurationUISchema: ""
+      genealogy: ""
+      instanceDetails: null
+      isAnnotation: false
+      isNamespaced: true
+      published: false
+      source_uri: git://github.com/kubernetes/kubernetes/master/api/openapi-spec/v3
+    configuration:
+      data:
+        README.md: |-
+          ### Hive 2 Configuration Files
+          This directory is used to store Hive 2 configuration files to be deployed to Dremio.
+      metadata:
+        name: dremio-hive2-config
+    component:
+      version: v1
+      kind: ConfigMap
+      schema: ""
+  - id: 5edea03a-412a-4474-a64b-dd12a8c18468
+    schemaVersion: components.meshery.io/v1beta1
+    version: v1.0.0
+    displayName: dremio-hive3-config
+    description: ""
+    format: ""
+    model:
+      id: b3f5bc0d-30f7-607d-6c73-784ddde6cad8
+      schemaVersion: models.meshery.io/v1beta1
+      version: v1.0.0
+      name: kubernetes
+      displayName: Kubernetes
+      status: enabled
+      registrant:
+        id: 5bc80e3c-5d43-9eb4-d16c-78a2769247a6
+        name: Github
+        credential_id: 00000000-0000-0000-0000-000000000000
+        type: registry
+        sub_type: ""
+        kind: github
+        status: registered
+        user_id: 00000000-0000-0000-0000-000000000000
+        created_at: "2025-10-12T14:26:03.160654794Z"
+        updated_at: "2025-10-12T14:26:03.160654794Z"
+        deleted_at: "0001-01-01T00:00:00Z"
+        schemaVersion: ""
+      connection_id: 5bc80e3c-5d43-9eb4-d16c-78a2769247a6
+      category:
+        id: 9ca27d0d-66ce-42a9-8c85-6236563f2ddb
+        name: Orchestration & Management
+      subCategory: Scheduling & Orchestration
+      metadata:
+        isAnnotation: false
+        primaryColor: '#326CE5'
+        secondaryColor: '#7aa1f0'
+        shape: circle
+        styleOverrides: ""
+        svgColor: ui/public/static/img/meshmodels/kubernetes/color/kubernetes-color.svg
+        svgComplete: ""
+        svgWhite: ui/public/static/img/meshmodels/kubernetes/white/kubernetes-white.svg
+      model:
+        version: v1.32.0-alpha.3
+      components_count: 0
+      relationships_count: 0
+      components: null
+      relationships: null
+    styles:
+      primaryColor: '#326CE5'
+      secondaryColor: '#7aa1f0'
+      shape: bottom-round-rectangle
+      svgColor: ui/public/static/img/meshmodels/kubernetes/color/configmap-color.svg
+      svgComplete: ""
+      svgWhite: ui/public/static/img/meshmodels/kubernetes/white/configmap-white.svg
+    capabilities: []
+    status: enabled
+    metadata:
+      configurationUISchema: ""
+      genealogy: ""
+      instanceDetails: null
+      isAnnotation: false
+      isNamespaced: true
+      published: false
+      source_uri: git://github.com/kubernetes/kubernetes/master/api/openapi-spec/v3
+    configuration:
+      data:
+        README.md: |-
+          ### Hive 3 Configuration Files
+          This directory is used to store Hive 3 configuration files to be deployed to Dremio.
+      metadata:
+        name: dremio-hive3-config
+    component:
+      version: v1
+      kind: ConfigMap
+      schema: ""
+  - id: 828b5037-459a-413c-9284-5d71bcbce7bf
+    schemaVersion: components.meshery.io/v1beta1
+    version: v1.0.0
+    displayName: dremio-client
+    description: ""
+    format: ""
+    model:
+      id: b3f5bc0d-30f7-607d-6c73-784ddde6cad8
+      schemaVersion: models.meshery.io/v1beta1
+      version: v1.0.0
+      name: kubernetes
+      displayName: Kubernetes
+      status: enabled
+      registrant:
+        id: 5bc80e3c-5d43-9eb4-d16c-78a2769247a6
+        name: Github
+        credential_id: 00000000-0000-0000-0000-000000000000
+        type: registry
+        sub_type: ""
+        kind: github
+        status: registered
+        user_id: 00000000-0000-0000-0000-000000000000
+        created_at: "2025-10-12T14:26:03.160654794Z"
+        updated_at: "2025-10-12T14:26:03.160654794Z"
+        deleted_at: "0001-01-01T00:00:00Z"
+        schemaVersion: ""
+      connection_id: 5bc80e3c-5d43-9eb4-d16c-78a2769247a6
+      category:
+        id: 9ca27d0d-66ce-42a9-8c85-6236563f2ddb
+        name: Orchestration & Management
+      subCategory: Scheduling & Orchestration
+      metadata:
+        isAnnotation: false
+        primaryColor: '#326CE5'
+        secondaryColor: '#7aa1f0'
+        shape: circle
+        styleOverrides: ""
+        svgColor: ui/public/static/img/meshmodels/kubernetes/color/kubernetes-color.svg
+        svgComplete: ""
+        svgWhite: ui/public/static/img/meshmodels/kubernetes/white/kubernetes-white.svg
+      model:
+        version: v1.32.0-alpha.3
+      components_count: 0
+      relationships_count: 0
+      components: null
+      relationships: null
+    styles:
+      background-position-y: "4.5"
+      height: 20
+      padding: 12
+      primaryColor: '#326CE5'
+      secondaryColor: '#7aa1f0'
+      shape: round-triangle
+      svgColor: ui/public/static/img/meshmodels/kubernetes/color/service-color.svg
+      svgComplete: ""
+      svgWhite: ui/public/static/img/meshmodels/kubernetes/white/service-white.svg
+      width: 20
+    capabilities: []
+    status: enabled
+    metadata:
+      configurationUISchema: ""
+      genealogy: ""
+      instanceDetails: null
+      isAnnotation: false
+      isNamespaced: true
+      published: false
+      source_uri: git://github.com/kubernetes/kubernetes/master/api/openapi-spec/v3
+    configuration:
+      metadata:
+        labels:
+          app: dremio-client
+        name: dremio-client
+      spec:
+        ports:
+          - name: client
+            port: 31010
+            targetPort: client
+          - name: web
+            port: 9047
+            targetPort: web
+          - name: flight
+            port: 32010
+            targetPort: flight
+        selector:
+          app: dremio-coordinator
+        type: LoadBalancer
+    component:
+      version: v1
+      kind: Service
+      schema: ""
+  - id: 10660c7d-2063-470a-840c-a6704504678b
+    schemaVersion: components.meshery.io/v1beta1
+    version: v1.0.0
+    displayName: dremio-cluster-pod
+    description: ""
+    format: ""
+    model:
+      id: b3f5bc0d-30f7-607d-6c73-784ddde6cad8
+      schemaVersion: models.meshery.io/v1beta1
+      version: v1.0.0
+      name: kubernetes
+      displayName: Kubernetes
+      status: enabled
+      registrant:
+        id: 5bc80e3c-5d43-9eb4-d16c-78a2769247a6
+        name: Github
+        credential_id: 00000000-0000-0000-0000-000000000000
+        type: registry
+        sub_type: ""
+        kind: github
+        status: registered
+        user_id: 00000000-0000-0000-0000-000000000000
+        created_at: "2025-10-12T14:26:03.160654794Z"
+        updated_at: "2025-10-12T14:26:03.160654794Z"
+        deleted_at: "0001-01-01T00:00:00Z"
+        schemaVersion: ""
+      connection_id: 5bc80e3c-5d43-9eb4-d16c-78a2769247a6
+      category:
+        id: 9ca27d0d-66ce-42a9-8c85-6236563f2ddb
+        name: Orchestration & Management
+      subCategory: Scheduling & Orchestration
+      metadata:
+        isAnnotation: false
+        primaryColor: '#326CE5'
+        secondaryColor: '#7aa1f0'
+        shape: circle
+        styleOverrides: ""
+        svgColor: ui/public/static/img/meshmodels/kubernetes/color/kubernetes-color.svg
+        svgComplete: ""
+        svgWhite: ui/public/static/img/meshmodels/kubernetes/white/kubernetes-white.svg
+      model:
+        version: v1.32.0-alpha.3
+      components_count: 0
+      relationships_count: 0
+      components: null
+      relationships: null
+    styles:
+      background-position-y: "4.5"
+      height: 20
+      padding: 12
+      primaryColor: '#326CE5'
+      secondaryColor: '#7aa1f0'
+      shape: round-triangle
+      svgColor: ui/public/static/img/meshmodels/kubernetes/color/service-color.svg
+      svgComplete: ""
+      svgWhite: ui/public/static/img/meshmodels/kubernetes/white/service-white.svg
+      width: 20
+    capabilities: []
+    status: enabled
+    metadata:
+      configurationUISchema: ""
+      genealogy: ""
+      instanceDetails: null
+      isAnnotation: false
+      isNamespaced: true
+      published: false
+      source_uri: git://github.com/kubernetes/kubernetes/master/api/openapi-spec/v3
+    configuration:
+      metadata:
+        name: dremio-cluster-pod
+      spec:
+        clusterIP: None
+        ports:
+          - port: 9999
+        selector:
+          role: dremio-cluster-pod
+    component:
+      version: v1
+      kind: Service
+      schema: ""
+  - id: be89b1a8-cb26-4b4a-aaea-f0ff236f1969
+    schemaVersion: components.meshery.io/v1beta1
+    version: v1.0.0
+    displayName: zk-hs
+    description: ""
+    format: ""
+    model:
+      id: b3f5bc0d-30f7-607d-6c73-784ddde6cad8
+      schemaVersion: models.meshery.io/v1beta1
+      version: v1.0.0
+      name: kubernetes
+      displayName: Kubernetes
+      status: enabled
+      registrant:
+        id: 5bc80e3c-5d43-9eb4-d16c-78a2769247a6
+        name: Github
+        credential_id: 00000000-0000-0000-0000-000000000000
+        type: registry
+        sub_type: ""
+        kind: github
+        status: registered
+        user_id: 00000000-0000-0000-0000-000000000000
+        created_at: "2025-10-12T14:26:03.160654794Z"
+        updated_at: "2025-10-12T14:26:03.160654794Z"
+        deleted_at: "0001-01-01T00:00:00Z"
+        schemaVersion: ""
+      connection_id: 5bc80e3c-5d43-9eb4-d16c-78a2769247a6
+      category:
+        id: 9ca27d0d-66ce-42a9-8c85-6236563f2ddb
+        name: Orchestration & Management
+      subCategory: Scheduling & Orchestration
+      metadata:
+        isAnnotation: false
+        primaryColor: '#326CE5'
+        secondaryColor: '#7aa1f0'
+        shape: circle
+        styleOverrides: ""
+        svgColor: ui/public/static/img/meshmodels/kubernetes/color/kubernetes-color.svg
+        svgComplete: ""
+        svgWhite: ui/public/static/img/meshmodels/kubernetes/white/kubernetes-white.svg
+      model:
+        version: v1.32.0-alpha.3
+      components_count: 0
+      relationships_count: 0
+      components: null
+      relationships: null
+    styles:
+      background-position-y: "4.5"
+      height: 20
+      padding: 12
+      primaryColor: '#326CE5'
+      secondaryColor: '#7aa1f0'
+      shape: round-triangle
+      svgColor: ui/public/static/img/meshmodels/kubernetes/color/service-color.svg
+      svgComplete: ""
+      svgWhite: ui/public/static/img/meshmodels/kubernetes/white/service-white.svg
+      width: 20
+    capabilities: []
+    status: enabled
+    metadata:
+      configurationUISchema: ""
+      genealogy: ""
+      instanceDetails: null
+      isAnnotation: false
+      isNamespaced: true
+      published: false
+      source_uri: git://github.com/kubernetes/kubernetes/master/api/openapi-spec/v3
+    configuration:
+      metadata:
+        labels:
+          app: zk
+        name: zk-hs
+      spec:
+        clusterIP: None
+        ports:
+          - name: client
+            port: 2181
+          - name: server
+            port: 2888
+          - name: leader-election
+            port: 3888
+        selector:
+          app: zk
+    component:
+      version: v1
+      kind: Service
+      schema: ""
+  - id: 3651ecb1-ad2b-4dc7-a877-af46a4c6b83f
+    schemaVersion: components.meshery.io/v1beta1
+    version: v1.0.0
+    displayName: zk-cs
+    description: ""
+    format: ""
+    model:
+      id: b3f5bc0d-30f7-607d-6c73-784ddde6cad8
+      schemaVersion: models.meshery.io/v1beta1
+      version: v1.0.0
+      name: kubernetes
+      displayName: Kubernetes
+      status: enabled
+      registrant:
+        id: 5bc80e3c-5d43-9eb4-d16c-78a2769247a6
+        name: Github
+        credential_id: 00000000-0000-0000-0000-000000000000
+        type: registry
+        sub_type: ""
+        kind: github
+        status: registered
+        user_id: 00000000-0000-0000-0000-000000000000
+        created_at: "2025-10-12T14:26:03.160654794Z"
+        updated_at: "2025-10-12T14:26:03.160654794Z"
+        deleted_at: "0001-01-01T00:00:00Z"
+        schemaVersion: ""
+      connection_id: 5bc80e3c-5d43-9eb4-d16c-78a2769247a6
+      category:
+        id: 9ca27d0d-66ce-42a9-8c85-6236563f2ddb
+        name: Orchestration & Management
+      subCategory: Scheduling & Orchestration
+      metadata:
+        isAnnotation: false
+        primaryColor: '#326CE5'
+        secondaryColor: '#7aa1f0'
+        shape: circle
+        styleOverrides: ""
+        svgColor: ui/public/static/img/meshmodels/kubernetes/color/kubernetes-color.svg
+        svgComplete: ""
+        svgWhite: ui/public/static/img/meshmodels/kubernetes/white/kubernetes-white.svg
+      model:
+        version: v1.32.0-alpha.3
+      components_count: 0
+      relationships_count: 0
+      components: null
+      relationships: null
+    styles:
+      background-position-y: "4.5"
+      height: 20
+      padding: 12
+      primaryColor: '#326CE5'
+      secondaryColor: '#7aa1f0'
+      shape: round-triangle
+      svgColor: ui/public/static/img/meshmodels/kubernetes/color/service-color.svg
+      svgComplete: ""
+      svgWhite: ui/public/static/img/meshmodels/kubernetes/white/service-white.svg
+      width: 20
+    capabilities: []
+    status: enabled
+    metadata:
+      configurationUISchema: ""
+      genealogy: ""
+      instanceDetails: null
+      isAnnotation: false
+      isNamespaced: true
+      published: false
+      source_uri: git://github.com/kubernetes/kubernetes/master/api/openapi-spec/v3
+    configuration:
+      metadata:
+        labels:
+          app: zk
+        name: zk-cs
+      spec:
+        ports:
+          - name: client
+            port: 2181
+        selector:
+          app: zk
+    component:
+      version: v1
+      kind: Service
+      schema: ""
+  - id: 553a5477-9d8c-4a53-a955-ce242bd9ab3f
+    schemaVersion: components.meshery.io/v1beta1
+    version: v1.0.0
+    displayName: dremio-coordinator
+    description: ""
+    format: ""
+    model:
+      id: b3f5bc0d-30f7-607d-6c73-784ddde6cad8
+      schemaVersion: models.meshery.io/v1beta1
+      version: v1.0.0
+      name: kubernetes
+      displayName: Kubernetes
+      status: enabled
+      registrant:
+        id: 5bc80e3c-5d43-9eb4-d16c-78a2769247a6
+        name: Github
+        credential_id: 00000000-0000-0000-0000-000000000000
+        type: registry
+        sub_type: ""
+        kind: github
+        status: registered
+        user_id: 00000000-0000-0000-0000-000000000000
+        created_at: "2025-10-12T14:26:03.160654794Z"
+        updated_at: "2025-10-12T14:26:03.160654794Z"
+        deleted_at: "0001-01-01T00:00:00Z"
+        schemaVersion: ""
+      connection_id: 5bc80e3c-5d43-9eb4-d16c-78a2769247a6
+      category:
+        id: 9ca27d0d-66ce-42a9-8c85-6236563f2ddb
+        name: Orchestration & Management
+      subCategory: Scheduling & Orchestration
+      metadata:
+        isAnnotation: false
+        primaryColor: '#326CE5'
+        secondaryColor: '#7aa1f0'
+        shape: circle
+        styleOverrides: ""
+        svgColor: ui/public/static/img/meshmodels/kubernetes/color/kubernetes-color.svg
+        svgComplete: ""
+        svgWhite: ui/public/static/img/meshmodels/kubernetes/white/kubernetes-white.svg
+      model:
+        version: v1.32.0-alpha.3
+      components_count: 0
+      relationships_count: 0
+      components: null
+      relationships: null
+    styles:
+      background-opacity: 0.2
+      height: 15
+      primaryColor: '#326CE5'
+      secondaryColor: '#7aa1f0'
+      shape: round-rectangle
+      svgColor: ui/public/static/img/meshmodels/kubernetes/color/statefulset-color.svg
+      svgComplete: ui/public/static/img/meshmodels/kubernetes/complete/statefulset-complete.svg
+      svgWhite: ui/public/static/img/meshmodels/kubernetes/white/statefulset-white.svg
+      width: 15
+      x: 12
+      y: 20
+    capabilities: []
+    status: enabled
+    metadata:
+      configurationUISchema: ""
+      genealogy: parent
+      instanceDetails: null
+      isAnnotation: false
+      isNamespaced: true
+      published: false
+      source_uri: git://github.com/kubernetes/kubernetes/master/api/openapi-spec/v3
+    configuration:
+      metadata:
+        name: dremio-coordinator
+      spec:
+        podManagementPolicy: Parallel
+        replicas: 0
+        revisionHistoryLimit: 1
+        selector:
+          matchLabels:
+            app: dremio-coordinator
+        serviceName: dremio-cluster-pod
+        template:
+          metadata:
+            annotations:
+              dremio-configmap/checksum: a58b53d2d09545ff4e9fa95b9e1262fb43dc18d70e2b50bf37f4270b9f8fe2a9
+            labels:
+              app: dremio-coordinator
+              diagnostics-collector-role: dremio-coordinator
+              role: dremio-cluster-pod
+          spec:
+            containers:
+              - args:
+                  - start-fg
+                command:
+                  - /opt/dremio/bin/dremio
+                env:
+                  - name: DREMIO_MAX_HEAP_MEMORY_SIZE_MB
+                    value: "16384"
+                  - name: DREMIO_MAX_DIRECT_MEMORY_SIZE_MB
+                    value: "100416"
+                  - name: DREMIO_JAVA_SERVER_EXTRA_OPTS
+                    value: -Dzookeeper=zk-hs:2181 -Dservices.coordinator.enabled=true -Dservices.coordinator.master.enabled=false -Dservices.coordinator.master.embedded-zookeeper.enabled=false -Dservices.executor.enabled=false -Dservices.conduit.port=45679 -XX:ActiveProcessorCount=15
+                  - name: AWS_CREDENTIAL_PROFILES_FILE
+                    value: /opt/dremio/aws/credentials
+                  - name: AWS_SHARED_CREDENTIALS_FILE
+                    value: /opt/dremio/aws/credentials
+                  - name: DREMIO_LOG_TO_CONSOLE
+                    value: "1"
+                image: dremio/dremio-oss:latest
+                imagePullPolicy: IfNotPresent
+                name: dremio-coordinator
+                ports:
+                  - containerPort: 31010
+                    name: client
+                  - containerPort: 32010
+                    name: flight
+                  - containerPort: 45678
+                    name: server-fabric
+                  - containerPort: 45679
+                    name: server-conduit
+                readinessProbe:
+                  failureThreshold: 120
+                  httpGet:
+                    path: /
+                    port: 9047
+                  periodSeconds: 1
+                resources:
+                  requests:
+                    cpu: 15
+                    memory: 122800Mi
+                securityContext:
+                  allowPrivilegeEscalation: false
+                  capabilities:
+                    drop:
+                      - ALL
+                  privileged: false
+                  readOnlyRootFilesystem: false
+                  runAsGroup: 999
+                  runAsNonRoot: true
+                  runAsUser: 999
+                  seccompProfile:
+                    type: RuntimeDefault
+                startupProbe:
+                  failureThreshold: 300
+                  httpGet:
+                    path: /
+                    port: 9047
+                  periodSeconds: 1
+                volumeMounts:
+                  - mountPath: /opt/dremio/conf
+                    name: dremio-config
+                  - mountPath: /opt/dremio/plugins/connectors/hive2.d
+                    name: dremio-hive2-config
+                  - mountPath: /opt/dremio/plugins/connectors/hive2-ee.d
+                    name: dremio-hive2-config
+                  - mountPath: /opt/dremio/plugins/connectors/hive3.d
+                    name: dremio-hive3-config
+                  - mountPath: /opt/dremio/plugins/connectors/hive3-ee.d
+                    name: dremio-hive3-config
+            initContainers:
+              - command:
+                  - sh
+                  - -c
+                  - until nc -z dremio-client 9047 > /dev/null; do echo Waiting for Dremio master.; sleep 2; done;
+                image: busybox
+                name: wait-for-dremio-master
+                securityContext:
+                  allowPrivilegeEscalation: false
+                  capabilities:
+                    drop:
+                      - ALL
+                  privileged: false
+                  readOnlyRootFilesystem: false
+                  runAsGroup: 999
+                  runAsNonRoot: true
+                  runAsUser: 999
+                  seccompProfile:
+                    type: RuntimeDefault
+            securityContext:
+              fsGroup: 999
+              fsGroupChangePolicy: OnRootMismatch
+            terminationGracePeriodSeconds: 120
+            volumes:
+              - configMap:
+                  name: dremio-config
+                name: dremio-config
+              - configMap:
+                  name: dremio-hive2-config
+                name: dremio-hive2-config
+              - configMap:
+                  name: dremio-hive3-config
+                name: dremio-hive3-config
+        volumeClaimTemplates: null
+    component:
+      version: apps/v1
+      kind: StatefulSet
+      schema: ""
+  - id: e279e1dd-d5af-4ff7-bb26-a2bf0ee42fee
+    schemaVersion: components.meshery.io/v1beta1
+    version: v1.0.0
+    displayName: dremio-executor
+    description: ""
+    format: ""
+    model:
+      id: b3f5bc0d-30f7-607d-6c73-784ddde6cad8
+      schemaVersion: models.meshery.io/v1beta1
+      version: v1.0.0
+      name: kubernetes
+      displayName: Kubernetes
+      status: enabled
+      registrant:
+        id: 5bc80e3c-5d43-9eb4-d16c-78a2769247a6
+        name: Github
+        credential_id: 00000000-0000-0000-0000-000000000000
+        type: registry
+        sub_type: ""
+        kind: github
+        status: registered
+        user_id: 00000000-0000-0000-0000-000000000000
+        created_at: "2025-10-12T14:26:03.160654794Z"
+        updated_at: "2025-10-12T14:26:03.160654794Z"
+        deleted_at: "0001-01-01T00:00:00Z"
+        schemaVersion: ""
+      connection_id: 5bc80e3c-5d43-9eb4-d16c-78a2769247a6
+      category:
+        id: 9ca27d0d-66ce-42a9-8c85-6236563f2ddb
+        name: Orchestration & Management
+      subCategory: Scheduling & Orchestration
+      metadata:
+        isAnnotation: false
+        primaryColor: '#326CE5'
+        secondaryColor: '#7aa1f0'
+        shape: circle
+        styleOverrides: ""
+        svgColor: ui/public/static/img/meshmodels/kubernetes/color/kubernetes-color.svg
+        svgComplete: ""
+        svgWhite: ui/public/static/img/meshmodels/kubernetes/white/kubernetes-white.svg
+      model:
+        version: v1.32.0-alpha.3
+      components_count: 0
+      relationships_count: 0
+      components: null
+      relationships: null
+    styles:
+      background-opacity: 0.2
+      height: 15
+      primaryColor: '#326CE5'
+      secondaryColor: '#7aa1f0'
+      shape: round-rectangle
+      svgColor: ui/public/static/img/meshmodels/kubernetes/color/statefulset-color.svg
+      svgComplete: ui/public/static/img/meshmodels/kubernetes/complete/statefulset-complete.svg
+      svgWhite: ui/public/static/img/meshmodels/kubernetes/white/statefulset-white.svg
+      width: 15
+      x: 12
+      y: 20
+    capabilities: []
+    status: enabled
+    metadata:
+      configurationUISchema: ""
+      genealogy: parent
+      instanceDetails: null
+      isAnnotation: false
+      isNamespaced: true
+      published: false
+      source_uri: git://github.com/kubernetes/kubernetes/master/api/openapi-spec/v3
+    configuration:
+      metadata:
+        name: dremio-executor
+      spec:
+        podManagementPolicy: Parallel
+        replicas: 3
+        revisionHistoryLimit: 1
+        selector:
+          matchLabels:
+            app: dremio-executor
+        serviceName: dremio-cluster-pod
+        template:
+          metadata:
+            annotations:
+              dremio-configmap/checksum: a58b53d2d09545ff4e9fa95b9e1262fb43dc18d70e2b50bf37f4270b9f8fe2a9
+            labels:
+              app: dremio-executor
+              diagnostics-collector-role: dremio-executor
+              role: dremio-cluster-pod
+          spec:
+            containers:
+              - args:
+                  - start-fg
+                command:
+                  - /opt/dremio/bin/dremio
+                env:
+                  - name: DREMIO_MAX_HEAP_MEMORY_SIZE_MB
+                    value: "8192"
+                  - name: DREMIO_MAX_DIRECT_MEMORY_SIZE_MB
+                    value: "108608"
+                  - name: DREMIO_JAVA_SERVER_EXTRA_OPTS
+                    value: |2-
+
+                      -Dzookeeper=zk-hs:2181 -Dservices.coordinator.enabled=false -Dservices.coordinator.master.enabled=false -Dservices.coordinator.master.embedded-zookeeper.enabled=false -Dservices.executor.enabled=true -Dservices.conduit.port=45679 -Dservices.node-tag=default -XX:ActiveProcessorCount=15
+                  - name: AWS_CREDENTIAL_PROFILES_FILE
+                    value: /opt/dremio/aws/credentials
+                  - name: AWS_SHARED_CREDENTIALS_FILE
+                    value: /opt/dremio/aws/credentials
+                  - name: DREMIO_LOG_TO_CONSOLE
+                    value: "1"
+                image: dremio/dremio-oss:latest
+                imagePullPolicy: IfNotPresent
+                name: dremio-executor
+                ports:
+                  - containerPort: 45678
+                    name: server-fabric
+                  - containerPort: 45679
+                    name: server-conduit
+                resources:
+                  requests:
+                    cpu: 15
+                    memory: 122800Mi
+                securityContext:
+                  allowPrivilegeEscalation: false
+                  capabilities:
+                    drop:
+                      - ALL
+                  privileged: false
+                  readOnlyRootFilesystem: false
+                  runAsGroup: 999
+                  runAsNonRoot: true
+                  runAsUser: 999
+                  seccompProfile:
+                    type: RuntimeDefault
+                volumeMounts:
+                  - mountPath: /opt/dremio/data
+                    name: dremio-default-executor-volume
+                  - mountPath: /opt/dremio/conf
+                    name: dremio-config
+                  - mountPath: /opt/dremio/plugins/connectors/hive2.d
+                    name: dremio-hive2-config
+                  - mountPath: /opt/dremio/plugins/connectors/hive2-ee.d
+                    name: dremio-hive2-config
+                  - mountPath: /opt/dremio/plugins/connectors/hive3.d
+                    name: dremio-hive3-config
+                  - mountPath: /opt/dremio/plugins/connectors/hive3-ee.d
+                    name: dremio-hive3-config
+                  - mountPath: /opt/dremio/cloudcache/c0
+                    name: dremio-default-executor-c3-0
+            initContainers:
+              - command:
+                  - sh
+                  - -c
+                  - until nc zk-hs 2181 -w1 > /dev/null; do echo Waiting for Zookeeper to be ready.; sleep 2; done;
+                image: busybox
+                name: wait-for-zookeeper
+                securityContext:
+                  allowPrivilegeEscalation: false
+                  capabilities:
+                    drop:
+                      - ALL
+                  privileged: false
+                  readOnlyRootFilesystem: false
+                  runAsGroup: 999
+                  runAsNonRoot: true
+                  runAsUser: 999
+                  seccompProfile:
+                    type: RuntimeDefault
+            securityContext:
+              fsGroup: 999
+              fsGroupChangePolicy: OnRootMismatch
+            terminationGracePeriodSeconds: 720
+            volumes:
+              - configMap:
+                  name: dremio-config
+                name: dremio-config
+              - configMap:
+                  name: dremio-hive2-config
+                name: dremio-hive2-config
+              - configMap:
+                  name: dremio-hive3-config
+                name: dremio-hive3-config
+        volumeClaimTemplates:
+          - metadata:
+              name: dremio-default-executor-volume
+            spec:
+              accessModes:
+                - ReadWriteOnce
+              resources:
+                requests:
+                  storage: 128Gi
+          - metadata:
+              name: dremio-default-executor-c3-0
+            spec:
+              accessModes:
+                - ReadWriteOnce
+              resources:
+                requests:
+                  storage: 100Gi
+    component:
+      version: apps/v1
+      kind: StatefulSet
+      schema: ""
+  - id: 5f5d2cff-5f51-4bdd-aaee-205ce378964a
+    schemaVersion: components.meshery.io/v1beta1
+    version: v1.0.0
+    displayName: dremio-master
+    description: ""
+    format: ""
+    model:
+      id: b3f5bc0d-30f7-607d-6c73-784ddde6cad8
+      schemaVersion: models.meshery.io/v1beta1
+      version: v1.0.0
+      name: kubernetes
+      displayName: Kubernetes
+      status: enabled
+      registrant:
+        id: 5bc80e3c-5d43-9eb4-d16c-78a2769247a6
+        name: Github
+        credential_id: 00000000-0000-0000-0000-000000000000
+        type: registry
+        sub_type: ""
+        kind: github
+        status: registered
+        user_id: 00000000-0000-0000-0000-000000000000
+        created_at: "2025-10-12T14:26:03.160654794Z"
+        updated_at: "2025-10-12T14:26:03.160654794Z"
+        deleted_at: "0001-01-01T00:00:00Z"
+        schemaVersion: ""
+      connection_id: 5bc80e3c-5d43-9eb4-d16c-78a2769247a6
+      category:
+        id: 9ca27d0d-66ce-42a9-8c85-6236563f2ddb
+        name: Orchestration & Management
+      subCategory: Scheduling & Orchestration
+      metadata:
+        isAnnotation: false
+        primaryColor: '#326CE5'
+        secondaryColor: '#7aa1f0'
+        shape: circle
+        styleOverrides: ""
+        svgColor: ui/public/static/img/meshmodels/kubernetes/color/kubernetes-color.svg
+        svgComplete: ""
+        svgWhite: ui/public/static/img/meshmodels/kubernetes/white/kubernetes-white.svg
+      model:
+        version: v1.32.0-alpha.3
+      components_count: 0
+      relationships_count: 0
+      components: null
+      relationships: null
+    styles:
+      background-opacity: 0.2
+      height: 15
+      primaryColor: '#326CE5'
+      secondaryColor: '#7aa1f0'
+      shape: round-rectangle
+      svgColor: ui/public/static/img/meshmodels/kubernetes/color/statefulset-color.svg
+      svgComplete: ui/public/static/img/meshmodels/kubernetes/complete/statefulset-complete.svg
+      svgWhite: ui/public/static/img/meshmodels/kubernetes/white/statefulset-white.svg
+      width: 15
+      x: 12
+      y: 20
+    capabilities: []
+    status: enabled
+    metadata:
+      configurationUISchema: ""
+      genealogy: parent
+      instanceDetails: null
+      isAnnotation: false
+      isNamespaced: true
+      published: false
+      source_uri: git://github.com/kubernetes/kubernetes/master/api/openapi-spec/v3
+    configuration:
+      metadata:
+        name: dremio-master
+      spec:
+        podManagementPolicy: Parallel
+        replicas: 1
+        selector:
+          matchLabels:
+            app: dremio-coordinator
+        serviceName: dremio-cluster-pod
+        template:
+          metadata:
+            annotations:
+              dremio-configmap/checksum: a58b53d2d09545ff4e9fa95b9e1262fb43dc18d70e2b50bf37f4270b9f8fe2a9
+            labels:
+              app: dremio-coordinator
+              diagnostics-collector-role: dremio-coordinator
+              role: dremio-cluster-pod
+          spec:
+            affinity:
+              podAntiAffinity:
+                requiredDuringSchedulingIgnoredDuringExecution:
+                  - labelSelector:
+                      matchExpressions:
+                        - key: app
+                          operator: In
+                          values:
+                            - dremio-coordinator
+                    topologyKey: kubernetes.io/hostname
+            containers:
+              - args:
+                  - start-fg
+                command:
+                  - /opt/dremio/bin/dremio
+                env:
+                  - name: DREMIO_MAX_HEAP_MEMORY_SIZE_MB
+                    value: "16384"
+                  - name: DREMIO_MAX_DIRECT_MEMORY_SIZE_MB
+                    value: "100416"
+                  - name: DREMIO_JAVA_SERVER_EXTRA_OPTS
+                    value: -Dzookeeper=zk-hs:2181 -Dservices.coordinator.enabled=true -Dservices.coordinator.master.enabled=true -Dservices.coordinator.master.embedded-zookeeper.enabled=false -Dservices.executor.enabled=false -Dservices.conduit.port=45679 -XX:ActiveProcessorCount=15
+                  - name: AWS_CREDENTIAL_PROFILES_FILE
+                    value: /opt/dremio/aws/credentials
+                  - name: AWS_SHARED_CREDENTIALS_FILE
+                    value: /opt/dremio/aws/credentials
+                  - name: DREMIO_LOG_TO_CONSOLE
+                    value: "1"
+                image: dremio/dremio-oss:latest
+                imagePullPolicy: IfNotPresent
+                name: dremio-master-coordinator
+                ports:
+                  - containerPort: 9047
+                    name: web
+                  - containerPort: 31010
+                    name: client
+                  - containerPort: 32010
+                    name: flight
+                  - containerPort: 45678
+                    name: server-fabric
+                  - containerPort: 45679
+                    name: server-conduit
+                readinessProbe:
+                  failureThreshold: 120
+                  httpGet:
+                    path: /
+                    port: web
+                  periodSeconds: 1
+                resources:
+                  requests:
+                    cpu: 15
+                    memory: 122800Mi
+                securityContext:
+                  allowPrivilegeEscalation: false
+                  capabilities:
+                    drop:
+                      - ALL
+                  privileged: false
+                  readOnlyRootFilesystem: false
+                  runAsGroup: 999
+                  runAsNonRoot: true
+                  runAsUser: 999
+                  seccompProfile:
+                    type: RuntimeDefault
+                startupProbe:
+                  failureThreshold: 300
+                  httpGet:
+                    path: /
+                    port: web
+                  periodSeconds: 1
+                volumeMounts:
+                  - mountPath: /opt/dremio/data
+                    name: dremio-master-volume
+                  - mountPath: /opt/dremio/conf
+                    name: dremio-config
+                  - mountPath: /opt/dremio/plugins/connectors/hive2.d
+                    name: dremio-hive2-config
+                  - mountPath: /opt/dremio/plugins/connectors/hive2-ee.d
+                    name: dremio-hive2-config
+                  - mountPath: /opt/dremio/plugins/connectors/hive3.d
+                    name: dremio-hive3-config
+                  - mountPath: /opt/dremio/plugins/connectors/hive3-ee.d
+                    name: dremio-hive3-config
+            initContainers:
+              - command:
+                  - sh
+                  - -c
+                  - 'INDEX=${HOSTNAME##*-}; if [ $INDEX -ne 0 ]; then echo Only one master should be running.; exit 1; fi; '
+                image: busybox
+                name: start-only-one-dremio-master
+                securityContext:
+                  allowPrivilegeEscalation: false
+                  capabilities:
+                    drop:
+                      - ALL
+                  privileged: false
+                  readOnlyRootFilesystem: false
+                  runAsGroup: 999
+                  runAsNonRoot: true
+                  runAsUser: 999
+                  seccompProfile:
+                    type: RuntimeDefault
+              - command:
+                  - sh
+                  - -c
+                  - until nc zk-hs 2181 -w1 > /dev/null; do echo Waiting for Zookeeper to be ready.; sleep 2; done;
+                image: busybox
+                name: wait-for-zookeeper
+                securityContext:
+                  allowPrivilegeEscalation: false
+                  capabilities:
+                    drop:
+                      - ALL
+                  privileged: false
+                  readOnlyRootFilesystem: false
+                  runAsGroup: 999
+                  runAsNonRoot: true
+                  runAsUser: 999
+                  seccompProfile:
+                    type: RuntimeDefault
+              - args:
+                  - upgrade
+                command:
+                  - /opt/dremio/bin/dremio-admin
+                image: dremio/dremio-oss:latest
+                imagePullPolicy: IfNotPresent
+                name: upgrade-task
+                securityContext:
+                  allowPrivilegeEscalation: false
+                  capabilities:
+                    drop:
+                      - ALL
+                  privileged: false
+                  readOnlyRootFilesystem: false
+                  runAsGroup: 999
+                  runAsNonRoot: true
+                  runAsUser: 999
+                  seccompProfile:
+                    type: RuntimeDefault
+                volumeMounts:
+                  - mountPath: /opt/dremio/data
+                    name: dremio-master-volume
+                  - mountPath: /opt/dremio/conf
+                    name: dremio-config
+            securityContext:
+              fsGroup: 999
+              fsGroupChangePolicy: OnRootMismatch
+            terminationGracePeriodSeconds: 120
+            volumes:
+              - configMap:
+                  name: dremio-config
+                name: dremio-config
+              - configMap:
+                  name: dremio-hive2-config
+                name: dremio-hive2-config
+              - configMap:
+                  name: dremio-hive3-config
+                name: dremio-hive3-config
+        volumeClaimTemplates:
+          - metadata:
+              name: dremio-master-volume
+            spec:
+              accessModes:
+                - ReadWriteOnce
+              resources:
+                requests:
+                  storage: 512Gi
+    component:
+      version: apps/v1
+      kind: StatefulSet
+      schema: ""
+  - id: 7597e56c-e2fe-4cef-aaaa-6a7d6f71046f
+    schemaVersion: components.meshery.io/v1beta1
+    version: v1.0.0
+    displayName: zk
+    description: ""
+    format: ""
+    model:
+      id: b3f5bc0d-30f7-607d-6c73-784ddde6cad8
+      schemaVersion: models.meshery.io/v1beta1
+      version: v1.0.0
+      name: kubernetes
+      displayName: Kubernetes
+      status: enabled
+      registrant:
+        id: 5bc80e3c-5d43-9eb4-d16c-78a2769247a6
+        name: Github
+        credential_id: 00000000-0000-0000-0000-000000000000
+        type: registry
+        sub_type: ""
+        kind: github
+        status: registered
+        user_id: 00000000-0000-0000-0000-000000000000
+        created_at: "2025-10-12T14:26:03.160654794Z"
+        updated_at: "2025-10-12T14:26:03.160654794Z"
+        deleted_at: "0001-01-01T00:00:00Z"
+        schemaVersion: ""
+      connection_id: 5bc80e3c-5d43-9eb4-d16c-78a2769247a6
+      category:
+        id: 9ca27d0d-66ce-42a9-8c85-6236563f2ddb
+        name: Orchestration & Management
+      subCategory: Scheduling & Orchestration
+      metadata:
+        isAnnotation: false
+        primaryColor: '#326CE5'
+        secondaryColor: '#7aa1f0'
+        shape: circle
+        styleOverrides: ""
+        svgColor: ui/public/static/img/meshmodels/kubernetes/color/kubernetes-color.svg
+        svgComplete: ""
+        svgWhite: ui/public/static/img/meshmodels/kubernetes/white/kubernetes-white.svg
+      model:
+        version: v1.32.0-alpha.3
+      components_count: 0
+      relationships_count: 0
+      components: null
+      relationships: null
+    styles:
+      background-opacity: 0.2
+      height: 15
+      primaryColor: '#326CE5'
+      secondaryColor: '#7aa1f0'
+      shape: round-rectangle
+      svgColor: ui/public/static/img/meshmodels/kubernetes/color/statefulset-color.svg
+      svgComplete: ui/public/static/img/meshmodels/kubernetes/complete/statefulset-complete.svg
+      svgWhite: ui/public/static/img/meshmodels/kubernetes/white/statefulset-white.svg
+      width: 15
+      x: 12
+      y: 20
+    capabilities: []
+    status: enabled
+    metadata:
+      configurationUISchema: ""
+      genealogy: parent
+      instanceDetails: null
+      isAnnotation: false
+      isNamespaced: true
+      published: false
+      source_uri: git://github.com/kubernetes/kubernetes/master/api/openapi-spec/v3
+    configuration:
+      metadata:
+        name: zk
+      spec:
+        podManagementPolicy: Parallel
+        replicas: 3
+        selector:
+          matchLabels:
+            app: zk
+        serviceName: zk-hs
+        template:
+          metadata:
+            labels:
+              app: zk
+          spec:
+            affinity:
+              podAntiAffinity:
+                requiredDuringSchedulingIgnoredDuringExecution:
+                  - labelSelector:
+                      matchExpressions:
+                        - key: app
+                          operator: In
+                          values:
+                            - zk
+                    topologyKey: kubernetes.io/hostname
+            containers:
+              - command:
+                  - bash
+                  - -ec
+                  - |
+                    # obtain ZOO_MY_ID based on POD hostname
+                    export HOST_NUMBER="${HOSTNAME##*-}"
+                    export ZOO_MY_ID="$((HOST_NUMBER + 1))"
+                    [ -z "${ZOO_MY_ID}" ] && echo "Failed to get index from hostname $HOSTNAME" && exit 1
+                    echo "ZOO_MY_ID=${ZOO_MY_ID}"
+
+                    # construct ZOO_SERVERS based on ensemble count
+                    DOMAIN="$(hostname -d)"
+                    SERVERS=3
+                    for (( i=${SERVERS},j=i-1; i>=1; i--,j-- )); do ZOO_SERVERS="server.${i}=zk-${j}.${DOMAIN}:2888:3888;2181 ${ZOO_SERVERS}"; done
+                    echo "ZOO_SERVERS=${ZOO_SERVERS}"
+                    export ZOO_SERVERS
+
+                    /docker-entrypoint.sh
+                    zkServer.sh start-foreground
+                env:
+                  - name: JVMFLAGS
+                    value: -Xmx924m
+                  - name: ZOO_STANDALONE_ENABLED
+                    value: "false"
+                  - name: ZOO_4LW_COMMANDS_WHITELIST
+                    value: ruok
+                  - name: ZOO_ADMINSERVER_ENABLED
+                    value: "false"
+                  - name: ZOO_AUTOPURGE_PURGEINTERVAL
+                    value: "12"
+                image: zookeeper:3.8.4-jre-17
+                imagePullPolicy: Always
+                livenessProbe:
+                  exec:
+                    command:
+                      - /bin/bash
+                      - -c
+                      - '[ "$(echo ruok | (exec 3<>/dev/tcp/127.0.0.1/2181; cat >&3; cat <&3; exec 3<&-))" == "imok" ]'
+                  initialDelaySeconds: 10
+                  timeoutSeconds: 5
+                name: kubernetes-zookeeper
+                ports:
+                  - containerPort: 2181
+                    name: client
+                  - containerPort: 2888
+                    name: server
+                  - containerPort: 3888
+                    name: leader-election
+                readinessProbe:
+                  exec:
+                    command:
+                      - /bin/bash
+                      - -c
+                      - '[ "$(echo ruok | (exec 3<>/dev/tcp/127.0.0.1/2181; cat >&3; cat <&3; exec 3<&-))" == "imok" ]'
+                  initialDelaySeconds: 10
+                  timeoutSeconds: 5
+                resources:
+                  requests:
+                    cpu: 0.5
+                    memory: 1024Mi
+                volumeMounts:
+                  - mountPath: /data
+                    name: datadir
+            securityContext:
+              fsGroup: 1000
+              runAsUser: 1000
+        updateStrategy:
+          type: RollingUpdate
+        volumeClaimTemplates:
+          - metadata:
+              name: datadir
+            spec:
+              accessModes:
+                - ReadWriteOnce
+              resources:
+                requests:
+                  storage: 10Gi
+    component:
+      version: apps/v1
+      kind: StatefulSet
+      schema: ""
+relationships: null


### PR DESCRIPTION
# [Design] Import Dremio Helm chart and publish to Meshery Catalog

## Summary
Adds a Meshery **Design** for Dremio (Helm-based) and prepares it for catalog sharing.

- **File Path:** `hacktoberfest_contributions/dremio-helm/design.yaml`
- **Source Chart:** `dremio-cloud-tools/charts/dremio_v2` (packaged as `dremio-2.0.0.tgz`)
- **Design Name:** `dremio-helm`
- **Visibility:** Public (ready to publish to Meshery Catalog)
- **Note:** `distStorage.type` configured to a non-`local` backend (required for Dremio ≥ 21).

## What’s Included
- Exported Meshery design YAML capturing the Dremio Helm topology (coordinator/executors, services, configs).
- Baseline values aligned for import/catalog; users can override chart values at deploy time (resources, ingress, persistence, credentials).

## Steps Performed
1. Packaged the official Dremio Helm chart:
   - `helm dependency update` in `charts/dremio_v2`
   - `helm package dremio_v2` → `dremio-2.0.0.tgz`
2. Imported into Meshery:
   - `mesheryctl design import -f dremio-2.0.0.tgz -n dremio-helm`
3. Verified presence:
   - `mesheryctl design list`
4. Published (ready for catalog):
   - `mesheryctl design publish -i <DESIGN_ID> --public`
5. Exported for PR:
   - `mesheryctl design export -i <DESIGN_ID> -o hacktoberfest_contributions/dremio-helm/design.yaml`

## Usage Notes
- **Storage:** Dremio ≥ 21 does **not** support `local` distStorage. Use `aws` / `azure` / `gcp` (S3/MinIO example included).
- **Secrets:** Provide real credentials via Kubernetes Secrets; avoid plaintext in values.
- **Persistence:** Ensure StorageClass and PVCs are available for metadata/scratch.
- **Ingress:** Configure hostname/TLS as needed; default is off.

---

**Notes for Reviewers**

- This PR fixes #15958 