### PR TITLE
Add ECR Repository to Deployment/Pod relationships

### DIFF
--- a/server/meshmodel/aws-ecr-controller/v1.0.28/v1.0.0/relationships/edge-non-binding-reference-repository-deployment.json
+++ b/server/meshmodel/aws-ecr-controller/v1.0.28/v1.0.0/relationships/edge-non-binding-reference-repository-deployment.json
@@ -51,12 +51,19 @@
               "patchStrategy": "replace",
               "mutatorRef": [
                 [
-                  "status",
-                  "repositoryURI"
+                  "displayName"
                 ]
               ],
-              "description": "Extract the ECR repository URI from the Repository status field. This URI is automatically populated by the AWS Controllers for Kubernetes (ACK) after the repository is created in AWS ECR."
-            }
+              "description": "ECR Repository can be visually referenced by Kubernetes workloads."
+            },
+            "match_strategy_matrix": [
+              [
+                "equal_as_strings",
+                "not_null"
+              ]
+            ],
+            "id": null,
+            "match": {}
           }
         ],
         "to": [
@@ -73,17 +80,19 @@
               "patchStrategy": "replace",
               "mutatedRef": [
                 [
-                  "configuration",
                   "spec",
                   "template",
                   "spec",
                   "containers",
-                  "0",
+                  "_",
                   "image"
                 ]
               ],
-              "description": "Automatically populate the Deployment's first container image field with the ECR repository URI. This eliminates manual typing of long ECR URIs and prevents errors."
-            }
+              "description": "Deployment containers can reference ECR repository images."
+            },
+            "match_strategy_matrix": null,
+            "id": null,
+            "match": {}
           }
         ]
       },
@@ -92,5 +101,6 @@
         "to": []
       }
     }
-  ]
+  ],
+  "evaluationQuery": "edge_non_binding_reference_relationship"
 }

--- a/server/meshmodel/aws-ecr-controller/v1.0.28/v1.0.0/relationships/edge-non-binding-reference-repository-pod.json
+++ b/server/meshmodel/aws-ecr-controller/v1.0.28/v1.0.0/relationships/edge-non-binding-reference-repository-pod.json
@@ -51,12 +51,19 @@
               "patchStrategy": "replace",
               "mutatorRef": [
                 [
-                  "status",
-                  "repositoryURI"
+                  "displayName"
                 ]
               ],
-              "description": "Extract the ECR repository URI from the Repository status field. This URI is automatically populated by the AWS Controllers for Kubernetes (ACK) after the repository is created in AWS ECR."
-            }
+              "description": "ECR Repository can be visually referenced by Kubernetes workloads."
+            },
+            "match_strategy_matrix": [
+              [
+                "equal_as_strings",
+                "not_null"
+              ]
+            ],
+            "id": null,
+            "match": {}
           }
         ],
         "to": [
@@ -73,15 +80,17 @@
               "patchStrategy": "replace",
               "mutatedRef": [
                 [
-                  "configuration",
                   "spec",
                   "containers",
-                  "0",
+                  "_",
                   "image"
                 ]
               ],
-              "description": "Automatically populate the Pod's first container image field with the ECR repository URI. This eliminates manual typing of long ECR URIs and prevents errors."
-            }
+              "description": "Pod containers can reference ECR repository images."
+            },
+            "match_strategy_matrix": null,
+            "id": null,
+            "match": {}
           }
         ]
       },
@@ -90,5 +99,6 @@
         "to": []
       }
     }
-  ]
+  ],
+  "evaluationQuery": "edge_non_binding_reference_relationship"
 }

--- a/server/meshmodel/aws-ecr-controller/v1.0.29/v1.0.0/relationships/edge-non-binding-reference-repository-deployment.json
+++ b/server/meshmodel/aws-ecr-controller/v1.0.29/v1.0.0/relationships/edge-non-binding-reference-repository-deployment.json
@@ -51,12 +51,19 @@
               "patchStrategy": "replace",
               "mutatorRef": [
                 [
-                  "status",
-                  "repositoryURI"
+                  "displayName"
                 ]
               ],
-              "description": "Extract the ECR repository URI from the Repository status field. This URI is automatically populated by the AWS Controllers for Kubernetes (ACK) after the repository is created in AWS ECR."
-            }
+              "description": "ECR Repository can be visually referenced by Kubernetes workloads."
+            },
+            "match_strategy_matrix": [
+              [
+                "equal_as_strings",
+                "not_null"
+              ]
+            ],
+            "id": null,
+            "match": {}
           }
         ],
         "to": [
@@ -73,17 +80,19 @@
               "patchStrategy": "replace",
               "mutatedRef": [
                 [
-                  "configuration",
                   "spec",
                   "template",
                   "spec",
                   "containers",
-                  "0",
+                  "_",
                   "image"
                 ]
               ],
-              "description": "Automatically populate the Deployment's first container image field with the ECR repository URI. This eliminates manual typing of long ECR URIs and prevents errors."
-            }
+              "description": "Deployment containers can reference ECR repository images."
+            },
+            "match_strategy_matrix": null,
+            "id": null,
+            "match": {}
           }
         ]
       },
@@ -92,5 +101,6 @@
         "to": []
       }
     }
-  ]
+  ],
+  "evaluationQuery": "edge_non_binding_reference_relationship"
 }

--- a/server/meshmodel/aws-ecr-controller/v1.0.29/v1.0.0/relationships/edge-non-binding-reference-repository-pod.json
+++ b/server/meshmodel/aws-ecr-controller/v1.0.29/v1.0.0/relationships/edge-non-binding-reference-repository-pod.json
@@ -51,12 +51,19 @@
               "patchStrategy": "replace",
               "mutatorRef": [
                 [
-                  "status",
-                  "repositoryURI"
+                  "displayName"
                 ]
               ],
