### PR TITLE
[CI] Remove explicit branch from auto-commit in Rego lint workflow

### DIFF
--- a/.github/workflows/rego-lint-and-test.yml
+++ b/.github/workflows/rego-lint-and-test.yml
@@ -57,7 +57,6 @@ jobs:
           commit_author: ${{ github.actor }} <${{ github.actor }}@users.noreply.github.com>
           commit_message: "chore: auto-format Rego files"
           commit_options: "--no-verify"
-          branch: ${{ github.head_ref || github.ref_name }}
 
       - name: Setup Regal
         uses: StyraInc/setup-regal@v1


### PR DESCRIPTION
**Notes for Reviewers**

- The branch parameter in git-auto-commit-action defaults to the current branch, making the explicit setting redundant.

**[Signed commits](https://github.com/meshery/meshery/blob/master/CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [x] Yes, I signed my commits.

<!--
Thank you for contributing to Meshery! 

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. Sign your commits.
4. Include before and after screenshots/terminal output.

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.
-->
