### PR TITLE
Added AWS RDS hierarchical relationships for snapshots and database instances

### DIFF
--- a/server/meshmodel/aws-rds-controller/v1.7.5/v1.0.0/relationships/hierarchical-parent-inventory-dbclustersnapshot-dbcluster.json
+++ b/server/meshmodel/aws-rds-controller/v1.7.5/v1.0.0/relationships/hierarchical-parent-inventory-dbclustersnapshot-dbcluster.json
@@ -57,7 +57,7 @@
                 }
               ]
             },
-             "match_strategy_matrix": [
+            "match_strategy_matrix": [
               [
                 "to_contains_from"
               ]
@@ -79,17 +79,17 @@
               "mutatorRef": [
                 [
                   "configuration",
-                  "spec", 
+                  "spec",
                   "dbClusterIdentifier"
                 ]
-             ]
+              ]
             }
           }
         ],
         "to": [
           {
             "id": null,
-            "kind": "DBCluster",
+            "kind": "GlobalCluster",
             "match": {
               "from": [
                 {

--- a/server/meshmodel/aws-rds-controller/v1.7.5/v1.0.0/relationships/hierarchical-parent-inventory-dbclustersnapshot-dbcluster.json
+++ b/server/meshmodel/aws-rds-controller/v1.7.5/v1.0.0/relationships/hierarchical-parent-inventory-dbclustersnapshot-dbcluster.json
@@ -1,0 +1,157 @@
+{
+  "id": "00000000-0000-0000-0000-000000000000",
+  "evaluationQuery": "",
+  "kind": "hierarchical",
+  "metadata": {
+    "description": "RDS Cluster Snapshot is logically owned by its source DB Cluster",
+    "styles": {
+      "primaryColor": "",
+      "svgColor": "",
+      "svgWhite": ""
+    },
+    "isAnnotation": false
+  },
+  "model": {
+    "version": "",
+    "name": "aws-rds-controller",
+    "displayName": "",
+    "id": "00000000-0000-0000-0000-000000000000",
+    "registrant": {
+      "kind": ""
+    },
+    "model": {
+      "version": "v1.7.5"
+    }
+  },
+  "schemaVersion": "relationships.meshery.io/v1alpha3",
+  "selectors": [
+    {
+      "allow": {
+        "from": [
+          {
+            "id": null,
+            "kind": "DBClusterSnapshot",
+            "match": {
+              "from": [
+                {
+                  "id": null,
+                  "kind": "DBClusterSnapshot",
+                  "mutatedRef": [
+                    [
+                      "configuration",
+                      "spec",
+                      "dbClusterIdentifier"
+                    ]
+                  ]
+                }
+              ],
+              "to": [
+                {
+                  "id": null,
+                  "kind": "DBCluster",
+                  "mutatorRef": [
+                    [
+                      "displayName"
+                    ]
+                  ]
+                }
+              ]
+            },
+             "match_strategy_matrix": [
+              [
+                "to_contains_from"
+              ]
+            ],
+            "model": {
+              "version": "",
+              "name": "aws-rds-controller",
+              "displayName": "",
+              "id": "00000000-0000-0000-0000-000000000000",
+              "registrant": {
+                "kind": "github"
+              },
+              "model": {
+                "version": ""
+              }
+            },
+            "patch": {
+              "patchStrategy": "replace",
+              "mutatorRef": [
+                [
+                  "configuration",
+                  "spec", 
+                  "dbClusterIdentifier"
+                ]
+             ]
+            }
+          }
+        ],
+        "to": [
+          {
+            "id": null,
+            "kind": "DBCluster",
+            "match": {
+              "from": [
+                {
+                  "id": null,
+                  "kind": "DBClusterSnapshot",
+                  "mutatedRef": [
+                    [
+                      "configuration",
+                      "spec",
+                      "dbClusterIdentifier"
+                    ]
+                  ]
+                }
+              ],
+              "to": [
+                {
+                  "id": null,
+                  "kind": "self",
+                  "mutatorRef": [
+                    [
+                      "displayName"
+                    ]
+                  ]
+                }
+              ]
+            },
+            "match_strategy_matrix": [
+              [
+                "to_contains_from"
+              ]
+            ],
+            "model": {
+              "version": "",
+              "name": "aws-rds-controller",
+              "displayName": "",
+              "id": "00000000-0000-0000-0000-000000000000",
+              "registrant": {
+                "kind": "github"
+              },
+              "model": {
+                "version": ""
+              }
+            },
+            "patch": {
+              "patchStrategy": "replace",
+              "mutatedRef": [
+                [
+                  "displayName"
+                ]
+              ]
+            }
+          }
+        ]
+      },
+      "deny": {
+        "from": [],
+        "to": []
+      }
+    }
+  ],
+  "subType": "inventory",
+  "status": "enabled",
+  "type": "parent",
+  "version": "v1.0.0"
+}

--- a/server/meshmodel/aws-rds-controller/v1.7.5/v1.0.0/relationships/hierarchical-parent-inventory-dbclustersnapshot-dbcluster.json
+++ b/server/meshmodel/aws-rds-controller/v1.7.5/v1.0.0/relationships/hierarchical-parent-inventory-dbclustersnapshot-dbcluster.json
@@ -57,24 +57,7 @@
                 }
               ]
             },
-            "match_strategy_matrix": [
-              [
-                "to_contains_from"
-              ]
-            ],
-            "model": {
-              "version": "",
-              "name": "aws-rds-controller",
-              "displayName": "",
-              "id": "00000000-0000-0000-0000-000000000000",
-              "registrant": {
-                "kind": "github"
-              },
-              "model": {
-                "version": ""
-              }
-            },
-            "patch": {
+              "patch": {
               "patchStrategy": "replace",
               "mutatorRef": [
                 [

--- a/server/meshmodel/aws-rds-controller/v1.7.5/v1.0.0/relationships/hierarchical-parent-inventory-dbinstance-dbparametergroup.json
+++ b/server/meshmodel/aws-rds-controller/v1.7.5/v1.0.0/relationships/hierarchical-parent-inventory-dbinstance-dbparametergroup.json
@@ -53,7 +53,7 @@
                     [
                       "displayName"
                     ]
-                 ]
+                  ]
                 }
               ]
             },
@@ -77,12 +77,12 @@
             "patch": {
               "patchStrategy": "replace",
               "mutatorRef": [
-                    [
-                      "configuration",
-                      "spec", 
-                      "dbParameterGroupName"
-                    ]
-                  ]
+                [
+                  "configuration",
+                  "spec",
+                  "dbParameterGroupName"
+                ]
+              ]
             }
           }
         ],
