### PR TITLE
[DOCS] Update mesheryctl documentations for `-p docker`

### DIFF
--- a/docs/_includes/mesheryctl/installation-bash.md
+++ b/docs/_includes/mesheryctl/installation-bash.md
@@ -49,3 +49,9 @@ You are ready to deploy Meshery `mesheryctl`. To do so, execute the following co
  <pre class="codeblock-pre"><div class="codeblock">
  <div class="clipboardjs">mesheryctl system start</div></div>
  </pre>
+
+If you are running Meshery on Docker, execute the following command.
+
+ <pre class="codeblock-pre"><div class="codeblock">
+ <div class="clipboardjs">mesheryctl system start -p docker</div></div>
+ </pre>

--- a/docs/_includes/mesheryctl/installation-brew.md
+++ b/docs/_includes/mesheryctl/installation-brew.md
@@ -23,6 +23,15 @@ You're ready to run Meshery. To do so, execute the following command.
 </div></div>
 </pre>
 
+If you are running Meshery on Docker, execute the following command.
+
+<pre class="codeblock-pre"><div class="codeblock">
+<div class="clipboardjs">
+ $ mesheryctl system start -p docker
+
+</div></div>
+</pre>
+
 Meshery server supports customizing authentication flow callback URL, which can be configured in the following way
 
 <pre class="codeblock-pre"><div class="codeblock">

--- a/docs/_includes/mesheryctl/installation-scoop.md
+++ b/docs/_includes/mesheryctl/installation-scoop.md
@@ -19,6 +19,12 @@ You're ready to run Meshery. To do so, execute the following command.
 <div class="clipboardjs">mesheryctl system start</div></div>
 </pre>
 
+If you are running Meshery on Docker, execute the following command.
+
+<pre class="codeblock-pre"><div class="codeblock">
+<div class="clipboardjs">mesheryctl system start -p docker</div></div>
+</pre>
+
 ### Upgrade `mesheryctl` with Scoop
 
 To upgrade `mesheryctl`, execute the following command.

--- a/docs/pages/installation/docker.md
+++ b/docs/pages/installation/docker.md
@@ -36,7 +36,7 @@ Start Meshery by executing:
 
  <script src="/assets/js/terminal.js" data-termynal-container="#termynal1"></script> -->
 
-{% capture code_content %}mesheryctl system start{% endcapture %}
+{% capture code_content %}mesheryctl system start -p docker{% endcapture %}
 {% include code.html code=code_content %}
 
 ## Advanced Configuration


### PR DESCRIPTION
**Notes for Reviewers**

This PR fixes DOCUMENTATION

The default platform for `mesheryctl system start` is `kubernetes`. This PR updates the installation documentation to explicitly include the `-p docker` flag for users deploying Meshery on Docker. This ensures that the correct platform is targeted during initialization and prevents errors for users without a Kubernetes context.

**Changes**

- Updated `docs/pages/installation/docker.md` to use `mesheryctl system start -p docker`.
- Updated installation guides (`brew`, `bash`, `scoop`) to include a specific instruction for Docker**Description**

**[Signed commits](https://github.com/meshery/meshery/blob/master/CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [x] Yes, I signed my commits.

<!--
Thank you for contributing to Meshery! 

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. Sign your commits.
4. Include before and after screenshots/terminal output.

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.
-->
