### PR TITLE
[Server] Fix rego evaluation depth-exceeded check being unreachable

### DIFF
--- a/server/handlers/policy_relationship_handler.go
+++ b/server/handlers/policy_relationship_handler.go
@@ -200,13 +200,16 @@ func (h *Handler) EvaluateDesign(
 		lastEvaluationResponse.Design = evaluationResponse.Design
 		lastEvaluationResponse.Actions = append(lastEvaluationResponse.Actions, evaluationResponse.Actions...)
 
-		if evalIterations == i+1 || doesntNeedReeval(evaluationResponse) {
+		if doesntNeedReeval(evaluationResponse) {
 			h.log.Info("Evaluation completed in iteration ", i+1)
 			break
 		}
 		if i == (MAX_RE_EVALUATION_DEPTH - 1) {
 			h.log.Info("Evaluation depth exceeded")
-			return lastEvaluationResponse, fmt.Errorf("Evaluation depth exceeded")
+			return lastEvaluationResponse, fmt.Errorf("evaluation depth exceeded")
+		}
+		if evalIterations == i+1 {
+			break
 		}
 
 	}


### PR DESCRIPTION
**Notes for Reviewers**

- This PR fixes the depth-exceeded error in EvaluateDesign was dead code, causing non-converging evaluations to silently return incomplete results as success.

**[Signed commits](https://github.com/meshery/meshery/blob/master/CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [x] Yes, I signed my commits.

<!--
Thank you for contributing to Meshery! 

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. Sign your commits.
4. Include before and after screenshots/terminal output.

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.
-->
