### PR TITLE
docs: add real-world examples for mesheryctl connection command

### DIFF
--- a/docs/pages/reference/mesheryctl/mesheryctl-connection.md
+++ b/docs/pages/reference/mesheryctl/mesheryctl-connection.md
@@ -30,11 +30,16 @@ mesheryctl connection [flags]
 ### Count all available connections
 
 Use this command to display the total number of connections configured in Meshery.
-This is useful for quick verification or scripting.
-
 <pre class='codeblock-pre'>
 <div class='codeblock'>
 mesheryctl connection --count
+</div>
+</pre>
+
+Example output:
+<pre class='codeblock-pre'>
+<div class='codeblock'>
+2
 </div>
 </pre>
 


### PR DESCRIPTION
This PR adds real-world usage examples for the mesheryctl connection command,
including count, list, and delete workflows with sample output.

Closes #16689
