### PR TITLE
chore: upgrade to Meshkit v0.8.56

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -47,7 +47,7 @@ require (
 	github.com/lib/pq v1.10.9
 	github.com/manifoldco/promptui v0.9.0
 	github.com/meshery/meshery-operator v0.8.11
-	github.com/meshery/meshkit v0.8.55
+	github.com/meshery/meshkit v0.8.56
 	github.com/meshery/meshsync v0.8.26
 	github.com/meshery/schemas v0.8.94
 	github.com/nsf/termbox-go v1.1.1

--- a/go.sum
+++ b/go.sum
@@ -1481,8 +1481,8 @@ github.com/maxatome/go-testdeep v1.14.0 h1:rRlLv1+kI8eOI3OaBXZwb3O7xY3exRzdW5QyX
 github.com/maxatome/go-testdeep v1.14.0/go.mod h1:lPZc/HAcJMP92l7yI6TRz1aZN5URwUBUAfUNvrclaNM=
 github.com/meshery/meshery-operator v0.8.11 h1:eDo2Sw0jjVrXsvvhF8LenADM58pK+7Z68ROPVIejTPc=
 github.com/meshery/meshery-operator v0.8.11/go.mod h1:hQEtFKKa5Fr/Mskk6bV5ip3bQ0+3F0u1voYS3XisBp4=
-github.com/meshery/meshkit v0.8.55 h1:4eUtTZi+MWouEk8Vr2kgS4pe/TNJzoS7iYewodWXX9A=
-github.com/meshery/meshkit v0.8.55/go.mod h1:p51cnhlf9UsNxhjNvB2+13ZtiRx4Br6j0cXXhU98Qmc=
+github.com/meshery/meshkit v0.8.56 h1:dDti5gBLaRH+/IDFAS3G2KtlzHOlhRBan2/JEwYOGSg=
+github.com/meshery/meshkit v0.8.56/go.mod h1:p51cnhlf9UsNxhjNvB2+13ZtiRx4Br6j0cXXhU98Qmc=
 github.com/meshery/meshsync v0.8.26 h1:GM5jzECZMCQGx3BMNo9cahcAfD/TXYue/DPWFGpjnho=
 github.com/meshery/meshsync v0.8.26/go.mod h1:RNQnmmg/hq/TaGbu6hIVAPCnjB4dIMm9Nmi729OgmFM=
 github.com/meshery/schemas v0.8.94 h1:Xmjc0+MKUbvFPO/LmS4/0ncVqPpHqID3tuThn4QltQ0=


### PR DESCRIPTION
Signed-off-by: Rian Cteulp <rian.cteulp@gmail.com>
