### PR TITLE
[Server] Policies: Remove unused variable in extract_components rego rule

### DIFF
--- a/server/meshmodel/meshery-core/0.7.2/v1.0.0/policies/helper_rules.rego
+++ b/server/meshmodel/meshery-core/0.7.2/v1.0.0/policies/helper_rules.rego
@@ -130,7 +130,6 @@ extract_components(declarations, selectors) := {declaration.id: declaration |
 	selector := selectors[_]
 	declaration := declarations[_]
 	is_relationship_feasible(selector, declaration.component.kind)
-	component := declaration
 }
 
 # Extracts components of a specific type from declarations.


### PR DESCRIPTION
Remove dead assignment component := declaration in extract_components in helper_rules.rego.

**Notes for Reviewers**

- This PR remove dead code assignment component := declaration adds noise without being referenced.

**[Signed commits](https://github.com/meshery/meshery/blob/master/CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [ ] Yes, I signed my commits.

<!--
Thank you for contributing to Meshery! 

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. Sign your commits.
4. Include before and after screenshots/terminal output.

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.
-->
