### PR TITLE
[Relationships] Add S3 Bucket to Deployment and Pod reference relationships

### DIFF
--- a/server/meshmodel/aws-s3-controller/v1.0.30/v1.0.0/relationships/edge-non-binding-reference-bucket-deployment.json
+++ b/server/meshmodel/aws-s3-controller/v1.0.30/v1.0.0/relationships/edge-non-binding-reference-bucket-deployment.json
@@ -1,110 +1,112 @@
 {
+  "id": "00000000-0000-0000-0000-000000000000",
+  "evaluationQuery": "",
+  "kind": "edge",
+  "metadata": {
+    "description": "A Bucket provides S3 storage configuration to a Deployment by auto-populating the bucket name in environment variables.",
+    "styles": {
+      "primaryColor": "",
+      "svgColor": "",
+      "svgWhite": ""
+    },
+    "isAnnotation": false
+  },
+  "model": {
+    "version": "",
+    "name": "aws-s3-controller",
+    "displayName": "",
     "id": "00000000-0000-0000-0000-000000000000",
-    "evaluationQuery": "",
-    "kind": "edge",
-    "metadata": {
-        "description": "A Bucket provides S3 storage configuration to a Deployment by auto-populating the bucket name in environment variables.",
-        "styles": {
-            "primaryColor": "",
-            "svgColor": "",
-            "svgWhite": ""
-        },
-        "isAnnotation": false
+    "registrant": {
+      "kind": ""
     },
     "model": {
-        "version": "",
-        "name": "aws-s3-controller",
-        "displayName": "",
-        "id": "00000000-0000-0000-0000-000000000000",
-        "registrant": {
-            "kind": ""
-        },
-        "model": {
-            "version": "v1.1.3"
-        }
-    },
-    "schemaVersion": "relationships.meshery.io/v1alpha3",
-    "selectors": [
-        {
-            "allow": {
-                "from": [
-                    {
-                        "id": null,
-                        "kind": "Bucket",
-                        "match": {},
-                        "match_strategy_matrix": [
-                            [
-                                "equal_as_strings",
-                                "not_null"
-                            ]
-                        ],
-                        "model": {
-                            "version": "",
-                            "name": "aws-s3-controller",
-                            "displayName": "",
-                            "id": "00000000-0000-0000-0000-000000000000",
-                            "registrant": {
-                                "kind": "github"
-                            },
-                            "model": {
-                                "version": ""
-                            }
-                        },
-                        "patch": {
-                            "patchStrategy": "replace",
-                            "mutatorRef": [
-                                [
-                                    "displayName"
-                                ]
-                            ]
-                        }
-                    }
-                ],
-                "to": [
-                    {
-                        "id": null,
-                        "kind": "Deployment",
-                        "match": {},
-                        "match_strategy_matrix": null,
-                        "model": {
-                            "version": "",
-                            "name": "kubernetes",
-                            "displayName": "",
-                            "id": "00000000-0000-0000-0000-000000000000",
-                            "registrant": {
-                                "kind": "github"
-                            },
-                            "model": {
-                                "version": ""
-                            }
-                        },
-                        "patch": {
-                            "patchStrategy": "replace",
-                            "mutatedRef": [
-                                [
-                                    "configuration",
-                                    "spec",
-                                    "template",
-                                    "spec",
-                                    "containers",
-                                    "0",
-                                    "env",
-                                    "0",
-                                    "value"
-                                ]
-                            ]
-                        }
-                    }
-                ]
+      "version": "v1.0.30"
+    }
+  },
+  "schemaVersion": "relationships.meshery.io/v1alpha3",
+  "selectors": [
+    {
+      "allow": {
+        "from": [
+          {
+            "id": null,
+            "kind": "Bucket",
+            "match": {},
+            "match_strategy_matrix": [
+              [
+                "equal_as_strings",
+                "not_null"
+              ]
+            ],
+            "model": {
+              "version": "",
+              "name": "aws-s3-controller",
+              "displayName": "",
+              "id": "00000000-0000-0000-0000-000000000000",
+              "registrant": {
+                "kind": "github"
+              },
+              "model": {
+                "version": ""
+              }
             },
-            "deny": {
-                "from": [],
-                "to": []
+            "patch": {
+              "patchStrategy": "replace",
+              "mutatorRef": [
+                [
+                  "configuration",
+                  "spec",
+                  "name"
+                ]
+              ]
             }
-        }
-    ],
-    "subType": "reference",
-    "status": "enabled",
-    "type": "non-binding",
-    "version": "v1.0.0"
+          }
+        ],
+        "to": [
+          {
+            "id": null,
+            "kind": "Deployment",
+            "match": {},
+            "match_strategy_matrix": null,
+            "model": {
+              "version": "",
+              "name": "kubernetes",
+              "displayName": "",
+              "id": "00000000-0000-0000-0000-000000000000",
+              "registrant": {
+                "kind": "github"
+              },
+              "model": {
+                "version": ""
+              }
+            },
+            "patch": {
+              "patchStrategy": "replace",
+              "mutatedRef": [
+                [
+                  "configuration",
+                  "spec",
+                  "template",
+                  "spec",
+                  "containers",
+                  "0",
+                  "env",
+                  "0",
+                  "value"
+                ]
+              ]
+            }
+          }
+        ]
+      },
+      "deny": {
+        "from": [],
+        "to": []
+      }
+    }
+  ],
+  "subType": "reference",
+  "status": "enabled",
+  "type": "non-binding",
+  "version": "v1.0.0"
 }

--- a/server/meshmodel/aws-s3-controller/v1.0.30/v1.0.0/relationships/edge-non-binding-reference-bucket-deployment.json
+++ b/server/meshmodel/aws-s3-controller/v1.0.30/v1.0.0/relationships/edge-non-binding-reference-bucket-deployment.json
@@ -1,0 +1,110 @@
+{
+    "id": "00000000-0000-0000-0000-000000000000",
+    "evaluationQuery": "",
+    "kind": "edge",
+    "metadata": {
+        "description": "A Bucket provides S3 storage configuration to a Deployment by auto-populating the bucket name in environment variables.",
+        "styles": {
+            "primaryColor": "",
+            "svgColor": "",
+            "svgWhite": ""
+        },
+        "isAnnotation": false
+    },
+    "model": {
+        "version": "",
+        "name": "aws-s3-controller",
+        "displayName": "",
+        "id": "00000000-0000-0000-0000-000000000000",
+        "registrant": {
+            "kind": ""
+        },
+        "model": {
+            "version": "v1.1.3"
+        }
+    },
+    "schemaVersion": "relationships.meshery.io/v1alpha3",
+    "selectors": [
+        {
+            "allow": {
+                "from": [
+                    {
+                        "id": null,
+                        "kind": "Bucket",
+                        "match": {},
+                        "match_strategy_matrix": [
+                            [
+                                "equal_as_strings",
+                                "not_null"
+                            ]
+                        ],
+                        "model": {
+                            "version": "",
+                            "name": "aws-s3-controller",
+                            "displayName": "",
+                            "id": "00000000-0000-0000-0000-000000000000",
+                            "registrant": {
+                                "kind": "github"
+                            },
+                            "model": {
+                                "version": ""
+                            }
+                        },
+                        "patch": {
+                            "patchStrategy": "replace",
+                            "mutatorRef": [
+                                [
+                                    "displayName"
+                                ]
+                            ]
+                        }
+                    }
+                ],
+                "to": [
+                    {
+                        "id": null,
+                        "kind": "Deployment",
+                        "match": {},
+                        "match_strategy_matrix": null,
+                        "model": {
+                            "version": "",
+                            "name": "kubernetes",
+                            "displayName": "",
+                            "id": "00000000-0000-0000-0000-000000000000",
+                            "registrant": {
+                                "kind": "github"
+                            },
+                            "model": {
+                                "version": ""
+                            }
+                        },
+                        "patch": {
+                            "patchStrategy": "replace",
+                            "mutatedRef": [
+                                [
+                                    "configuration",
+                                    "spec",
+                                    "template",
+                                    "spec",
+                                    "containers",
+                                    "0",
+                                    "env",
+                                    "0",
+                                    "value"
+                                ]
+                            ]
+                        }
+                    }
+                ]
+            },
+            "deny": {
+                "from": [],
+                "to": []
+            }
+        }
+    ],
+    "subType": "reference",
+    "status": "enabled",
+    "type": "non-binding",
+    "version": "v1.0.0"
+}

--- a/server/meshmodel/aws-s3-controller/v1.0.30/v1.0.0/relationships/edge-non-binding-reference-bucket-pod.json
+++ b/server/meshmodel/aws-s3-controller/v1.0.30/v1.0.0/relationships/edge-non-binding-reference-bucket-pod.json
@@ -1,0 +1,108 @@
+{
+    "id": "00000000-0000-0000-0000-000000000000",
+    "evaluationQuery": "",
+    "kind": "edge",
+    "metadata": {
+        "description": "A Bucket provides S3 storage configuration to a Pod by auto-populating the bucket name in environment variables.",
+        "styles": {
+            "primaryColor": "",
+            "svgColor": "",
+            "svgWhite": ""
+        },
+        "isAnnotation": false
+    },
+    "model": {
+        "version": "",
+        "name": "aws-s3-controller",
+        "displayName": "",
+        "id": "00000000-0000-0000-0000-000000000000",
+        "registrant": {
+            "kind": ""
+        },
+        "model": {
+            "version": "v1.1.3"
+        }
+    },
+    "schemaVersion": "relationships.meshery.io/v1alpha3",
+    "selectors": [
+        {
+            "allow": {
+                "from": [
+                    {
+                        "id": null,
+                        "kind": "Bucket",
+                        "match": {},
+                        "match_strategy_matrix": [
+                            [
+                                "equal_as_strings",
+                                "not_null"
+                            ]
+                        ],
+                        "model": {
+                            "version": "",
+                            "name": "aws-s3-controller",
+                            "displayName": "",
+                            "id": "00000000-0000-0000-0000-000000000000",
+                            "registrant": {
+                                "kind": "github"
+                            },
+                            "model": {
+                                "version": ""
+                            }
+                        },
+                        "patch": {
+                            "patchStrategy": "replace",
+                            "mutatorRef": [
+                                [
+                                    "displayName"
+                                ]
+                            ]
+                        }
+                    }
+                ],
+                "to": [
+                    {
+                        "id": null,
+                        "kind": "Pod",
+                        "match": {},
+                        "match_strategy_matrix": null,
+                        "model": {
+                            "version": "",
+                            "name": "kubernetes",
+                            "displayName": "",
+                            "id": "00000000-0000-0000-0000-000000000000",
+                            "registrant": {
+                                "kind": "github"
+                            },
+                            "model": {
+                                "version": ""
+                            }
+                        },
+                        "patch": {
+                            "patchStrategy": "replace",
+                            "mutatedRef": [
+                                [
+                                    "configuration",
+                                    "spec",
+                                    "containers",
+                                    "0",
+                                    "env",
+                                    "0",
+                                    "value"
+                                ]
+                            ]
+                        }
+                    }
+                ]
+            },
+            "deny": {
+                "from": [],
+                "to": []
+            }
+        }
+    ],
+    "subType": "reference",
+    "status": "enabled",
+    "type": "non-binding",
+    "version": "v1.0.0"
+}

--- a/server/meshmodel/aws-s3-controller/v1.0.30/v1.0.0/relationships/edge-non-binding-reference-bucket-pod.json
+++ b/server/meshmodel/aws-s3-controller/v1.0.30/v1.0.0/relationships/edge-non-binding-reference-bucket-pod.json
@@ -1,108 +1,110 @@
 {
+  "id": "00000000-0000-0000-0000-000000000000",
+  "evaluationQuery": "",
+  "kind": "edge",
+  "metadata": {
+    "description": "A Bucket provides S3 storage configuration to a Pod by auto-populating the bucket name in environment variables.",
+    "styles": {
+      "primaryColor": "",
+      "svgColor": "",
+      "svgWhite": ""
+    },
+    "isAnnotation": false
+  },
+  "model": {
+    "version": "",
+    "name": "aws-s3-controller",
+    "displayName": "",
     "id": "00000000-0000-0000-0000-000000000000",
-    "evaluationQuery": "",
-    "kind": "edge",
-    "metadata": {
-        "description": "A Bucket provides S3 storage configuration to a Pod by auto-populating the bucket name in environment variables.",
-        "styles": {
-            "primaryColor": "",
-            "svgColor": "",
-            "svgWhite": ""
-        },
-        "isAnnotation": false
+    "registrant": {
+      "kind": ""
     },
     "model": {
-        "version": "",
-        "name": "aws-s3-controller",
-        "displayName": "",
-        "id": "00000000-0000-0000-0000-000000000000",
-        "registrant": {
-            "kind": ""
-        },
-        "model": {
-            "version": "v1.1.3"
-        }
-    },
-    "schemaVersion": "relationships.meshery.io/v1alpha3",
-    "selectors": [
-        {
-            "allow": {
-                "from": [
-                    {
-                        "id": null,
-                        "kind": "Bucket",
-                        "match": {},
-                        "match_strategy_matrix": [
-                            [
-                                "equal_as_strings",
-                                "not_null"
-                            ]
-                        ],
-                        "model": {
-                            "version": "",
-                            "name": "aws-s3-controller",
-                            "displayName": "",
-                            "id": "00000000-0000-0000-0000-000000000000",
-                            "registrant": {
-                                "kind": "github"
-                            },
-                            "model": {
-                                "version": ""
-                            }
-                        },
-                        "patch": {
-                            "patchStrategy": "replace",
-                            "mutatorRef": [
-                                [
-                                    "displayName"
-                                ]
-                            ]
-                        }
-                    }
-                ],
-                "to": [
-                    {
-                        "id": null,
-                        "kind": "Pod",
-                        "match": {},
-                        "match_strategy_matrix": null,
-                        "model": {
-                            "version": "",
-                            "name": "kubernetes",
-                            "displayName": "",
-                            "id": "00000000-0000-0000-0000-000000000000",
-                            "registrant": {
-                                "kind": "github"
-                            },
-                            "model": {
-                                "version": ""
-                            }
-                        },
-                        "patch": {
-                            "patchStrategy": "replace",
-                            "mutatedRef": [
-                                [
-                                    "configuration",
-                                    "spec",
-                                    "containers",
-                                    "0",
-                                    "env",
-                                    "0",
-                                    "value"
-                                ]
-                            ]
-                        }
-                    }
-                ]
+      "version": "v1.0.30"
+    }
+  },
+  "schemaVersion": "relationships.meshery.io/v1alpha3",
+  "selectors": [
+    {
+      "allow": {
+        "from": [
+          {
+            "id": null,
+            "kind": "Bucket",
+            "match": {},
+            "match_strategy_matrix": [
+              [
+                "equal_as_strings",
+                "not_null"
+              ]
+            ],
+            "model": {
+              "version": "",
+              "name": "aws-s3-controller",
+              "displayName": "",
+              "id": "00000000-0000-0000-0000-000000000000",
+              "registrant": {
+                "kind": "github"
+              },
+              "model": {
+                "version": ""
+              }
             },
-            "deny": {
-                "from": [],
-                "to": []
+            "patch": {
+              "patchStrategy": "replace",
+              "mutatorRef": [
+                [
+                  "configuration",
+                  "spec",
+                  "name"
+                ]
+              ]
             }
-        }
-    ],
-    "subType": "reference",
-    "status": "enabled",
-    "type": "non-binding",
-    "version": "v1.0.0"
+          }
+        ],
+        "to": [
+          {
+            "id": null,
+            "kind": "Pod",
+            "match": {},
+            "match_strategy_matrix": null,
+            "model": {
+              "version": "",
+              "name": "kubernetes",
+              "displayName": "",
+              "id": "00000000-0000-0000-0000-000000000000",
+              "registrant": {
+                "kind": "github"
+              },
+              "model": {
+                "version": ""
+              }
+            },
+            "patch": {
+              "patchStrategy": "replace",
+              "mutatedRef": [
+                [
+                  "configuration",
+                  "spec",
+                  "containers",
+                  "0",
+                  "env",
+                  "0",
+                  "value"
+                ]
+              ]
+            }
+          }
+        ]
+      },
+      "deny": {
+        "from": [],
+        "to": []
+      }
+    }
+  ],
+  "subType": "reference",
+  "status": "enabled",
+  "type": "non-binding",
+  "version": "v1.0.0"
 }

--- a/server/meshmodel/aws-s3-controller/v1.0.31/v1.0.0/relationships/edge-non-binding-reference-bucket-deployment.json
+++ b/server/meshmodel/aws-s3-controller/v1.0.31/v1.0.0/relationships/edge-non-binding-reference-bucket-deployment.json
@@ -1,110 +1,112 @@
 {
+  "id": "00000000-0000-0000-0000-000000000000",
+  "evaluationQuery": "",
+  "kind": "edge",
+  "metadata": {
+    "description": "A Bucket provides S3 storage configuration to a Deployment by auto-populating the bucket name in environment variables.",
+    "styles": {
+      "primaryColor": "",
+      "svgColor": "",
+      "svgWhite": ""
+    },
+    "isAnnotation": false
+  },
+  "model": {
+    "version": "",
+    "name": "aws-s3-controller",
+    "displayName": "",
     "id": "00000000-0000-0000-0000-000000000000",
-    "evaluationQuery": "",
-    "kind": "edge",
-    "metadata": {
-        "description": "A Bucket provides S3 storage configuration to a Deployment by auto-populating the bucket name in environment variables.",
-        "styles": {
-            "primaryColor": "",
-            "svgColor": "",
-            "svgWhite": ""
-        },
-        "isAnnotation": false
+    "registrant": {
+      "kind": ""
     },
     "model": {
-        "version": "",
-        "name": "aws-s3-controller",
-        "displayName": "",
-        "id": "00000000-0000-0000-0000-000000000000",
-        "registrant": {
-            "kind": ""
-        },
-        "model": {
-            "version": "v1.1.3"
-        }
-    },
-    "schemaVersion": "relationships.meshery.io/v1alpha3",
-    "selectors": [
-        {
-            "allow": {
-                "from": [
-                    {
-                        "id": null,
-                        "kind": "Bucket",
-                        "match": {},
-                        "match_strategy_matrix": [
-                            [
-                                "equal_as_strings",
-                                "not_null"
-                            ]
-                        ],
-                        "model": {
-                            "version": "",
-                            "name": "aws-s3-controller",
-                            "displayName": "",
-                            "id": "00000000-0000-0000-0000-000000000000",
-                            "registrant": {
-                                "kind": "github"
-                            },
-                            "model": {
-                                "version": ""
-                            }
-                        },
-                        "patch": {
-                            "patchStrategy": "replace",
-                            "mutatorRef": [
-                                [
-                                    "displayName"
-                                ]
-                            ]
-                        }
-                    }
-                ],
-                "to": [
-                    {
-                        "id": null,
-                        "kind": "Deployment",
-                        "match": {},
-                        "match_strategy_matrix": null,
-                        "model": {
-                            "version": "",
-                            "name": "kubernetes",
-                            "displayName": "",
-                            "id": "00000000-0000-0000-0000-000000000000",
-                            "registrant": {
-                                "kind": "github"
-                            },
-                            "model": {
-                                "version": ""
-                            }
-                        },
-                        "patch": {
-                            "patchStrategy": "replace",
-                            "mutatedRef": [
-                                [
-                                    "configuration",
-                                    "spec",
-                                    "template",
-                                    "spec",
-                                    "containers",
-                                    "0",
-                                    "env",
-                                    "0",
-                                    "value"
-                                ]
-                            ]
-                        }
-                    }
-                ]
+      "version": "v1.0.31"
+    }
+  },
+  "schemaVersion": "relationships.meshery.io/v1alpha3",
+  "selectors": [
+    {
+      "allow": {
+        "from": [
+          {
+            "id": null,
+            "kind": "Bucket",
+            "match": {},
+            "match_strategy_matrix": [
+              [
+                "equal_as_strings",
+                "not_null"
+              ]
+            ],
+            "model": {
+              "version": "",
+              "name": "aws-s3-controller",
+              "displayName": "",
+              "id": "00000000-0000-0000-0000-000000000000",
+              "registrant": {
+                "kind": "github"
+              },
+              "model": {
+                "version": ""
+              }
             },
-            "deny": {
-                "from": [],
-                "to": []
+            "patch": {
+              "patchStrategy": "replace",
+              "mutatorRef": [
+                [
+                  "configuration",
+                  "spec",
+                  "name"
+                ]
+              ]
             }
-        }
-    ],
-    "subType": "reference",
-    "status": "enabled",
-    "type": "non-binding",
-    "version": "v1.0.0"
+          }
+        ],
+        "to": [
+          {
+            "id": null,
+            "kind": "Deployment",
+            "match": {},
+            "match_strategy_matrix": null,
+            "model": {
+              "version": "",
+              "name": "kubernetes",
+              "displayName": "",
+              "id": "00000000-0000-0000-0000-000000000000",
+              "registrant": {
+                "kind": "github"
+              },
+              "model": {
+                "version": ""
+              }
+            },
+            "patch": {
+              "patchStrategy": "replace",
+              "mutatedRef": [
+                [
+                  "configuration",
+                  "spec",
+                  "template",
+                  "spec",
+                  "containers",
+                  "0",
+                  "env",
+                  "0",
+                  "value"
+                ]
+              ]
+            }
+          }
+        ]
+      },
+      "deny": {
+        "from": [],
+        "to": []
+      }
+    }
+  ],
+  "subType": "reference",
+  "status": "enabled",
+  "type": "non-binding",
+  "version": "v1.0.0"
 }

--- a/server/meshmodel/aws-s3-controller/v1.0.31/v1.0.0/relationships/edge-non-binding-reference-bucket-deployment.json
+++ b/server/meshmodel/aws-s3-controller/v1.0.31/v1.0.0/relationships/edge-non-binding-reference-bucket-deployment.json
@@ -1,0 +1,110 @@
+{
+    "id": "00000000-0000-0000-0000-000000000000",
+    "evaluationQuery": "",
+    "kind": "edge",
+    "metadata": {
+        "description": "A Bucket provides S3 storage configuration to a Deployment by auto-populating the bucket name in environment variables.",
+        "styles": {
+            "primaryColor": "",
+            "svgColor": "",
+            "svgWhite": ""
+        },
+        "isAnnotation": false
+    },
+    "model": {
+        "version": "",
+        "name": "aws-s3-controller",
+        "displayName": "",
+        "id": "00000000-0000-0000-0000-000000000000",
+        "registrant": {
+            "kind": ""
+        },
+        "model": {
+            "version": "v1.1.3"
+        }
+    },
+    "schemaVersion": "relationships.meshery.io/v1alpha3",
+    "selectors": [
+        {
+            "allow": {
+                "from": [
+                    {
+                        "id": null,
+                        "kind": "Bucket",
+                        "match": {},
+                        "match_strategy_matrix": [
+                            [
+                                "equal_as_strings",
+                                "not_null"
+                            ]
+                        ],
+                        "model": {
+                            "version": "",
+                            "name": "aws-s3-controller",
+                            "displayName": "",
+                            "id": "00000000-0000-0000-0000-000000000000",
+                            "registrant": {
+                                "kind": "github"
+                            },
+                            "model": {
+                                "version": ""
+                            }
+                        },
+                        "patch": {
+                            "patchStrategy": "replace",
+                            "mutatorRef": [
+                                [
+                                    "displayName"
+                                ]
+                            ]
+                        }
+                    }
+                ],
+                "to": [
+                    {
+                        "id": null,
+                        "kind": "Deployment",
+                        "match": {},
+                        "match_strategy_matrix": null,
+                        "model": {
+                            "version": "",
+                            "name": "kubernetes",
+                            "displayName": "",
+                            "id": "00000000-0000-0000-0000-000000000000",
+                            "registrant": {
+                                "kind": "github"
+                            },
+                            "model": {
+                                "version": ""
+                            }
+                        },
+                        "patch": {
+                            "patchStrategy": "replace",
+                            "mutatedRef": [
+                                [
+                                    "configuration",
+                                    "spec",
+                                    "template",
+                                    "spec",
+                                    "containers",
+                                    "0",
+                                    "env",
+                                    "0",
+                                    "value"
+                                ]
+                            ]
+                        }
+                    }
+                ]
+            },
+            "deny": {
+                "from": [],
+                "to": []
+            }
+        }
+    ],
+    "subType": "reference",
+    "status": "enabled",
+    "type": "non-binding",
+    "version": "v1.0.0"
+}

--- a/server/meshmodel/aws-s3-controller/v1.0.31/v1.0.0/relationships/edge-non-binding-reference-bucket-pod.json
+++ b/server/meshmodel/aws-s3-controller/v1.0.31/v1.0.0/relationships/edge-non-binding-reference-bucket-pod.json
@@ -1,0 +1,108 @@
+{
+    "id": "00000000-0000-0000-0000-000000000000",
+    "evaluationQuery": "",
+    "kind": "edge",
+    "metadata": {
+        "description": "A Bucket provides S3 storage configuration to a Pod by auto-populating the bucket name in environment variables.",
+        "styles": {
+            "primaryColor": "",
+            "svgColor": "",
+            "svgWhite": ""
+        },
+        "isAnnotation": false
+    },
+    "model": {
+        "version": "",
+        "name": "aws-s3-controller",
+        "displayName": "",
+        "id": "00000000-0000-0000-0000-000000000000",
+        "registrant": {
+            "kind": ""
+        },
+        "model": {
+            "version": "v1.1.3"
+        }
+    },
+    "schemaVersion": "relationships.meshery.io/v1alpha3",
+    "selectors": [
+        {
+            "allow": {
+                "from": [
+                    {
+                        "id": null,
+                        "kind": "Bucket",
+                        "match": {},
+                        "match_strategy_matrix": [
+                            [
+                                "equal_as_strings",
+                                "not_null"
+                            ]
+                        ],
+                        "model": {
+                            "version": "",
+                            "name": "aws-s3-controller",
+                            "displayName": "",
+                            "id": "00000000-0000-0000-0000-000000000000",
+                            "registrant": {
+                                "kind": "github"
+                            },
+                            "model": {
+                                "version": ""
+                            }
+                        },
+                        "patch": {
+                            "patchStrategy": "replace",
+                            "mutatorRef": [
+                                [
+                                    "displayName"
+                                ]
+                            ]
+                        }
+                    }
+                ],
+                "to": [
+                    {
+                        "id": null,
+                        "kind": "Pod",
+                        "match": {},
+                        "match_strategy_matrix": null,
+                        "model": {
+                            "version": "",
+                            "name": "kubernetes",
+                            "displayName": "",
+                            "id": "00000000-0000-0000-0000-000000000000",
+                            "registrant": {
+                                "kind": "github"
+                            },
+                            "model": {
+                                "version": ""
+                            }
+                        },
+                        "patch": {
+                            "patchStrategy": "replace",
+                            "mutatedRef": [
+                                [
+                                    "configuration",
+                                    "spec",
+                                    "containers",
+                                    "0",
+                                    "env",
+                                    "0",
+                                    "value"
+                                ]
+                            ]
+                        }
+                    }
+                ]
+            },
+            "deny": {
+                "from": [],
+                "to": []
+            }
+        }
+    ],
+    "subType": "reference",
+    "status": "enabled",
+    "type": "non-binding",
+    "version": "v1.0.0"
+}

--- a/server/meshmodel/aws-s3-controller/v1.0.31/v1.0.0/relationships/edge-non-binding-reference-bucket-pod.json
+++ b/server/meshmodel/aws-s3-controller/v1.0.31/v1.0.0/relationships/edge-non-binding-reference-bucket-pod.json
@@ -1,108 +1,110 @@
 {
+  "id": "00000000-0000-0000-0000-000000000000",
+  "evaluationQuery": "",
+  "kind": "edge",
+  "metadata": {
+    "description": "A Bucket provides S3 storage configuration to a Pod by auto-populating the bucket name in environment variables.",
+    "styles": {
+      "primaryColor": "",
+      "svgColor": "",
+      "svgWhite": ""
+    },
+    "isAnnotation": false
+  },
+  "model": {
+    "version": "",
+    "name": "aws-s3-controller",
+    "displayName": "",
     "id": "00000000-0000-0000-0000-000000000000",
-    "evaluationQuery": "",
-    "kind": "edge",
-    "metadata": {
-        "description": "A Bucket provides S3 storage configuration to a Pod by auto-populating the bucket name in environment variables.",
-        "styles": {
-            "primaryColor": "",
-            "svgColor": "",
-            "svgWhite": ""
-        },
-        "isAnnotation": false
+    "registrant": {
+      "kind": ""
     },
     "model": {
-        "version": "",
-        "name": "aws-s3-controller",
-        "displayName": "",
-        "id": "00000000-0000-0000-0000-000000000000",
-        "registrant": {
-            "kind": ""
-        },
-        "model": {
-            "version": "v1.1.3"
-        }
-    },
-    "schemaVersion": "relationships.meshery.io/v1alpha3",
-    "selectors": [
-        {
-            "allow": {
-                "from": [
-                    {
-                        "id": null,
-                        "kind": "Bucket",
-                        "match": {},
-                        "match_strategy_matrix": [
-                            [
-                                "equal_as_strings",
-                                "not_null"
-                            ]
-                        ],
-                        "model": {
-                            "version": "",
-                            "name": "aws-s3-controller",
-                            "displayName": "",
-                            "id": "00000000-0000-0000-0000-000000000000",
-                            "registrant": {
-                                "kind": "github"
-                            },
-                            "model": {
-                                "version": ""
-                            }
-                        },
-                        "patch": {
-                            "patchStrategy": "replace",
-                            "mutatorRef": [
-                                [
-                                    "displayName"
-                                ]
-                            ]
-                        }
-                    }
-                ],
-                "to": [
-                    {
-                        "id": null,
-                        "kind": "Pod",
-                        "match": {},
-                        "match_strategy_matrix": null,
-                        "model": {
-                            "version": "",
-                            "name": "kubernetes",
-                            "displayName": "",
-                            "id": "00000000-0000-0000-0000-000000000000",
-                            "registrant": {
-                                "kind": "github"
-                            },
-                            "model": {
-                                "version": ""
-                            }
-                        },
-                        "patch": {
-                            "patchStrategy": "replace",
-                            "mutatedRef": [
-                                [
-                                    "configuration",
-                                    "spec",
-                                    "containers",
-                                    "0",
-                                    "env",
-                                    "0",
-                                    "value"
-                                ]
-                            ]
-                        }
-                    }
-                ]
+      "version": "v1.0.31"
+    }
+  },
+  "schemaVersion": "relationships.meshery.io/v1alpha3",
+  "selectors": [
+    {
+      "allow": {
+        "from": [
+          {
+            "id": null,
+            "kind": "Bucket",
+            "match": {},
+            "match_strategy_matrix": [
+              [
+                "equal_as_strings",
+                "not_null"
+              ]
+            ],
+            "model": {
+              "version": "",
+              "name": "aws-s3-controller",
+              "displayName": "",
+              "id": "00000000-0000-0000-0000-000000000000",
+              "registrant": {
+                "kind": "github"
+              },
+              "model": {
+                "version": ""
+              }
             },
-            "deny": {
-                "from": [],
-                "to": []
+            "patch": {
+              "patchStrategy": "replace",
+              "mutatorRef": [
+                [
+                  "configuration",
+                  "spec",
+                  "name"
+                ]
+              ]
             }
-        }
-    ],
-    "subType": "reference",
-    "status": "enabled",
-    "type": "non-binding",
-    "version": "v1.0.0"
+          }
+        ],
+        "to": [
+          {
+            "id": null,
+            "kind": "Pod",
+            "match": {},
+            "match_strategy_matrix": null,
+            "model": {
+              "version": "",
+              "name": "kubernetes",
+              "displayName": "",
+              "id": "00000000-0000-0000-0000-000000000000",
+              "registrant": {
+                "kind": "github"
+              },
+              "model": {
+                "version": ""
+              }
+            },
+            "patch": {
+              "patchStrategy": "replace",
+              "mutatedRef": [
+                [
+                  "configuration",
+                  "spec",
+                  "containers",
+                  "0",
+                  "env",
+                  "0",
+                  "value"
+                ]
+              ]
+            }
+          }
+        ]
+      },
+      "deny": {
+        "from": [],
+        "to": []
+      }
+    }
+  ],
+  "subType": "reference",
+  "status": "enabled",
+  "type": "non-binding",
+  "version": "v1.0.0"
 }

--- a/server/meshmodel/aws-s3-controller/v1.0.32/v1.0.0/relationships/edge-non-binding-reference-bucket-deployment.json
+++ b/server/meshmodel/aws-s3-controller/v1.0.32/v1.0.0/relationships/edge-non-binding-reference-bucket-deployment.json
@@ -1,0 +1,110 @@
+{
+    "id": "00000000-0000-0000-0000-000000000000",
+    "evaluationQuery": "",
+    "kind": "edge",
+    "metadata": {
+        "description": "A Bucket provides S3 storage configuration to a Deployment by auto-populating the bucket name in environment variables.",
+        "styles": {
+            "primaryColor": "",
+            "svgColor": "",
+            "svgWhite": ""
+        },
+        "isAnnotation": false
+    },
+    "model": {
+        "version": "",
+        "name": "aws-s3-controller",
+        "displayName": "",
+        "id": "00000000-0000-0000-0000-000000000000",
+        "registrant": {
+            "kind": ""
+        },
+        "model": {
+            "version": "v1.1.3"
+        }
+    },
+    "schemaVersion": "relationships.meshery.io/v1alpha3",
+    "selectors": [
+        {
+            "allow": {
+                "from": [
+                    {
+                        "id": null,
+                        "kind": "Bucket",
+                        "match": {},
+                        "match_strategy_matrix": [
+                            [
+                                "equal_as_strings",
+                                "not_null"
+                            ]
+                        ],
+                        "model": {
+                            "version": "",
+                            "name": "aws-s3-controller",
+                            "displayName": "",
+                            "id": "00000000-0000-0000-0000-000000000000",
+                            "registrant": {
+                                "kind": "github"
+                            },
+                            "model": {
+                                "version": ""
+                            }
+                        },
+                        "patch": {
+                            "patchStrategy": "replace",
+                            "mutatorRef": [
+                                [
+                                    "displayName"
+                                ]
+                            ]
+                        }
+                    }
+                ],
+                "to": [
+                    {
+                        "id": null,
+                        "kind": "Deployment",
+                        "match": {},
+                        "match_strategy_matrix": null,
+                        "model": {
+                            "version": "",
+                            "name": "kubernetes",
+                            "displayName": "",
+                            "id": "00000000-0000-0000-0000-000000000000",
+                            "registrant": {
+                                "kind": "github"
+                            },
+                            "model": {
+                                "version": ""
+                            }
+                        },
+                        "patch": {
+                            "patchStrategy": "replace",
+                            "mutatedRef": [
+                                [
+                                    "configuration",
+                                    "spec",
+                                    "template",
+                                    "spec",
+                                    "containers",
+                                    "0",
+                                    "env",
+                                    "0",
+                                    "value"
+                                ]
+                            ]
+                        }
+                    }
+                ]
+            },
+            "deny": {
+                "from": [],
+                "to": []
+            }
+        }
+    ],
+    "subType": "reference",
+    "status": "enabled",
+    "type": "non-binding",
+    "version": "v1.0.0"
+}

--- a/server/meshmodel/aws-s3-controller/v1.0.32/v1.0.0/relationships/edge-non-binding-reference-bucket-deployment.json
+++ b/server/meshmodel/aws-s3-controller/v1.0.32/v1.0.0/relationships/edge-non-binding-reference-bucket-deployment.json
@@ -1,110 +1,112 @@
 {
+  "id": "00000000-0000-0000-0000-000000000000",
+  "evaluationQuery": "",
+  "kind": "edge",
+  "metadata": {
+    "description": "A Bucket provides S3 storage configuration to a Deployment by auto-populating the bucket name in environment variables.",
+    "styles": {
+      "primaryColor": "",
+      "svgColor": "",
+      "svgWhite": ""
+    },
+    "isAnnotation": false
+  },
+  "model": {
+    "version": "",
+    "name": "aws-s3-controller",
+    "displayName": "",
     "id": "00000000-0000-0000-0000-000000000000",
-    "evaluationQuery": "",
-    "kind": "edge",
-    "metadata": {
-        "description": "A Bucket provides S3 storage configuration to a Deployment by auto-populating the bucket name in environment variables.",
-        "styles": {
-            "primaryColor": "",
-            "svgColor": "",
-            "svgWhite": ""
-        },
-        "isAnnotation": false
+    "registrant": {
+      "kind": ""
     },
     "model": {
-        "version": "",
-        "name": "aws-s3-controller",
-        "displayName": "",
-        "id": "00000000-0000-0000-0000-000000000000",
-        "registrant": {
-            "kind": ""
-        },
-        "model": {
-            "version": "v1.1.3"
-        }
-    },
-    "schemaVersion": "relationships.meshery.io/v1alpha3",
-    "selectors": [
-        {
-            "allow": {
-                "from": [
-                    {
-                        "id": null,
-                        "kind": "Bucket",
-                        "match": {},
-                        "match_strategy_matrix": [
-                            [
-                                "equal_as_strings",
-                                "not_null"
-                            ]
-                        ],
-                        "model": {
-                            "version": "",
-                            "name": "aws-s3-controller",
-                            "displayName": "",
-                            "id": "00000000-0000-0000-0000-000000000000",
-                            "registrant": {
-                                "kind": "github"
-                            },
-                            "model": {
-                                "version": ""
-                            }
-                        },
-                        "patch": {
-                            "patchStrategy": "replace",
-                            "mutatorRef": [
-                                [
-                                    "displayName"
-                                ]
-                            ]
-                        }
-                    }
-                ],
-                "to": [
-                    {
-                        "id": null,
-                        "kind": "Deployment",
-                        "match": {},
-                        "match_strategy_matrix": null,
-                        "model": {
-                            "version": "",
-                            "name": "kubernetes",
-                            "displayName": "",
-                            "id": "00000000-0000-0000-0000-000000000000",
-                            "registrant": {
-                                "kind": "github"
-                            },
-                            "model": {
-                                "version": ""
-                            }
-                        },
-                        "patch": {
-                            "patchStrategy": "replace",
-                            "mutatedRef": [
-                                [
-                                    "configuration",
-                                    "spec",
-                                    "template",
-                                    "spec",
-                                    "containers",
-                                    "0",
-                                    "env",
-                                    "0",
-                                    "value"
-                                ]
-                            ]
-                        }
-                    }
-                ]
+      "version": "v1.0.32"
+    }
+  },
+  "schemaVersion": "relationships.meshery.io/v1alpha3",
+  "selectors": [
+    {
+      "allow": {
+        "from": [
+          {
+            "id": null,
+            "kind": "Bucket",
+            "match": {},
+            "match_strategy_matrix": [
+              [
+                "equal_as_strings",
+                "not_null"
+              ]
+            ],
+            "model": {
+              "version": "",
+              "name": "aws-s3-controller",
+              "displayName": "",
+              "id": "00000000-0000-0000-0000-000000000000",
+              "registrant": {
+                "kind": "github"
+              },
+              "model": {
+                "version": ""
+              }
             },
-            "deny": {
-                "from": [],
-                "to": []
+            "patch": {
+              "patchStrategy": "replace",
+              "mutatorRef": [
+                [
+                  "configuration",
+                  "spec",
+                  "name"
+                ]
+              ]
             }
-        }
-    ],
-    "subType": "reference",
-    "status": "enabled",
-    "type": "non-binding",
-    "version": "v1.0.0"
+          }
+        ],
+        "to": [
+          {
+            "id": null,
+            "kind": "Deployment",
+            "match": {},
+            "match_strategy_matrix": null,
+            "model": {
+              "version": "",
+              "name": "kubernetes",
+              "displayName": "",
+              "id": "00000000-0000-0000-0000-000000000000",
+              "registrant": {
+                "kind": "github"
+              },
+              "model": {
+                "version": ""
+              }
+            },
+            "patch": {
+              "patchStrategy": "replace",
+              "mutatedRef": [
+                [
+                  "configuration",
+                  "spec",
+                  "template",
+                  "spec",
+                  "containers",
+                  "0",
+                  "env",
+                  "0",
+                  "value"
+                ]
+              ]
+            }
+          }
+        ]
+      },
+      "deny": {
+        "from": [],
+        "to": []
+      }
+    }
+  ],
+  "subType": "reference",
+  "status": "enabled",
+  "type": "non-binding",
+  "version": "v1.0.0"
 }

--- a/server/meshmodel/aws-s3-controller/v1.0.32/v1.0.0/relationships/edge-non-binding-reference-bucket-pod.json
+++ b/server/meshmodel/aws-s3-controller/v1.0.32/v1.0.0/relationships/edge-non-binding-reference-bucket-pod.json
@@ -1,0 +1,108 @@
+{
+    "id": "00000000-0000-0000-0000-000000000000",
+    "evaluationQuery": "",
+    "kind": "edge",
+    "metadata": {
+        "description": "A Bucket provides S3 storage configuration to a Pod by auto-populating the bucket name in environment variables.",
+        "styles": {
+            "primaryColor": "",
+            "svgColor": "",
+            "svgWhite": ""
+        },
+        "isAnnotation": false
+    },
+    "model": {
+        "version": "",
+        "name": "aws-s3-controller",
+        "displayName": "",
+        "id": "00000000-0000-0000-0000-000000000000",
+        "registrant": {
+            "kind": ""
+        },
+        "model": {
+            "version": "v1.1.3"
+        }
+    },
+    "schemaVersion": "relationships.meshery.io/v1alpha3",
+    "selectors": [
+        {
+            "allow": {
+                "from": [
+                    {
+                        "id": null,
+                        "kind": "Bucket",
+                        "match": {},
+                        "match_strategy_matrix": [
+                            [
+                                "equal_as_strings",
+                                "not_null"
+                            ]
+                        ],
+                        "model": {
+                            "version": "",
+                            "name": "aws-s3-controller",
+                            "displayName": "",
+                            "id": "00000000-0000-0000-0000-000000000000",
+                            "registrant": {
+                                "kind": "github"
+                            },
+                            "model": {
+                                "version": ""
+                            }
+                        },
+                        "patch": {
+                            "patchStrategy": "replace",
+                            "mutatorRef": [
+                                [
+                                    "displayName"
+                                ]
+                            ]
+                        }
+                    }
+                ],
+                "to": [
+                    {
+                        "id": null,
+                        "kind": "Pod",
+                        "match": {},
+                        "match_strategy_matrix": null,
+                        "model": {
+                            "version": "",
+                            "name": "kubernetes",
+                            "displayName": "",
+                            "id": "00000000-0000-0000-0000-000000000000",
+                            "registrant": {
+                                "kind": "github"
+                            },
+                            "model": {
+                                "version": ""
+                            }
+                        },
+                        "patch": {
+                            "patchStrategy": "replace",
+                            "mutatedRef": [
+                                [
+                                    "configuration",
+                                    "spec",
+                                    "containers",
+                                    "0",
+                                    "env",
+                                    "0",
+                                    "value"
+                                ]
+                            ]
+                        }
+                    }
+                ]
+            },
+            "deny": {
+                "from": [],
+                "to": []
+            }
+        }
+    ],
+    "subType": "reference",
+    "status": "enabled",
+    "type": "non-binding",
+    "version": "v1.0.0"
+}

--- a/server/meshmodel/aws-s3-controller/v1.0.32/v1.0.0/relationships/edge-non-binding-reference-bucket-pod.json
+++ b/server/meshmodel/aws-s3-controller/v1.0.32/v1.0.0/relationships/edge-non-binding-reference-bucket-pod.json
@@ -1,108 +1,110 @@
 {
+  "id": "00000000-0000-0000-0000-000000000000",
+  "evaluationQuery": "",
+  "kind": "edge",
+  "metadata": {
+    "description": "A Bucket provides S3 storage configuration to a Pod by auto-populating the bucket name in environment variables.",
+    "styles": {
+      "primaryColor": "",
+      "svgColor": "",
+      "svgWhite": ""
+    },
+    "isAnnotation": false
+  },
+  "model": {
+    "version": "",
+    "name": "aws-s3-controller",
+    "displayName": "",
     "id": "00000000-0000-0000-0000-000000000000",
-    "evaluationQuery": "",
-    "kind": "edge",
-    "metadata": {
-        "description": "A Bucket provides S3 storage configuration to a Pod by auto-populating the bucket name in environment variables.",
-        "styles": {
-            "primaryColor": "",
-            "svgColor": "",
-            "svgWhite": ""
-        },
-        "isAnnotation": false
+    "registrant": {
+      "kind": ""
     },
     "model": {
-        "version": "",
-        "name": "aws-s3-controller",
-        "displayName": "",
-        "id": "00000000-0000-0000-0000-000000000000",
-        "registrant": {
-            "kind": ""
-        },
-        "model": {
-            "version": "v1.1.3"
-        }
-    },
-    "schemaVersion": "relationships.meshery.io/v1alpha3",
-    "selectors": [
-        {
-            "allow": {
-                "from": [
-                    {
-                        "id": null,
-                        "kind": "Bucket",
-                        "match": {},
-                        "match_strategy_matrix": [
-                            [
-                                "equal_as_strings",
-                                "not_null"
-                            ]
-                        ],
-                        "model": {
-                            "version": "",
-                            "name": "aws-s3-controller",
-                            "displayName": "",
-                            "id": "00000000-0000-0000-0000-000000000000",
-                            "registrant": {
-                                "kind": "github"
-                            },
-                            "model": {
-                                "version": ""
-                            }
-                        },
-                        "patch": {
-                            "patchStrategy": "replace",
-                            "mutatorRef": [
-                                [
-                                    "displayName"
-                                ]
-                            ]
-                        }
-                    }
-                ],
-                "to": [
-                    {
-                        "id": null,
-                        "kind": "Pod",
-                        "match": {},
-                        "match_strategy_matrix": null,
-                        "model": {
-                            "version": "",
-                            "name": "kubernetes",
-                            "displayName": "",
-                            "id": "00000000-0000-0000-0000-000000000000",
-                            "registrant": {
-                                "kind": "github"
-                            },
-                            "model": {
-                                "version": ""
-                            }
-                        },
-                        "patch": {
-                            "patchStrategy": "replace",
-                            "mutatedRef": [
-                                [
-                                    "configuration",
-                                    "spec",
-                                    "containers",
-                                    "0",
-                                    "env",
-                                    "0",
-                                    "value"
-                                ]
-                            ]
-                        }
-                    }
-                ]
+      "version": "v1.0.32"
+    }
+  },
+  "schemaVersion": "relationships.meshery.io/v1alpha3",
+  "selectors": [
+    {
+      "allow": {
+        "from": [
+          {
+            "id": null,
+            "kind": "Bucket",
+            "match": {},
+            "match_strategy_matrix": [
+              [
+                "equal_as_strings",
+                "not_null"
+              ]
+            ],
+            "model": {
+              "version": "",
+              "name": "aws-s3-controller",
+              "displayName": "",
+              "id": "00000000-0000-0000-0000-000000000000",
+              "registrant": {
+                "kind": "github"
+              },
+              "model": {
+                "version": ""
+              }
             },
-            "deny": {
-                "from": [],
-                "to": []
+            "patch": {
+              "patchStrategy": "replace",
+              "mutatorRef": [
+                [
+                  "configuration",
+                  "spec",
+                  "name"
+                ]
+              ]
             }
-        }
-    ],
-    "subType": "reference",
-    "status": "enabled",
-    "type": "non-binding",
-    "version": "v1.0.0"
+          }
+        ],
+        "to": [
+          {
+            "id": null,
+            "kind": "Pod",
+            "match": {},
+            "match_strategy_matrix": null,
+            "model": {
+              "version": "",
+              "name": "kubernetes",
+              "displayName": "",
+              "id": "00000000-0000-0000-0000-000000000000",
+              "registrant": {
+                "kind": "github"
+              },
+              "model": {
+                "version": ""
+              }
+            },
+            "patch": {
+              "patchStrategy": "replace",
+              "mutatedRef": [
+                [
+                  "configuration",
+                  "spec",
+                  "containers",
+                  "0",
+                  "env",
+                  "0",
+                  "value"
+                ]
+              ]
+            }
+          }
+        ]
+      },
+      "deny": {
+        "from": [],
+        "to": []
+      }
+    }
+  ],
+  "subType": "reference",
+  "status": "enabled",
+  "type": "non-binding",
+  "version": "v1.0.0"
 }

--- a/server/meshmodel/aws-s3-controller/v1.0.33/v1.0.0/relationships/edge-non-binding-reference-bucket-deployment.json
+++ b/server/meshmodel/aws-s3-controller/v1.0.33/v1.0.0/relationships/edge-non-binding-reference-bucket-deployment.json
@@ -1,110 +1,112 @@
 {
+  "id": "00000000-0000-0000-0000-000000000000",
+  "evaluationQuery": "",
+  "kind": "edge",
+  "metadata": {
+    "description": "A Bucket provides S3 storage configuration to a Deployment by auto-populating the bucket name in environment variables.",
+    "styles": {
+      "primaryColor": "",
+      "svgColor": "",
+      "svgWhite": ""
+    },
+    "isAnnotation": false
+  },
+  "model": {
+    "version": "",
+    "name": "aws-s3-controller",
+    "displayName": "",
     "id": "00000000-0000-0000-0000-000000000000",
-    "evaluationQuery": "",
-    "kind": "edge",
-    "metadata": {
-        "description": "A Bucket provides S3 storage configuration to a Deployment by auto-populating the bucket name in environment variables.",
-        "styles": {
-            "primaryColor": "",
-            "svgColor": "",
-            "svgWhite": ""
-        },
-        "isAnnotation": false
+    "registrant": {
+      "kind": ""
     },
     "model": {
-        "version": "",
-        "name": "aws-s3-controller",
-        "displayName": "",
-        "id": "00000000-0000-0000-0000-000000000000",
-        "registrant": {
-            "kind": ""
-        },
-        "model": {
-            "version": "v1.1.3"
-        }
-    },
-    "schemaVersion": "relationships.meshery.io/v1alpha3",
-    "selectors": [
-        {
-            "allow": {
-                "from": [
-                    {
-                        "id": null,
-                        "kind": "Bucket",
-                        "match": {},
-                        "match_strategy_matrix": [
-                            [
-                                "equal_as_strings",
-                                "not_null"
-                            ]
-                        ],
-                        "model": {
-                            "version": "",
-                            "name": "aws-s3-controller",
-                            "displayName": "",
-                            "id": "00000000-0000-0000-0000-000000000000",
-                            "registrant": {
-                                "kind": "github"
-                            },
-                            "model": {
-                                "version": ""
-                            }
-                        },
-                        "patch": {
-                            "patchStrategy": "replace",
-                            "mutatorRef": [
-                                [
-                                    "displayName"
-                                ]
-                            ]
-                        }
-                    }
-                ],
-                "to": [
-                    {
-                        "id": null,
-                        "kind": "Deployment",
-                        "match": {},
-                        "match_strategy_matrix": null,
-                        "model": {
-                            "version": "",
-                            "name": "kubernetes",
-                            "displayName": "",
-                            "id": "00000000-0000-0000-0000-000000000000",
-                            "registrant": {
-                                "kind": "github"
-                            },
-                            "model": {
-                                "version": ""
-                            }
-                        },
-                        "patch": {
-                            "patchStrategy": "replace",
-                            "mutatedRef": [
-                                [
-                                    "configuration",
-                                    "spec",
-                                    "template",
-                                    "spec",
-                                    "containers",
-                                    "0",
-                                    "env",
-                                    "0",
-                                    "value"
-                                ]
-                            ]
-                        }
-                    }
-                ]
+      "version": "v1.0.33"
+    }
+  },
+  "schemaVersion": "relationships.meshery.io/v1alpha3",
+  "selectors": [
+    {
+      "allow": {
+        "from": [
+          {
+            "id": null,
+            "kind": "Bucket",
+            "match": {},
+            "match_strategy_matrix": [
+              [
+                "equal_as_strings",
+                "not_null"
+              ]
+            ],
+            "model": {
+              "version": "",
+              "name": "aws-s3-controller",
+              "displayName": "",
+              "id": "00000000-0000-0000-0000-000000000000",
+              "registrant": {
+                "kind": "github"
+              },
+              "model": {
+                "version": ""
+              }
             },
-            "deny": {
-                "from": [],
-                "to": []
+            "patch": {
+              "patchStrategy": "replace",
+              "mutatorRef": [
+                [
+                  "configuration",
+                  "spec",
+                  "name"
+                ]
+              ]
             }
-        }
-    ],
-    "subType": "reference",
-    "status": "enabled",
-    "type": "non-binding",
-    "version": "v1.0.0"
+          }
+        ],
+        "to": [
+          {
+            "id": null,
+            "kind": "Deployment",
+            "match": {},
+            "match_strategy_matrix": null,
+            "model": {
+              "version": "",
+              "name": "kubernetes",
+              "displayName": "",
+              "id": "00000000-0000-0000-0000-000000000000",
+              "registrant": {
+                "kind": "github"
+              },
+              "model": {
+                "version": ""
+              }
+            },
+            "patch": {
+              "patchStrategy": "replace",
+              "mutatedRef": [
+                [
+                  "configuration",
+                  "spec",
+                  "template",
+                  "spec",
+                  "containers",
+                  "0",
+                  "env",
+                  "0",
+                  "value"
+                ]
+              ]
+            }
+          }
+        ]
+      },
+      "deny": {
+        "from": [],
+        "to": []
+      }
+    }
+  ],
+  "subType": "reference",
+  "status": "enabled",
+  "type": "non-binding",
+  "version": "v1.0.0"
 }

--- a/server/meshmodel/aws-s3-controller/v1.0.33/v1.0.0/relationships/edge-non-binding-reference-bucket-deployment.json
+++ b/server/meshmodel/aws-s3-controller/v1.0.33/v1.0.0/relationships/edge-non-binding-reference-bucket-deployment.json
@@ -1,0 +1,110 @@
+{
+    "id": "00000000-0000-0000-0000-000000000000",
+    "evaluationQuery": "",
+    "kind": "edge",
+    "metadata": {
+        "description": "A Bucket provides S3 storage configuration to a Deployment by auto-populating the bucket name in environment variables.",
+        "styles": {
+            "primaryColor": "",
+            "svgColor": "",
+            "svgWhite": ""
+        },
+        "isAnnotation": false
+    },
+    "model": {
+        "version": "",
+        "name": "aws-s3-controller",
+        "displayName": "",
+        "id": "00000000-0000-0000-0000-000000000000",
+        "registrant": {
+            "kind": ""
+        },
+        "model": {
+            "version": "v1.1.3"
+        }
+    },
+    "schemaVersion": "relationships.meshery.io/v1alpha3",
+    "selectors": [
+        {
+            "allow": {
+                "from": [
+                    {
+                        "id": null,
+                        "kind": "Bucket",
+                        "match": {},
+                        "match_strategy_matrix": [
+                            [
+                                "equal_as_strings",
+                                "not_null"
+                            ]
+                        ],
+                        "model": {
+                            "version": "",
+                            "name": "aws-s3-controller",
+                            "displayName": "",
+                            "id": "00000000-0000-0000-0000-000000000000",
+                            "registrant": {
+                                "kind": "github"
+                            },
+                            "model": {
+                                "version": ""
+                            }
+                        },
+                        "patch": {
+                            "patchStrategy": "replace",
+                            "mutatorRef": [
+                                [
+                                    "displayName"
+                                ]
+                            ]
+                        }
+                    }
+                ],
+                "to": [
+                    {
+                        "id": null,
+                        "kind": "Deployment",
+                        "match": {},
+                        "match_strategy_matrix": null,
+                        "model": {
+                            "version": "",
+                            "name": "kubernetes",
+                            "displayName": "",
+                            "id": "00000000-0000-0000-0000-000000000000",
+                            "registrant": {
+                                "kind": "github"
+                            },
+                            "model": {
+                                "version": ""
+                            }
+                        },
+                        "patch": {
+                            "patchStrategy": "replace",
+                            "mutatedRef": [
+                                [
+                                    "configuration",
+                                    "spec",
+                                    "template",
+                                    "spec",
+                                    "containers",
+                                    "0",
+                                    "env",
+                                    "0",
+                                    "value"
+                                ]
+                            ]
+                        }
+                    }
+                ]
+            },
+            "deny": {
+                "from": [],
+                "to": []
+            }
+        }
+    ],
+    "subType": "reference",
+    "status": "enabled",
+    "type": "non-binding",
+    "version": "v1.0.0"
+}

--- a/server/meshmodel/aws-s3-controller/v1.0.33/v1.0.0/relationships/edge-non-binding-reference-bucket-pod.json
+++ b/server/meshmodel/aws-s3-controller/v1.0.33/v1.0.0/relationships/edge-non-binding-reference-bucket-pod.json
@@ -1,108 +1,110 @@
 {
+  "id": "00000000-0000-0000-0000-000000000000",
+  "evaluationQuery": "",
+  "kind": "edge",
+  "metadata": {
+    "description": "A Bucket provides S3 storage configuration to a Pod by auto-populating the bucket name in environment variables.",
+    "styles": {
+      "primaryColor": "",
+      "svgColor": "",
+      "svgWhite": ""
+    },
+    "isAnnotation": false
+  },
+  "model": {
+    "version": "",
+    "name": "aws-s3-controller",
+    "displayName": "",
     "id": "00000000-0000-0000-0000-000000000000",
-    "evaluationQuery": "",
-    "kind": "edge",
-    "metadata": {
-        "description": "A Bucket provides S3 storage configuration to a Pod by auto-populating the bucket name in environment variables.",
-        "styles": {
-            "primaryColor": "",
-            "svgColor": "",
-            "svgWhite": ""
-        },
-        "isAnnotation": false
+    "registrant": {
+      "kind": ""
     },
     "model": {
-        "version": "",
-        "name": "aws-s3-controller",
-        "displayName": "",
-        "id": "00000000-0000-0000-0000-000000000000",
-        "registrant": {
-            "kind": ""
-        },
-        "model": {
-            "version": "v1.1.3"
-        }
-    },
-    "schemaVersion": "relationships.meshery.io/v1alpha3",
-    "selectors": [
-        {
-            "allow": {
-                "from": [
-                    {
-                        "id": null,
-                        "kind": "Bucket",
-                        "match": {},
-                        "match_strategy_matrix": [
-                            [
-                                "equal_as_strings",
-                                "not_null"
-                            ]
-                        ],
-                        "model": {
-                            "version": "",
-                            "name": "aws-s3-controller",
-                            "displayName": "",
-                            "id": "00000000-0000-0000-0000-000000000000",
-                            "registrant": {
-                                "kind": "github"
-                            },
-                            "model": {
-                                "version": ""
-                            }
-                        },
-                        "patch": {
-                            "patchStrategy": "replace",
-                            "mutatorRef": [
-                                [
-                                    "displayName"
-                                ]
-                            ]
-                        }
-                    }
-                ],
-                "to": [
-                    {
-                        "id": null,
-                        "kind": "Pod",
-                        "match": {},
-                        "match_strategy_matrix": null,
-                        "model": {
-                            "version": "",
-                            "name": "kubernetes",
-                            "displayName": "",
-                            "id": "00000000-0000-0000-0000-000000000000",
-                            "registrant": {
-                                "kind": "github"
-                            },
-                            "model": {
-                                "version": ""
-                            }
-                        },
-                        "patch": {
-                            "patchStrategy": "replace",
-                            "mutatedRef": [
-                                [
-                                    "configuration",
-                                    "spec",
-                                    "containers",
-                                    "0",
-                                    "env",
-                                    "0",
-                                    "value"
-                                ]
-                            ]
-                        }
-                    }
-                ]
+      "version": "v1.0.33"
+    }
+  },
+  "schemaVersion": "relationships.meshery.io/v1alpha3",
+  "selectors": [
+    {
+      "allow": {
+        "from": [
+          {
+            "id": null,
+            "kind": "Bucket",
+            "match": {},
+            "match_strategy_matrix": [
+              [
+                "equal_as_strings",
+                "not_null"
+              ]
+            ],
+            "model": {
+              "version": "",
+              "name": "aws-s3-controller",
+              "displayName": "",
+              "id": "00000000-0000-0000-0000-000000000000",
+              "registrant": {
+                "kind": "github"
+              },
+              "model": {
+                "version": ""
+              }
             },
-            "deny": {
-                "from": [],
-                "to": []
+            "patch": {
+              "patchStrategy": "replace",
+              "mutatorRef": [
+                [
+                  "configuration",
+                  "spec",
+                  "name"
+                ]
+              ]
             }
-        }
-    ],
-    "subType": "reference",
-    "status": "enabled",
-    "type": "non-binding",
-    "version": "v1.0.0"
+          }
+        ],
+        "to": [
+          {
+            "id": null,
+            "kind": "Pod",
+            "match": {},
+            "match_strategy_matrix": null,
+            "model": {
+              "version": "",
+              "name": "kubernetes",
+              "displayName": "",
+              "id": "00000000-0000-0000-0000-000000000000",
+              "registrant": {
+                "kind": "github"
+              },
+              "model": {
+                "version": ""
+              }
+            },
+            "patch": {
+              "patchStrategy": "replace",
+              "mutatedRef": [
+                [
+                  "configuration",
+                  "spec",
+                  "containers",
+                  "0",
+                  "env",
+                  "0",
+                  "value"
+                ]
+              ]
+            }
+          }
+        ]
+      },
+      "deny": {
+        "from": [],
+        "to": []
+      }
+    }
+  ],
+  "subType": "reference",
+  "status": "enabled",
+  "type": "non-binding",
+  "version": "v1.0.0"
 }

--- a/server/meshmodel/aws-s3-controller/v1.0.33/v1.0.0/relationships/edge-non-binding-reference-bucket-pod.json
+++ b/server/meshmodel/aws-s3-controller/v1.0.33/v1.0.0/relationships/edge-non-binding-reference-bucket-pod.json
@@ -1,0 +1,108 @@
+{
+    "id": "00000000-0000-0000-0000-000000000000",
+    "evaluationQuery": "",
+    "kind": "edge",
+    "metadata": {
+        "description": "A Bucket provides S3 storage configuration to a Pod by auto-populating the bucket name in environment variables.",
+        "styles": {
+            "primaryColor": "",
+            "svgColor": "",
+            "svgWhite": ""
+        },
+        "isAnnotation": false
+    },
+    "model": {
+        "version": "",
+        "name": "aws-s3-controller",
+        "displayName": "",
+        "id": "00000000-0000-0000-0000-000000000000",
+        "registrant": {
+            "kind": ""
+        },
+        "model": {
+            "version": "v1.1.3"
+        }
+    },
+    "schemaVersion": "relationships.meshery.io/v1alpha3",
+    "selectors": [
+        {
+            "allow": {
+                "from": [
+                    {
+                        "id": null,
+                        "kind": "Bucket",
+                        "match": {},
+                        "match_strategy_matrix": [
+                            [
+                                "equal_as_strings",
+                                "not_null"
+                            ]
+                        ],
+                        "model": {
+                            "version": "",
+                            "name": "aws-s3-controller",
+                            "displayName": "",
+                            "id": "00000000-0000-0000-0000-000000000000",
+                            "registrant": {
+                                "kind": "github"
+                            },
+                            "model": {
+                                "version": ""
+                            }
+                        },
+                        "patch": {
+                            "patchStrategy": "replace",
+                            "mutatorRef": [
+                                [
+                                    "displayName"
+                                ]
+                            ]
+                        }
+                    }
+                ],
+                "to": [
+                    {
+                        "id": null,
+                        "kind": "Pod",
+                        "match": {},
+                        "match_strategy_matrix": null,
+                        "model": {
+                            "version": "",
+                            "name": "kubernetes",
+                            "displayName": "",
+                            "id": "00000000-0000-0000-0000-000000000000",
+                            "registrant": {
+                                "kind": "github"
+                            },
+                            "model": {
+                                "version": ""
+                            }
+                        },
+                        "patch": {
+                            "patchStrategy": "replace",
+                            "mutatedRef": [
+                                [
+                                    "configuration",
+                                    "spec",
+                                    "containers",
+                                    "0",
+                                    "env",
+                                    "0",
+                                    "value"
+                                ]
+                            ]
+                        }
+                    }
+                ]
+            },
+            "deny": {
+                "from": [],
+                "to": []
+            }
+        }
+    ],
+    "subType": "reference",
+    "status": "enabled",
+    "type": "non-binding",
+    "version": "v1.0.0"
+}

--- a/server/meshmodel/aws-s3-controller/v1.0.34/v1.0.0/relationships/edge-non-binding-reference-bucket-deployment.json
+++ b/server/meshmodel/aws-s3-controller/v1.0.34/v1.0.0/relationships/edge-non-binding-reference-bucket-deployment.json
@@ -1,110 +1,112 @@
 {
+  "id": "00000000-0000-0000-0000-000000000000",
+  "evaluationQuery": "",
+  "kind": "edge",
+  "metadata": {
+    "description": "A Bucket provides S3 storage configuration to a Deployment by auto-populating the bucket name in environment variables.",
+    "styles": {
+      "primaryColor": "",
+      "svgColor": "",
+      "svgWhite": ""
+    },
+    "isAnnotation": false
+  },
+  "model": {
+    "version": "",
+    "name": "aws-s3-controller",
+    "displayName": "",
     "id": "00000000-0000-0000-0000-000000000000",
-    "evaluationQuery": "",
-    "kind": "edge",
-    "metadata": {
-        "description": "A Bucket provides S3 storage configuration to a Deployment by auto-populating the bucket name in environment variables.",
-        "styles": {
-            "primaryColor": "",
-            "svgColor": "",
-            "svgWhite": ""
-        },
-        "isAnnotation": false
+    "registrant": {
+      "kind": ""
     },
     "model": {
-        "version": "",
-        "name": "aws-s3-controller",
-        "displayName": "",
-        "id": "00000000-0000-0000-0000-000000000000",
-        "registrant": {
-            "kind": ""
-        },
-        "model": {
-            "version": "v1.1.3"
-        }
-    },
-    "schemaVersion": "relationships.meshery.io/v1alpha3",
-    "selectors": [
-        {
-            "allow": {
-                "from": [
-                    {
-                        "id": null,
-                        "kind": "Bucket",
-                        "match": {},
-                        "match_strategy_matrix": [
-                            [
-                                "equal_as_strings",
-                                "not_null"
-                            ]
-                        ],
-                        "model": {
-                            "version": "",
-                            "name": "aws-s3-controller",
-                            "displayName": "",
-                            "id": "00000000-0000-0000-0000-000000000000",
-                            "registrant": {
-                                "kind": "github"
-                            },
-                            "model": {
-                                "version": ""
-                            }
-                        },
-                        "patch": {
-                            "patchStrategy": "replace",
-                            "mutatorRef": [
-                                [
-                                    "displayName"
-                                ]
-                            ]
-                        }
-                    }
-                ],
-                "to": [
-                    {
-                        "id": null,
-                        "kind": "Deployment",
-                        "match": {},
-                        "match_strategy_matrix": null,
-                        "model": {
-                            "version": "",
-                            "name": "kubernetes",
-                            "displayName": "",
-                            "id": "00000000-0000-0000-0000-000000000000",
-                            "registrant": {
-                                "kind": "github"
-                            },
-                            "model": {
-                                "version": ""
-                            }
-                        },
-                        "patch": {
-                            "patchStrategy": "replace",
-                            "mutatedRef": [
-                                [
-                                    "configuration",
-                                    "spec",
-                                    "template",
-                                    "spec",
-                                    "containers",
-                                    "0",
-                                    "env",
-                                    "0",
-                                    "value"
-                                ]
-                            ]
-                        }
-                    }
-                ]
+      "version": "v1.0.34"
+    }
+  },
+  "schemaVersion": "relationships.meshery.io/v1alpha3",
+  "selectors": [
+    {
+      "allow": {
+        "from": [
+          {
+            "id": null,
+            "kind": "Bucket",
+            "match": {},
+            "match_strategy_matrix": [
+              [
+                "equal_as_strings",
+                "not_null"
+              ]
+            ],
+            "model": {
+              "version": "",
+              "name": "aws-s3-controller",
+              "displayName": "",
+              "id": "00000000-0000-0000-0000-000000000000",
+              "registrant": {
+                "kind": "github"
+              },
+              "model": {
+                "version": ""
+              }
             },
-            "deny": {
-                "from": [],
-                "to": []
+            "patch": {
+              "patchStrategy": "replace",
+              "mutatorRef": [
+                [
+                  "configuration",
+                  "spec",
+                  "name"
+                ]
+              ]
             }
-        }
-    ],
-    "subType": "reference",
-    "status": "enabled",
-    "type": "non-binding",
-    "version": "v1.0.0"
+          }
+        ],
+        "to": [
+          {
+            "id": null,
+            "kind": "Deployment",
+            "match": {},
+            "match_strategy_matrix": null,
+            "model": {
+              "version": "",
+              "name": "kubernetes",
+              "displayName": "",
+              "id": "00000000-0000-0000-0000-000000000000",
+              "registrant": {
+                "kind": "github"
+              },
+              "model": {
+                "version": ""
+              }
+            },
+            "patch": {
+              "patchStrategy": "replace",
+              "mutatedRef": [
+                [
+                  "configuration",
+                  "spec",
+                  "template",
+                  "spec",
+                  "containers",
+                  "0",
+                  "env",
+                  "0",
+                  "value"
+                ]
+              ]
+            }
+          }
+        ]
+      },
+      "deny": {
+        "from": [],
+        "to": []
+      }
+    }
+  ],
+  "subType": "reference",
+  "status": "enabled",
+  "type": "non-binding",
+  "version": "v1.0.0"
 }

--- a/server/meshmodel/aws-s3-controller/v1.0.34/v1.0.0/relationships/edge-non-binding-reference-bucket-deployment.json
+++ b/server/meshmodel/aws-s3-controller/v1.0.34/v1.0.0/relationships/edge-non-binding-reference-bucket-deployment.json
@@ -1,0 +1,110 @@
+{
+    "id": "00000000-0000-0000-0000-000000000000",
+    "evaluationQuery": "",
+    "kind": "edge",
+    "metadata": {
+        "description": "A Bucket provides S3 storage configuration to a Deployment by auto-populating the bucket name in environment variables.",
+        "styles": {
+            "primaryColor": "",
+            "svgColor": "",
+            "svgWhite": ""
+        },
+        "isAnnotation": false
+    },
+    "model": {
+        "version": "",
+        "name": "aws-s3-controller",
+        "displayName": "",
+        "id": "00000000-0000-0000-0000-000000000000",
+        "registrant": {
+            "kind": ""
+        },
+        "model": {
+            "version": "v1.1.3"
+        }
+    },
+    "schemaVersion": "relationships.meshery.io/v1alpha3",
+    "selectors": [
+        {
+            "allow": {
+                "from": [
+                    {
+                        "id": null,
+                        "kind": "Bucket",
+                        "match": {},
+                        "match_strategy_matrix": [
+                            [
+                                "equal_as_strings",
+                                "not_null"
+                            ]
+                        ],
+                        "model": {
+                            "version": "",
+                            "name": "aws-s3-controller",
+                            "displayName": "",
+                            "id": "00000000-0000-0000-0000-000000000000",
+                            "registrant": {
+                                "kind": "github"
+                            },
+                            "model": {
+                                "version": ""
+                            }
+                        },
+                        "patch": {
+                            "patchStrategy": "replace",
+                            "mutatorRef": [
+                                [
+                                    "displayName"
+                                ]
+                            ]
+                        }
+                    }
+                ],
+                "to": [
+                    {
+                        "id": null,
+                        "kind": "Deployment",
+                        "match": {},
+                        "match_strategy_matrix": null,
+                        "model": {
+                            "version": "",
+                            "name": "kubernetes",
+                            "displayName": "",
+                            "id": "00000000-0000-0000-0000-000000000000",
+                            "registrant": {
+                                "kind": "github"
+                            },
+                            "model": {
+                                "version": ""
+                            }
+                        },
+                        "patch": {
+                            "patchStrategy": "replace",
+                            "mutatedRef": [
+                                [
+                                    "configuration",
+                                    "spec",
+                                    "template",
+                                    "spec",
+                                    "containers",
+                                    "0",
+                                    "env",
+                                    "0",
+                                    "value"
+                                ]
+                            ]
+                        }
+                    }
+                ]
+            },
+            "deny": {
+                "from": [],
+                "to": []
+            }
+        }
+    ],
+    "subType": "reference",
+    "status": "enabled",
+    "type": "non-binding",
+    "version": "v1.0.0"
+}

--- a/server/meshmodel/aws-s3-controller/v1.0.34/v1.0.0/relationships/edge-non-binding-reference-bucket-pod.json
+++ b/server/meshmodel/aws-s3-controller/v1.0.34/v1.0.0/relationships/edge-non-binding-reference-bucket-pod.json
@@ -1,108 +1,110 @@
 {
+  "id": "00000000-0000-0000-0000-000000000000",
+  "evaluationQuery": "",
+  "kind": "edge",
+  "metadata": {
+    "description": "A Bucket provides S3 storage configuration to a Pod by auto-populating the bucket name in environment variables.",
+    "styles": {
+      "primaryColor": "",
+      "svgColor": "",
+      "svgWhite": ""
+    },
+    "isAnnotation": false
+  },
+  "model": {
+    "version": "",
+    "name": "aws-s3-controller",
+    "displayName": "",
     "id": "00000000-0000-0000-0000-000000000000",
-    "evaluationQuery": "",
-    "kind": "edge",
-    "metadata": {
-        "description": "A Bucket provides S3 storage configuration to a Pod by auto-populating the bucket name in environment variables.",
-        "styles": {
-            "primaryColor": "",
-            "svgColor": "",
-            "svgWhite": ""
-        },
-        "isAnnotation": false
+    "registrant": {
+      "kind": ""
     },
     "model": {
-        "version": "",
-        "name": "aws-s3-controller",
-        "displayName": "",
-        "id": "00000000-0000-0000-0000-000000000000",
-        "registrant": {
-            "kind": ""
-        },
-        "model": {
-            "version": "v1.1.3"
-        }
-    },
-    "schemaVersion": "relationships.meshery.io/v1alpha3",
-    "selectors": [
-        {
-            "allow": {
-                "from": [
-                    {
-                        "id": null,
-                        "kind": "Bucket",
-                        "match": {},
-                        "match_strategy_matrix": [
-                            [
-                                "equal_as_strings",
-                                "not_null"
-                            ]
-                        ],
-                        "model": {
-                            "version": "",
-                            "name": "aws-s3-controller",
-                            "displayName": "",
-                            "id": "00000000-0000-0000-0000-000000000000",
-                            "registrant": {
-                                "kind": "github"
-                            },
-                            "model": {
-                                "version": ""
-                            }
-                        },
-                        "patch": {
-                            "patchStrategy": "replace",
-                            "mutatorRef": [
-                                [
-                                    "displayName"
-                                ]
-                            ]
-                        }
-                    }
-                ],
-                "to": [
-                    {
-                        "id": null,
-                        "kind": "Pod",
-                        "match": {},
-                        "match_strategy_matrix": null,
-                        "model": {
-                            "version": "",
-                            "name": "kubernetes",
-                            "displayName": "",
-                            "id": "00000000-0000-0000-0000-000000000000",
-                            "registrant": {
-                                "kind": "github"
-                            },
-                            "model": {
-                                "version": ""
-                            }
-                        },
-                        "patch": {
-                            "patchStrategy": "replace",
-                            "mutatedRef": [
-                                [
-                                    "configuration",
-                                    "spec",
-                                    "containers",
-                                    "0",
-                                    "env",
-                                    "0",
-                                    "value"
-                                ]
-                            ]
-                        }
-                    }
-                ]
+      "version": "v1.0.34"
+    }
+  },
+  "schemaVersion": "relationships.meshery.io/v1alpha3",
+  "selectors": [
+    {
+      "allow": {
+        "from": [
+          {
+            "id": null,
+            "kind": "Bucket",
+            "match": {},
+            "match_strategy_matrix": [
+              [
+                "equal_as_strings",
+                "not_null"
+              ]
+            ],
+            "model": {
+              "version": "",
+              "name": "aws-s3-controller",
+              "displayName": "",
+              "id": "00000000-0000-0000-0000-000000000000",
+              "registrant": {
+                "kind": "github"
+              },
+              "model": {
+                "version": ""
+              }
             },
-            "deny": {
-                "from": [],
-                "to": []
+            "patch": {
+              "patchStrategy": "replace",
+              "mutatorRef": [
+                [
+                  "configuration",
+                  "spec",
+                  "name"
+                ]
+              ]
             }
-        }
-    ],
-    "subType": "reference",
-    "status": "enabled",
-    "type": "non-binding",
-    "version": "v1.0.0"
+          }
+        ],
+        "to": [
+          {
+            "id": null,
+            "kind": "Pod",
+            "match": {},
+            "match_strategy_matrix": null,
+            "model": {
+              "version": "",
+              "name": "kubernetes",
+              "displayName": "",
+              "id": "00000000-0000-0000-0000-000000000000",
+              "registrant": {
+                "kind": "github"
+              },
+              "model": {
+                "version": ""
+              }
+            },
+            "patch": {
+              "patchStrategy": "replace",
+              "mutatedRef": [
+                [
+                  "configuration",
+                  "spec",
+                  "containers",
+                  "0",
+                  "env",
+                  "0",
+                  "value"
+                ]
+              ]
+            }
+          }
+        ]
+      },
+      "deny": {
+        "from": [],
+        "to": []
+      }
+    }
+  ],
+  "subType": "reference",
+  "status": "enabled",
+  "type": "non-binding",
+  "version": "v1.0.0"
 }

--- a/server/meshmodel/aws-s3-controller/v1.0.34/v1.0.0/relationships/edge-non-binding-reference-bucket-pod.json
+++ b/server/meshmodel/aws-s3-controller/v1.0.34/v1.0.0/relationships/edge-non-binding-reference-bucket-pod.json
@@ -1,0 +1,108 @@
+{
+    "id": "00000000-0000-0000-0000-000000000000",
+    "evaluationQuery": "",
+    "kind": "edge",
+    "metadata": {
+        "description": "A Bucket provides S3 storage configuration to a Pod by auto-populating the bucket name in environment variables.",
+        "styles": {
+            "primaryColor": "",
+            "svgColor": "",
+            "svgWhite": ""
+        },
+        "isAnnotation": false
+    },
+    "model": {
+        "version": "",
+        "name": "aws-s3-controller",
+        "displayName": "",
+        "id": "00000000-0000-0000-0000-000000000000",
+        "registrant": {
+            "kind": ""
+        },
+        "model": {
+            "version": "v1.1.3"
+        }
+    },
+    "schemaVersion": "relationships.meshery.io/v1alpha3",
+    "selectors": [
+        {
+            "allow": {
+                "from": [
+                    {
+                        "id": null,
+                        "kind": "Bucket",
+                        "match": {},
+                        "match_strategy_matrix": [
+                            [
+                                "equal_as_strings",
+                                "not_null"
+                            ]
+                        ],
+                        "model": {
+                            "version": "",
+                            "name": "aws-s3-controller",
+                            "displayName": "",
+                            "id": "00000000-0000-0000-0000-000000000000",
+                            "registrant": {
+                                "kind": "github"
+                            },
+                            "model": {
+                                "version": ""
+                            }
+                        },
+                        "patch": {
+                            "patchStrategy": "replace",
+                            "mutatorRef": [
+                                [
+                                    "displayName"
+                                ]
+                            ]
+                        }
+                    }
+                ],
+                "to": [
+                    {
+                        "id": null,
+                        "kind": "Pod",
+                        "match": {},
+                        "match_strategy_matrix": null,
+                        "model": {
+                            "version": "",
+                            "name": "kubernetes",
+                            "displayName": "",
+                            "id": "00000000-0000-0000-0000-000000000000",
+                            "registrant": {
+                                "kind": "github"
+                            },
+                            "model": {
+                                "version": ""
+                            }
+                        },
+                        "patch": {
+                            "patchStrategy": "replace",
+                            "mutatedRef": [
+                                [
+                                    "configuration",
+                                    "spec",
+                                    "containers",
+                                    "0",
+                                    "env",
+                                    "0",
+                                    "value"
+                                ]
+                            ]
+                        }
+                    }
+                ]
+            },
+            "deny": {
+                "from": [],
+                "to": []
+            }
+        }
+    ],
+    "subType": "reference",
+    "status": "enabled",
+    "type": "non-binding",
+    "version": "v1.0.0"
+}

--- a/server/meshmodel/aws-s3-controller/v1.0.35/v1.0.0/relationships/edge-non-binding-reference-bucket-deployment.json
+++ b/server/meshmodel/aws-s3-controller/v1.0.35/v1.0.0/relationships/edge-non-binding-reference-bucket-deployment.json
@@ -1,110 +1,112 @@
 {
+  "id": "00000000-0000-0000-0000-000000000000",
+  "evaluationQuery": "",
+  "kind": "edge",
+  "metadata": {
+    "description": "A Bucket provides S3 storage configuration to a Deployment by auto-populating the bucket name in environment variables.",
+    "styles": {
+      "primaryColor": "",
+      "svgColor": "",
+      "svgWhite": ""
+    },
+    "isAnnotation": false
+  },
+  "model": {
+    "version": "",
+    "name": "aws-s3-controller",
+    "displayName": "",
     "id": "00000000-0000-0000-0000-000000000000",
-    "evaluationQuery": "",
-    "kind": "edge",
-    "metadata": {
-        "description": "A Bucket provides S3 storage configuration to a Deployment by auto-populating the bucket name in environment variables.",
-        "styles": {
-            "primaryColor": "",
-            "svgColor": "",
-            "svgWhite": ""
-        },
-        "isAnnotation": false
+    "registrant": {
+      "kind": ""
     },
     "model": {
-        "version": "",
-        "name": "aws-s3-controller",
-        "displayName": "",
-        "id": "00000000-0000-0000-0000-000000000000",
-        "registrant": {
-            "kind": ""
-        },
-        "model": {
-            "version": "v1.1.3"
-        }
-    },
-    "schemaVersion": "relationships.meshery.io/v1alpha3",
-    "selectors": [
-        {
-            "allow": {
-                "from": [
-                    {
-                        "id": null,
-                        "kind": "Bucket",
-                        "match": {},
-                        "match_strategy_matrix": [
-                            [
-                                "equal_as_strings",
-                                "not_null"
-                            ]
-                        ],
-                        "model": {
-                            "version": "",
-                            "name": "aws-s3-controller",
-                            "displayName": "",
-                            "id": "00000000-0000-0000-0000-000000000000",
-                            "registrant": {
-                                "kind": "github"
-                            },
-                            "model": {
-                                "version": ""
-                            }
-                        },
-                        "patch": {
-                            "patchStrategy": "replace",
-                            "mutatorRef": [
-                                [
-                                    "displayName"
-                                ]
-                            ]
-                        }
-                    }
-                ],
-                "to": [
-                    {
-                        "id": null,
-                        "kind": "Deployment",
-                        "match": {},
-                        "match_strategy_matrix": null,
-                        "model": {
-                            "version": "",
-                            "name": "kubernetes",
-                            "displayName": "",
-                            "id": "00000000-0000-0000-0000-000000000000",
-                            "registrant": {
-                                "kind": "github"
-                            },
-                            "model": {
-                                "version": ""
-                            }
-                        },
-                        "patch": {
-                            "patchStrategy": "replace",
-                            "mutatedRef": [
-                                [
-                                    "configuration",
-                                    "spec",
-                                    "template",
-                                    "spec",
-                                    "containers",
-                                    "0",
-                                    "env",
-                                    "0",
-                                    "value"
-                                ]
-                            ]
-                        }
-                    }
-                ]
+      "version": "v1.0.35"
+    }
+  },
+  "schemaVersion": "relationships.meshery.io/v1alpha3",
+  "selectors": [
+    {
+      "allow": {
+        "from": [
+          {
+            "id": null,
+            "kind": "Bucket",
+            "match": {},
+            "match_strategy_matrix": [
+              [
+                "equal_as_strings",
+                "not_null"
+              ]
+            ],
+            "model": {
+              "version": "",
+              "name": "aws-s3-controller",
+              "displayName": "",
+              "id": "00000000-0000-0000-0000-000000000000",
+              "registrant": {
+                "kind": "github"
+              },
+              "model": {
+                "version": ""
+              }
             },
-            "deny": {
-                "from": [],
-                "to": []
+            "patch": {
+              "patchStrategy": "replace",
+              "mutatorRef": [
+                [
+                  "configuration",
+                  "spec",
+                  "name"
+                ]
+              ]
             }
-        }
-    ],
-    "subType": "reference",
-    "status": "enabled",
-    "type": "non-binding",
-    "version": "v1.0.0"
+          }
+        ],
+        "to": [
+          {
+            "id": null,
+            "kind": "Deployment",
+            "match": {},
+            "match_strategy_matrix": null,
+            "model": {
+              "version": "",
+              "name": "kubernetes",
+              "displayName": "",
+              "id": "00000000-0000-0000-0000-000000000000",
+              "registrant": {
+                "kind": "github"
+              },
+              "model": {
+                "version": ""
+              }
+            },
+            "patch": {
+              "patchStrategy": "replace",
+              "mutatedRef": [
+                [
+                  "configuration",
+                  "spec",
+                  "template",
+                  "spec",
+                  "containers",
+                  "0",
+                  "env",
+                  "0",
+                  "value"
+                ]
+              ]
+            }
+          }
+        ]
+      },
+      "deny": {
+        "from": [],
+        "to": []
+      }
+    }
+  ],
+  "subType": "reference",
+  "status": "enabled",
+  "type": "non-binding",
+  "version": "v1.0.0"
 }

--- a/server/meshmodel/aws-s3-controller/v1.0.35/v1.0.0/relationships/edge-non-binding-reference-bucket-deployment.json
+++ b/server/meshmodel/aws-s3-controller/v1.0.35/v1.0.0/relationships/edge-non-binding-reference-bucket-deployment.json
@@ -1,0 +1,110 @@
+{
+    "id": "00000000-0000-0000-0000-000000000000",
+    "evaluationQuery": "",
+    "kind": "edge",
+    "metadata": {
+        "description": "A Bucket provides S3 storage configuration to a Deployment by auto-populating the bucket name in environment variables.",
+        "styles": {
+            "primaryColor": "",
+            "svgColor": "",
+            "svgWhite": ""
+        },
+        "isAnnotation": false
+    },
+    "model": {
+        "version": "",
+        "name": "aws-s3-controller",
+        "displayName": "",
+        "id": "00000000-0000-0000-0000-000000000000",
+        "registrant": {
+            "kind": ""
+        },
+        "model": {
+            "version": "v1.1.3"
+        }
+    },
+    "schemaVersion": "relationships.meshery.io/v1alpha3",
+    "selectors": [
+        {
+            "allow": {
+                "from": [
+                    {
+                        "id": null,
+                        "kind": "Bucket",
+                        "match": {},
+                        "match_strategy_matrix": [
+                            [
+                                "equal_as_strings",
+                                "not_null"
+                            ]
+                        ],
+                        "model": {
+                            "version": "",
+                            "name": "aws-s3-controller",
+                            "displayName": "",
+                            "id": "00000000-0000-0000-0000-000000000000",
+                            "registrant": {
+                                "kind": "github"
+                            },
+                            "model": {
+                                "version": ""
+                            }
+                        },
+                        "patch": {
+                            "patchStrategy": "replace",
+                            "mutatorRef": [
+                                [
+                                    "displayName"
+                                ]
+                            ]
+                        }
+                    }
+                ],
+                "to": [
+                    {
+                        "id": null,
+                        "kind": "Deployment",
+                        "match": {},
+                        "match_strategy_matrix": null,
+                        "model": {
+                            "version": "",
+                            "name": "kubernetes",
+                            "displayName": "",
+                            "id": "00000000-0000-0000-0000-000000000000",
+                            "registrant": {
+                                "kind": "github"
+                            },
+                            "model": {
+                                "version": ""
+                            }
+                        },
+                        "patch": {
+                            "patchStrategy": "replace",
+                            "mutatedRef": [
+                                [
+                                    "configuration",
+                                    "spec",
+                                    "template",
+                                    "spec",
+                                    "containers",
+                                    "0",
+                                    "env",
+                                    "0",
+                                    "value"
+                                ]
+                            ]
+                        }
+                    }
+                ]
+            },
+            "deny": {
+                "from": [],
+                "to": []
+            }
+        }
+    ],
+    "subType": "reference",
+    "status": "enabled",
+    "type": "non-binding",
+    "version": "v1.0.0"
+}

--- a/server/meshmodel/aws-s3-controller/v1.0.35/v1.0.0/relationships/edge-non-binding-reference-bucket-pod.json
+++ b/server/meshmodel/aws-s3-controller/v1.0.35/v1.0.0/relationships/edge-non-binding-reference-bucket-pod.json
@@ -1,0 +1,108 @@
+{
+    "id": "00000000-0000-0000-0000-000000000000",
+    "evaluationQuery": "",
+    "kind": "edge",
+    "metadata": {
+        "description": "A Bucket provides S3 storage configuration to a Pod by auto-populating the bucket name in environment variables.",
+        "styles": {
+            "primaryColor": "",
+            "svgColor": "",
+            "svgWhite": ""
+        },
+        "isAnnotation": false
+    },
+    "model": {
+        "version": "",
+        "name": "aws-s3-controller",
+        "displayName": "",
+        "id": "00000000-0000-0000-0000-000000000000",
+        "registrant": {
+            "kind": ""
+        },
+        "model": {
+            "version": "v1.1.3"
+        }
+    },
+    "schemaVersion": "relationships.meshery.io/v1alpha3",
+    "selectors": [
+        {
+            "allow": {
+                "from": [
+                    {
+                        "id": null,
+                        "kind": "Bucket",
+                        "match": {},
+                        "match_strategy_matrix": [
+                            [
+                                "equal_as_strings",
+                                "not_null"
+                            ]
+                        ],
+                        "model": {
+                            "version": "",
+                            "name": "aws-s3-controller",
+                            "displayName": "",
+                            "id": "00000000-0000-0000-0000-000000000000",
+                            "registrant": {
+                                "kind": "github"
+                            },
+                            "model": {
+                                "version": ""
+                            }
+                        },
+                        "patch": {
+                            "patchStrategy": "replace",
+                            "mutatorRef": [
+                                [
+                                    "displayName"
+                                ]
+                            ]
+                        }
+                    }
+                ],
+                "to": [
+                    {
+                        "id": null,
+                        "kind": "Pod",
+                        "match": {},
+                        "match_strategy_matrix": null,
+                        "model": {
+                            "version": "",
+                            "name": "kubernetes",
+                            "displayName": "",
+                            "id": "00000000-0000-0000-0000-000000000000",
+                            "registrant": {
+                                "kind": "github"
+                            },
+                            "model": {
+                                "version": ""
+                            }
+                        },
+                        "patch": {
+                            "patchStrategy": "replace",
+                            "mutatedRef": [
+                                [
+                                    "configuration",
+                                    "spec",
+                                    "containers",
+                                    "0",
+                                    "env",
+                                    "0",
+                                    "value"
+                                ]
+                            ]
+                        }
+                    }
+                ]
+            },
+            "deny": {
+                "from": [],
+                "to": []
+            }
+        }
+    ],
+    "subType": "reference",
+    "status": "enabled",
+    "type": "non-binding",
+    "version": "v1.0.0"
+}

--- a/server/meshmodel/aws-s3-controller/v1.0.35/v1.0.0/relationships/edge-non-binding-reference-bucket-pod.json
+++ b/server/meshmodel/aws-s3-controller/v1.0.35/v1.0.0/relationships/edge-non-binding-reference-bucket-pod.json
@@ -1,108 +1,110 @@
 {
+  "id": "00000000-0000-0000-0000-000000000000",
+  "evaluationQuery": "",
+  "kind": "edge",
+  "metadata": {
+    "description": "A Bucket provides S3 storage configuration to a Pod by auto-populating the bucket name in environment variables.",
+    "styles": {
+      "primaryColor": "",
+      "svgColor": "",
+      "svgWhite": ""
+    },
+    "isAnnotation": false
+  },
+  "model": {
+    "version": "",
+    "name": "aws-s3-controller",
+    "displayName": "",
     "id": "00000000-0000-0000-0000-000000000000",
-    "evaluationQuery": "",
-    "kind": "edge",
-    "metadata": {
-        "description": "A Bucket provides S3 storage configuration to a Pod by auto-populating the bucket name in environment variables.",
-        "styles": {
-            "primaryColor": "",
-            "svgColor": "",
-            "svgWhite": ""
-        },
-        "isAnnotation": false
+    "registrant": {
+      "kind": ""
     },
     "model": {
-        "version": "",
-        "name": "aws-s3-controller",
-        "displayName": "",
-        "id": "00000000-0000-0000-0000-000000000000",
-        "registrant": {
-            "kind": ""
-        },
-        "model": {
-            "version": "v1.1.3"
-        }
-    },
-    "schemaVersion": "relationships.meshery.io/v1alpha3",
-    "selectors": [
-        {
-            "allow": {
-                "from": [
-                    {
-                        "id": null,
-                        "kind": "Bucket",
-                        "match": {},
-                        "match_strategy_matrix": [
-                            [
-                                "equal_as_strings",
-                                "not_null"
-                            ]
-                        ],
-                        "model": {
-                            "version": "",
-                            "name": "aws-s3-controller",
-                            "displayName": "",
-                            "id": "00000000-0000-0000-0000-000000000000",
-                            "registrant": {
-                                "kind": "github"
-                            },
-                            "model": {
-                                "version": ""
-                            }
-                        },
-                        "patch": {
-                            "patchStrategy": "replace",
-                            "mutatorRef": [
-                                [
-                                    "displayName"
-                                ]
-                            ]
-                        }
-                    }
-                ],
-                "to": [
-                    {
-                        "id": null,
-                        "kind": "Pod",
-                        "match": {},
-                        "match_strategy_matrix": null,
-                        "model": {
-                            "version": "",
-                            "name": "kubernetes",
-                            "displayName": "",
-                            "id": "00000000-0000-0000-0000-000000000000",
-                            "registrant": {
-                                "kind": "github"
-                            },
-                            "model": {
-                                "version": ""
-                            }
-                        },
-                        "patch": {
-                            "patchStrategy": "replace",
-                            "mutatedRef": [
-                                [
-                                    "configuration",
-                                    "spec",
-                                    "containers",
-                                    "0",
-                                    "env",
-                                    "0",
-                                    "value"
-                                ]
-                            ]
-                        }
-                    }
-                ]
+      "version": "v1.0.35"
+    }
+  },
+  "schemaVersion": "relationships.meshery.io/v1alpha3",
+  "selectors": [
+    {
+      "allow": {
+        "from": [
+          {
+            "id": null,
+            "kind": "Bucket",
+            "match": {},
+            "match_strategy_matrix": [
+              [
+                "equal_as_strings",
+                "not_null"
+              ]
+            ],
+            "model": {
+              "version": "",
+              "name": "aws-s3-controller",
+              "displayName": "",
+              "id": "00000000-0000-0000-0000-000000000000",
+              "registrant": {
+                "kind": "github"
+              },
+              "model": {
+                "version": ""
+              }
             },
-            "deny": {
-                "from": [],
-                "to": []
+            "patch": {
+              "patchStrategy": "replace",
+              "mutatorRef": [
+                [
+                  "configuration",
+                  "spec",
+                  "name"
+                ]
+              ]
             }
-        }
-    ],
-    "subType": "reference",
-    "status": "enabled",
-    "type": "non-binding",
-    "version": "v1.0.0"
+          }
+        ],
+        "to": [
+          {
+            "id": null,
+            "kind": "Pod",
+            "match": {},
+            "match_strategy_matrix": null,
+            "model": {
+              "version": "",
+              "name": "kubernetes",
+              "displayName": "",
+              "id": "00000000-0000-0000-0000-000000000000",
+              "registrant": {
+                "kind": "github"
+              },
+              "model": {
+                "version": ""
+              }
+            },
+            "patch": {
+              "patchStrategy": "replace",
+              "mutatedRef": [
+                [
+                  "configuration",
+                  "spec",
+                  "containers",
+                  "0",
+                  "env",
+                  "0",
+                  "value"
+                ]
+              ]
+            }
+          }
+        ]
+      },
+      "deny": {
+        "from": [],
+        "to": []
+      }
+    }
+  ],
+  "subType": "reference",
+  "status": "enabled",
+  "type": "non-binding",
+  "version": "v1.0.0"
 }

--- a/server/meshmodel/aws-s3-controller/v1.1.0/v1.0.0/relationships/edge-non-binding-reference-bucket-deployment.json
+++ b/server/meshmodel/aws-s3-controller/v1.1.0/v1.0.0/relationships/edge-non-binding-reference-bucket-deployment.json
@@ -1,110 +1,112 @@
 {
+  "id": "00000000-0000-0000-0000-000000000000",
+  "evaluationQuery": "",
+  "kind": "edge",
+  "metadata": {
+    "description": "A Bucket provides S3 storage configuration to a Deployment by auto-populating the bucket name in environment variables.",
+    "styles": {
+      "primaryColor": "",
+      "svgColor": "",
+      "svgWhite": ""
+    },
+    "isAnnotation": false
+  },
+  "model": {
+    "version": "",
+    "name": "aws-s3-controller",
+    "displayName": "",
     "id": "00000000-0000-0000-0000-000000000000",
-    "evaluationQuery": "",
-    "kind": "edge",
-    "metadata": {
-        "description": "A Bucket provides S3 storage configuration to a Deployment by auto-populating the bucket name in environment variables.",
-        "styles": {
-            "primaryColor": "",
-            "svgColor": "",
-            "svgWhite": ""
-        },
-        "isAnnotation": false
+    "registrant": {
+      "kind": ""
     },
     "model": {
-        "version": "",
-        "name": "aws-s3-controller",
-        "displayName": "",
-        "id": "00000000-0000-0000-0000-000000000000",
-        "registrant": {
-            "kind": ""
-        },
-        "model": {
-            "version": "v1.1.3"
-        }
-    },
-    "schemaVersion": "relationships.meshery.io/v1alpha3",
-    "selectors": [
-        {
-            "allow": {
-                "from": [
-                    {
-                        "id": null,
-                        "kind": "Bucket",
-                        "match": {},
-                        "match_strategy_matrix": [
-                            [
-                                "equal_as_strings",
-                                "not_null"
-                            ]
-                        ],
-                        "model": {
-                            "version": "",
-                            "name": "aws-s3-controller",
-                            "displayName": "",
-                            "id": "00000000-0000-0000-0000-000000000000",
-                            "registrant": {
-                                "kind": "github"
-                            },
-                            "model": {
-                                "version": ""
-                            }
-                        },
-                        "patch": {
-                            "patchStrategy": "replace",
-                            "mutatorRef": [
-                                [
-                                    "displayName"
-                                ]
-                            ]
-                        }
-                    }
-                ],
-                "to": [
-                    {
-                        "id": null,
-                        "kind": "Deployment",
-                        "match": {},
-                        "match_strategy_matrix": null,
-                        "model": {
-                            "version": "",
-                            "name": "kubernetes",
-                            "displayName": "",
-                            "id": "00000000-0000-0000-0000-000000000000",
-                            "registrant": {
-                                "kind": "github"
-                            },
-                            "model": {
-                                "version": ""
-                            }
-                        },
-                        "patch": {
-                            "patchStrategy": "replace",
-                            "mutatedRef": [
-                                [
-                                    "configuration",
-                                    "spec",
-                                    "template",
-                                    "spec",
-                                    "containers",
-                                    "0",
-                                    "env",
-                                    "0",
-                                    "value"
-                                ]
-                            ]
-                        }
-                    }
-                ]
+      "version": "v1.1.0"
+    }
+  },
+  "schemaVersion": "relationships.meshery.io/v1alpha3",
+  "selectors": [
+    {
+      "allow": {
+        "from": [
+          {
+            "id": null,
+            "kind": "Bucket",
+            "match": {},
+            "match_strategy_matrix": [
+              [
+                "equal_as_strings",
+                "not_null"
+              ]
+            ],
+            "model": {
+              "version": "",
+              "name": "aws-s3-controller",
+              "displayName": "",
+              "id": "00000000-0000-0000-0000-000000000000",
+              "registrant": {
+                "kind": "github"
+              },
+              "model": {
+                "version": ""
+              }
             },
-            "deny": {
-                "from": [],
-                "to": []
+            "patch": {
+              "patchStrategy": "replace",
+              "mutatorRef": [
+                [
+                  "configuration",
+                  "spec",
+                  "name"
+                ]
+              ]
             }
-        }
-    ],
-    "subType": "reference",
-    "status": "enabled",
-    "type": "non-binding",
-    "version": "v1.0.0"
+          }
+        ],
+        "to": [
+          {
+            "id": null,
+            "kind": "Deployment",
+            "match": {},
+            "match_strategy_matrix": null,
+            "model": {
+              "version": "",
+              "name": "kubernetes",
+              "displayName": "",
+              "id": "00000000-0000-0000-0000-000000000000",
+              "registrant": {
+                "kind": "github"
+              },
+              "model": {
+                "version": ""
+              }
+            },
+            "patch": {
+              "patchStrategy": "replace",
+              "mutatedRef": [
+                [
+                  "configuration",
+                  "spec",
+                  "template",
+                  "spec",
+                  "containers",
+                  "0",
+                  "env",
+                  "0",
+                  "value"
+                ]
+              ]
+            }
+          }
+        ]
+      },
+      "deny": {
+        "from": [],
+        "to": []
+      }
+    }
+  ],
+  "subType": "reference",
+  "status": "enabled",
+  "type": "non-binding",
+  "version": "v1.0.0"
 }

--- a/server/meshmodel/aws-s3-controller/v1.1.0/v1.0.0/relationships/edge-non-binding-reference-bucket-deployment.json
+++ b/server/meshmodel/aws-s3-controller/v1.1.0/v1.0.0/relationships/edge-non-binding-reference-bucket-deployment.json
@@ -1,0 +1,110 @@
+{
+    "id": "00000000-0000-0000-0000-000000000000",
+    "evaluationQuery": "",
+    "kind": "edge",
+    "metadata": {
+        "description": "A Bucket provides S3 storage configuration to a Deployment by auto-populating the bucket name in environment variables.",
+        "styles": {
+            "primaryColor": "",
+            "svgColor": "",
+            "svgWhite": ""
+        },
+        "isAnnotation": false
+    },
+    "model": {
+        "version": "",
+        "name": "aws-s3-controller",
+        "displayName": "",
+        "id": "00000000-0000-0000-0000-000000000000",
+        "registrant": {
+            "kind": ""
+        },
+        "model": {
+            "version": "v1.1.3"
+        }
+    },
+    "schemaVersion": "relationships.meshery.io/v1alpha3",
+    "selectors": [
+        {
+            "allow": {
+                "from": [
+                    {
+                        "id": null,
+                        "kind": "Bucket",
+                        "match": {},
+                        "match_strategy_matrix": [
+                            [
+                                "equal_as_strings",
+                                "not_null"
+                            ]
+                        ],
+                        "model": {
+                            "version": "",
+                            "name": "aws-s3-controller",
+                            "displayName": "",
+                            "id": "00000000-0000-0000-0000-000000000000",
+                            "registrant": {
+                                "kind": "github"
+                            },
+                            "model": {
+                                "version": ""
+                            }
+                        },
+                        "patch": {
+                            "patchStrategy": "replace",
+                            "mutatorRef": [
+                                [
+                                    "displayName"
+                                ]
+                            ]
+                        }
+                    }
+                ],
+                "to": [
+                    {
+                        "id": null,
+                        "kind": "Deployment",
+                        "match": {},
+                        "match_strategy_matrix": null,
+                        "model": {
+                            "version": "",
+                            "name": "kubernetes",
+                            "displayName": "",
+                            "id": "00000000-0000-0000-0000-000000000000",
+                            "registrant": {
+                                "kind": "github"
+                            },
+                            "model": {
+                                "version": ""
+                            }
+                        },
+                        "patch": {
+                            "patchStrategy": "replace",
+                            "mutatedRef": [
+                                [
+                                    "configuration",
+                                    "spec",
+                                    "template",
+                                    "spec",
+                                    "containers",
+                                    "0",
+                                    "env",
+                                    "0",
+                                    "value"
+                                ]
+                            ]
+                        }
+                    }
+                ]
+            },
+            "deny": {
+                "from": [],
+                "to": []
+            }
+        }
+    ],
+    "subType": "reference",
+    "status": "enabled",
+    "type": "non-binding",
+    "version": "v1.0.0"
+}

--- a/server/meshmodel/aws-s3-controller/v1.1.0/v1.0.0/relationships/edge-non-binding-reference-bucket-pod.json
+++ b/server/meshmodel/aws-s3-controller/v1.1.0/v1.0.0/relationships/edge-non-binding-reference-bucket-pod.json
@@ -1,0 +1,108 @@
+{
+    "id": "00000000-0000-0000-0000-000000000000",
+    "evaluationQuery": "",
+    "kind": "edge",
+    "metadata": {
+        "description": "A Bucket provides S3 storage configuration to a Pod by auto-populating the bucket name in environment variables.",
+        "styles": {
+            "primaryColor": "",
+            "svgColor": "",
+            "svgWhite": ""
+        },
+        "isAnnotation": false
+    },
+    "model": {
+        "version": "",
+        "name": "aws-s3-controller",
+        "displayName": "",
+        "id": "00000000-0000-0000-0000-000000000000",
+        "registrant": {
+            "kind": ""
+        },
+        "model": {
+            "version": "v1.1.3"
+        }
+    },
+    "schemaVersion": "relationships.meshery.io/v1alpha3",
+    "selectors": [
+        {
+            "allow": {
+                "from": [
+                    {
+                        "id": null,
+                        "kind": "Bucket",
+                        "match": {},
+                        "match_strategy_matrix": [
+                            [
+                                "equal_as_strings",
+                                "not_null"
+                            ]
+                        ],
+                        "model": {
+                            "version": "",
+                            "name": "aws-s3-controller",
+                            "displayName": "",
+                            "id": "00000000-0000-0000-0000-000000000000",
+                            "registrant": {
+                                "kind": "github"
+                            },
+                            "model": {
+                                "version": ""
+                            }
+                        },
+                        "patch": {
+                            "patchStrategy": "replace",
+                            "mutatorRef": [
+                                [
+                                    "displayName"
+                                ]
+                            ]
+                        }
+                    }
+                ],
+                "to": [
+                    {
+                        "id": null,
+                        "kind": "Pod",
+                        "match": {},
+                        "match_strategy_matrix": null,
+                        "model": {
+                            "version": "",
+                            "name": "kubernetes",
+                            "displayName": "",
+                            "id": "00000000-0000-0000-0000-000000000000",
+                            "registrant": {
+                                "kind": "github"
+                            },
+                            "model": {
+                                "version": ""
+                            }
+                        },
+                        "patch": {
+                            "patchStrategy": "replace",
+                            "mutatedRef": [
+                                [
+                                    "configuration",
+                                    "spec",
+                                    "containers",
+                                    "0",
+                                    "env",
+                                    "0",
+                                    "value"
+                                ]
+                            ]
+                        }
+                    }
+                ]
+            },
+            "deny": {
+                "from": [],
+                "to": []
+            }
+        }
+    ],
+    "subType": "reference",
+    "status": "enabled",
+    "type": "non-binding",
+    "version": "v1.0.0"
+}

--- a/server/meshmodel/aws-s3-controller/v1.1.0/v1.0.0/relationships/edge-non-binding-reference-bucket-pod.json
+++ b/server/meshmodel/aws-s3-controller/v1.1.0/v1.0.0/relationships/edge-non-binding-reference-bucket-pod.json
@@ -1,108 +1,110 @@
 {
+  "id": "00000000-0000-0000-0000-000000000000",
+  "evaluationQuery": "",
+  "kind": "edge",
+  "metadata": {
+    "description": "A Bucket provides S3 storage configuration to a Pod by auto-populating the bucket name in environment variables.",
+    "styles": {
+      "primaryColor": "",
+      "svgColor": "",
+      "svgWhite": ""
+    },
+    "isAnnotation": false
+  },
+  "model": {
+    "version": "",
+    "name": "aws-s3-controller",
+    "displayName": "",
     "id": "00000000-0000-0000-0000-000000000000",
-    "evaluationQuery": "",
-    "kind": "edge",
-    "metadata": {
-        "description": "A Bucket provides S3 storage configuration to a Pod by auto-populating the bucket name in environment variables.",
-        "styles": {
-            "primaryColor": "",
-            "svgColor": "",
-            "svgWhite": ""
-        },
-        "isAnnotation": false
+    "registrant": {
+      "kind": ""
     },
     "model": {
-        "version": "",
-        "name": "aws-s3-controller",
-        "displayName": "",
-        "id": "00000000-0000-0000-0000-000000000000",
-        "registrant": {
-            "kind": ""
-        },
-        "model": {
-            "version": "v1.1.3"
-        }
-    },
-    "schemaVersion": "relationships.meshery.io/v1alpha3",
-    "selectors": [
-        {
-            "allow": {
-                "from": [
-                    {
-                        "id": null,
-                        "kind": "Bucket",
-                        "match": {},
-                        "match_strategy_matrix": [
-                            [
-                                "equal_as_strings",
-                                "not_null"
-                            ]
-                        ],
-                        "model": {
-                            "version": "",
-                            "name": "aws-s3-controller",
-                            "displayName": "",
-                            "id": "00000000-0000-0000-0000-000000000000",
-                            "registrant": {
-                                "kind": "github"
-                            },
-                            "model": {
-                                "version": ""
-                            }
-                        },
-                        "patch": {
-                            "patchStrategy": "replace",
-                            "mutatorRef": [
-                                [
-                                    "displayName"
-                                ]
-                            ]
-                        }
-                    }
-                ],
-                "to": [
-                    {
-                        "id": null,
-                        "kind": "Pod",
-                        "match": {},
-                        "match_strategy_matrix": null,
-                        "model": {
-                            "version": "",
-                            "name": "kubernetes",
-                            "displayName": "",
-                            "id": "00000000-0000-0000-0000-000000000000",
-                            "registrant": {
-                                "kind": "github"
-                            },
-                            "model": {
-                                "version": ""
-                            }
-                        },
-                        "patch": {
-                            "patchStrategy": "replace",
-                            "mutatedRef": [
-                                [
-                                    "configuration",
-                                    "spec",
-                                    "containers",
-                                    "0",
-                                    "env",
-                                    "0",
-                                    "value"
-                                ]
-                            ]
-                        }
-                    }
-                ]
+      "version": "v1.1.0"
+    }
+  },
+  "schemaVersion": "relationships.meshery.io/v1alpha3",
+  "selectors": [
+    {
+      "allow": {
+        "from": [
+          {
+            "id": null,
+            "kind": "Bucket",
+            "match": {},
+            "match_strategy_matrix": [
+              [
+                "equal_as_strings",
+                "not_null"
+              ]
+            ],
+            "model": {
+              "version": "",
+              "name": "aws-s3-controller",
+              "displayName": "",
+              "id": "00000000-0000-0000-0000-000000000000",
+              "registrant": {
+                "kind": "github"
+              },
+              "model": {
+                "version": ""
+              }
             },
-            "deny": {
-                "from": [],
-                "to": []
+            "patch": {
+              "patchStrategy": "replace",
+              "mutatorRef": [
+                [
+                  "configuration",
+                  "spec",
+                  "name"
+                ]
+              ]
             }
-        }
-    ],
-    "subType": "reference",
-    "status": "enabled",
-    "type": "non-binding",
-    "version": "v1.0.0"
+          }
+        ],
+        "to": [
+          {
+            "id": null,
+            "kind": "Pod",
+            "match": {},
+            "match_strategy_matrix": null,
+            "model": {
+              "version": "",
+              "name": "kubernetes",
+              "displayName": "",
+              "id": "00000000-0000-0000-0000-000000000000",
+              "registrant": {
+                "kind": "github"
+              },
+              "model": {
+                "version": ""
+              }
+            },
+            "patch": {
+              "patchStrategy": "replace",
+              "mutatedRef": [
+                [
+                  "configuration",
+                  "spec",
+                  "containers",
+                  "0",
+                  "env",
+                  "0",
+                  "value"
+                ]
+              ]
+            }
+          }
+        ]
+      },
+      "deny": {
+        "from": [],
+        "to": []
+      }
+    }
+  ],
+  "subType": "reference",
+  "status": "enabled",
+  "type": "non-binding",
+  "version": "v1.0.0"
 }

--- a/server/meshmodel/aws-s3-controller/v1.1.1/v1.0.0/relationships/edge-non-binding-reference-bucket-deployment.json
+++ b/server/meshmodel/aws-s3-controller/v1.1.1/v1.0.0/relationships/edge-non-binding-reference-bucket-deployment.json
@@ -1,110 +1,112 @@
 {
+  "id": "00000000-0000-0000-0000-000000000000",
+  "evaluationQuery": "",
+  "kind": "edge",
+  "metadata": {
+    "description": "A Bucket provides S3 storage configuration to a Deployment by auto-populating the bucket name in environment variables.",
+    "styles": {
+      "primaryColor": "",
+      "svgColor": "",
+      "svgWhite": ""
+    },
+    "isAnnotation": false
+  },
+  "model": {
+    "version": "",
+    "name": "aws-s3-controller",
+    "displayName": "",
     "id": "00000000-0000-0000-0000-000000000000",
-    "evaluationQuery": "",
-    "kind": "edge",
-    "metadata": {
-        "description": "A Bucket provides S3 storage configuration to a Deployment by auto-populating the bucket name in environment variables.",
-        "styles": {
-            "primaryColor": "",
-            "svgColor": "",
-            "svgWhite": ""
-        },
-        "isAnnotation": false
+    "registrant": {
+      "kind": ""
     },
     "model": {
-        "version": "",
-        "name": "aws-s3-controller",
-        "displayName": "",
-        "id": "00000000-0000-0000-0000-000000000000",
-        "registrant": {
-            "kind": ""
-        },
-        "model": {
-            "version": "v1.1.3"
-        }
-    },
-    "schemaVersion": "relationships.meshery.io/v1alpha3",
-    "selectors": [
-        {
-            "allow": {
-                "from": [
-                    {
-                        "id": null,
-                        "kind": "Bucket",
-                        "match": {},
-                        "match_strategy_matrix": [
-                            [
-                                "equal_as_strings",
-                                "not_null"
-                            ]
-                        ],
-                        "model": {
-                            "version": "",
-                            "name": "aws-s3-controller",
-                            "displayName": "",
-                            "id": "00000000-0000-0000-0000-000000000000",
-                            "registrant": {
-                                "kind": "github"
-                            },
-                            "model": {
-                                "version": ""
-                            }
-                        },
-                        "patch": {
-                            "patchStrategy": "replace",
-                            "mutatorRef": [
-                                [
-                                    "displayName"
-                                ]
-                            ]
-                        }
-                    }
-                ],
-                "to": [
-                    {
-                        "id": null,
-                        "kind": "Deployment",
-                        "match": {},
-                        "match_strategy_matrix": null,
-                        "model": {
-                            "version": "",
-                            "name": "kubernetes",
-                            "displayName": "",
-                            "id": "00000000-0000-0000-0000-000000000000",
-                            "registrant": {
-                                "kind": "github"
-                            },
-                            "model": {
-                                "version": ""
-                            }
-                        },
-                        "patch": {
-                            "patchStrategy": "replace",
-                            "mutatedRef": [
-                                [
-                                    "configuration",
-                                    "spec",
-                                    "template",
-                                    "spec",
-                                    "containers",
-                                    "0",
-                                    "env",
-                                    "0",
-                                    "value"
-                                ]
-                            ]
-                        }
-                    }
-                ]
+      "version": "v1.1.1"
+    }
+  },
+  "schemaVersion": "relationships.meshery.io/v1alpha3",
+  "selectors": [
+    {
+      "allow": {
+        "from": [
+          {
+            "id": null,
+            "kind": "Bucket",
+            "match": {},
+            "match_strategy_matrix": [
+              [
+                "equal_as_strings",
+                "not_null"
+              ]
+            ],
+            "model": {
+              "version": "",
+              "name": "aws-s3-controller",
+              "displayName": "",
+              "id": "00000000-0000-0000-0000-000000000000",
+              "registrant": {
+                "kind": "github"
+              },
+              "model": {
+                "version": ""
+              }
             },
-            "deny": {
-                "from": [],
-                "to": []
+            "patch": {
+              "patchStrategy": "replace",
+              "mutatorRef": [
+                [
+                  "configuration",
+                  "spec",
+                  "name"
+                ]
+              ]
             }
-        }
-    ],
-    "subType": "reference",
-    "status": "enabled",
-    "type": "non-binding",
-    "version": "v1.0.0"
+          }
+        ],
+        "to": [
+          {
+            "id": null,
+            "kind": "Deployment",
+            "match": {},
+            "match_strategy_matrix": null,
+            "model": {
+              "version": "",
+              "name": "kubernetes",
+              "displayName": "",
+              "id": "00000000-0000-0000-0000-000000000000",
+              "registrant": {
+                "kind": "github"
+              },
+              "model": {
+                "version": ""
+              }
+            },
+            "patch": {
+              "patchStrategy": "replace",
+              "mutatedRef": [
+                [
+                  "configuration",
+                  "spec",
+                  "template",
+                  "spec",
+                  "containers",
+                  "0",
+                  "env",
+                  "0",
+                  "value"
+                ]
+              ]
+            }
+          }
+        ]
+      },
+      "deny": {
+        "from": [],
+        "to": []
+      }
+    }
+  ],
+  "subType": "reference",
+  "status": "enabled",
+  "type": "non-binding",
+  "version": "v1.0.0"
 }

--- a/server/meshmodel/aws-s3-controller/v1.1.1/v1.0.0/relationships/edge-non-binding-reference-bucket-deployment.json
+++ b/server/meshmodel/aws-s3-controller/v1.1.1/v1.0.0/relationships/edge-non-binding-reference-bucket-deployment.json
@@ -1,0 +1,110 @@
+{
+    "id": "00000000-0000-0000-0000-000000000000",
+    "evaluationQuery": "",
+    "kind": "edge",
+    "metadata": {
+        "description": "A Bucket provides S3 storage configuration to a Deployment by auto-populating the bucket name in environment variables.",
+        "styles": {
+            "primaryColor": "",
+            "svgColor": "",
+            "svgWhite": ""
+        },
+        "isAnnotation": false
+    },
+    "model": {
+        "version": "",
+        "name": "aws-s3-controller",
+        "displayName": "",
+        "id": "00000000-0000-0000-0000-000000000000",
+        "registrant": {
+            "kind": ""
+        },
+        "model": {
+            "version": "v1.1.3"
+        }
+    },
+    "schemaVersion": "relationships.meshery.io/v1alpha3",
+    "selectors": [
+        {
+            "allow": {
+                "from": [
+                    {
+                        "id": null,
+                        "kind": "Bucket",
+                        "match": {},
+                        "match_strategy_matrix": [
+                            [
+                                "equal_as_strings",
+                                "not_null"
+                            ]
+                        ],
+                        "model": {
+                            "version": "",
+                            "name": "aws-s3-controller",
+                            "displayName": "",
+                            "id": "00000000-0000-0000-0000-000000000000",
+                            "registrant": {
+                                "kind": "github"
+                            },
+                            "model": {
+                                "version": ""
+                            }
+                        },
+                        "patch": {
+                            "patchStrategy": "replace",
+                            "mutatorRef": [
+                                [
+                                    "displayName"
+                                ]
+                            ]
+                        }
+                    }
+                ],
+                "to": [
+                    {
+                        "id": null,
+                        "kind": "Deployment",
+                        "match": {},
+                        "match_strategy_matrix": null,
+                        "model": {
+                            "version": "",
+                            "name": "kubernetes",
+                            "displayName": "",
+                            "id": "00000000-0000-0000-0000-000000000000",
+                            "registrant": {
+                                "kind": "github"
+                            },
+                            "model": {
+                                "version": ""
+                            }
+                        },
+                        "patch": {
+                            "patchStrategy": "replace",
+                            "mutatedRef": [
+                                [
+                                    "configuration",
+                                    "spec",
+                                    "template",
+                                    "spec",
+                                    "containers",
+                                    "0",
+                                    "env",
+                                    "0",
+                                    "value"
+                                ]
+                            ]
+                        }
+                    }
+                ]
+            },
+            "deny": {
+                "from": [],
+                "to": []
+            }
+        }
+    ],
+    "subType": "reference",
+    "status": "enabled",
+    "type": "non-binding",
+    "version": "v1.0.0"
+}

--- a/server/meshmodel/aws-s3-controller/v1.1.1/v1.0.0/relationships/edge-non-binding-reference-bucket-pod.json
+++ b/server/meshmodel/aws-s3-controller/v1.1.1/v1.0.0/relationships/edge-non-binding-reference-bucket-pod.json
@@ -1,108 +1,110 @@
 {
+  "id": "00000000-0000-0000-0000-000000000000",
+  "evaluationQuery": "",
+  "kind": "edge",
+  "metadata": {
+    "description": "A Bucket provides S3 storage configuration to a Pod by auto-populating the bucket name in environment variables.",
+    "styles": {
+      "primaryColor": "",
+      "svgColor": "",
+      "svgWhite": ""
+    },
+    "isAnnotation": false
+  },
+  "model": {
+    "version": "",
+    "name": "aws-s3-controller",
+    "displayName": "",
     "id": "00000000-0000-0000-0000-000000000000",
-    "evaluationQuery": "",
-    "kind": "edge",
-    "metadata": {
-        "description": "A Bucket provides S3 storage configuration to a Pod by auto-populating the bucket name in environment variables.",
-        "styles": {
-            "primaryColor": "",
-            "svgColor": "",
-            "svgWhite": ""
-        },
-        "isAnnotation": false
+    "registrant": {
+      "kind": ""
     },
     "model": {
-        "version": "",
-        "name": "aws-s3-controller",
-        "displayName": "",
-        "id": "00000000-0000-0000-0000-000000000000",
-        "registrant": {
-            "kind": ""
-        },
-        "model": {
-            "version": "v1.1.3"
-        }
-    },
-    "schemaVersion": "relationships.meshery.io/v1alpha3",
-    "selectors": [
-        {
-            "allow": {
-                "from": [
-                    {
-                        "id": null,
-                        "kind": "Bucket",
-                        "match": {},
-                        "match_strategy_matrix": [
-                            [
-                                "equal_as_strings",
-                                "not_null"
-                            ]
-                        ],
-                        "model": {
-                            "version": "",
-                            "name": "aws-s3-controller",
-                            "displayName": "",
-                            "id": "00000000-0000-0000-0000-000000000000",
-                            "registrant": {
-                                "kind": "github"
-                            },
-                            "model": {
-                                "version": ""
-                            }
-                        },
-                        "patch": {
-                            "patchStrategy": "replace",
-                            "mutatorRef": [
-                                [
-                                    "displayName"
-                                ]
-                            ]
-                        }
-                    }
-                ],
-                "to": [
-                    {
-                        "id": null,
-                        "kind": "Pod",
-                        "match": {},
-                        "match_strategy_matrix": null,
-                        "model": {
-                            "version": "",
-                            "name": "kubernetes",
-                            "displayName": "",
-                            "id": "00000000-0000-0000-0000-000000000000",
-                            "registrant": {
-                                "kind": "github"
-                            },
-                            "model": {
-                                "version": ""
-                            }
-                        },
-                        "patch": {
-                            "patchStrategy": "replace",
-                            "mutatedRef": [
-                                [
-                                    "configuration",
-                                    "spec",
-                                    "containers",
-                                    "0",
-                                    "env",
-                                    "0",
-                                    "value"
-                                ]
-                            ]
-                        }
-                    }
-                ]
+      "version": "v1.1.1"
+    }
+  },
+  "schemaVersion": "relationships.meshery.io/v1alpha3",
+  "selectors": [
+    {
+      "allow": {
+        "from": [
+          {
+            "id": null,
+            "kind": "Bucket",
+            "match": {},
+            "match_strategy_matrix": [
+              [
+                "equal_as_strings",
+                "not_null"
+              ]
+            ],
+            "model": {
+              "version": "",
+              "name": "aws-s3-controller",
+              "displayName": "",
+              "id": "00000000-0000-0000-0000-000000000000",
+              "registrant": {
+                "kind": "github"
+              },
+              "model": {
+                "version": ""
+              }
             },
-            "deny": {
-                "from": [],
-                "to": []
+            "patch": {
+              "patchStrategy": "replace",
+              "mutatorRef": [
+                [
+                  "configuration",
+                  "spec",
+                  "name"
+                ]
+              ]
             }
-        }
-    ],
-    "subType": "reference",
-    "status": "enabled",
-    "type": "non-binding",
-    "version": "v1.0.0"
+          }
+        ],
+        "to": [
+          {
+            "id": null,
+            "kind": "Pod",
+            "match": {},
+            "match_strategy_matrix": null,
+            "model": {
+              "version": "",
+              "name": "kubernetes",
+              "displayName": "",
+              "id": "00000000-0000-0000-0000-000000000000",
+              "registrant": {
+                "kind": "github"
+              },
+              "model": {
+                "version": ""
+              }
+            },
+            "patch": {
+              "patchStrategy": "replace",
+              "mutatedRef": [
+                [
+                  "configuration",
+                  "spec",
+                  "containers",
+                  "0",
+                  "env",
+                  "0",
+                  "value"
+                ]
+              ]
+            }
+          }
+        ]
+      },
+      "deny": {
+        "from": [],
+        "to": []
+      }
+    }
+  ],
+  "subType": "reference",
+  "status": "enabled",
+  "type": "non-binding",
+  "version": "v1.0.0"
 }

--- a/server/meshmodel/aws-s3-controller/v1.1.1/v1.0.0/relationships/edge-non-binding-reference-bucket-pod.json
+++ b/server/meshmodel/aws-s3-controller/v1.1.1/v1.0.0/relationships/edge-non-binding-reference-bucket-pod.json
@@ -1,0 +1,108 @@
+{
+    "id": "00000000-0000-0000-0000-000000000000",
+    "evaluationQuery": "",
+    "kind": "edge",
+    "metadata": {
+        "description": "A Bucket provides S3 storage configuration to a Pod by auto-populating the bucket name in environment variables.",
+        "styles": {
+            "primaryColor": "",
+            "svgColor": "",
+            "svgWhite": ""
+        },
+        "isAnnotation": false
+    },
+    "model": {
+        "version": "",
+        "name": "aws-s3-controller",
+        "displayName": "",
+        "id": "00000000-0000-0000-0000-000000000000",
+        "registrant": {
+            "kind": ""
+        },
+        "model": {
+            "version": "v1.1.3"
+        }
+    },
+    "schemaVersion": "relationships.meshery.io/v1alpha3",
+    "selectors": [
+        {
+            "allow": {
+                "from": [
+                    {
+                        "id": null,
+                        "kind": "Bucket",
+                        "match": {},
+                        "match_strategy_matrix": [
+                            [
+                                "equal_as_strings",
+                                "not_null"
+                            ]
+                        ],
+                        "model": {
+                            "version": "",
+                            "name": "aws-s3-controller",
+                            "displayName": "",
+                            "id": "00000000-0000-0000-0000-000000000000",
+                            "registrant": {
+                                "kind": "github"
+                            },
+                            "model": {
+                                "version": ""
+                            }
+                        },
+                        "patch": {
+                            "patchStrategy": "replace",
+                            "mutatorRef": [
+                                [
+                                    "displayName"
+                                ]
+                            ]
+                        }
+                    }
+                ],
+                "to": [
+                    {
+                        "id": null,
+                        "kind": "Pod",
+                        "match": {},
+                        "match_strategy_matrix": null,
+                        "model": {
+                            "version": "",
+                            "name": "kubernetes",
+                            "displayName": "",
+                            "id": "00000000-0000-0000-0000-000000000000",
+                            "registrant": {
+                                "kind": "github"
+                            },
+                            "model": {
+                                "version": ""
+                            }
+                        },
+                        "patch": {
+                            "patchStrategy": "replace",
+                            "mutatedRef": [
+                                [
+                                    "configuration",
+                                    "spec",
+                                    "containers",
+                                    "0",
+                                    "env",
+                                    "0",
+                                    "value"
+                                ]
+                            ]
+                        }
+                    }
+                ]
+            },
+            "deny": {
+                "from": [],
+                "to": []
+            }
+        }
+    ],
+    "subType": "reference",
+    "status": "enabled",
+    "type": "non-binding",
+    "version": "v1.0.0"
+}

--- a/server/meshmodel/aws-s3-controller/v1.1.2/v1.0.0/relationships/edge-non-binding-reference-bucket-deployment.json
+++ b/server/meshmodel/aws-s3-controller/v1.1.2/v1.0.0/relationships/edge-non-binding-reference-bucket-deployment.json
@@ -1,0 +1,110 @@
+{
+    "id": "00000000-0000-0000-0000-000000000000",
+    "evaluationQuery": "",
+    "kind": "edge",
+    "metadata": {
+        "description": "A Bucket provides S3 storage configuration to a Deployment by auto-populating the bucket name in environment variables.",
+        "styles": {
+            "primaryColor": "",
+            "svgColor": "",
+            "svgWhite": ""
+        },
+        "isAnnotation": false
+    },
+    "model": {
+        "version": "",
+        "name": "aws-s3-controller",
+        "displayName": "",
+        "id": "00000000-0000-0000-0000-000000000000",
+        "registrant": {
+            "kind": ""
+        },
+        "model": {
+            "version": "v1.1.3"
+        }
+    },
+    "schemaVersion": "relationships.meshery.io/v1alpha3",
+    "selectors": [
+        {
+            "allow": {
+                "from": [
+                    {
+                        "id": null,
+                        "kind": "Bucket",
+                        "match": {},
+                        "match_strategy_matrix": [
+                            [
+                                "equal_as_strings",
+                                "not_null"
+                            ]
+                        ],
+                        "model": {
+                            "version": "",
+                            "name": "aws-s3-controller",
+                            "displayName": "",
+                            "id": "00000000-0000-0000-0000-000000000000",
+                            "registrant": {
+                                "kind": "github"
+                            },
+                            "model": {
+                                "version": ""
+                            }
+                        },
+                        "patch": {
+                            "patchStrategy": "replace",
+                            "mutatorRef": [
+                                [
+                                    "displayName"
+                                ]
+                            ]
+                        }
+                    }
+                ],
+                "to": [
+                    {
+                        "id": null,
+                        "kind": "Deployment",
+                        "match": {},
+                        "match_strategy_matrix": null,
+                        "model": {
+                            "version": "",
+                            "name": "kubernetes",
+                            "displayName": "",
+                            "id": "00000000-0000-0000-0000-000000000000",
+                            "registrant": {
+                                "kind": "github"
+                            },
+                            "model": {
+                                "version": ""
+                            }
+                        },
+                        "patch": {
+                            "patchStrategy": "replace",
+                            "mutatedRef": [
+                                [
+                                    "configuration",
+                                    "spec",
+                                    "template",
+                                    "spec",
+                                    "containers",
+                                    "0",
+                                    "env",
+                                    "0",
+                                    "value"
+                                ]
+                            ]
+                        }
+                    }
+                ]
+            },
+            "deny": {
+                "from": [],
+                "to": []
+            }
+        }
+    ],
+    "subType": "reference",
+    "status": "enabled",
+    "type": "non-binding",
+    "version": "v1.0.0"
+}

--- a/server/meshmodel/aws-s3-controller/v1.1.2/v1.0.0/relationships/edge-non-binding-reference-bucket-deployment.json
+++ b/server/meshmodel/aws-s3-controller/v1.1.2/v1.0.0/relationships/edge-non-binding-reference-bucket-deployment.json
@@ -1,110 +1,112 @@
 {
+  "id": "00000000-0000-0000-0000-000000000000",
+  "evaluationQuery": "",
+  "kind": "edge",
+  "metadata": {
+    "description": "A Bucket provides S3 storage configuration to a Deployment by auto-populating the bucket name in environment variables.",
+    "styles": {
+      "primaryColor": "",
+      "svgColor": "",
+      "svgWhite": ""
+    },
+    "isAnnotation": false
+  },
+  "model": {
+    "version": "",
+    "name": "aws-s3-controller",
+    "displayName": "",
     "id": "00000000-0000-0000-0000-000000000000",
-    "evaluationQuery": "",
-    "kind": "edge",
-    "metadata": {
-        "description": "A Bucket provides S3 storage configuration to a Deployment by auto-populating the bucket name in environment variables.",
-        "styles": {
-            "primaryColor": "",
-            "svgColor": "",
-            "svgWhite": ""
-        },
-        "isAnnotation": false
+    "registrant": {
+      "kind": ""
     },
     "model": {
-        "version": "",
-        "name": "aws-s3-controller",
-        "displayName": "",
-        "id": "00000000-0000-0000-0000-000000000000",
-        "registrant": {
-            "kind": ""
-        },
-        "model": {
-            "version": "v1.1.3"
-        }
-    },
-    "schemaVersion": "relationships.meshery.io/v1alpha3",
-    "selectors": [
-        {
-            "allow": {
-                "from": [
-                    {
-                        "id": null,
-                        "kind": "Bucket",
-                        "match": {},
-                        "match_strategy_matrix": [
-                            [
-                                "equal_as_strings",
-                                "not_null"
-                            ]
-                        ],
-                        "model": {
-                            "version": "",
-                            "name": "aws-s3-controller",
-                            "displayName": "",
-                            "id": "00000000-0000-0000-0000-000000000000",
-                            "registrant": {
-                                "kind": "github"
-                            },
-                            "model": {
-                                "version": ""
-                            }
-                        },
-                        "patch": {
-                            "patchStrategy": "replace",
-                            "mutatorRef": [
-                                [
-                                    "displayName"
-                                ]
-                            ]
-                        }
-                    }
-                ],
-                "to": [
-                    {
-                        "id": null,
-                        "kind": "Deployment",
-                        "match": {},
-                        "match_strategy_matrix": null,
-                        "model": {
-                            "version": "",
-                            "name": "kubernetes",
-                            "displayName": "",
-                            "id": "00000000-0000-0000-0000-000000000000",
-                            "registrant": {
-                                "kind": "github"
-                            },
-                            "model": {
-                                "version": ""
-                            }
-                        },
-                        "patch": {
-                            "patchStrategy": "replace",
-                            "mutatedRef": [
-                                [
-                                    "configuration",
-                                    "spec",
-                                    "template",
-                                    "spec",
-                                    "containers",
-                                    "0",
-                                    "env",
-                                    "0",
-                                    "value"
-                                ]
-                            ]
-                        }
-                    }
-                ]
+      "version": "v1.1.2"
+    }
+  },
+  "schemaVersion": "relationships.meshery.io/v1alpha3",
+  "selectors": [
+    {
+      "allow": {
+        "from": [
+          {
+            "id": null,
+            "kind": "Bucket",
+            "match": {},
+            "match_strategy_matrix": [
+              [
+                "equal_as_strings",
+                "not_null"
+              ]
+            ],
+            "model": {
+              "version": "",
+              "name": "aws-s3-controller",
+              "displayName": "",
+              "id": "00000000-0000-0000-0000-000000000000",
+              "registrant": {
+                "kind": "github"
+              },
+              "model": {
+                "version": ""
+              }
             },
-            "deny": {
-                "from": [],
-                "to": []
+            "patch": {
+              "patchStrategy": "replace",
+              "mutatorRef": [
+                [
+                  "configuration",
+                  "spec",
+                  "name"
+                ]
+              ]
             }
-        }
-    ],
-    "subType": "reference",
-    "status": "enabled",
-    "type": "non-binding",
-    "version": "v1.0.0"
+          }
+        ],
+        "to": [
+          {
+            "id": null,
+            "kind": "Deployment",
+            "match": {},
+            "match_strategy_matrix": null,
+            "model": {
+              "version": "",
+              "name": "kubernetes",
+              "displayName": "",
+              "id": "00000000-0000-0000-0000-000000000000",
+              "registrant": {
+                "kind": "github"
+              },
+              "model": {
+                "version": ""
+              }
+            },
+            "patch": {
+              "patchStrategy": "replace",
+              "mutatedRef": [
+                [
+                  "configuration",
+                  "spec",
+                  "template",
+                  "spec",
+                  "containers",
+                  "0",
+                  "env",
+                  "0",
+                  "value"
+                ]
+              ]
+            }
+          }
+        ]
+      },
+      "deny": {
+        "from": [],
+        "to": []
+      }
+    }
+  ],
+  "subType": "reference",
+  "status": "enabled",
+  "type": "non-binding",
+  "version": "v1.0.0"
 }

--- a/server/meshmodel/aws-s3-controller/v1.1.2/v1.0.0/relationships/edge-non-binding-reference-bucket-pod.json
+++ b/server/meshmodel/aws-s3-controller/v1.1.2/v1.0.0/relationships/edge-non-binding-reference-bucket-pod.json
@@ -1,108 +1,110 @@
 {
+  "id": "00000000-0000-0000-0000-000000000000",
+  "evaluationQuery": "",
+  "kind": "edge",
+  "metadata": {
+    "description": "A Bucket provides S3 storage configuration to a Pod by auto-populating the bucket name in environment variables.",
+    "styles": {
+      "primaryColor": "",
+      "svgColor": "",
+      "svgWhite": ""
+    },
+    "isAnnotation": false
+  },
+  "model": {
+    "version": "",
+    "name": "aws-s3-controller",
+    "displayName": "",
     "id": "00000000-0000-0000-0000-000000000000",
-    "evaluationQuery": "",
-    "kind": "edge",
-    "metadata": {
-        "description": "A Bucket provides S3 storage configuration to a Pod by auto-populating the bucket name in environment variables.",
-        "styles": {
-            "primaryColor": "",
-            "svgColor": "",
-            "svgWhite": ""
-        },
-        "isAnnotation": false
+    "registrant": {
+      "kind": ""
     },
     "model": {
-        "version": "",
-        "name": "aws-s3-controller",
-        "displayName": "",
-        "id": "00000000-0000-0000-0000-000000000000",
-        "registrant": {
-            "kind": ""
-        },
-        "model": {
-            "version": "v1.1.3"
-        }
-    },
-    "schemaVersion": "relationships.meshery.io/v1alpha3",
-    "selectors": [
-        {
-            "allow": {
-                "from": [
-                    {
-                        "id": null,
-                        "kind": "Bucket",
-                        "match": {},
-                        "match_strategy_matrix": [
-                            [
-                                "equal_as_strings",
-                                "not_null"
-                            ]
-                        ],
-                        "model": {
-                            "version": "",
-                            "name": "aws-s3-controller",
-                            "displayName": "",
-                            "id": "00000000-0000-0000-0000-000000000000",
-                            "registrant": {
-                                "kind": "github"
-                            },
-                            "model": {
-                                "version": ""
-                            }
-                        },
-                        "patch": {
-                            "patchStrategy": "replace",
-                            "mutatorRef": [
-                                [
-                                    "displayName"
-                                ]
-                            ]
-                        }
-                    }
-                ],
-                "to": [
-                    {
-                        "id": null,
-                        "kind": "Pod",
-                        "match": {},
-                        "match_strategy_matrix": null,
-                        "model": {
-                            "version": "",
-                            "name": "kubernetes",
-                            "displayName": "",
-                            "id": "00000000-0000-0000-0000-000000000000",
-                            "registrant": {
-                                "kind": "github"
-                            },
-                            "model": {
-                                "version": ""
-                            }
-                        },
-                        "patch": {
-                            "patchStrategy": "replace",
-                            "mutatedRef": [
-                                [
-                                    "configuration",
-                                    "spec",
-                                    "containers",
-                                    "0",
-                                    "env",
-                                    "0",
-                                    "value"
-                                ]
-                            ]
-                        }
-                    }
-                ]
+      "version": "v1.1.2"
+    }
+  },
+  "schemaVersion": "relationships.meshery.io/v1alpha3",
+  "selectors": [
+    {
+      "allow": {
+        "from": [
+          {
+            "id": null,
+            "kind": "Bucket",
+            "match": {},
+            "match_strategy_matrix": [
+              [
+                "equal_as_strings",
+                "not_null"
+              ]
+            ],
+            "model": {
+              "version": "",
+              "name": "aws-s3-controller",
+              "displayName": "",
+              "id": "00000000-0000-0000-0000-000000000000",
+              "registrant": {
+                "kind": "github"
+              },
+              "model": {
+                "version": ""
+              }
             },
-            "deny": {
-                "from": [],
-                "to": []
+            "patch": {
+              "patchStrategy": "replace",
+              "mutatorRef": [
+                [
+                  "configuration",
+                  "spec",
+                  "name"
+                ]
+              ]
             }
-        }
-    ],
-    "subType": "reference",
-    "status": "enabled",
-    "type": "non-binding",
-    "version": "v1.0.0"
+          }
+        ],
+        "to": [
+          {
+            "id": null,
+            "kind": "Pod",
+            "match": {},
+            "match_strategy_matrix": null,
+            "model": {
+              "version": "",
+              "name": "kubernetes",
+              "displayName": "",
+              "id": "00000000-0000-0000-0000-000000000000",
+              "registrant": {
+                "kind": "github"
+              },
+              "model": {
+                "version": ""
+              }
+            },
+            "patch": {
+              "patchStrategy": "replace",
+              "mutatedRef": [
+                [
+                  "configuration",
+                  "spec",
+                  "containers",
+                  "0",
+                  "env",
+                  "0",
+                  "value"
+                ]
+              ]
+            }
+          }
+        ]
+      },
+      "deny": {
+        "from": [],
+        "to": []
+      }
+    }
+  ],
+  "subType": "reference",
+  "status": "enabled",
+  "type": "non-binding",
+  "version": "v1.0.0"
 }

--- a/server/meshmodel/aws-s3-controller/v1.1.2/v1.0.0/relationships/edge-non-binding-reference-bucket-pod.json
+++ b/server/meshmodel/aws-s3-controller/v1.1.2/v1.0.0/relationships/edge-non-binding-reference-bucket-pod.json
@@ -1,0 +1,108 @@
+{
+    "id": "00000000-0000-0000-0000-000000000000",
+    "evaluationQuery": "",
+    "kind": "edge",
+    "metadata": {
+        "description": "A Bucket provides S3 storage configuration to a Pod by auto-populating the bucket name in environment variables.",
+        "styles": {
+            "primaryColor": "",
+            "svgColor": "",
+            "svgWhite": ""
+        },
+        "isAnnotation": false
+    },
+    "model": {
+        "version": "",
+        "name": "aws-s3-controller",
+        "displayName": "",
+        "id": "00000000-0000-0000-0000-000000000000",
+        "registrant": {
+            "kind": ""
+        },
+        "model": {
+            "version": "v1.1.3"
+        }
+    },
+    "schemaVersion": "relationships.meshery.io/v1alpha3",
+    "selectors": [
+        {
+            "allow": {
+                "from": [
+                    {
+                        "id": null,
+                        "kind": "Bucket",
+                        "match": {},
+                        "match_strategy_matrix": [
+                            [
+                                "equal_as_strings",
+                                "not_null"
+                            ]
+                        ],
+                        "model": {
+                            "version": "",
+                            "name": "aws-s3-controller",
+                            "displayName": "",
+                            "id": "00000000-0000-0000-0000-000000000000",
+                            "registrant": {
+                                "kind": "github"
+                            },
+                            "model": {
+                                "version": ""
+                            }
+                        },
+                        "patch": {
+                            "patchStrategy": "replace",
+                            "mutatorRef": [
+                                [
+                                    "displayName"
+                                ]
+                            ]
+                        }
+                    }
+                ],
+                "to": [
+                    {
+                        "id": null,
+                        "kind": "Pod",
+                        "match": {},
+                        "match_strategy_matrix": null,
+                        "model": {
+                            "version": "",
+                            "name": "kubernetes",
+                            "displayName": "",
+                            "id": "00000000-0000-0000-0000-000000000000",
+                            "registrant": {
+                                "kind": "github"
+                            },
+                            "model": {
+                                "version": ""
+                            }
+                        },
+                        "patch": {
+                            "patchStrategy": "replace",
+                            "mutatedRef": [
+                                [
+                                    "configuration",
+                                    "spec",
+                                    "containers",
+                                    "0",
+                                    "env",
+                                    "0",
+                                    "value"
+                                ]
+                            ]
+                        }
+                    }
+                ]
+            },
+            "deny": {
+                "from": [],
+                "to": []
+            }
+        }
+    ],
+    "subType": "reference",
+    "status": "enabled",
+    "type": "non-binding",
+    "version": "v1.0.0"
+}

--- a/server/meshmodel/aws-s3-controller/v1.1.3/v1.0.0/relationships/edge-non-binding-reference-bucket-deployment.json
+++ b/server/meshmodel/aws-s3-controller/v1.1.3/v1.0.0/relationships/edge-non-binding-reference-bucket-deployment.json
@@ -1,110 +1,112 @@
 {
+  "id": "00000000-0000-0000-0000-000000000000",
+  "evaluationQuery": "",
+  "kind": "edge",
+  "metadata": {
+    "description": "A Bucket provides S3 storage configuration to a Deployment by auto-populating the bucket name in environment variables.",
+    "styles": {
+      "primaryColor": "",
+      "svgColor": "",
+      "svgWhite": ""
+    },
+    "isAnnotation": false
+  },
+  "model": {
+    "version": "",
+    "name": "aws-s3-controller",
+    "displayName": "",
     "id": "00000000-0000-0000-0000-000000000000",
-    "evaluationQuery": "",
-    "kind": "edge",
-    "metadata": {
-        "description": "A Bucket provides S3 storage configuration to a Deployment by auto-populating the bucket name in environment variables.",
-        "styles": {
-            "primaryColor": "",
-            "svgColor": "",
-            "svgWhite": ""
-        },
-        "isAnnotation": false
+    "registrant": {
+      "kind": ""
     },
     "model": {
-        "version": "",
-        "name": "aws-s3-controller",
-        "displayName": "",
-        "id": "00000000-0000-0000-0000-000000000000",
-        "registrant": {
-            "kind": ""
-        },
-        "model": {
-            "version": "v1.1.3"
-        }
-    },
-    "schemaVersion": "relationships.meshery.io/v1alpha3",
-    "selectors": [
-        {
-            "allow": {
-                "from": [
-                    {
-                        "id": null,
-                        "kind": "Bucket",
-                        "match": {},
-                        "match_strategy_matrix": [
-                            [
-                                "equal_as_strings",
-                                "not_null"
-                            ]
-                        ],
-                        "model": {
-                            "version": "",
-                            "name": "aws-s3-controller",
-                            "displayName": "",
-                            "id": "00000000-0000-0000-0000-000000000000",
-                            "registrant": {
-                                "kind": "github"
-                            },
-                            "model": {
-                                "version": ""
-                            }
-                        },
-                        "patch": {
-                            "patchStrategy": "replace",
-                            "mutatorRef": [
-                                [
-                                    "displayName"
-                                ]
-                            ]
-                        }
-                    }
-                ],
-                "to": [
-                    {
-                        "id": null,
-                        "kind": "Deployment",
-                        "match": {},
-                        "match_strategy_matrix": null,
-                        "model": {
-                            "version": "",
-                            "name": "kubernetes",
-                            "displayName": "",
-                            "id": "00000000-0000-0000-0000-000000000000",
-                            "registrant": {
-                                "kind": "github"
-                            },
-                            "model": {
-                                "version": ""
-                            }
-                        },
-                        "patch": {
-                            "patchStrategy": "replace",
-                            "mutatedRef": [
-                                [
-                                    "configuration",
-                                    "spec",
-                                    "template",
-                                    "spec",
-                                    "containers",
-                                    "0",
-                                    "env",
-                                    "0",
-                                    "value"
-                                ]
-                            ]
-                        }
-                    }
-                ]
+      "version": "v1.1.3"
+    }
+  },
+  "schemaVersion": "relationships.meshery.io/v1alpha3",
+  "selectors": [
+    {
+      "allow": {
+        "from": [
+          {
+            "id": null,
+            "kind": "Bucket",
+            "match": {},
+            "match_strategy_matrix": [
+              [
+                "equal_as_strings",
+                "not_null"
+              ]
+            ],
+            "model": {
+              "version": "",
+              "name": "aws-s3-controller",
+              "displayName": "",
+              "id": "00000000-0000-0000-0000-000000000000",
+              "registrant": {
+                "kind": "github"
+              },
+              "model": {
+                "version": ""
+              }
             },
-            "deny": {
-                "from": [],
-                "to": []
+            "patch": {
+              "patchStrategy": "replace",
+              "mutatorRef": [
+                [
+                  "configuration",
+                  "spec",
+                  "name"
+                ]
+              ]
             }
-        }
-    ],
-    "subType": "reference",
-    "status": "enabled",
-    "type": "non-binding",
-    "version": "v1.0.0"
+          }
+        ],
+        "to": [
+          {
+            "id": null,
+            "kind": "Deployment",
+            "match": {},
+            "match_strategy_matrix": null,
+            "model": {
+              "version": "",
+              "name": "kubernetes",
+              "displayName": "",
+              "id": "00000000-0000-0000-0000-000000000000",
+              "registrant": {
+                "kind": "github"
+              },
+              "model": {
+                "version": ""
+              }
+            },
+            "patch": {
+              "patchStrategy": "replace",
+              "mutatedRef": [
+                [
+                  "configuration",
+                  "spec",
+                  "template",
+                  "spec",
+                  "containers",
+                  "0",
+                  "env",
+                  "0",
+                  "value"
+                ]
+              ]
+            }
+          }
+        ]
+      },
+      "deny": {
+        "from": [],
+        "to": []
+      }
+    }
+  ],
+  "subType": "reference",
+  "status": "enabled",
+  "type": "non-binding",
+  "version": "v1.0.0"
 }

--- a/server/meshmodel/aws-s3-controller/v1.1.3/v1.0.0/relationships/edge-non-binding-reference-bucket-deployment.json
+++ b/server/meshmodel/aws-s3-controller/v1.1.3/v1.0.0/relationships/edge-non-binding-reference-bucket-deployment.json
@@ -1,0 +1,110 @@
+{
+    "id": "00000000-0000-0000-0000-000000000000",
+    "evaluationQuery": "",
+    "kind": "edge",
+    "metadata": {
+        "description": "A Bucket provides S3 storage configuration to a Deployment by auto-populating the bucket name in environment variables.",
+        "styles": {
+            "primaryColor": "",
+            "svgColor": "",
+            "svgWhite": ""
+        },
+        "isAnnotation": false
+    },
+    "model": {
+        "version": "",
+        "name": "aws-s3-controller",
+        "displayName": "",
+        "id": "00000000-0000-0000-0000-000000000000",
+        "registrant": {
+            "kind": ""
+        },
+        "model": {
+            "version": "v1.1.3"
+        }
+    },
+    "schemaVersion": "relationships.meshery.io/v1alpha3",
+    "selectors": [
+        {
+            "allow": {
+                "from": [
+                    {
+                        "id": null,
+                        "kind": "Bucket",
+                        "match": {},
+                        "match_strategy_matrix": [
+                            [
+                                "equal_as_strings",
+                                "not_null"
+                            ]
+                        ],
+                        "model": {
+                            "version": "",
+                            "name": "aws-s3-controller",
+                            "displayName": "",
+                            "id": "00000000-0000-0000-0000-000000000000",
+                            "registrant": {
+                                "kind": "github"
+                            },
+                            "model": {
+                                "version": ""
+                            }
+                        },
+                        "patch": {
+                            "patchStrategy": "replace",
+                            "mutatorRef": [
+                                [
+                                    "displayName"
+                                ]
+                            ]
+                        }
+                    }
+                ],
+                "to": [
+                    {
+                        "id": null,
+                        "kind": "Deployment",
+                        "match": {},
+                        "match_strategy_matrix": null,
+                        "model": {
+                            "version": "",
+                            "name": "kubernetes",
+                            "displayName": "",
+                            "id": "00000000-0000-0000-0000-000000000000",
+                            "registrant": {
+                                "kind": "github"
+                            },
+                            "model": {
+                                "version": ""
+                            }
+                        },
+                        "patch": {
+                            "patchStrategy": "replace",
+                            "mutatedRef": [
+                                [
+                                    "configuration",
+                                    "spec",
+                                    "template",
+                                    "spec",
+                                    "containers",
+                                    "0",
+                                    "env",
+                                    "0",
+                                    "value"
+                                ]
+                            ]
+                        }
+                    }
+                ]
+            },
+            "deny": {
+                "from": [],
+                "to": []
+            }
+        }
+    ],
+    "subType": "reference",
+    "status": "enabled",
+    "type": "non-binding",
+    "version": "v1.0.0"
+}

--- a/server/meshmodel/aws-s3-controller/v1.1.3/v1.0.0/relationships/edge-non-binding-reference-bucket-pod.json
+++ b/server/meshmodel/aws-s3-controller/v1.1.3/v1.0.0/relationships/edge-non-binding-reference-bucket-pod.json
@@ -1,108 +1,110 @@
 {
+  "id": "00000000-0000-0000-0000-000000000000",
+  "evaluationQuery": "",
+  "kind": "edge",
+  "metadata": {
+    "description": "A Bucket provides S3 storage configuration to a Pod by auto-populating the bucket name in environment variables.",
+    "styles": {
+      "primaryColor": "",
+      "svgColor": "",
+      "svgWhite": ""
+    },
+    "isAnnotation": false
+  },
+  "model": {
+    "version": "",
+    "name": "aws-s3-controller",
+    "displayName": "",
     "id": "00000000-0000-0000-0000-000000000000",
-    "evaluationQuery": "",
-    "kind": "edge",
-    "metadata": {
-        "description": "A Bucket provides S3 storage configuration to a Pod by auto-populating the bucket name in environment variables.",
-        "styles": {
-            "primaryColor": "",
-            "svgColor": "",
-            "svgWhite": ""
-        },
-        "isAnnotation": false
+    "registrant": {
+      "kind": ""
     },
     "model": {
-        "version": "",
-        "name": "aws-s3-controller",
-        "displayName": "",
-        "id": "00000000-0000-0000-0000-000000000000",
-        "registrant": {
-            "kind": ""
-        },
-        "model": {
-            "version": "v1.1.3"
-        }
-    },
-    "schemaVersion": "relationships.meshery.io/v1alpha3",
-    "selectors": [
-        {
-            "allow": {
-                "from": [
-                    {
-                        "id": null,
-                        "kind": "Bucket",
-                        "match": {},
-                        "match_strategy_matrix": [
-                            [
-                                "equal_as_strings",
-                                "not_null"
-                            ]
-                        ],
-                        "model": {
-                            "version": "",
-                            "name": "aws-s3-controller",
-                            "displayName": "",
-                            "id": "00000000-0000-0000-0000-000000000000",
-                            "registrant": {
-                                "kind": "github"
-                            },
-                            "model": {
-                                "version": ""
-                            }
-                        },
-                        "patch": {
-                            "patchStrategy": "replace",
-                            "mutatorRef": [
-                                [
-                                    "displayName"
-                                ]
-                            ]
-                        }
-                    }
-                ],
-                "to": [
-                    {
-                        "id": null,
-                        "kind": "Pod",
-                        "match": {},
-                        "match_strategy_matrix": null,
-                        "model": {
-                            "version": "",
-                            "name": "kubernetes",
-                            "displayName": "",
-                            "id": "00000000-0000-0000-0000-000000000000",
-                            "registrant": {
-                                "kind": "github"
-                            },
-                            "model": {
-                                "version": ""
-                            }
-                        },
-                        "patch": {
-                            "patchStrategy": "replace",
-                            "mutatedRef": [
-                                [
-                                    "configuration",
-                                    "spec",
-                                    "containers",
-                                    "0",
-                                    "env",
-                                    "0",
-                                    "value"
-                                ]
-                            ]
-                        }
-                    }
-                ]
+      "version": "v1.1.3"
+    }
+  },
+  "schemaVersion": "relationships.meshery.io/v1alpha3",
+  "selectors": [
+    {
+      "allow": {
+        "from": [
+          {
+            "id": null,
+            "kind": "Bucket",
+            "match": {},
+            "match_strategy_matrix": [
+              [
+                "equal_as_strings",
+                "not_null"
+              ]
+            ],
+            "model": {
+              "version": "",
+              "name": "aws-s3-controller",
+              "displayName": "",
+              "id": "00000000-0000-0000-0000-000000000000",
+              "registrant": {
+                "kind": "github"
+              },
+              "model": {
+                "version": ""
+              }
             },
-            "deny": {
-                "from": [],
-                "to": []
+            "patch": {
+              "patchStrategy": "replace",
+              "mutatorRef": [
+                [
+                  "configuration",
+                  "spec",
+                  "name"
+                ]
+              ]
             }
-        }
-    ],
-    "subType": "reference",
-    "status": "enabled",
-    "type": "non-binding",
-    "version": "v1.0.0"
+          }
+        ],
+        "to": [
+          {
+            "id": null,
+            "kind": "Pod",
+            "match": {},
+            "match_strategy_matrix": null,
+            "model": {
+              "version": "",
+              "name": "kubernetes",
+              "displayName": "",
+              "id": "00000000-0000-0000-0000-000000000000",
+              "registrant": {
+                "kind": "github"
+              },
+              "model": {
+                "version": ""
+              }
+            },
+            "patch": {
+              "patchStrategy": "replace",
+              "mutatedRef": [
+                [
+                  "configuration",
+                  "spec",
+                  "containers",
+                  "0",
+                  "env",
+                  "0",
+                  "value"
+                ]
+              ]
+            }
+          }
+        ]
+      },
+      "deny": {
+        "from": [],
+        "to": []
+      }
+    }
+  ],
+  "subType": "reference",
+  "status": "enabled",
+  "type": "non-binding",
+  "version": "v1.0.0"
 }

--- a/server/meshmodel/aws-s3-controller/v1.1.3/v1.0.0/relationships/edge-non-binding-reference-bucket-pod.json
+++ b/server/meshmodel/aws-s3-controller/v1.1.3/v1.0.0/relationships/edge-non-binding-reference-bucket-pod.json
@@ -1,0 +1,108 @@
+{
+    "id": "00000000-0000-0000-0000-000000000000",
+    "evaluationQuery": "",
+    "kind": "edge",
+    "metadata": {
+        "description": "A Bucket provides S3 storage configuration to a Pod by auto-populating the bucket name in environment variables.",
+        "styles": {
+            "primaryColor": "",
+            "svgColor": "",
+            "svgWhite": ""
+        },
+        "isAnnotation": false
+    },
+    "model": {
+        "version": "",
+        "name": "aws-s3-controller",
+        "displayName": "",
+        "id": "00000000-0000-0000-0000-000000000000",
+        "registrant": {
+            "kind": ""
+        },
+        "model": {
+            "version": "v1.1.3"
+        }
+    },
+    "schemaVersion": "relationships.meshery.io/v1alpha3",
+    "selectors": [
+        {
+            "allow": {
+                "from": [
+                    {
+                        "id": null,
+                        "kind": "Bucket",
+                        "match": {},
+                        "match_strategy_matrix": [
+                            [
+                                "equal_as_strings",
+                                "not_null"
+                            ]
+                        ],
+                        "model": {
+                            "version": "",
+                            "name": "aws-s3-controller",
+                            "displayName": "",
+                            "id": "00000000-0000-0000-0000-000000000000",
+                            "registrant": {
+                                "kind": "github"
+                            },
+                            "model": {
+                                "version": ""
+                            }
+                        },
+                        "patch": {
+                            "patchStrategy": "replace",
+                            "mutatorRef": [
+                                [
+                                    "displayName"
+                                ]
+                            ]
+                        }
+                    }
+                ],
+                "to": [
+                    {
+                        "id": null,
+                        "kind": "Pod",
+                        "match": {},
+                        "match_strategy_matrix": null,
+                        "model": {
+                            "version": "",
+                            "name": "kubernetes",
+                            "displayName": "",
+                            "id": "00000000-0000-0000-0000-000000000000",
+                            "registrant": {
+                                "kind": "github"
+                            },
+                            "model": {
+                                "version": ""
+                            }
+                        },
+                        "patch": {
+                            "patchStrategy": "replace",
+                            "mutatedRef": [
+                                [
+                                    "configuration",
+                                    "spec",
+                                    "containers",
+                                    "0",
+                                    "env",
+                                    "0",
+                                    "value"
+                                ]
+                            ]
+                        }
+                    }
+                ]
+            },
+            "deny": {
+                "from": [],
+                "to": []
+            }
+        }
+    ],
+    "subType": "reference",
+    "status": "enabled",
+    "type": "non-binding",
+    "version": "v1.0.0"
+}

--- a/server/meshmodel/aws-s3-controller/v1.2.0/v1.0.0/relationships/edge-non-binding-reference-bucket-deployment.json
+++ b/server/meshmodel/aws-s3-controller/v1.2.0/v1.0.0/relationships/edge-non-binding-reference-bucket-deployment.json
@@ -1,110 +1,112 @@
 {
+  "id": "00000000-0000-0000-0000-000000000000",
+  "evaluationQuery": "",
+  "kind": "edge",
+  "metadata": {
+    "description": "A Bucket provides S3 storage configuration to a Deployment by auto-populating the bucket name in environment variables.",
+    "styles": {
+      "primaryColor": "",
+      "svgColor": "",
+      "svgWhite": ""
+    },
+    "isAnnotation": false
+  },
+  "model": {
+    "version": "",
+    "name": "aws-s3-controller",
+    "displayName": "",
     "id": "00000000-0000-0000-0000-000000000000",
-    "evaluationQuery": "",
-    "kind": "edge",
-    "metadata": {
-        "description": "A Bucket provides S3 storage configuration to a Deployment by auto-populating the bucket name in environment variables.",
-        "styles": {
-            "primaryColor": "",
-            "svgColor": "",
-            "svgWhite": ""
-        },
-        "isAnnotation": false
+    "registrant": {
+      "kind": ""
     },
     "model": {
-        "version": "",
-        "name": "aws-s3-controller",
-        "displayName": "",
-        "id": "00000000-0000-0000-0000-000000000000",
-        "registrant": {
-            "kind": ""
-        },
-        "model": {
-            "version": "v1.1.3"
-        }
-    },
-    "schemaVersion": "relationships.meshery.io/v1alpha3",
-    "selectors": [
-        {
-            "allow": {
-                "from": [
-                    {
-                        "id": null,
-                        "kind": "Bucket",
-                        "match": {},
-                        "match_strategy_matrix": [
-                            [
-                                "equal_as_strings",
-                                "not_null"
-                            ]
-                        ],
-                        "model": {
-                            "version": "",
-                            "name": "aws-s3-controller",
-                            "displayName": "",
-                            "id": "00000000-0000-0000-0000-000000000000",
-                            "registrant": {
-                                "kind": "github"
-                            },
-                            "model": {
-                                "version": ""
-                            }
-                        },
-                        "patch": {
-                            "patchStrategy": "replace",
-                            "mutatorRef": [
-                                [
-                                    "displayName"
-                                ]
-                            ]
-                        }
-                    }
-                ],
-                "to": [
-                    {
-                        "id": null,
-                        "kind": "Deployment",
-                        "match": {},
-                        "match_strategy_matrix": null,
-                        "model": {
-                            "version": "",
-                            "name": "kubernetes",
-                            "displayName": "",
-                            "id": "00000000-0000-0000-0000-000000000000",
-                            "registrant": {
-                                "kind": "github"
-                            },
-                            "model": {
-                                "version": ""
-                            }
-                        },
-                        "patch": {
-                            "patchStrategy": "replace",
-                            "mutatedRef": [
-                                [
-                                    "configuration",
-                                    "spec",
-                                    "template",
-                                    "spec",
-                                    "containers",
-                                    "0",
-                                    "env",
-                                    "0",
-                                    "value"
-                                ]
-                            ]
-                        }
-                    }
-                ]
+      "version": "v1.2.0"
+    }
+  },
+  "schemaVersion": "relationships.meshery.io/v1alpha3",
+  "selectors": [
+    {
+      "allow": {
+        "from": [
+          {
+            "id": null,
+            "kind": "Bucket",
+            "match": {},
+            "match_strategy_matrix": [
+              [
+                "equal_as_strings",
+                "not_null"
+              ]
+            ],
+            "model": {
+              "version": "",
+              "name": "aws-s3-controller",
+              "displayName": "",
+              "id": "00000000-0000-0000-0000-000000000000",
+              "registrant": {
+                "kind": "github"
+              },
+              "model": {
+                "version": ""
+              }
             },
-            "deny": {
-                "from": [],
-                "to": []
+            "patch": {
+              "patchStrategy": "replace",
+              "mutatorRef": [
+                [
+                  "configuration",
+                  "spec",
+                  "name"
+                ]
+              ]
             }
-        }
-    ],
-    "subType": "reference",
-    "status": "enabled",
-    "type": "non-binding",
-    "version": "v1.0.0"
+          }
+        ],
+        "to": [
+          {
+            "id": null,
+            "kind": "Deployment",
+            "match": {},
+            "match_strategy_matrix": null,
+            "model": {
+              "version": "",
+              "name": "kubernetes",
+              "displayName": "",
+              "id": "00000000-0000-0000-0000-000000000000",
+              "registrant": {
+                "kind": "github"
+              },
+              "model": {
+                "version": ""
+              }
+            },
+            "patch": {
+              "patchStrategy": "replace",
+              "mutatedRef": [
+                [
+                  "configuration",
+                  "spec",
+                  "template",
+                  "spec",
+                  "containers",
+                  "0",
+                  "env",
+                  "0",
+                  "value"
+                ]
+              ]
+            }
+          }
+        ]
+      },
+      "deny": {
+        "from": [],
+        "to": []
+      }
+    }
+  ],
+  "subType": "reference",
+  "status": "enabled",
+  "type": "non-binding",
+  "version": "v1.0.0"
 }

--- a/server/meshmodel/aws-s3-controller/v1.2.0/v1.0.0/relationships/edge-non-binding-reference-bucket-deployment.json
+++ b/server/meshmodel/aws-s3-controller/v1.2.0/v1.0.0/relationships/edge-non-binding-reference-bucket-deployment.json
@@ -1,0 +1,110 @@
+{
+    "id": "00000000-0000-0000-0000-000000000000",
+    "evaluationQuery": "",
+    "kind": "edge",
+    "metadata": {
+        "description": "A Bucket provides S3 storage configuration to a Deployment by auto-populating the bucket name in environment variables.",
+        "styles": {
+            "primaryColor": "",
+            "svgColor": "",
+            "svgWhite": ""
+        },
+        "isAnnotation": false
+    },
+    "model": {
+        "version": "",
+        "name": "aws-s3-controller",
+        "displayName": "",
+        "id": "00000000-0000-0000-0000-000000000000",
+        "registrant": {
+            "kind": ""
+        },
+        "model": {
+            "version": "v1.1.3"
+        }
+    },
+    "schemaVersion": "relationships.meshery.io/v1alpha3",
+    "selectors": [
+        {
+            "allow": {
+                "from": [
+                    {
+                        "id": null,
+                        "kind": "Bucket",
+                        "match": {},
+                        "match_strategy_matrix": [
+                            [
+                                "equal_as_strings",
+                                "not_null"
+                            ]
+                        ],
+                        "model": {
+                            "version": "",
+                            "name": "aws-s3-controller",
+                            "displayName": "",
+                            "id": "00000000-0000-0000-0000-000000000000",
+                            "registrant": {
+                                "kind": "github"
+                            },
+                            "model": {
+                                "version": ""
+                            }
+                        },
+                        "patch": {
+                            "patchStrategy": "replace",
+                            "mutatorRef": [
+                                [
+                                    "displayName"
+                                ]
+                            ]
+                        }
+                    }
+                ],
+                "to": [
+                    {
+                        "id": null,
+                        "kind": "Deployment",
+                        "match": {},
+                        "match_strategy_matrix": null,
+                        "model": {
+                            "version": "",
+                            "name": "kubernetes",
+                            "displayName": "",
+                            "id": "00000000-0000-0000-0000-000000000000",
+                            "registrant": {
+                                "kind": "github"
+                            },
+                            "model": {
+                                "version": ""
+                            }
+                        },
+                        "patch": {
+                            "patchStrategy": "replace",
+                            "mutatedRef": [
+                                [
+                                    "configuration",
+                                    "spec",
+                                    "template",
+                                    "spec",
+                                    "containers",
+                                    "0",
+                                    "env",
+                                    "0",
+                                    "value"
+                                ]
+                            ]
+                        }
+                    }
+                ]
+            },
+            "deny": {
+                "from": [],
+                "to": []
+            }
+        }
+    ],
+    "subType": "reference",
+    "status": "enabled",
+    "type": "non-binding",
+    "version": "v1.0.0"
+}

--- a/server/meshmodel/aws-s3-controller/v1.2.0/v1.0.0/relationships/edge-non-binding-reference-bucket-pod.json
+++ b/server/meshmodel/aws-s3-controller/v1.2.0/v1.0.0/relationships/edge-non-binding-reference-bucket-pod.json
@@ -1,108 +1,110 @@
 {
+  "id": "00000000-0000-0000-0000-000000000000",
+  "evaluationQuery": "",
+  "kind": "edge",
+  "metadata": {
+    "description": "A Bucket provides S3 storage configuration to a Pod by auto-populating the bucket name in environment variables.",
+    "styles": {
+      "primaryColor": "",
+      "svgColor": "",
+      "svgWhite": ""
+    },
+    "isAnnotation": false
+  },
+  "model": {
+    "version": "",
+    "name": "aws-s3-controller",
+    "displayName": "",
     "id": "00000000-0000-0000-0000-000000000000",
-    "evaluationQuery": "",
-    "kind": "edge",
-    "metadata": {
-        "description": "A Bucket provides S3 storage configuration to a Pod by auto-populating the bucket name in environment variables.",
-        "styles": {
-            "primaryColor": "",
-            "svgColor": "",
-            "svgWhite": ""
-        },
-        "isAnnotation": false
+    "registrant": {
+      "kind": ""
     },
     "model": {
-        "version": "",
-        "name": "aws-s3-controller",
-        "displayName": "",
-        "id": "00000000-0000-0000-0000-000000000000",
-        "registrant": {
-            "kind": ""
-        },
-        "model": {
-            "version": "v1.1.3"
-        }
-    },
-    "schemaVersion": "relationships.meshery.io/v1alpha3",
-    "selectors": [
-        {
-            "allow": {
-                "from": [
-                    {
-                        "id": null,
-                        "kind": "Bucket",
-                        "match": {},
-                        "match_strategy_matrix": [
-                            [
-                                "equal_as_strings",
-                                "not_null"
-                            ]
-                        ],
-                        "model": {
-                            "version": "",
-                            "name": "aws-s3-controller",
-                            "displayName": "",
-                            "id": "00000000-0000-0000-0000-000000000000",
-                            "registrant": {
-                                "kind": "github"
-                            },
-                            "model": {
-                                "version": ""
-                            }
-                        },
-                        "patch": {
-                            "patchStrategy": "replace",
-                            "mutatorRef": [
-                                [
-                                    "displayName"
-                                ]
-                            ]
-                        }
-                    }
-                ],
-                "to": [
-                    {
-                        "id": null,
-                        "kind": "Pod",
-                        "match": {},
-                        "match_strategy_matrix": null,
-                        "model": {
-                            "version": "",
-                            "name": "kubernetes",
-                            "displayName": "",
-                            "id": "00000000-0000-0000-0000-000000000000",
-                            "registrant": {
-                                "kind": "github"
-                            },
-                            "model": {
-                                "version": ""
-                            }
-                        },
-                        "patch": {
-                            "patchStrategy": "replace",
-                            "mutatedRef": [
-                                [
-                                    "configuration",
-                                    "spec",
-                                    "containers",
-                                    "0",
-                                    "env",
-                                    "0",
-                                    "value"
-                                ]
-                            ]
-                        }
-                    }
-                ]
+      "version": "v1.2.0"
+    }
+  },
+  "schemaVersion": "relationships.meshery.io/v1alpha3",
+  "selectors": [
+    {
+      "allow": {
+        "from": [
+          {
+            "id": null,
+            "kind": "Bucket",
+            "match": {},
+            "match_strategy_matrix": [
+              [
+                "equal_as_strings",
+                "not_null"
+              ]
+            ],
+            "model": {
+              "version": "",
+              "name": "aws-s3-controller",
+              "displayName": "",
+              "id": "00000000-0000-0000-0000-000000000000",
+              "registrant": {
+                "kind": "github"
+              },
+              "model": {
+                "version": ""
+              }
             },
-            "deny": {
-                "from": [],
-                "to": []
+            "patch": {
+              "patchStrategy": "replace",
+              "mutatorRef": [
+                [
+                  "configuration",
+                  "spec",
+                  "name"
+                ]
+              ]
             }
-        }
-    ],
-    "subType": "reference",
-    "status": "enabled",
-    "type": "non-binding",
-    "version": "v1.0.0"
+          }
+        ],
+        "to": [
+          {
+            "id": null,
+            "kind": "Pod",
+            "match": {},
+            "match_strategy_matrix": null,
+            "model": {
+              "version": "",
+              "name": "kubernetes",
+              "displayName": "",
+              "id": "00000000-0000-0000-0000-000000000000",
+              "registrant": {
+                "kind": "github"
+              },
+              "model": {
+                "version": ""
+              }
+            },
+            "patch": {
+              "patchStrategy": "replace",
+              "mutatedRef": [
+                [
+                  "configuration",
+                  "spec",
+                  "containers",
+                  "0",
+                  "env",
+                  "0",
+                  "value"
+                ]
+              ]
+            }
+          }
+        ]
+      },
+      "deny": {
+        "from": [],
+        "to": []
+      }
+    }
+  ],
+  "subType": "reference",
+  "status": "enabled",
+  "type": "non-binding",
+  "version": "v1.0.0"
 }

--- a/server/meshmodel/aws-s3-controller/v1.2.0/v1.0.0/relationships/edge-non-binding-reference-bucket-pod.json
+++ b/server/meshmodel/aws-s3-controller/v1.2.0/v1.0.0/relationships/edge-non-binding-reference-bucket-pod.json
@@ -1,0 +1,108 @@
+{
+    "id": "00000000-0000-0000-0000-000000000000",
+    "evaluationQuery": "",
+    "kind": "edge",
+    "metadata": {
+        "description": "A Bucket provides S3 storage configuration to a Pod by auto-populating the bucket name in environment variables.",
+        "styles": {
+            "primaryColor": "",
+            "svgColor": "",
+            "svgWhite": ""
+        },
+        "isAnnotation": false
+    },
+    "model": {
+        "version": "",
+        "name": "aws-s3-controller",
+        "displayName": "",
+        "id": "00000000-0000-0000-0000-000000000000",
+        "registrant": {
+            "kind": ""
+        },
+        "model": {
+            "version": "v1.1.3"
+        }
+    },
+    "schemaVersion": "relationships.meshery.io/v1alpha3",
+    "selectors": [
+        {
+            "allow": {
+                "from": [
+                    {
+                        "id": null,
+                        "kind": "Bucket",
+                        "match": {},
+                        "match_strategy_matrix": [
+                            [
+                                "equal_as_strings",
+                                "not_null"
+                            ]
+                        ],
+                        "model": {
+                            "version": "",
+                            "name": "aws-s3-controller",
+                            "displayName": "",
+                            "id": "00000000-0000-0000-0000-000000000000",
+                            "registrant": {
+                                "kind": "github"
+                            },
+                            "model": {
+                                "version": ""
+                            }
+                        },
+                        "patch": {
+                            "patchStrategy": "replace",
+                            "mutatorRef": [
+                                [
+                                    "displayName"
+                                ]
+                            ]
+                        }
+                    }
+                ],
+                "to": [
+                    {
+                        "id": null,
+                        "kind": "Pod",
+                        "match": {},
+                        "match_strategy_matrix": null,
+                        "model": {
+                            "version": "",
+                            "name": "kubernetes",
+                            "displayName": "",
+                            "id": "00000000-0000-0000-0000-000000000000",
+                            "registrant": {
+                                "kind": "github"
+                            },
+                            "model": {
+                                "version": ""
+                            }
+                        },
+                        "patch": {
+                            "patchStrategy": "replace",
+                            "mutatedRef": [
+                                [
+                                    "configuration",
+                                    "spec",
+                                    "containers",
+                                    "0",
+                                    "env",
+                                    "0",
+                                    "value"
+                                ]
+                            ]
+                        }
+                    }
+                ]
+            },
+            "deny": {
+                "from": [],
+                "to": []
+            }
+        }
+    ],
+    "subType": "reference",
+    "status": "enabled",
+    "type": "non-binding",
+    "version": "v1.0.0"
+}

--- a/server/meshmodel/aws-s3-controller/v1.2.1/v1.0.0/relationships/edge-non-binding-reference-bucket-deployment.json
+++ b/server/meshmodel/aws-s3-controller/v1.2.1/v1.0.0/relationships/edge-non-binding-reference-bucket-deployment.json
@@ -1,110 +1,112 @@
 {
+  "id": "00000000-0000-0000-0000-000000000000",
+  "evaluationQuery": "",
+  "kind": "edge",
+  "metadata": {
+    "description": "A Bucket provides S3 storage configuration to a Deployment by auto-populating the bucket name in environment variables.",
+    "styles": {
+      "primaryColor": "",
+      "svgColor": "",
+      "svgWhite": ""
+    },
+    "isAnnotation": false
+  },
+  "model": {
+    "version": "",
+    "name": "aws-s3-controller",
+    "displayName": "",
     "id": "00000000-0000-0000-0000-000000000000",
-    "evaluationQuery": "",
-    "kind": "edge",
-    "metadata": {
-        "description": "A Bucket provides S3 storage configuration to a Deployment by auto-populating the bucket name in environment variables.",
-        "styles": {
-            "primaryColor": "",
-            "svgColor": "",
-            "svgWhite": ""
-        },
-        "isAnnotation": false
+    "registrant": {
+      "kind": ""
     },
     "model": {
-        "version": "",
-        "name": "aws-s3-controller",
-        "displayName": "",
-        "id": "00000000-0000-0000-0000-000000000000",
-        "registrant": {
-            "kind": ""
-        },
-        "model": {
-            "version": "v1.1.3"
-        }
-    },
-    "schemaVersion": "relationships.meshery.io/v1alpha3",
-    "selectors": [
-        {
-            "allow": {
-                "from": [
-                    {
-                        "id": null,
-                        "kind": "Bucket",
-                        "match": {},
-                        "match_strategy_matrix": [
-                            [
-                                "equal_as_strings",
-                                "not_null"
-                            ]
-                        ],
-                        "model": {
-                            "version": "",
-                            "name": "aws-s3-controller",
-                            "displayName": "",
-                            "id": "00000000-0000-0000-0000-000000000000",
-                            "registrant": {
-                                "kind": "github"
-                            },
-                            "model": {
-                                "version": ""
-                            }
-                        },
-                        "patch": {
-                            "patchStrategy": "replace",
-                            "mutatorRef": [
-                                [
-                                    "displayName"
-                                ]
-                            ]
-                        }
-                    }
-                ],
-                "to": [
-                    {
-                        "id": null,
-                        "kind": "Deployment",
-                        "match": {},
-                        "match_strategy_matrix": null,
-                        "model": {
-                            "version": "",
-                            "name": "kubernetes",
-                            "displayName": "",
-                            "id": "00000000-0000-0000-0000-000000000000",
-                            "registrant": {
-                                "kind": "github"
-                            },
-                            "model": {
-                                "version": ""
-                            }
-                        },
-                        "patch": {
-                            "patchStrategy": "replace",
-                            "mutatedRef": [
-                                [
-                                    "configuration",
-                                    "spec",
-                                    "template",
-                                    "spec",
-                                    "containers",
-                                    "0",
-                                    "env",
-                                    "0",
-                                    "value"
-                                ]
-                            ]
-                        }
-                    }
-                ]
+      "version": "v1.2.1"
+    }
+  },
+  "schemaVersion": "relationships.meshery.io/v1alpha3",
+  "selectors": [
+    {
+      "allow": {
+        "from": [
+          {
+            "id": null,
+            "kind": "Bucket",
+            "match": {},
+            "match_strategy_matrix": [
+              [
+                "equal_as_strings",
+                "not_null"
+              ]
+            ],
+            "model": {
+              "version": "",
+              "name": "aws-s3-controller",
+              "displayName": "",
+              "id": "00000000-0000-0000-0000-000000000000",
+              "registrant": {
+                "kind": "github"
+              },
+              "model": {
+                "version": ""
+              }
             },
-            "deny": {
-                "from": [],
-                "to": []
+            "patch": {
+              "patchStrategy": "replace",
+              "mutatorRef": [
+                [
+                  "configuration",
+                  "spec",
+                  "name"
+                ]
+              ]
             }
-        }
-    ],
-    "subType": "reference",
-    "status": "enabled",
-    "type": "non-binding",
-    "version": "v1.0.0"
+          }
+        ],
+        "to": [
+          {
+            "id": null,
+            "kind": "Deployment",
+            "match": {},
+            "match_strategy_matrix": null,
+            "model": {
+              "version": "",
+              "name": "kubernetes",
+              "displayName": "",
+              "id": "00000000-0000-0000-0000-000000000000",
+              "registrant": {
+                "kind": "github"
+              },
+              "model": {
+                "version": ""
+              }
+            },
+            "patch": {
+              "patchStrategy": "replace",
+              "mutatedRef": [
+                [
+                  "configuration",
+                  "spec",
+                  "template",
+                  "spec",
+                  "containers",
+                  "0",
+                  "env",
+                  "0",
+                  "value"
+                ]
+              ]
+            }
+          }
+        ]
+      },
+      "deny": {
+        "from": [],
+        "to": []
+      }
+    }
+  ],
+  "subType": "reference",
+  "status": "enabled",
+  "type": "non-binding",
+  "version": "v1.0.0"
 }

--- a/server/meshmodel/aws-s3-controller/v1.2.1/v1.0.0/relationships/edge-non-binding-reference-bucket-deployment.json
+++ b/server/meshmodel/aws-s3-controller/v1.2.1/v1.0.0/relationships/edge-non-binding-reference-bucket-deployment.json
@@ -1,0 +1,110 @@
+{
+    "id": "00000000-0000-0000-0000-000000000000",
+    "evaluationQuery": "",
+    "kind": "edge",
+    "metadata": {
+        "description": "A Bucket provides S3 storage configuration to a Deployment by auto-populating the bucket name in environment variables.",
+        "styles": {
+            "primaryColor": "",
+            "svgColor": "",
+            "svgWhite": ""
+        },
+        "isAnnotation": false
+    },
+    "model": {
+        "version": "",
+        "name": "aws-s3-controller",
+        "displayName": "",
+        "id": "00000000-0000-0000-0000-000000000000",
+        "registrant": {
+            "kind": ""
+        },
+        "model": {
+            "version": "v1.1.3"
+        }
+    },
+    "schemaVersion": "relationships.meshery.io/v1alpha3",
+    "selectors": [
+        {
+            "allow": {
+                "from": [
+                    {
+                        "id": null,
+                        "kind": "Bucket",
+                        "match": {},
+                        "match_strategy_matrix": [
+                            [
+                                "equal_as_strings",
+                                "not_null"
+                            ]
+                        ],
+                        "model": {
+                            "version": "",
+                            "name": "aws-s3-controller",
+                            "displayName": "",
+                            "id": "00000000-0000-0000-0000-000000000000",
+                            "registrant": {
+                                "kind": "github"
+                            },
+                            "model": {
+                                "version": ""
+                            }
+                        },
+                        "patch": {
+                            "patchStrategy": "replace",
+                            "mutatorRef": [
+                                [
+                                    "displayName"
+                                ]
+                            ]
+                        }
+                    }
+                ],
+                "to": [
+                    {
+                        "id": null,
+                        "kind": "Deployment",
+                        "match": {},
+                        "match_strategy_matrix": null,
+                        "model": {
+                            "version": "",
+                            "name": "kubernetes",
+                            "displayName": "",
+                            "id": "00000000-0000-0000-0000-000000000000",
+                            "registrant": {
+                                "kind": "github"
+                            },
+                            "model": {
+                                "version": ""
+                            }
+                        },
+                        "patch": {
+                            "patchStrategy": "replace",
+                            "mutatedRef": [
+                                [
+                                    "configuration",
+                                    "spec",
+                                    "template",
+                                    "spec",
+                                    "containers",
+                                    "0",
+                                    "env",
+                                    "0",
+                                    "value"
+                                ]
+                            ]
+                        }
+                    }
+                ]
+            },
+            "deny": {
+                "from": [],
+                "to": []
+            }
+        }
+    ],
+    "subType": "reference",
+    "status": "enabled",
+    "type": "non-binding",
+    "version": "v1.0.0"
+}

--- a/server/meshmodel/aws-s3-controller/v1.2.1/v1.0.0/relationships/edge-non-binding-reference-bucket-pod.json
+++ b/server/meshmodel/aws-s3-controller/v1.2.1/v1.0.0/relationships/edge-non-binding-reference-bucket-pod.json
@@ -1,108 +1,110 @@
 {
+  "id": "00000000-0000-0000-0000-000000000000",
+  "evaluationQuery": "",
+  "kind": "edge",
+  "metadata": {
+    "description": "A Bucket provides S3 storage configuration to a Pod by auto-populating the bucket name in environment variables.",
+    "styles": {
+      "primaryColor": "",
+      "svgColor": "",
+      "svgWhite": ""
+    },
+    "isAnnotation": false
+  },
+  "model": {
+    "version": "",
+    "name": "aws-s3-controller",
+    "displayName": "",
     "id": "00000000-0000-0000-0000-000000000000",
-    "evaluationQuery": "",
-    "kind": "edge",
-    "metadata": {
-        "description": "A Bucket provides S3 storage configuration to a Pod by auto-populating the bucket name in environment variables.",
-        "styles": {
-            "primaryColor": "",
-            "svgColor": "",
-            "svgWhite": ""
-        },
-        "isAnnotation": false
+    "registrant": {
+      "kind": ""
     },
     "model": {
-        "version": "",
-        "name": "aws-s3-controller",
-        "displayName": "",
-        "id": "00000000-0000-0000-0000-000000000000",
-        "registrant": {
-            "kind": ""
-        },
-        "model": {
-            "version": "v1.1.3"
-        }
-    },
-    "schemaVersion": "relationships.meshery.io/v1alpha3",
-    "selectors": [
-        {
-            "allow": {
-                "from": [
-                    {
-                        "id": null,
-                        "kind": "Bucket",
-                        "match": {},
-                        "match_strategy_matrix": [
-                            [
-                                "equal_as_strings",
-                                "not_null"
-                            ]
-                        ],
-                        "model": {
-                            "version": "",
-                            "name": "aws-s3-controller",
-                            "displayName": "",
-                            "id": "00000000-0000-0000-0000-000000000000",
-                            "registrant": {
-                                "kind": "github"
-                            },
-                            "model": {
-                                "version": ""
-                            }
-                        },
-                        "patch": {
-                            "patchStrategy": "replace",
-                            "mutatorRef": [
-                                [
-                                    "displayName"
-                                ]
-                            ]
-                        }
-                    }
-                ],
-                "to": [
-                    {
-                        "id": null,
-                        "kind": "Pod",
-                        "match": {},
-                        "match_strategy_matrix": null,
-                        "model": {
-                            "version": "",
-                            "name": "kubernetes",
-                            "displayName": "",
-                            "id": "00000000-0000-0000-0000-000000000000",
-                            "registrant": {
-                                "kind": "github"
-                            },
-                            "model": {
-                                "version": ""
-                            }
-                        },
-                        "patch": {
-                            "patchStrategy": "replace",
-                            "mutatedRef": [
-                                [
-                                    "configuration",
-                                    "spec",
-                                    "containers",
-                                    "0",
-                                    "env",
-                                    "0",
-                                    "value"
-                                ]
-                            ]
-                        }
-                    }
-                ]
+      "version": "v1.2.1"
+    }
+  },
+  "schemaVersion": "relationships.meshery.io/v1alpha3",
+  "selectors": [
+    {
+      "allow": {
+        "from": [
+          {
+            "id": null,
+            "kind": "Bucket",
+            "match": {},
+            "match_strategy_matrix": [
+              [
+                "equal_as_strings",
+                "not_null"
+              ]
+            ],
+            "model": {
+              "version": "",
+              "name": "aws-s3-controller",
+              "displayName": "",
+              "id": "00000000-0000-0000-0000-000000000000",
+              "registrant": {
+                "kind": "github"
+              },
+              "model": {
+                "version": ""
+              }
             },
-            "deny": {
-                "from": [],
-                "to": []
+            "patch": {
+              "patchStrategy": "replace",
+              "mutatorRef": [
+                [
+                  "configuration",
+                  "spec",
+                  "name"
+                ]
+              ]
             }
-        }
-    ],
-    "subType": "reference",
-    "status": "enabled",
-    "type": "non-binding",
-    "version": "v1.0.0"
+          }
+        ],
+        "to": [
+          {
+            "id": null,
+            "kind": "Pod",
+            "match": {},
+            "match_strategy_matrix": null,
+            "model": {
+              "version": "",
+              "name": "kubernetes",
+              "displayName": "",
+              "id": "00000000-0000-0000-0000-000000000000",
+              "registrant": {
+                "kind": "github"
+              },
+              "model": {
+                "version": ""
+              }
+            },
+            "patch": {
+              "patchStrategy": "replace",
+              "mutatedRef": [
+                [
+                  "configuration",
+                  "spec",
+                  "containers",
+                  "0",
+                  "env",
+                  "0",
+                  "value"
+                ]
+              ]
+            }
+          }
+        ]
+      },
+      "deny": {
+        "from": [],
+        "to": []
+      }
+    }
+  ],
+  "subType": "reference",
+  "status": "enabled",
+  "type": "non-binding",
+  "version": "v1.0.0"
 }

--- a/server/meshmodel/aws-s3-controller/v1.2.1/v1.0.0/relationships/edge-non-binding-reference-bucket-pod.json
+++ b/server/meshmodel/aws-s3-controller/v1.2.1/v1.0.0/relationships/edge-non-binding-reference-bucket-pod.json
@@ -1,0 +1,108 @@
+{
+    "id": "00000000-0000-0000-0000-000000000000",
+    "evaluationQuery": "",
+    "kind": "edge",
+    "metadata": {
+        "description": "A Bucket provides S3 storage configuration to a Pod by auto-populating the bucket name in environment variables.",
+        "styles": {
+            "primaryColor": "",
+            "svgColor": "",
+            "svgWhite": ""
+        },
+        "isAnnotation": false
+    },
+    "model": {
+        "version": "",
+        "name": "aws-s3-controller",
+        "displayName": "",
+        "id": "00000000-0000-0000-0000-000000000000",
+        "registrant": {
+            "kind": ""
+        },
+        "model": {
+            "version": "v1.1.3"
+        }
+    },
+    "schemaVersion": "relationships.meshery.io/v1alpha3",
+    "selectors": [
+        {
+            "allow": {
+                "from": [
+                    {
+                        "id": null,
+                        "kind": "Bucket",
+                        "match": {},
+                        "match_strategy_matrix": [
+                            [
+                                "equal_as_strings",
+                                "not_null"
+                            ]
+                        ],
+                        "model": {
+                            "version": "",
+                            "name": "aws-s3-controller",
+                            "displayName": "",
+                            "id": "00000000-0000-0000-0000-000000000000",
+                            "registrant": {
+                                "kind": "github"
+                            },
+                            "model": {
+                                "version": ""
+                            }
+                        },
+                        "patch": {
+                            "patchStrategy": "replace",
+                            "mutatorRef": [
+                                [
+                                    "displayName"
+                                ]
+                            ]
+                        }
+                    }
+                ],
+                "to": [
+                    {
+                        "id": null,
+                        "kind": "Pod",
+                        "match": {},
+                        "match_strategy_matrix": null,
+                        "model": {
+                            "version": "",
+                            "name": "kubernetes",
+                            "displayName": "",
+                            "id": "00000000-0000-0000-0000-000000000000",
+                            "registrant": {
+                                "kind": "github"
+                            },
+                            "model": {
+                                "version": ""
+                            }
+                        },
+                        "patch": {
+                            "patchStrategy": "replace",
+                            "mutatedRef": [
+                                [
+                                    "configuration",
+                                    "spec",
+                                    "containers",
+                                    "0",
+                                    "env",
+                                    "0",
+                                    "value"
+                                ]
+                            ]
+                        }
+                    }
+                ]
+            },
+            "deny": {
+                "from": [],
+                "to": []
+            }
+        }
+    ],
+    "subType": "reference",
+    "status": "enabled",
+    "type": "non-binding",
+    "version": "v1.0.0"
+}

--- a/server/meshmodel/aws-s3-controller/v1.2.2/v1.0.0/relationships/edge-non-binding-reference-bucket-deployment.json
+++ b/server/meshmodel/aws-s3-controller/v1.2.2/v1.0.0/relationships/edge-non-binding-reference-bucket-deployment.json
@@ -1,110 +1,112 @@
 {
+  "id": "00000000-0000-0000-0000-000000000000",
+  "evaluationQuery": "",
+  "kind": "edge",
+  "metadata": {
+    "description": "A Bucket provides S3 storage configuration to a Deployment by auto-populating the bucket name in environment variables.",
+    "styles": {
+      "primaryColor": "",
+      "svgColor": "",
+      "svgWhite": ""
+    },
+    "isAnnotation": false
+  },
+  "model": {
+    "version": "",
+    "name": "aws-s3-controller",
+    "displayName": "",
     "id": "00000000-0000-0000-0000-000000000000",
-    "evaluationQuery": "",
-    "kind": "edge",
-    "metadata": {
-        "description": "A Bucket provides S3 storage configuration to a Deployment by auto-populating the bucket name in environment variables.",
-        "styles": {
-            "primaryColor": "",
-            "svgColor": "",
-            "svgWhite": ""
-        },
-        "isAnnotation": false
+    "registrant": {
+      "kind": ""
     },
     "model": {
-        "version": "",
-        "name": "aws-s3-controller",
-        "displayName": "",
-        "id": "00000000-0000-0000-0000-000000000000",
-        "registrant": {
-            "kind": ""
-        },
-        "model": {
-            "version": "v1.1.3"
-        }
-    },
-    "schemaVersion": "relationships.meshery.io/v1alpha3",
-    "selectors": [
-        {
-            "allow": {
-                "from": [
-                    {
-                        "id": null,
-                        "kind": "Bucket",
-                        "match": {},
-                        "match_strategy_matrix": [
-                            [
-                                "equal_as_strings",
-                                "not_null"
-                            ]
-                        ],
-                        "model": {
-                            "version": "",
-                            "name": "aws-s3-controller",
-                            "displayName": "",
-                            "id": "00000000-0000-0000-0000-000000000000",
-                            "registrant": {
-                                "kind": "github"
-                            },
-                            "model": {
-                                "version": ""
-                            }
-                        },
-                        "patch": {
-                            "patchStrategy": "replace",
-                            "mutatorRef": [
-                                [
-                                    "displayName"
-                                ]
-                            ]
-                        }
-                    }
-                ],
-                "to": [
-                    {
-                        "id": null,
-                        "kind": "Deployment",
-                        "match": {},
-                        "match_strategy_matrix": null,
-                        "model": {
-                            "version": "",
-                            "name": "kubernetes",
-                            "displayName": "",
-                            "id": "00000000-0000-0000-0000-000000000000",
-                            "registrant": {
-                                "kind": "github"
-                            },
-                            "model": {
-                                "version": ""
-                            }
-                        },
-                        "patch": {
-                            "patchStrategy": "replace",
-                            "mutatedRef": [
-                                [
-                                    "configuration",
-                                    "spec",
-                                    "template",
-                                    "spec",
-                                    "containers",
-                                    "0",
-                                    "env",
-                                    "0",
-                                    "value"
-                                ]
-                            ]
-                        }
-                    }
-                ]
+      "version": "v1.2.2"
+    }
+  },
+  "schemaVersion": "relationships.meshery.io/v1alpha3",
+  "selectors": [
+    {
+      "allow": {
+        "from": [
+          {
+            "id": null,
+            "kind": "Bucket",
+            "match": {},
+            "match_strategy_matrix": [
+              [
+                "equal_as_strings",
+                "not_null"
+              ]
+            ],
+            "model": {
+              "version": "",
+              "name": "aws-s3-controller",
+              "displayName": "",
+              "id": "00000000-0000-0000-0000-000000000000",
+              "registrant": {
+                "kind": "github"
+              },
+              "model": {
+                "version": ""
+              }
             },
-            "deny": {
-                "from": [],
-                "to": []
+            "patch": {
+              "patchStrategy": "replace",
+              "mutatorRef": [
+                [
+                  "configuration",
+                  "spec",
+                  "name"
+                ]
+              ]
             }
-        }
-    ],
-    "subType": "reference",
-    "status": "enabled",
-    "type": "non-binding",
-    "version": "v1.0.0"
+          }
+        ],
+        "to": [
+          {
+            "id": null,
+            "kind": "Deployment",
+            "match": {},
+            "match_strategy_matrix": null,
+            "model": {
+              "version": "",
+              "name": "kubernetes",
+              "displayName": "",
+              "id": "00000000-0000-0000-0000-000000000000",
+              "registrant": {
+                "kind": "github"
+              },
+              "model": {
+                "version": ""
+              }
+            },
+            "patch": {
+              "patchStrategy": "replace",
+              "mutatedRef": [
+                [
+                  "configuration",
+                  "spec",
+                  "template",
+                  "spec",
+                  "containers",
+                  "0",
+                  "env",
+                  "0",
+                  "value"
+                ]
+              ]
+            }
+          }
+        ]
+      },
+      "deny": {
+        "from": [],
+        "to": []
+      }
+    }
+  ],
+  "subType": "reference",
+  "status": "enabled",
+  "type": "non-binding",
+  "version": "v1.0.0"
 }

--- a/server/meshmodel/aws-s3-controller/v1.2.2/v1.0.0/relationships/edge-non-binding-reference-bucket-deployment.json
+++ b/server/meshmodel/aws-s3-controller/v1.2.2/v1.0.0/relationships/edge-non-binding-reference-bucket-deployment.json
@@ -1,0 +1,110 @@
+{
+    "id": "00000000-0000-0000-0000-000000000000",
+    "evaluationQuery": "",
+    "kind": "edge",
+    "metadata": {
+        "description": "A Bucket provides S3 storage configuration to a Deployment by auto-populating the bucket name in environment variables.",
+        "styles": {
+            "primaryColor": "",
+            "svgColor": "",
+            "svgWhite": ""
+        },
+        "isAnnotation": false
+    },
+    "model": {
+        "version": "",
+        "name": "aws-s3-controller",
+        "displayName": "",
+        "id": "00000000-0000-0000-0000-000000000000",
+        "registrant": {
+            "kind": ""
+        },
+        "model": {
+            "version": "v1.1.3"
+        }
+    },
+    "schemaVersion": "relationships.meshery.io/v1alpha3",
+    "selectors": [
+        {
+            "allow": {
+                "from": [
+                    {
+                        "id": null,
+                        "kind": "Bucket",
+                        "match": {},
+                        "match_strategy_matrix": [
+                            [
+                                "equal_as_strings",
+                                "not_null"
+                            ]
+                        ],
+                        "model": {
+                            "version": "",
+                            "name": "aws-s3-controller",
+                            "displayName": "",
+                            "id": "00000000-0000-0000-0000-000000000000",
+                            "registrant": {
+                                "kind": "github"
+                            },
+                            "model": {
+                                "version": ""
+                            }
+                        },
+                        "patch": {
+                            "patchStrategy": "replace",
+                            "mutatorRef": [
+                                [
+                                    "displayName"
+                                ]
+                            ]
+                        }
+                    }
+                ],
+                "to": [
+                    {
+                        "id": null,
+                        "kind": "Deployment",
+                        "match": {},
+                        "match_strategy_matrix": null,
+                        "model": {
+                            "version": "",
+                            "name": "kubernetes",
+                            "displayName": "",
+                            "id": "00000000-0000-0000-0000-000000000000",
+                            "registrant": {
+                                "kind": "github"
+                            },
+                            "model": {
+                                "version": ""
+                            }
+                        },
+                        "patch": {
+                            "patchStrategy": "replace",
+                            "mutatedRef": [
+                                [
+                                    "configuration",
+                                    "spec",
+                                    "template",
+                                    "spec",
+                                    "containers",
+                                    "0",
+                                    "env",
+                                    "0",
+                                    "value"
+                                ]
+                            ]
+                        }
+                    }
+                ]
+            },
+            "deny": {
+                "from": [],
+                "to": []
+            }
+        }
+    ],
+    "subType": "reference",
+    "status": "enabled",
+    "type": "non-binding",
+    "version": "v1.0.0"
+}

--- a/server/meshmodel/aws-s3-controller/v1.2.2/v1.0.0/relationships/edge-non-binding-reference-bucket-pod.json
+++ b/server/meshmodel/aws-s3-controller/v1.2.2/v1.0.0/relationships/edge-non-binding-reference-bucket-pod.json
@@ -1,0 +1,108 @@
+{
+    "id": "00000000-0000-0000-0000-000000000000",
+    "evaluationQuery": "",
+    "kind": "edge",
+    "metadata": {
+        "description": "A Bucket provides S3 storage configuration to a Pod by auto-populating the bucket name in environment variables.",
+        "styles": {
+            "primaryColor": "",
+            "svgColor": "",
+            "svgWhite": ""
+        },
+        "isAnnotation": false
+    },
+    "model": {
+        "version": "",
+        "name": "aws-s3-controller",
+        "displayName": "",
+        "id": "00000000-0000-0000-0000-000000000000",
+        "registrant": {
+            "kind": ""
+        },
+        "model": {
+            "version": "v1.1.3"
+        }
+    },
+    "schemaVersion": "relationships.meshery.io/v1alpha3",
+    "selectors": [
+        {
+            "allow": {
+                "from": [
+                    {
+                        "id": null,
+                        "kind": "Bucket",
+                        "match": {},
+                        "match_strategy_matrix": [
+                            [
+                                "equal_as_strings",
+                                "not_null"
+                            ]
+                        ],
+                        "model": {
+                            "version": "",
+                            "name": "aws-s3-controller",
+                            "displayName": "",
+                            "id": "00000000-0000-0000-0000-000000000000",
+                            "registrant": {
+                                "kind": "github"
+                            },
+                            "model": {
+                                "version": ""
+                            }
+                        },
+                        "patch": {
+                            "patchStrategy": "replace",
+                            "mutatorRef": [
+                                [
+                                    "displayName"
+                                ]
+                            ]
+                        }
+                    }
+                ],
+                "to": [
+                    {
+                        "id": null,
+                        "kind": "Pod",
+                        "match": {},
+                        "match_strategy_matrix": null,
+                        "model": {
+                            "version": "",
+                            "name": "kubernetes",
+                            "displayName": "",
+                            "id": "00000000-0000-0000-0000-000000000000",
+                            "registrant": {
+                                "kind": "github"
+                            },
+                            "model": {
+                                "version": ""
+                            }
+                        },
+                        "patch": {
+                            "patchStrategy": "replace",
+                            "mutatedRef": [
+                                [
+                                    "configuration",
+                                    "spec",
+                                    "containers",
+                                    "0",
+                                    "env",
+                                    "0",
+                                    "value"
+                                ]
+                            ]
+                        }
+                    }
+                ]
+            },
+            "deny": {
+                "from": [],
+                "to": []
+            }
+        }
+    ],
+    "subType": "reference",
+    "status": "enabled",
+    "type": "non-binding",
+    "version": "v1.0.0"
+}

--- a/server/meshmodel/aws-s3-controller/v1.2.2/v1.0.0/relationships/edge-non-binding-reference-bucket-pod.json
+++ b/server/meshmodel/aws-s3-controller/v1.2.2/v1.0.0/relationships/edge-non-binding-reference-bucket-pod.json
@@ -1,108 +1,110 @@
 {
+  "id": "00000000-0000-0000-0000-000000000000",
+  "evaluationQuery": "",
+  "kind": "edge",
+  "metadata": {
+    "description": "A Bucket provides S3 storage configuration to a Pod by auto-populating the bucket name in environment variables.",
+    "styles": {
+      "primaryColor": "",
+      "svgColor": "",
+      "svgWhite": ""
+    },
+    "isAnnotation": false
+  },
+  "model": {
+    "version": "",
+    "name": "aws-s3-controller",
+    "displayName": "",
     "id": "00000000-0000-0000-0000-000000000000",
-    "evaluationQuery": "",
-    "kind": "edge",
-    "metadata": {
-        "description": "A Bucket provides S3 storage configuration to a Pod by auto-populating the bucket name in environment variables.",
-        "styles": {
-            "primaryColor": "",
-            "svgColor": "",
-            "svgWhite": ""
-        },
-        "isAnnotation": false
+    "registrant": {
+      "kind": ""
     },
     "model": {
-        "version": "",
-        "name": "aws-s3-controller",
-        "displayName": "",
-        "id": "00000000-0000-0000-0000-000000000000",
-        "registrant": {
-            "kind": ""
-        },
-        "model": {
-            "version": "v1.1.3"
-        }
-    },
-    "schemaVersion": "relationships.meshery.io/v1alpha3",
-    "selectors": [
-        {
-            "allow": {
-                "from": [
-                    {
-                        "id": null,
-                        "kind": "Bucket",
-                        "match": {},
-                        "match_strategy_matrix": [
-                            [
-                                "equal_as_strings",
-                                "not_null"
-                            ]
-                        ],
-                        "model": {
-                            "version": "",
-                            "name": "aws-s3-controller",
-                            "displayName": "",
-                            "id": "00000000-0000-0000-0000-000000000000",
-                            "registrant": {
-                                "kind": "github"
-                            },
-                            "model": {
-                                "version": ""
-                            }
-                        },
-                        "patch": {
-                            "patchStrategy": "replace",
-                            "mutatorRef": [
-                                [
-                                    "displayName"
-                                ]
-                            ]
-                        }
-                    }
-                ],
-                "to": [
-                    {
-                        "id": null,
-                        "kind": "Pod",
-                        "match": {},
-                        "match_strategy_matrix": null,
-                        "model": {
-                            "version": "",
-                            "name": "kubernetes",
-                            "displayName": "",
-                            "id": "00000000-0000-0000-0000-000000000000",
-                            "registrant": {
-                                "kind": "github"
-                            },
-                            "model": {
-                                "version": ""
-                            }
-                        },
-                        "patch": {
-                            "patchStrategy": "replace",
-                            "mutatedRef": [
-                                [
-                                    "configuration",
-                                    "spec",
-                                    "containers",
-                                    "0",
-                                    "env",
-                                    "0",
-                                    "value"
-                                ]
-                            ]
-                        }
-                    }
-                ]
+      "version": "v1.2.2"
+    }
+  },
+  "schemaVersion": "relationships.meshery.io/v1alpha3",
+  "selectors": [
+    {
+      "allow": {
+        "from": [
+          {
+            "id": null,
+            "kind": "Bucket",
+            "match": {},
+            "match_strategy_matrix": [
+              [
+                "equal_as_strings",
+                "not_null"
+              ]
+            ],
+            "model": {
+              "version": "",
+              "name": "aws-s3-controller",
+              "displayName": "",
+              "id": "00000000-0000-0000-0000-000000000000",
+              "registrant": {
+                "kind": "github"
+              },
+              "model": {
+                "version": ""
+              }
             },
-            "deny": {
-                "from": [],
-                "to": []
+            "patch": {
+              "patchStrategy": "replace",
+              "mutatorRef": [
+                [
+                  "configuration",
+                  "spec",
+                  "name"
+                ]
+              ]
             }
-        }
-    ],
-    "subType": "reference",
-    "status": "enabled",
-    "type": "non-binding",
-    "version": "v1.0.0"
+          }
+        ],
+        "to": [
+          {
+            "id": null,
+            "kind": "Pod",
+            "match": {},
+            "match_strategy_matrix": null,
+            "model": {
+              "version": "",
+              "name": "kubernetes",
+              "displayName": "",
+              "id": "00000000-0000-0000-0000-000000000000",
+              "registrant": {
+                "kind": "github"
+              },
+              "model": {
+                "version": ""
+              }
+            },
+            "patch": {
+              "patchStrategy": "replace",
+              "mutatedRef": [
+                [
+                  "configuration",
+                  "spec",
+                  "containers",
+                  "0",
+                  "env",
+                  "0",
+                  "value"
+                ]
+              ]
+            }
+          }
+        ]
+      },
+      "deny": {
+        "from": [],
+        "to": []
+      }
+    }
+  ],
+  "subType": "reference",
+  "status": "enabled",
+  "type": "non-binding",
+  "version": "v1.0.0"
 }


### PR DESCRIPTION
## Description

This PR adds two new reference relationships that enable automatic configuration of S3 bucket names in Kubernetes Pods and Deployments through Meshery Kanvas:

- **Bucket → Deployment**: Auto-populates S3 bucket name in Deployment environment variables
- **Bucket → Pod**: Auto-populates S3 bucket name in Pod environment variables

- Contributes to #17096 

## Changes

- Added `edge-non-binding-reference-bucket-deployment.json` across 13 aws-s3-controller versions
- Added `edge-non-binding-reference-bucket-pod.json` across 13 aws-s3-controller versions
- Total: 26 new relationship files

## How It Works

When users connect an S3 Bucket to a Deployment/Pod in Kanvas, the relationship automatically populates the bucket name (from `spec.name`) into the first environment variable (`env[0].value`) of the target component.

**Example**:
```yaml
# Before connection
env:
- name: S3_BUCKET
  value: ""

# After connecting Bucket → Deployment
env:
- name: S3_BUCKET
  value: "my-app-uploads"  # Auto-populated from Bucket.spec.name
```
---
<img width="1023" height="810" alt="image" src="https://github.com/user-attachments/assets/fcfaf966-f041-425a-981f-32f0bbd5f9e6" />

---
## Benefits

- ✅ Eliminates manual YAML editing for S3 integration
- ✅ Prevents typos and configuration errors
- ✅ Follows 12-factor app pattern (environment variables)
- ✅ Enables visual infrastructure design in Kanvas

**Notes for Reviewers**

- Relationships use `mutatorRef: ["configuration", "spec", "name"]` to extract the actual AWS bucket name (not the Kubernetes resource name)
- Auto-populates first environment variable only (`env[0].value`)
- Non-binding reference type (components can exist independently)

**[Signed commits](https://github.com/meshery/meshery/blob/master/CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [x] Yes, I signed my commits.
