### PR TITLE
[Server] Wire up missing is_same_binding call in relationship diff policy

### DIFF
--- a/server/meshmodel/meshery-core/0.7.2/v1.0.0/policies/relationship_diff_policy.rego
+++ b/server/meshmodel/meshery-core/0.7.2/v1.0.0/policies/relationship_diff_policy.rego
@@ -79,9 +79,10 @@ is_same_selector(existing_rel, new_rel) if {
 	# is relationship between same components or different
 	ex_from_selector.id == from_selector.id
 	ex_to_selector.id == to_selector.id
+
 	# check if the relationship includes binding component.
 	# If present, verify the binding component for the existing and the identified relationship are same or different.
-
+	is_same_binding(ex_from_selector, from_selector, ex_to_selector, to_selector)
 }
 
 is_same_binding(ex_from_selector, from_selector, ex_to_selector, to_selector) if {

--- a/server/meshmodel/meshery-core/0.7.2/v1.0.0/policies/tests/relationship_diff_policy_test.rego
+++ b/server/meshmodel/meshery-core/0.7.2/v1.0.0/policies/tests/relationship_diff_policy_test.rego
@@ -1,0 +1,291 @@
+package relationship_diff_policy_test
+
+import rego.v1
+
+import data.relationship_evaluation_policy
+
+# Test is_same_binding with matching binding declarations
+test_is_same_binding_with_matching_bindings if {
+	ex_from := {
+		"id": "from-1",
+		"kind": "Role",
+		"match": {
+			"from": [{"id": "role-1"}],
+			"to": [{"id": "binding-1"}],
+		},
+	}
+	from := {
+		"id": "from-1",
+		"kind": "Role",
+		"match": {
+			"from": [{"id": "role-1"}],
+			"to": [{"id": "binding-1"}],
+		},
+	}
+	ex_to := {
+		"id": "to-1",
+		"kind": "ServiceAccount",
+		"match": {"to": [{"id": "sa-1"}]},
+	}
+	to := {
+		"id": "to-1",
+		"kind": "ServiceAccount",
+		"match": {"to": [{"id": "sa-1"}]},
+	}
+
+	relationship_evaluation_policy.is_same_binding(ex_from, from, ex_to, to)
+}
+
+# Test is_same_binding with different binding declarations
+test_is_same_binding_with_different_bindings if {
+	ex_from := {
+		"id": "from-1",
+		"kind": "Role",
+		"match": {
+			"from": [{"id": "role-1"}],
+			"to": [{"id": "binding-1"}],
+		},
+	}
+	from := {
+		"id": "from-1",
+		"kind": "Role",
+		"match": {
+			"from": [{"id": "role-1"}],
+			"to": [{"id": "binding-2"}],
+		},
+	}
+	ex_to := {
+		"id": "to-1",
+		"kind": "ServiceAccount",
+		"match": {"to": [{"id": "sa-1"}]},
+	}
+	to := {
+		"id": "to-1",
+		"kind": "ServiceAccount",
+		"match": {"to": [{"id": "sa-1"}]},
+	}
+
+	not relationship_evaluation_policy.is_same_binding(ex_from, from, ex_to, to)
+}
+
+# Test is_same_binding without match fields (non-binding relationships)
+test_is_same_binding_without_match_fields if {
+	ex_from := {"id": "from-1", "kind": "Service"}
+	from := {"id": "from-1", "kind": "Service"}
+	ex_to := {"id": "to-1", "kind": "Deployment"}
+	to := {"id": "to-1", "kind": "Deployment"}
+
+	relationship_evaluation_policy.is_same_binding(ex_from, from, ex_to, to)
+}
+
+# Test does_relationship_exist_in_design for non-binding relationships
+test_does_relationship_exist_non_binding if {
+	relationships := [{
+		"kind": "edge",
+		"type": "non-binding",
+		"subType": "network",
+		"status": "approved",
+		"model": {"name": "kubernetes", "version": ""},
+		"selectors": [{"allow": {
+			"from": [{"id": "svc-1", "kind": "Service"}],
+			"to": [{"id": "deploy-1", "kind": "Deployment"}],
+		}}],
+	}]
+
+	rel := {
+		"kind": "edge",
+		"type": "non-binding",
+		"subType": "network",
+		"status": "approved",
+		"model": {"name": "kubernetes", "version": ""},
+		"selectors": [{"allow": {
+			"from": [{"id": "svc-1", "kind": "Service"}],
+			"to": [{"id": "deploy-1", "kind": "Deployment"}],
+		}}],
+	}
+
+	relationship_evaluation_policy.does_relationship_exist_in_design(relationships, rel)
+}
+
+# Test does_relationship_exist_in_design for binding relationships with same binding
+test_does_relationship_exist_binding_same if {
+	relationships := [{
+		"kind": "edge",
+		"type": "binding",
+		"subType": "mount",
+		"status": "approved",
+		"model": {"name": "kubernetes", "version": ""},
+		"selectors": [{"allow": {
+			"from": [{
+				"id": "role-1",
+				"kind": "Role",
+				"match": {
+					"from": [{"id": "role-1"}],
+					"to": [{"id": "rb-1"}],
+				},
+			}],
+			"to": [{
+				"id": "sa-1",
+				"kind": "ServiceAccount",
+				"match": {"to": [{"id": "sa-1"}]},
+			}],
+		}}],
+	}]
+
+	rel := {
+		"kind": "edge",
+		"type": "binding",
+		"subType": "mount",
+		"status": "approved",
+		"model": {"name": "kubernetes", "version": ""},
+		"selectors": [{"allow": {
+			"from": [{
+				"id": "role-1",
+				"kind": "Role",
+				"match": {
+					"from": [{"id": "role-1"}],
+					"to": [{"id": "rb-1"}],
+				},
+			}],
+			"to": [{
+				"id": "sa-1",
+				"kind": "ServiceAccount",
+				"match": {"to": [{"id": "sa-1"}]},
+			}],
+		}}],
+	}
+
+	relationship_evaluation_policy.does_relationship_exist_in_design(relationships, rel)
+}
+
+# Test does_relationship_exist_in_design for binding relationships with different binding component
+test_does_relationship_not_exist_binding_different if {
+	relationships := [{
+		"kind": "edge",
+		"type": "binding",
+		"subType": "mount",
+		"status": "approved",
+		"model": {"name": "kubernetes", "version": ""},
+		"selectors": [{"allow": {
+			"from": [{
+				"id": "role-1",
+				"kind": "Role",
+				"match": {
+					"from": [{"id": "role-1"}],
+					"to": [{"id": "rb-1"}],
+				},
+			}],
+			"to": [{
+				"id": "sa-1",
+				"kind": "ServiceAccount",
+				"match": {"to": [{"id": "sa-1"}]},
+			}],
+		}}],
+	}]
+
+	# Same from/to components but different binding component (rb-2 instead of rb-1)
+	rel := {
+		"kind": "edge",
+		"type": "binding",
+		"subType": "mount",
+		"status": "approved",
+		"model": {"name": "kubernetes", "version": ""},
+		"selectors": [{"allow": {
+			"from": [{
+				"id": "role-1",
+				"kind": "Role",
+				"match": {
+					"from": [{"id": "role-1"}],
+					"to": [{"id": "rb-2"}],
+				},
+			}],
+			"to": [{
+				"id": "sa-1",
+				"kind": "ServiceAccount",
+				"match": {"to": [{"id": "sa-1"}]},
+			}],
+		}}],
+	}
+
+	# Should NOT exist because the binding component differs
+	not relationship_evaluation_policy.does_relationship_exist_in_design(relationships, rel)
+}
+
+# Test evaluate_relationships_added includes binding rels with different binding components
+test_evaluate_relationships_added_different_binding if {
+	design_relationships := [{
+		"kind": "edge",
+		"type": "binding",
+		"subType": "mount",
+		"status": "approved",
+		"model": {"name": "kubernetes", "version": ""},
+		"selectors": [{"allow": {
+			"from": [{
+				"id": "role-1",
+				"kind": "Role",
+				"match": {
+					"from": [{"id": "role-1"}],
+					"to": [{"id": "rb-1"}],
+				},
+			}],
+			"to": [{
+				"id": "sa-1",
+				"kind": "ServiceAccount",
+				"match": {"to": [{"id": "sa-1"}]},
+			}],
+		}}],
+	}]
+
+	# A new binding relationship with a different binding component
+	identified_relationships := [{
+		"kind": "edge",
+		"type": "binding",
+		"subType": "mount",
+		"status": "approved",
+		"model": {"name": "kubernetes", "version": ""},
+		"selectors": [{"allow": {
+			"from": [{
+				"id": "role-1",
+				"kind": "Role",
+				"match": {
+					"from": [{"id": "role-1"}],
+					"to": [{"id": "rb-2"}],
+				},
+			}],
+			"to": [{
+				"id": "sa-1",
+				"kind": "ServiceAccount",
+				"match": {"to": [{"id": "sa-1"}]},
+			}],
+		}}],
+	}]
+
+	result := relationship_evaluation_policy.evaluate_relationships_added(design_relationships, identified_relationships)
+	count(result) == 1
+}
+
+# Test is_of_same_kind
+test_is_of_same_kind_true if {
+	rel_a := {"kind": "edge", "type": "binding", "subType": "mount"}
+	rel_b := {"kind": "Edge", "type": "Binding", "subType": "Mount"}
+	relationship_evaluation_policy.is_of_same_kind(rel_a, rel_b)
+}
+
+test_is_of_same_kind_false if {
+	rel_a := {"kind": "edge", "type": "binding", "subType": "mount"}
+	rel_b := {"kind": "hierarchical", "type": "parent", "subType": "inventory"}
+	not relationship_evaluation_policy.is_of_same_kind(rel_a, rel_b)
+}
+
+# Test does_belongs_to_same_model
+test_does_belongs_to_same_model_true if {
+	rel_a := {"model": {"name": "kubernetes", "version": "v1.25.0"}}
+	rel_b := {"model": {"name": "kubernetes", "version": "v1.25.0"}}
+	relationship_evaluation_policy.does_belongs_to_same_model(rel_a, rel_b)
+}
+
+test_does_belongs_to_same_model_different_name if {
+	rel_a := {"model": {"name": "kubernetes", "version": "v1.25.0"}}
+	rel_b := {"model": {"name": "istio", "version": "v1.25.0"}}
+	not relationship_evaluation_policy.does_belongs_to_same_model(rel_a, rel_b)
+}


### PR DESCRIPTION
**Notes for Reviewers**

## Why

is_same_selector never called the already-defined is_same_binding, causing binding relationships with different
intermediary components to be incorrectly treated as duplicates.

## How

- Add is_same_binding call to is_same_selector in relationship_diff_policy.rego
- Add 11 unit tests covering binding comparison, diff detection, and edge cases

**[Signed commits](https://github.com/meshery/meshery/blob/master/CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [x] Yes, I signed my commits.

<!--
Thank you for contributing to Meshery! 

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. Sign your commits.
4. Include before and after screenshots/terminal output.

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.
-->
