### PR TITLE
feat(meshmodel): add AWS CloudWatch monitoring relationships →Deployment/StatefulSet

### DIFF
--- a/server/meshmodel/aws-cloudwatch-controller/v1.4.1/v1.0.0/relationships/edge-non-binding-reference-dashboard-deployment.json
+++ b/server/meshmodel/aws-cloudwatch-controller/v1.4.1/v1.0.0/relationships/edge-non-binding-reference-dashboard-deployment.json
@@ -44,15 +44,6 @@
               "model": {
                 "version": "v1.4.1"
               }
-            },
-            "patch": {
-              "patchStrategy": "replace",
-              "mutatorRef": [
-                [
-                  "spec",
-                  "widgets"
-                ]
-              ]
             }
           }
         ],
@@ -73,15 +64,6 @@
               "model": {
                 "version": ""
               }
-            },
-            "patch": {
-              "patchStrategy": "replace",
-              "mutatedRef": [
-                [
-                  "metadata",
-                  "name"
-                ]
-              ]
             }
           }
         ]

--- a/server/meshmodel/aws-cloudwatch-controller/v1.4.1/v1.0.0/relationships/edge-non-binding-reference-dashboard-deployment.json
+++ b/server/meshmodel/aws-cloudwatch-controller/v1.4.1/v1.0.0/relationships/edge-non-binding-reference-dashboard-deployment.json
@@ -1,5 +1,5 @@
 {
-  "id": "00000000-0000-0000-0000-000000000000",
+  "id": "afcd67ce-0624-443a-a14b-bc0da08e12ae",
   "evaluationQuery": "edge_non-binding_reference_relationship",
   "kind": "edge",
   "metadata": {
@@ -15,7 +15,7 @@
     "version": "",
     "name": "aws-cloudwatch-controller",
     "displayName": "",
-    "id": "00000000-0000-0000-0000-000000000000",
+    "id": "afcd67ce-0624-443a-a14b-bc0da08e12ae",
     "registrant": {
       "kind": "github"
     },
@@ -37,7 +37,7 @@
               "version": "",
               "name": "aws-cloudwatch-controller",
               "displayName": "",
-              "id": "00000000-0000-0000-0000-000000000000",
+              "id": "72ea127b-8064-4221-9b4f-65d732ec1f4d",
               "registrant": {
                 "kind": "github"
               },
@@ -89,7 +89,7 @@
               "version": "",
               "name": "kubernetes",
               "displayName": "",
-              "id": "00000000-0000-0000-0000-000000000000",
+              "id": "ce9b8d73-eae1-4f44-809b-5a6726e0be15",
               "registrant": {
                 "kind": "github"
               },

--- a/server/meshmodel/aws-cloudwatch-controller/v1.4.1/v1.0.0/relationships/edge-non-binding-reference-dashboard-deployment.json
+++ b/server/meshmodel/aws-cloudwatch-controller/v1.4.1/v1.0.0/relationships/edge-non-binding-reference-dashboard-deployment.json
@@ -49,13 +49,11 @@
               "patchStrategy": "replace",
               "mutatorRef": [
                 [
-                  "configuration",
-                  "spec",
-                  "queries"
+                  "metadata",
+                  "labels"
                 ]
               ]
             }
-            
           }
         ],
         "to": [

--- a/server/meshmodel/aws-cloudwatch-controller/v1.4.1/v1.0.0/relationships/edge-non-binding-reference-dashboard-deployment.json
+++ b/server/meshmodel/aws-cloudwatch-controller/v1.4.1/v1.0.0/relationships/edge-non-binding-reference-dashboard-deployment.json
@@ -1,6 +1,6 @@
 {
   "id": "00000000-0000-0000-0000-000000000000",
-  "evaluationQuery": "",
+  "evaluationQuery": "edge_non-binding_reference_relationship",
   "kind": "edge",
   "metadata": {
     "description": "Deployment monitored by CloudWatch Dashboard",
@@ -44,7 +44,18 @@
               "model": {
                 "version": "v1.4.1"
               }
+            },
+            "patch": {
+              "patchStrategy": "replace",
+              "mutatorRef": [
+                [
+                  "configuration",
+                  "spec",
+                  "queries"
+                ]
+              ]
             }
+            
           }
         ],
         "to": [
@@ -64,6 +75,16 @@
               "model": {
                 "version": ""
               }
+            },
+            "patch": {
+              "patchStrategy": "replace",
+              "mutatedRef": [
+                [
+                  "metadata",
+                  "labels",
+                  "monitored-by-aws-cloudwatch-dashboard"
+                ]
+              ]
             }
           }
         ]

--- a/server/meshmodel/aws-cloudwatch-controller/v1.4.1/v1.0.0/relationships/edge-non-binding-reference-dashboard-deployment.json
+++ b/server/meshmodel/aws-cloudwatch-controller/v1.4.1/v1.0.0/relationships/edge-non-binding-reference-dashboard-deployment.json
@@ -49,8 +49,8 @@
               "patchStrategy": "replace",
               "mutatorRef": [
                 [
-                  "metadata",
-                  "labels"
+                  "spec",
+                  "widgets"
                 ]
               ]
             }
@@ -78,9 +78,14 @@
               "patchStrategy": "replace",
               "mutatedRef": [
                 [
+                  [
                   "metadata",
-                  "labels",
-                  "monitored-by-aws-cloudwatch-dashboard"
+                  "name"
+                ],
+                [
+                  "metadata",
+                  "namespace"
+                ]
                 ]
               ]
             }

--- a/server/meshmodel/aws-cloudwatch-controller/v1.4.1/v1.0.0/relationships/edge-non-binding-reference-dashboard-deployment.json
+++ b/server/meshmodel/aws-cloudwatch-controller/v1.4.1/v1.0.0/relationships/edge-non-binding-reference-dashboard-deployment.json
@@ -1,5 +1,5 @@
 {
-  "id": "afcd67ce-0624-443a-a14b-bc0da08e12ae",
+  "id": "00000000-0000-0000-0000-000000000000",
   "evaluationQuery": "edge_non-binding_reference_relationship",
   "kind": "edge",
   "metadata": {
@@ -15,7 +15,7 @@
     "version": "",
     "name": "aws-cloudwatch-controller",
     "displayName": "",
-    "id": "afcd67ce-0624-443a-a14b-bc0da08e12ae",
+    "id": "00000000-0000-0000-0000-000000000000",
     "registrant": {
       "kind": "github"
     },
@@ -37,7 +37,7 @@
               "version": "",
               "name": "aws-cloudwatch-controller",
               "displayName": "",
-              "id": "72ea127b-8064-4221-9b4f-65d732ec1f4d",
+              "id": "00000000-0000-0000-0000-000000000000",
               "registrant": {
                 "kind": "github"
               },
@@ -89,7 +89,7 @@
               "version": "",
               "name": "kubernetes",
               "displayName": "",
-              "id": "ce9b8d73-eae1-4f44-809b-5a6726e0be15",
+              "id": "00000000-0000-0000-0000-000000000000",
               "registrant": {
                 "kind": "github"
               },

--- a/server/meshmodel/aws-cloudwatch-controller/v1.4.1/v1.0.0/relationships/edge-non-binding-reference-dashboard-deployment.json
+++ b/server/meshmodel/aws-cloudwatch-controller/v1.4.1/v1.0.0/relationships/edge-non-binding-reference-dashboard-deployment.json
@@ -46,13 +46,36 @@
               }
             },
             "patch": {
-              "patchStrategy": "replace",
+              "patchStrategy": "add",
               "mutatorRef": [
                 [
-                  "metadata",
-                  "name"
+                  "spec",
+                  "widgets"
                 ]
-              ]
+              ],
+              "value": {
+                "type": "metric",
+                "properties": {
+                  "metrics": [
+                    {
+                      "metricStat": {
+                        "metric": {
+                          "namespace": "ContainerInsights",
+                          "metricName": "pod_cpu_utilization",
+                          "dimensions": {
+                            "Namespace": "{{ .mutatedRef.namespace }}",
+                            "Service": "{{ .mutatedRef.name }}"
+                          }
+                        },
+                        "period": 300,
+                        "stat": "Average"
+                      }
+                    }
+                  ],
+                  "region": "us-east-1",
+                  "title": "Deployment: {{ .mutatedRef.name }}"
+                }
+              }
             }
           }
         ],
