### PR TITLE
replace logrus - Part 2 - internal/cli/root/adapter

### DIFF
--- a/mesheryctl/internal/cli/root/adapter/adapter.go
+++ b/mesheryctl/internal/cli/root/adapter/adapter.go
@@ -27,7 +27,6 @@ import (
 	"github.com/manifoldco/promptui"
 	"github.com/meshery/meshery/mesheryctl/internal/cli/root/config"
 	"github.com/meshery/meshery/mesheryctl/pkg/utils"
-	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 )
@@ -253,10 +252,10 @@ func waitForDeployResponse(mctlCfg *config.MesheryCtlConfig, query string) (stri
 		for i := range event {
 			if strings.Contains(i.Data.Details, query) {
 				eventChan <- "successful"
-				log.Infof("%s\n%s\n", i.Data.Summary, i.Data.Details)
+				utils.Log.Infof("%s\n%s\n", i.Data.Summary, i.Data.Details)
 			} else if strings.Contains(i.Data.Details, "Error") {
 				eventChan <- "error"
-				log.Infof("%s\n", i.Data.Summary)
+				utils.Log.Infof("%s\n", i.Data.Summary)
 			}
 		}
 	}()
@@ -301,10 +300,10 @@ func waitForValidateResponse(mctlCfg *config.MesheryCtlConfig, query string) (st
 		for i := range event {
 			if strings.Contains(i.Data.Summary, query) {
 				eventChan <- "successful"
-				log.Infof("%s\n%s", i.Data.Summary, i.Data.Details)
+				utils.Log.Infof("%s\n%s", i.Data.Summary, i.Data.Details)
 			} else if strings.Contains(i.Data.Details, "error") {
 				eventChan <- "error"
-				log.Infof("%s", i.Data.Summary)
+				utils.Log.Infof("%s", i.Data.Summary)
 			}
 		}
 	}()

