### PR TITLE
[mesheryctl] skip registry spreadsheet e2e cases when credentials are missing

### DIFF
--- a/mesheryctl/tests/e2e/006-registry/01-generate.bats
+++ b/mesheryctl/tests/e2e/006-registry/01-generate.bats
@@ -7,9 +7,9 @@ setup() {
     mkdir -p "$TESTDATA_DIR"  
     export FIXTURES_DIR="$BATS_TEST_DIRNAME/fixtures"
     
-    # add CREDS & ID for integration sheets here
-    export TEST_SPREADSHEET_ID=""
-    export TEST_SPREADSHEET_CRED=""
+    # allow CI/environment to provide integration spreadsheet credentials
+    export TEST_SPREADSHEET_ID="${TEST_SPREADSHEET_ID:-}"
+    export TEST_SPREADSHEET_CRED="${TEST_SPREADSHEET_CRED:-}"
 }
 
 common_outputs_on_success() {
@@ -18,7 +18,13 @@ common_outputs_on_success() {
     assert_output --partial "generated."
 }
 
-@test "mesheryctl registry generate displays usage instructions when no arguments are provided" {
+require_spreadsheet_credentials() {
+    if [[ -z "$TEST_SPREADSHEET_ID" || -z "$TEST_SPREADSHEET_CRED" ]]; then
+        skip "Spreadsheet credentials not configured"
+    fi
+}
+
+@test "given no arguments when running mesheryctl registry generate then usage instructions are displayed" {
     run $MESHERYCTL_BIN registry generate 
     assert_failure
     assert_output --partial "[ Spreadsheet ID | Registrant Connection Definition Path | Local Directory | Individual CSV files ] isn't specified"
@@ -26,38 +32,40 @@ common_outputs_on_success() {
     assert_output --partial "mesheryctl registry generate --spreadsheet-id [Spreadsheet ID] --spreadsheet-cred \$CRED"
 }
 
-@test "mesheryctl registry generate fails when spreadsheet-id is provided without spreadsheet-cred" {
+@test "given spreadsheet-id without spreadsheet-cred when running mesheryctl registry generate then an error message is displayed" {
     run $MESHERYCTL_BIN registry generate --spreadsheet-id "test-id"
     assert_failure
     assert_output --partial "Spreadsheet Credentials is required"
 }
 
-@test "mesheryctl registry generate fails when registrant-def is provided without registrant-cred" {
+@test "given registrant-def without registrant-cred when running mesheryctl registry generate then an error message is displayed" {
     run $MESHERYCTL_BIN registry generate --registrant-def "$FIXTURES_DIR/connection-def.json"
     assert_failure
     assert_output --partial "Registrant Credentials is required"
 }
 
-@test "mesheryctl registry generate fails with invalid directory" {
+@test "given an invalid directory when running mesheryctl registry generate then an error message is displayed" {
     run $MESHERYCTL_BIN registry generate --directory "invalid-directory"
     assert_failure
     assert_output --partial "error reading the directory"
 }
 
-@test "mesheryctl registry generate fails with directory missing required CSV files" {
+@test "given a directory missing required csv files when running mesheryctl registry generate then an error message is displayed" {
     run $MESHERYCTL_BIN registry generate --directory "$FIXTURES_DIR/incomplete-csv-dir"
     assert_failure
     assert_output --partial "error reading the directory"
     assert_output --partial "either the model csv or component csv is missing"
 }
 
-@test "mesheryctl registry generate supports model-specific generation with spreadsheet" {
+@test "given valid spreadsheet credentials and a model name when running mesheryctl registry generate then only that model is generated" {
+    require_spreadsheet_credentials
     run $MESHERYCTL_BIN registry generate --spreadsheet-id "$TEST_SPREADSHEET_ID" --spreadsheet-cred "$TEST_SPREADSHEET_CRED" --model "flyte"
     assert_success
     common_outputs_on_success
 }
 
-@test "mesheryctl registry generate succeeds with valid spreadsheet credentials" {
+@test "given valid spreadsheet credentials when running mesheryctl registry generate then models are generated successfully" {
+    require_spreadsheet_credentials
     run $MESHERYCTL_BIN registry generate --spreadsheet-id "$TEST_SPREADSHEET_ID" --spreadsheet-cred "$TEST_SPREADSHEET_CRED"
     assert_success
     common_outputs_on_success


### PR DESCRIPTION
### Summary
Registry generate e2e was failing in CI when spreadsheet credentials were not set.This PR makes spreadsheet-dependent tests skip when creds are missing, instead of failing. I've also renamed the tests titles into bdd format as best approach. 

**Notes for Reviewers**
- This PR fixes #17143

**Tested Locally**
0 failures, 2 tests skipped other all tests are passing

**[Signed commits](https://github.com/meshery/meshery/blob/master/CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [x] Yes, I signed my commits.

<!--
Thank you for contributing to Meshery! 

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. Sign your commits.
4. Include before and after screenshots/terminal output.

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.
-->
