### PR TITLE
chore(ui): dedupe imports across UI to satisfy eslint no-duplicate-imports

### DIFF
--- a/ui/components/ViewInfoModal.js
+++ b/ui/components/ViewInfoModal.js
@@ -1,30 +1,31 @@
 import {
   Avatar,
+  Box,
   Chip,
   CircularProgress,
   FormLabel,
+  Modal,
+  ModalBody,
+  ModalFooter,
+  ModalButtonPrimary,
+  ModalButtonSecondary,
   Typography,
   ViewIcon,
+  VisibilityChipMenu,
   getFullFormattedTime,
   styled,
   useTheme,
 } from '@sistent/sistent';
 import React, { useState } from 'react';
 import _ from 'lodash';
-import { Box, Modal, ModalBody, ModalFooter } from '@sistent/sistent';
+import rehypeSanitize from 'rehype-sanitize';
+import { Lock, Public } from '@mui/icons-material';
 import { useGetViewQuery, useUpdateViewVisibilityMutation } from '@/rtk-query/view';
 import { useGetLoggedInUserQuery, useGetUserProfileSummaryByIdQuery } from '@/rtk-query/user';
 import { iconLarge } from 'css/icons.styles';
-import { VisibilityChipMenu } from '@sistent/sistent';
-import RJSFWrapper from './MesheryMeshInterface/PatternService/RJSF_wrapper';
-import { MDEditor } from './Markdown';
 import { useNotification } from '@/utils/hooks/useNotification';
 import { EVENT_TYPES } from 'lib/event-types';
-import { ModalButtonSecondary } from '@sistent/sistent';
 import { handleUpdateViewVisibility, viewPath } from './SpacesSwitcher/hooks';
-import { ModalButtonPrimary } from '@sistent/sistent';
-import rehypeSanitize from 'rehype-sanitize';
-import { Lock, Public } from '@mui/icons-material';
 import { VIEW_VISIBILITY } from '@/utils/Enum';
 import ProviderStoreWrapper from '@/store/ProviderStoreWrapper';
 

--- a/ui/components/configuratorComponents/MeshModel/index.js
+++ b/ui/components/configuratorComponents/MeshModel/index.js
@@ -8,6 +8,7 @@ import {
   MenuItem,
   TextField,
   Toolbar,
+  NoSsr,
   CustomTooltip,
   styled,
 } from '@sistent/sistent';
@@ -15,7 +16,6 @@ import React, { useEffect, useRef, useState } from 'react';
 import AppBarComponent from './styledComponents/AppBar';
 import DeleteIcon from '@mui/icons-material/Delete';
 import SaveIcon from '@mui/icons-material/Save';
-import { NoSsr } from '@sistent/sistent';
 import { iconMedium } from '../../../css/icons.styles';
 import { useMeshModelComponents } from '../../../utils/hooks/useMeshModelComponents';
 import { getWebAdress } from '../../../utils/webApis';

--- a/ui/components/connections/ConnectionChip.js
+++ b/ui/components/connections/ConnectionChip.js
@@ -1,4 +1,4 @@
-import { Avatar, useTheme } from '@sistent/sistent';
+import { Avatar, useTheme, CustomTooltip } from '@sistent/sistent';
 import CheckCircleIcon from '@mui/icons-material/CheckCircle';
 import AssignmentTurnedInIcon from '@mui/icons-material/AssignmentTurnedIn';
 import ExploreIcon from '@mui/icons-material/Explore';
@@ -10,7 +10,6 @@ import { notificationColors } from '../../themes';
 import DisconnectIcon from '../../assets/icons/disconnect';
 import NotInterestedRoundedIcon from '@mui/icons-material/NotInterestedRounded';
 import { CONNECTION_STATES, CONTROLLER_STATES } from '../../utils/Enum';
