### PR TITLE
fix: update QA repo name from meshery-extensions/qa to meshery/qa

### DIFF
--- a/.github/workflows/build-ui-and-server.yml
+++ b/.github/workflows/build-ui-and-server.yml
@@ -119,7 +119,7 @@ jobs:
         # run only for pushes to master
         if: ${{ !cancelled() &&  github.event_name == 'push' }}
         with:
-          repository: meshery-extensions/qa
+          repository: meshery/qa
           path: ./qa
           file_pattern: meshery-results
           token: ${{ secrets.GH_ACCESS_TOKEN }}


### PR DESCRIPTION
The QA repository was migrated from meshery-extensions/qa to meshery/qa. This updates the workflow to use the current repo name.

**Notes for Reviewers**

Simple one-liner fix. The old repo name still works (GitHub redirects), but this ensures we're using the canonical name.

**[Signed commits](https://github.com/meshery/meshery/blob/master/CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [x] Yes, I signed my commits.