@@ -79,8 +102,11 @@
               "mutatedRef": [
                 [
                   "metadata",
-                  "labels",
-                  "cloudwatch-dashboard"
+                  "name"
+                ],
+                [
+                  "metadata",
+                  "namespace"
                 ]
               ]
             }

--- a/server/meshmodel/aws-cloudwatch-controller/v1.4.1/v1.0.0/relationships/edge-non-binding-reference-dashboard-deployment.json
+++ b/server/meshmodel/aws-cloudwatch-controller/v1.4.1/v1.0.0/relationships/edge-non-binding-reference-dashboard-deployment.json
@@ -46,17 +46,11 @@
               }
             },
             "patch": {
-              "patchStrategy": "merge",
+              "patchStrategy": "replace",
               "mutatorRef": [
                 [
-                  "spec",
-                  "widgets",
-                  "[]",
-                  "properties",
-                  "metrics",
-                  "[]",
-                  "dimensions",
-                  "deployment"
+                  "metadata",
+                  "name"
                 ]
               ]
             }
@@ -85,11 +79,8 @@
               "mutatedRef": [
                 [
                   "metadata",
-                  "name"
-                ],
-                [
-                  "metadata",
-                  "namespace"
+                  "labels",
+                  "cloudwatch-dashboard"
                 ]
               ]
             }

--- a/server/meshmodel/aws-cloudwatch-controller/v1.4.1/v1.0.0/relationships/edge-non-binding-reference-dashboard-deployment.json
+++ b/server/meshmodel/aws-cloudwatch-controller/v1.4.1/v1.0.0/relationships/edge-non-binding-reference-dashboard-deployment.json
@@ -1,0 +1,99 @@
+{
+  "id": "00000000-0000-0000-0000-000000000000",
+  "evaluationQuery": "",
+  "kind": "edge",
+  "metadata": {
+    "description": "Deployment monitored by CloudWatch Dashboard",
+    "styles": {
+      "primaryColor": "",
+      "svgColor": "",
+      "svgWhite": ""
+    },
+    "isAnnotation": false
+  },
+  "model": {
+    "version": "",
+    "name": "aws-cloudwatch-controller",
+    "displayName": "",
+    "id": "00000000-0000-0000-0000-000000000000",
+    "registrant": {
+      "kind": "github"
+    },
+    "model": {
+      "version": "v1.4.1"
+    }
+  },
+  "schemaVersion": "relationships.meshery.io/v1alpha3",
+  "selectors": [
+    {
+      "allow": {
+        "from": [
+          {
+            "id": null,
+            "kind": "Dashboard",
+            "match": {},
+            "match_strategy_matrix": null,
+            "model": {
+              "version": "",
+              "name": "aws-cloudwatch-controller",
+              "displayName": "",
+              "id": "00000000-0000-0000-0000-000000000000",
+              "registrant": {
+                "kind": "github"
+              },
+              "model": {
+                "version": "v1.4.1"
+              }
+            },
+            "patch": {
+              "patchStrategy": "replace",
+              "mutatorRef": [
+                [
+                  "spec",
+                  "widgets"
+                ]
+              ]
+            }
+          }
+        ],
+        "to": [
+          {
+            "id": null,
+            "kind": "Deployment",
+            "match": {},
+            "match_strategy_matrix": null,
+            "model": {
+              "version": "",
+              "name": "kubernetes",
+              "displayName": "",
+              "id": "00000000-0000-0000-0000-000000000000",
+              "registrant": {
+                "kind": "github"
+              },
+              "model": {
+                "version": ""
+              }
+            },
+            "patch": {
+              "patchStrategy": "replace",
+              "mutatedRef": [
+                [
+                  "metadata",
+                  "name"
+                ]
+              ]
+            }
+          }
+        ]
+      },
+      "deny": {
+        "from": [],
+        "to": []
+      }
+    }
+  ],
+  "subType": "reference",
+  "status": "enabled",
+  "type": "non-binding",
+  "version": "v1.0.0"
+}

