### PR TITLE
Add relationship for CloudWatch LogGroup → Deployment /StatefulSet/Pod

### DIFF
--- a/server/meshmodel/aws-cloudwatchlogs-controller/v1.2.1/v1.0.0/relationships/edge-non-binding-reference-loggroup-deployment.json
+++ b/server/meshmodel/aws-cloudwatchlogs-controller/v1.2.1/v1.0.0/relationships/edge-non-binding-reference-loggroup-deployment.json
@@ -1,5 +1,5 @@
 {
-  "id": "00000000-0000-0000-0000-000000000002",
+  "id": "00000000-0000-0000-0000-000000000000",
   "evaluationQuery": "edge_loggroup_deployment_logs",
   "kind": "edge",
   "metadata": {
@@ -15,7 +15,7 @@
     "version": "",
     "name": "aws-cloudwatchlogs-controller",
     "displayName": "",
-    "id": "00000000-0000-0000-0000-000000000002",
+    "id": "00000000-0000-0000-0000-000000000000",
     "registrant": {
       "kind": "github"
     },
@@ -37,7 +37,7 @@
               "version": "",
               "name": "aws-cloudwatchlogs-controller",
               "displayName": "",
-              "id": "00000000-0000-0000-0000-000000000002",
+              "id": "00000000-0000-0000-0000-000000000000",
               "registrant": {
                 "kind": "github"
               },
@@ -67,7 +67,7 @@
               "version": "",
               "name": "kubernetes",
               "displayName": "",
-              "id": "00000000-0000-0000-0000-000000000002",
+              "id": "00000000-0000-0000-0000-000000000000",
               "registrant": {
                 "kind": "github"
               },

--- a/server/meshmodel/aws-cloudwatchlogs-controller/v1.2.1/v1.0.0/relationships/edge-non-binding-reference-loggroup-pod.json
+++ b/server/meshmodel/aws-cloudwatchlogs-controller/v1.2.1/v1.0.0/relationships/edge-non-binding-reference-loggroup-pod.json
@@ -1,5 +1,5 @@
 {
-  "id": "00000000-0000-0000-0000-000000000001",
+  "id": "00000000-0000-0000-0000-000000000000",
   "evaluationQuery": "edge_loggroup_pod_logs",
   "kind": "edge",
   "metadata": {
@@ -15,7 +15,7 @@
     "version": "",
     "name": "aws-cloudwatchlogs-controller",
     "displayName": "",
-    "id": "00000000-0000-0000-0000-000000000001",
+    "id": "00000000-0000-0000-0000-000000000000",
     "registrant": {
       "kind": "github"
     },
@@ -37,7 +37,7 @@
               "version": "",
               "name": "aws-cloudwatchlogs-controller",
               "displayName": "",
-              "id": "00000000-0000-0000-0000-000000000001",
+              "id": "00000000-0000-0000-0000-000000000000",
               "registrant": {
                 "kind": "github"
               },
@@ -67,7 +67,7 @@
               "version": "",
               "name": "kubernetes",
               "displayName": "",
-              "id": "00000000-0000-0000-0000-000000000001",
+              "id": "00000000-0000-0000-0000-000000000000",
               "registrant": {
                 "kind": "github"
               },

--- a/server/meshmodel/aws-cloudwatchlogs-controller/v1.2.1/v1.0.0/relationships/edge-non-binding-reference-loggroup-statefulset.json
+++ b/server/meshmodel/aws-cloudwatchlogs-controller/v1.2.1/v1.0.0/relationships/edge-non-binding-reference-loggroup-statefulset.json
@@ -1,5 +1,5 @@
 {
-  "id": "00000000-0000-0000-0000-000000000003",
+  "id": "00000000-0000-0000-0000-000000000000",
   "evaluationQuery": "edge_loggroup_statefulset_logs",
   "kind": "edge",
   "metadata": {
@@ -15,7 +15,7 @@
     "version": "",
     "name": "aws-cloudwatchlogs-controller",
     "displayName": "",
-    "id": "00000000-0000-0000-0000-000000000003",
+    "id": "00000000-0000-0000-0000-000000000000",
     "registrant": {
       "kind": "github"
     },
@@ -37,7 +37,7 @@
               "version": "",
               "name": "aws-cloudwatchlogs-controller",
               "displayName": "",
-              "id": "00000000-0000-0000-0000-000000000003",
+              "id": "00000000-0000-0000-0000-000000000000",
               "registrant": {
                 "kind": "github"
               },
@@ -67,7 +67,7 @@
               "version": "",
               "name": "kubernetes",
               "displayName": "",
-              "id": "00000000-0000-0000-0000-000000000003",
+              "id": "00000000-0000-0000-0000-000000000000",
               "registrant": {
                 "kind": "github"
               },


### PR DESCRIPTION
## What does this PR do?

Adds **AWS CloudWatch Logs edge relationships** to Meshery, enabling visualization of **LogGroup → Kubernetes Workload** logging dependencies for comprehensive observability.

## Related Issue

**Contributes to #17096** (Relationships for AWS Services)

## Changes

Added **3 new edge relationships** for **`aws-cloudwatchlogs-controller`**:

1. **`LogGroup → Pod`** (`edge-non-binding-reference-loggroup-pod.json`)
2. **`LogGroup → Deployment`** (`edge-non-binding-reference-loggroup-deployment.json`)  
3. **`LogGroup → StatefulSet`** (`edge-non-binding-reference-loggroup-statefulset.json`)  

**All follow `relationships.meshery.io/v1alpha3` schema** 

## Testing

- [x] **Kanvas Validation**: 
  - ✅ LogGroup → Pod 
  - ✅ LogGroup → Deployment  
  - ✅ LogGroup → StatefulSet
- [x] **Selector matching**: Log stream naming convention verified

**Screenshot Proof:**

**CloudWatch Logs LogGroup → Pod/ Deployment/ Stateful Set**
<img width="1920" height="1080" alt="Screenshot from 2026-02-04 10-31-40" src="https://github.com/user-attachments/assets/c19a53db-01ca-45b9-ad12-a62e8c438c8e" />


---

**[Signed commits](https://github.com/meshery/meshery/blob/master/CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [x] Yes, I signed my commits.
