### PR TITLE
[Critical] [vulnerability] Fix RCE & secrets-exfiltration in build-ui-and-server workflow

### DIFF
--- a/.github/workflows/build-ui-and-server.yml
+++ b/.github/workflows/build-ui-and-server.yml
@@ -23,7 +23,7 @@ permissions: read-all
 jobs:
   ui-build:
     name: UI build
-    if: github.repository == 'meshery/meshery'
+    if: github.repository == 'meshery/meshery' && ${{ contains(github.event.pull_request.labels.*.name, 'ready-to-run') }}
     runs-on: ubuntu-24.04
     steps:
       - name: Check out code
@@ -55,7 +55,7 @@ jobs:
     needs: [ui-build]
     name: UI end-to-end tests
     environment: staging-playground
-    if: github.repository == 'meshery/meshery'
+    if: github.repository == 'meshery/meshery' && ${{ contains(github.event.pull_request.labels.*.name, 'ready-to-run') }}
     runs-on: ubuntu-24.04
     timeout-minutes: 45
     steps:
@@ -151,7 +151,7 @@ jobs:
           retention-days: 14
   docker-build-test:
     name: Docker build
-    if: github.repository == 'meshery/meshery'
+    if: github.repository == 'meshery/meshery' && ${{ contains(github.event.pull_request.labels.*.name, 'ready-to-run') }}
     runs-on: ubuntu-24.04
     steps:
       - name: Check out code
@@ -186,7 +186,7 @@ jobs:
           repository: ${{ secrets.IMAGE_NAME }}
   # validate the swagger docs
   swaggerci:
-    if: github.repository == 'meshery/meshery'
+    if: github.repository == 'meshery/meshery' && ${{ contains(github.event.pull_request.labels.*.name, 'ready-to-run') }}
     name: swagger-docs
     runs-on: ubuntu-24.04
     steps:
@@ -213,7 +213,7 @@ jobs:
   # validate graphQL schema
   graphql_validate:
     name: Validate GraphQL schema
-    if: github.repository == 'meshery/meshery'
+    if: github.repository == 'meshery/meshery' && ${{ contains(github.event.pull_request.labels.*.name, 'ready-to-run') }}
     runs-on: ubuntu-24.04
     steps:
       - name: Check out code


### PR DESCRIPTION


### 🚨 Security Issue

The vulnerable workflow is defined in:

`/.github/workflows/build-ui-and-server.yml`

and is triggered using:

```yaml
on:
  pull_request_target:
    types: [opened, synchronize, reopened]
    branches:
      - "master"
```

Because `pull_request_target` runs in the **base repository’s security context**, it grants access to:

- repository-level secrets  
- protected environments  
- elevated permissions  

Even when the PR is created from a **fork**.

In this workflow, attacker-controlled PR code is checked out and built:

```yaml
ui-build:
  name: UI build
  if: github.repository == 'meshery/meshery'
  steps:
    - uses: actions/checkout@v4
      with:
        ref: ${{ github.event.pull_request.head.sha }}
    - run: make ui-build
```

Followed by running a Meshery server and full UI end-to-end tests that expose real secrets:

```yaml
Run Playwright End-to-End Tests
env:
  REMOTE_PROVIDER_USER_EMAIL: ${{ secrets.REMOTE_PROVIDER_TEST_USER_EMAIL }}
  REMOTE_PROVIDER_USER_PASSWORD: ${{ secrets.REMOTE_PROVIDER_TEST_USER_PASS }}
  PROVIDER_TOKEN: ${{ secrets.REMOTE_PROVIDER_TEST_USER_TOKEN }}
  GITHUB_TOKEN: ${{ secrets.MESHERY_CI }}
run: make test-e2e-ci
```

A fork PR author can modify:

- Makefiles (`ui-build`, `server`, `test-e2e-ci`)
- JS/Go backend code executed at runtime
- Any script invoked in the workflow

This results in a full RCE primitive with the ability to **steal all secrets injected into the job**.

A working PoC demonstrating arbitrary code execution is here:

🔗 https://github.com/meshery/meshery/actions/runs/20005310119/job/57366926663?pr=16596#step:13:13

---

### ✅ What This PR Improves

This PR restricts the `ui-build` job so it **only runs for trusted (non-fork) PRs**, eliminating the RCE path and preventing secrets from being exposed to attacker-controlled code.

The applied fix:
Force Label ready-to-run on all jobs
${{ contains(github.event.pull_request.labels.*.name, 'ready-to-run') }}

---

### 📝 Additional Recommendation

We recommend auditing other workflows that:

- use `pull_request_target`
- run application servers or integration tests
- inject secrets via `env:`
- execute PR-sourced code

As these patterns commonly create CI supply-chain risks.

---

### 🧪 Proof of Concept

A working demonstration of attacker-controlled code executing inside this workflow:

https://github.com/meshery/meshery/actions/runs/20005310119/job/57366926663?pr=16596#step:13:13