--- a/server/meshmodel/aws-cloudwatch-controller/v1.4.1/v1.0.0/relationships/edge-non-binding-reference-dashboard-deployment.json
+++ b/server/meshmodel/aws-cloudwatch-controller/v1.4.1/v1.0.0/relationships/edge-non-binding-reference-dashboard-deployment.json
@@ -46,7 +46,7 @@
               }
             },
             "patch": {
-              "patchStrategy": "replace",
+              "patchStrategy": "merge",
               "mutatorRef": [
                 [
                   "spec",
@@ -78,14 +78,12 @@
               "patchStrategy": "replace",
               "mutatedRef": [
                 [
-                  [
                   "metadata",
                   "name"
                 ],
                 [
                   "metadata",
                   "namespace"
-                ]
                 ]
               ]
             }

--- a/server/meshmodel/aws-cloudwatch-controller/v1.4.1/v1.0.0/relationships/edge-non-binding-reference-dashboard-deployment.json
+++ b/server/meshmodel/aws-cloudwatch-controller/v1.4.1/v1.0.0/relationships/edge-non-binding-reference-dashboard-deployment.json
@@ -50,7 +50,13 @@
               "mutatorRef": [
                 [
                   "spec",
-                  "widgets"
+                  "widgets",
+                  "[]",
+                  "properties",
+                  "metrics",
+                  "[]",
+                  "dimensions",
+                  "deployment"
                 ]
               ]
             }

--- a/server/meshmodel/aws-cloudwatch-controller/v1.4.1/v1.0.0/relationships/edge-non-binding-reference-dashboard-statefulset.json
+++ b/server/meshmodel/aws-cloudwatch-controller/v1.4.1/v1.0.0/relationships/edge-non-binding-reference-dashboard-statefulset.json
@@ -1,5 +1,5 @@
 {
-  "id": "3b952a9a-5203-4e11-b007-697556f486de",
+  "id": "00000000-0000-0000-0000-000000000000",
   "evaluationQuery": "edge_non-binding_reference_relationship",
   "kind": "edge",
   "metadata": {
@@ -15,7 +15,7 @@
     "version": "",
     "name": "aws-cloudwatch-controller",
     "displayName": "",
-    "id": "3b952a9a-5203-4e11-b007-697556f486de",
+    "id": "00000000-0000-0000-0000-000000000000",
     "registrant": {
       "kind": "github"
     },
@@ -37,7 +37,7 @@
               "version": "",
               "name": "aws-cloudwatch-controller",
               "displayName": "",
-              "id": "027361e6-1658-4efb-9321-fd61621c73cc",
+              "id": "00000000-0000-0000-0000-000000000000",
               "registrant": {
                 "kind": "github"
               },
@@ -89,7 +89,7 @@
               "version": "",
               "name": "kubernetes",
               "displayName": "",
-              "id": "79488562-1d55-4022-ac17-5d009b8cd348",
+              "id": "00000000-0000-0000-0000-000000000000",
               "registrant": {
                 "kind": "github"
               },

--- a/server/meshmodel/aws-cloudwatch-controller/v1.4.1/v1.0.0/relationships/edge-non-binding-reference-dashboard-statefulset.json
+++ b/server/meshmodel/aws-cloudwatch-controller/v1.4.1/v1.0.0/relationships/edge-non-binding-reference-dashboard-statefulset.json
@@ -1,5 +1,5 @@
 {
-  "id": "00000000-0000-0000-0000-000000000000",
+  "id": "3b952a9a-5203-4e11-b007-697556f486de",
   "evaluationQuery": "edge_non-binding_reference_relationship",
   "kind": "edge",
   "metadata": {
@@ -15,7 +15,7 @@
     "version": "",
     "name": "aws-cloudwatch-controller",
     "displayName": "",
-    "id": "00000000-0000-0000-0000-000000000000",
+    "id": "3b952a9a-5203-4e11-b007-697556f486de",
     "registrant": {
       "kind": "github"
     },
@@ -37,7 +37,7 @@
               "version": "",
               "name": "aws-cloudwatch-controller",
               "displayName": "",
-              "id": "00000000-0000-0000-0000-000000000000",
+              "id": "027361e6-1658-4efb-9321-fd61621c73cc",
               "registrant": {
                 "kind": "github"
               },
@@ -89,7 +89,7 @@
               "version": "",
               "name": "kubernetes",
               "displayName": "",
-              "id": "00000000-0000-0000-0000-000000000000",
+              "id": "79488562-1d55-4022-ac17-5d009b8cd348",
               "registrant": {
                 "kind": "github"
               },

--- a/server/meshmodel/aws-cloudwatch-controller/v1.4.1/v1.0.0/relationships/edge-non-binding-reference-dashboard-statefulset.json
+++ b/server/meshmodel/aws-cloudwatch-controller/v1.4.1/v1.0.0/relationships/edge-non-binding-reference-dashboard-statefulset.json
@@ -49,8 +49,8 @@
               "patchStrategy": "replace",
               "mutatorRef": [
                 [
-                  "metadata",
-                  "labels"
+                  "spec",
+                  "widgets"
                 ]
               ]
             }
@@ -78,9 +78,14 @@
               "patchStrategy": "replace",
               "mutatedRef": [
                 [
+                  [
                   "metadata",
-                  "labels",
-                  "monitored-by-aws-cloudwatch-dashboard"
+                  "name"
+                ],
+                [
+                  "metadata",
+                  "namespace"
+                ]
                 ]
               ]
             }

--- a/server/meshmodel/aws-cloudwatch-controller/v1.4.1/v1.0.0/relationships/edge-non-binding-reference-dashboard-statefulset.json
+++ b/server/meshmodel/aws-cloudwatch-controller/v1.4.1/v1.0.0/relationships/edge-non-binding-reference-dashboard-statefulset.json
@@ -1,6 +1,6 @@
 {
   "id": "00000000-0000-0000-0000-000000000000",
-  "evaluationQuery": "edge_non_binding_reference_relationship",
+  "evaluationQuery": "edge_non-binding_reference_relationship",
   "kind": "edge",
   "metadata": {
     "description": "StatefulSet monitored by CloudWatch Dashboard",
@@ -46,17 +46,11 @@
               }
             },
             "patch": {
-              "patchStrategy": "merge",
+              "patchStrategy": "replace",
               "mutatorRef": [
                 [
-                  "spec",
-                  "widgets",
-                  "[]",
-                  "properties",
-                  "metrics",
-                  "[]",
-                  "dimensions",
-                  "deployment"
+                  "metadata",
+                  "name"
                 ]
               ]
             }
@@ -85,11 +79,8 @@
               "mutatedRef": [
                 [
                   "metadata",
-                  "name"
-                ],
-                [
-                  "metadata",
-                  "namespace"
+                  "labels",
+                  "cloudwatch-dashboard"
                 ]
               ]
             }

--- a/server/meshmodel/aws-cloudwatch-controller/v1.4.1/v1.0.0/relationships/edge-non-binding-reference-dashboard-statefulset.json
+++ b/server/meshmodel/aws-cloudwatch-controller/v1.4.1/v1.0.0/relationships/edge-non-binding-reference-dashboard-statefulset.json
@@ -1,0 +1,99 @@
+{
+  "id": "00000000-0000-0000-0000-000000000000",
+  "evaluationQuery": "",
+  "kind": "edge",
+  "metadata": {
+    "description": "StatefulSet monitored by CloudWatch Dashboard",
+    "styles": {
+      "primaryColor": "",
+      "svgColor": "",
+      "svgWhite": ""
+    },
+    "isAnnotation": false
+  },
+  "model": {
+    "version": "",
+    "name": "aws-cloudwatch-controller",
+    "displayName": "",
+    "id": "00000000-0000-0000-0000-000000000000",
+    "registrant": {
+      "kind": "github"
+    },
+    "model": {
+      "version": "v1.4.1"
+    }
+  },
+  "schemaVersion": "relationships.meshery.io/v1alpha3",
+  "selectors": [
+    {
+      "allow": {
+        "from": [
+          {
+            "id": null,
+            "kind": "Dashboard",
+            "match": {},
+            "match_strategy_matrix": null,
+            "model": {
+              "version": "",
+              "name": "aws-cloudwatch-controller",
+              "displayName": "",
+              "id": "00000000-0000-0000-0000-000000000000",
+              "registrant": {
+                "kind": "github"
+              },
+              "model": {
+                "version": "v1.4.1"
+              }
+            },
+            "patch": {
+              "patchStrategy": "replace",
+              "mutatorRef": [
+                [
+                  "spec",
+                  "widgets"
+                ]
+              ]
+            }
+          }
+        ],
+        "to": [
+          {
+            "id": null,
+            "kind": "StatefulSet",
+            "match": {},
+            "match_strategy_matrix": null,
+            "model": {
+              "version": "",
+              "name": "kubernetes",
+              "displayName": "",
+              "id": "00000000-0000-0000-0000-000000000000",
+              "registrant": {
+                "kind": "github"
+              },
+              "model": {
+                "version": ""
+              }
+            },
+            "patch": {
+              "patchStrategy": "replace",
+              "mutatedRef": [
+                [
+                  "metadata",
+                  "name"
+                ]
+              ]
+            }
+          }
+        ]
+      },
+      "deny": {
+        "from": [],
+        "to": []
+      }
+    }
+  ],
+  "subType": "reference",
+  "status": "enabled",
+  "type": "non-binding",
+  "version": "v1.0.0"
+}

--- a/server/meshmodel/aws-cloudwatch-controller/v1.4.1/v1.0.0/relationships/edge-non-binding-reference-dashboard-statefulset.json
+++ b/server/meshmodel/aws-cloudwatch-controller/v1.4.1/v1.0.0/relationships/edge-non-binding-reference-dashboard-statefulset.json
@@ -49,9 +49,8 @@
               "patchStrategy": "replace",
               "mutatorRef": [
                 [
-                  "configuration",
-                  "spec",
-                  "queries"
+                  "metadata",
+                  "labels"
                 ]
               ]
             }

--- a/server/meshmodel/aws-cloudwatch-controller/v1.4.1/v1.0.0/relationships/edge-non-binding-reference-dashboard-statefulset.json
+++ b/server/meshmodel/aws-cloudwatch-controller/v1.4.1/v1.0.0/relationships/edge-non-binding-reference-dashboard-statefulset.json
@@ -1,6 +1,6 @@
 {
   "id": "00000000-0000-0000-0000-000000000000",
-  "evaluationQuery": "",
+  "evaluationQuery": "edge_non_binding_reference_relationship",
   "kind": "edge",
   "metadata": {
     "description": "StatefulSet monitored by CloudWatch Dashboard",
@@ -46,11 +46,12 @@
               }
             },
             "patch": {
-              "patchStrategy": "merge",
+              "patchStrategy": "replace",
               "mutatorRef": [
                 [
+                  "configuration",
                   "spec",
-                  "dashboardBody"
+                  "queries"
                 ]
               ]
             }
@@ -75,7 +76,14 @@
               }
             },
             "patch": {
-              "patchStrategy": "none"
+              "patchStrategy": "replace",
+              "mutatedRef": [
+                [
+                  "metadata",
+                  "labels",
+                  "monitored-by-aws-cloudwatch-dashboard"
+                ]
+              ]
             }
           }
         ]

--- a/server/meshmodel/aws-cloudwatch-controller/v1.4.1/v1.0.0/relationships/edge-non-binding-reference-dashboard-statefulset.json
+++ b/server/meshmodel/aws-cloudwatch-controller/v1.4.1/v1.0.0/relationships/edge-non-binding-reference-dashboard-statefulset.json
@@ -46,7 +46,7 @@
               }
             },
             "patch": {
-              "patchStrategy": "replace",
+              "patchStrategy": "merge",
               "mutatorRef": [
                 [
                   "spec",
@@ -78,14 +78,12 @@
               "patchStrategy": "replace",
               "mutatedRef": [
                 [
-                  [
                   "metadata",
                   "name"
                 ],
                 [
                   "metadata",
                   "namespace"
-                ]
                 ]
               ]
             }

--- a/server/meshmodel/aws-cloudwatch-controller/v1.4.1/v1.0.0/relationships/edge-non-binding-reference-dashboard-statefulset.json
+++ b/server/meshmodel/aws-cloudwatch-controller/v1.4.1/v1.0.0/relationships/edge-non-binding-reference-dashboard-statefulset.json
@@ -50,7 +50,13 @@
               "mutatorRef": [
                 [
                   "spec",
-                  "widgets"
+                  "widgets",
+                  "[]",
+                  "properties",
+                  "metrics",
+                  "[]",
+                  "dimensions",
+                  "deployment"
                 ]
               ]
             }

--- a/server/meshmodel/aws-cloudwatch-controller/v1.4.1/v1.0.0/relationships/edge-non-binding-reference-dashboard-statefulset.json
+++ b/server/meshmodel/aws-cloudwatch-controller/v1.4.1/v1.0.0/relationships/edge-non-binding-reference-dashboard-statefulset.json
@@ -46,11 +46,11 @@
               }
             },
             "patch": {
-              "patchStrategy": "replace",
+              "patchStrategy": "merge",
               "mutatorRef": [
                 [
                   "spec",
-                  "widgets"
+                  "dashboardBody"
                 ]
               ]
             }
