### PR TITLE
chore(ci): Add conditional execution for Kubernetes in integration tests

### DIFF
--- a/.github/workflows/go-testing-ci.yml
+++ b/.github/workflows/go-testing-ci.yml
@@ -119,6 +119,7 @@ jobs:
         uses: docker/setup-buildx-action@v3
       - name: Create k8s Kind Cluster
         uses: helm/kind-action@v1.13.0
+        if: matrix.platform == 'kubernetes'
         with:
           cluster_name: "kind-cluster"
       - name: Run mesheryctl integration tests


### PR DESCRIPTION
Signed-off-by: lekaf974 <matthieu.evrin@gmail.com>

**Notes for Reviewers**

- This PR add skip support for kind cluster creation when platform is not kubernetes

**[Signed commits](https://github.com/meshery/meshery/blob/master/CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [x] Yes, I signed my commits.

<!--
Thank you for contributing to Meshery! 

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. Sign your commits.
4. Include before and after screenshots/terminal output.

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.
-->
