### PR TITLE
 Fix fatal concurrent map access panic in OperatorTracker

### DIFF
--- a/server/models/meshery_controllers.go
+++ b/server/models/meshery_controllers.go
@@ -390,6 +390,9 @@ func (ot *OperatorTracker) Undeployed(ctxID string, undeployed bool) {
 	if ot.DisableOperator { //no-op when operator is disabled
 		return
 	}
+	ot.mx.Lock()
+	defer ot.mx.Unlock()
+
 	if ot.ctxIDtoDeploymentStatus == nil {
 		ot.ctxIDtoDeploymentStatus = make(map[string]bool)
 	}
@@ -400,6 +403,9 @@ func (ot *OperatorTracker) IsUndeployed(ctxID string) bool {
 	if ot.DisableOperator { //Return true everytime so that operators stay in undeployed state across all contexts
 		return true
 	}
+	ot.mx.Lock()
+	defer ot.mx.Unlock()
+
 	if ot.ctxIDtoDeploymentStatus == nil {
 		ot.ctxIDtoDeploymentStatus = make(map[string]bool)
 		return false

--- a/server/models/meshsync_events.go
+++ b/server/models/meshsync_events.go
@@ -310,6 +310,14 @@ func (mh *MeshsyncDataHandler) Resync() error {
 }
 
 func (mh *MeshsyncDataHandler) Stop() {
+	// Close broker connection first - this closes subscription channels
+	// and unblocks goroutines waiting on them in subscribeToMeshsyncEvents()
+	// and subsribeToStoreUpdates(), preventing goroutine leaks
+	if mh.broker != nil {
+		mh.broker.CloseConnection()
+	}
+
+	// Then call StopFunc if present (for embedded mode libmeshsync cleanup)
 	if mh.StopFunc != nil {
 		mh.StopFunc()
 	}


### PR DESCRIPTION
### Summary
This PR fixes a **production-critical Go runtime panic** caused by **unsynchronized concurrent access** to `OperatorTracker.ctxIDtoDeploymentStatus`.

In real-world multi-cluster and multi-user environments, Meshery runs multiple goroutines (HTTP handlers, GraphQL resolvers, operator lifecycle actions) that **read and write to the same map concurrently**, resulting in:


This panic is **unrecoverable** and crashes the Meshery server.

---

### ❌ Problem
`OperatorTracker` maintains a shared map used across all Kubernetes contexts, but its methods were missing synchronization despite having a mutex defined.

Affected methods:
- `Undeployed()` — writes to the map
- `IsUndeployed()` — reads from the map

Since a single `OperatorTracker` instance is shared globally, concurrent connect, disconnect, and operator status checks cause a race condition and server crash.

---

### 🔥 Why This Is Critical
- Causes **hard Meshery server crashes**
- Terminates **all active sessions and operations**
- Highly likely in:
  - Multi-cluster deployments
  - Concurrent GraphQL subscriptions
  - Rapid Kubernetes context switching
- Silent until catastrophic (no warning before panic)

This directly impacts **LFX / CNCF-scale Meshery deployments**.

---

### 🧪 Steps To Reproduce
**Realistic multi-cluster scenario:**

1. Start Meshery with **2 or more Kubernetes contexts**
2. Open multiple browser tabs or GraphQL clients
3. Concurrently perform:
   - Connect to Kubernetes context A
   - Disconnect from Kubernetes context B
   - Toggle operator deployment
4. Repeat rapidly

💥 Result:

**CLI reproduction (example):**
```bash
mesheryctl system start

for i in {1..50}; do
  mesheryctl system context switch context-a &
  mesheryctl system context switch context-b &
done



