### PR TITLE
docs: fix broken relationship design links

### DIFF
--- a/docs/_includes/relationships.html
+++ b/docs/_includes/relationships.html
@@ -7,12 +7,12 @@
     <summary>Example Visual Representations</summary>
     <details close><summary>Kind: Hierarchical</summary>
         <figure>
-            <figcaption>subType: Parent | Namespace (Parent) and ConfigMap (child), Role (Child)<a target="_blank" href="https://playground.meshery.io/extension/meshmap?mode=design&design=6370ffcd-13a6-4a65-b426-30f1e63dc381"> (open in playground)</a></figcaption>
+            <figcaption>subType: Parent | Namespace (Parent) and ConfigMap (child), Role (Child)<a target="_blank" href="https://playground.meshery.io/extension/meshmap?mode=design&design=d08affe9-04a4-4965-9a8e-97cec1fc3d4e"> (open in playground)</a></figcaption>
         </figure>
         <img alt="Hierarchical - Parent: Namespace to other components" src="{{ site.baseurl }}/assets/img/meshmodel/relationships/hierarchical_parent_relationship.svg"/>
         <br>
         <figure>
-            <figcaption>subType: Inventory | Namespace and ConfigMap<a target="_blank" href="https://playground.meshery.io/extension/meshmap?design=21d40e36-8ab7-4f9f-9fed-f6a818510446"> (open in playground)</a></figcaption>
+            <figcaption>subType: Inventory | Namespace and ConfigMap<a target="_blank" href="https://playground.meshery.io/extension/meshmap?mode=design&design=863e5181-1ad4-4b10-8f6c-98d748e3eafa"> (open in playground)</a></figcaption>
         </figure>
         <img alt="Hierarchical - Parent: Namespace to other components" src="{{ site.baseurl }}/assets/img/meshmodel/relationships/hierarchical_inventory_relationship.svg"/>
     </details>
@@ -53,7 +53,7 @@
         <img alt="Edge - Network" src="{{ site.baseurl }}/assets/img/meshmodel/relationships/edge_network_service_to_endpoints_relationship.svg"/>
         <br>
         <figure>
-            <figcaption>Type: `Non-Binding`, subType: `Network`: Service to Deployment<a target="_blank" href="https://playground.meshery.io/extension/meshmap?mode=design&design=33742281-428d-4340-b42e-6a0fd4ba1d0a"> (open in playground)</a></figcaption>
+            <figcaption>Type: `Non-Binding`, subType: `Network`: Service to Deployment<a target="_blank" href="https://playground.meshery.io/extension/meshmap?mode=design&design=df5ec300-76d7-49a4-b049-6d507e685e95"> (open in playground)</a></figcaption>
         </figure>
         <img alt="Edge - Network" src="{{ site.baseurl }}/assets/img/meshmodel/relationships/network_edge_relationship_service_deployment.svg"/>
         <br>
@@ -88,7 +88,7 @@
         <img alt="Edge - Permission" src="{{ site.baseurl }}/assets/img/meshmodel/relationships/permission_edge_relationship_clusterrole_deployment.png"/> -->
         <br>
         <figure>
-            <figcaption><code>type:non-binding</code>, subType: `Network`: Network Policy (Pod to Pod) <a target="_blank" href="https://playground.meshery.io/extension/meshmap?mode=design&design=58fda714-eaa4-490f-b228-b8bcfe3a1e47s"> (open in playground)</a></figcaption>
+            <figcaption>Type: `Non-Binding`, subType: `Network`: Network Policy (Pod to Pod) <a target="_blank" href="https://playground.meshery.io/extension/meshmap?mode=design&design=7fafed12-f261-4dd3-b7e4-85cac11d9d47"> (open in playground)</a></figcaption>
         </figure>
         <img alt="Edge - Network Policy" src="{{ site.baseurl }}/assets/img/meshmodel/relationships/edge_firewall_relationship_pod_to_pod.svg">
         </details>

--- a/docs/_includes/relationships.html
+++ b/docs/_includes/relationships.html
@@ -1,63 +1,158 @@
 <style>
-    figcaption {
-        margin: 1rem auto;
-    }
+  figcaption {
+    margin: 1rem auto;
+  }
 </style>
 <details open>
