### PR TITLE
Change event severity from error to warning for forbidden design access

### DIFF
--- a/ui/components/SpacesSwitcher/MainDesignsContent.js
+++ b/ui/components/SpacesSwitcher/MainDesignsContent.js
@@ -120,18 +120,37 @@ const MainDesignsContent = ({
   });
 
   const handleInfoModal = async (design) => {
-    const selectedDesignWithPatternFile = await getDesign({
+    const result = await getDesign({
       design_id: design?.id,
     });
 
-    setSelectedDesign(selectedDesignWithPatternFile?.data);
+    if (result?.error?.status === 403) {
+      notify({
+        message:
+          'You don’t have access to this design. Ask the owner to share it or check your permissions.',
+        severity: 'warning',
+      });
+      return;
+    }
+
+    if (!result?.data) {
+      notify({
+        message: 'Failed to fetch Design',
+        severity: 'error',
+      });
+      return;
+    }
+
+    const fetchedDesign = result.data;
+
+    setSelectedDesign(fetchedDesign);
 
     sistentInfoModal.openModal({
-      title: selectedDesign?.name,
+      title: fetchedDesign?.name,
     });
     setInfoModal({
       open: true,
-      userId: selectedDesignWithPatternFile?.data?.user_id,
+      userId: fetchedDesign?.user_id,
     });
   };
 


### PR DESCRIPTION
**Notes for Reviewers**

- This PR fixes #15220

Updates the Design Info flow to treat forbidden access (403) as a warning instead of an error. When a user lacks permission to view a design, a warning notification is shown and the Info modal is not opened, providing clearer and more appropriate feedback.

**[Signed commits](https://github.com/meshery/meshery/blob/master/CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [x] Yes, I signed my commits.

<!--
Thank you for contributing to Meshery! 

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. Sign your commits.
4. Include before and after screenshots/terminal output.

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.
-->
