### PR TITLE
fix: add missing return for subscription cleanup in operationsCenter

### DIFF
--- a/ui/machines/operationsCenter.js
+++ b/ui/machines/operationsCenter.js
@@ -53,7 +53,7 @@ const subscriptionActor = fromCallback(({ sendBack }) => {
     },
   );
 
-  () => {
+  return () => {
     subscription.dispose();
   };
 });


### PR DESCRIPTION

## Description

This PR fixes a memory leak in the Operations Center caused by a missing cleanup return in an XState `fromCallback` actor.  
The GraphQL subscription is now properly disposed when the actor stops or restarts.

---

## Problem

The `subscriptionActor` did not return a cleanup function from `fromCallback`.  
When the actor was stopped and respawned (for example, after a subscription error), the previous Relay GraphQL subscription remained active.

This resulted in:
- Undisposed WebSocket subscriptions
- Gradual memory growth in the browser
- Duplicate event processing
- Duplicate UI notifications
- Orphaned server-side connections

---

## Root Cause

A cleanup function was defined but never returned:
```
() => {
  subscription.dispose();
};
```

In XState v5, fromCallback requires returning a cleanup function. Without it, the actor lifecycle is violated and resources are never released.

---

## Fix

The cleanup function is now returned so XState can properly dispose of the subscription:

```
return () => {
  subscription.dispose();
};
```

---

## Impact
	•	GraphQL subscriptions are correctly terminated
	•	WebSocket connections are closed on actor cleanup
	•	Memory usage remains stable over long sessions
	•	Duplicate events and notifications are eliminated
	•	Actor lifecycle now fully complies with XState v5

---

## How Has This Been Tested?
	•	Verified locally by triggering subscription errors
	•	Confirmed that old subscriptions are disposed on actor restart
	•	Observed stable memory usage and no duplicate notifications

---

## Checklist
	•	Bug fix (non-breaking change)
	•	Fix verified locally
	•	No new dependencies added
	•	No breaking changes