-              "description": "Extract the ECR repository URI from the Repository status field. This URI is automatically populated by the AWS Controllers for Kubernetes (ACK) after the repository is created in AWS ECR."
-            }
+              "description": "ECR Repository can be visually referenced by Kubernetes workloads."
+            },
+            "match_strategy_matrix": [
+              [
+                "equal_as_strings",
+                "not_null"
+              ]
+            ],
+            "id": null,
+            "match": {}
           }
         ],
         "to": [
@@ -73,15 +80,17 @@
               "patchStrategy": "replace",
               "mutatedRef": [
                 [
-                  "configuration",
                   "spec",
                   "containers",
-                  "0",
+                  "_",
                   "image"
                 ]
               ],
-              "description": "Automatically populate the Pod's first container image field with the ECR repository URI. This eliminates manual typing of long ECR URIs and prevents errors."
-            }
+              "description": "Pod containers can reference ECR repository images."
+            },
+            "match_strategy_matrix": null,
+            "id": null,
+            "match": {}
           }
         ]
       },
@@ -90,5 +99,6 @@
         "to": []
       }
     }
-  ]
+  ],
+  "evaluationQuery": "edge_non_binding_reference_relationship"
 }

--- a/server/meshmodel/aws-ecr-controller/v1.0.30/v1.0.0/relationships/edge-non-binding-reference-repository-deployment.json
+++ b/server/meshmodel/aws-ecr-controller/v1.0.30/v1.0.0/relationships/edge-non-binding-reference-repository-deployment.json
@@ -51,12 +51,19 @@
               "patchStrategy": "replace",
               "mutatorRef": [
                 [
-                  "status",
-                  "repositoryURI"
+                  "displayName"
                 ]
               ],
-              "description": "Extract the ECR repository URI from the Repository status field. This URI is automatically populated by the AWS Controllers for Kubernetes (ACK) after the repository is created in AWS ECR."
-            }
+              "description": "ECR Repository can be visually referenced by Kubernetes workloads."
+            },
+            "match_strategy_matrix": [
+              [
+                "equal_as_strings",
+                "not_null"
+              ]
+            ],
+            "id": null,
+            "match": {}
           }
         ],
         "to": [
@@ -73,17 +80,19 @@
               "patchStrategy": "replace",
               "mutatedRef": [
                 [
-                  "configuration",
                   "spec",
                   "template",
                   "spec",
                   "containers",
-                  "0",
+                  "_",
                   "image"
                 ]
               ],
-              "description": "Automatically populate the Deployment's first container image field with the ECR repository URI. This eliminates manual typing of long ECR URIs and prevents errors."
-            }
+              "description": "Deployment containers can reference ECR repository images."
+            },
+            "match_strategy_matrix": null,
+            "id": null,
+            "match": {}
           }
         ]
       },
@@ -92,5 +101,6 @@
         "to": []
       }
     }
-  ]
+  ],
+  "evaluationQuery": "edge_non_binding_reference_relationship"
 }

--- a/server/meshmodel/aws-ecr-controller/v1.0.30/v1.0.0/relationships/edge-non-binding-reference-repository-pod.json
+++ b/server/meshmodel/aws-ecr-controller/v1.0.30/v1.0.0/relationships/edge-non-binding-reference-repository-pod.json
@@ -51,12 +51,19 @@
               "patchStrategy": "replace",
               "mutatorRef": [
                 [
-                  "status",
-                  "repositoryURI"
+                  "displayName"
                 ]
               ],
-              "description": "Extract the ECR repository URI from the Repository status field. This URI is automatically populated by the AWS Controllers for Kubernetes (ACK) after the repository is created in AWS ECR."
-            }
+              "description": "ECR Repository can be visually referenced by Kubernetes workloads."
+            },
+            "match_strategy_matrix": [
+              [
+                "equal_as_strings",
+                "not_null"
+              ]
+            ],
+            "id": null,
+            "match": {}
           }
         ],
         "to": [
@@ -73,15 +80,17 @@
               "patchStrategy": "replace",
               "mutatedRef": [
                 [
-                  "configuration",
                   "spec",
                   "containers",
-                  "0",
+                  "_",
                   "image"
                 ]
               ],
-              "description": "Automatically populate the Pod's first container image field with the ECR repository URI. This eliminates manual typing of long ECR URIs and prevents errors."
-            }
+              "description": "Pod containers can reference ECR repository images."
+            },
+            "match_strategy_matrix": null,
+            "id": null,
+            "match": {}
           }
         ]
       },
@@ -90,5 +99,6 @@
         "to": []
       }
     }
-  ]
+  ],
+  "evaluationQuery": "edge_non_binding_reference_relationship"
 }

--- a/server/meshmodel/aws-ecr-controller/v1.0.31/v1.0.0/relationships/edge-non-binding-reference-repository-deployment.json
+++ b/server/meshmodel/aws-ecr-controller/v1.0.31/v1.0.0/relationships/edge-non-binding-reference-repository-deployment.json
@@ -51,12 +51,19 @@
               "patchStrategy": "replace",
               "mutatorRef": [
                 [
-                  "status",
-                  "repositoryURI"
+                  "displayName"
                 ]
               ],
-              "description": "Extract the ECR repository URI from the Repository status field. This URI is automatically populated by the AWS Controllers for Kubernetes (ACK) after the repository is created in AWS ECR."
-            }
+              "description": "ECR Repository can be visually referenced by Kubernetes workloads."
+            },
+            "match_strategy_matrix": [
+              [
+                "equal_as_strings",
+                "not_null"
+              ]
+            ],
+            "id": null,
+            "match": {}
           }
         ],
         "to": [
@@ -73,17 +80,19 @@
               "patchStrategy": "replace",
               "mutatedRef": [
                 [
-                  "configuration",
                   "spec",
                   "template",
                   "spec",
                   "containers",
-                  "0",
+                  "_",
                   "image"
                 ]
               ],
-              "description": "Automatically populate the Deployment's first container image field with the ECR repository URI. This eliminates manual typing of long ECR URIs and prevents errors."
-            }
+              "description": "Deployment containers can reference ECR repository images."
+            },
+            "match_strategy_matrix": null,
+            "id": null,
+            "match": {}
           }
         ]
       },
@@ -92,5 +101,6 @@
         "to": []
       }
     }
-  ]
+  ],
+  "evaluationQuery": "edge_non_binding_reference_relationship"
 }

