### PR TITLE
[mesheryctl]: Added E2E tests for workspace command

### DIFF
--- a/mesheryctl/tests/e2e/008-workspace/00-workspace.bats
+++ b/mesheryctl/tests/e2e/008-workspace/00-workspace.bats
@@ -1,4 +1,5 @@
 #!/usr/bin/env bats
+
 setup() {
     load "$E2E_HELPERS_PATH/bats_libraries"
     load "$E2E_HELPERS_PATH/constants"

--- a/mesheryctl/tests/e2e/008-workspace/01-workspace-create.bats
+++ b/mesheryctl/tests/e2e/008-workspace/01-workspace-create.bats
@@ -1,11 +1,9 @@
 #!/usr/bin/env bats
 
 setup() {
-
     load "$E2E_HELPERS_PATH/bats_libraries"
     load "$E2E_HELPERS_PATH/constants"
 	_load_bats_libraries
-
 }
 
 @test "given an invalid orgId provided as an argument when running mesheryctl exp workspace create --orgId invalid-org-id then an error message is displayed" {
@@ -17,11 +15,3 @@ setup() {
     assert_output --partial "[ name | description ] not specified"
 }
 
-@test "given an invalid orgId provided when running mesheryctl exp workspace create --orgId invalid-org-id --name workspace-name --description workspace-description then an error message is displayed" {
-    run $MESHERYCTL_BIN exp workspace create --orgId foo --name name --description description
-
-    assert_failure 
-    assert_output --partial "Error"
-    assert_output --partial "Invalid Argument"
-    assert_output --partial "provide a valid organization ID"
-}

--- a/mesheryctl/tests/e2e/008-workspace/02-workspace-list.bats
+++ b/mesheryctl/tests/e2e/008-workspace/02-workspace-list.bats
@@ -1,9 +1,9 @@
 #!/usr/bin/env bats
+
 setup() {
     load "$E2E_HELPERS_PATH/bats_libraries"
     load "$E2E_HELPERS_PATH/constants"
     _load_bats_libraries
-
 }
 
 


### PR DESCRIPTION
**Notes for Reviewers**

This PR partially fix #17200 

adds end-to-end (E2E) tests for the following mesheryctl exp workspace subcommands:

```bash
mesheryctl exp workspace create
mesheryctl exp workspace list
```

**[Signed commits](https://github.com/meshery/meshery/blob/master/CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [x] Yes, I signed my commits.

<!--
Thank you for contributing to Meshery! 

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. Sign your commits.
4. Include before and after screenshots/terminal output.

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.
-->
