### PR TITLE
fix: correct hover selector for LearnMore

### DIFF
--- a/provider-ui/components/Provider.style.js
+++ b/provider-ui/components/Provider.style.js
@@ -73,7 +73,7 @@ export const LearnMore = styled("div")(() => ({
   marginLeft: "auto",
   marginRight: "auto",
   marginTop: "3rem",
-  "& :hover": {
+  "&:hover": {
     cursor: "pointer",
   },
 }));


### PR DESCRIPTION
Fixes hover selector for LearnMore to apply cursor style correctly.

Changes:
- Updated hover selector from "& :hover" to "&:hover"
- Improves UI hover behavior in Provider UI