--- a/server/meshmodel/aws-ecr-controller/v1.0.31/v1.0.0/relationships/edge-non-binding-reference-repository-pod.json
+++ b/server/meshmodel/aws-ecr-controller/v1.0.31/v1.0.0/relationships/edge-non-binding-reference-repository-pod.json
@@ -51,12 +51,19 @@
               "patchStrategy": "replace",
               "mutatorRef": [
                 [
-                  "status",
-                  "repositoryURI"
+                  "displayName"
                 ]
               ],
-              "description": "Extract the ECR repository URI from the Repository status field. This URI is automatically populated by the AWS Controllers for Kubernetes (ACK) after the repository is created in AWS ECR."
-            }
+              "description": "ECR Repository can be visually referenced by Kubernetes workloads."
+            },
+            "match_strategy_matrix": [
+              [
+                "equal_as_strings",
+                "not_null"
+              ]
+            ],
+            "id": null,
+            "match": {}
           }
         ],
         "to": [
@@ -73,15 +80,17 @@
               "patchStrategy": "replace",
               "mutatedRef": [
                 [
-                  "configuration",
                   "spec",
                   "containers",
-                  "0",
+                  "_",
                   "image"
                 ]
               ],
-              "description": "Automatically populate the Pod's first container image field with the ECR repository URI. This eliminates manual typing of long ECR URIs and prevents errors."
-            }
+              "description": "Pod containers can reference ECR repository images."
+            },
+            "match_strategy_matrix": null,
+            "id": null,
+            "match": {}
           }
         ]
       },
@@ -90,5 +99,6 @@
         "to": []
       }
     }
-  ]
+  ],
+  "evaluationQuery": "edge_non_binding_reference_relationship"
 }

--- a/server/meshmodel/aws-ecr-controller/v1.0.32/v1.0.0/relationships/edge-non-binding-reference-repository-deployment.json
+++ b/server/meshmodel/aws-ecr-controller/v1.0.32/v1.0.0/relationships/edge-non-binding-reference-repository-deployment.json
@@ -51,12 +51,19 @@
               "patchStrategy": "replace",
               "mutatorRef": [
                 [
-                  "status",
-                  "repositoryURI"
+                  "displayName"
                 ]
               ],
-              "description": "Extract the ECR repository URI from the Repository status field. This URI is automatically populated by the AWS Controllers for Kubernetes (ACK) after the repository is created in AWS ECR."
-            }
+              "description": "ECR Repository can be visually referenced by Kubernetes workloads."
+            },
+            "match_strategy_matrix": [
+              [
+                "equal_as_strings",
+                "not_null"
+              ]
+            ],
+            "id": null,
+            "match": {}
           }
         ],
         "to": [
@@ -73,17 +80,19 @@
               "patchStrategy": "replace",
               "mutatedRef": [
                 [
-                  "configuration",
                   "spec",
                   "template",
                   "spec",
                   "containers",
-                  "0",
+                  "_",
                   "image"
                 ]
               ],
-              "description": "Automatically populate the Deployment's first container image field with the ECR repository URI. This eliminates manual typing of long ECR URIs and prevents errors."
-            }
+              "description": "Deployment containers can reference ECR repository images."
+            },
+            "match_strategy_matrix": null,
+            "id": null,
+            "match": {}
           }
         ]
       },
@@ -92,5 +101,6 @@
         "to": []
       }
     }
-  ]
+  ],
+  "evaluationQuery": "edge_non_binding_reference_relationship"
 }

--- a/server/meshmodel/aws-ecr-controller/v1.0.32/v1.0.0/relationships/edge-non-binding-reference-repository-pod.json
+++ b/server/meshmodel/aws-ecr-controller/v1.0.32/v1.0.0/relationships/edge-non-binding-reference-repository-pod.json
@@ -51,12 +51,19 @@
               "patchStrategy": "replace",
               "mutatorRef": [
                 [
-                  "status",
-                  "repositoryURI"
+                  "displayName"
                 ]
               ],
-              "description": "Extract the ECR repository URI from the Repository status field. This URI is automatically populated by the AWS Controllers for Kubernetes (ACK) after the repository is created in AWS ECR."
-            }
+              "description": "ECR Repository can be visually referenced by Kubernetes workloads."
+            },
+            "match_strategy_matrix": [
+              [
+                "equal_as_strings",
+                "not_null"
+              ]
+            ],
+            "id": null,
+            "match": {}
           }
         ],
         "to": [
@@ -73,15 +80,17 @@
               "patchStrategy": "replace",
               "mutatedRef": [
                 [
-                  "configuration",
                   "spec",
                   "containers",
-                  "0",
+                  "_",
                   "image"
                 ]
               ],
-              "description": "Automatically populate the Pod's first container image field with the ECR repository URI. This eliminates manual typing of long ECR URIs and prevents errors."
-            }
+              "description": "Pod containers can reference ECR repository images."
+            },
+            "match_strategy_matrix": null,
+            "id": null,
+            "match": {}
           }
         ]
       },
@@ -90,5 +99,6 @@
         "to": []
       }
     }
-  ]
+  ],
+  "evaluationQuery": "edge_non_binding_reference_relationship"
 }

--- a/server/meshmodel/aws-ecr-controller/v1.0.33/v1.0.0/relationships/edge-non-binding-reference-repository-deployment.json
+++ b/server/meshmodel/aws-ecr-controller/v1.0.33/v1.0.0/relationships/edge-non-binding-reference-repository-deployment.json
@@ -51,12 +51,19 @@
               "patchStrategy": "replace",
               "mutatorRef": [
                 [
-                  "status",
-                  "repositoryURI"
+                  "displayName"
                 ]
               ],
