### PR TITLE
[mesheryctl] Update system context outdated golden files 

### DIFF
--- a/mesheryctl/internal/cli/root/system/testdata/check/check.output.golden
+++ b/mesheryctl/internal/cli/root/system/testdata/check/check.output.golden
@@ -2,7 +2,7 @@
 Docker 
 --------------
 ✓ Docker is running
-✓ docker-compose is available
+✓ docker-compose is available (via library)
 
 Kubernetes API 
 --------------

--- a/mesheryctl/internal/cli/root/system/testdata/context/addExpected.golden
+++ b/mesheryctl/internal/cli/root/system/testdata/context/addExpected.golden
@@ -23,7 +23,7 @@ contexts:
         platform: kubernetes
         channel: stable
         version: latest
-        provider: Meshery
+        provider: Layer5
 current-context: local
 tokens:
     - name: default


### PR DESCRIPTION
## Description
- Updates the `system context` golden test files to reflect the current default provider value.
- This outdated files was causing `TestAddContextCmd/add_given_context` test case to fail.

- This PR fixes #

**[Signed commits](https://github.com/meshery/meshery/blob/master/CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [x] Yes, I signed my commits.

<!--
Thank you for contributing to Meshery! 

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. Sign your commits.
4. Include before and after screenshots/terminal output.

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.
-->
