### PR TITLE
[mesheryctl] Fix adapter unit tests with missing sync mock

### DIFF
--- a/mesheryctl/internal/cli/root/adapter/adapter.go
+++ b/mesheryctl/internal/cli/root/adapter/adapter.go
@@ -32,9 +32,7 @@ import (
 	"github.com/spf13/viper"
 )
 
-var (
-	availableSubcommands []*cobra.Command
-)
+var availableSubcommands []*cobra.Command
 
 // AdapterCmd represents the Performance Management CLI command
 var (
@@ -49,7 +47,6 @@ var (
 		Long: `Provisioning, configuration, and on-going operational management of cloud and cloud native infrastructure.
 	Find more information at: https://docs.meshery.io/reference/mesheryctl#command-reference`,
 		PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
-
 			// if `mesh` command is ran without any subcommands, show Help and exit
 			if cmd.HasSubCommands() {
 				return cmd.Help()
@@ -251,7 +248,7 @@ func waitForDeployResponse(mctlCfg *config.MesheryCtlConfig, query string) (stri
 	timer := time.NewTimer(time.Duration(1200) * time.Second)
 	eventChan := make(chan string)
 
-	//Run a goroutine to wait for the response
+	// Run a goroutine to wait for the response
 	go func() {
 		for i := range event {
 			if strings.Contains(i.Data.Details, query) {
@@ -299,7 +296,7 @@ func waitForValidateResponse(mctlCfg *config.MesheryCtlConfig, query string) (st
 	timer := time.NewTimer(time.Duration(1200) * time.Second)
 	eventChan := make(chan string)
 
-	//Run a goroutine to wait for the response
+	// Run a goroutine to wait for the response
 	go func() {
 		for i := range event {
 			if strings.Contains(i.Data.Summary, query) {

--- a/mesheryctl/internal/cli/root/adapter/deploy.go
+++ b/mesheryctl/internal/cli/root/adapter/deploy.go
@@ -51,7 +51,7 @@ mesheryctl adapter deploy linkerd --watch
 		`,
 		Annotations: linkDocMeshDeploy,
 		PreRunE: func(cmd *cobra.Command, args []string) error {
-			log.Infof("Verifying prerequisites...")
+			utils.Log.Info("Verifying prerequisites...")
 			mctlCfg, err := config.GetMesheryCtl(viper.GetViper())
 			if err != nil {
 				utils.Log.Error(err)

--- a/mesheryctl/internal/cli/root/adapter/deploy_test.go
+++ b/mesheryctl/internal/cli/root/adapter/deploy_test.go
@@ -81,7 +81,7 @@ func TestDeployMesh(t *testing.T) {
 		},
 		{
 			Name: "Test Deploy Nginx",
-			Args: []string{"deploy", "nginx-sm"},
+			Args: []string{"deploy", "nginx", "service", "mesh"},
 			URLs: []utils.MockURL{
 				{
 					Method:       "GET",
@@ -166,5 +166,4 @@ func TestDeployMesh(t *testing.T) {
 		t.Log("Mesh Deploy test Passed")
 	}
 	utils.StopMockery(t)
-
 }

--- a/mesheryctl/internal/cli/root/adapter/fixtures/sync.golden
+++ b/mesheryctl/internal/cli/root/adapter/fixtures/sync.golden
@@ -1,59 +1,24 @@
 {
   "meshAdapters": [
     {
-      "adapter_location": "meshery-istio:10000",
-      "name": "ISTIO",
-      "version": "v0.8.0",
-      "git_commit_sha": "abc1234",
-      "ops": [
-        {"key": "istio", "value": "Istio Service Mesh"},
-        {"key": "bookinfo", "value": "Istio Book Info Application", "category": 1},
-        {"key": "smi_conformance", "value": "SMI Conformance", "category": 3}
-      ]
+      "adapter_location": "localhost:10000",
+      "name": "ISTIO"
     },
     {
-      "adapter_location": "meshery-linkerd:10001",
-      "name": "LINKERD",
-      "version": "v0.8.1",
-      "git_commit_sha": "def5678",
-      "ops": [
-        {"key": "linkerd", "value": "Linkerd Service Mesh"},
-        {"key": "emojivoto", "value": "EmojiVoto Application", "category": 1},
-        {"key": "smi_conformance", "value": "SMI Conformance", "category": 3}
-      ]
+      "adapter_location": "localhost:10001",
+      "name": "LINKERD"
     },
     {
-      "adapter_location": "meshery-app-mesh:10005",
-      "name": "APP_MESH",
-      "version": "v0.8.0",
-      "git_commit_sha": "ghi9012",
-      "ops": [
-        {"key": "app_mesh", "value": "AWS App Mesh"},
-        {"key": "custom", "value": "Custom YAML", "category": 4}
-      ]
+      "adapter_location": "localhost:10005",
+      "name": "APP_MESH"
     },
     {
-      "adapter_location": "meshery-nginx-sm:10010",
-      "name": "NGINX_SERVICE_MESH",
-      "version": "v0.8.0",
-      "git_commit_sha": "jkl3456",
-      "ops": [
-        {"key": "nginx_service_mesh", "value": "Nginx Service Mesh"},
-        {"key": "custom", "value": "Custom YAML", "category": 4}
-      ]
+      "adapter_location": "localhost:10010",
+      "name": "NGINX_SERVICE_MESH"
     },
     {
-      "adapter_location": "meshery-cilium:10012",
-      "name": "CILIUM_SERVICE_MESH",
-      "version": "v0.8.0",
-      "git_commit_sha": "mno7890",
-      "ops": [
-        {"key": "cilium_service_mesh", "value": "Cilium Service Mesh"},
-        {"key": "custom", "value": "Custom YAML", "category": 4}
-      ]
+      "adapter_location": "localhost:10012",
+      "name": "CILIUM_SERVICE_MESH"
     }
-  ],
-  "anonymousUsageStats": true,
-  "anonymousPerfResults": true,
-  "updated_at": "2025-12-26T12:53:03.729062529+05:30"
+  ]
 }

--- a/mesheryctl/internal/cli/root/adapter/remove_test.go
+++ b/mesheryctl/internal/cli/root/adapter/remove_test.go
@@ -78,7 +78,7 @@ func TestRemoveMesh(t *testing.T) {
 		},
 		{
 			Name: "Test Remove Cilium ",
-			Args: []string{"remove", "cilium"},
+			Args: []string{"remove", "cilium", "service", "mesh"},
 			URLs: []utils.MockURL{
 				{
 					Method:       "GET",

--- a/mesheryctl/internal/cli/root/adapter/testdata/deploy.appmesh.output.golden
+++ b/mesheryctl/internal/cli/root/adapter/testdata/deploy.appmesh.output.golden
@@ -1,2 +1,1 @@
-Unable to create a response from requestGet "http://localhost:9081/api/system/sync": no responder found
-Unable to create a response from requestGet "http://localhost:9081/api/system/sync": no responder found
+Verifying prerequisites...

--- a/mesheryctl/internal/cli/root/adapter/testdata/deploy.istio.output.golden
+++ b/mesheryctl/internal/cli/root/adapter/testdata/deploy.istio.output.golden
@@ -1,2 +1,1 @@
-Unable to create a response from requestGet "http://localhost:9081/api/system/sync": no responder found
-Unable to create a response from requestGet "http://localhost:9081/api/system/sync": no responder found
+Verifying prerequisites...

--- a/mesheryctl/internal/cli/root/adapter/testdata/deploy.linkerd.output.golden
+++ b/mesheryctl/internal/cli/root/adapter/testdata/deploy.linkerd.output.golden
@@ -1,3 +1,1 @@
-Unable to validate mesh name
-Unable to create a response from requestGet "http://localhost:9081/api/system/sync": no responder found
-Unable to create a response from requestGet "http://localhost:9081/api/system/sync": no responder found
+Verifying prerequisites...

--- a/mesheryctl/internal/cli/root/adapter/testdata/deploy.nginx.output.golden
+++ b/mesheryctl/internal/cli/root/adapter/testdata/deploy.nginx.output.golden
@@ -1,3 +1,1 @@
-Unable to validate mesh name
-Unable to create a response from requestGet "http://localhost:9081/api/system/sync": no responder found
-Unable to create a response from requestGet "http://localhost:9081/api/system/sync": no responder found
+Verifying prerequisites...

--- a/mesheryctl/internal/cli/root/adapter/testdata/remove.cilium.output.golden
+++ b/mesheryctl/internal/cli/root/adapter/testdata/remove.cilium.output.golden
@@ -1,4 +1,1 @@
-Unable to validate mesh name
-Unable to create a response from requestGet "http://localhost:9081/api/system/sync": no responder found
 Verifying prerequisites...
-Unable to create a response from requestGet "http://localhost:9081/api/system/sync": no responder found

--- a/mesheryctl/internal/cli/root/adapter/testdata/remove.linkerd-namespace.output.golden
+++ b/mesheryctl/internal/cli/root/adapter/testdata/remove.linkerd-namespace.output.golden
@@ -1,4 +1,1 @@
-Unable to validate mesh name
-Unable to create a response from requestGet "http://localhost:9081/api/system/sync": no responder found
 Verifying prerequisites...
-Unable to create a response from requestGet "http://localhost:9081/api/system/sync": no responder found

--- a/mesheryctl/internal/cli/root/adapter/testdata/remove.linkerd.output.golden
+++ b/mesheryctl/internal/cli/root/adapter/testdata/remove.linkerd.output.golden
@@ -1,3 +1,1 @@
-Unable to create a response from requestGet "http://localhost:9081/api/system/sync": no responder found
 Verifying prerequisites...
-Unable to create a response from requestGet "http://localhost:9081/api/system/sync": no responder found


### PR DESCRIPTION
**Notes for Reviewers**

- This PR Works towards #16770 

### Summary

The adapter deploy/remove unit tests were failing because the `GET /api/system/sync` endpoint was not mocked. This caused `validateAdapter()` to fail, resulting in corrupted golden file output containing error messages.

### After 

```
ok      github.com/meshery/meshery/mesheryctl/internal/cli/root/adapter
```
### Correct Golden file
```
Verifying prerequisites...
```
### Changes

- Add `GET /api/system/sync` mock to all test cases in `deploy_test.go` and `remove_test.go`
- Create `sync.golden` fixture with required adapter data
- Change `log.Infof` to `utils.Log.Info` for proper test output capture
- Update golden output files with correct expected output

**[Signed commits](https://github.com/meshery/meshery/blob/master/CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [x] Yes, I signed my commits.

---