-              "description": "Extract the ECR repository URI from the Repository status field. This URI is automatically populated by the AWS Controllers for Kubernetes (ACK) after the repository is created in AWS ECR."
-            }
+              "description": "ECR Repository can be visually referenced by Kubernetes workloads."
+            },
+            "match_strategy_matrix": [
+              [
+                "equal_as_strings",
+                "not_null"
+              ]
+            ],
+            "id": null,
+            "match": {}
           }
         ],
         "to": [
@@ -73,17 +80,19 @@
               "patchStrategy": "replace",
               "mutatedRef": [
                 [
-                  "configuration",
                   "spec",
                   "template",
                   "spec",
                   "containers",
-                  "0",
+                  "_",
                   "image"
                 ]
               ],
-              "description": "Automatically populate the Deployment's first container image field with the ECR repository URI. This eliminates manual typing of long ECR URIs and prevents errors."
-            }
+              "description": "Deployment containers can reference ECR repository images."
+            },
+            "match_strategy_matrix": null,
+            "id": null,
+            "match": {}
           }
         ]
       },
@@ -92,5 +101,6 @@
         "to": []
       }
     }
-  ]
+  ],
+  "evaluationQuery": "edge_non_binding_reference_relationship"
 }

--- a/server/meshmodel/aws-ecr-controller/v1.0.33/v1.0.0/relationships/edge-non-binding-reference-repository-pod.json
+++ b/server/meshmodel/aws-ecr-controller/v1.0.33/v1.0.0/relationships/edge-non-binding-reference-repository-pod.json
@@ -51,12 +51,19 @@
               "patchStrategy": "replace",
               "mutatorRef": [
                 [
-                  "status",
-                  "repositoryURI"
+                  "displayName"
                 ]
               ],
-              "description": "Extract the ECR repository URI from the Repository status field. This URI is automatically populated by the AWS Controllers for Kubernetes (ACK) after the repository is created in AWS ECR."
-            }
+              "description": "ECR Repository can be visually referenced by Kubernetes workloads."
+            },
+            "match_strategy_matrix": [
+              [
+                "equal_as_strings",
+                "not_null"
+              ]
+            ],
+            "id": null,
+            "match": {}
           }
         ],
         "to": [
@@ -73,15 +80,17 @@
               "patchStrategy": "replace",
               "mutatedRef": [
                 [
-                  "configuration",
                   "spec",
                   "containers",
-                  "0",
+                  "_",
                   "image"
                 ]
               ],
-              "description": "Automatically populate the Pod's first container image field with the ECR repository URI. This eliminates manual typing of long ECR URIs and prevents errors."
-            }
+              "description": "Pod containers can reference ECR repository images."
+            },
+            "match_strategy_matrix": null,
+            "id": null,
+            "match": {}
           }
         ]
       },
@@ -90,5 +99,6 @@
         "to": []
       }
     }
-  ]
+  ],
+  "evaluationQuery": "edge_non_binding_reference_relationship"
 }

--- a/server/meshmodel/aws-ecr-controller/v1.1.0/v1.0.0/relationships/edge-non-binding-reference-repository-deployment.json
+++ b/server/meshmodel/aws-ecr-controller/v1.1.0/v1.0.0/relationships/edge-non-binding-reference-repository-deployment.json
@@ -51,12 +51,19 @@
               "patchStrategy": "replace",
               "mutatorRef": [
                 [
-                  "status",
-                  "repositoryURI"
+                  "displayName"
                 ]
               ],
-              "description": "Extract the ECR repository URI from the Repository status field. This URI is automatically populated by the AWS Controllers for Kubernetes (ACK) after the repository is created in AWS ECR."
-            }
+              "description": "ECR Repository can be visually referenced by Kubernetes workloads."
+            },
+            "match_strategy_matrix": [
+              [
+                "equal_as_strings",
+                "not_null"
+              ]
+            ],
+            "id": null,
+            "match": {}
           }
         ],
         "to": [
@@ -73,17 +80,19 @@
               "patchStrategy": "replace",
               "mutatedRef": [
                 [
-                  "configuration",
                   "spec",
                   "template",
                   "spec",
                   "containers",
-                  "0",
+                  "_",
                   "image"
                 ]
               ],
-              "description": "Automatically populate the Deployment's first container image field with the ECR repository URI. This eliminates manual typing of long ECR URIs and prevents errors."
-            }
+              "description": "Deployment containers can reference ECR repository images."
+            },
+            "match_strategy_matrix": null,
+            "id": null,
+            "match": {}
           }
         ]
       },
@@ -92,5 +101,6 @@
         "to": []
       }
     }
-  ]
+  ],
+  "evaluationQuery": "edge_non_binding_reference_relationship"
 }

--- a/server/meshmodel/aws-ecr-controller/v1.1.0/v1.0.0/relationships/edge-non-binding-reference-repository-pod.json
+++ b/server/meshmodel/aws-ecr-controller/v1.1.0/v1.0.0/relationships/edge-non-binding-reference-repository-pod.json
@@ -51,12 +51,19 @@
               "patchStrategy": "replace",
               "mutatorRef": [
                 [
-                  "status",
-                  "repositoryURI"
+                  "displayName"
                 ]
               ],
-              "description": "Extract the ECR repository URI from the Repository status field. This URI is automatically populated by the AWS Controllers for Kubernetes (ACK) after the repository is created in AWS ECR."
-            }
+              "description": "ECR Repository can be visually referenced by Kubernetes workloads."
+            },
+            "match_strategy_matrix": [
+              [
+                "equal_as_strings",
+                "not_null"
+              ]
+            ],
+            "id": null,
+            "match": {}
           }
         ],
         "to": [
@@ -73,15 +80,17 @@
               "patchStrategy": "replace",
               "mutatedRef": [
                 [
-                  "configuration",
                   "spec",
                   "containers",
-                  "0",
+                  "_",
                   "image"
                 ]
               ],
-              "description": "Automatically populate the Pod's first container image field with the ECR repository URI. This eliminates manual typing of long ECR URIs and prevents errors."
-            }
+              "description": "Pod containers can reference ECR repository images."
+            },
+            "match_strategy_matrix": null,
+            "id": null,
+            "match": {}
           }
         ]
       },
@@ -90,5 +99,6 @@
         "to": []
       }
     }
-  ]
+  ],
+  "evaluationQuery": "edge_non_binding_reference_relationship"
 }

--- a/server/meshmodel/aws-ecr-controller/v1.2.0/v1.0.0/relationships/edge-non-binding-reference-repository-deployment.json
+++ b/server/meshmodel/aws-ecr-controller/v1.2.0/v1.0.0/relationships/edge-non-binding-reference-repository-deployment.json
@@ -51,12 +51,19 @@
               "patchStrategy": "replace",
               "mutatorRef": [
                 [
-                  "status",
-                  "repositoryURI"
+                  "displayName"
                 ]
               ],