@@ -75,13 +75,7 @@
               }
             },
             "patch": {
-              "patchStrategy": "replace",
-              "mutatedRef": [
-                [
-                  "metadata",
-                  "name"
-                ]
-              ]
+              "patchStrategy": "none"
             }
           }
         ]

--- a/server/meshmodel/aws-cloudwatch-controller/v1.4.1/v1.0.0/relationships/edge-non-binding-reference-dashboard-statefulset.json
+++ b/server/meshmodel/aws-cloudwatch-controller/v1.4.1/v1.0.0/relationships/edge-non-binding-reference-dashboard-statefulset.json
@@ -46,13 +46,36 @@
               }
             },
             "patch": {
-              "patchStrategy": "replace",
+              "patchStrategy": "add",
               "mutatorRef": [
                 [
-                  "metadata",
-                  "name"
+                  "spec",
+                  "widgets"
                 ]
-              ]
+              ],
+              "value": {
+                "type": "metric",
+                "properties": {
+                  "metrics": [
+                    {
+                      "metricStat": {
+                        "metric": {
+                          "namespace": "ContainerInsights",
+                          "metricName": "pod_cpu_utilization",
+                          "dimensions": {
+                            "Namespace": "{{ .mutatedRef.namespace }}",
+                            "Service": "{{ .mutatedRef.name }}"
+                          }
+                        },
+                        "period": 300,
+                        "stat": "Average"
+                      }
+                    }
+                  ],
+                  "region": "us-east-1",
+                  "title": "StatefulSet: {{ .mutatedRef.name }}"
+                }
+              }
             }
           }
         ],
@@ -79,8 +102,11 @@
               "mutatedRef": [
                 [
                   "metadata",
-                  "labels",
-                  "cloudwatch-dashboard"
+                  "name"
+                ],
+                [
+                  "metadata",
+                  "namespace"
                 ]
               ]
             }

--- a/server/meshmodel/aws-cloudwatch-controller/v1.4.1/v1.0.0/relationships/edge-non-binding-reference-metricalarm-deployment.json
+++ b/server/meshmodel/aws-cloudwatch-controller/v1.4.1/v1.0.0/relationships/edge-non-binding-reference-metricalarm-deployment.json
@@ -44,15 +44,6 @@
               "model": {
                 "version": "v1.4.1"
               }
-            },
-            "patch": {
-              "patchStrategy": "replace",
-              "mutatorRef": [
-                [
-                  "spec",
-                  "metricName"
-                ]
-              ]
             }
           }
         ],
@@ -73,15 +64,6 @@
               "model": {
                 "version": ""
               }
-            },
-            "patch": {
-              "patchStrategy": "replace",
-              "mutatedRef": [
-                [
-                  "metadata",
-                  "name"
-                ]
-              ]
             }
           }
         ]

--- a/server/meshmodel/aws-cloudwatch-controller/v1.4.1/v1.0.0/relationships/edge-non-binding-reference-metricalarm-deployment.json
+++ b/server/meshmodel/aws-cloudwatch-controller/v1.4.1/v1.0.0/relationships/edge-non-binding-reference-metricalarm-deployment.json
@@ -1,6 +1,6 @@
 {
   "id": "00000000-0000-0000-0000-000000000000",
-  "evaluationQuery": "",
+  "evaluationQuery": "edge_non_binding_reference_relationship",
   "kind": "edge",
   "metadata": {
     "description": "Deployment monitored by CloudWatch MetricAlarm",
@@ -44,6 +44,16 @@
               "model": {
                 "version": "v1.4.1"
               }
+            },       
+              "patch": {
+                "patchStrategy": "replace",
+                "mutatorRef": [
+                [
+                  "configuration",
+                  "spec",
+                  "dimensions"
+                ]
+              ]
             }
           }
         ],
@@ -64,6 +74,16 @@
               "model": {
                 "version": ""
               }
+            },
+            "patch": {
+              "patchStrategy": "replace",
+              "mutatedRef": [
+                [
+                  "metadata",
+                  "labels",
+                  "monitored-by-aws-cloudwatch-metricalarm"
+                ]
+              ]
             }
           }
         ]

--- a/server/meshmodel/aws-cloudwatch-controller/v1.4.1/v1.0.0/relationships/edge-non-binding-reference-metricalarm-deployment.json
+++ b/server/meshmodel/aws-cloudwatch-controller/v1.4.1/v1.0.0/relationships/edge-non-binding-reference-metricalarm-deployment.json
@@ -1,5 +1,5 @@
 {
-  "id": "00000000-0000-0000-0000-000000000000",
+  "id": "3b9e3b45-f899-4d51-b759-834c66b71ff1",
   "evaluationQuery": "edge_non-binding_reference_relationship",
   "kind": "edge",
   "metadata": {
@@ -15,7 +15,7 @@
     "version": "",
     "name": "aws-cloudwatch-controller",
     "displayName": "",
-    "id": "00000000-0000-0000-0000-000000000000",
+    "id": "3b9e3b45-f899-4d51-b759-834c66b71ff1",
     "registrant": {
       "kind": "github"
     },
@@ -37,7 +37,7 @@
               "version": "",
               "name": "aws-cloudwatch-controller",
               "displayName": "",
-              "id": "00000000-0000-0000-0000-000000000000",
+              "id": "d2fb0313-4c10-4350-acf1-0a4b434605a9",
               "registrant": {
                 "kind": "github"
               },
@@ -71,7 +71,7 @@
               "version": "",
               "name": "kubernetes",
               "displayName": "",
-              "id": "00000000-0000-0000-0000-000000000000",
+              "id": "effd8357-ff89-4ee4-8801-021de0092b4a",
               "registrant": {
                 "kind": "github"
               },

--- a/server/meshmodel/aws-cloudwatch-controller/v1.4.1/v1.0.0/relationships/edge-non-binding-reference-metricalarm-deployment.json
+++ b/server/meshmodel/aws-cloudwatch-controller/v1.4.1/v1.0.0/relationships/edge-non-binding-reference-metricalarm-deployment.json
@@ -1,6 +1,6 @@
 {
   "id": "00000000-0000-0000-0000-000000000000",
-  "evaluationQuery": "edge_non_binding_reference_relationship",
+  "evaluationQuery": "edge_non-binding_reference_relationship",
   "kind": "edge",
   "metadata": {
     "description": "Deployment monitored by CloudWatch MetricAlarm",
@@ -44,16 +44,20 @@
               "model": {
                 "version": "v1.4.1"
               }
-            },       
-              "patch": {
-                "patchStrategy": "replace",
-                "mutatorRef": [
+            },
+            "patch": {
+              "patchStrategy": "add",
+              "mutatorRef": [
                 [
                   "configuration",
                   "spec",
                   "dimensions"
                 ]
-              ]
+              ],
+              "value": {
+                "name": "Service",
+                "value": "{{ .mutatedRef.name }}"
+              }
             }
           }
         ],
@@ -80,8 +84,11 @@
               "mutatedRef": [
                 [
                   "metadata",
-                  "labels",
-                  "monitored-by-aws-cloudwatch-metricalarm"
+                  "name"
+                ],
+                [
+                  "metadata",
+                  "namespace"
                 ]
               ]
             }

