### PR TITLE
fix(server): explicitly ignore fmt return values (Batch 2)

### DIFF
--- a/server/handlers/component_handler.go
+++ b/server/handlers/component_handler.go
@@ -1590,7 +1590,7 @@ func (h *Handler) ExportModel(rw http.ResponseWriter, r *http.Request) {
 		// http.Error(rw, ErrGetMeshModels(err).Error(), http.StatusNotFound)
 		rw.WriteHeader(http.StatusNotFound)
 		// rw.Write([]byte(message))
-		fmt.Fprintln(rw, message)
+		_, _ = fmt.Fprintln(rw, message)
 		return
 	}
 

--- a/server/handlers/database_handlers.go
+++ b/server/handlers/database_handlers.go
@@ -85,7 +85,7 @@ func (h *Handler) GetSystemDatabase(w http.ResponseWriter, r *http.Request, _ *m
 	if err != nil {
 		fmt.Println(err)
 	}
-	fmt.Fprint(w, string(val))
+	_, _ = fmt.Fprint(w, string(val))
 }
 
 // swagger:route DELETE /api/system/database/reset ResetSystemDatabase
@@ -196,6 +196,6 @@ func (h *Handler) ResetSystemDatabase(w http.ResponseWriter, r *http.Request, _ 
 			krh.SeedKeys(viper.GetString("KEYS_PATH"))
 		}()
 		w.Header().Set("Content-Type", "application/json")
-		fmt.Fprint(w, "Database reset successful")
+		_, _ = fmt.Fprint(w, "Database reset successful")
 	}
 }

--- a/server/handlers/design_engine_handler.go
+++ b/server/handlers/design_engine_handler.go
@@ -69,7 +69,7 @@ func (h *Handler) PatternFileHandler(
 		http.Error(rw, ErrRequestBody(err).Error(), http.StatusInternalServerError)
 
 		rw.WriteHeader(http.StatusBadRequest)
-		fmt.Fprintf(rw, "failed to read request body: %s", err)
+		_, _ = fmt.Fprintf(rw, "failed to read request body: %s", err)
 		return
 	}
 
@@ -78,7 +78,7 @@ func (h *Handler) PatternFileHandler(
 		http.Error(rw, ErrRequestBody(err).Error(), http.StatusInternalServerError)
 
 		rw.WriteHeader(http.StatusBadRequest)
-		fmt.Fprintf(rw, "failed to unmarshal request body: %s", err)
+		_, _ = fmt.Fprintf(rw, "failed to unmarshal request body: %s", err)
 		return
 	}
 

--- a/server/handlers/environments_handlers.go
+++ b/server/handlers/environments_handlers.go
@@ -48,7 +48,7 @@ func (h *Handler) GetEnvironments(w http.ResponseWriter, req *http.Request, _ *m
 	}
 
 	w.Header().Set("Content-Type", "application/json")
-	fmt.Fprint(w, string(resp))
+	_, _ = fmt.Fprint(w, string(resp))
 }
 
 // swagger:route GET /api/environments/{id} EnvironmentAPI idGetEnvironmentByIDHandler

--- a/server/models/default_local_provider.go
+++ b/server/models/default_local_provider.go
@@ -1762,7 +1762,7 @@ func downloadContent(comp string, downloadpath string) error {
 			if err != nil {
 				return err
 			}
-			fmt.Fprintf(file, "%s", content)
+			_, _ = fmt.Fprintf(file, "%s", content)
 			return nil
 		}).Walk()
 	case "Filter":


### PR DESCRIPTION
**Notes for Reviewers**

- This PR is Batch 2 of the staticcheck cleanup (#16667). It explicitly ignores error return values from fmt.Fprint family functions where the output error can be safely disregarded (mostly HTTP response writers).

**[Signed commits](https://github.com/meshery/meshery/blob/master/CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [x] Yes, I signed my commits.

<!--
Thank you for contributing to Meshery! 

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. Sign your commits.
4. Include before and after screenshots/terminal output.

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.
-->