-              "description": "Extract the ECR repository URI from the Repository status field. This URI is automatically populated by the AWS Controllers for Kubernetes (ACK) after the repository is created in AWS ECR."
-            }
+              "description": "ECR Repository can be visually referenced by Kubernetes workloads."
+            },
+            "match_strategy_matrix": [
+              [
+                "equal_as_strings",
+                "not_null"
+              ]
+            ],
+            "id": null,
+            "match": {}
           }
         ],
         "to": [
@@ -73,17 +80,19 @@
               "patchStrategy": "replace",
               "mutatedRef": [
                 [
-                  "configuration",
                   "spec",
                   "template",
                   "spec",
                   "containers",
-                  "0",
+                  "_",
                   "image"
                 ]
               ],
-              "description": "Automatically populate the Deployment's first container image field with the ECR repository URI. This eliminates manual typing of long ECR URIs and prevents errors."
-            }
+              "description": "Deployment containers can reference ECR repository images."
+            },
+            "match_strategy_matrix": null,
+            "id": null,
+            "match": {}
           }
         ]
       },
@@ -92,5 +101,6 @@
         "to": []
       }
     }
-  ]
+  ],
+  "evaluationQuery": "edge_non_binding_reference_relationship"
 }

--- a/server/meshmodel/aws-ecr-controller/v1.2.0/v1.0.0/relationships/edge-non-binding-reference-repository-pod.json
+++ b/server/meshmodel/aws-ecr-controller/v1.2.0/v1.0.0/relationships/edge-non-binding-reference-repository-pod.json
@@ -51,12 +51,19 @@
               "patchStrategy": "replace",
               "mutatorRef": [
                 [
-                  "status",
-                  "repositoryURI"
+                  "displayName"
                 ]
               ],
-              "description": "Extract the ECR repository URI from the Repository status field. This URI is automatically populated by the AWS Controllers for Kubernetes (ACK) after the repository is created in AWS ECR."
-            }
+              "description": "ECR Repository can be visually referenced by Kubernetes workloads."
+            },
+            "match_strategy_matrix": [
+              [
+                "equal_as_strings",
+                "not_null"
+              ]
+            ],
+            "id": null,
+            "match": {}
           }
         ],
         "to": [
@@ -73,15 +80,17 @@
               "patchStrategy": "replace",
               "mutatedRef": [
                 [
-                  "configuration",
                   "spec",
                   "containers",
-                  "0",
+                  "_",
                   "image"
                 ]
               ],
-              "description": "Automatically populate the Pod's first container image field with the ECR repository URI. This eliminates manual typing of long ECR URIs and prevents errors."
-            }
+              "description": "Pod containers can reference ECR repository images."
+            },
+            "match_strategy_matrix": null,
+            "id": null,
+            "match": {}
           }
         ]
       },
@@ -90,5 +99,6 @@
         "to": []
       }
     }
-  ]
+  ],
+  "evaluationQuery": "edge_non_binding_reference_relationship"
 }

--- a/server/meshmodel/aws-ecr-controller/v1.3.0/v1.0.0/relationships/edge-non-binding-reference-repository-deployment.json
+++ b/server/meshmodel/aws-ecr-controller/v1.3.0/v1.0.0/relationships/edge-non-binding-reference-repository-deployment.json
@@ -51,12 +51,19 @@
               "patchStrategy": "replace",
               "mutatorRef": [
                 [
-                  "status",
-                  "repositoryURI"
+                  "displayName"
                 ]
               ],
-              "description": "Extract the ECR repository URI from the Repository status field. This URI is automatically populated by the AWS Controllers for Kubernetes (ACK) after the repository is created in AWS ECR."
-            }
+              "description": "ECR Repository can be visually referenced by Kubernetes workloads."
+            },
+            "match_strategy_matrix": [
+              [
+                "equal_as_strings",
+                "not_null"
+              ]
+            ],
+            "id": null,
+            "match": {}
           }
         ],
         "to": [
@@ -73,17 +80,19 @@
               "patchStrategy": "replace",
               "mutatedRef": [
                 [
-                  "configuration",
                   "spec",
                   "template",
                   "spec",
                   "containers",
-                  "0",
+                  "_",
                   "image"
                 ]
               ],
-              "description": "Automatically populate the Deployment's first container image field with the ECR repository URI. This eliminates manual typing of long ECR URIs and prevents errors."
-            }
+              "description": "Deployment containers can reference ECR repository images."
+            },
+            "match_strategy_matrix": null,
+            "id": null,
+            "match": {}
           }
         ]
       },
@@ -92,5 +101,6 @@
         "to": []
       }
     }
-  ]
+  ],
+  "evaluationQuery": "edge_non_binding_reference_relationship"
 }

--- a/server/meshmodel/aws-ecr-controller/v1.3.0/v1.0.0/relationships/edge-non-binding-reference-repository-pod.json
+++ b/server/meshmodel/aws-ecr-controller/v1.3.0/v1.0.0/relationships/edge-non-binding-reference-repository-pod.json
@@ -51,12 +51,19 @@
               "patchStrategy": "replace",
               "mutatorRef": [
                 [
-                  "status",
-                  "repositoryURI"
+                  "displayName"
                 ]
               ],
-              "description": "Extract the ECR repository URI from the Repository status field. This URI is automatically populated by the AWS Controllers for Kubernetes (ACK) after the repository is created in AWS ECR."
-            }
+              "description": "ECR Repository can be visually referenced by Kubernetes workloads."
+            },
+            "match_strategy_matrix": [
+              [
+                "equal_as_strings",
+                "not_null"
+              ]
+            ],
+            "id": null,
+            "match": {}
           }
         ],
         "to": [
@@ -73,15 +80,17 @@
               "patchStrategy": "replace",
               "mutatedRef": [
                 [
-                  "configuration",
                   "spec",
                   "containers",
-                  "0",
+                  "_",
                   "image"
                 ]
               ],
-              "description": "Automatically populate the Pod's first container image field with the ECR repository URI. This eliminates manual typing of long ECR URIs and prevents errors."
-            }
+              "description": "Pod containers can reference ECR repository images."
+            },
+            "match_strategy_matrix": null,
+            "id": null,
+            "match": {}
           }
         ]
       },