--- a/server/meshmodel/aws-cloudwatch-controller/v1.4.1/v1.0.0/relationships/edge-non-binding-reference-metricalarm-deployment.json
+++ b/server/meshmodel/aws-cloudwatch-controller/v1.4.1/v1.0.0/relationships/edge-non-binding-reference-metricalarm-deployment.json
@@ -1,5 +1,5 @@
 {
-  "id": "3b9e3b45-f899-4d51-b759-834c66b71ff1",
+  "id": "00000000-0000-0000-0000-000000000001",
   "evaluationQuery": "edge_non-binding_reference_relationship",
   "kind": "edge",
   "metadata": {
@@ -15,7 +15,7 @@
     "version": "",
     "name": "aws-cloudwatch-controller",
     "displayName": "",
-    "id": "3b9e3b45-f899-4d51-b759-834c66b71ff1",
+    "id": "00000000-0000-0000-0000-000000000001",
     "registrant": {
       "kind": "github"
     },
@@ -37,7 +37,7 @@
               "version": "",
               "name": "aws-cloudwatch-controller",
               "displayName": "",
-              "id": "d2fb0313-4c10-4350-acf1-0a4b434605a9",
+              "id": "00000000-0000-0000-0000-000000000001",
               "registrant": {
                 "kind": "github"
               },
@@ -71,7 +71,7 @@
               "version": "",
               "name": "kubernetes",
               "displayName": "",
-              "id": "effd8357-ff89-4ee4-8801-021de0092b4a",
+              "id": "00000000-0000-0000-0000-000000000001",
               "registrant": {
                 "kind": "github"
               },

--- a/server/meshmodel/aws-cloudwatch-controller/v1.4.1/v1.0.0/relationships/edge-non-binding-reference-metricalarm-deployment.json
+++ b/server/meshmodel/aws-cloudwatch-controller/v1.4.1/v1.0.0/relationships/edge-non-binding-reference-metricalarm-deployment.json
@@ -1,0 +1,99 @@
+{
+  "id": "00000000-0000-0000-0000-000000000000",
+  "evaluationQuery": "",
+  "kind": "edge",
+  "metadata": {
+    "description": "Deployment monitored by CloudWatch MetricAlarm",
+    "styles": {
+      "primaryColor": "",
+      "svgColor": "",
+      "svgWhite": ""
+    },
+    "isAnnotation": false
+  },
+  "model": {
+    "version": "",
+    "name": "aws-cloudwatch-controller",
+    "displayName": "",
+    "id": "00000000-0000-0000-0000-000000000000",
+    "registrant": {
+      "kind": "github"
+    },
+    "model": {
+      "version": "v1.4.1"
+    }
+  },
+  "schemaVersion": "relationships.meshery.io/v1alpha3",
+  "selectors": [
+    {
+      "allow": {
+        "from": [
+          {
+            "id": null,
+            "kind": "MetricAlarm",
+            "match": {},
+            "match_strategy_matrix": null,
+            "model": {
+              "version": "",
+              "name": "aws-cloudwatch-controller",
+              "displayName": "",
+              "id": "00000000-0000-0000-0000-000000000000",
+              "registrant": {
+                "kind": "github"
+              },
+              "model": {
+                "version": "v1.4.1"
+              }
+            },
+            "patch": {
+              "patchStrategy": "replace",
+              "mutatorRef": [
+                [
+                  "spec",
+                  "metricName"
+                ]
+              ]
+            }
+          }
+        ],
+        "to": [
+          {
+            "id": null,
+            "kind": "Deployment",
+            "match": {},
+            "match_strategy_matrix": null,
+            "model": {
+              "version": "",
+              "name": "kubernetes",
+              "displayName": "",
+              "id": "00000000-0000-0000-0000-000000000000",
+              "registrant": {
+                "kind": "github"
+              },
+              "model": {
+                "version": ""
+              }
+            },
+            "patch": {
+              "patchStrategy": "replace",
+              "mutatedRef": [
+                [
+                  "metadata",
+                  "name"
+                ]
+              ]
+            }
+          }
+        ]
+      },
+      "deny": {
+        "from": [],
+        "to": []
+      }
+    }
+  ],
+  "subType": "reference",
+  "status": "enabled",
+  "type": "non-binding",
+  "version": "v1.0.0"
+}

--- a/server/meshmodel/aws-cloudwatch-controller/v1.4.1/v1.0.0/relationships/edge-non-binding-reference-metricalarm-statefulset.json
+++ b/server/meshmodel/aws-cloudwatch-controller/v1.4.1/v1.0.0/relationships/edge-non-binding-reference-metricalarm-statefulset.json
@@ -44,15 +44,6 @@
               "model": {
                 "version": "v1.4.1"
               }
-            },
-            "patch": {
-              "patchStrategy": "replace",
-              "mutatorRef": [
-                [
-                  "spec",
-                  "metricName"
-                ]
-              ]
             }
           }
         ],
@@ -73,15 +64,6 @@
               "model": {
                 "version": ""
               }
-            },
-            "patch": {
-              "patchStrategy": "replace",
-              "mutatedRef": [
-                [
-                  "metadata",
-                  "name"
-                ]
-              ]
             }
           }
         ]

--- a/server/meshmodel/aws-cloudwatch-controller/v1.4.1/v1.0.0/relationships/edge-non-binding-reference-metricalarm-statefulset.json
+++ b/server/meshmodel/aws-cloudwatch-controller/v1.4.1/v1.0.0/relationships/edge-non-binding-reference-metricalarm-statefulset.json
@@ -1,5 +1,5 @@
 {
-  "id": "0250841c-0e31-4f10-a72f-2d43fc753587",
+  "id": "00000000-0000-0000-0000-000000000001",
   "evaluationQuery": "edge_non-binding_reference_relationship",
   "kind": "edge",
   "metadata": {
@@ -15,7 +15,7 @@
     "version": "",
     "name": "aws-cloudwatch-controller",
     "displayName": "",
-    "id": "0250841c-0e31-4f10-a72f-2d43fc753587",
+    "id": "00000000-0000-0000-0000-000000000001",
     "registrant": {
       "kind": "github"
     },
@@ -37,7 +37,7 @@
               "version": "",
               "name": "aws-cloudwatch-controller",
               "displayName": "",
-              "id": "d34db3bd-67e4-496b-9bdd-54f58fd300e6",
+              "id": "00000000-0000-0000-0000-000000000001",
               "registrant": {
                 "kind": "github"
               },
@@ -71,7 +71,7 @@
               "version": "",
               "name": "kubernetes",
               "displayName": "",
-              "id": "6a1aca14-648f-4a18-a625-7010c1fe0dda",
+              "id": "00000000-0000-0000-0000-000000000001",
               "registrant": {
                 "kind": "github"
               },

--- a/server/meshmodel/aws-cloudwatch-controller/v1.4.1/v1.0.0/relationships/edge-non-binding-reference-metricalarm-statefulset.json
+++ b/server/meshmodel/aws-cloudwatch-controller/v1.4.1/v1.0.0/relationships/edge-non-binding-reference-metricalarm-statefulset.json
@@ -1,6 +1,6 @@
 {
   "id": "00000000-0000-0000-0000-000000000000",
-  "evaluationQuery": "",
+  "evaluationQuery": "edge_non_binding_reference_relationship",
   "kind": "edge",
   "metadata": {
     "description": "StatefulSet monitored by CloudWatch MetricAlarm",
@@ -44,6 +44,16 @@
               "model": {
                 "version": "v1.4.1"
               }
+            },
+               "patch": {
+              "patchStrategy": "replace",
+              "mutatorRef": [
+                [
+                  "configuration",
+                  "spec",
+                  "dimensions"
+                ]
+              ]
             }
           }
         ],
@@ -64,6 +74,16 @@
               "model": {
                 "version": ""
               }
+            },
+            "patch": {
+              "patchStrategy": "replace",
+              "mutatedRef": [
+                [
+                  "metadata",
+                  "labels",
+                  "monitored-by-aws-cloudwatch-metricalarm"
+                ]
+              ]
             }
           }
         ]

