### PR TITLE
[mesheryctl] Pretty print API response in connection create

### DIFF
--- a/mesheryctl/internal/cli/root/connections/create.go
+++ b/mesheryctl/internal/cli/root/connections/create.go
@@ -263,7 +263,12 @@ func getContexts(configFile string) ([]string, error) {
 		return nil, utils.ErrReadResponseBody(err)
 	}
 
-	log.Debugf("Get context API response: %s", string(body))
+	var prettyJSON bytes.Buffer
+	if err := json.Indent(&prettyJSON, body, "", "  "); err == nil {
+		log.Debugf("Get context API response:\n%s", prettyJSON.String())
+	} else {
+		log.Debugf("Get context API response: %s", string(body))
+	}
 	var results []map[string]interface{}
 	err = json.Unmarshal(body, &results)
 	if err != nil {


### PR DESCRIPTION
Beautifies the output of the connection creation command by pretty-printing the JSON response from the server.

Fixes #16925

**Notes for Reviewers**

- This PR fixes #16925

**[Signed commits](https://github.com/meshery/meshery/blob/master/CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [x] Yes, I signed my commits.

<!--
Thank you for contributing to Meshery! 

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. Sign your commits.
4. Include before and after screenshots/terminal output.

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.
-->
