### PR TITLE
fix: resolve duplicate error code 1156 in mesheryctl

### DIFF
--- a/mesheryctl/helpers/component_info.json
+++ b/mesheryctl/helpers/component_info.json
@@ -1,5 +1,5 @@
 {
   "name": "mesheryctl",
   "type": "client",
-  "next_error_code": 1158
+  "next_error_code": 1159
 }

--- a/mesheryctl/pkg/utils/format/error.go
+++ b/mesheryctl/pkg/utils/format/error.go
@@ -4,7 +4,7 @@ import "github.com/meshery/meshkit/errors"
 
 var (
 	ErrOutputToJsonCode = "mesheryctl-1147"
-	ErrOutputToYamlCode = "mesheryctl-1156"
+	ErrOutputToYamlCode = "mesheryctl-1158"
 )
 
 func ErrOutputToJson() error {


### PR DESCRIPTION
#### Description
This PR resolves a collision on error code `1156` which is currently causing the `MeshKit Error Codes Utility` check to fail in CI.
Both `ErrMesheryServerNotRunningCode` and `ErrOutputToYamlCode` were claiming code `1156`.

#### Changes
- Updated `ErrOutputToYamlCode` in `mesheryctl/pkg/utils/format/error.go` to **1158** to ensure uniqueness.
- Updated `next_error_code` in `mesheryctl/helpers/component_info.json` to **1159** to maintain the correct counter.

#### Verification
- Ran `make error` locally in `mesheryctl/` ,No duplicate errors found.

#### Signed-off-by
- [x] I have signed off on my commits (DCO).