### PR TITLE
Fix mesheryctl registry link in registry concept page

### DIFF
--- a/docs/pages/concepts/logical/registry.md
+++ b/docs/pages/concepts/logical/registry.md
@@ -12,7 +12,7 @@ list: include
 
 # Meshery Registry: A Central Hub for Capabilities
 
-The Meshery Registry is a vital component within Meshery, serving as a centralized repository for managing a diverse range of cloud and cloud native resources. It stores and organizes crucial information such as models, categories, components, and relationships, enabling efficient interaction and utilization of these resources within the Meshery ecosystem. You can conveniently [access and manage registry data](#interacting-with-the-meshery-registry) through Meshery UI, and through Meshery CLI ([mesheryctl registry]({{site.baseurl}}/reference/mesheryctl/registry)).
+The Meshery Registry is a vital component within Meshery, serving as a centralized repository for managing a diverse range of cloud and cloud native resources. It stores and organizes crucial information such as models, categories, components, and relationships, enabling efficient interaction and utilization of these resources within the Meshery ecosystem. You can conveniently [access and manage registry data](#interacting-with-the-meshery-registry) through Meshery UI, and through Meshery CLI ([mesheryctl registry](/reference/mesheryctl/registry)).
 
 As the central repository for all capabilities known to Meshery, the registry contains various entities.
 


### PR DESCRIPTION
Point the mesheryctl registry hyperlink under Concepts → Logical → Registry to /reference/mesheryctl/registry.
Testing: Not run (docs-only change).