### PR TITLE
Fix nil pointer dereference in state machine context extraction

### DIFF
--- a/server/machines/actions.go
+++ b/server/machines/actions.go
@@ -31,9 +31,16 @@ func (da *DefaultConnectAction) ExecuteOnEntry(ctx context.Context, machineCtx i
 }
 
 func (da *DefaultConnectAction) Execute(ctx context.Context, machineCtx interface{}, data interface{}) (EventType, *events.Event, error) {
-
-	user, _ := ctx.Value(models.UserCtxKey).(*models.User)
-	sysID, _ := ctx.Value(models.SystemIDKey).(*uuid.UUID)
+	user, ok := ctx.Value(models.UserCtxKey).(*models.User)
+	if !ok || user == nil {
+		err := ErrMissingUserContext()
+		return NoOp, nil, err
+	}
+	sysID, ok := ctx.Value(models.SystemIDKey).(*uuid.UUID)
+	if !ok || sysID == nil {
+		err := ErrMissingSystemIDContext()
+		return NoOp, nil, err
+	}
 	userUUID := user.ID
 
 	token, _ := ctx.Value(models.TokenCtxKey).(string)

--- a/server/machines/error.go
+++ b/server/machines/error.go
@@ -12,6 +12,8 @@ const (
 	ErrInititalizeK8sMachineCode  = "meshery-server-1216"
 	ErrAssetMachineCtxCode        = "meshery-server-1217"
 	ErrInvalidTypeCode            = "meshery-server-1218"
+	ErrMissingUserContextCode     = "meshery-server-1219"
+	ErrMissingSystemIDContextCode = "meshery-server-1220"
 )
 
 func ErrInvalidTransition(from, to StateType) error {
@@ -32,4 +34,12 @@ func ErrAssertMachineCtx(err error) error {
 
 func ErrInvalidType(err error) error {
 	return errors.New(ErrInvalidTypeCode, errors.Alert, []string{"Provided connection id is invalid"}, []string{err.Error()}, []string{"Provided ID is not a valid uuid."}, []string{"Hard delete and reinitialise the connection process."})
+}
+
+func ErrMissingUserContext() error {
+	return errors.New(ErrMissingUserContextCode, errors.Critical, []string{"User context is missing or invalid"}, []string{"Failed to extract user information from context"}, []string{"The request context does not contain valid user information.", "This can occur when a background operation runs after the HTTP request has completed.", "The user session may have expired."}, []string{"Ensure the operation is initiated through a properly authenticated request.", "Check if the user session is still valid.", "Retry the operation after re-authenticating."})
+}
+
+func ErrMissingSystemIDContext() error {
+	return errors.New(ErrMissingSystemIDContextCode, errors.Critical, []string{"System ID context is missing or invalid"}, []string{"Failed to extract system ID from context"}, []string{"The request context does not contain a valid system ID.", "This can occur during server initialization or when context propagation fails."}, []string{"Ensure the server is properly initialized.", "Check the middleware chain is correctly configured.", "Retry the operation."})
 }

--- a/server/machines/grafana/register.go
+++ b/server/machines/grafana/register.go
@@ -35,8 +35,18 @@ func (ra *RegisterAction) Execute(ctx context.Context, machineCtx interface{}, d
 		os.Exit(1)
 	}
 
-	user, _ := ctx.Value(models.UserCtxKey).(*models.User)
-	sysID, _ := ctx.Value(models.SystemIDKey).(*uuid.UUID)
+	user, ok := ctx.Value(models.UserCtxKey).(*models.User)
+	if !ok || user == nil {
+		err := machines.ErrMissingUserContext()
+		log.Error(err)
+		return machines.NoOp, nil, err
+	}
+	sysID, ok := ctx.Value(models.SystemIDKey).(*uuid.UUID)
+	if !ok || sysID == nil {
+		err := machines.ErrMissingSystemIDContext()
+		log.Error(err)
+		return machines.NoOp, nil, err
+	}
 	userUUID := user.ID
 
 	eventBuilder := events.NewEvent().ActedUpon(userUUID).WithCategory("connection").WithAction("update").FromSystem(*sysID).FromUser(userUUID).WithDescription("Failed to interact with the connection.").WithSeverity(events.Error)

--- a/server/machines/kubernetes/delete.go
+++ b/server/machines/kubernetes/delete.go
@@ -34,8 +34,18 @@ func (da *DeleteAction) Execute(ctx context.Context, machineCtx interface{}, dat
 		logrus.Error(err)
 		os.Exit(1)
 	}
-	user, _ := ctx.Value(models.UserCtxKey).(*models.User)
-	sysID, _ := ctx.Value(models.SystemIDKey).(*uuid.UUID)
+	user, ok := ctx.Value(models.UserCtxKey).(*models.User)
+	if !ok || user == nil {
+		err := machines.ErrMissingUserContext()
+		log.Error(err)
+		return machines.NoOp, nil, err
+	}
+	sysID, ok := ctx.Value(models.SystemIDKey).(*uuid.UUID)
+	if !ok || sysID == nil {
+		err := machines.ErrMissingSystemIDContext()
+		log.Error(err)
+		return machines.NoOp, nil, err
+	}
 	provider, _ := ctx.Value(models.ProviderCtxKey).(models.Provider)
 	userUUID := user.ID
 

--- a/server/machines/kubernetes/disconnect.go
+++ b/server/machines/kubernetes/disconnect.go
@@ -17,8 +17,16 @@ func (da *DisconnectAction) ExecuteOnEntry(ctx context.Context, machineCtx inter
 
 }
 func (da *DisconnectAction) Execute(ctx context.Context, machineCtx interface{}, data interface{}) (machines.EventType, *events.Event, error) {
-	user, _ := ctx.Value(models.UserCtxKey).(*models.User)
-	sysID, _ := ctx.Value(models.SystemIDKey).(*uuid.UUID)
+	user, ok := ctx.Value(models.UserCtxKey).(*models.User)
+	if !ok || user == nil {
+		err := machines.ErrMissingUserContext()
+		return machines.NoOp, nil, err
+	}
+	sysID, ok := ctx.Value(models.SystemIDKey).(*uuid.UUID)
+	if !ok || sysID == nil {
+		err := machines.ErrMissingSystemIDContext()
+		return machines.NoOp, nil, err
+	}
 	userUUID := user.ID
 
 	eventBuilder := events.NewEvent().ActedUpon(userUUID).WithCategory("connection").WithAction("update").FromSystem(*sysID).FromUser(userUUID).WithDescription("Failed to interact with the connection.")

--- a/server/machines/kubernetes/discover.go
+++ b/server/machines/kubernetes/discover.go
@@ -19,8 +19,16 @@ func (da *DiscoverAction) ExecuteOnEntry(ctx context.Context, machineCtx interfa
 }
 
 func (da *DiscoverAction) Execute(ctx context.Context, machineCtx interface{}, data interface{}) (machines.EventType, *events.Event, error) {
-	user, _ := ctx.Value(models.UserCtxKey).(*models.User)
-	sysID, _ := ctx.Value(models.SystemIDKey).(*uuid.UUID)
+	user, ok := ctx.Value(models.UserCtxKey).(*models.User)
+	if !ok || user == nil {
+		err := machines.ErrMissingUserContext()
+		return machines.NoOp, nil, err
+	}
+	sysID, ok := ctx.Value(models.SystemIDKey).(*uuid.UUID)
+	if !ok || sysID == nil {
+		err := machines.ErrMissingSystemIDContext()
+		return machines.NoOp, nil, err
+	}
 	userUUID := user.ID
 	provider, _ := ctx.Value(models.ProviderCtxKey).(models.Provider)
 

--- a/server/machines/kubernetes/machine.go
+++ b/server/machines/kubernetes/machine.go
@@ -147,8 +147,18 @@ func New(ID string, userID uuid.UUID, log logger.Handler) (*machines.StateMachin
 }
 
 func AssignInitialCtx(ctx context.Context, machineCtx interface{}, log logger.Handler) (interface{}, *events.Event, error) {
-	user, _ := ctx.Value(models.UserCtxKey).(*models.User)
-	sysID, _ := ctx.Value(models.SystemIDKey).(*uuid.UUID)
+	user, ok := ctx.Value(models.UserCtxKey).(*models.User)
+	if !ok || user == nil {
+		err := machines.ErrMissingUserContext()
+		log.Error(err)
+		return nil, nil, err
+	}
+	sysID, ok := ctx.Value(models.SystemIDKey).(*uuid.UUID)
+	if !ok || sysID == nil {
+		err := machines.ErrMissingSystemIDContext()
+		log.Error(err)
+		return nil, nil, err
+	}
 	provider, _ := ctx.Value(models.ProviderCtxKey).(models.Provider)
 	userUUID := user.ID
 

--- a/server/machines/kubernetes/register.go
+++ b/server/machines/kubernetes/register.go
@@ -19,8 +19,16 @@ func (ra *RegisterAction) ExecuteOnEntry(ctx context.Context, machineCtx interfa
 }
 
 func (ra *RegisterAction) Execute(ctx context.Context, machineCtx interface{}, data interface{}) (machines.EventType, *events.Event, error) {
-	user, _ := ctx.Value(models.UserCtxKey).(*models.User)
-	sysID, _ := ctx.Value(models.SystemIDKey).(*uuid.UUID)
+	user, ok := ctx.Value(models.UserCtxKey).(*models.User)
+	if !ok || user == nil {
+		err := machines.ErrMissingUserContext()
+		return machines.NoOp, nil, err
+	}
+	sysID, ok := ctx.Value(models.SystemIDKey).(*uuid.UUID)
+	if !ok || sysID == nil {
+		err := machines.ErrMissingSystemIDContext()
+		return machines.NoOp, nil, err
+	}
 	userUUID := user.ID
 	provider, _ := ctx.Value(models.ProviderCtxKey).(models.Provider)
 	eventBuilder := events.NewEvent().ActedUpon(uuid.Nil).WithCategory("connection").WithAction("register").FromSystem(*sysID).FromUser(userUUID).WithDescription("Failed to interact with the connection.")

--- a/server/machines/prometheus/register.go
+++ b/server/machines/prometheus/register.go
@@ -35,8 +35,18 @@ func (ra *RegisterAction) Execute(ctx context.Context, machineCtx interface{}, d
 		os.Exit(1)
 	}
 
-	user, _ := ctx.Value(models.UserCtxKey).(*models.User)
-	sysID, _ := ctx.Value(models.SystemIDKey).(*uuid.UUID)
+	user, ok := ctx.Value(models.UserCtxKey).(*models.User)
+	if !ok || user == nil {
+		err := machines.ErrMissingUserContext()
+		log.Error(err)
+		return machines.NoOp, nil, err
+	}
+	sysID, ok := ctx.Value(models.SystemIDKey).(*uuid.UUID)
+	if !ok || sysID == nil {
+		err := machines.ErrMissingSystemIDContext()
+		log.Error(err)
+		return machines.NoOp, nil, err
+	}
 	userUUID := user.ID
 
 	eventBuilder := events.NewEvent().ActedUpon(userUUID).WithCategory("connection").WithAction("update").FromSystem(*sysID).FromUser(userUUID).WithDescription("Failed to interact with the connection.").WithSeverity(events.Error)


### PR DESCRIPTION
### Summary

This PR adds defensive checks when extracting User and SystemID from context.Context in the state machine and related connection action handlers to prevent potential nil pointer dereferences.

Previously, several handlers assumed these values were always present and dereferenced them without validating the type assertion result, which could lead to server panics in certain async or edge cases.

---

### Fix
	•	Added validation for User and SystemID context values before use
	•	Introduced structured errors for missing or invalid context
	•	Applied the same checks consistently across all affected state machine actions

This preserves existing behavior for valid requests while preventing crashes when context is incomplete.

---

### Impact

Prevents Meshery server panics during connection lifecycle operations (connect, disconnect, register, discover) and allows such failures to be handled gracefully with proper error reporting instead of crashing the process.