### PR TITLE
[Docs] Highlight Schema-Driven Development across contributing guides

### DIFF
--- a/docs/_includes/sdd-alert.md
+++ b/docs/_includes/sdd-alert.md
@@ -1,0 +1,1 @@
+{% include alert.html type="info" title="Schema-Driven Development" content="Meshery follows <b>Schema-Driven Development (SDD)</b>. Schemas are the single source of truth, used for validation, API documentation, and code generation. Before contributing, review the <a href='/project/contributing/contributing-schemas'>Contributing to Schemas</a> guide." %}

--- a/docs/pages/project/contributing/contributing-adapters.md
+++ b/docs/pages/project/contributing/contributing-adapters.md
@@ -10,7 +10,7 @@ list: include
 abstract: How to contribute to Meshery Adapters
 ---
 
-{% include alert.html type="info" title="Schema-Driven Development" content="Meshery follows <b>Schema-Driven Development (SDD)</b>. Schemas are the single source of truth, used for validation, API documentation, and code generation. Before contributing, review the <a href='/project/contributing/contributing-schemas'>Contributing to Schemas</a> guide." %}
+{% include sdd-alert.md %}
 
 Meshery Adapters are the Extension Points in Meshery's architecture. Their design, the process of creating a new adapter is documented in [Extensibility: Meshery Adapters]({{site.baseurl}}/extensibility/adapters).
 

--- a/docs/pages/project/contributing/contributing-cli-tests.md
+++ b/docs/pages/project/contributing/contributing-cli-tests.md
@@ -10,7 +10,7 @@ list: include
 display-title: false
 ---
 
-{% include alert.html type="info" title="Schema-Driven Development" content="Meshery follows <b>Schema-Driven Development (SDD)</b>. Schemas are the single source of truth, used for validation, API documentation, and code generation. Before contributing, review the <a href='/project/contributing/contributing-schemas'>Contributing to Schemas</a> guide." %}
+{% include sdd-alert.md %}
 
 Meshery CLI is the command line interface for Meshery. Meshery CLI, otherwise known as `mesheryctl`, is a client of Meshery Server's [REST API]({{site.baseurl}}/extensibility/api). It provides a way to interact with Meshery and perform various operations such as installing, configuring, and managing cloud native infrastructure.
 

--- a/docs/pages/project/contributing/contributing-cli.md
+++ b/docs/pages/project/contributing/contributing-cli.md
@@ -9,7 +9,7 @@ category: contributing
 list: include
 ---
 
