### PR TITLE
Revert "[server] Add workspace_id and organization_id to GET /api/pattern/{id} endpoint"

### DIFF
--- a/server/models/meshery_pattern.go
+++ b/server/models/meshery_pattern.go
@@ -92,11 +92,6 @@ type MesheryPattern struct {
 	// but the remote provider is allowed to provide one
 	UserID *string `json:"user_id"`
 
-	// WorkspaceID is the ID of the workspace this pattern belongs to
-	WorkspaceID *uuid.UUID `json:"workspace_id,omitempty" gorm:"-"`
-	// OrganizationID is the ID of the organization this pattern belongs to
-	OrganizationID *uuid.UUID `json:"organization_id,omitempty" gorm:"-"`
-
 	Location      isql.Map             `json:"location"`
 	Visibility    string               `json:"visibility"`
 	CatalogData   v1alpha1.CatalogData `json:"catalog_data,omitempty" gorm:"type:bytes;serializer:json"`

--- a/server/models/meshery_pattern_persister.go
+++ b/server/models/meshery_pattern_persister.go
@@ -245,35 +245,8 @@ func (mpp *MesheryPatternPersister) SaveMesheryPatterns(mesheryPatterns []Mesher
 func (mpp *MesheryPatternPersister) GetMesheryPattern(id uuid.UUID) ([]byte, error) {
 	var mesheryPattern MesheryPattern
 
-	// First, get the pattern
 	err := mpp.DB.First(&mesheryPattern, id).Error
-	if err != nil {
-		return marshalMesheryPattern(&mesheryPattern), err
-	}
-
-	// Then, try to get the workspace_id and organization_id from the workspace mapping
-	type WorkspaceInfo struct {
-		WorkspaceID    *uuid.UUID
-		OrganizationID *uuid.UUID
-	}
-	var workspaceInfo WorkspaceInfo
-
-	// Join workspaces_designs_mappings with workspaces to get both workspace_id and organization_id
-	err = mpp.DB.Table("workspaces_designs_mappings AS wdm").
-		Select("wdm.workspace_id, w.organization_id").
-		Joins("LEFT JOIN workspaces AS w ON wdm.workspace_id = w.id").
-		Where("wdm.design_id = ? AND wdm.deleted_at IS NULL AND (w.id IS NULL OR w.deleted_at IS NULL)", id).
-		Scan(&workspaceInfo).Error
-
-	// If workspace mapping is found, populate the fields
-	// Note: OrganizationID may be nil even if WorkspaceID exists if the workspace has no organization
-	if err == nil && workspaceInfo.WorkspaceID != nil {
-		mesheryPattern.WorkspaceID = workspaceInfo.WorkspaceID
-		mesheryPattern.OrganizationID = workspaceInfo.OrganizationID
-	}
-	// If no workspace mapping is found, that's okay - the pattern might not be assigned to a workspace
-
-	return marshalMesheryPattern(&mesheryPattern), nil
+	return marshalMesheryPattern(&mesheryPattern), err
 }
 
 func (mpp *MesheryPatternPersister) GetMesheryPatternSource(id uuid.UUID) ([]byte, error) {


### PR DESCRIPTION
Reverts meshery/meshery#16500 

this is already handled in the workspace context pr now .   there is a bug in this one so going with other pr and reverting this