--- a/server/meshmodel/aws-cloudwatch-controller/v1.4.1/v1.0.0/relationships/edge-non-binding-reference-metricalarm-statefulset.json
+++ b/server/meshmodel/aws-cloudwatch-controller/v1.4.1/v1.0.0/relationships/edge-non-binding-reference-metricalarm-statefulset.json
@@ -1,5 +1,5 @@
 {
-  "id": "00000000-0000-0000-0000-000000000000",
+  "id": "0250841c-0e31-4f10-a72f-2d43fc753587",
   "evaluationQuery": "edge_non-binding_reference_relationship",
   "kind": "edge",
   "metadata": {
@@ -15,7 +15,7 @@
     "version": "",
     "name": "aws-cloudwatch-controller",
     "displayName": "",
-    "id": "00000000-0000-0000-0000-000000000000",
+    "id": "0250841c-0e31-4f10-a72f-2d43fc753587",
     "registrant": {
       "kind": "github"
     },
@@ -37,7 +37,7 @@
               "version": "",
               "name": "aws-cloudwatch-controller",
               "displayName": "",
-              "id": "00000000-0000-0000-0000-000000000000",
+              "id": "d34db3bd-67e4-496b-9bdd-54f58fd300e6",
               "registrant": {
                 "kind": "github"
               },
@@ -71,7 +71,7 @@
               "version": "",
               "name": "kubernetes",
               "displayName": "",
-              "id": "00000000-0000-0000-0000-000000000000",
+              "id": "6a1aca14-648f-4a18-a625-7010c1fe0dda",
               "registrant": {
                 "kind": "github"
               },

--- a/server/meshmodel/aws-cloudwatch-controller/v1.4.1/v1.0.0/relationships/edge-non-binding-reference-metricalarm-statefulset.json
+++ b/server/meshmodel/aws-cloudwatch-controller/v1.4.1/v1.0.0/relationships/edge-non-binding-reference-metricalarm-statefulset.json
@@ -1,0 +1,99 @@
+{
+  "id": "00000000-0000-0000-0000-000000000000",
+  "evaluationQuery": "",
+  "kind": "edge",
+  "metadata": {
+    "description": "StatefulSet monitored by CloudWatch MetricAlarm",
+    "styles": {
+      "primaryColor": "",
+      "svgColor": "",
+      "svgWhite": ""
+    },
+    "isAnnotation": false
+  },
+  "model": {
+    "version": "",
+    "name": "aws-cloudwatch-controller",
+    "displayName": "",
+    "id": "00000000-0000-0000-0000-000000000000",
+    "registrant": {
+      "kind": "github"
+    },
+    "model": {
+      "version": "v1.4.1"
+    }
+  },
+  "schemaVersion": "relationships.meshery.io/v1alpha3",
+  "selectors": [
+    {
+      "allow": {
+        "from": [
+          {
+            "id": null,
+            "kind": "MetricAlarm",
+            "match": {},
+            "match_strategy_matrix": null,
+            "model": {
+              "version": "",
+              "name": "aws-cloudwatch-controller",
+              "displayName": "",
+              "id": "00000000-0000-0000-0000-000000000000",
+              "registrant": {
+                "kind": "github"
+              },
+              "model": {
+                "version": "v1.4.1"
+              }
+            },
+            "patch": {
+              "patchStrategy": "replace",
+              "mutatorRef": [
+                [
+                  "spec",
+                  "metricName"
+                ]
+              ]
+            }
+          }
+        ],
+        "to": [
+          {
+            "id": null,
+            "kind": "StatefulSet",
+            "match": {},
+            "match_strategy_matrix": null,
+            "model": {
+              "version": "",
+              "name": "kubernetes",
+              "displayName": "",
+              "id": "00000000-0000-0000-0000-000000000000",
+              "registrant": {
+                "kind": "github"
+              },
+              "model": {
+                "version": ""
+              }
+            },
+            "patch": {
+              "patchStrategy": "replace",
+              "mutatedRef": [
+                [
+                  "metadata",
+                  "name"
+                ]
+              ]
+            }
+          }
+        ]
+      },
+      "deny": {
+        "from": [],
+        "to": []
+      }
+    }
+  ],
+  "subType": "reference",
+  "status": "enabled",
+  "type": "non-binding",
+  "version": "v1.0.0"
+}

--- a/server/meshmodel/aws-cloudwatch-controller/v1.4.1/v1.0.0/relationships/edge-non-binding-reference-metricalarm-statefulset.json
+++ b/server/meshmodel/aws-cloudwatch-controller/v1.4.1/v1.0.0/relationships/edge-non-binding-reference-metricalarm-statefulset.json
@@ -1,6 +1,6 @@
 {
   "id": "00000000-0000-0000-0000-000000000000",
-  "evaluationQuery": "edge_non_binding_reference_relationship",
+  "evaluationQuery": "edge_non-binding_reference_relationship",
   "kind": "edge",
   "metadata": {
     "description": "StatefulSet monitored by CloudWatch MetricAlarm",
@@ -45,15 +45,19 @@
                 "version": "v1.4.1"
               }
             },
-               "patch": {
-              "patchStrategy": "replace",
+            "patch": {
+              "patchStrategy": "add",
               "mutatorRef": [
                 [
                   "configuration",
                   "spec",
                   "dimensions"
                 ]
-              ]
+              ],
+              "value": {
+                "name": "Service",
+                "value": "{{ .mutatedRef.name }}"
+              }
             }
           }
         ],
@@ -80,8 +84,11 @@
               "mutatedRef": [
                 [
                   "metadata",
-                  "labels",
-                  "monitored-by-aws-cloudwatch-metricalarm"
+                  "name"
+                ],
+                [
+                  "metadata",
+                  "namespace"
                 ]
               ]
             }

--- a/server/meshmodel/aws-cloudwatch-controller/v1.4.1/v1.0.0/relationships/edge-non-binding-reference-metricstream-deployment.json
+++ b/server/meshmodel/aws-cloudwatch-controller/v1.4.1/v1.0.0/relationships/edge-non-binding-reference-metricstream-deployment.json
@@ -1,0 +1,99 @@
+{
+  "id": "00000000-0000-0000-0000-000000000000",
+  "evaluationQuery": "",
+  "kind": "edge",
+  "metadata": {
+    "description": "Deployment monitored by CloudWatch MetricStream",
+    "styles": {
+      "primaryColor": "",
+      "svgColor": "",
+      "svgWhite": ""
+    },
+    "isAnnotation": false
+  },
+  "model": {
+    "version": "",
+    "name": "aws-cloudwatch-controller",
+    "displayName": "",
+    "id": "00000000-0000-0000-0000-000000000000",
+    "registrant": {
+      "kind": "github"
+    },
+    "model": {
+      "version": "v1.4.1"
+    }
+  },
+  "schemaVersion": "relationships.meshery.io/v1alpha3",
+  "selectors": [
+    {
+      "allow": {
+        "from": [
+          {
+            "id": null,
+            "kind": "MetricStream",
+            "match": {},
+            "match_strategy_matrix": null,
+            "model": {
+              "version": "",
+              "name": "aws-cloudwatch-controller",
+              "displayName": "",
+              "id": "00000000-0000-0000-0000-000000000000",
+              "registrant": {
+                "kind": "github"
+              },
+              "model": {
+                "version": "v1.4.1"
+              }
+            },
+            "patch": {
+              "patchStrategy": "replace",
+              "mutatorRef": [
+                [
+                  "spec",
+                  "includeFilters"
+                ]
+              ]
+            }
+          }
+        ],
+        "to": [
+          {
+            "id": null,
+            "kind": "Deployment",
+            "match": {},
+            "match_strategy_matrix": null,
+            "model": {
+              "version": "",
+              "name": "kubernetes",
+              "displayName": "",
+              "id": "00000000-0000-0000-0000-000000000000",
+              "registrant": {
+                "kind": "github"
+              },
+              "model": {
+                "version": ""
+              }
+            },
+            "patch": {
+              "patchStrategy": "replace",
+              "mutatedRef": [
+                [
+                  "metadata",
+                  "name"
+                ]
+              ]
+            }
+          }
+        ]
+      },
+      "deny": {
+        "from": [],
+        "to": []
+      }
+    }
+  ],
+  "subType": "reference",
+  "status": "enabled",
+  "type": "non-binding",
+  "version": "v1.0.0"
+}

--- a/server/meshmodel/aws-cloudwatch-controller/v1.4.1/v1.0.0/relationships/edge-non-binding-reference-metricstream-deployment.json
+++ b/server/meshmodel/aws-cloudwatch-controller/v1.4.1/v1.0.0/relationships/edge-non-binding-reference-metricstream-deployment.json
@@ -1,5 +1,5 @@
 {
-  "id": "26bd8d93-dd3e-4644-a760-98e105b74033",
+  "id": "00000000-0000-0000-0000-000000000001",
   "evaluationQuery": "edge_non_binding_reference_relationship",
   "kind": "edge",
   "metadata": {
@@ -15,7 +15,7 @@
     "version": "",
     "name": "aws-cloudwatch-controller",
     "displayName": "",
-    "id": "26bd8d93-dd3e-4644-a760-98e105b74033",
+    "id": "00000000-0000-0000-0000-000000000001",
     "registrant": {
       "kind": "github"
     },
@@ -37,7 +37,7 @@
               "version": "",
               "name": "aws-cloudwatch-controller",
               "displayName": "",
-              "id": "29780ca6-977a-49af-8769-82e72c3ded3d",
+              "id": "00000000-0000-0000-0000-000000000001",
               "registrant": {
                 "kind": "github"
               },
@@ -84,7 +84,7 @@
               "version": "",
               "name": "kubernetes",
               "displayName": "",
-              "id": "418f4c09-df2f-4b30-be05-defcbd8d64a0",
+              "id": "00000000-0000-0000-0000-000000000001",
               "registrant": {
                 "kind": "github"
               },

--- a/server/meshmodel/aws-cloudwatch-controller/v1.4.1/v1.0.0/relationships/edge-non-binding-reference-metricstream-deployment.json
+++ b/server/meshmodel/aws-cloudwatch-controller/v1.4.1/v1.0.0/relationships/edge-non-binding-reference-metricstream-deployment.json
@@ -44,15 +44,6 @@
               "model": {
                 "version": "v1.4.1"
               }
-            },
-            "patch": {
-              "patchStrategy": "replace",
-              "mutatorRef": [
-                [
-                  "spec",
-                  "includeFilters"
-                ]
-              ]
             }
           }
         ],
