### PR TITLE
fix(CI): update workflow to publish multiple artifacts for each tested k8s versions

### DIFF
--- a/.github/workflows/test_adaptersv2.yaml
+++ b/.github/workflows/test_adaptersv2.yaml
@@ -54,7 +54,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        k8s_version: ['v1.31.4', 'v1.32.0']
+        k8s_version: ["v1.31.4", "v1.32.0"]
     runs-on: ubuntu-24.04
     outputs:
       exitstatus: ${{ steps.runresources.outputs.exitstatus }}
@@ -259,7 +259,15 @@ jobs:
           MESHERY_VERSION=$(curl -L -s https://github.com/meshery/meshery/releases/latest | grep -oP 'releases/tag/\K[^"]+' | grep -E '^v[0-9]+\.[0-9]+\.[0-9]+' | head -1)    
           echo $(jq '.metadata."meshery-server-version" |="'$MESHERY_VERSION'"' data.json ) > data.json
           echo "exitstatus=$exitstatus" >> $GITHUB_ENV
-      - name: UploadResults
+      - name: UploadResults (Versioned)
+        uses: actions/upload-artifact@v6
+        with:
+          name: ${{ inputs.output_filename }}-${{ matrix.k8s_version }}
+          path: ./${{ inputs.output_filename }}
+          overwrite: true
+        continue-on-error: true
+
+      - name: UploadResults (Legacy)
         uses: actions/upload-artifact@v6
         with:
           name: ${{ inputs.output_filename }}
@@ -271,4 +279,3 @@ jobs:
           if [ "$exitstatus" -eq 1 ];then
               exit 1
           fi
-


### PR DESCRIPTION
**Notes for Reviewers**

- This PR fixes #16882

**[Signed commits](https://github.com/meshery/meshery/blob/master/CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [x] Yes, I signed my commits.

I have updated the testadaptersv2.yaml workflow to include dynamic Kubernetes version extraction from the versions defined in the matrix and upload artifacts with version names appended to it.

Currently the workflow uploads both versioned artifacts and the old data.json named artifacts for backward compatibilty once all the adapters consuming this file has been changed to accept these changes I'll raise a PR to remove this legacy artifact upload.

@leecalcote @aabidsofi19 
