### PR TITLE
add lambda-to-pod relationships

### DIFF
--- a/server/meshmodel/aws-lambda-controller/v1.10.1/v1.0.0/relationships/edge-non-binding-reference-function-configmap.json
+++ b/server/meshmodel/aws-lambda-controller/v1.10.1/v1.0.0/relationships/edge-non-binding-reference-function-configmap.json
@@ -1,0 +1,112 @@
+{
+  "id": "00000000-0000-0000-0000-000000000000",
+  "evaluationQuery": "",
+  "schemaVersion": "relationships.meshery.io/v1alpha3",
+  "version": "v1.0.0",
+  "kind": "edge",
+  "type": "non-binding",
+  "subType": "reference",
+  "metadata": {
+    "description": "AWS Lambda Function ARN can be stored in Kubernetes ConfigMaps for centralized configuration management. Pods can reference the ConfigMap to retrieve the Lambda Function ARN for invocation via AWS SDK/CLI.",
+    "capabilities": {
+      "designer": {
+        "edit": {
+          "style": true,
+          "config": false,
+          "label": true
+        }
+      }
+    }
+  },
+  "model": {
+    "schemaVersion": "models.meshery.io/v1beta1",
+    "version": "v1.0.0",
+    "name": "aws-lambda-controller",
+    "registrant": {
+      "kind": "github"
+    },
+    "model": {
+      "version": "v1.10.1"
+    }
+  },
+  "status": "enabled",
+  "selectors": [
+    {
+      "allow": {
+        "from": [
+          {
+            "id": null,
+            "kind": "Function",
+            "match": {},
+            "match_strategy_matrix": null,
+            "model": {
+              "version": "",
+              "name": "aws-lambda-controller",
+              "displayName": "",
+              "id": "00000000-0000-0000-0000-000000000000",
+              "registrant": {
+                "kind": "github"
+              },
+              "model": {
+                "version": ""
+              }
+            },
+            "patch": {
+              "patchStrategy": "replace",
+              "mutatorRef": [
+                [
+                  "configuration",
+                  "status",
+                  "ackResourceMetadata",
+                  "arn"
+                ],
+                [
+                  "displayName"
+                ]
+              ],
+              "description": "Lambda Function ARN is read from the ACK resource status and can be stored in ConfigMaps for centralized configuration."
+            }
+          }
+        ],
+        "to": [
+          {
+            "id": null,
+            "kind": "ConfigMap",
+            "match": {},
+            "match_strategy_matrix": null,
+            "model": {
+              "version": "",
+              "name": "kubernetes",
+              "displayName": "",
+              "id": "00000000-0000-0000-0000-000000000000",
+              "registrant": {
+                "kind": "github"
+              },
+              "model": {
+                "version": ""
+              }
+            },
+            "patch": {
+              "patchStrategy": "replace",
+              "mutatedRef": [
+                [
+                  "configuration",
+                  "data",
+                  "LAMBDA_FUNCTION_ARN"
+                ],
+                [
+                  "displayName"
+                ]
+              ],
+              "description": "ConfigMap data can store the Lambda Function ARN, which Pods can reference via configMapKeyRef."
+            }
+          }
+        ]
+      },
+      "deny": {
+        "from": [],
+        "to": []
+      }
+    }
+  ]
+}

--- a/server/meshmodel/aws-lambda-controller/v1.10.1/v1.0.0/relationships/edge-non-binding-reference-function-deployment.json
+++ b/server/meshmodel/aws-lambda-controller/v1.10.1/v1.0.0/relationships/edge-non-binding-reference-function-deployment.json
@@ -1,0 +1,118 @@
+{
+  "id": "00000000-0000-0000-0000-000000000000",
+  "evaluationQuery": "",
+  "schemaVersion": "relationships.meshery.io/v1alpha3",
+  "version": "v1.0.0",
+  "kind": "edge",
+  "type": "non-binding",
+  "subType": "reference",
+  "metadata": {
+    "description": "AWS Lambda Function ARN can be referenced by Kubernetes Deployments for function invocation via AWS SDK/CLI. The function ARN is typically stored in Deployment Pod template environment variables to enable applications to invoke Lambda functions programmatically.",
+    "capabilities": {
+      "designer": {
+        "edit": {
+          "style": true,
+          "config": false,
+          "label": true
+        }
+      }
+    }
+  },
+  "model": {
+    "schemaVersion": "models.meshery.io/v1beta1",
+    "version": "v1.0.0",
+    "name": "aws-lambda-controller",
+    "registrant": {
+      "kind": "github"
+    },
+    "model": {
+      "version": "v1.10.1"
+    }
+  },
+  "status": "enabled",
+  "selectors": [
+    {
+      "allow": {
+        "from": [
+          {
+            "id": null,
+            "kind": "Function",
+            "match": {},
+            "match_strategy_matrix": null,
+            "model": {
+              "version": "",
+              "name": "aws-lambda-controller",
+              "displayName": "",
+              "id": "00000000-0000-0000-0000-000000000000",
+              "registrant": {
+                "kind": "github"
+              },
+              "model": {
+                "version": ""
+              }
+            },
+            "patch": {
+              "patchStrategy": "replace",
+              "mutatorRef": [
+                [
+                  "configuration",
+                  "status",
+                  "ackResourceMetadata",
+                  "arn"
+                ],
+                [
+                  "displayName"
+                ]
+              ],
+              "description": "Lambda Function ARN is read from the ACK resource status and can be used by Deployments to invoke the function."
+            }
+          }
+        ],
+        "to": [
+          {
+            "id": null,
+            "kind": "Deployment",
+            "match": {},
+            "match_strategy_matrix": null,
+            "model": {
+              "version": "",
+              "name": "kubernetes",
+              "displayName": "",
+              "id": "00000000-0000-0000-0000-000000000000",
+              "registrant": {
+                "kind": "github"
+              },
+              "model": {
+                "version": ""
+              }
+            },
+            "patch": {
+              "patchStrategy": "replace",
+              "mutatedRef": [
+                [
+                  "configuration",
+                  "spec",
+                  "template",
+                  "spec",
+                  "containers",
+                  "_",
+                  "env",
+                  "_",
+                  "value"
+                ],
+                [
+                  "displayName"
+                ]
+              ],
+              "description": "Deployment Pod template container environment variables can store the Lambda Function ARN for invocation via AWS SDK."
+            }
+          }
+        ]
+      },
+      "deny": {
+        "from": [],
+        "to": []
+      }
+    }
+  ]
+}

