### PR TITLE
Modify ui-setup-ci to use npm ci

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -342,7 +342,9 @@ ui-setup:
 	cd provider-ui; npm i; cd ..
 
 ## Clean Install dependencies for building Meshery UI.
-ui-setup-ci:ui-setup
+ui-setup-ci:
+	cd ui; npm ci; cd ..
+	cd provider-ui; npm ci; cd ..
 
 
 ## Run Meshery UI on your local machine. Listen for changes.


### PR DESCRIPTION
Updated ui-setup-ci target to use 'npm ci' for clean installs.

**Notes for Reviewers**

- This PR fixes #

**[Signed commits](https://github.com/meshery/meshery/blob/master/CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [ ] Yes, I signed my commits.

<!--
Thank you for contributing to Meshery! 

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. Sign your commits.
4. Include before and after screenshots/terminal output.

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.
-->