@@ -90,5 +99,6 @@
         "to": []
       }
     }
-  ]
+  ],
+  "evaluationQuery": "edge_non_binding_reference_relationship"
 }

--- a/server/meshmodel/aws-ecr-controller/v1.3.1/v1.0.0/relationships/edge-non-binding-reference-repository-deployment.json
+++ b/server/meshmodel/aws-ecr-controller/v1.3.1/v1.0.0/relationships/edge-non-binding-reference-repository-deployment.json
@@ -51,12 +51,19 @@
               "patchStrategy": "replace",
               "mutatorRef": [
                 [
-                  "status",
-                  "repositoryURI"
+                  "displayName"
                 ]
               ],
-              "description": "Extract the ECR repository URI from the Repository status field. This URI is automatically populated by the AWS Controllers for Kubernetes (ACK) after the repository is created in AWS ECR."
-            }
+              "description": "ECR Repository can be visually referenced by Kubernetes workloads."
+            },
+            "match_strategy_matrix": [
+              [
+                "equal_as_strings",
+                "not_null"
+              ]
+            ],
+            "id": null,
+            "match": {}
           }
         ],
         "to": [
@@ -73,17 +80,19 @@
               "patchStrategy": "replace",
               "mutatedRef": [
                 [
-                  "configuration",
                   "spec",
                   "template",
                   "spec",
                   "containers",
-                  "0",
+                  "_",
                   "image"
                 ]
               ],
-              "description": "Automatically populate the Deployment's first container image field with the ECR repository URI. This eliminates manual typing of long ECR URIs and prevents errors."
-            }
+              "description": "Deployment containers can reference ECR repository images."
+            },
+            "match_strategy_matrix": null,
+            "id": null,
+            "match": {}
           }
         ]
       },
@@ -92,5 +101,6 @@
         "to": []
       }
     }
-  ]
+  ],
+  "evaluationQuery": "edge_non_binding_reference_relationship"
 }

--- a/server/meshmodel/aws-ecr-controller/v1.3.1/v1.0.0/relationships/edge-non-binding-reference-repository-pod.json
+++ b/server/meshmodel/aws-ecr-controller/v1.3.1/v1.0.0/relationships/edge-non-binding-reference-repository-pod.json
@@ -51,12 +51,19 @@
               "patchStrategy": "replace",
               "mutatorRef": [
                 [
-                  "status",
-                  "repositoryURI"
+                  "displayName"
                 ]
               ],
-              "description": "Extract the ECR repository URI from the Repository status field. This URI is automatically populated by the AWS Controllers for Kubernetes (ACK) after the repository is created in AWS ECR."
-            }
+              "description": "ECR Repository can be visually referenced by Kubernetes workloads."
+            },
+            "match_strategy_matrix": [
+              [
+                "equal_as_strings",
+                "not_null"
+              ]
+            ],
+            "id": null,
+            "match": {}
           }
         ],
         "to": [
@@ -73,15 +80,17 @@
               "patchStrategy": "replace",
               "mutatedRef": [
                 [
-                  "configuration",
                   "spec",
                   "containers",
-                  "0",
+                  "_",
                   "image"
                 ]
               ],
-              "description": "Automatically populate the Pod's first container image field with the ECR repository URI. This eliminates manual typing of long ECR URIs and prevents errors."
-            }
+              "description": "Pod containers can reference ECR repository images."
+            },
+            "match_strategy_matrix": null,
+            "id": null,
+            "match": {}
           }
         ]
       },
@@ -90,5 +99,6 @@
         "to": []
       }
     }
-  ]
+  ],
+  "evaluationQuery": "edge_non_binding_reference_relationship"
 }

--- a/server/meshmodel/aws-ecr-controller/v1.3.2/v1.0.0/relationships/edge-non-binding-reference-repository-deployment.json
+++ b/server/meshmodel/aws-ecr-controller/v1.3.2/v1.0.0/relationships/edge-non-binding-reference-repository-deployment.json
@@ -51,12 +51,19 @@
               "patchStrategy": "replace",
               "mutatorRef": [
                 [
-                  "status",
-                  "repositoryURI"
+                  "displayName"
                 ]
               ],
-              "description": "Extract the ECR repository URI from the Repository status field. This URI is automatically populated by the AWS Controllers for Kubernetes (ACK) after the repository is created in AWS ECR."
-            }
+              "description": "ECR Repository can be visually referenced by Kubernetes workloads."
+            },
+            "match_strategy_matrix": [
+              [
+                "equal_as_strings",
+                "not_null"
+              ]
+            ],
+            "id": null,
+            "match": {}
           }
         ],
         "to": [
@@ -73,17 +80,19 @@
               "patchStrategy": "replace",
               "mutatedRef": [
                 [
-                  "configuration",
                   "spec",
                   "template",
                   "spec",
                   "containers",
-                  "0",
+                  "_",
                   "image"
                 ]
               ],
-              "description": "Automatically populate the Deployment's first container image field with the ECR repository URI. This eliminates manual typing of long ECR URIs and prevents errors."
-            }
+              "description": "Deployment containers can reference ECR repository images."
+            },
+            "match_strategy_matrix": null,
+            "id": null,
+            "match": {}
           }
         ]
       },
@@ -92,5 +101,6 @@
         "to": []
       }
     }
-  ]
+  ],
+  "evaluationQuery": "edge_non_binding_reference_relationship"
 }

--- a/server/meshmodel/aws-ecr-controller/v1.3.2/v1.0.0/relationships/edge-non-binding-reference-repository-pod.json
+++ b/server/meshmodel/aws-ecr-controller/v1.3.2/v1.0.0/relationships/edge-non-binding-reference-repository-pod.json
@@ -51,12 +51,19 @@
               "patchStrategy": "replace",
               "mutatorRef": [
                 [
-                  "status",
-                  "repositoryURI"
+                  "displayName"
                 ]
               ],