-{% include alert.html type="info" title="Schema-Driven Development" content="Meshery follows <b>Schema-Driven Development (SDD)</b>. Schemas are the single source of truth, used for validation, API documentation, and code generation. Before contributing, review the <a href='/project/contributing/contributing-schemas'>Contributing to Schemas</a> guide." %}
+{% include sdd-alert.md %}
 
 `mesheryctl` is written in Golang or the Go Programming Language. For development use Go version 1.23+. `mesheryctl` uses the [Cobra](https://github.com/spf13/cobra) framework. A good first-step towards contributing to `mesheryctl` would be to familiarise yourself with the [Cobra concepts](https://github.com/spf13/cobra#concepts). For manipulating config files, `mesheryctl` uses [Viper](https://github.com/spf13/viper).
 

--- a/docs/pages/project/contributing/contributing-docker-extension.md
+++ b/docs/pages/project/contributing/contributing-docker-extension.md
@@ -10,7 +10,7 @@ category: contributing
 list: include
 ---
 
-{% include alert.html type="info" title="Schema-Driven Development" content="Meshery follows <b>Schema-Driven Development (SDD)</b>. Schemas are the single source of truth, used for validation, API documentation, and code generation. Before contributing, review the <a href='/project/contributing/contributing-schemas'>Contributing to Schemas</a> guide." %}
+{% include sdd-alert.md %}
 
 ## Prerequisites
 To start contributing to Meshery Docker Extension, make sure you have [Docker](https://docs.docker.com/get-docker/) installed on your system.

--- a/docs/pages/project/contributing/contributing-error.md
+++ b/docs/pages/project/contributing/contributing-error.md
@@ -9,7 +9,7 @@ category: contributing
 list: include
 ---
 
-{% include alert.html type="info" title="Schema-Driven Development" content="Meshery follows <b>Schema-Driven Development (SDD)</b>. Schemas are the single source of truth, used for validation, API documentation, and code generation. Before contributing, review the <a href='/project/contributing/contributing-schemas'>Contributing to Schemas</a> guide." %}
+{% include sdd-alert.md %}
 
 Meshery pervasively uses MeshKit as a golang and infrastructure management-specific library in all of its components. MeshKit helps populate error messages with a uniform and useful set of informative attributes.
 

--- a/docs/pages/project/contributing/contributing-model-components.md
+++ b/docs/pages/project/contributing/contributing-model-components.md
@@ -10,7 +10,7 @@ category: contributing
 list: include
 ---
 
-{% include alert.html type="info" title="Schema-Driven Development" content="Meshery follows <b>Schema-Driven Development (SDD)</b>. Schemas are the single source of truth, used for validation, API documentation, and code generation. Before contributing, review the <a href='/project/contributing/contributing-schemas'>Contributing to Schemas</a> guide." %}
+{% include sdd-alert.md %}
 
 In Meshery, a [Components](/concepts/logical/components) is a fundamental building block used to represent and define the infrastructure under management. Each component provides granular and specific support for your infrastructure and applications. Once registered with Meshery Server (in the [Registry](/concepts/logical/registry)), components are available for inclusion in [Designs](/concepts/logical/designs) that you create. Components can be created and published by anyone, allowing you to share you custom extensions with the community.
 

--- a/docs/pages/project/contributing/contributing-model-relationships.md
+++ b/docs/pages/project/contributing/contributing-model-relationships.md
@@ -10,7 +10,7 @@ category: contributing
 list: include
 ---
 
-{% include alert.html type="info" title="Schema-Driven Development" content="Meshery follows <b>Schema-Driven Development (SDD)</b>. Schemas are the single source of truth, used for validation, API documentation, and code generation. Before contributing, review the <a href='/project/contributing/contributing-schemas'>Contributing to Schemas</a> guide." %}
+{% include sdd-alert.md %}
 
 [Relationships](/concepts/logical/relationships) within [Models](/concepts/logical/models) play a crucial role in establishing concrete visualisations of efficient data flow between different components of Meshery. These are used to classify the nature of interaction between one or more interconnected [Components](/concepts/logical/components).
 

--- a/docs/pages/project/contributing/contributing-models-quick-start.md
+++ b/docs/pages/project/contributing/contributing-models-quick-start.md
@@ -10,7 +10,7 @@ category: contributing
 list: include
 ---
 
-{% include alert.html type="info" title="Schema-Driven Development" content="Meshery follows <b>Schema-Driven Development (SDD)</b>. Schemas are the single source of truth, used for validation, API documentation, and code generation. Before contributing, review the <a href='/project/contributing/contributing-schemas'>Contributing to Schemas</a> guide." %}
+{% include sdd-alert.md %}
 
 [Meshery Models](/concepts/logical/models) are a way to represent the architecture of a system or application. Models are defined in JSON and can be used to visualize the components and relationships between them. This guide will walk you through the process of creating a new model.
 

--- a/docs/pages/project/contributing/contributing-models.md
+++ b/docs/pages/project/contributing/contributing-models.md
@@ -10,7 +10,7 @@ category: contributing
 list: include
 ---
 
-{% include alert.html type="info" title="Schema-Driven Development" content="Meshery follows <b>Schema-Driven Development (SDD)</b>. Schemas are the single source of truth, used for validation, API documentation, and code generation. Before contributing, review the <a href='/project/contributing/contributing-schemas'>Contributing to Schemas</a> guide." %}
+{% include sdd-alert.md %}
 
 ## Understanding the internals of Meshery's logical object model
 

--- a/docs/pages/project/contributing/contributing-rego.md
+++ b/docs/pages/project/contributing/contributing-rego.md
@@ -9,7 +9,7 @@ category: contributing
 list: include
 ---
 
-{% include alert.html type="info" title="Schema-Driven Development" content="Meshery follows <b>Schema-Driven Development (SDD)</b>. Schemas are the single source of truth, used for validation, API documentation, and code generation. Before contributing, review the <a href='/project/contributing/contributing-schemas'>Contributing to Schemas</a> guide." %}
+{% include sdd-alert.md %}
 
 ## Background
 Meshery has a built-in policy engine, based on [Open Policy Agent (OPA)](https://www.openpolicyagent.org/docs/latest/). Meshery uses the [Rego](https://www.openpolicyagent.org/docs/latest/policy-language/) query language to create these [policies](https://docs.meshery.io/concepts/logical/policies). 

--- a/docs/pages/project/contributing/contributing-sever-events.md
+++ b/docs/pages/project/contributing/contributing-sever-events.md
@@ -9,7 +9,7 @@ language: en
 list: include
 ---
 
-{% include alert.html type="info" title="Schema-Driven Development" content="Meshery follows <b>Schema-Driven Development (SDD)</b>. Schemas are the single source of truth, used for validation, API documentation, and code generation. Before contributing, review the <a href='/project/contributing/contributing-schemas'>Contributing to Schemas</a> guide." %}
+{% include sdd-alert.md %}
 
 Meshery incorporates an internal events publication mechanism that provides users with real-time updates on the processes occurring within the Meshery server when interacting with its endpoints. It ensures that users are kept in the loop regarding the ongoing activities within the API, and guides users towards future steps to resolve issues. This guide will provide step-by-step instructions on sending events from the server, including when to trigger events and what information to include.
 

--- a/docs/pages/project/contributing/contributing-ui-notification-center.md
+++ b/docs/pages/project/contributing/contributing-ui-notification-center.md
@@ -10,7 +10,7 @@ category: contributing
 list: include
 ---
 
-{% include alert.html type="info" title="Schema-Driven Development" content="Meshery follows <b>Schema-Driven Development (SDD)</b>. Schemas are the single source of truth, used for validation, API documentation, and code generation. Before contributing, review the <a href='/project/contributing/contributing-schemas'>Contributing to Schemas</a> guide." %}
+{% include sdd-alert.md %}
 
 <div class="prereqs"><p><strong style="font-size: 20px;">Prerequisite Reading</strong></p>
   <ol><li><a href="contributing-ui">Contributing to Meshery UI</a></li></ol>

--- a/docs/pages/project/contributing/contributing-ui-sistent.md
+++ b/docs/pages/project/contributing/contributing-ui-sistent.md
@@ -10,7 +10,7 @@ category: contributing
 list: include
 ---
 
-{% include alert.html type="info" title="Schema-Driven Development" content="Meshery follows <b>Schema-Driven Development (SDD)</b>. Schemas are the single source of truth, used for validation, API documentation, and code generation. Before contributing, review the <a href='/project/contributing/contributing-schemas'>Contributing to Schemas</a> guide." %}
+{% include sdd-alert.md %}
 
 <div class="prereqs"><p><strong style="font-size: 20px;">Prerequisite Reading</strong></p>
   <ol><li><a href="contributing-ui">Contributing to Meshery UI</a></li></ol>

--- a/docs/pages/project/contributing/contributing-ui-tests.md
+++ b/docs/pages/project/contributing/contributing-ui-tests.md
@@ -9,7 +9,7 @@ category: contributing
 list: include
 ---
 
-{% include alert.html type="info" title="Schema-Driven Development" content="Meshery follows <b>Schema-Driven Development (SDD)</b>. Schemas are the single source of truth, used for validation, API documentation, and code generation. Before contributing, review the <a href='/project/contributing/contributing-schemas'>Contributing to Schemas</a> guide." %}
+{% include sdd-alert.md %}
 
 To automate functional integration and end-to-end testing Meshery uses [Playwright](https://playwright.dev/) as one of the tools to automate browser testing. End-to-end tests run with each pull request to ensure that the changes do not break the existing functionality.
 

--- a/docs/pages/project/contributing/contributing-ui-widgets.md
+++ b/docs/pages/project/contributing/contributing-ui-widgets.md
@@ -10,7 +10,7 @@ category: contributing
 list: include
 ---
 
-{% include alert.html type="info" title="Schema-Driven Development" content="Meshery follows <b>Schema-Driven Development (SDD)</b>. Schemas are the single source of truth, used for validation, API documentation, and code generation. Before contributing, review the <a href='/project/contributing/contributing-schemas'>Contributing to Schemas</a> guide." %}
+{% include sdd-alert.md %}
 
 <div class="prereqs"><p><strong style="font-size: 20px;">Prerequisite Reading</strong></p>
   <ol><li><a href="contributing-ui">Contributing to Meshery UI</a></li></ol>

--- a/docs/pages/project/contributing/contributing-ui.md
+++ b/docs/pages/project/contributing/contributing-ui.md
@@ -9,7 +9,7 @@ category: contributing
 list: include
 ---
 
-{% include alert.html type="info" title="Schema-Driven Development" content="Meshery follows <b>Schema-Driven Development (SDD)</b>. Schemas are the single source of truth, used for validation, API documentation, and code generation. Before contributing, review the <a href='/project/contributing/contributing-schemas'>Contributing to Schemas</a> guide." %}
+{% include sdd-alert.md %}
 
 ## <a name="contributing-ui">UI Contribution Flow</a>
 

--- a/docs/pages/project/contributing/contributing.md
+++ b/docs/pages/project/contributing/contributing.md
@@ -14,7 +14,7 @@ display-suggested-reading: false
 abstract: How to contribute to the Meshery project and any of its components.
 ---
 
-{% include alert.html type="info" title="Schema-Driven Development" content="Meshery follows <b>Schema-Driven Development (SDD)</b>. Schemas are the single source of truth, used for validation, API documentation, and code generation. Before contributing, review the <a href='/project/contributing/contributing-schemas'>Contributing to Schemas</a> guide." %}
+{% include sdd-alert.md %}
 
 # Contributing
 

--- a/docs/pages/project/contributing/meshery-server.md
+++ b/docs/pages/project/contributing/meshery-server.md
@@ -10,7 +10,7 @@ category: contributing
 list: include
 ---
 
-{% include alert.html type="info" title="Schema-Driven Development" content="Meshery follows <b>Schema-Driven Development (SDD)</b>. Schemas are the single source of truth, used for validation, API documentation, and code generation. Before contributing, review the <a href='/project/contributing/contributing-schemas'>Contributing to Schemas</a> guide." %}
+{% include sdd-alert.md %}
 
 As a new contributor, you’re going to want to familiarize with the project in order to resolve the issues in the best way. Installing and playing around with Meshery will give you context for any issues that you might work on.
 


### PR DESCRIPTION
**Notes for Reviewers**

- Fixes #16962

**[Signed commits](https://github.com/meshery/meshery/blob/master/CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [x] Yes, I signed my commits.

---

## Summary

Added a standardized note about Schema-Driven Development (SDD) at the top of all code-related contributing documentation files, linking to the [Contributing to Schemas](https://docs.meshery.io/project/contributing/contributing-schemas) guide.

### Problem

Contributors may not be aware that Meshery follows Schema-Driven Development, where schemas are the single source of truth for generating code artifacts.

### Solution

Added the following alert to 18 contributing guides:

```
{% include alert.html type="info" title="Schema-Driven Development" 
content="Meshery follows Schema-Driven Development (SDD). Schemas are the 
single source of truth, used for validation, API documentation, and code 
generation. Before contributing, review the Contributing to Schemas guide." %}
```

### Files Modified

| Category | Files |
|----------|-------|
| Main | `contributing.md` |
| CLI | `contributing-cli.md`, `contributing-cli-tests.md` |
| UI | `contributing-ui.md`, `-notification-center`, `-sistent`, `-tests`, `-widgets` |
| Models | `contributing-models.md`, `-components`, `-relationships`, `-quick-start` |
| Server | `meshery-server.md`, `contributing-error.md`, `contributing-sever-events.md` |
| Other | `contributing-adapters.md`, `contributing-docker-extension.md`, `contributing-rego.md` |

### Files Not Modified (already have SDD content or not code-related)

- `contributing-schemas.md` - already the SDD guide itself
- `contributing-ui-schemas.md` - already describes schema-driven approach
- `contributing-docs.md`, `contributing-gitflow.md`, etc. - documentation/process guides

## Screenshots

N/A - text-only changes