### PR TITLE
[Server] Restore body on provider retry

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -292,7 +292,7 @@ server-playground: dep-check
 
 ## Lint check Meshery Server.
 golangci: error dep-check
-	golangci-lint run
+	golangci-lint run --config=.github/.golangci.yml --timeout=10m
 
 ## Build Meshery's protobufs.
 proto-build:


### PR DESCRIPTION
### Current Behavior in Meshery Server

The following errors/warnings happen regularly, but should not be happening. The user has a fresh and valid session. The  user is updating a Meshery design, saving changes in their own organization and workspace (so they have necessary  permissions).

```
WARN[2026-01-29T14:41:36-06:00] Short Description: Error occurred, retrying after refresh to fetch token  app=meshery
  caller="github.com/meshery/meshery/server/models.(*RemoteProvider).DoRequest remote_auth.go:57" code=meshery-server-1334
  probable-cause= severity=2 short-description="Error occurred, retrying after refresh to fetch token"
  suggested-remediation=
  INFO[2026-01-29T14:41:36-06:00] token refresh successful                      app=meshery
  caller="github.com/meshery/meshery/server/models.(*RemoteProvider).DoRequest remote_auth.go:62"
  ERRO[2026-01-29T14:41:36-06:00] Status Code: 400 .error persisting event with the remote provider | Short Description:
  Unable to post data to the Provider.event  app=meshery
  caller="github.com/meshery/meshery/server/models.(*RemoteProvider).PersistEvent remote_provider.go:1555"
  code=meshery-server-1271 probable-cause= severity=2 short-description="Unable to post data to the Provider.event"
  suggested-remediation=
```



### Fix for this behavior
The 400 error after token refresh is likely caused by the HTTP request body being drained and not reset before retry in  the remote provider's DoRequest method; the fix involves resetting the body from GetBody before retrying.