--- a/server/meshmodel/aws-lambda-controller/v1.10.1/v1.0.0/relationships/edge-non-binding-reference-function-pod.json
+++ b/server/meshmodel/aws-lambda-controller/v1.10.1/v1.0.0/relationships/edge-non-binding-reference-function-pod.json
@@ -1,0 +1,116 @@
+{
+  "id": "00000000-0000-0000-0000-000000000000",
+  "evaluationQuery": "",
+  "schemaVersion": "relationships.meshery.io/v1alpha3",
+  "version": "v1.0.0",
+  "kind": "edge",
+  "type": "non-binding",
+  "subType": "reference",
+  "metadata": {
+    "description": "AWS Lambda Function ARN can be referenced by Kubernetes Pods for function invocation via AWS SDK/CLI. The function ARN is typically stored in Pod environment variables to enable applications to invoke Lambda functions programmatically.",
+    "capabilities": {
+      "designer": {
+        "edit": {
+          "style": true,
+          "config": false,
+          "label": true
+        }
+      }
+    }
+  },
+  "model": {
+    "schemaVersion": "models.meshery.io/v1beta1",
+    "version": "v1.0.0",
+    "name": "aws-lambda-controller",
+    "registrant": {
+      "kind": "github"
+    },
+    "model": {
+      "version": "v1.10.1"
+    }
+  },
+  "status": "enabled",
+  "selectors": [
+    {
+      "allow": {
+        "from": [
+          {
+            "id": null,
+            "kind": "Function",
+            "match": {},
+            "match_strategy_matrix": null,
+            "model": {
+              "version": "",
+              "name": "aws-lambda-controller",
+              "displayName": "",
+              "id": "00000000-0000-0000-0000-000000000000",
+              "registrant": {
+                "kind": "github"
+              },
+              "model": {
+                "version": ""
+              }
+            },
+            "patch": {
+              "patchStrategy": "replace",
+              "mutatorRef": [
+                [
+                  "configuration",
+                  "status",
+                  "ackResourceMetadata",
+                  "arn"
+                ],
+                [
+                  "displayName"
+                ]
+              ],
+              "description": "Lambda Function ARN is read from the ACK resource status and can be used by Pods to invoke the function."
+            }
+          }
+        ],
+        "to": [
+          {
+            "id": null,
+            "kind": "Pod",
+            "match": {},
+            "match_strategy_matrix": null,
+            "model": {
+              "version": "",
+              "name": "kubernetes",
+              "displayName": "",
+              "id": "00000000-0000-0000-0000-000000000000",
+              "registrant": {
+                "kind": "github"
+              },
+              "model": {
+                "version": ""
+              }
+            },
+            "patch": {
+              "patchStrategy": "replace",
+              "mutatedRef": [
+                [
+                  "configuration",
+                  "spec",
+                  "containers",
+                  "_",
+                  "env",
+                  "_",
+                  "value"
+                ],
+                [
+                  "displayName"
+                ]
+              ],
+              "description": "Pod container environment variables can store the Lambda Function ARN for invocation via AWS SDK."
+            }
+          }
+        ]
+      },
+      "deny": {
+        "from": [],
+        "to": []
+      }
+    }
+  ]
+}


### PR DESCRIPTION
## Description

Add non-binding relationships for AWS Lambda Function to Kubernetes Pod, Deployment, and ConfigMap. These relationships visualize how Lambda ARNs are referenced by Kubernetes workloads for serverless function invocation.

- Contributes to #17096 

## Changes

Added 3 relationship files in `server/meshmodel/aws-lambda-controller/v1.10.1/v1.0.0/relationships/`:
- `edge-non-binding-reference-function-pod.json` - Lambda Function → Pod
- `edge-non-binding-reference-function-deployment.json` - Lambda Function → Deployment  
- `edge-non-binding-reference-function-configmap.json` - Lambda Function → ConfigMap

**Relationship Details:**
- Type: `non-binding` (visual only, no auto-population)
- SubType: `reference`
- Source: Lambda Function `status.ackResourceMetadata.arn`
- Target: Pod/Deployment env vars, ConfigMap data

## Validation

- ✅ Field paths validated against ACK Lambda CRD
- ✅ Structure matches existing non-binding relationships
- ✅ Follows production usage patterns (IRSA + env vars)

## Notes for Reviewers

- Non-binding relationships for visual representation in Kanvas
- Field paths confirmed against ACK Lambda controller v1.10.1
---
<img width="864" height="607" alt="Screenshot from 2026-02-03 11-47-01" src="https://github.com/user-attachments/assets/8182f628-d7d6-46a1-a77f-117147dbbd6a" />

---

**[Signed commits](https://github.com/meshery/meshery/blob/master/CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [x] Yes, I signed my commits.