### PR TITLE
Add SNS Topic → Kubernetes Deployment/Pod Relationships

### DIFF
--- a/server/meshmodel/aws-sns-controller/v1.3.1/v1.0.0/relationships/edge-non-binding-reference-topic-deployment.json
+++ b/server/meshmodel/aws-sns-controller/v1.3.1/v1.0.0/relationships/edge-non-binding-reference-topic-deployment.json
@@ -1,0 +1,102 @@
+{
+    "id": "00000000-0000-0000-0000-000000000000",
+    "evaluationQuery": "",
+    "kind": "edge",
+    "metadata": {
+        "description": "",
+        "styles": {
+            "primaryColor": "",
+            "svgColor": "",
+            "svgWhite": ""
+        },
+        "isAnnotation": false
+    },
+    "model": {
+        "version": "",
+        "name": "aws-sns-controller",
+        "displayName": "",
+        "id": "00000000-0000-0000-0000-000000000000",
+        "registrant": {
+            "kind": ""
+        },
+        "model": {
+            "version": "v1.3.1"
+        }
+    },
+    "schemaVersion": "relationships.meshery.io/v1alpha3",
+    "selectors": [
+        {
+            "allow": {
+                "from": [
+                    {
+                        "id": null,
+                        "kind": "Topic",
+                        "match": {},
+                        "match_strategy_matrix": null,
+                        "model": {
+                            "version": "",
+                            "name": "aws-sns-controller",
+                            "displayName": "",
+                            "id": "00000000-0000-0000-0000-000000000000",
+                            "registrant": {
+                                "kind": "artifacthub"
+                            },
+                            "model": {
+                                "version": ""
+                            }
+                        },
+                        "patch": {
+                            "patchStrategy": "replace",
+                            "mutatorRef": [
+                                [
+                                    "displayName"
+                                ]
+                            ]
+                        }
+                    }
+                ],
+                "to": [
+                    {
+                        "id": null,
+                        "kind": "Deployment",
+                        "match": {},
+                        "match_strategy_matrix": null,
+                        "model": {
+                            "version": "",
+                            "name": "kubernetes",
+                            "displayName": "",
+                            "id": "00000000-0000-0000-0000-000000000000",
+                            "registrant": {
+                                "kind": "artifacthub"
+                            },
+                            "model": {
+                                "version": ""
+                            }
+                        },
+                        "patch": {
+                            "patchStrategy": "replace",
+                            "mutatedRef": [
+                                [
+                                    "spec",
+                                    "template",
+                                    "spec",
+                                    "containers",
+                                    "_",
+                                    "env"
+                                ]
+                            ]
+                        }
+                    }
+                ]
+            },
+            "deny": {
+                "from": [],
+                "to": []
+            }
+        }
+    ],
+    "subType": "reference",
+    "status": "enabled",
+    "type": "non-binding",
+    "version": "v1.0.0"
+}

--- a/server/meshmodel/aws-sns-controller/v1.3.1/v1.0.0/relationships/edge-non-binding-reference-topic-pod.json
+++ b/server/meshmodel/aws-sns-controller/v1.3.1/v1.0.0/relationships/edge-non-binding-reference-topic-pod.json
@@ -1,0 +1,100 @@
+{
+    "id": "00000000-0000-0000-0000-000000000000",
+    "evaluationQuery": "",
+    "kind": "edge",
+    "metadata": {
+        "description": "",
+        "styles": {
+            "primaryColor": "",
+            "svgColor": "",
+            "svgWhite": ""
+        },
+        "isAnnotation": false
+    },
+    "model": {
+        "version": "",
+        "name": "aws-sns-controller",
+        "displayName": "",
+        "id": "00000000-0000-0000-0000-000000000000",
+        "registrant": {
+            "kind": ""
+        },
+        "model": {
+            "version": "v1.3.1"
+        }
+    },
+    "schemaVersion": "relationships.meshery.io/v1alpha3",
+    "selectors": [
+        {
+            "allow": {
+                "from": [
+                    {
+                        "id": null,
+                        "kind": "Topic",
+                        "match": {},
+                        "match_strategy_matrix": null,
+                        "model": {
+                            "version": "",
+                            "name": "aws-sns-controller",
+                            "displayName": "",
+                            "id": "00000000-0000-0000-0000-000000000000",
+                            "registrant": {
+                                "kind": "artifacthub"
+                            },
+                            "model": {
+                                "version": ""
+                            }
+                        },
+                        "patch": {
+                            "patchStrategy": "replace",
+                            "mutatorRef": [
+                                [
+                                    "displayName"
+                                ]
+                            ]
+                        }
+                    }
+                ],
+                "to": [
+                    {
+                        "id": null,
+                        "kind": "Pod",
+                        "match": {},
+                        "match_strategy_matrix": null,
+                        "model": {
+                            "version": "",
+                            "name": "kubernetes",
+                            "displayName": "",
+                            "id": "00000000-0000-0000-0000-000000000000",
+                            "registrant": {
+                                "kind": "artifacthub"
+                            },
+                            "model": {
+                                "version": ""
+                            }
+                        },
+                        "patch": {
+                            "patchStrategy": "replace",
+                            "mutatedRef": [
+                                [
+                                    "spec",
+                                    "containers",
+                                    "_",
+                                    "env"
+                                ]
+                            ]
+                        }
+                    }
+                ]
+            },
+            "deny": {
+                "from": [],
+                "to": []
+            }
+        }
+    ],
+    "subType": "reference",
+    "status": "enabled",
+    "type": "non-binding",
+    "version": "v1.0.0"
+}


### PR DESCRIPTION
**Notes for Reviewers**
- Adds visual-only relationships between AWS SNS `Topic` and Kubernetes `Deployment` / `Pod` components to support event-  driven architecture visualization in Meshery Kanvas.

- Contributes to #17096 

**Changes**
- Added `edge-non-binding-reference-topic-deployment.json`
- Added `edge-non-binding-reference-topic-pod.json`
- **Controller Version**: `v1.3.1` (Latest)
- **Relationship Type**: Visual-only (non-binding reference)
---
<img width="540" height="570" alt="image" src="https://github.com/user-attachments/assets/6d6fa4ea-485d-48e6-b55e-9a0cabf630d0" />

---

**[Signed commits](https://github.com/meshery/meshery/blob/master/CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [x] Yes, I signed my commits.

<!--
Thank you for contributing to Meshery! 

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. Sign your commits.
4. Include before and after screenshots/terminal output.

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.
-->
