### PR TITLE
docs: add Meshery Bluesky account to footer (#16454)

### DIFF
--- a/docs/_includes/footer.html
+++ b/docs/_includes/footer.html
@@ -81,9 +81,7 @@ meshery-custom-end -->
     </div>
         <div class="footer-icons">
   <a class="social__link" href="https://bsky.app/profile/mesheryio.bsky.social" target="_blank" rel="noreferrer">
-    <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 600 600" width="24" height="24" fill="currentColor">
-      <path d="M300 350c40 60 120 140 160 140s40-80 20-140c-20-60-80-120-140-140 60-20 120-80 140-140s0-140-20-140-120 80-160 140c-40-60-120-140-160-140s-40 80-20 140 80 120 140 140c-60 20-120 80-140 140s0 140 20 140 120-80 160-140z"/>
-    </svg>
+    <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 640 640"><!--!Font Awesome Free v7.1.0 by @fontawesome - https://fontawesome.com License - https://fontawesome.com/license/free Copyright 2025 Fonticons, Inc.--><path d="M439.8 358.7C436.5 358.3 433.1 357.9 429.8 357.4C433.2 357.8 436.5 358.3 439.8 358.7zM320 291.1C293.9 240.4 222.9 145.9 156.9 99.3C93.6 54.6 69.5 62.3 53.6 69.5C35.3 77.8 32 105.9 32 122.4C32 138.9 41.1 258 47 277.9C66.5 343.6 136.1 365.8 200.2 358.6C203.5 358.1 206.8 357.7 210.2 357.2C206.9 357.7 203.6 358.2 200.2 358.6C106.3 372.6 22.9 406.8 132.3 528.5C252.6 653.1 297.1 501.8 320 425.1C342.9 501.8 369.2 647.6 505.6 528.5C608 425.1 533.7 372.5 439.8 358.6C436.5 358.2 433.1 357.8 429.8 357.3C433.2 357.7 436.5 358.2 439.8 358.6C503.9 365.7 573.4 343.5 593 277.9C598.9 258 608 139 608 122.4C608 105.8 604.7 77.7 586.4 69.5C570.6 62.4 546.4 54.6 483.2 99.3C417.1 145.9 346.1 240.4 320 291.1z"/></svg>
     <span class="footer-icons-text">Follow on Bluesky</span>
   </a>
 </div>


### PR DESCRIPTION
Fixes: #16454

Summary
Added Bluesky social link to the documentation footer.

Changes
- Updated docs/_includes/footer.html to include a Bluesky link.

Notes
- Used https://bsky.app/profile/mesheryio.bsky.social
 as the Bluesky URL; maintainers may update it if needed.

