### PR TITLE
[UI] : Fix api url by removing redundant prefix api

### DIFF
--- a/ui/rtk-query/user.ts
+++ b/ui/rtk-query/user.ts
@@ -18,7 +18,7 @@ export const userApi = api
     endpoints: (builder) => ({
       getLoadTestPrefs: builder.query({
         query: (selectedK8sContexts) => ({
-          url: ctxUrl('/api/user/prefs', selectedK8sContexts),
+          url: ctxUrl('/user/prefs', selectedK8sContexts),
           method: 'GET',
           credentials: 'include',
         }),
@@ -29,7 +29,7 @@ export const userApi = api
 
       updateLoadTestPrefs: builder.mutation({
         query: (queryArg) => ({
-          url: ctxUrl('/api/user/prefs', queryArg.selectedK8sContexts),
+          url: ctxUrl('/user/prefs', queryArg.selectedK8sContexts),
           method: 'POST',
           credentials: 'include',
           headers: { 'Content-Type': 'application/json;charset=UTF-8' },


### PR DESCRIPTION
**Notes for Reviewers**

This PR fixes a bug in the User Preferences component where the API endpoint was being malformed.

Changes:

   - Removed a hardcoded /api string from the fetch call in the User Preferences ui.

   - Reason: The base URL already includes the API prefix. Appending it again resulted in a double path (/api/api/user/prefs), causing 404 Not Found or 405 Method Not Allowed errors when saving preferences.

This PR fixes #17173 

**[Signed commits](https://github.com/meshery/meshery/blob/master/CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [x] Yes, I signed my commits.


