### PR TITLE
[CI] Disable ST1005 staticcheck lint rule globally (fixes #16867)

### DIFF
--- a/.github/.golangci.yml
+++ b/.github/.golangci.yml
@@ -5,9 +5,10 @@ run:
 linters:
   disable:
     - errcheck
-    - staticcheck
+  settings:
+    staticcheck:
+      checks: ["all", "-ST1005"]
   exclusions:
     paths:
       - server/handlers/doc.go
       - server/models/meshmodel/core/register.go
- 


### PR DESCRIPTION
## Description
Globally and permanently disable ST1005 staticcheck lint rule, allowing capitalized error strings.

## Changes
- Updated [.github/.golangci.yml](cci:7://file:///home/yash/meshery/.github/.golangci.yml:0:0-0:0) to enable staticcheck with ST1005 excluded
- Changed from disabling entire staticcheck linter to targeted exclusion

Fixes #16867

## Testing
- Verified config validates with `golangci-lint config verify`
- Tested locally that ST1005 violations are no longer reported

---
**Signed commits**
- [x] Yes, I signed my commits.