--- a/mesheryctl/internal/cli/root/adapter/deploy.go
+++ b/mesheryctl/internal/cli/root/adapter/deploy.go
@@ -20,7 +20,6 @@ import (
 
 	"github.com/meshery/meshery/mesheryctl/internal/cli/root/config"
 	"github.com/meshery/meshery/mesheryctl/pkg/utils"
-	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 )
@@ -81,7 +80,7 @@ mesheryctl adapter deploy linkerd --watch
 			s.Stop()
 
 			if watch {
-				log.Infof("Verifying Operation")
+				utils.Log.Info("Verifying Operation")
 				_, err = waitForDeployResponse(mctlCfg, "mesh is now installed")
 				if err != nil {
 					utils.Log.Error(err)

--- a/mesheryctl/internal/cli/root/adapter/validate.go
+++ b/mesheryctl/internal/cli/root/adapter/validate.go
@@ -21,7 +21,6 @@ import (
 	"github.com/meshery/meshery/mesheryctl/internal/cli/root/config"
 	"github.com/meshery/meshery/mesheryctl/pkg/utils"
 	"github.com/pkg/errors"
-	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 )
@@ -56,7 +55,7 @@ mesheryctl adapter validate istio --adapter meshery-istio --spec smi
 	Annotations: linkDocMeshValidate,
 	Long:        `Validate predefined conformance to different standard specifications`,
 	PreRunE: func(cmd *cobra.Command, args []string) error {
-		log.Infof("Verifying prerequisites...")
+		utils.Log.Info("Verifying prerequisites...")
 
 		mctlCfg, err := config.GetMesheryCtl(viper.GetViper())
 		if err != nil {
@@ -80,11 +79,11 @@ mesheryctl adapter validate istio --adapter meshery-istio --spec smi
 		if err = validateAdapter(mctlCfg, meshName); err != nil {
 			utils.Log.Error(ErrValidatingAdapters(errors.Wrap(err, "Unable to sync with available adapters. \n")))
 		}
-		log.Info("verified prerequisites")
+		utils.Log.Info("verified prerequisites")
 		return nil
 	},
 	RunE: func(cmd *cobra.Command, args []string) error {
-		log.Infof("Starting cloud and cloud native infrastructure validation...")
+		utils.Log.Info("Starting cloud and cloud native infrastructure validation...")
 
 		mctlCfg, err := config.GetMesheryCtl(viper.GetViper())
 		if err != nil {
@@ -101,7 +100,7 @@ mesheryctl adapter validate istio --adapter meshery-istio --spec smi
 		s.Stop()
 
 		if watch {
-			log.Infof("Verifying Operation")
+			utils.Log.Info("Verifying Operation")
 			_, err = waitForValidateResponse(mctlCfg, "Smi conformance test")
 			if err != nil {
 				utils.Log.Error(ErrWaitValidateResponse(err))


### PR DESCRIPTION
**Notes for Reviewers**

- This PR fixes #4705 
  
### Test  
```bash
go test --short ./... -race -coverprofile=coverage.txt -covermode=atomic
        github.com/meshery/meshery/mesheryctl/cmd/mesheryctl            coverage: 0.0% of statements
ok      github.com/meshery/meshery/mesheryctl/doc       1.211s  coverage: 77.5% of statements
?       github.com/meshery/meshery/mesheryctl/internal/cli/pkg  [no test files]
ok      github.com/meshery/meshery/mesheryctl/internal/cli/pkg/api      1.447s  coverage: 36.7% of statements
ok      github.com/meshery/meshery/mesheryctl/internal/cli/pkg/display  1.253s  coverage: 53.4% of statements
ok      github.com/meshery/meshery/mesheryctl/internal/cli/pkg/flags    (cached)        coverage: 76.3% of statements
ok      github.com/meshery/meshery/mesheryctl/internal/cli/root (cached)        coverage: 22.4% of statements
ok      github.com/meshery/meshery/mesheryctl/internal/cli/root/adapter 1.397s  coverage: 35.0% of statements
ok      github.com/meshery/meshery/mesheryctl/internal/cli/root/components      1.265s  coverage: 68.6% of statements
ok      github.com/meshery/meshery/mesheryctl/internal/cli/root/config  (cached)        coverage: 16.0% of statements
        github.com/meshery/meshery/mesheryctl/internal/cli/root/connections             coverage: 0.0% of statements
        github.com/meshery/meshery/mesheryctl/internal/cli/root/constants               coverage: 0.0% of statements
ok      github.com/meshery/meshery/mesheryctl/internal/cli/root/design  1.243s  coverage: 41.4% of statements
ok      github.com/meshery/meshery/mesheryctl/internal/cli/root/environments    1.163s  coverage: 29.7% of statements
        github.com/meshery/meshery/mesheryctl/internal/cli/root/experimental            coverage: 0.0% of statements
ok      github.com/meshery/meshery/mesheryctl/internal/cli/root/filter  1.167s  coverage: 37.9% of statements
ok      github.com/meshery/meshery/mesheryctl/internal/cli/root/model   1.354s  coverage: 57.0% of statements
ok      github.com/meshery/meshery/mesheryctl/internal/cli/root/organizations   1.165s  coverage: 71.9% of statements
ok      github.com/meshery/meshery/mesheryctl/internal/cli/root/perf    1.387s  coverage: 36.0% of statements
ok      github.com/meshery/meshery/mesheryctl/internal/cli/root/registry        (cached)        coverage: 9.5% of statements
ok      github.com/meshery/meshery/mesheryctl/internal/cli/root/relationships   1.185s  coverage: 61.8% of statements
ok      github.com/meshery/meshery/mesheryctl/internal/cli/root/system  3.073s  coverage: 14.6% of statements
ok      github.com/meshery/meshery/mesheryctl/internal/cli/root/workspaces      1.187s  coverage: 90.9% of statements
        github.com/meshery/meshery/mesheryctl/pkg/constants             coverage: 0.0% of statements
ok      github.com/meshery/meshery/mesheryctl/pkg/utils (cached)        coverage: 11.9% of statements
        github.com/meshery/meshery/mesheryctl/pkg/utils/format          coverage: 0.0% of statements
```

**[Signed commits](https://github.com/meshery/meshery/blob/master/CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [x] Yes, I signed my commits.

<!--
Thank you for contributing to Meshery! 

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. Sign your commits.
4. Include before and after screenshots/terminal output.

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.
-->