-import { CustomTooltip } from '@sistent/sistent';
 import {
   ChipWrapper,
   ConnectedChip,

--- a/ui/components/connections/ConnectionTable.js
+++ b/ui/components/connections/ConnectionTable.js
@@ -19,6 +19,7 @@ import {
   TableCell,
   TableRow,
   Popover,
+  DeleteIcon,
 } from '@sistent/sistent';
 import {
   ContentContainer,
@@ -64,7 +65,6 @@ import {
 } from '@/rtk-query/connection';
 import { CustomTextTooltip } from '../MesheryMeshInterface/PatternService/CustomTextTooltip';
 import InfoOutlinedIcon from '@/assets/icons/InfoOutlined';
-import { DeleteIcon } from '@sistent/sistent';
 
 import { formatDate } from '../DataFormatter';
 import { getFallbackImageBasedOnKind } from '@/utils/fallback';

--- a/ui/components/connections/index.js
+++ b/ui/components/connections/index.js
@@ -1,6 +1,5 @@
 import React, { useRef, useState } from 'react';
-import { NoSsr } from '@sistent/sistent';
-import { ErrorBoundary, AppBar } from '@sistent/sistent';
+import { NoSsr, ErrorBoundary, AppBar } from '@sistent/sistent';
 import Modal from '../General/Modals/Modal';
 import { ConnectionIconText, ConnectionTab, ConnectionTabs } from './styles';
 import MeshSyncTable from './meshSync';

--- a/ui/components/connections/meshSync/index.js
+++ b/ui/components/connections/meshSync/index.js
@@ -1,15 +1,7 @@
 import React, { useEffect, useRef, useState } from 'react';
-import { Tooltip, Grid2, FormControl, MenuItem, Table, FormattedTime } from '@sistent/sistent';
+import { Tooltip, Grid2, FormControl, MenuItem, Table, FormattedTime, CustomColumnVisibilityControl, ResponsiveDataTable, SearchBar, UniversalFilter, TableCell, TableRow } from '@sistent/sistent';
 import { useNotification } from '../../../utils/hooks/useNotification';
 import { EVENT_TYPES } from '../../../lib/event-types';
-import {
-  CustomColumnVisibilityControl,
-  ResponsiveDataTable,
-  SearchBar,
-  UniversalFilter,
-  TableCell,
-  TableRow,
-} from '@sistent/sistent';
 import { MeshSyncDataFormatter } from '../metadata';
 import { getK8sClusterIdsFromCtxId } from '../../../utils/multi-ctx';
 import { DefaultTableCell, SortableTableCell } from '../common';

--- a/ui/components/multi-select-wrapper.js
+++ b/ui/components/multi-select-wrapper.js
@@ -2,8 +2,7 @@ import { useState } from 'react';
 import { components } from 'react-select';
 import CreatableSelect from 'react-select/creatable';
 import { Colors } from '../themes/app';
-import { Checkbox, MenuItem, Paper, FormControlLabel } from '@sistent/sistent';
-import { useTheme } from '@sistent/sistent';
+import { Checkbox, MenuItem, Paper, FormControlLabel, useTheme } from '@sistent/sistent';
 
 const MultiSelectWrapper = (props) => {
   const [selectInput, setSelectInput] = useState('');

--- a/ui/components/telemetry/grafana/GrafanaCharts.js
+++ b/ui/components/telemetry/grafana/GrafanaCharts.js
@@ -1,7 +1,6 @@
 import React, { useState } from 'react';
 import PropTypes from 'prop-types';
-import { NoSsr } from '@sistent/sistent';
-import { Grid2, ExpansionPanelDetails, Typography, styled } from '@sistent/sistent';
+import { NoSsr, Grid2, ExpansionPanelDetails, Typography, styled } from '@sistent/sistent';
 import ExpandMoreIcon from '@mui/icons-material/ExpandMore';
 import LazyLoad from 'react-lazyload';
 import GrafanaDateRangePicker from './GrafanaDateRangePicker';

--- a/ui/components/telemetry/grafana/GrafanaComponent.js
+++ b/ui/components/telemetry/grafana/GrafanaComponent.js
@@ -1,7 +1,6 @@
 import React, { useState, useEffect } from 'react';
 import PropTypes from 'prop-types';
-import { NoSsr } from '@sistent/sistent';
-import { Typography, Box, styled, useTheme } from '@sistent/sistent';
+import { NoSsr, Typography, Box, styled, useTheme } from '@sistent/sistent';
 
 import GrafanaConfigComponent from './GrafanaConfigComponent';
 import GrafanaSelectionComponent from './GrafanaSelectionComponent';

--- a/ui/components/telemetry/grafana/GrafanaConfigComponent.js
+++ b/ui/components/telemetry/grafana/GrafanaConfigComponent.js
@@ -1,7 +1,6 @@
 import React, { useEffect, useState } from 'react';
 import PropTypes from 'prop-types';
-import { NoSsr } from '@sistent/sistent';
-import { TextField, Grid2, Button, styled } from '@sistent/sistent';
+import { NoSsr, TextField, Grid2, Button, styled } from '@sistent/sistent';
 import ReactSelectWrapper from '../../ReactSelectWrapper';
 import CAN from '@/utils/can';
 import { keys } from '@/utils/permission_constants';

--- a/ui/components/telemetry/grafana/GrafanaCustomCharts.js
+++ b/ui/components/telemetry/grafana/GrafanaCustomCharts.js
@@ -1,11 +1,11 @@
 import React, { useState, useCallback } from 'react';
 import PropTypes from 'prop-types';
-import { NoSsr } from '@sistent/sistent';
 import ExpandMoreIcon from '@mui/icons-material/ExpandMore';
 import GrafanaDateRangePicker from './GrafanaDateRangePicker';
 import { StyledAccordion, StyledAccordionSummary } from '../../StyledAccordion';
 import GrafanaCustomChart from './GrafanaCustomChart';
 import {
+  NoSsr,
   Grid2,
   AccordionDetails,
   Typography,

--- a/ui/components/telemetry/grafana/GrafanaCustomGaugeChart.js
+++ b/ui/components/telemetry/grafana/GrafanaCustomGaugeChart.js
@@ -1,7 +1,6 @@
 import React, { useEffect } from 'react';
-import { Box, styled, useTheme } from '@sistent/sistent';
+import { Box, styled, useTheme, NoSsr } from '@sistent/sistent';
 import bb, { gauge } from 'billboard.js';
-import { NoSsr } from '@sistent/sistent';
 
 const ChartRoot = styled(Box)(() => ({
   width: '100%',

--- a/ui/components/telemetry/grafana/GrafanaDateRangePicker.js
+++ b/ui/components/telemetry/grafana/GrafanaDateRangePicker.js
@@ -1,6 +1,6 @@
 import React, { useState } from 'react';
-import { NoSsr } from '@sistent/sistent';
 import {
+  NoSsr,
   Button,
   TextField,
   MenuItem,

--- a/ui/components/telemetry/grafana/GrafanaDisplaySelection.js
+++ b/ui/components/telemetry/grafana/GrafanaDisplaySelection.js
@@ -1,7 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { NoSsr } from '@sistent/sistent';
-import { Chip, Box, styled } from '@sistent/sistent';
+import { NoSsr, Chip, Box, styled } from '@sistent/sistent';
 import MUIDataTable from 'mui-datatables';
 
 const Root = styled(Box)(({ theme }) => ({

--- a/ui/components/telemetry/grafana/GrafanaMetricsCompare.js
+++ b/ui/components/telemetry/grafana/GrafanaMetricsCompare.js
@@ -1,7 +1,6 @@
 import React, { useState, useEffect } from 'react';
 import PropTypes from 'prop-types';
-import { NoSsr } from '@sistent/sistent';
-import { MenuItem, TextField, Box, styled } from '@sistent/sistent';
+import { NoSsr, MenuItem, TextField, Box, styled } from '@sistent/sistent';
 import { connect } from 'react-redux';
 
 const Root = styled(Box)(() => ({

--- a/ui/components/telemetry/grafana/GrafanaSelectionComponent.js
+++ b/ui/components/telemetry/grafana/GrafanaSelectionComponent.js
@@ -1,7 +1,6 @@
 import React, { useState, useEffect } from 'react';
 import PropTypes from 'prop-types';
-import { NoSsr } from '@sistent/sistent';
-import { TextField, Grid2, Button, Chip, MenuItem, useTheme, styled, Box } from '@sistent/sistent';
+import { NoSsr, TextField, Grid2, Button, Chip, MenuItem, useTheme, styled, Box } from '@sistent/sistent';
 import dataFetch from '../../../lib/data-fetch';
 import { trueRandom } from '../../../lib/trueRandom';
 import { updateProgress } from '@/store/slices/mesheryUi';

--- a/ui/components/telemetry/prometheus/PrometheusComponent.js
+++ b/ui/components/telemetry/prometheus/PrometheusComponent.js
@@ -1,7 +1,6 @@
 import React, { useState, useEffect } from 'react';
 import PropTypes from 'prop-types';
-import { NoSsr } from '@sistent/sistent';
-import { Typography, styled, Box } from '@sistent/sistent';
+import { NoSsr, Typography, styled, Box } from '@sistent/sistent';
 import {
   useConfigureConnectionMutation,
   useUpdateConnectionMutation,

--- a/ui/components/telemetry/prometheus/PrometheusConfigComponent.js
+++ b/ui/components/telemetry/prometheus/PrometheusConfigComponent.js
@@ -1,7 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { NoSsr } from '@sistent/sistent';
-import { Grid2, Button, styled } from '@sistent/sistent';
+import { NoSsr, Grid2, Button, styled } from '@sistent/sistent';
 import ReactSelectWrapper from '../../ReactSelectWrapper';
 import CAN from '@/utils/can';
 import { keys } from '@/utils/permission_constants';

--- a/ui/machines/validator/designValidator.js
+++ b/ui/machines/validator/designValidator.js
@@ -5,6 +5,7 @@ import {
   dataValidatorMachine,
   selectIsValidating,
   selectValidationResults,
+  fromWorkerfiedActor,
 } from '@sistent/sistent';
 import { useSelector } from '@xstate/react';
 import { encodeDesignFile, processDesign } from '@/utils/utils';
@@ -12,7 +13,6 @@ import { designsApi } from '@/rtk-query/design';
 import { initiateQuery } from '@/rtk-query/utils';
 
 import { componentKey } from './schemaValidator';
-import { fromWorkerfiedActor } from '@sistent/sistent';
 
 const DESIGN_VALIDATOR_COMMANDS = {
   VALIDATE_DESIGN_SCHEMA: 'VALIDATE_DESIGN_SCHEMA',

--- a/ui/pages/configuration/filters.js
+++ b/ui/pages/configuration/filters.js
@@ -1,9 +1,8 @@
 import React, { useEffect } from 'react';
-import { NoSsr } from '@sistent/sistent';
+import { NoSsr, Box } from '@sistent/sistent';
 import MesheryFilters from '../../components/MesheryFilters/Filters';
 import Head from 'next/head';
 import { getPath } from '../../lib/path';
-import { Box } from '@sistent/sistent';
 import { useDispatch } from 'react-redux';
 import { updatePage } from '@/store/slices/mesheryUi';
 

--- a/ui/pages/management/workspaces.js
+++ b/ui/pages/management/workspaces.js
@@ -1,9 +1,8 @@
 import React, { useEffect } from 'react';
-import { NoSsr } from '@sistent/sistent';
+import { NoSsr, Box } from '@sistent/sistent';
 import { connect, useDispatch } from 'react-redux';
 import Head from 'next/head';
 import { WorkspacesComponent } from '../../components/Lifecycle';
-import { Box } from '@sistent/sistent';
 import { updatePage } from '@/store/slices/mesheryUi';
 import { getPath } from 'lib/path';
 

--- a/ui/themes/hooks.js
+++ b/ui/themes/hooks.js
@@ -1,6 +1,5 @@
-import React, { useEffect } from 'react';
+import React, { useEffect, useState } from 'react';
 import { useGetUserPrefQuery, useUpdateUserPrefWithContextMutation } from '@/rtk-query/user';
-import { useState } from 'react';
 import _ from 'lodash/fp';
 import ProviderStoreWrapper from '@/store/ProviderStoreWrapper';
 

--- a/ui/utils/TooltipButton.js
+++ b/ui/utils/TooltipButton.js
@@ -1,5 +1,4 @@
-import { Button } from '@sistent/sistent';
-import { CustomTooltip, IconButton } from '@sistent/sistent';
+import { Button, CustomTooltip, IconButton } from '@sistent/sistent';
 
 export default function TooltipButton({ children, onClick, title, variant, ...props }) {
   return (

--- a/ui/utils/utils.js
+++ b/ui/utils/utils.js
@@ -6,8 +6,6 @@ import _ from 'lodash';
 import { getWebAdress } from './webApis';
 import { APPLICATION, DESIGN, FILTER } from '../constants/navigator';
 import { Tooltip } from '@sistent/sistent';
-import jsyaml from 'js-yaml';
-import yaml from 'js-yaml';
 import { mesheryExtensionRoute } from '../pages/_app';
 import { mesheryEventBus } from './eventBus';
 import { useSelector } from 'react-redux';


### PR DESCRIPTION

Summary
Consolidates duplicate import declarations (e.g., '@sistent/sistent', 'react', 'js-yaml') across UI files to resolve CI failures on the no-duplicate-imports rule. No runtime changes.

Key updates
- Merge split imports into single declarations per module.
- Remove redundant 'js-yaml' duplicate imports in utils/utils.js.

Files
- components/connections/{ConnectionChip.js,ConnectionTable.js,index.js,meshSync/index.js}
- components/multi-select-wrapper.js
- components/telemetry/grafana/{GrafanaCharts.js,GrafanaComponent.js,GrafanaConfigComponent.js,GrafanaCustomCharts.js,GrafanaCustomGaugeChart.js,GrafanaDateRangePicker.js,GrafanaDisplaySelection.js,GrafanaMetricsCompare.js,GrafanaSelectionComponent.js}
- components/telemetry/prometheus/{PrometheusComponent.js,PrometheusConfigComponent.js}
- machines/validator/designValidator.js
- pages/configuration/filters.js
- pages/management/workspaces.js
- themes/hooks.js
- utils/{TooltipButton.js,utils.js}

Related
- Part of #16042

Test plan
- Run lint to confirm no “no-duplicate-imports” errors in touched files.