-              "description": "Extract the ECR repository URI from the Repository status field. This URI is automatically populated by the AWS Controllers for Kubernetes (ACK) after the repository is created in AWS ECR."
-            }
+              "description": "ECR Repository can be visually referenced by Kubernetes workloads."
+            },
+            "match_strategy_matrix": [
+              [
+                "equal_as_strings",
+                "not_null"
+              ]
+            ],
+            "id": null,
+            "match": {}
           }
         ],
         "to": [
@@ -73,15 +80,17 @@
               "patchStrategy": "replace",
               "mutatedRef": [
                 [
-                  "configuration",
                   "spec",
                   "containers",
-                  "0",
+                  "_",
                   "image"
                 ]
               ],
-              "description": "Automatically populate the Pod's first container image field with the ECR repository URI. This eliminates manual typing of long ECR URIs and prevents errors."
-            }
+              "description": "Pod containers can reference ECR repository images."
+            },
+            "match_strategy_matrix": null,
+            "id": null,
+            "match": {}
           }
         ]
       },
@@ -90,5 +99,6 @@
         "to": []
       }
     }
-  ]
+  ],
+  "evaluationQuery": "edge_non_binding_reference_relationship"
 }

--- a/server/meshmodel/aws-ecr-controller/v1.3.3/v1.0.0/relationships/edge-non-binding-reference-repository-deployment.json
+++ b/server/meshmodel/aws-ecr-controller/v1.3.3/v1.0.0/relationships/edge-non-binding-reference-repository-deployment.json
@@ -51,12 +51,19 @@
               "patchStrategy": "replace",
               "mutatorRef": [
                 [
-                  "status",
-                  "repositoryURI"
+                  "displayName"
                 ]
               ],
-              "description": "Extract the ECR repository URI from the Repository status field. This URI is automatically populated by the AWS Controllers for Kubernetes (ACK) after the repository is created in AWS ECR."
-            }
+              "description": "ECR Repository can be visually referenced by Kubernetes workloads."
+            },
+            "match_strategy_matrix": [
+              [
+                "equal_as_strings",
+                "not_null"
+              ]
+            ],
+            "id": null,
+            "match": {}
           }
         ],
         "to": [
@@ -73,17 +80,19 @@
               "patchStrategy": "replace",
               "mutatedRef": [
                 [
-                  "configuration",
                   "spec",
                   "template",
                   "spec",
                   "containers",
-                  "0",
+                  "_",
                   "image"
                 ]
               ],
-              "description": "Automatically populate the Deployment's first container image field with the ECR repository URI. This eliminates manual typing of long ECR URIs and prevents errors."
-            }
+              "description": "Deployment containers can reference ECR repository images."
+            },
+            "match_strategy_matrix": null,
+            "id": null,
+            "match": {}
           }
         ]
       },
@@ -92,5 +101,6 @@
         "to": []
       }
     }
-  ]
+  ],
+  "evaluationQuery": "edge_non_binding_reference_relationship"
 }

--- a/server/meshmodel/aws-ecr-controller/v1.3.3/v1.0.0/relationships/edge-non-binding-reference-repository-pod.json
+++ b/server/meshmodel/aws-ecr-controller/v1.3.3/v1.0.0/relationships/edge-non-binding-reference-repository-pod.json
@@ -51,12 +51,19 @@
               "patchStrategy": "replace",
               "mutatorRef": [
                 [
-                  "status",
-                  "repositoryURI"
+                  "displayName"
                 ]
               ],
-              "description": "Extract the ECR repository URI from the Repository status field. This URI is automatically populated by the AWS Controllers for Kubernetes (ACK) after the repository is created in AWS ECR."
-            }
+              "description": "ECR Repository can be visually referenced by Kubernetes workloads."
+            },
+            "match_strategy_matrix": [
+              [
+                "equal_as_strings",
+                "not_null"
+              ]
+            ],
+            "id": null,
+            "match": {}
           }
         ],
         "to": [
@@ -73,15 +80,17 @@
               "patchStrategy": "replace",
               "mutatedRef": [
                 [
-                  "configuration",
                   "spec",
                   "containers",
-                  "0",
+                  "_",
                   "image"
                 ]
               ],
-              "description": "Automatically populate the Pod's first container image field with the ECR repository URI. This eliminates manual typing of long ECR URIs and prevents errors."
-            }
+              "description": "Pod containers can reference ECR repository images."
+            },
+            "match_strategy_matrix": null,
+            "id": null,
+            "match": {}
           }
         ]
       },
@@ -90,5 +99,6 @@
         "to": []
       }
     }
-  ]
+  ],
+  "evaluationQuery": "edge_non_binding_reference_relationship"
 }

--- a/server/meshmodel/aws-ecr-controller/v1.4.0/v1.0.0/relationships/edge-non-binding-reference-repository-deployment.json
+++ b/server/meshmodel/aws-ecr-controller/v1.4.0/v1.0.0/relationships/edge-non-binding-reference-repository-deployment.json
@@ -51,12 +51,19 @@
               "patchStrategy": "replace",
               "mutatorRef": [
                 [
-                  "status",
-                  "repositoryURI"
+                  "displayName"
                 ]
               ],
-              "description": "Extract the ECR repository URI from the Repository status field. This URI is automatically populated by the AWS Controllers for Kubernetes (ACK) after the repository is created in AWS ECR."
-            }
+              "description": "ECR Repository can be visually referenced by Kubernetes workloads."
+            },
+            "match_strategy_matrix": [
+              [
+                "equal_as_strings",
+                "not_null"
+              ]
+            ],
+            "id": null,
+            "match": {}
           }
         ],
         "to": [
@@ -73,17 +80,19 @@
               "patchStrategy": "replace",
               "mutatedRef": [
                 [
-                  "configuration",
                   "spec",
                   "template",
                   "spec",
                   "containers",
-                  "0",
+                  "_",
                   "image"
                 ]
               ],
-              "description": "Automatically populate the Deployment's first container image field with the ECR repository URI. This eliminates manual typing of long ECR URIs and prevents errors."
-            }
+              "description": "Deployment containers can reference ECR repository images."
+            },
+            "match_strategy_matrix": null,
+            "id": null,
+            "match": {}
           }
         ]
       },
