### PR TITLE
docs: add id attribute to error code table rows

### DIFF
--- a/docs/pages/reference/error-codes.md
+++ b/docs/pages/reference/error-codes.md
@@ -188,7 +188,7 @@ text-orientation: mixed;" %}
         {% assign severity = "background-color: transparent; color: black; writing-mode: vertical-rl;
 text-orientation: mixed;" %}
       {% endif %}
-      <tr class="tbl-body-row hover-effect" onclick="toggle_visibility('{{ component[1].component_name }}-{{ err_code[1]["name"] }}-more-info');">
+      <tr id="{{err_code[1]['name']}}-{{err_code[1]['code']}}" class="tbl-body-row hover-effect" onclick="toggle_visibility('{{ component[1].component_name }}-{{ err_code[1]['name'] }}-more-info');">
         <td style="{{ severity }}">{{ err_code[1]["severity"] }}</td>
         <td id="{{ heading | slugify }}-{{err_code[1]["code"] }}" class="error-name-code">
           <code>{{ err_code[1]["name"] | xml_escape }}-{{ err_code[1]["code"] }}</code>


### PR DESCRIPTION
**Notes for Reviewers**

- This PR fixes #16687 

**[Signed commits](https://github.com/meshery/meshery/blob/master/CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [ x] Yes, I signed my commits.

### Description
I've updated the Error Codes Reference table to include a unique `id` for each row (format: `Name-Code`). This ensures that specific error codes can be linked directly as requested.

### Changes
- Modified `docs/pages/reference/error-codes.md` to include `id="{{ err_code[1]['name'] }}-{{ err_code[1]['code'] }}"` in the `<tr>` tag.

