### PR TITLE
doc(mesheryctl): add missing model import subcommand flags

### DIFF
--- a/docs/_data/mesheryctlcommands/cmds.yml
+++ b/docs/_data/mesheryctlcommands/cmds.yml
@@ -928,7 +928,7 @@ model:
     import:
       name: import
       description: Import models using a file or filepath directly to the meshery registry
-      usage: mesheryctl model import [ file | filepath ]
+      usage: mesheryctl model import --file [ file | path | URL ]
       examples:
         - mesheryctl model import /path/to/[file.yaml|file.json]
         - mesheryctl model import /path/to/models
@@ -936,7 +936,7 @@ model:
         file:
           name: --file, -f
           description: (optional) path to a single model file to import from local filesystem or URL to import from web location
-          usage: mesheryctl model import --file [file-path or URL]
+          usage: mesheryctl model import --file [ file | path | URL ]
           examples: 
             - mesheryctl model import --file /path/to/model.tar
             - mesheryctl model import --file /path/to/model.tar.gz


### PR DESCRIPTION
**Notes for Reviewers**

- This PR fixes missing flags documentation for model import sub command

**[Signed commits](https://github.com/meshery/meshery/blob/master/CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [x] Yes, I signed my commits.

<!--
Thank you for contributing to Meshery! 

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. Sign your commits.
4. Include before and after screenshots/terminal output.

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.
-->

before

<img width="1084" height="867" alt="image" src="https://github.com/user-attachments/assets/96193d02-3b6f-4b3c-82ca-b93a452301c7" />


after

<img width="988" height="804" alt="image" src="https://github.com/user-attachments/assets/b3ac2818-b62c-43e5-b102-0d5f56730388" />
