### PR TITLE
[mesheryctl]: Improved error output readability for mesheryctl connection delete command

### DIFF
--- a/mesheryctl/helpers/component_info.json
+++ b/mesheryctl/helpers/component_info.json
@@ -1,5 +1,5 @@
 {
   "name": "mesheryctl",
   "type": "client",
-  "next_error_code": 1196
+  "next_error_code": 1197
 }

--- a/mesheryctl/internal/cli/root/connections/delete.go
+++ b/mesheryctl/internal/cli/root/connections/delete.go
@@ -37,7 +37,7 @@ mesheryctl connection delete [connection_id]
 		_, err := api.Delete(fmt.Sprintf("%s/%s", connectionApiPath, args[0]))
 		if err != nil {
 			if strings.Contains(err.Error(), "no rows in result set") {
-				return ErrConnectionNotFound(fmt.Errorf("non-existent connection ID: %q", args[0]))
+				return errConnectionNotFound(fmt.Errorf("No connection with id %q found", args[0]))
 			}
 
 			return err

--- a/mesheryctl/internal/cli/root/connections/error.go
+++ b/mesheryctl/internal/cli/root/connections/error.go
@@ -16,7 +16,7 @@ var (
 	ErrGcpGKEGetCredentialsCode   = "mesheryctl-1175"
 	ErrReadKubeConfigCode         = "mesheryctl-1187"
 	ErrWriteKubeConfigCode        = "mesheryctl-1188"
-	ErrConnectionNotFoundCode     = "replace_me"
+	ErrConnectionNotFoundCode     = "mesheryctl-1196"
 
 	invalidOutputFormatMsg = "output-format choice is invalid, use [json|yaml]"
 )
@@ -53,6 +53,6 @@ func errGcpGKEGetCredentials(err error) error {
 	return errors.New(ErrGcpGKEGetCredentialsCode, errors.Alert, []string{"Unable to get GKE cluster credentials"}, []string{"There was an error while fetching the GKE cluster credentials"}, []string{err.Error()}, []string{"Ensure that the GKE cluster name, zone, and project ID are correct, and that you have the necessary permissions to access the cluster"})
 }
 
-func ErrConnectionNotFound(err error) error {
+func errConnectionNotFound(err error) error {
 	return errors.New(ErrConnectionNotFoundCode, errors.Alert, []string{"Connection not found"}, []string{err.Error()}, []string{"The specified connection ID does not exist"}, []string{"Verify the connection ID using `mesheryctl connection list`"})
 }


### PR DESCRIPTION
**Notes for Reviewers**

- This PR fixes #17145

When deleting a connection using non-existent ID it returns returns internal error including provider, database errors and HTTP 500 responses.

before
<img width="1920" height="253" alt="Screenshot_2026-01-26_01 56 02" src="https://github.com/user-attachments/assets/4059ebac-2f6a-4ecf-9549-9e4c3b192f86" />


This Pr improves the readability of the output

after
<img width="1367" height="129" alt="Screenshot_2026-01-26_17 52 03" src="https://github.com/user-attachments/assets/9227d8b9-a183-46df-8338-50ca9ea3b158" />


**[Signed commits](https://github.com/meshery/meshery/blob/master/CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [x] Yes, I signed my commits.

<!--
Thank you for contributing to Meshery! 

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. Sign your commits.
4. Include before and after screenshots/terminal output.

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.
-->
