### PR TITLE
fix: prevent duplicate PR entries in release notes added no-duplicate-categories: true to to .github/release-drafter.yml

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -1,5 +1,6 @@
 name-template: 'Meshery v$NEXT_PATCH_VERSION'
 tag-template: 'v$NEXT_PATCH_VERSION'
+no-duplicate-categories: true
 categories:
   - title: '🚀 Features'
     labels:


### PR DESCRIPTION
Add no-duplicate-categories: true to release-drafter config to ensure each PR appears only once in release notes, even when it matches multiple category labels.

Fixes #16603

**Notes for Reviewers**

- This PR fixes #16603

**[Signed commits](https://github.com/meshery/meshery/blob/master/CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [x] Yes, I signed my commits.

<!--
Thank you for contributing to Meshery! 

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. Sign your commits.
4. Include before and after screenshots/terminal output.

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.
-->
