### PR TITLE
[Models] Add AWS Secrets Manager relationships for Deployment and Pod workloads

### DIFF
--- a/server/meshmodel/aws-secretsmanager-controller/v1.0.7/v1.0.0/relationships/edge-non-binding-network-deployment.json
+++ b/server/meshmodel/aws-secretsmanager-controller/v1.0.7/v1.0.0/relationships/edge-non-binding-network-deployment.json
@@ -3,7 +3,7 @@
   "evaluationQuery": "",
   "kind": "edge",
   "metadata": {
-    "description": "",
+    "description": "Defines a non-binding network relationship from AWS Secrets Manager Secret to Kubernetes Deployment through Secrets Store CSI Driver volumes and volume mounts in Pod templates.",
     "styles": {
       "primaryColor": "",
       "svgColor": "",
@@ -14,10 +14,10 @@
   "model": {
     "version": "",
     "name": "aws-secretsmanager-controller",
-    "displayName": "",
+    "displayName": "AWS Secrets Manager Controller",
     "id": "00000000-0000-0000-0000-000000000000",
     "registrant": {
-      "kind": ""
+      "kind": "artifacthub"
     },
     "model": {
       "version": "v1.0.7"
@@ -36,7 +36,7 @@
             "model": {
               "version": "",
               "name": "aws-secretsmanager-controller",
-              "displayName": "",
+              "displayName": "AWS Secrets Manager Controller",
               "id": "00000000-0000-0000-0000-000000000000",
               "registrant": {
                 "kind": "artifacthub"
@@ -68,7 +68,7 @@
             "model": {
               "version": "",
               "name": "kubernetes",
-              "displayName": "",
+              "displayName": "Kubernetes",
               "id": "00000000-0000-0000-0000-000000000000",
               "registrant": {
                 "kind": "artifacthub"
@@ -88,9 +88,19 @@
                   "spec",
                   "template",
                   "spec",
+                  "volumes",
+                  "_",
+                  "csi"
+                ],
+                [
+                  "configuration",
+                  "spec",
+                  "template",
+                  "spec",
                   "containers",
-                  "0",
-                  "envFrom"
+                  "_",
+                  "volumeMounts",
+                  "_"
                 ]
               ]
             }

--- a/server/meshmodel/aws-secretsmanager-controller/v1.0.7/v1.0.0/relationships/edge-non-binding-network-deployment.json
+++ b/server/meshmodel/aws-secretsmanager-controller/v1.0.7/v1.0.0/relationships/edge-non-binding-network-deployment.json
@@ -1,0 +1,110 @@
+{
+  "id": "00000000-0000-0000-0000-000000000000",
+  "evaluationQuery": "",
+  "kind": "edge",
+  "metadata": {
+    "description": "",
+    "styles": {
+      "primaryColor": "",
+      "svgColor": "",
+      "svgWhite": ""
+    },
+    "isAnnotation": false
+  },
+  "model": {
+    "version": "",
+    "name": "aws-secretsmanager-controller",
+    "displayName": "",
+    "id": "00000000-0000-0000-0000-000000000000",
+    "registrant": {
+      "kind": ""
+    },
+    "model": {
+      "version": "v1.0.7"
+    }
+  },
+  "schemaVersion": "relationships.meshery.io/v1alpha3",
+  "selectors": [
+    {
+      "allow": {
+        "from": [
+          {
+            "id": null,
+            "kind": "Secret",
+            "match": {},
+            "match_strategy_matrix": null,
+            "model": {
+              "version": "",
+              "name": "aws-secretsmanager-controller",
+              "displayName": "",
+              "id": "00000000-0000-0000-0000-000000000000",
+              "registrant": {
+                "kind": "artifacthub"
+              },
+              "model": {
+                "version": ""
+              }
+            },
+            "patch": {
+              "patchStrategy": "replace",
+              "mutatorRef": [
+                [
+                  "name"
+                ],
+                [
+                  "configuration",
+                  "arn"
+                ]
+              ]
+            }
+          }
+        ],
+        "to": [
+          {
+            "id": null,
+            "kind": "Deployment",
+            "match": {},
+            "match_strategy_matrix": null,
+            "model": {
+              "version": "",
+              "name": "kubernetes",
+              "displayName": "",
+              "id": "00000000-0000-0000-0000-000000000000",
+              "registrant": {
+                "kind": "artifacthub"
+              },
+              "model": {
+                "version": ""
+              }
+            },
+            "patch": {
+              "patchStrategy": "replace",
+              "mutatedRef": [
+                [
+                  "name"
+                ],
+                [
+                  "configuration",
+                  "spec",
+                  "template",
+                  "spec",
+                  "containers",
+                  "0",
+                  "envFrom"
+                ]
+              ]
+            }
+          }
+        ]
+      },
+      "deny": {
+        "from": [],
+        "to": []
+      }
+    }
+  ],
+  "subType": "network",
+  "status": "enabled",
+  "type": "non-binding",
+  "version": "v1.0.0"
+}

--- a/server/meshmodel/aws-secretsmanager-controller/v1.0.7/v1.0.0/relationships/edge-non-binding-network-pod.json
+++ b/server/meshmodel/aws-secretsmanager-controller/v1.0.7/v1.0.0/relationships/edge-non-binding-network-pod.json
@@ -1,108 +1,116 @@
 {
+  "id": "00000000-0000-0000-0000-000000000000",
+  "evaluationQuery": "",
+  "kind": "edge",
+  "metadata": {
+    "description": "Defines a non-binding network relationship from AWS Secrets Manager Secret to Kubernetes Pod through Secrets Store CSI Driver volumes and container volume mounts.",
+    "styles": {
+      "primaryColor": "",
+      "svgColor": "",
+      "svgWhite": ""
+    },
+    "isAnnotation": false
+  },
+  "model": {
+    "version": "",
+    "name": "aws-secretsmanager-controller",
+    "displayName": "AWS Secrets Manager Controller",
     "id": "00000000-0000-0000-0000-000000000000",
-    "evaluationQuery": "",
-    "kind": "edge",
-    "metadata": {
-        "description": "",
-        "styles": {
-            "primaryColor": "",
-            "svgColor": "",
-            "svgWhite": ""
-        },
-        "isAnnotation": false
+    "registrant": {
+      "kind": "artifacthub"
     },
     "model": {
-        "version": "",
-        "name": "aws-secretsmanager-controller",
-        "displayName": "",
-        "id": "00000000-0000-0000-0000-000000000000",
-        "registrant": {
-            "kind": ""
-        },
-        "model": {
-            "version": "v1.0.7"
-        }
-    },
-    "schemaVersion": "relationships.meshery.io/v1alpha3",
-    "selectors": [
-        {
-            "allow": {
-                "from": [
-                    {
-                        "id": null,
-                        "kind": "Secret",
-                        "match": {},
-                        "match_strategy_matrix": null,
-                        "model": {
-                            "version": "",
-                            "name": "aws-secretsmanager-controller",
-                            "displayName": "",
-                            "id": "00000000-0000-0000-0000-000000000000",
-                            "registrant": {
-                                "kind": "artifacthub"
-                            },
-                            "model": {
-                                "version": ""
-                            }
-                        },
-                        "patch": {
-                            "patchStrategy": "replace",
-                            "mutatorRef": [
-                                [
-                                    "name"
-                                ],
-                                [
-                                    "configuration",
-                                    "arn"
-                                ]
-                            ]
-                        }
-                    }
-                ],
-                "to": [
-                    {
-                        "id": null,
-                        "kind": "Pod",
-                        "match": {},
-                        "match_strategy_matrix": null,
-                        "model": {
-                            "version": "",
-                            "name": "kubernetes",
-                            "displayName": "",
-                            "id": "00000000-0000-0000-0000-000000000000",
-                            "registrant": {
-                                "kind": "artifacthub"
-                            },
-                            "model": {
-                                "version": ""
-                            }
-                        },
-                        "patch": {
-                            "patchStrategy": "replace",
-                            "mutatedRef": [
-                                [
-                                    "name"
-                                ],
-                                [
-                                    "configuration",
-                                    "spec",
-                                    "containers",
-                                    "0",
-                                    "envFrom"
-                                ]
-                            ]
-                        }
-                    }
-                ]
+      "version": "v1.0.7"
+    }
+  },
+  "schemaVersion": "relationships.meshery.io/v1alpha3",
+  "selectors": [
+    {
+      "allow": {
+        "from": [
+          {
+            "id": null,
+            "kind": "Secret",
+            "match": {},
+            "match_strategy_matrix": null,
+            "model": {
+              "version": "",
+              "name": "aws-secretsmanager-controller",
+              "displayName": "AWS Secrets Manager Controller",
+              "id": "00000000-0000-0000-0000-000000000000",
+              "registrant": {
+                "kind": "artifacthub"
+              },
+              "model": {
+                "version": ""
+              }
             },
-            "deny": {
-                "from": [],
-                "to": []
+            "patch": {
+              "patchStrategy": "replace",
+              "mutatorRef": [
+                [
+                  "name"
+                ],
+                [
+                  "configuration",
+                  "arn"
+                ]
+              ]
             }
-        }
-    ],
-    "subType": "network",
-    "status": "enabled",
-    "type": "non-binding",
-    "version": "v1.0.0"
+          }
+        ],
+        "to": [
+          {
+            "id": null,
+            "kind": "Pod",
+            "match": {},
+            "match_strategy_matrix": null,
+            "model": {
+              "version": "",
+              "name": "kubernetes",
+              "displayName": "Kubernetes",
+              "id": "00000000-0000-0000-0000-000000000000",
+              "registrant": {
+                "kind": "artifacthub"
+              },
+              "model": {
+                "version": ""
+              }
+            },
+            "patch": {
+              "patchStrategy": "replace",
+              "mutatedRef": [
+                [
+                  "name"
+                ],
+                [
+                  "configuration",
+                  "spec",
+                  "volumes",
+                  "_",
+                  "csi"
+                ],
+                [
+                  "configuration",
+                  "spec",
+                  "containers",
+                  "_",
+                  "volumeMounts",
+                  "_"
+                ]
+              ]
+            }
+          }
+        ]
+      },
+      "deny": {
+        "from": [],
+        "to": []
+      }
+    }
+  ],
+  "subType": "network",
+  "status": "enabled",
+  "type": "non-binding",
+  "version": "v1.0.0"
 }

--- a/server/meshmodel/aws-secretsmanager-controller/v1.0.7/v1.0.0/relationships/edge-non-binding-network-pod.json
+++ b/server/meshmodel/aws-secretsmanager-controller/v1.0.7/v1.0.0/relationships/edge-non-binding-network-pod.json
@@ -1,0 +1,108 @@
+{
+    "id": "00000000-0000-0000-0000-000000000000",
+    "evaluationQuery": "",
+    "kind": "edge",
+    "metadata": {
+        "description": "",
+        "styles": {
+            "primaryColor": "",
+            "svgColor": "",
+            "svgWhite": ""
+        },
+        "isAnnotation": false
+    },
+    "model": {
+        "version": "",
+        "name": "aws-secretsmanager-controller",
+        "displayName": "",
+        "id": "00000000-0000-0000-0000-000000000000",
+        "registrant": {
+            "kind": ""
+        },
+        "model": {
+            "version": "v1.0.7"
+        }
+    },
+    "schemaVersion": "relationships.meshery.io/v1alpha3",
+    "selectors": [
+        {
+            "allow": {
+                "from": [
+                    {
+                        "id": null,
+                        "kind": "Secret",
+                        "match": {},
+                        "match_strategy_matrix": null,
+                        "model": {
+                            "version": "",
+                            "name": "aws-secretsmanager-controller",
+                            "displayName": "",
+                            "id": "00000000-0000-0000-0000-000000000000",
+                            "registrant": {
+                                "kind": "artifacthub"
+                            },
+                            "model": {
+                                "version": ""
+                            }
+                        },
+                        "patch": {
+                            "patchStrategy": "replace",
+                            "mutatorRef": [
+                                [
+                                    "name"
+                                ],
+                                [
+                                    "configuration",
+                                    "arn"
+                                ]
+                            ]
+                        }
+                    }
+                ],
+                "to": [
+                    {
+                        "id": null,
+                        "kind": "Pod",
+                        "match": {},
+                        "match_strategy_matrix": null,
+                        "model": {
+                            "version": "",
+                            "name": "kubernetes",
+                            "displayName": "",
+                            "id": "00000000-0000-0000-0000-000000000000",
+                            "registrant": {
+                                "kind": "artifacthub"
+                            },
+                            "model": {
+                                "version": ""
+                            }
+                        },
+                        "patch": {
+                            "patchStrategy": "replace",
+                            "mutatedRef": [
+                                [
+                                    "name"
+                                ],
+                                [
+                                    "configuration",
+                                    "spec",
+                                    "containers",
+                                    "0",
+                                    "envFrom"
+                                ]
+                            ]
+                        }
+                    }
+                ]
+            },
+            "deny": {
+                "from": [],
+                "to": []
+            }
+        }
+    ],
+    "subType": "network",
+    "status": "enabled",
+    "type": "non-binding",
+    "version": "v1.0.0"
+}


### PR DESCRIPTION
## Summary
This PR fixes #17179 by adding AWS Secrets Manager Secret relationships to Kubernetes Deployment and Pod workloads in Meshery Kanvas.

## Changes Made
- Updated `edge-non-binding-network-deployment.json` - Secret -> Deployment relationship
- Updated `edge-non-binding-network-pod.json` - Secret -> Pod relationship
- Changes scoped to `server/meshmodel/aws-secretsmanager-controller/v1.0.7/v1.0.0/relationships/`
- No scripts or unrelated files changed for this fix

<img width="1868" height="996" alt="Screenshot from 2026-03-01 11-45-53" src="https://github.com/user-attachments/assets/58369705-17f0-439e-a545-f8d7104adaab" />


## Relationship Details
- Secret (`aws-secretsmanager-controller`) -> Deployment (`kubernetes`) - `edge`, `non-binding`, `network`
- Secret (`aws-secretsmanager-controller`) -> Pod (`kubernetes`) - `edge`, `non-binding`, `network`
- Schema: `relationships.meshery.io/v1alpha3`

## Notes for Reviewers
- Fixes #17179
- Relationship definitions now include proper selector + patch paths for Deployment and Pod targets
- This update is currently scoped to `v1.0.7`; propagation to other versions can be done in follow-up PR(s)

## Validation
- Verified in Kanvas that Secret can be connected to Deployment and Pod
- Save/refresh persistence checked

**[Signed commits](https://github.com/meshery/meshery/blob/master/CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [x] Yes, I signed my commits.
