### PR TITLE
chore: remove stale TODO from auth.go

### DIFF
--- a/mesheryctl/pkg/utils/auth.go
+++ b/mesheryctl/pkg/utils/auth.go
@@ -176,7 +176,6 @@ func UpdateAuthDetails(filepath string) error {
 		return ErrLoadConfig(err)
 	}
 
-	// TODO: get this from the global config
 	req, err := http.NewRequest("GET", mctlCfg.GetBaseMesheryURL()+"/api/user/token", bytes.NewBuffer([]byte("")))
 	if err != nil {
 		err = errors.Wrap(err, "error Creating the request: ")


### PR DESCRIPTION
**Notes for Reviewers**

- This PR fixes #16494
- Removes a stale `TODO` comment in `mesheryctl/pkg/utils/auth.go` as the code is already confirmed to be using the global configuration.

**[Signed commits](https://github.com/meshery/meshery/blob/master/CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [x] Yes, I signed my commits.