@@ -92,5 +101,6 @@
         "to": []
       }
     }
-  ]
+  ],
+  "evaluationQuery": "edge_non_binding_reference_relationship"
 }

--- a/server/meshmodel/aws-ecr-controller/v1.4.0/v1.0.0/relationships/edge-non-binding-reference-repository-pod.json
+++ b/server/meshmodel/aws-ecr-controller/v1.4.0/v1.0.0/relationships/edge-non-binding-reference-repository-pod.json
@@ -51,12 +51,19 @@
               "patchStrategy": "replace",
               "mutatorRef": [
                 [
-                  "status",
-                  "repositoryURI"
+                  "displayName"
                 ]
               ],
-              "description": "Extract the ECR repository URI from the Repository status field. This URI is automatically populated by the AWS Controllers for Kubernetes (ACK) after the repository is created in AWS ECR."
-            }
+              "description": "ECR Repository can be visually referenced by Kubernetes workloads."
+            },
+            "match_strategy_matrix": [
+              [
+                "equal_as_strings",
+                "not_null"
+              ]
+            ],
+            "id": null,
+            "match": {}
           }
         ],
         "to": [
@@ -73,15 +80,17 @@
               "patchStrategy": "replace",
               "mutatedRef": [
                 [
-                  "configuration",
                   "spec",
                   "containers",
-                  "0",
+                  "_",
                   "image"
                 ]
               ],
-              "description": "Automatically populate the Pod's first container image field with the ECR repository URI. This eliminates manual typing of long ECR URIs and prevents errors."
-            }
+              "description": "Pod containers can reference ECR repository images."
+            },
+            "match_strategy_matrix": null,
+            "id": null,
+            "match": {}
           }
         ]
       },
@@ -90,5 +99,6 @@
         "to": []
       }
     }
-  ]
+  ],
+  "evaluationQuery": "edge_non_binding_reference_relationship"
 }

--- a/server/meshmodel/aws-ecr-controller/v1.4.1/v1.0.0/relationships/edge-non-binding-reference-repository-deployment.json
+++ b/server/meshmodel/aws-ecr-controller/v1.4.1/v1.0.0/relationships/edge-non-binding-reference-repository-deployment.json
@@ -51,12 +51,19 @@
               "patchStrategy": "replace",
               "mutatorRef": [
                 [
-                  "status",
-                  "repositoryURI"
+                  "displayName"
                 ]
               ],
-              "description": "Extract the ECR repository URI from the Repository status field. This URI is automatically populated by the AWS Controllers for Kubernetes (ACK) after the repository is created in AWS ECR."
-            }
+              "description": "ECR Repository can be visually referenced by Kubernetes workloads."
+            },
+            "match_strategy_matrix": [
+              [
+                "equal_as_strings",
+                "not_null"
+              ]
+            ],
+            "id": null,
+            "match": {}
           }
         ],
         "to": [
@@ -73,17 +80,19 @@
               "patchStrategy": "replace",
               "mutatedRef": [
                 [
-                  "configuration",
                   "spec",
                   "template",
                   "spec",
                   "containers",
-                  "0",
+                  "_",
                   "image"
                 ]
               ],
-              "description": "Automatically populate the Deployment's first container image field with the ECR repository URI. This eliminates manual typing of long ECR URIs and prevents errors."
-            }
+              "description": "Deployment containers can reference ECR repository images."
+            },
+            "match_strategy_matrix": null,
+            "id": null,
+            "match": {}
           }
         ]
       },
@@ -92,5 +101,6 @@
         "to": []
       }
     }
-  ]
+  ],
+  "evaluationQuery": "edge_non_binding_reference_relationship"
 }

--- a/server/meshmodel/aws-ecr-controller/v1.4.1/v1.0.0/relationships/edge-non-binding-reference-repository-pod.json
+++ b/server/meshmodel/aws-ecr-controller/v1.4.1/v1.0.0/relationships/edge-non-binding-reference-repository-pod.json
@@ -51,12 +51,19 @@
               "patchStrategy": "replace",
               "mutatorRef": [
                 [
-                  "status",
-                  "repositoryURI"
+                  "displayName"
                 ]
               ],
-              "description": "Extract the ECR repository URI from the Repository status field. This URI is automatically populated by the AWS Controllers for Kubernetes (ACK) after the repository is created in AWS ECR."
-            }
+              "description": "ECR Repository can be visually referenced by Kubernetes workloads."
+            },
+            "match_strategy_matrix": [
+              [
+                "equal_as_strings",
+                "not_null"
+              ]
+            ],
+            "id": null,
+            "match": {}
           }
         ],
         "to": [
@@ -73,15 +80,17 @@
               "patchStrategy": "replace",
               "mutatedRef": [
                 [
-                  "configuration",
                   "spec",
                   "containers",
-                  "0",
+                  "_",
                   "image"
                 ]
               ],
-              "description": "Automatically populate the Pod's first container image field with the ECR repository URI. This eliminates manual typing of long ECR URIs and prevents errors."
-            }
+              "description": "Pod containers can reference ECR repository images."
+            },
+            "match_strategy_matrix": null,
+            "id": null,
+            "match": {}
           }
         ]
       },
@@ -90,5 +99,6 @@
         "to": []
       }
     }
-  ]
+  ],
+  "evaluationQuery": "edge_non_binding_reference_relationship"
 }


### PR DESCRIPTION
## Description

- Adds ECR Repository → Deployment/Pod relationships in Kanvas.

- 28 relationship files (Repository → Deployment and Repository → Pod) across 14 ECR controller versions
---
<img width="1284" height="898" alt="image" src="https://github.com/user-attachments/assets/f2999ac7-1988-495c-93b6-a237a72f5294" />

---
## Notes for Reviewers

- Covers all 14 aws-ecr-controller versions (v1.0.28 - v1.4.1)
- Related to issue #17096

**[Signed commits](https://github.com/meshery/meshery/blob/master/CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [x] Yes, I signed my commits.