@@ -98,13 +98,13 @@
                   "mutatedRef": [
                     [
                       "configuration",
-                      "spec", 
+                      "spec",
                       "dbParameterGroupName"
                     ]
                   ]
                 }
               ],
-             "to": [
+              "to": [
                 {
                   "id": null,
                   "kind": "self",

--- a/server/meshmodel/aws-rds-controller/v1.7.5/v1.0.0/relationships/hierarchical-parent-inventory-dbinstance-dbparametergroup.json
+++ b/server/meshmodel/aws-rds-controller/v1.7.5/v1.0.0/relationships/hierarchical-parent-inventory-dbinstance-dbparametergroup.json
@@ -1,0 +1,157 @@
+{
+  "id": "00000000-0000-0000-0000-000000000000",
+  "evaluationQuery": "",
+  "kind": "hierarchical",
+  "metadata": {
+    "description": "RDS Instance configuration is nested under its DB Parameter Group",
+    "styles": {
+      "primaryColor": "",
+      "svgColor": "",
+      "svgWhite": ""
+    },
+    "isAnnotation": false
+  },
+  "model": {
+    "version": "",
+    "name": "aws-rds-controller",
+    "displayName": "",
+    "id": "00000000-0000-0000-0000-000000000000",
+    "registrant": {
+      "kind": ""
+    },
+    "model": {
+      "version": "v1.7.5"
+    }
+  },
+  "schemaVersion": "relationships.meshery.io/v1alpha3",
+  "selectors": [
+    {
+      "allow": {
+        "from": [
+          {
+            "id": null,
+            "kind": "DBInstance",
+            "match": {
+              "from": [
+                {
+                  "id": null,
+                  "kind": "DBInstance",
+                  "mutatedRef": [
+                    [
+                      "configuration",
+                      "spec",
+                      "dbParameterGroupName"
+                    ]
+                  ]
+                }
+              ],
+              "to": [
+                {
+                  "id": null,
+                  "kind": "DBParameterGroup",
+                  "mutatorRef": [
+                    [
+                      "displayName"
+                    ]
+                 ]
+                }
+              ]
+            },
+            "match_strategy_matrix": [
+              [
+                "to_contains_from"
+              ]
+            ],
+            "model": {
+              "version": "",
+              "name": "aws-rds-controller",
+              "displayName": "",
+              "id": "00000000-0000-0000-0000-000000000000",
+              "registrant": {
+                "kind": "github"
+              },
+              "model": {
+                "version": ""
+              }
+            },
+            "patch": {
+              "patchStrategy": "replace",
+              "mutatorRef": [
+                    [
+                      "configuration",
+                      "spec", 
+                      "dbParameterGroupName"
+                    ]
+                  ]
+            }
+          }
+        ],
+        "to": [
+          {
+            "id": null,
+            "kind": "DBParameterGroup",
+            "match": {
+              "from": [
+                {
+                  "id": null,
+                  "kind": "DBInstance",
+                  "mutatedRef": [
+                    [
+                      "configuration",
+                      "spec", 
+                      "dbParameterGroupName"
+                    ]
+                  ]
+                }
+              ],
+             "to": [
+                {
+                  "id": null,
+                  "kind": "self",
+                  "mutatorRef": [
+                    [
+                      "displayName"
+                    ]
+                  ]
+                }
+              ]
+            },
+            "match_strategy_matrix": [
+              [
+                "to_contains_from"
+              ]
+            ],
+            "model": {
+              "version": "",
+              "name": "aws-rds-controller",
+              "displayName": "",
+              "id": "00000000-0000-0000-0000-000000000000",
+              "registrant": {
+                "kind": "github"
+              },
+              "model": {
+                "version": ""
+              }
+            },
+            "patch": {
+              "patchStrategy": "replace",
+              "mutatedRef": [
+                [
+                  "displayName"
+                ]
+              ]
+            }
+          }
+        ]
+      },
+      "deny": {
+        "from": [],
+        "to": []
+      }
+    }
+  ],
+  "subType": "inventory",
+  "status": "enabled",
+  "type": "parent",
+  "version": "v1.0.0"
+}

--- a/server/meshmodel/aws-rds-controller/v1.7.5/v1.0.0/relationships/hierarchical-parent-inventory-dbsnapshot-dbinstance.json
+++ b/server/meshmodel/aws-rds-controller/v1.7.5/v1.0.0/relationships/hierarchical-parent-inventory-dbsnapshot-dbinstance.json
@@ -16,8 +16,12 @@
     "name": "aws-rds-controller",
     "displayName": "",
     "id": "00000000-0000-0000-0000-000000000000",
-    "registrant": { "kind": "" },
-    "model": { "version": "v1.7.5" }
+    "registrant": {
+      "kind": ""
+    },
+    "model": {
+      "version": "v1.7.5"
+    }
   },
   "schemaVersion": "relationships.meshery.io/v1alpha3",
   "selectors": [
@@ -33,11 +37,12 @@
                   "id": null,
                   "kind": "DBSnapshot",
                   "mutatedRef": [
-                    ["configuration",
-                     "spec",
-                     "dbInstanceIdentifier"
+                    [
+                      "configuration",
+                      "spec",
+                      "dbInstanceIdentifier"
                     ]
-                 ]
+                  ]
                 }
               ],
               "to": [
@@ -48,7 +53,7 @@
                     [
                       "displayName"
                     ]
-                 ]
+                  ]
                 }
               ]
             },
