### PR TITLE
Remove no-duplicate-categories setting from config

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -1,6 +1,5 @@
 name-template: 'Meshery v$NEXT_PATCH_VERSION'
 tag-template: 'v$NEXT_PATCH_VERSION'
-no-duplicate-categories: true
 categories:
   - title: '🚀 Features'
     labels:


### PR DESCRIPTION
**Notes for Reviewers**

- This PR reverts #16604 

-  `no-duplicate-categories` is not a supported setting in Release Drafter. PRs are matched to all categories based on their labels, and there’s currently no built-in way to restrict a PR to appear in only the first matching category.

**[Signed commits](https://github.com/meshery/meshery/blob/master/CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [x] Yes, I signed my commits.

<!--
Thank you for contributing to Meshery! 

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. Sign your commits.
4. Include before and after screenshots/terminal output.

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.
-->
