### PR TITLE
Fix blank page issue when accessing /user/login with local provider

### DIFF
--- a/server/models/default_local_provider.go
+++ b/server/models/default_local_provider.go
@@ -139,8 +139,17 @@ func (l *DefaultLocalProvider) GetProviderCapabilities(w http.ResponseWriter, _ 
 }
 
 // InitiateLogin - initiates login flow and returns a true to indicate the handler to "return" or false to continue
-func (l *DefaultLocalProvider) InitiateLogin(_ http.ResponseWriter, _ *http.Request, _ bool) {
+// For local auth we just send the user to the home page and avoid caching.
+func (l *DefaultLocalProvider) InitiateLogin(w http.ResponseWriter, r *http.Request, _ bool) {
 	// l.issueSession(w, r, fromMiddleWare)
+
+	// Prevent stale cached redirects.
+	w.Header().Set("Cache-Control", "no-store, no-cache, must-revalidate, max-age=0")
+	w.Header().Set("Pragma", "no-cache")
+	w.Header().Set("Expires", "Thu, 01 Jan 1970 00:00:00 GMT")
+
+	// Nothing to authenticate locally; land on the app shell.
+	http.Redirect(w, r, "/", http.StatusFound)
 }
 
 func (l *DefaultLocalProvider) fetchUserDetails() *User {


### PR DESCRIPTION

**Notes for Reviewers**

- This PR fixes #17087 

### Description
When users set the provider to "None" (local provider) and access the `/user/login?` endpoint, they encounter a blank white page instead of being redirected to the Meshery UI. The HTTP response returns a 200 status code but with no content or redirect, leaving users unable to access the application.

### Root Cause
The `InitiateLogin()` method in `DefaultLocalProvider` (`server/models/default_local_provider.go:142-144`) was empty and performed no action, resulting in an incomplete HTTP response.

### Changes
- Implemented proper authentication flow logic in `DefaultLocalProvider.InitiateLogin()`
- Added cache-control headers to prevent stale redirects
- Added HTTP redirect to home page for local provider users
- Ensured consistency with `RemoteProvider.InitiateLogin()` pattern

### Before
```go
func (l *DefaultLocalProvider) InitiateLogin(_ http.ResponseWriter, _ *http.Request, _ bool) {
    // l.issueSession(w, r, fromMiddleWare)
}
```

###After
```go
func (l *DefaultLocalProvider) InitiateLogin(w http.ResponseWriter, r *http.Request, _ bool) {
    // Set cache-control headers to prevent browsers from caching the redirect response.
    w.Header().Set("Cache-Control", "no-store, no-cache, must-revalidate, max-age=0")
    w.Header().Set("Pragma", "no-cache")
    w.Header().Set("Expires", "Thu, 01 Jan 1970 00:00:00 GMT")

    // For the local provider, no authentication is needed.
    // Simply redirect the user to the home page.
    http.Redirect(w, r, "/", http.StatusFound)
}
```


**[Signed commits](https://github.com/meshery/meshery/blob/master/CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [X] Yes, I signed my commits.

<!--
Thank you for contributing to Meshery! 

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. Sign your commits.
4. Include before and after screenshots/terminal output.

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.
-->
