### PR TITLE
fix(ui): resolve non-serializable value warning in notification store

### DIFF
--- a/ui/components/NotificationCenter/index.js
+++ b/ui/components/NotificationCenter/index.js
@@ -215,7 +215,12 @@ const Header = ({ handleFilter, handleClose }) => {
     });
   };
 
-  const Icon = uiConfig.icon || BellIcon;
+  // Map the string identifiers to actual components
+  const iconMap = {
+    bell: BellIcon,
+  };
+
+  const Icon = iconMap[uiConfig.icon] || BellIcon;
   return (
     <NotificationContainer>
       <Title>

--- a/ui/store/slices/events.js
+++ b/ui/store/slices/events.js
@@ -1,6 +1,6 @@
 import { createEntityAdapter, createSlice } from '@reduxjs/toolkit';
 import { SEVERITY, STATUS } from '../../components/NotificationCenter/constants';
-import { BellIcon } from '@sistent/sistent';
+// import { BellIcon } from '@sistent/sistent';
 
 const initialState = {
   current_view: {
@@ -24,7 +24,7 @@ const initialState = {
     history_mode: false, // used to determine if the notification center is in history mode . so we render in a different way
     title: 'Notifications', // title of the operation center
     empty_message: 'No notifications found', // message to show when there are no notifications
-    icon: BellIcon,
+    icon: 'bell', // FIXED: Storing string identifier instead of Component
   },
   isNotificationCenterOpen: false,
 };


### PR DESCRIPTION
**Notes for Reviewers**
This PR resolves the Redux warning: `A non-serializable value was detected in the state`. 

Previously, the `events` slice in Redux was storing a React Component (`BellIcon`) directly in the `ui.icon` state. This violates Redux best practices and causes serialization errors.

- This PR fixes #16873

**Changes Made:**
1. Refactored `ui/store/slices/events.js` to store a string identifier (`'bell'`) instead of the component itself.
2. Updated `ui/components/NotificationCenter/index.js` to map the string identifier back to the `BellIcon` component during rendering.

**Verification:**
- Verified that the "Non-serializable value" warning no longer appears in the browser console during development.
- Verified that the notification header still renders the Bell icon correctly.

**[Signed commits](https://github.com/meshery/meshery/blob/master/CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [x] Yes, I signed my commits.