@@ -73,15 +64,6 @@
               "model": {
                 "version": ""
               }
-            },
-            "patch": {
-              "patchStrategy": "replace",
-              "mutatedRef": [
-                [
-                  "metadata",
-                  "name"
-                ]
-              ]
             }
           }
         ]

--- a/server/meshmodel/aws-cloudwatch-controller/v1.4.1/v1.0.0/relationships/edge-non-binding-reference-metricstream-deployment.json
+++ b/server/meshmodel/aws-cloudwatch-controller/v1.4.1/v1.0.0/relationships/edge-non-binding-reference-metricstream-deployment.json
@@ -1,5 +1,5 @@
 {
-  "id": "00000000-0000-0000-0000-000000000000",
+  "id": "26bd8d93-dd3e-4644-a760-98e105b74033",
   "evaluationQuery": "edge_non_binding_reference_relationship",
   "kind": "edge",
   "metadata": {
@@ -15,7 +15,7 @@
     "version": "",
     "name": "aws-cloudwatch-controller",
     "displayName": "",
-    "id": "00000000-0000-0000-0000-000000000000",
+    "id": "26bd8d93-dd3e-4644-a760-98e105b74033",
     "registrant": {
       "kind": "github"
     },
@@ -37,7 +37,7 @@
               "version": "",
               "name": "aws-cloudwatch-controller",
               "displayName": "",
-              "id": "00000000-0000-0000-0000-000000000000",
+              "id": "29780ca6-977a-49af-8769-82e72c3ded3d",
               "registrant": {
                 "kind": "github"
               },
@@ -45,15 +45,32 @@
                 "version": "v1.4.1"
               }
             },
-              "patch": {
-              "patchStrategy": "replace",
+            "patch": {
+              "patchStrategy": "add",
               "mutatorRef": [
                 [
                   "configuration",
                   "spec",
                   "includeFilters"
                 ]
-              ]
+              ],
+              "value": {
+                "Namespace": "ContainerInsights",
+                "MetricNames": [
+                  "pod_cpu_utilization",
+                  "pod_memory_utilization"
+                ],
+                "Dimensions": [
+                  {
+                    "Name": "Namespace",
+                    "Value": "{{ .mutatedRef.namespace }}"
+                  },
+                  {
+                    "Name": "Service",
+                    "Value": "{{ .mutatedRef.name }}"
+                  }
+                ]
+              }
             }
           }
         ],
@@ -67,7 +84,7 @@
               "version": "",
               "name": "kubernetes",
               "displayName": "",
-              "id": "00000000-0000-0000-0000-000000000000",
+              "id": "418f4c09-df2f-4b30-be05-defcbd8d64a0",
               "registrant": {
                 "kind": "github"
               },
@@ -80,8 +97,11 @@
               "mutatedRef": [
                 [
                   "metadata",
-                  "labels",
-                  "monitored-by-aws-cloudwatch-metricstream"
+                  "name"
+                ],
+                [
+                  "metadata",
+                  "namespace"
                 ]
               ]
             }

--- a/server/meshmodel/aws-cloudwatch-controller/v1.4.1/v1.0.0/relationships/edge-non-binding-reference-metricstream-deployment.json
+++ b/server/meshmodel/aws-cloudwatch-controller/v1.4.1/v1.0.0/relationships/edge-non-binding-reference-metricstream-deployment.json
@@ -1,6 +1,6 @@
 {
   "id": "00000000-0000-0000-0000-000000000000",
-  "evaluationQuery": "",
+  "evaluationQuery": "edge_non_binding_reference_relationship",
   "kind": "edge",
   "metadata": {
     "description": "Deployment monitored by CloudWatch MetricStream",
@@ -44,6 +44,16 @@
               "model": {
                 "version": "v1.4.1"
               }
+            },
+              "patch": {
+              "patchStrategy": "replace",
+              "mutatorRef": [
+                [
+                  "configuration",
+                  "spec",
+                  "includeFilters"
+                ]
+              ]
             }
           }
         ],
@@ -64,6 +74,16 @@
               "model": {
                 "version": ""
               }
+            },
+            "patch": {
+              "patchStrategy": "replace",
+              "mutatedRef": [
+                [
+                  "metadata",
+                  "labels",
+                  "monitored-by-aws-cloudwatch-metricstream"
+                ]
+              ]
             }
           }
         ]

--- a/server/meshmodel/aws-cloudwatch-controller/v1.4.1/v1.0.0/relationships/edge-non-binding-reference-metricstream-statefulset.json
+++ b/server/meshmodel/aws-cloudwatch-controller/v1.4.1/v1.0.0/relationships/edge-non-binding-reference-metricstream-statefulset.json
@@ -1,6 +1,6 @@
 {
-  "id": "00000000-0000-0000-0000-000000000000",
-  "evaluationQuery": "edge_non_binding_reference_relationship",
+  "id": "15277ac5-aa77-4bb7-a2e3-3a75198cd418",
+  "evaluationQuery": "edge_non-binding_reference_relationship",
   "kind": "edge",
   "metadata": {
     "description": "StatefulSet monitored by CloudWatch MetricStream",
@@ -15,7 +15,7 @@
     "version": "",
     "name": "aws-cloudwatch-controller",
     "displayName": "",
-    "id": "00000000-0000-0000-0000-000000000000",
+    "id": "15277ac5-aa77-4bb7-a2e3-3a75198cd418",
     "registrant": {
       "kind": "github"
     },
@@ -37,7 +37,7 @@
               "version": "",
               "name": "aws-cloudwatch-controller",
               "displayName": "",
-              "id": "00000000-0000-0000-0000-000000000000",
+              "id": "f29d0622-4c87-4086-ad70-3ff489b3a9b5",
               "registrant": {
                 "kind": "github"
               },
@@ -45,15 +45,32 @@
                 "version": "v1.4.1"
               }
             },
-              "patch": {
-              "patchStrategy": "replace",
+            "patch": {
+              "patchStrategy": "add",
               "mutatorRef": [
                 [
                   "configuration",
                   "spec",
                   "includeFilters"
                 ]
-              ]
+              ],
+              "value": {
+                "Namespace": "ContainerInsights",
+                "MetricNames": [
+                  "pod_cpu_utilization",
+                  "pod_memory_utilization"
+                ],
+                "Dimensions": [
+                  {
+                    "Name": "Namespace",
+                    "Value": "{{ .mutatedRef.namespace }}"
+                  },
+                  {
+                    "Name": "Service",
+                    "Value": "{{ .mutatedRef.name }}"
+                  }
+                ]
+              }
             }
           }
         ],
@@ -67,7 +84,7 @@
               "version": "",
               "name": "kubernetes",
               "displayName": "",
-              "id": "00000000-0000-0000-0000-000000000000",
+              "id": "c4a9ad8f-882b-44d7-a5df-522f26ac8b95",
               "registrant": {
                 "kind": "github"
               },
@@ -80,8 +97,11 @@
               "mutatedRef": [
                 [
                   "metadata",
-                  "labels",
-                  "monitored-by-aws-cloudwatch-metricstream"
+                  "name"
+                ],
+                [
+                  "metadata",
+                  "namespace"
                 ]
               ]
             }

