### PR TITLE
[CI] Fix scheduled e2e tests failing on Ubuntu 24.04

### DIFF
--- a/.github/workflows/mesheryctl-e2e.yaml
+++ b/.github/workflows/mesheryctl-e2e.yaml
@@ -143,7 +143,7 @@ jobs:
         platform: ['docker', 'kubernetes']
     steps:
       - name: Setup Kubernetes
-        uses: manusa/actions-setup-minikube@v2.11.0
+        uses: manusa/actions-setup-minikube@v2.14.0
         with:
           minikube version: 'v1.35.0'
           kubernetes version: ${{ matrix.k8s_version }}


### PR DESCRIPTION
## [CI] Fix scheduled e2e tests failing on Ubuntu 24.04

### Description
The `scheduled-test` job in `mesheryctl-e2e.yaml` was using `manusa/actions-setup-minikube@v2.11.0`, which does not support Ubuntu 24.04. Since `ubuntu-latest` now runs on Ubuntu 24.04, all scheduled E2E tests were failing with:

Error: Unsupported OS, action only works in Ubuntu 18, 20, or 22

### Fix
Updated `manusa/actions-setup-minikube` to a newer version that supports Ubuntu 24.04.

### Result
All scheduled E2E tests should now run successfully on Ubuntu 24.04.
