### PR TITLE
fix(server): explicitly ignore Close() errors for read-only resources (Batch 4)

### DIFF
--- a/server/helpers/adapters_tracker.go
+++ b/server/helpers/adapters_tracker.go
@@ -79,7 +79,9 @@ func (a *AdaptersTracker) DeployAdapter(ctx context.Context, adapter models.Adap
 		if err != nil {
 			return ErrDeployingAdapterInDocker(err)
 		}
-		defer cli.Close()
+		defer func() {
+			_ = cli.Close()
+		}()
 
 		containers, err := cli.ContainerList(ctx, container.ListOptions{All: true})
 		if err != nil {
@@ -99,7 +101,9 @@ func (a *AdaptersTracker) DeployAdapter(ctx context.Context, adapter models.Adap
 			return ErrDeployingAdapterInDocker(err)
 		}
 
-		defer resp.Close()
+		defer func() {
+			_ = resp.Close()
+		}()
 		_, err = io.ReadAll(resp)
 		if err != nil {
 			return ErrDeployingAdapterInDocker(err)
@@ -224,7 +228,9 @@ func (a *AdaptersTracker) UndeployAdapter(ctx context.Context, adapter models.Ad
 		if err != nil {
 			return ErrUnDeployingAdapterInDocker(err)
 		}
-		defer cli.Close()
+		defer func() {
+			_ = cli.Close()
+		}()
 
 		containers, err := cli.ContainerList(ctx, container.ListOptions{})
 		if err != nil {

--- a/server/internal/graphql/model/helpers.go
+++ b/server/internal/graphql/model/helpers.go
@@ -305,7 +305,9 @@ func SelectivelyFetchNamespaces(cids []string, provider models.Provider) ([]stri
 		return nil, err
 	}
 
-	defer rows.Close()
+	defer func() {
+		_ = rows.Close()
+	}()
 
 	for rows.Next() {
 		var name string

--- a/server/internal/graphql/resolver/kubernetes.go
+++ b/server/internal/graphql/resolver/kubernetes.go
@@ -146,7 +146,9 @@ func (r *Resolver) getClusterResources(ctx context.Context, provider models.Prov
 		r.Log.Error(ErrGettingClusterResources(err))
 	}
 
-	defer rows.Close()
+	defer func() {
+		_ = rows.Close()
+	}()
 
 	resources := make([]*model.Resource, 0)
 	for rows.Next() {

--- a/server/internal/graphql/resolver/meshsync.go
+++ b/server/internal/graphql/resolver/meshsync.go
@@ -50,7 +50,9 @@ func (r *Resolver) resyncCluster(ctx context.Context, provider models.Provider, 
 			if err != nil {
 				return "", err
 			}
-			defer fin.Close()
+			defer func() {
+				_ = fin.Close()
+			}()
 
 			fout, err := os.Create(dst)
 			if err != nil {

--- a/server/internal/graphql/resolver/telemetry.go
+++ b/server/internal/graphql/resolver/telemetry.go
@@ -31,7 +31,9 @@ func (r *Resolver) getTelemetryComps(ctx context.Context, provider models.Provid
 	}
 
 	components := make([]*model.TelemetryComp, 0)
-	defer rows.Close()
+	defer func() {
+		_ = rows.Close()
+	}()
 	for rows.Next() {
 		var component model.TelemetryComp
 		err := rows.Scan(&component.Name, &component.Spec, &component.Status)

--- a/server/models/remote_auth.go
+++ b/server/models/remote_auth.go
@@ -53,7 +53,7 @@ func (l *RemoteProvider) DoRequest(req *http.Request, tokenString string) (*http
 		// Read and close response body before reusing request
 		// https://github.com/golang/go/issues/19653#issuecomment-341540384
 		_, _ = io.ReadAll(resp.Body)
-		resp.Body.Close()
+		_ = resp.Body.Close()
 		l.Log.Warn(ErrTokenRetry)
 		newToken, err := l.refreshToken(tokenString)
 		if err != nil {
@@ -257,7 +257,7 @@ func (l *RemoteProvider) VerifyToken(tokenString string) (*jwt.MapClaims, error)
 	_, ok := jtk["exp"]
 	if ok {
 		exp := int64(jtk["exp"].(float64))
-		if time.Now().Unix()  > exp {
+		if time.Now().Unix() > exp {
 			return nil, ErrTokenExpired
 		}
 	}

--- a/server/models/remote_provider.go
+++ b/server/models/remote_provider.go
@@ -414,8 +414,9 @@ func (l *RemoteProvider) InterceptLoginAndInitiateAnonymousUserSession(req *http
 		http.Redirect(res, req, errorUI, http.StatusFound)
 		return
 	}
-	defer resp.Body.Close()
-
+	defer func() {
+		_ = resp.Body.Close()
+	}()
 	flowResponse := AnonymousFlowResponse{}
 	err = json.NewDecoder(resp.Body).Decode(&flowResponse)
 	if err != nil {
@@ -936,7 +937,7 @@ func (l *RemoteProvider) SaveK8sContext(token string, k8sContext K8sContext, add
 
 	connection, err := l.SaveConnection(conn, token, true)
 
-	l.Log.Infof("Persisting k8s context to remote_provider, %v %v",connection,err)
+	l.Log.Infof("Persisting k8s context to remote_provider, %v %v", connection, err)
 
 	if err != nil {
 		l.Log.Error(ErrPersistConnection(err))
@@ -4422,8 +4423,9 @@ func (l *RemoteProvider) GetConnections(req *http.Request, userID string, page, 
 	if err != nil {
 		return nil, ErrFetch(err, "Connections Page", resp.StatusCode)
 	}
-	defer resp.Body.Close()
-
+	defer func() {
+		_ = resp.Body.Close()
+	}()
 	bdr, _ := io.ReadAll(resp.Body)
 	if resp.StatusCode != http.StatusOK {
 		return nil, ErrFetch(fmt.Errorf("could not retrieve list of connections: %d", resp.StatusCode), fmt.Sprint(bdr), resp.StatusCode)


### PR DESCRIPTION
This handles errcheck linter errors for:
- http.Response.Body.Close()
- sql.Rows.Close()
- os.File.Close() (read-only handles only)

Since these are read-only streams, ignoring the close error is safe.

**Notes for Reviewers**

- This PR is Batch 4 of the cleanup #16667.

**[Signed commits](https://github.com/meshery/meshery/blob/master/CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [x] Yes, I signed my commits.

<!--
Thank you for contributing to Meshery! 

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. Sign your commits.
4. Include before and after screenshots/terminal output.

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.
-->
