### PR TITLE
chore: remove leftover debug print statements in patterns

### DIFF
--- a/server/models/pattern/patterns/patterns.go
+++ b/server/models/pattern/patterns/patterns.go
@@ -42,8 +42,6 @@ func Process(kconfigs []string, componets []component.ComponentDefinition, isDel
 		return nil, err
 	}
 
-	fmt.Println("\n\n\nTEST DEPHANDLER : ", depHandler)
-
 	msgs := make([]DeploymentMessagePerContext, 0)
 	var msgsMx sync.Mutex
 
@@ -66,9 +64,7 @@ func Process(kconfigs []string, componets []component.ComponentDefinition, isDel
 
 			msgsPerComp := make([]DeploymentMessagePerComp, 0)
 			for _, comp := range componets {
-				fmt.Println("TEST INSIDE line 70 : ", comp.Component.Kind)
 				if !skipCrdAndOperator && depHandler != nil && comp.Model.Name != (_models.Kubernetes{}).String() {
-					fmt.Println("TEST INSIDE line 72 : ")
 					deploymentMsg := DeploymentMessagePerComp{
 						Kind:       comp.Component.Kind,
 						Model:      comp.Model.Name,
@@ -105,7 +101,6 @@ func Process(kconfigs []string, componets []component.ComponentDefinition, isDel
 					_msg.Error = err
 					_msg.Success = false
 				}
-				fmt.Println("TEST INSIDE line 108 after deploying : ", err)
 				msgsPerComp = append(msgsPerComp, _msg)
 			}
 


### PR DESCRIPTION
## Description

This PR removes leftover debug print statements from the pattern deployment handler that were outputting unstructured diagnostic information to stdout during runtime.

## Related Issue

Fixes #16550 

## Changes

- Removed `fmt.Println` debug statements from `server/models/pattern/patterns/patterns.go`
- Cleaned up the following debug outputs:
  - `TEST INSIDE line 70 : ...`
  - `TEST DEPHANDLER : ...`
  - `TEST INSIDE line 108 after deploying : ...`

## Testing

**Before:**
```
$ make server
[server starts]
TEST INSIDE line 70 : ...
TEST DEPHANDLER : ...
TEST INSIDE line 108 after deploying : ...
[additional debug output]
```

**After:**
```
$ make server
[server starts with clean output]
[no debug print statements in console]
```

### Steps to Test
1. Start Meshery Server: `make server`
2. Deploy a design/pattern through the UI or API
3. Verify that no "TEST INSIDE" or "TEST DEPHANDLER" messages appear in the console output
4. Confirm that pattern deployment still functions correctly

## Impact

- Improves code quality by removing temporary debugging code
- Cleans up server logs for better readability
- No functional changes to pattern deployment logic

---

**Notes for Reviewers**
- This PR fixes #[ISSUE_NUMBER]

**[[Signed commits](https://github.com/meshery/meshery/blob/master/CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)](https://github.com/meshery/meshery/blob/master/CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [x] Yes, I signed my commits.