-    <summary>Example Visual Representations</summary>
-    <details close><summary>Kind: Hierarchical</summary>
-        <figure>
-            <figcaption>subType: Parent | Namespace (Parent) and ConfigMap (child), Role (Child)<a target="_blank" href="https://playground.meshery.io/extension/meshmap?mode=design&design=d08affe9-04a4-4965-9a8e-97cec1fc3d4e"> (open in playground)</a></figcaption>
-        </figure>
-        <img alt="Hierarchical - Parent: Namespace to other components" src="{{ site.baseurl }}/assets/img/meshmodel/relationships/hierarchical_parent_relationship.svg"/>
-        <br>
-        <figure>
-            <figcaption>subType: Inventory | Namespace and ConfigMap<a target="_blank" href="https://playground.meshery.io/extension/meshmap?mode=design&design=863e5181-1ad4-4b10-8f6c-98d748e3eafa"> (open in playground)</a></figcaption>
-        </figure>
-        <img alt="Hierarchical - Parent: Namespace to other components" src="{{ site.baseurl }}/assets/img/meshmodel/relationships/hierarchical_inventory_relationship.svg"/>
-    </details>
-    <!-- <details close><summary>Kind: Sibling</summary>
+  <summary>Example Visual Representations</summary>
+  <details close>
+    <summary>Kind: Hierarchical</summary>
+    <figure>
+      <figcaption>
+        subType: Parent | Namespace (Parent) and ConfigMap (child), Role
+        (Child)<a
+          target="_blank"
+          href="https://playground.meshery.io/extension/meshmap?mode=design&amp;design=d08affe9-04a4-4965-9a8e-97cec1fc3d4e"
+        >
+          (open in playground)</a
+        >
+      </figcaption>
+    </figure>
+    <img
+      alt="Hierarchical - Parent: Namespace to other components"
+      src="{{ site.baseurl }}/assets/img/meshmodel/relationships/hierarchical_parent_relationship.svg"
+    />
+    <br />
+    <figure>
+      <figcaption>
+        subType: Inventory | Namespace and ConfigMap<a
+          target="_blank"
+          href="https://playground.meshery.io/extension/meshmap?mode=design&amp;design=863e5181-1ad4-4b10-8f6c-98d748e3eafa"
+        >
+          (open in playground)</a
+        >
+      </figcaption>
+    </figure>
+    <img
+      alt="Hierarchical - Parent: Namespace to other components"
+      src="{{ site.baseurl }}/assets/img/meshmodel/relationships/hierarchical_inventory_relationship.svg"
+    />
+  </details>
+  <!-- <details close><summary>Kind: Sibling</summary>
         <figure>
             <figcaption>Type: Match, subType: Matching Label Selectors</figcaption>
         </figure>
         <img alt=Sibling src="{{ site.baseurl }}/assets/img/meshmodel/relationships/sibling_relationship.png"/>
     </details> -->
