### PR TITLE
Add Kubernetes Deployment to Service relationship

### DIFF
--- a/server/meshmodel/kubernetes/v1.35.0/v1.0.0/relationships/hierarchical-parent-deployment-service.json
+++ b/server/meshmodel/kubernetes/v1.35.0/v1.0.0/relationships/hierarchical-parent-deployment-service.json
@@ -52,8 +52,8 @@
                   "configuration",
                   "spec",
                   "template",
-                  "spec",
-                  "containers",
+                  "metadata",
+                  "labels",
                   "_"
                 ]
               ]
@@ -84,9 +84,7 @@
                 [
                   "configuration",
                   "spec",
-                  "template",
-                  "spec",
-                  "containers",
+                  "selector",
                   "_"
                 ]
               ]

--- a/server/meshmodel/kubernetes/v1.35.0/v1.0.0/relationships/hierarchical-parent-deployment-service.json
+++ b/server/meshmodel/kubernetes/v1.35.0/v1.0.0/relationships/hierarchical-parent-deployment-service.json
@@ -1,0 +1,107 @@
+{
+  "id": "00000000-0000-0000-0000-000000000000",
+  "evaluationQuery": "",
+  "kind": "hierarchical",
+  "metadata": {
+    "description": "A Kubernetes Service fronts and exposes a Deployment",
+    "styles": {
+      "primaryColor": "",
+      "svgColor": "",
+      "svgWhite": ""
+    },
+    "isAnnotation": false
+  },
+  "model": {
+    "version": "",
+    "name": "kubernetes",
+    "displayName": "",
+    "id": "00000000-0000-0000-0000-000000000000",
+    "registrant": {
+      "kind": ""
+    },
+    "model": {
+      "version": "v1.35.0"
+    }
+  },
+  "schemaVersion": "relationships.meshery.io/v1alpha3",
+  "selectors": [
+    {
+      "allow": {
+        "from": [
+          {
+            "id": null,
+            "kind": "Deployment",
+            "match": {},
+            "match_strategy_matrix": null,
+            "model": {
+              "version": "",
+              "name": "kubernetes",
+              "displayName": "",
+              "id": "00000000-0000-0000-0000-000000000000",
+              "registrant": {
+                "kind": "github"
+              },
+              "model": {
+                "version": ""
+              }
+            },
+            "patch": {
+              "patchStrategy": "replace",
+              "mutatorRef": [
+                [
+                  "configuration",
+                  "spec",
+                  "template",
+                  "spec",
+                  "containers",
+                  "_"
+                ]
+              ]
+            }
+          }
+        ],
+        "to": [
+          {
+            "id": null,
+            "kind": "Service",
+            "match": {},
+            "match_strategy_matrix": null,
+            "model": {
+              "version": "",
+              "name": "kubernetes",
+              "displayName": "",
+              "id": "00000000-0000-0000-0000-000000000000",
+              "registrant": {
+                "kind": "github"
+              },
+              "model": {
+                "version": ""
+              }
+            },
+            "patch": {
+              "patchStrategy": "replace",
+              "mutatedRef": [
+                [
+                  "configuration",
+                  "spec",
+                  "template",
+                  "spec",
+                  "containers",
+                  "_"
+                ]
+              ]
+            }
+          }
+        ]
+      },
+      "deny": {
+        "from": [],
+        "to": []
+      }
+    }
+  ],
+  "subType": "alias",
+  "status": "enabled",
+  "type": "parent",
+  "version": "v1.0.0"
+}


### PR DESCRIPTION
### Summary
This PR adds a hierarchical relationship definition describing how a Kubernetes Service fronts and exposes a Deployment.

### Details
- Introduces a Kubernetes Deployment → Service relationship under the v1.35.0 model
- Uses correct Kubernetes semantics:
  - Deployment pod labels at `spec.template.metadata.labels`
  - Service selectors at `spec.selector`
- Follows existing Meshery relationship and patch patterns

### Related Issue
Fixes #14794
