### PR TITLE
feat(fix): honor insecure-skip-tls-verify flag for k3s clusters.

### DIFF
--- a/server/helpers/helpers_test.go
+++ b/server/helpers/helpers_test.go
@@ -1,0 +1,117 @@
+package helpers
+
+import (
+    "testing"
+    
+    "github.com/stretchr/testify/assert"
+    "github.com/stretchr/testify/require"
+)
+
+func TestGetK8SClientSetWithInsecureSkipVerify(t *testing.T) {
+    // Test kubeconfig with insecure-skip-tls-verify set to true
+    kubeconfigContent := []byte(`
+apiVersion: v1
+clusters:
+- cluster:
+    insecure-skip-tls-verify: true
+    server: https://127.0.0.1:6443
+  name: test-cluster
+contexts:
+- context:
+    cluster: test-cluster
+    user: test-user
+  name: test-context
+current-context: test-context
+kind: Config
+users:
+- name: test-user
+  user:
+    token: test-token
+`)
+    
+    // Test that the clientset can be created without errors
+    clientset, err := getK8SClientSet(kubeconfigContent, "")
+    
+    // The clientset should be created successfully
+    require.NoError(t, err)
+    require.NotNil(t, clientset)
+}
+
+func TestGetK8SClientSetWithCADataAndInsecureSkipVerify(t *testing.T) {
+    // Test that when both CA data and insecure-skip-tls-verify are present,
+    // the insecure flag takes precedence and CA data is cleared
+    kubeconfigContent := []byte(`
+apiVersion: v1
+clusters:
+- cluster:
+    certificate-authority-data: LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUM1ekNDQWMrZ0F3SUJBZ0lCQURBTkJna3Foa2lHOXcwQkFRc0ZBREFWTVJNd0VRWURWUVFERXdwcmRXSmwKY201bGRHVnpNQjRYRFRJd01EWXdOakEzTVRReE0xb1hEVE13TURZd05EQTNNVFF4TTFvd0ZURVRNQkVHQTFVRQpBeE1LYTNWaVpYSnVaWFJsY3pDQ0FTSXdEUVlKS29aSWh2Y05BUUVCQlFBRGdnRVBBRENDQVFvQ2dnRUJBTDNqCg==
+    insecure-skip-tls-verify: true
+    server: https://127.0.0.1:6443
+  name: test-cluster
+contexts:
+- context:
+    cluster: test-cluster
+    user: test-user
+  name: test-context
+current-context: test-context
+kind: Config
+users:
+- name: test-user
+  user:
+    token: test-token
+`)
+    
+    clientset, err := getK8SClientSet(kubeconfigContent, "")
+    
+    // Should succeed without "specifying a root certificates file with the insecure flag is not allowed" error
+    require.NoError(t, err)
+    require.NotNil(t, clientset)
+}
+
+func TestGetK8SClientSetWithContextName(t *testing.T) {
+    // Test that context switching works correctly
+    kubeconfigContent := []byte(`
+apiVersion: v1
+clusters:
+- cluster:
+    insecure-skip-tls-verify: true
+    server: https://127.0.0.1:6443
+  name: cluster-1
+- cluster:
+    insecure-skip-tls-verify: true
+    server: https://192.168.1.1:6443
+  name: cluster-2
+contexts:
+- context:
+    cluster: cluster-1
+    user: user-1
+  name: context-1
+- context:
+    cluster: cluster-2
+    user: user-2
+  name: context-2
+current-context: context-1
+kind: Config
+users:
+- name: user-1
+  user:
+    token: token-1
+- name: user-2
+  user:
+    token: token-2
+`)
+    
+    // Test with specific context name
+    clientset, err := getK8SClientSet(kubeconfigContent, "context-2")
+    
+    require.NoError(t, err)
+    require.NotNil(t, clientset)
+}
+
+func TestGetK8SClientSetWithEmptyKubeconfig(t *testing.T) {
+    // Test that in-cluster config is attempted when kubeconfig is empty
+    _, err := getK8SClientSet([]byte{}, "")
+    
+    // We expect an error since we're not running inside a cluster
+    assert.Error(t, err)
+}

--- a/server/helpers/kubernetes.go
+++ b/server/helpers/kubernetes.go
@@ -33,6 +33,10 @@ func getK8SClientSet(kubeconfig []byte, contextName string) (*kubernetes.Clients
 		if err != nil {
 			return nil, ErrClientConfig(err)
 		}
+		if clientConfig.TLSClientConfig.Insecure {
+			clientConfig.TLSClientConfig.CAFile = ""
+			clientConfig.TLSClientConfig.CAData = nil
+		}
 	}
 	clientConfig.Timeout = 2 * time.Minute
 	clientset, err := kubernetes.NewForConfig(clientConfig)


### PR DESCRIPTION
**Notes for Reviewers**

- This PR fixes #16210 
## Description

### Current Behavior
When connecting Meshery to k3s clusters with self-signed certificates, TLS verification fails with error: x509: certificate is valid for 127.0.0.1, not <public-ip> even when `insecure-skip-tls-verify: true` is set in kubeconfig.

This occurs because the Kubernetes client-go library throws a conflict error when both `certificate-authority-data` (or `CAFile`) and `insecure-skip-tls-verify: true` are present in the kubeconfig.

### Desired Behavior
Meshery should properly honor the `insecure-skip-tls-verify` flag and successfully connect to k3s clusters without TLS verification errors.

## Changes

### Implementation
Modified `getK8SClientSet()` function in `server/helpers/helpers.go` to explicitly clear CA certificate data when `insecure-skip-tls-verify` is detected in the kubeconfig.

**Code Changes:**

// After building client config, check and handle insecure flag
if clientConfig.TLSClientConfig.Insecure {
clientConfig.TLSClientConfig.CAFile = ""
clientConfig.TLSClientConfig.CAData = nil
}

This ensures that when the insecure flag is set to `true`, the CA data is cleared to prevent conflicts that cause TLS verification failures.

### Testing
Created comprehensive unit tests in `server/helpers/helpers_test.go`:

1. **TestGetK8SClientSetWithInsecureSkipVerify** - Verifies basic insecure-skip-tls-verify functionality
2. **TestGetK8SClientSetWithCADataAndInsecureSkipVerify** - Tests the conflict scenario when both CA data and insecure flag are present
3. **TestGetK8SClientSetWithContextName** - Validates context switching with insecure connections
4. **TestGetK8SClientSetWithEmptyKubeconfig** - Tests edge case handling

### Test Results
Before-
<img width="1866" height="504" alt="image" src="https://github.com/user-attachments/assets/32ef0ffe-4cb5-4882-82f0-c74af2b6e07d" />
After-
<img width="1404" height="346" alt="image" src="https://github.com/user-attachments/assets/4c3cbd96-77e5-48fb-8a08-37cc95d82cb4" />

**[Signed commits](https://github.com/meshery/meshery/blob/master/CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [x] Yes, I signed my commits.

<!--
Thank you for contributing to Meshery! 

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. Sign your commits.
4. Include before and after screenshots/terminal output.

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.
-->
