### PR TITLE
Lint only staged files in the pre-commit hook

### DIFF
--- a/ui/.lintstagedrc.js
+++ b/ui/.lintstagedrc.js
@@ -1,8 +1,8 @@
 module.exports = {
   // Lint & Prettify only staged JS/JSX/TS/TSX files
   '**/*.(ts|tsx|js|jsx)': (filenames) => [
-    `npx eslint --fix --max-warnings=0 ${filenames.join(' ')}`,
-    `npx prettier --write ${filenames.join(' ')}`,
+    `npx eslint --fix --max-warnings=0 ${filenames.map((f) => `"${f}"`).join(' ')}`,
+    `npx prettier --write ${filenames.map((f) => `"${f}"`).join(' ')}`
   ],
 
   // Prettify only Markdown and JSON files


### PR DESCRIPTION
**Notes for Reviewers**

- Lint only staged files in the pre-commit hook not the whole project by iterating upon staged files

- This PR fixes #

**[Signed commits](https://github.com/meshery/meshery/blob/master/CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [x] Yes, I signed my commits.

<!--
Thank you for contributing to Meshery! 

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. Sign your commits.
4. Include before and after screenshots/terminal output.

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.
-->
