### PR TITLE
Add note for default mesheryctl platform in docs

### DIFF
--- a/docs/pages/installation/mesheryctl.md
+++ b/docs/pages/installation/mesheryctl.md
@@ -19,7 +19,7 @@ Meshery's command line client is `mesheryctl` and is the recommended tool for co
 
 `mesheryctl` can be installed via [bash]({{site.baseurl}}/installation/linux-mac/bash), [Homebrew]({{site.baseurl}}/installation/linux-mac/brew), [Scoop]({{site.baseurl}}/installation/windows/scoop) or [directly downloaded](https://github.com/meshery/meshery/releases/latest).
 
-{% include alert.html type="info" title="NOTE" content="Mesheryctl is configured for Kubernetes by default. To specify a different supported plateform, use the -p flag." %}
+{% include alert.html type="info" title="NOTE" content="Mesheryctl is configured for Kubernetes by default. To specify a different supported platform, use the `-p` flag." %}
 
 # Install Meshery CLI with Brew
 

--- a/docs/pages/installation/windows.md
+++ b/docs/pages/installation/windows.md
@@ -25,7 +25,7 @@ Follow the installation steps to install the mesheryctl CLI. Then, execute:
 <div class="codeblock"><div class="clipboardjs">./mesheryctl system start</div></div>
 </pre>
 
-If you are running Meshery on Docker, execute the following command.
+If you are installing Meshery on Docker, execute the following command.
 <pre class="codeblock-pre">
 <div class="codeblock"><div class="clipboardjs">./mesheryctl system start -p docker</div></div>
 </pre>


### PR DESCRIPTION
**Notes for Reviewers**

This PR fixes the `mesheryctl` installation documentation to clarify that the default platform is set to **Kubernetes**.

Newcomers installing `mesheryctl` often assume it will work out-of-the-box with Docker. However, since the default context is initialized with `platform: kubernetes`, running `mesheryctl system start` without flags fails if a Kubernetes cluster is not configured. This update helps prevent confusion by explicitly guiding Docker users to use the `-p docker` flag.

Changes:
- Added a NOTE that `Mesheryctl is configured for Kubernetes by default. To specify a different supported plateform, use the -p flag` in https://docs.meshery.io/installation/mesheryctl.
- Added `./mesheryctl system start -p docker` in https://docs.meshery.io/installation/windows#Install-mesheryctl-as-a-direct-download.

**[Signed commits](https://github.com/meshery/meshery/blob/master/CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [x] Yes, I signed my commits.

<!--
Thank you for contributing to Meshery! 

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. Sign your commits.
4. Include before and after screenshots/terminal output.

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.
-->
