### PR TITLE
docs: clarify Docker Compose v2 usage on Debian 13

### DIFF
--- a/docs/pages/installation/docker.md
+++ b/docs/pages/installation/docker.md
@@ -39,6 +39,19 @@ Start Meshery by executing:
 {% capture code_content %}mesheryctl system start -p docker{% endcapture %}
 {% include code.html code=code_content %}
 
+## Docker Compose v2 on Debian 13
+
+On Debian 13 and newer Linux distributions, Docker Compose is installed as a
+Docker plugin and is available via the `docker compose` command instead of the
+legacy `docker-compose` binary.
+
+You can verify Docker Compose v2 installation using:
+
+```bash
+docker compose version
+```
+
+
 ## Advanced Configuration
 
 ### Customizing Kubernetes Configuration Location


### PR DESCRIPTION
## Notes for Reviewers

This PR adds documentation clarifying Docker Compose v2 usage on Debian 13.
Docker Compose is installed as a Docker plugin (`docker compose`), which can
cause Meshery to incorrectly attempt installation of the legacy
`docker-compose` binary.

No functional changes are included.

Fixes #16522

## Signed commits
- [x] Yes, I signed my commits.
