### PR TITLE
[Server] Policies: Add deny selector checking to edge non-binding relationship

### DIFF
--- a/server/meshmodel/meshery-core/0.7.2/v1.0.0/policies/eval_rules.rego
+++ b/server/meshmodel/meshery-core/0.7.2/v1.0.0/policies/eval_rules.rego
@@ -5,6 +5,7 @@ import rego.v1
 import data.actions
 import data.core_utils
 import data.core_utils.truncate_set
+import data.feasibility_evaluation_utils
 
 approve_relationships_action(relationships, status, max_limit) := update_actions if {
 	update_actions := truncate_set(
@@ -187,6 +188,11 @@ identify_relationships_based_on_matching_mutator_and_mutated_fields(relationship
 
 	component_from.component.kind == from_selector.kind
 	component_to.component.kind == to_selector.kind
+
+	# Skip if this component pair is denied by the selector set's deny selectors.
+	deny_from := object.get(selector_set, ["deny", "from"], [])
+	deny_to := object.get(selector_set, ["deny", "to"], [])
+	not feasibility_evaluation_utils.is_selector_set_feasible_between(component_to, component_from, deny_to, deny_from)
 
 	matching_selectors := matching_mutators(component_from, component_to, from_selector, to_selector, design_file)
 


### PR DESCRIPTION
**Notes for Reviewers**

- This PR fixes part of #12274

## Why

The edge non-binding evaluation path never checked deny selectors, allowing duplicate or invalid relationships (e.g.,
Service-to-Service) even when explicitly denied in the relationship definition.

## How

- Add deny selector check in `identify_relationships_based_on_matching_mutator_and_mutated_fields` using existing
`feasibility_evaluation_utils.is_selector_set_feasible_between`
- Skip component pairs that match `selector_set.deny` before running expensive mutator matching
- Add 3 unit tests covering denied pairs, allowed pairs, and selective deny behavior

**[Signed commits](https://github.com/meshery/meshery/blob/master/CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [ ] Yes, I signed my commits.

<!--
Thank you for contributing to Meshery! 

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. Sign your commits.
4. Include before and after screenshots/terminal output.

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.
-->
