### PR TITLE
[mesheryctl] Fix E2E test failures (provider name, assertions, error messages)

### DIFF
--- a/mesheryctl/tests/e2e/000-prerequisites/00-config.bats
+++ b/mesheryctl/tests/e2e/000-prerequisites/00-config.bats
@@ -15,7 +15,7 @@ setup() {
     run yq '.contexts.local.provider' "$MESHERY_CONFIG_FILE_PATH"
     assert_success
 
-    assert_output  --partial "Meshery"       
+    assert_output  --partial "Layer5"       
 }
 
 @test "mesehry auth.json file as been created" {

--- a/mesheryctl/tests/e2e/001-system/01-system-context.bats
+++ b/mesheryctl/tests/e2e/001-system/01-system-context.bats
@@ -7,7 +7,7 @@ setup() {
     ENDPOINT_REGEX_MATCH='^[[:space:]]*endpoint:[[:space:]](http|https)://.*:[[:digit:]]+$'
     TOKEN_REGEX_MATCH='^[[:space:]]*token:[[:space:]][[:alnum:]]+$'
     PLATFORM_REGEX_MATCH='^[[:space:]]*platform:[[:space:]](kubernetes|docker)+$'
-    PROVIDER_REGEX_MATCH='^[[:space:]]*provider:[[:space:]][a-zA-Z]+$'
+    PROVIDER_REGEX_MATCH='^[[:space:]]*provider:[[:space:]][a-zA-Z0-9]+$'
     CONTEXT_REGEXP_MATCH='^Current[[:space:]]Context:[[:space:]][a-zA-Z]+$'
 }
 

--- a/mesheryctl/tests/e2e/004-perf/00-perf-apply.bats
+++ b/mesheryctl/tests/e2e/004-perf/00-perf-apply.bats
@@ -8,7 +8,7 @@ setup() {
 @test "mesheryctl perf apply fails when new profile and URL is missing" {
     run $MESHERYCTL_BIN perf apply dummy-test-profile -y
 
-    assert_success
+    assert_failure
     assert_line --partial "Unable to get URL for performing test"
 }
 

--- a/mesheryctl/tests/e2e/005-component/03-component-view.bats
+++ b/mesheryctl/tests/e2e/005-component/03-component-view.bats
@@ -87,13 +87,11 @@ test_view_save() {
 }
 
 @test "view command fails with an invalid output format" {
-  local expected_error="Error: output-format \"xml\" is invalid. Available options [json|yaml]
-See https://docs.meshery.io/reference/mesheryctl/exp/components/view for usage details"
-
   run $MESHERYCTL_BIN component view some-component -o xml
 
   assert_failure
-  assert_output "$expected_error"
+  assert_output --partial "output-format \"xml\" is invalid"
+  assert_output --partial "Available options [json|yaml]"
 }
 
 @test "view command displays JSON output for a known component" {

--- a/mesheryctl/tests/e2e/006-registry/01-generate.bats
+++ b/mesheryctl/tests/e2e/006-registry/01-generate.bats
@@ -21,7 +21,7 @@ common_outputs_on_success() {
 @test "mesheryctl registry generate displays usage instructions when no arguments are provided" {
     run $MESHERYCTL_BIN registry generate 
     assert_failure
-    assert_output --partial "[ Spreadsheet ID | Registrant Connection Definition Path | Local Directory ] isn't specified"
+    assert_output --partial "[ Spreadsheet ID | Registrant Connection Definition Path | Local Directory | Individual CSV files ] isn't specified"
     assert_output --partial "Usage:"
     assert_output --partial "mesheryctl registry generate --spreadsheet-id [Spreadsheet ID] --spreadsheet-cred \$CRED"
 }


### PR DESCRIPTION
## Description

This PR fixes 16 E2E test failures in the `mesheryctl-e2e.yaml` workflow as identified in #17038.

## Changes

### 1. Provider Name Mismatch (Tests 4, 15, 16)

**File:** `mesheryctl/tests/e2e/000-prerequisites/00-config.bats`
- Changed expected provider name from `"Meshery"` to `"Layer5"` (line 18)
- Test 6 already expects `"Layer5"` and passes, confirming this is the correct provider name

**File:** `mesheryctl/tests/e2e/001-system/01-system-context.bats`
- Updated provider regex from `[a-zA-Z]+` to `[a-zA-Z0-9]+` to match provider names with numbers (like `Layer5`)

### 2. Perf Apply Assertion Fix (Test 73)

**File:** `mesheryctl/tests/e2e/004-perf/00-perf-apply.bats`
- Changed `assert_success` to `assert_failure` (line 11)
- The command exits with status `1` and outputs an error message, so it should be testing for failure

### 3. Component View Output Matching Fix (Test 88)

**File:** `mesheryctl/tests/e2e/005-component/03-component-view.bats`
- Changed from exact `assert_output` to `assert_output --partial` for core error message
- mesheryctl now outputs additional context lines, so partial matching is more robust

### 4. Registry Generate Message Update (Test 93)

**File:** `mesheryctl/tests/e2e/006-registry/01-generate.bats`
- Updated expected error message to include `Individual CSV files` option
- **Before:** `[ Spreadsheet ID | Registrant Connection Definition Path | Local Directory ] isn't specified`
- **After:** `[ Spreadsheet ID | Registrant Connection Definition Path | Local Directory | Individual CSV files ] isn't specified`

## Testing

These changes align test expectations with actual mesheryctl behavior. The fixes are straightforward test updates that don't modify any production code.

## Related Issue

Fixes #17038

---

<!-- Gittensor Contribution Tag: @GlobalStar117 -->