### PR TITLE
[mesheryctl] Handle non-UUID organization_id in environment list

### DIFF
--- a/mesheryctl/internal/cli/root/environments/fixtures/list.environment.non_uuid_orgid.response.golden
+++ b/mesheryctl/internal/cli/root/environments/fixtures/list.environment.non_uuid_orgid.response.golden
@@ -1,0 +1,19 @@
+{
+    "page": 0,
+    "page_size": 10,
+    "total_count": 1,
+    "environments": [
+        {
+            "id": "2d2c0b60-076a-4f0a-8a63-de538570a553",
+            "name": "test-environment",
+            "description": "integration test",
+            "organization_id": "Gingergeek",
+            "created_at":"2025-03-23T02:34:18.001826Z",
+            "updated_at":"2025-03-23T02:34:18.001828Z",
+            "deleted_at": {
+                "Time":"0001-01-01T00:00:00Z",
+                "Valid":false
+            }
+        }
+    ]
+}

--- a/mesheryctl/internal/cli/root/environments/list_test.go
+++ b/mesheryctl/internal/cli/root/environments/list_test.go
@@ -1,6 +1,7 @@
 package environments
 
 import (
+	"fmt"
 	"path/filepath"
 	"runtime"
 	"testing"
@@ -28,6 +29,14 @@ func TestListEnvironment(t *testing.T) {
 			ExpectError:      true,
 			IsOutputGolden:   false,
 			ExpectedError:    utils.ErrInvalidArgument(errors.New("[ orgID ] isn't specified\n\nUsage: mesheryctl environment list --orgID [orgID]\nRun 'mesheryctl environment list --help' to see detailed help message")),
+		},
+		{
+			Name:             "List environments when server returns non-UUID organization_id",
+			Args:             []string{"list", "--orgID", testConstants["orgID"]},
+			URL:              fmt.Sprintf("/%s?orgID=%s&page=0&pagesize=10", environmentApiPath, testConstants["orgID"]),
+			Fixture:          "list.environment.non_uuid_orgid.response.golden",
+			ExpectedResponse: "list.environment.non_uuid_orgid.success.golden",
+			ExpectError:      false,
 		},
 		// TODO: Enable this test case after other opened PR is merged
 		// {

--- a/mesheryctl/internal/cli/root/environments/testdata/list.environment.non_uuid_orgid.success.golden
+++ b/mesheryctl/internal/cli/root/environments/testdata/list.environment.non_uuid_orgid.success.golden
@@ -1,0 +1,4 @@
+Total number of environments: 1
+Page: 1
+ID                                    NAME              ORGANIZATION ID                       DESCRIPTION       CREATED AT                            UPDATED AT                            
+2d2c0b60-076a-4f0a-8a63-de538570a553  test-environment  2d2c0b60-076a-4f0a-8a63-de538570a553  integration test  2025-03-23 02:34:18.001826 +0000 UTC  2025-03-23 02:34:18.001828 +0000 UTC  


### PR DESCRIPTION
**Notes for Reviewers**

- This PR fixes [#16684](https://github.com/meshery/meshery/issues/16684) by making `mesheryctl environment list --orgID` resilient when the server returns a non-UUID `organization_id` value (for example, organization name strings like `"Gingergeek"`).

#### Why this change is needed

`environment list` previously decoded API responses into a strict UUID-backed type. If `organization_id` was returned as a string name, decode failed with:
`uuid: incorrect UUID length 10 in string "Gingergeek"`

This prevented listing environments even though the request itself was valid.

**Before:**

```bash
# Before (on parent commit, reproducible test failure)
$ go test ./mesheryctl/internal/cli/root/environments -run TestListEnvironment/List_environments_when_server_returns_non-UUID_organization_id -count=1
Error: uuid: incorrect UUID length 10 in string "Gingergeek"
--- FAIL: TestListEnvironment/List_environments_when_server_returns_non-UUID_organization_id
FAIL
```

**After:**

```bash
# After (current branch)
$ go test ./mesheryctl/internal/cli/root/environments -run TestListEnvironment/List_environments_when_server_returns_non-UUID_organization_id -count=1
ok  	github.com/meshery/meshery/mesheryctl/internal/cli/root/environments	0.xxxs
```

**[Signed commits](https://github.com/meshery/meshery/blob/master/CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [x] Yes, I signed my commits.

<!--
Thank you for contributing to Meshery! 

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. Sign your commits.
4. Include before and after screenshots/terminal output.

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.
-->
