### PR TITLE
[CI] Fix duplicate setup execution in mesheryctl E2E BATS tests

### DIFF
--- a/mesheryctl/tests/e2e/run_tests.bash
+++ b/mesheryctl/tests/e2e/run_tests.bash
@@ -6,8 +6,6 @@ source ./setup_suite.bash
 # echo "DEBUG: MESHERYCTL_BIN=$MESHERYCTL_BIN"
 # echo "DEBUG: TEMP_DATA_DIR=$TEMP_DATA_DIR"
 
-./setup_suite.bash
-
 # Run the tests
 # Uncomment the following line to enable junit format output
 FORMATTER="--formatter tap"


### PR DESCRIPTION
## Description 

Remove duplicate ./setup_suite.bash call that was causing:
- Helm conflict: cannot re-use a name that is still in use
- Port conflict: address already in use on port 9999
- Cascading test failures with connection refused

The setup_suite.bash is already executed via 'source' on line 4, which runs the main function at the end of the file.

**Notes for Reviewers**

- This PR fixes #16999 

**[Signed commits](https://github.com/meshery/meshery/blob/master/CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [x] Yes, I signed my commits.

<!--
Thank you for contributing to Meshery! 

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. Sign your commits.
4. Include before and after screenshots/terminal output.

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.
-->
