### PR TITLE
Docs: migrate Jekyll script includes to Hugo partials

### DIFF
--- a/docs-new/layouts/partials/scripts/google-analytics.html
+++ b/docs-new/layouts/partials/scripts/google-analytics.html
@@ -1,0 +1,9 @@
+{{ with .Site.GoogleAnalytics }}<script async src='https://www.google-analytics.com/analytics.js'></script>
+<script type="application/javascript">
+var doNotTrack = false;
+if (!doNotTrack) {
+	window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+	ga('create', '{{ . }}', 'auto');
+	ga('send', 'pageview');
+}
+</script>{{ end }}

--- a/docs-new/layouts/partials/scripts/google-tagmanager-body.html
+++ b/docs-new/layouts/partials/scripts/google-tagmanager-body.html
@@ -1,0 +1,2 @@
+<noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-PCGTC98C"
+height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>

--- a/docs-new/layouts/partials/scripts/google-tagmanager-head.html
+++ b/docs-new/layouts/partials/scripts/google-tagmanager-head.html
@@ -1,0 +1,5 @@
+<script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
+    new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
+    j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
+    'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
+    })(window,document,'script','dataLayer','GTM-PCGTC98C');</script>


### PR DESCRIPTION
### Notes for Reviewers

Fixes #17245  
Part of #17095

Adds the missing Hugo script partials under `docs-new/layouts/partials/scripts/`
to match the existing Jekyll includes and unblock `docs-new` builds.

### Signed commits
- ✅ Yes, I signed my commits.

<!--
Thank you for contributing to Meshery! 

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. Sign your commits.
4. Include before and after screenshots/terminal output.

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.
-->
