### PR TITLE
DOCS: Fix minor link in Meshery CLI Style Guide

### DIFF
--- a/docs/pages/project/contributing/contributing-guidelines.md
+++ b/docs/pages/project/contributing/contributing-guidelines.md
@@ -54,7 +54,7 @@ Command line interfaces offer less context to the user, which makes them inheren
 
 - Provide only relevant output. Use "debug" logs that can be accessed with `--verbose` flag wherever needed.
 - Add headers to output to give context to the user.
-- As mentioned [above](#intuition-vs-consistency), similar commands should behave similarly.
+- As mentioned [above](#flags), similar commands should behave similarly.
 - Confirm steps for risky commands. For example, use the `AskForConfirmation` function which will prompt the user to type in "yes" or "no" to continue.
 - Anticipate user actions. If the user creates a new context with `mesheryctl system context create` then the next action might be `mesheryctl system start` to start Meshery ot `mesheryctl system context switch` to switch context names.
 - Anticipate user errors. For example, if the user types in `mesheryctl system satrt`, using the inbuilt features with the [cobra library](https://github.com/spf13/cobra), we can correct it to `start` and alert the user.


### PR DESCRIPTION
**Notes for Reviewers**

before: no such link as intuition-vs-consistency
after: linked to #flags where the actual link should point to

**[Signed commits](https://github.com/meshery/meshery/blob/master/CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [x] Yes, I signed my commits.

<!--
Thank you for contributing to Meshery! 

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. Sign your commits.
4. Include before and after screenshots/terminal output.

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.
-->