-    <details close><summary>Kind: Edge</summary>
-        <figure>
-            <figcaption>Type: `Non-Binding`, subType: `Permission`: Cluster Role with Cluster Role Binding to Service Account<a target="_blank" href="https://playground.meshery.io/extension/meshmap?mode=design&design=7dd39d30-7b14-4f9f-a66c-06ba3e5000fa"> (open in playground)</a></figcaption>
-        </figure>
-        <img alt=Binding src="{{ site.baseurl }}/assets/img/meshmodel/relationships/edge_permission_relationship_cluster_role_service_account.svg"/>
-        <figure>
-            <figcaption>Type: `Binding`, subType: `Mount`: Pod to Persistent volume via Persistent volume claim<a target="_blank" href="https://playground.meshery.io/extension/meshmap?mode=design&design=43d5fdfe-25f8-4c2c-be9d-30861bbc2a08"> (open in playground)</a> </figcaption>
-        </figure>
-        <img alt="Edge - Mount" src="{{ site.baseurl }}/assets/img/meshmodel/relationships/edge_mount_relationship_pod_persistent_volume.svg"/>
-        <br>
-        <figure>
-            <figcaption>Type: `Non-Binding`, subType: `Network`: Ingress to Service<a target="_blank" href="https://playground.meshery.io/extension/meshmap?mode=design&design=1f79b0c6-2efe-4ee9-b08c-e1bd07a3926b"> (open in playground)</a></figcaption>
-        </figure>
-        <img alt="Edge - Network" src="{{ site.baseurl }}/assets/img/meshmodel/relationships/edge_network_ingress_to_service_relationship.svg"/>
-        <br>
-        <figure>
-            <figcaption>Type: `Non-Binding`, subType: `Network`: Service to Pod<a target="_blank" href="https://playground.meshery.io/extension/meshmap?mode=design&design=90a9b4a0-a296-44b5-b1c5-7b1cb4827a77"> (open in playground)</a></figcaption>
-        </figure>
-        <img alt="Edge - Network: Ingress to Service" src="{{ site.baseurl }}/assets/img/meshmodel/relationships/edge_network_service_to_pod_relationship.svg"/>
-        <br>
-        <figure>
-            <figcaption>Type: `Non-Binding`, subType: `Network`: Service to Service<a target="_blank" href="https://playground.meshery.io/extension/meshmap?mode=design&design=4e368e07-5039-400e-b637-96b0241af799"> (open in playground)</a></figcaption>
-        </figure>
-        <img alt="Edge - Network" src="{{ site.baseurl }}/assets/img/meshmodel/relationships/edge_network_service_to_service_relationship.svg"/>
-        <br>
-        <figure>
-            <figcaption>Type: `Non-Binding`, subType: `Network`: Service to Endpoint<a target="_blank" href="https://playground.meshery.io/extension/meshmap?mode=design&design=ab35416d-7cf7-4540-8b2e-7271ffeadde2"> (open in playground)</a></figcaption>
-        </figure>
-        <img alt="Edge - Network" src="{{ site.baseurl }}/assets/img/meshmodel/relationships/edge_network_service_to_endpoints_relationship.svg"/>
-        <br>
-        <figure>
-            <figcaption>Type: `Non-Binding`, subType: `Network`: Service to Deployment<a target="_blank" href="https://playground.meshery.io/extension/meshmap?mode=design&design=df5ec300-76d7-49a4-b049-6d507e685e95"> (open in playground)</a></figcaption>
-        </figure>
-        <img alt="Edge - Network" src="{{ site.baseurl }}/assets/img/meshmodel/relationships/network_edge_relationship_service_deployment.svg"/>
-        <br>
-        <!-- <figure>
+  <details close>
+    <summary>Kind: Edge</summary>
+    <figure>
+      <figcaption>
+        Type: `Non-Binding`, subType: `Permission`: Cluster Role with Cluster
+        Role Binding to Service Account<a
+          target="_blank"
+          href="https://playground.meshery.io/extension/meshmap?mode=design&design=7dd39d30-7b14-4f9f-a66c-06ba3e5000fa"
+        >
+          (open in playground)</a
+        >
+      </figcaption>
+    </figure>
+    <img
+      alt="Binding"
+      src="{{ site.baseurl }}/assets/img/meshmodel/relationships/edge_permission_relationship_cluster_role_service_account.svg"
+    />
+    <figure>
+      <figcaption>
+        Type: `Binding`, subType: `Mount`: Pod to Persistent volume via
+        Persistent volume claim<a
+          target="_blank"
+          href="https://playground.meshery.io/extension/meshmap?mode=design&design=43d5fdfe-25f8-4c2c-be9d-30861bbc2a08"
+        >
+          (open in playground)</a
+        >
+      </figcaption>
+    </figure>
+    <img
+      alt="Edge - Mount"
+      src="{{ site.baseurl }}/assets/img/meshmodel/relationships/edge_mount_relationship_pod_persistent_volume.svg"
+    />
+    <br />
+    <figure>
+      <figcaption>
+        Type: `Non-Binding`, subType: `Network`: Ingress to Service<a
+          target="_blank"
+          href="https://playground.meshery.io/extension/meshmap?mode=design&design=1f79b0c6-2efe-4ee9-b08c-e1bd07a3926b"
+        >
+          (open in playground)</a
+        >
+      </figcaption>
+    </figure>
+    <img
+      alt="Edge - Network"
+      src="{{ site.baseurl }}/assets/img/meshmodel/relationships/edge_network_ingress_to_service_relationship.svg"
+    />
+    <br />
+    <figure>
+      <figcaption>
+        Type: `Non-Binding`, subType: `Network`: Service to Pod<a
+          target="_blank"
+          href="https://playground.meshery.io/extension/meshmap?mode=design&design=90a9b4a0-a296-44b5-b1c5-7b1cb4827a77"
+        >
+          (open in playground)</a
+        >
+      </figcaption>
+    </figure>
+    <img
+      alt="Edge - Network: Ingress to Service"
+      src="{{ site.baseurl }}/assets/img/meshmodel/relationships/edge_network_service_to_pod_relationship.svg"
+    />
+    <br />
+    <figure>
+      <figcaption>
+        Type: `Non-Binding`, subType: `Network`: Service to Service<a
+          target="_blank"
+          href="https://playground.meshery.io/extension/meshmap?mode=design&design=4e368e07-5039-400e-b637-96b0241af799"
+        >
+          (open in playground)</a
+        >
+      </figcaption>
+    </figure>
+    <img
+      alt="Edge - Network"
+      src="{{ site.baseurl }}/assets/img/meshmodel/relationships/edge_network_service_to_service_relationship.svg"
+    />
+    <br />
+    <figure>
+      <figcaption>
+        Type: `Non-Binding`, subType: `Network`: Service to Endpoint<a
+          target="_blank"
+          href="https://playground.meshery.io/extension/meshmap?mode=design&design=ab35416d-7cf7-4540-8b2e-7271ffeadde2"
+        >
+          (open in playground)</a
+        >
+      </figcaption>
+    </figure>
+    <img
+      alt="Edge - Network"
+      src="{{ site.baseurl }}/assets/img/meshmodel/relationships/edge_network_service_to_endpoints_relationship.svg"
+    />
+    <br />
+    <figure>
+      <figcaption>
+        Type: `Non-Binding`, subType: `Network`: Service to Deployment<a
+          target="_blank"
+          href="https://playground.meshery.io/extension/meshmap?mode=design&amp;design=df5ec300-76d7-49a4-b049-6d507e685e95"
+        >
+          (open in playground)</a
+        >
+      </figcaption>
+    </figure>
+    <img
+      alt="Edge - Network"
+      src="{{ site.baseurl }}/assets/img/meshmodel/relationships/network_edge_relationship_service_deployment.svg"
+    />
+    <br />
+    <!-- <figure>
             <figcaption>Type: `Binding`, subType: `Permission`</figcaption>
         </figure>
         <img alt="Edge - Permission" src="{{ site.baseurl }}/assets/img/meshmodel/relationships/permission_edge_relationship_role_service.png"/>
