### PR TITLE
[Server] reduce retry log spam when capability fetch fails

### DIFF
--- a/server/models/remote_provider.go
+++ b/server/models/remote_provider.go
@@ -189,7 +189,7 @@ func (l *RemoteProvider) loadCapabilities(token string) (ProviderProperties, err
 				break // Successfully fetched response
 			}
 			if i == 0 {
-				l.Log.Warnf("Failed to fetch capabilities from remote provider. Retrying (%s)... ", i)
+				l.Log.Warnf("Failed to fetch capabilities from remote provider (URL: %s). Retrying (%d)... ", remoteProviderURL.String(), i)
 			}
 			l.Log.Debugf("Attempt %d/%d: Failed to fetch capabilities: %v. Retrying in 3 seconds...", i+1, maxRetries, err)
 			time.Sleep(3 * time.Second)


### PR DESCRIPTION
**Notes for Reviewers**

- This PR fixes #16989

**How**
- First failure: log one WARN so operators know something is wrong.                                                                                      
- Each retry attempt: log at DEBUG level (visible only when debugging).                                                                                  
- All retries exhausted: log a final WARN summary. 

**[Signed commits](https://github.com/meshery/meshery/blob/master/CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [x] Yes, I signed my commits.

<!--
Thank you for contributing to Meshery! 

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. Sign your commits.
4. Include before and after screenshots/terminal output.

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.
-->
