### PR TITLE
[UI] Close sidebar on outside click / route change (mobile)

### DIFF
--- a/ui/components/Navigator.js
+++ b/ui/components/Navigator.js
@@ -342,7 +342,7 @@ const Navigator_ = () => {
     router.events.on('routeChangeStart', handleRouteChange);
 
     return () => {
-      document.removeEventListener('click', handleClickOutside);
+      document.removeEventListener('mousedown', handleClickOutside);
       router.events.off('routeChangeStart', handleRouteChange);
     };
   }, [isMobile, isDrawerCollapsed, router.events, dispatch]);

--- a/ui/components/Navigator.js
+++ b/ui/components/Navigator.js
@@ -338,7 +338,7 @@ const Navigator_ = () => {
       dispatch(toggleDrawer({ isDrawerCollapsed: true }));
     };
 
-    document.addEventListener('click', handleClickOutside);
+    document.addEventListener('mousedown', handleClickOutside);
     router.events.on('routeChangeStart', handleRouteChange);
 
     return () => {
@@ -1133,16 +1133,14 @@ const Navigator_ = () => {
 
   return (
     <NoSsr>
-      <SidebarDrawer isCollapsed={isDrawerCollapsed} variant="permanent">
-        <div ref={sidebarNodeRef}>
-          {Title}
-          {Menu}
-          <FixedSidebarFooter>
-            {Chevron}
-            {HelpIcons}
-            {Version}
-          </FixedSidebarFooter>
-        </div>
+      <SidebarDrawer ref={sidebarNodeRef} isCollapsed={isDrawerCollapsed} variant="permanent">
+        {Title}
+        {Menu}
+        <FixedSidebarFooter>
+          {Chevron}
+          {HelpIcons}
+          {Version}
+        </FixedSidebarFooter>
       </SidebarDrawer>
     </NoSsr>
   );


### PR DESCRIPTION
…only (mobile)

### **What this PR does**

This PR improves the sidebar behavior on **small screen devices (mobile max-width:599px)** by automatically closing the sidebar when:

* A user clicks outside the sidebar area, or
* The application route/path changes (navigation occurs).

The existing sidebar toggle behavior on **larger screens (desktop)** remains unchanged and continues to rely solely on the toggle arrow button.

### **Why this change is needed**

On small screens, keeping the sidebar open after navigation or outside interaction reduces usable screen space and negatively impacts user experience. This change aligns the sidebar behavior with common mobile UX patterns while preserving current desktop behavior.

---

### **Notes for Reviewers**

* The auto-close logic is applied **only on small screen sizes**.
* Route change detection uses Next.js router events.
* Outside-click handling uses a ref-based approach with proper event cleanup.
* Desktop behavior is intentionally untouched.
* Files changed: Navigator.js
* How to test: “1) Resize to ≤599px; 2) open sidebar; 3) click outside → expect close; 4) navigate → expect close; 5) verify desktop unchanged.”

---

* This PR fixes #15283"
Note that I added additional functions to this issue and indicate what I will include in the Slack UI.

---

### **Checklist**

**[[Signed commits](https://github.com/meshery/meshery/blob/master/CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)](https://github.com/meshery/meshery/blob/master/CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**

* [x] Yes, I signed my commits.

---

### **Screenshots / Demo**

**Before (Mobile):**
* Sidebar remains open after navigation or outside click.
<img width="422" height="579" alt="Screenshot 2025-12-18 at 14 37 52" src="https://github.com/user-attachments/assets/e54f274d-d364-4668-a01b-55089021ea6a" />



**After (Mobile):**
* Sidebar automatically closes on outside click or route change.
<img width="425" height="579" alt="Screenshot 2025-12-18 at 14 38 28" src="https://github.com/user-attachments/assets/2ea55e08-f77a-45fe-b626-91f4d85f425a" />

---