### PR TITLE
fix: prevent grep exit code from terminating with bash -e

### DIFF
--- a/.github/workflows/rego-lint-and-test.yml
+++ b/.github/workflows/rego-lint-and-test.yml
@@ -97,10 +97,12 @@ jobs:
           echo "opa-exit-code=$OPA_EXIT_CODE" >> $GITHUB_OUTPUT
           
           # Parse results
-          PASSED=$(grep -c "PASS" opa-test-results.txt 2>/dev/null)
-          PASSED=${PASSED:-0}
-          FAILED=$(grep -c "FAIL" opa-test-results.txt 2>/dev/null)
-          FAILED=${FAILED:-0}
+          PASSED=0
+          FAILED=0
+          if [ -f opa-test-results.txt ]; then
+            PASSED=$(grep -c "PASS" opa-test-results.txt 2>/dev/null || true)
+            FAILED=$(grep -c "FAIL" opa-test-results.txt 2>/dev/null || true)
+          fi
           TOTAL=$((PASSED + FAILED))
           
           echo "passed=$PASSED" >> $GITHUB_OUTPUT


### PR DESCRIPTION
**Notes for Reviewers**
- The grep command [here](https://github.com/meshery/meshery/blob/master/.github/workflows/rego-lint-and-test.yml#L102) is returning an `exit code 1` when the relevant match is not found, and the script fails immediately without reaching this [default line](https://github.com/meshery/meshery/blob/master/.github/workflows/rego-lint-and-test.yml#L103) as GitHub Actions run the shell with [`bash -e`](https://docs.github.com/en/actions/reference/workflows-and-actions/workflow-syntax#defaultsrunshell) i.e exit immediately on any error. 
- Fixed it to gracefully exit
- This PR fixes #16830

**[Signed commits](https://github.com/meshery/meshery/blob/master/CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [x] Yes, I signed my commits.
