### PR TITLE
[Relationships] Add Pod to PVC reference relationship

### DIFF
--- a/server/meshmodel/kubernetes/v1.37.0-alpha.1/v1.0.0/relationships/edge-non-binding-reference-pod-pvc.json
+++ b/server/meshmodel/kubernetes/v1.37.0-alpha.1/v1.0.0/relationships/edge-non-binding-reference-pod-pvc.json
@@ -3,25 +3,25 @@
   "evaluationQuery": "",
   "kind": "edge",
   "metadata": {
-    "description": "Reference relationship between PersistentVolumeClaim and Pod. Automatically configures the Pod's volumes to reference the PVC's claim name.",
-    "isAnnotation": false,
+    "description": "Mount relationship between Pod and PersistentVolumeClaim. Automatically configures the Pod's volumes to reference the PVC.",
     "styles": {
       "primaryColor": "",
       "svgColor": "",
       "svgWhite": ""
-    }
+    },
+    "isAnnotation": false
   },
   "model": {
+    "version": "",
+    "name": "kubernetes",
     "displayName": "",
     "id": "00000000-0000-0000-0000-000000000000",
-    "model": {
-      "version": "v1.37.0-alpha.1"
-    },
-    "name": "kubernetes",
     "registrant": {
       "kind": ""
     },
-    "version": ""
+    "model": {
+      "version": "v1.37.0-alpha.1"
+    }
   },
   "schemaVersion": "relationships.meshery.io/v1beta2",
   "selectors": [
@@ -39,24 +39,24 @@
               ]
             ],
             "model": {
+              "version": "",
+              "name": "kubernetes",
               "displayName": "",
               "id": "00000000-0000-0000-0000-000000000000",
-              "model": {
-                "version": ""
-              },
-              "name": "kubernetes",
               "registrant": {
                 "kind": "github"
               },
-              "version": ""
+              "model": {
+                "version": ""
+              }
             },
             "patch": {
+              "patchStrategy": "replace",
               "mutatorRef": [
                 [
                   "displayName"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ],
@@ -67,18 +67,19 @@
             "match": {},
             "match_strategy_matrix": null,
             "model": {
+              "version": "",
+              "name": "kubernetes",
               "displayName": "",
               "id": "00000000-0000-0000-0000-000000000000",
-              "model": {
-                "version": ""
-              },
-              "name": "kubernetes",
               "registrant": {
                 "kind": "github"
               },
-              "version": ""
+              "model": {
+                "version": ""
+              }
             },
             "patch": {
+              "patchStrategy": "replace",
               "mutatedRef": [
                 [
                   "configuration",
@@ -88,8 +89,7 @@
                   "persistentVolumeClaim",
                   "claimName"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ]

--- a/server/meshmodel/kubernetes/v1.37.0-alpha.1/v1.0.0/relationships/edge-non-binding-reference-pod-pvc.json
+++ b/server/meshmodel/kubernetes/v1.37.0-alpha.1/v1.0.0/relationships/edge-non-binding-reference-pod-pvc.json
@@ -1,0 +1,107 @@
+{
+  "id": "00000000-0000-0000-0000-000000000000",
+  "evaluationQuery": "",
+  "kind": "edge",
+  "metadata": {
+    "description": "Reference relationship between PersistentVolumeClaim and Pod. Automatically configures the Pod's volumes to reference the PVC's claim name.",
+    "isAnnotation": false,
+    "styles": {
+      "primaryColor": "",
+      "svgColor": "",
+      "svgWhite": ""
+    }
+  },
+  "model": {
+    "displayName": "",
+    "id": "00000000-0000-0000-0000-000000000000",
+    "model": {
+      "version": "v1.37.0-alpha.1"
+    },
+    "name": "kubernetes",
+    "registrant": {
+      "kind": ""
+    },
+    "version": ""
+  },
+  "schemaVersion": "relationships.meshery.io/v1beta2",
+  "selectors": [
+    {
+      "allow": {
+        "from": [
+          {
+            "id": null,
+            "kind": "PersistentVolumeClaim",
+            "match": {},
+            "match_strategy_matrix": [
+              [
+                "equal_as_strings",
+                "not_null"
+              ]
+            ],
+            "model": {
+              "displayName": "",
+              "id": "00000000-0000-0000-0000-000000000000",
+              "model": {
+                "version": ""
+              },
+              "name": "kubernetes",
+              "registrant": {
+                "kind": "github"
+              },
+              "version": ""
+            },
+            "patch": {
+              "mutatorRef": [
+                [
+                  "displayName"
+                ]
+              ],
+              "patchStrategy": "replace"
+            }
+          }
+        ],
+        "to": [
+          {
+            "id": null,
+            "kind": "Pod",
+            "match": {},
+            "match_strategy_matrix": null,
+            "model": {
+              "displayName": "",
+              "id": "00000000-0000-0000-0000-000000000000",
+              "model": {
+                "version": ""
+              },
+              "name": "kubernetes",
+              "registrant": {
+                "kind": "github"
+              },
+              "version": ""
+            },
+            "patch": {
+              "mutatedRef": [
+                [
+                  "configuration",
+                  "spec",
+                  "volumes",
+                  "0",
+                  "persistentVolumeClaim",
+                  "claimName"
+                ]
+              ],
+              "patchStrategy": "replace"
+            }
+          }
+        ]
+      },
+      "deny": {
+        "from": [],
+        "to": []
+      }
+    }
+  ],
+  "subType": "reference",
+  "status": "enabled",
+  "type": "non-binding",
+  "version": "v1.0.0"
+}


### PR DESCRIPTION
Fixes #15077

**Description**

Adds Pod→PersistentVolumeClaim reference relationship to Kanvas, enabling automatic population of `Pod.spec.volumes[0].persistentVolumeClaim.claimName` when connecting a PVC to a Pod.

- Contributes to #17096 

**Changes**:
- Added [edge-non-binding-reference-pod-pvc.json](cci:7://file:///home/yash/meshery/server/meshmodel/kubernetes/v1.35.0/v1.0.0/relationships/edge-non-binding-reference-pod-pvc.json:0:0-0:0) for Kubernetes v1.35.0 and pre-release versions
- Follows existing [deployment-to-pvc-reference.json](cci:7://file:///home/yash/meshery/server/meshmodel/kubernetes/v1.35.0/v1.0.0/relationships/deployment-to-pvc-reference.json:0:0-0:0) pattern
- Type: `edge / non-binding / reference`

**Behavior**:
- Auto-populates Pod volume claimName when PVC→Pod relationship created
---
<img width="1004" height="630" alt="image" src="https://github.com/user-attachments/assets/7954e210-8d34-4f23-8696-ca2959edcd3b" />

---

**Notes for Reviewers**

- This PR fixes #15077
- Tested locally in Kanvas - auto-population confirmed working
- Implementation matches Deployment→PVC reference pattern exactly

**[Signed commits](https://github.com/meshery/meshery/blob/master/CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [x] Yes, I signed my commits.