### PR TITLE
[Docs] Fix merged-openapi reference in contributing guide

### DIFF
--- a/docs/pages/project/contributing/contributing-schemas.md
+++ b/docs/pages/project/contributing/contributing-schemas.md
@@ -85,7 +85,7 @@ To generate Go structs from schemas, use:
 ```bash
 make golang-generate
 ```
-This also generates a merged_openapi.yml file which can be used to generate the redoc documentation and for rtk-api
+This also generates a merged-openapi.json file which can be used to generate the redoc documentation and for rtk-api
 
 ### Generating TypeScript Models, JSON and YAML templates
 To generate


### PR DESCRIPTION
## Description
Updates the contributing documentation to reference `merged-openapi.json` instead of `merged-openapi.yml`.

This change aligns with the file renaming in meshery/schemas [#500](https://github.com/meshery/schemas/pull/500).


**[Signed commits](https://github.com/meshery/meshery/blob/master/CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [x] Yes, I signed my commits.