### PR TITLE
[Models] Add AWS API Gateway relationships with Kubernetes Service and Ingress

### DIFF
--- a/server/meshmodel/aws/0.7.2/v1.0.0/relationships/apigateway-ingress.json
+++ b/server/meshmodel/aws/0.7.2/v1.0.0/relationships/apigateway-ingress.json
@@ -1,18 +1,85 @@
 {
+  "id": "00000000-0000-0000-0000-000000000000",
+  "schemaVersion": "relationships.meshery.io/v1alpha3",
+  "version": "v1.0.0",
   "kind": "edge",
-  "type": "parent",
+  "type": "non-binding",
   "subType": "network",
-  "metadata": {
-    "name": "aws-apigateway-to-k8s-ingress"
-  },
-  "selectors": {
-    "from": {
-      "kind": "AWS API Gateway",
-      "model": "aws"
+  "status": "enabled",
+  "evaluationQuery": "",
+
+  "model": {
+    "name": "aws",
+    "version": "0.7.2",
+    "displayName": "",
+    "id": "00000000-0000-0000-0000-000000000000",
+    "registrant": {
+      "kind": "github"
     },
-    "to": {
-      "kind": "Ingress",
-      "model": "kubernetes"
+    "model": {
+      "version": ""
     }
-  }
+  },
+
+  "metadata": {
+    "description": "Traffic flow from AWS API Gateway to Kubernetes Ingress",
+    "styles": {
+      "primaryColor": "",
+      "svgColor": "",
+      "svgWhite": ""
+    },
+    "isAnnotation": false
+  },
+
+  "selectors": [
+    {
+      "allow": {
+        "from": [
+          {
+            "id": null,
+            "kind": "AWS API Gateway",
+            "match": {},
+            "match_strategy_matrix": null,
+            "model": {
+              "name": "aws",
+              "version": "",
+              "displayName": "",
+              "id": "00000000-0000-0000-0000-000000000000",
+              "registrant": {
+                "kind": "github"
+              },
+              "model": {
+                "version": ""
+              }
+            }
+          }
+        ],
+        "to": [
+          {
+            "id": null,
+            "kind": "Ingress",
+            "match": {},
+            "match_strategy_matrix": null,
+            "model": {
+              "name": "kubernetes",
+              "version": "",
+              "displayName": "",
+              "id": "00000000-0000-0000-0000-000000000000",
+              "registrant": {
+                "kind": "github"
+              },
+              "model": {
+                "version": ""
+              }
+            }
+          }
+        ]
+      },
+      "deny": {
+        "from": [],
+        "to": []
+      }
+    }
+  ]
 }
+

--- a/server/meshmodel/aws/0.7.2/v1.0.0/relationships/apigateway-service.json
+++ b/server/meshmodel/aws/0.7.2/v1.0.0/relationships/apigateway-service.json
@@ -1,18 +1,85 @@
 {
+  "id": "00000000-0000-0000-0000-000000000000",
+  "schemaVersion": "relationships.meshery.io/v1alpha3",
+  "version": "v1.0.0",
   "kind": "edge",
-  "type": "parent",
+  "type": "non-binding",
   "subType": "network",
-  "metadata": {
-    "name": "aws-apigateway-to-k8s-service"
-  },
-  "selectors": {
-    "from": {
-      "kind": "AWS API Gateway",
-      "model": "aws"
+  "status": "enabled",
+  "evaluationQuery": "",
+
+  "model": {
+    "name": "aws",
+    "version": "0.7.2",
+    "displayName": "",
+    "id": "00000000-0000-0000-0000-000000000000",
+    "registrant": {
+      "kind": "github"
     },
-    "to": {
-      "kind": "Service",
-      "model": "kubernetes"
+    "model": {
+      "version": ""
     }
-  }
+  },
+
+  "metadata": {
+    "description": "Traffic flow from AWS API Gateway to Kubernetes Ingress",
+    "styles": {
+      "primaryColor": "",
+      "svgColor": "",
+      "svgWhite": ""
+    },
+    "isAnnotation": false
+  },
+
+  "selectors": [
+    {
+      "allow": {
+        "from": [
+          {
+            "id": null,
+            "kind": "AWS API Gateway",
+            "match": {},
+            "match_strategy_matrix": null,
+            "model": {
+              "name": "aws",
+              "version": "",
+              "displayName": "",
+              "id": "00000000-0000-0000-0000-000000000000",
+              "registrant": {
+                "kind": "github"
+              },
+              "model": {
+                "version": ""
+              }
+            }
+          }
+        ],
+        "to": [
+          {
+            "id": null,
+            "kind": "Service",
+            "match": {},
+            "match_strategy_matrix": null,
+            "model": {
+              "name": "kubernetes",
+              "version": "",
+              "displayName": "",
+              "id": "00000000-0000-0000-0000-000000000000",
+              "registrant": {
+                "kind": "github"
+              },
+              "model": {
+                "version": ""
+              }
+            }
+          }
+        ]
+      },
+      "deny": {
+        "from": [],
+        "to": []
+      }
+    }
+  ]
 }
+


### PR DESCRIPTION
Summary
This PR adds MeshModel relationships to visually connect AWS API Gateway with Kubernetes Service and Ingress resources in Meshery Kanvas.
These relationships enable clearer visualization of API-driven traffic flow from AWS API Gateway into Kubernetes workloads.

What this PR does
Adds a relationship between AWS API Gateway → Kubernetes Service
Adds a relationship between AWS API Gateway → Kubernetes Ingress
Enables drawing and visualization of these connections in Kanvas
Screenshots / Demo
Screenshots attached showing:
Screenshot from 2026-02-06 16-05-31

AWS API Gateway connected to Kubernetes Service
AWS API Gateway connected to Kubernetes Ingress in Kanvas
Notes for Reviewers
This PR fixes https://github.com/meshery/meshery/issues/17276
Changes are limited to MeshModel relationship definitions only
No runtime or backend logic changes
Signed commits

 Yes, I signed my commits (-s)