### PR TITLE
fix: update archive formats for Windows builds in goreleaser configuration

### DIFF
--- a/.github/.goreleaser.yml
+++ b/.github/.goreleaser.yml
@@ -53,10 +53,10 @@ archives:
     # windows: Windows
     # 386: i386
     # amd64: x86_64
-    format: tar.gz
+  - formats: [ 'tar.gz' ]
     format_overrides:
       - goos: windows
-        format: zip
+        formats: [ 'zip' ]
   # files:
   #   - setup_scripts/*
 


### PR DESCRIPTION
Signed-off-by: Lee Calcote <lee.calcote@layer5.io>

This helps improve the goreleaser configuration in help with #16700.