--- a/server/meshmodel/aws-cloudwatch-controller/v1.4.1/v1.0.0/relationships/edge-non-binding-reference-metricstream-statefulset.json
+++ b/server/meshmodel/aws-cloudwatch-controller/v1.4.1/v1.0.0/relationships/edge-non-binding-reference-metricstream-statefulset.json
@@ -1,5 +1,5 @@
 {
-  "id": "15277ac5-aa77-4bb7-a2e3-3a75198cd418",
+  "id": "00000000-0000-0000-0000-000000000001",
   "evaluationQuery": "edge_non-binding_reference_relationship",
   "kind": "edge",
   "metadata": {
@@ -15,7 +15,7 @@
     "version": "",
     "name": "aws-cloudwatch-controller",
     "displayName": "",
-    "id": "15277ac5-aa77-4bb7-a2e3-3a75198cd418",
+    "id": "00000000-0000-0000-0000-000000000001",
     "registrant": {
       "kind": "github"
     },
@@ -37,7 +37,7 @@
               "version": "",
               "name": "aws-cloudwatch-controller",
               "displayName": "",
-              "id": "f29d0622-4c87-4086-ad70-3ff489b3a9b5",
+              "id": "00000000-0000-0000-0000-000000000001",
               "registrant": {
                 "kind": "github"
               },
@@ -84,7 +84,7 @@
               "version": "",
               "name": "kubernetes",
               "displayName": "",
-              "id": "c4a9ad8f-882b-44d7-a5df-522f26ac8b95",
+              "id": "00000000-0000-0000-0000-000000000001",
               "registrant": {
                 "kind": "github"
               },

--- a/server/meshmodel/aws-cloudwatch-controller/v1.4.1/v1.0.0/relationships/edge-non-binding-reference-metricstream-statefulset.json
+++ b/server/meshmodel/aws-cloudwatch-controller/v1.4.1/v1.0.0/relationships/edge-non-binding-reference-metricstream-statefulset.json
@@ -1,6 +1,6 @@
 {
   "id": "00000000-0000-0000-0000-000000000000",
-  "evaluationQuery": "",
+  "evaluationQuery": "edge_non_binding_reference_relationship",
   "kind": "edge",
   "metadata": {
     "description": "StatefulSet monitored by CloudWatch MetricStream",
@@ -44,6 +44,16 @@
               "model": {
                 "version": "v1.4.1"
               }
+            },
+              "patch": {
+              "patchStrategy": "replace",
+              "mutatorRef": [
+                [
+                  "configuration",
+                  "spec",
+                  "includeFilters"
+                ]
+              ]
             }
           }
         ],
@@ -64,6 +74,16 @@
               "model": {
                 "version": ""
               }
+            },
+            "patch": {
+              "patchStrategy": "replace",
+              "mutatedRef": [
+                [
+                  "metadata",
+                  "labels",
+                  "monitored-by-aws-cloudwatch-metricstream"
+                ]
+              ]
             }
           }
         ]

--- a/server/meshmodel/aws-cloudwatch-controller/v1.4.1/v1.0.0/relationships/edge-non-binding-reference-metricstream-statefulset.json
+++ b/server/meshmodel/aws-cloudwatch-controller/v1.4.1/v1.0.0/relationships/edge-non-binding-reference-metricstream-statefulset.json
@@ -1,0 +1,99 @@
+{
+  "id": "00000000-0000-0000-0000-000000000000",
+  "evaluationQuery": "",
+  "kind": "edge",
+  "metadata": {
+    "description": "StatefulSet monitored by CloudWatch MetricStream",
+    "styles": {
+      "primaryColor": "",
+      "svgColor": "",
+      "svgWhite": ""
+    },
+    "isAnnotation": false
+  },
+  "model": {
+    "version": "",
+    "name": "aws-cloudwatch-controller",
+    "displayName": "",
+    "id": "00000000-0000-0000-0000-000000000000",
+    "registrant": {
+      "kind": "github"
+    },
+    "model": {
+      "version": "v1.4.1"
+    }
+  },
+  "schemaVersion": "relationships.meshery.io/v1alpha3",
+  "selectors": [
+    {
+      "allow": {
+        "from": [
+          {
+            "id": null,
+            "kind": "MetricStream",
+            "match": {},
+            "match_strategy_matrix": null,
+            "model": {
+              "version": "",
+              "name": "aws-cloudwatch-controller",
+              "displayName": "",
+              "id": "00000000-0000-0000-0000-000000000000",
+              "registrant": {
+                "kind": "github"
+              },
+              "model": {
+                "version": "v1.4.1"
+              }
+            },
+            "patch": {
+              "patchStrategy": "replace",
+              "mutatorRef": [
+                [
+                  "spec",
+                  "includeFilters"
+                ]
+              ]
+            }
+          }
+        ],
+        "to": [
+          {
+            "id": null,
+            "kind": "StatefulSet",
+            "match": {},
+            "match_strategy_matrix": null,
+            "model": {
+              "version": "",
+              "name": "kubernetes",
+              "displayName": "",
+              "id": "00000000-0000-0000-0000-000000000000",
+              "registrant": {
+                "kind": "github"
+              },
+              "model": {
+                "version": ""
+              }
+            },
+            "patch": {
+              "patchStrategy": "replace",
+              "mutatedRef": [
+                [
+                  "metadata",
+                  "name"
+                ]
+              ]
+            }
+          }
+        ]
+      },
+      "deny": {
+        "from": [],
+        "to": []
+      }
+    }
+  ],
+  "subType": "reference",
+  "status": "enabled",
+  "type": "non-binding",
+  "version": "v1.0.0"
+}

--- a/server/meshmodel/aws-cloudwatch-controller/v1.4.1/v1.0.0/relationships/edge-non-binding-reference-metricstream-statefulset.json
+++ b/server/meshmodel/aws-cloudwatch-controller/v1.4.1/v1.0.0/relationships/edge-non-binding-reference-metricstream-statefulset.json
@@ -44,15 +44,6 @@
               "model": {
                 "version": "v1.4.1"
               }
-            },
-            "patch": {
-              "patchStrategy": "replace",
-              "mutatorRef": [
-                [
-                  "spec",
-                  "includeFilters"
-                ]
-              ]
             }
           }
         ],
@@ -73,15 +64,6 @@
               "model": {
                 "version": ""
               }
-            },
-            "patch": {
-              "patchStrategy": "replace",
-              "mutatedRef": [
-                [
-                  "metadata",
-                  "name"
-                ]
-              ]
             }
           }
         ]


### PR DESCRIPTION
## What does this PR do?

Adds **AWS CloudWatch monitoring relationships** to Meshery, enabling visualization of CloudWatch service dependencies to Kubernetes workloads for comprehensive observability.

## Related Issue

**Contributes to #15518, #17096

## Changes

Added **6 new relationships** across 1 AWS controller:

1. **`aws-cloudwatch-controller/v1.4.1`**  
   - CloudWatch `Dashboard` → **Deployment** (`edge-non-binding-reference-dashboard-deployment.json`)  
   - CloudWatch `Dashboard` → **StatefulSet** (`edge-non-binding-reference-dashboard-statefulset.json`)  
   - CloudWatch `MetricAlarm` → **Deployment** (`edge-non-binding-reference-metricalarm-deployment.json`)  
   - CloudWatch `MetricAlarm` → **StatefulSet** (`edge-non-binding-reference-metricalarm-statefulset.json`)  
   - CloudWatch `MetricStream` → **Deployment** (`edge-non-binding-reference-metricstream-deployment.json`)  
   - CloudWatch `MetricStream` → **StatefulSet** (`edge-non-binding-reference-metricstream-statefulset.json`)  

All follow `relationships.meshery.io/v1alpha3` schema.

## Testing

- [x] **Validated in Kanvas**: All monitoring reference edges render correctly ✅

**Screenshot Proof:**

**CloudWatch Dashboard Relationships:**
<img width="1920" height="1080" alt="0Dashboard" src="https://github.com/user-attachments/assets/0db6bd82-7b68-46b4-a7fe-9b3f7ccf9799" />


**CloudWatch MetricAlarm Relationships:**
<img width="1920" height="1080" alt="0MetricAlarm" src="https://github.com/user-attachments/assets/a359abef-8d8a-4357-a7c2-3a2a263b6a13" />



**CloudWatch MetricStream Relationships:**
<img width="1920" height="1080" alt="0MetricStream" src="https://github.com/user-attachments/assets/ed8449d9-2eec-43f6-af47-54644a6e3fb1" />



---

**[Signed commits](https://github.com/meshery/meshery/blob/master/CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [x] Yes, I signed my commits.