@@ -86,10 +181,21 @@
             <figcaption>type: `Binding`, subType: `Permission`: Cluster Role to Deployment</figcaption>
         </figure>
         <img alt="Edge - Permission" src="{{ site.baseurl }}/assets/img/meshmodel/relationships/permission_edge_relationship_clusterrole_deployment.png"/> -->
-        <br>
-        <figure>
-            <figcaption>Type: `Non-Binding`, subType: `Network`: Network Policy (Pod to Pod) <a target="_blank" href="https://playground.meshery.io/extension/meshmap?mode=design&design=7fafed12-f261-4dd3-b7e4-85cac11d9d47"> (open in playground)</a></figcaption>
-        </figure>
-        <img alt="Edge - Network Policy" src="{{ site.baseurl }}/assets/img/meshmodel/relationships/edge_firewall_relationship_pod_to_pod.svg">
-        </details>
-    </details>
+    <br />
+    <figure>
+      <figcaption>
+        Type: `Non-Binding`, subType: `Network`: Network Policy (Pod to Pod)
+        <a
+          target="_blank"
+          href="https://playground.meshery.io/extension/meshmap?mode=design&amp;design=7fafed12-f261-4dd3-b7e4-85cac11d9d47"
+        >
+          (open in playground)</a
+        >
+      </figcaption>
+    </figure>
+    <img
+      alt="Edge - Network Policy"
+      src="{{ site.baseurl }}/assets/img/meshmodel/relationships/edge_firewall_relationship_pod_to_pod.svg"
+    />
+  </details>
+</details>

--- a/docs/pages/concepts/logical/relationships.md
+++ b/docs/pages/concepts/logical/relationships.md
@@ -107,7 +107,7 @@ This Relationship type configures the networking between one or more components.
            <figure><figcaption>4. Edge - Network: Service to Endpoint<a target="_blank" href="https://playground.meshery.io/extension/meshmap?mode=design&design=ab35416d-7cf7-4540-8b2e-7271ffeadde2"> (open in playground)</a></figcaption>
            <img alt="Edge - Network" src="{{ site.baseurl }}/assets/img/meshmodel/relationships/edge_network_service_to_endpoints_relationship.svg"/>
            </figure>
