### PR TITLE
fix[ci]: add job_type input to testadapter workflow

### DIFF
--- a/.github/workflows/test_adaptersv2.yaml
+++ b/.github/workflows/test_adaptersv2.yaml
@@ -45,6 +45,9 @@ on:
       provider: #default to local
         required: false
         type: string
+      job_type:
+        required: true
+        type: string
     secrets:
       token:
         required: true
@@ -262,7 +265,7 @@ jobs:
       - name: UploadResults (Versioned)
         uses: actions/upload-artifact@v6
         with:
-          name: ${{ inputs.output_filename }}-${{ matrix.k8s_version }}
+          name: ${{ inputs.job_type }}-${{ matrix.k8s_version }}
           path: ./${{ inputs.output_filename }}
           overwrite: true
         continue-on-error: true


### PR DESCRIPTION
**Notes for Reviewers**

- This PR fixes #17080

**[Signed commits](https://github.com/meshery/meshery/blob/master/CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [x] Yes, I signed my commits.

This PR is a follow up PR to: https://github.com/meshery/meshery/pull/16883

while propagating the changes introduced by the above PR to e2etests in meshery-extensions there is still a problem of artifacts getting overwritten with each other.
causing job2 to consume job1's artifacts and similarly job3

sequential execution of jobs in e2etests doesn't affect anything
but if the jobs run parallely artifacts getting overwritten. 

This is the draft PR for the same,
https://github.com/meshery-extensions/meshery-istio/pull/757


@lekaf974 

<!--
Thank you for contributing to Meshery! 

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. Sign your commits.
4. Include before and after screenshots/terminal output.

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.
-->
