### PR TITLE
feat: added the schemas and docs which were previously causing error

### DIFF
--- a/server/internal/graphql/graphql.go
+++ b/server/internal/graphql/graphql.go
@@ -54,12 +54,7 @@ func New(opts Options) http.Handler {
 	}
 
 	srv := handler.New(generated.NewExecutableSchema(config))
-
-	
     srv.Use(extension.Introspection{})
-    
-   
-
 	srv.AddTransport(transport.POST{})
 	srv.AddTransport(transport.GET{})
 	srv.AddTransport(transport.Websocket{


### PR DESCRIPTION
**Notes for Reviewers**

- This PR fixes #4936
- [x] Yes, I signed my commits.

This pr fixes the issue in graphql playground where schemas couldn't get fetched. The following approach saw that introspection wasn't explicitly turned on causing errors while fetching the schemas and docs. Hence, introspection was turned on resulting in the docs and schemas being available

Before screenshots:
<img width="1856" height="1012" alt="image" src="https://github.com/user-attachments/assets/c044cdba-523a-4f63-b2bb-9a7182f7e7bb" />
After screenshots:
<img width="1856" height="1012" alt="Screenshot from 2025-12-01 17-42-28" src="https://github.com/user-attachments/assets/e3491a02-b2b8-471f-8629-9aa9f1b361f1" />

Signed-off-by : Abhiyan31415 <abhiyankhanal7@gmail.com>