-           <figure><figcaption>5. Edge - Network: Service to Deployment<a target="_blank" href="https://playground.meshery.io/extension/meshmap?mode=design&design=df5ec300-76d7-49a4-b049-6d507e685e95"> (open in playground)</a></figcaption>
+           <figure><figcaption>5. Edge - Network: Service to Deployment<a target="_blank" href="https://playground.meshery.io/extension/meshmap?mode=design&amp;design=df5ec300-76d7-49a4-b049-6d507e685e95"> (open in playground)</a></figcaption>
            <img alt="Edge - Network" src="{{ site.baseurl }}/assets/img/meshmodel/relationships/network_edge_relationship_service_deployment.svg"/>
            </figure>
    </details>
@@ -149,7 +149,7 @@ Kubernetes Network Policy for controlling ingress and egress traffic from Pod-to
 
 <details close><summary>Visual Representation of Edge-Firewall Relationship</summary>
            <br>
-           <figure><figcaption>Edge - Firewall: Pod to Pod<a target="_blank" href="https://playground.meshery.io/extension/meshmap?mode=design&design=7fafed12-f261-4dd3-b7e4-85cac11d9d47"> (open in playground)</a></figcaption>
+           <figure><figcaption>Edge - Firewall: Pod to Pod<a target="_blank" href="https://playground.meshery.io/extension/meshmap?mode=design&amp;design=7fafed12-f261-4dd3-b7e4-85cac11d9d47"> (open in playground)</a></figcaption>
            <img alt="Edge - Firewall" src="{{ site.baseurl }}/assets/img/meshmodel/relationships/edge_firewall_relationship_pod_to_pod.svg">
            </figure>
    </details>

--- a/docs/pages/concepts/logical/relationships.md
+++ b/docs/pages/concepts/logical/relationships.md
@@ -107,7 +107,7 @@ This Relationship type configures the networking between one or more components.
            <figure><figcaption>4. Edge - Network: Service to Endpoint<a target="_blank" href="https://playground.meshery.io/extension/meshmap?mode=design&design=ab35416d-7cf7-4540-8b2e-7271ffeadde2"> (open in playground)</a></figcaption>
            <img alt="Edge - Network" src="{{ site.baseurl }}/assets/img/meshmodel/relationships/edge_network_service_to_endpoints_relationship.svg"/>
            </figure>
-           <figure><figcaption>5. Edge - Network: Service to Deployment<a target="_blank" href="https://playground.meshery.io/extension/meshmap?mode=design&design=33742281-428d-4340-b42e-6a0fd4ba1d0a"> (open in playground)</a></figcaption>
+           <figure><figcaption>5. Edge - Network: Service to Deployment<a target="_blank" href="https://playground.meshery.io/extension/meshmap?mode=design&design=df5ec300-76d7-49a4-b049-6d507e685e95"> (open in playground)</a></figcaption>
            <img alt="Edge - Network" src="{{ site.baseurl }}/assets/img/meshmodel/relationships/network_edge_relationship_service_deployment.svg"/>
            </figure>
    </details>
@@ -149,7 +149,7 @@ Kubernetes Network Policy for controlling ingress and egress traffic from Pod-to
 
 <details close><summary>Visual Representation of Edge-Firewall Relationship</summary>
            <br>
-           <figure><figcaption>Edge - Firewall: Pod to Pod<a target="_blank" href="https://playground.meshery.io/extension/meshmap?mode=design&design=58fda714-eaa4-490f-b228-b8bcfe3a1e47s"> (open in playground)</a></figcaption>
+           <figure><figcaption>Edge - Firewall: Pod to Pod<a target="_blank" href="https://playground.meshery.io/extension/meshmap?mode=design&design=7fafed12-f261-4dd3-b7e4-85cac11d9d47"> (open in playground)</a></figcaption>
            <img alt="Edge - Firewall" src="{{ site.baseurl }}/assets/img/meshmodel/relationships/edge_firewall_relationship_pod_to_pod.svg">
            </figure>
    </details>


### PR DESCRIPTION
**Notes for Reviewers**

Currently some links in the documentation of *Meshery Relationships* are corrupted or contain wrong designs. This PR replaces them with the correct existing design links.

- This PR fixes #16745 

**[Signed commits](https://github.com/meshery/meshery/blob/master/CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [x] Yes, I signed my commits.


