### PR TITLE
fix: open playground profile in new tab with popup blocker check

### DIFF
--- a/ui/components/User.tsx
+++ b/ui/components/User.tsx
@@ -38,7 +38,7 @@ const User = (props) => {
       if (!newWindow || newWindow.closed || typeof newWindow.closed === 'undefined') {
         notify({
           message: 'Redirect Blocked',
-          details: 'Your browser blocked the new tab. Please allow popups to view your profile.',
+          details: `Your browser blocked the new tab. Please allow popups to view your profile or manually open: ${profileUrl}`,
           event_type: EVENT_TYPES.WARNING,
         });
       }


### PR DESCRIPTION
**Notes for Reviewers**

- This PR fixes #17148 
->Updated User.js to open the profile URL in a new tab (_blank).
->Added logic to detect if the browser blocked the popup.
->Uses notify() to warn the user if the redirect was blocked, ensuring better UX than a silent failure.

**[Signed commits](https://github.com/meshery/meshery/blob/master/CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [x] Yes, I signed my commits.

<!--
Thank you for contributing to Meshery! 

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. Sign your commits.
4. Include before and after screenshots/terminal output.

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.
-->
