### PR TITLE
Docs: Reframe model generation terminology from filtering to grouping

### DIFF
--- a/docs/pages/project/contributing/contributing-models.md
+++ b/docs/pages/project/contributing/contributing-models.md
@@ -28,7 +28,7 @@ Models can describe traditional technologies (like Kubernetes workloads), or mor
 
 #### What Is the Model Schema?
 
-Each model includes a set of entities (in the form of definitions) that Meshery can manage. Models are defined and versioned using on the [Model Schema](https://github.com/meshery/schemas/blob/master/schemas/constructs/openapi/meshmodels.yml).
+Each model includes a set of entities (in the form of definitions) that Meshery can manage. Models are defined and versioned using the [Model Schema](https://github.com/meshery/schemas/blob/master/schemas/constructs/openapi/meshmodels.yml).
 
 The schema defines the structure of the model, including the entities it contains, their relationships, and the properties they have. The schema also defines the version of the model and the version of the schema itself.
 
@@ -219,28 +219,28 @@ In the CRD below, the `spec.group` field has the value `cloudquota.cnrm.cloud.go
 {% capture code_content %}apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
-annotations:
-cnrm.cloud.google.com/version: 1.140.0
-name: apiquotaadjustersettings.cloudquota.cnrm.cloud.google.com
+  annotations:
+    cnrm.cloud.google.com/version: 1.140.0
+  name: apiquotaadjustersettings.cloudquota.cnrm.cloud.google.com
 spec:
-group: cloudquota.cnrm.cloud.google.com # API group used for filtering
-names:
-kind: APIQuotaAdjusterSettings
-plural: apiquotaadjustersettings
-scope: Namespaced
-versions:
+  group: cloudquota.cnrm.cloud.google.com # API group used for filtering
+  names:
+    kind: APIQuotaAdjusterSettings
+    plural: apiquotaadjustersettings
+  scope: Namespaced
+  versions:
+    - name: v1beta1
+      schema:
+        openAPIV3Schema:
+          properties:
+            apiVersion:
+              type: string
+            kind:
+              type: string
 
-- name: v1beta1
-  schema:
-  openAPIV3Schema:
-  properties:
-  apiVersion:
-  type: string
-  kind:
-  type: string
+
   {% endcapture %}
   {% include code.html code=code_content %}
-
 **CSV Model Definition Example:**
 
 ```csv


### PR DESCRIPTION


Updates the "Model Generation" documentation to address feedback regarding the distinction between automatic component grouping and user-specified filtering.

After conducting a codebase audit of the import handlers (`server/handlers`) and generators (`meshkit`), I determined that the previous documentation describing "User-Specified Group Filtering" via the UI was inaccurate.

**Key Findings from Code Analysis:**
1. **Direct Imports (Helm, Git, K8s):** Do not support user-specified filtering. They automatically **group** components into Models based on the source name (e.g., Repo Name, Chart Name, or "Kubernetes").
2. **CSV Imports:** Do support a `group` column which **filters** CRDs by `spec.group` (verified in `meshkit/registry/model.go`).

**Changes in this PR:**
- Reframes the core concept as **'Component Grouping'** (Source-based) to align with the universal behavior of the system.
- Clarifies that explicit **'Group Filtering'** (selecting specific CRDs by API group) is an advanced capability specific to **CSV/Spreadsheet imports**.
- Removes incorrect claims that users can specify group filters via the UI/API for direct imports.
- Updates examples to verify correct model assignment for Helm, GitHub, and Kubernetes sources.

**Notes for Reviewers**

- This PR fixes #16636 

**[Signed commits](https://github.com/meshery/meshery/blob/master/CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [x] Yes, I signed my commits.