@@ -77,7 +82,7 @@
                   "spec",
                   "dbInstanceIdentifier"
                 ]
-             ]
+              ]
             }
           }
         ],
@@ -96,7 +101,7 @@
                       "spec",
                       "dbInstanceIdentifier"
                     ]
-                 ]
+                  ]
                 }
               ],
               "to": [

--- a/server/meshmodel/aws-rds-controller/v1.7.5/v1.0.0/relationships/hierarchical-parent-inventory-dbsnapshot-dbinstance.json
+++ b/server/meshmodel/aws-rds-controller/v1.7.5/v1.0.0/relationships/hierarchical-parent-inventory-dbsnapshot-dbinstance.json
@@ -1,0 +1,152 @@
+{
+  "id": "00000000-0000-0000-0000-000000000000",
+  "evaluationQuery": "",
+  "kind": "hierarchical",
+  "metadata": {
+    "description": "RDS Database Snapshot is logically owned by its source DB Instance",
+    "styles": {
+      "primaryColor": "",
+      "svgColor": "",
+      "svgWhite": ""
+    },
+    "isAnnotation": false
+  },
+  "model": {
+    "version": "",
+    "name": "aws-rds-controller",
+    "displayName": "",
+    "id": "00000000-0000-0000-0000-000000000000",
+    "registrant": { "kind": "" },
+    "model": { "version": "v1.7.5" }
+  },
+  "schemaVersion": "relationships.meshery.io/v1alpha3",
+  "selectors": [
+    {
+      "allow": {
+        "from": [
+          {
+            "id": null,
+            "kind": "DBSnapshot",
+            "match": {
+              "from": [
+                {
+                  "id": null,
+                  "kind": "DBSnapshot",
+                  "mutatedRef": [
+                    ["configuration",
+                     "spec",
+                     "dbInstanceIdentifier"
+                    ]
+                 ]
+                }
+              ],
+              "to": [
+                {
+                  "id": null,
+                  "kind": "DBInstance",
+                  "mutatorRef": [
+                    [
+                      "displayName"
+                    ]
+                 ]
+                }
+              ]
+            },
+            "match_strategy_matrix": [
+              [
+                "to_contains_from"
+              ]
+            ],
+            "model": {
+              "version": "",
+              "name": "aws-rds-controller",
+              "displayName": "",
+              "id": "00000000-0000-0000-0000-000000000000",
+              "registrant": {
+                "kind": "github"
+              },
+              "model": {
+                "version": ""
+              }
+            },
+            "patch": {
+              "patchStrategy": "replace",
+              "mutatorRef": [
+                [
+                  "configuration",
+                  "spec",
+                  "dbInstanceIdentifier"
+                ]
+             ]
+            }
+          }
+        ],
+        "to": [
+          {
+            "id": null,
+            "kind": "DBInstance",
+            "match": {
+              "from": [
+                {
+                  "id": null,
+                  "kind": "DBSnapshot",
+                  "mutatedRef": [
+                    [
+                      "configuration",
+                      "spec",
+                      "dbInstanceIdentifier"
+                    ]
+                 ]
+                }
+              ],
+              "to": [
+                {
+                  "id": null,
+                  "kind": "self",
+                  "mutatorRef": [
+                    [
+                      "displayName"
+                    ]
+                  ]
+                }
+              ]
+            },
+            "match_strategy_matrix": [
+              [
+                "to_contains_from"
+              ]
+            ],
+            "model": {
+              "version": "",
+              "name": "aws-rds-controller",
+              "displayName": "",
+              "id": "00000000-0000-0000-0000-000000000000",
+              "registrant": {
+                "kind": "github"
+              },
+              "model": {
+                "version": ""
+              }
+            },
+            "patch": {
+              "patchStrategy": "replace",
+              "mutatedRef": [
+                [
+                  "displayName"
+                ]
+              ]
+            }
+          }
+        ]
+      },
+      "deny": {
+        "from": [],
+        "to": []
+      }
+    }
+  ],
+  "subType": "inventory",
+  "status": "enabled",
+  "type": "parent",
+  "version": "v1.0.0"
+}


### PR DESCRIPTION
## What does this PR do?

Adds **AWS RDS hierarchical inventory relationships** to Meshery. These relationships enable logical containment and lifecycle visualization, ensuring that RDS snapshots and engine configurations are correctly nested under their parent database resources within Meshery Kanvas.

## Related Issue

**Contributes to #15518, #17096**

## Changes

Added **3 new hierarchical relationships** within the **`aws-rds-controller/v1.7.5`** model using the official branched match-strategy logic:

1. **`aws-rds-controller/v1.7.5`**  
   `DBClusterSnapshot` (Child) → **DBCluster** (Parent)   `hierarchical-inventory-dbclustersnapshot-dbcluster.json`
   `DBSnapshot` (Child) → **DBInstance** (Parent)   `hierarchical-inventory-dbsnapshot-dbinstance.json`
   `DBInstance` (Child) → **DBParameterGroup** (Parent)   `hierarchical-inventory-dbinstance-dbparametergroup.json`


## Testing

- [x] **Validated in Kanvas**: Verified that child components (Snapshots/ParameterGroups) correctly identify and logically bind to their respective parents. ✅

**Screenshot Proof:**

**1. RDS  DBCluster Snapshot Hierarchy:**


<img width="1920" height="1080" alt="Screenshot from 2026-02-10 03-30-35" src="https://github.com/user-attachments/assets/f9589d58-df6d-4196-95b3-7598ec7f19a2" />


**2. RDS DBInstance Snapshot Hierarchy:**


<img width="1920" height="1080" alt="Screenshot from 2026-02-10 03-31-15" src="https://github.com/user-attachments/assets/92629333-fa66-4fef-9d46-fb3070f661ab" />

**3. RDS DBParameter Group Hierarchy:**


<img width="1920" height="1080" alt="Screenshot from 2026-02-10 03-32-12" src="https://github.com/user-attachments/assets/3523debc-1861-4bc4-bfbe-91c3c81295b2" />


---

**[Signed commits](https://github.com/meshery/meshery/blob/master/CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [x] Yes, I signed my commits.