### PR TITLE
[UI] Migrate Playwright models spec to use Page Object Model

### DIFF
--- a/ui/tests/e2e/models.spec.js
+++ b/ui/tests/e2e/models.spec.js
@@ -1,6 +1,6 @@
 import { test, expect } from '@playwright/test';
 import path from 'path';
-import { DashboardPage } from './pages/DashboardPage';
+import { ModelsPage } from './pages/ModelsPage';
 
 const model = {
   MODEL_URL: 'git://github.com/aws-controllers-k8s/apigatewayv2-controller/main/helm',
@@ -22,118 +22,33 @@ const model_import = {
 };
 
 test.describe.serial('Model Workflow Tests', () => {
+  let modelsPage;
+
   test.beforeEach(async ({ page }) => {
-    const dashboardPage = new DashboardPage(page);
-    await dashboardPage.navigateToDashboard();
-    await dashboardPage.navigateToSettings();
-    await page.getByTestId('settings-tab-registry').click();
+    modelsPage = new ModelsPage(page);
+    await modelsPage.navigateToRegistrySettings();
   });
 
-  test('Create a Model', async ({ page }) => {
-    await page.getByTestId('TabBar-Button-CreateModel').click();
-
-    await page.locator('#model-name').fill(model.MODEL_NAME);
-    await page.locator('#model-display-name').fill(model.MODEL_DISPLAY_NAME);
-
-    await page.getByTestId('UrlStepper-Button-Next').click();
-
-    await expect(page.getByTestId('UrlStepper-Select-Category')).toBeVisible();
-    await expect(page.getByTestId('UrlStepper-Select-Subcategory')).toBeVisible();
-
-    await page.getByTestId('UrlStepper-Button-Next').click();
-
-    await expect(page.getByTestId('UrlStepper-Select-Logo-Dark-Theme')).toBeVisible();
-    await expect(page.getByTestId('UrlStepper-Select-Logo-Light-Theme')).toBeVisible();
-
-    await expect(page.getByTestId('UrlStepper-Select-Primary-Color')).toBeVisible();
-    await expect(page.getByTestId('UrlStepper-Select-Secondary-Color')).toBeVisible();
-    await expect(page.getByTestId('UrlStepper-Select-Shape')).toBeVisible();
-
-    await page.getByTestId('UrlStepper-Button-Next').click();
-
-    await page.getByTestId('UrlStepper-Select-Source-GitHub').check();
-    await page.locator('#model-url').fill(model.MODEL_URL);
-
-    await page.getByTestId('UrlStepper-Button-Next').click();
-    await page.getByTestId('UrlStepper-Visual-Annotation-Checkbox').check();
-    await page.getByTestId('UrlStepper-Button-Next').click();
-
-    await page.getByTestId('UrlStepper-Button-Generate').click();
-
-    await expect(
-      page.getByTestId(`ModelImportedSection-ModelHeader-${model.MODEL_NAME}`),
-    ).toBeVisible();
-    await expect(page.getByTestId('ModelImportMessages-Wrapper')).toBeVisible();
-
-    await page.getByTestId('UrlStepper-Button-Finish').click();
+  test('Create a Model', async () => {
+    await modelsPage.createModel(model);
   });
 
-  test('Search a Model and Export it', async ({ page }) => {
-    await page.getByTestId('search-icon').click();
-    await page.locator('#searchClick').click();
-    await page.locator('#searchClick').fill(model.MODEL_DISPLAY_NAME);
-    await page.getByText(model.MODEL_DISPLAY_NAME).click();
-
-    const downloadPromise = page.waitForEvent('download');
-    await page.getByTestId('export-model-button').click();
-    const download = await downloadPromise;
+  test('Search a Model and Export it', async () => {
+    await modelsPage.searchModel(model.MODEL_DISPLAY_NAME);
+    const download = await modelsPage.exportModel();
     expect(download).toBeDefined();
-    await page.getByRole('combobox', { name: 'enabled' }).click();
-    await page.getByRole('option', { name: 'ignored' }).click();
-    await expect(page.getByRole('combobox', { name: 'ignored' })).toBeVisible();
+    await modelsPage.setModelStatus('ignored');
   });
 
-  test('Import a Model via File Import', async ({ page }) => {
-    await page.getByTestId('TabBar-Button-ImportModel').click();
-    await page.getByRole('heading', { name: 'File Import' }).click();
-
-    await page.setInputFiles('input[type="file"]', model_import.MODEL_FILE_IMPORT);
-
-    await page.getByRole('button', { name: 'Next' }).click();
-
-    await expect(
-      page.getByTestId(`ModelImportedSection-ModelHeader-${model_import.MODEL_NAME}`),
-    ).toBeVisible();
-    await expect(page.getByTestId('ModelImportMessages-Wrapper')).toBeVisible();
-    await page.getByRole('button', { name: 'Finish' }).click();
+  test('Import a Model via File Import', async () => {
+    await modelsPage.importModelViaFile(model_import.MODEL_FILE_IMPORT, model_import.MODEL_NAME);
   });
 
-  test('Import a Model via Url Import', async ({ page }) => {
-    await page.getByTestId('TabBar-Button-ImportModel').click();
-    await page.getByRole('heading', { name: 'URL Import' }).click();
-
-    await page.getByRole('textbox', { name: 'URL' }).click();
-    await page.getByRole('textbox', { name: 'URL' }).fill(model_import.MODEL_URL_IMPORT);
-
-    await page.getByRole('button', { name: 'Next' }).click();
-
-    await expect(
-      page.getByTestId(`ModelImportedSection-ModelHeader-${model_import.MODEL_NAME}`),
-    ).toBeVisible();
-    await expect(page.getByTestId('ModelImportMessages-Wrapper')).toBeVisible();
-    await page.getByRole('button', { name: 'Finish' }).click();
+  test('Import a Model via Url Import', async () => {
+    await modelsPage.importModelViaUrl(model_import.MODEL_URL_IMPORT, model_import.MODEL_NAME);
   });
 
-  test('Import a Model via CSV Import', async ({ page }) => {
-    await page.getByTestId('TabBar-Button-ImportModel').click();
-    await page.getByRole('heading', { name: 'CSV Import' }).click();
-
-    await page.getByRole('button', { name: 'Next' }).click();
-
-    await page.setInputFiles('input[type="file"]', model_import.MODEL_CSV_IMPORT.Models);
-    await page.getByRole('button', { name: 'Next' }).click();
-    await page.setInputFiles('input[type="file"]', model_import.MODEL_CSV_IMPORT.Components);
-    await page.getByRole('button', { name: 'Next' }).click();
-    await page.setInputFiles('input[type="file"]', model_import.MODEL_CSV_IMPORT.Relationships);
-
-    await page.getByRole('button', { name: 'Generate' }).click();
-
-    await expect(
-      page.getByTestId(
-        `ModelImportedSection-ModelHeader-${model_import.MODEL_CSV_IMPORT.Model_Name}`,
-      ),
-    ).toBeVisible();
-    await expect(page.getByTestId('ModelImportMessages-Wrapper')).toBeVisible();
-    await page.getByRole('button', { name: 'Finish' }).click();
+  test('Import a Model via CSV Import', async () => {
+    await modelsPage.importModelViaCsv(model_import.MODEL_CSV_IMPORT);
   });
 });

--- a/ui/tests/e2e/pages/ModelsPage.js
+++ b/ui/tests/e2e/pages/ModelsPage.js
@@ -1,0 +1,151 @@
+import { expect } from '@playwright/test';
+import { DashboardPage } from './DashboardPage';
+
+export class ModelsPage {
+  constructor(page) {
+    this.page = page;
+    this.dashboardPage = new DashboardPage(page);
+
+    this.registryTab = page.getByTestId('settings-tab-registry');
+
+    this.createModelButton = page.getByTestId('TabBar-Button-CreateModel');
+    this.importModelButton = page.getByTestId('TabBar-Button-ImportModel');
+
+    this.modelNameInput = page.locator('#model-name');
+    this.modelDisplayNameInput = page.locator('#model-display-name');
+    this.modelUrlInput = page.locator('#model-url');
+
+    this.stepNextButton = page.getByTestId('UrlStepper-Button-Next');
+    this.stepGenerateButton = page.getByTestId('UrlStepper-Button-Generate');
+    this.stepFinishButton = page.getByTestId('UrlStepper-Button-Finish');
+
+    this.categorySelect = page.getByTestId('UrlStepper-Select-Category');
+    this.subcategorySelect = page.getByTestId('UrlStepper-Select-Subcategory');
+
+    this.logoDarkSelect = page.getByTestId('UrlStepper-Select-Logo-Dark-Theme');
+    this.logoLightSelect = page.getByTestId('UrlStepper-Select-Logo-Light-Theme');
+    this.primaryColorSelect = page.getByTestId('UrlStepper-Select-Primary-Color');
+    this.secondaryColorSelect = page.getByTestId('UrlStepper-Select-Secondary-Color');
+    this.shapeSelect = page.getByTestId('UrlStepper-Select-Shape');
+
+    this.sourceGithubRadio = page.getByTestId('UrlStepper-Select-Source-GitHub');
+    this.visualAnnotationCheckbox = page.getByTestId('UrlStepper-Visual-Annotation-Checkbox');
+
+    this.searchIcon = page.getByTestId('search-icon');
+    this.searchInput = page.locator('#searchClick');
+    this.exportModelButton = page.getByTestId('export-model-button');
+    this.statusCombobox = page.getByRole('combobox', { name: 'enabled' });
+
+    this.fileInput = page.locator('input[type="file"]');
+  }
+
+  async navigateToRegistrySettings() {
+    await this.dashboardPage.navigateToDashboard();
+    await this.dashboardPage.navigateToSettings();
+    await this.registryTab.click();
+  }
+
+  async createModel(model) {
+    await this.createModelButton.click();
+
+    await this.modelNameInput.fill(model.MODEL_NAME);
+    await this.modelDisplayNameInput.fill(model.MODEL_DISPLAY_NAME);
+
+    await this.stepNextButton.click();
+
+    await expect(this.categorySelect).toBeVisible();
+    await expect(this.subcategorySelect).toBeVisible();
+
+    await this.stepNextButton.click();
+
+    await expect(this.logoDarkSelect).toBeVisible();
+    await expect(this.logoLightSelect).toBeVisible();
+
+    await expect(this.primaryColorSelect).toBeVisible();
+    await expect(this.secondaryColorSelect).toBeVisible();
+    await expect(this.shapeSelect).toBeVisible();
+
+    await this.stepNextButton.click();
+
+    await this.sourceGithubRadio.check();
+    await this.modelUrlInput.fill(model.MODEL_URL);
+
+    await this.stepNextButton.click();
+    await this.visualAnnotationCheckbox.check();
+    await this.stepNextButton.click();
+
+    await this.stepGenerateButton.click();
+
+    await this.expectModelImportSuccess(model.MODEL_NAME);
+
+    await this.stepFinishButton.click();
+  }
+
+  async searchModel(displayName) {
+    await this.searchIcon.click();
+    await this.searchInput.click();
+    await this.searchInput.fill(displayName);
+    await this.page.getByText(displayName).click();
+  }
+
+  async exportModel() {
+    const downloadPromise = this.page.waitForEvent('download');
+    await this.exportModelButton.click();
+    return downloadPromise;
+  }
+
+  async setModelStatus(statusLabel) {
+    await this.statusCombobox.click();
+    await this.page.getByRole('option', { name: statusLabel }).click();
+    await expect(this.page.getByRole('combobox', { name: statusLabel })).toBeVisible();
+  }
+
+  async importModelViaFile(filePath, modelName) {
+    await this.importModelButton.click();
+    await this.page.getByRole('heading', { name: 'File Import' }).click();
+
+    await this.fileInput.setInputFiles(filePath);
+    await this.page.getByRole('button', { name: 'Next' }).click();
+
+    await this.expectModelImportSuccess(modelName);
+    await this.page.getByRole('button', { name: 'Finish' }).click();
+  }
+
+  async importModelViaUrl(modelUrl, modelName) {
+    await this.importModelButton.click();
+    await this.page.getByRole('heading', { name: 'URL Import' }).click();
+
+    await this.page.getByRole('textbox', { name: 'URL' }).click();
+    await this.page.getByRole('textbox', { name: 'URL' }).fill(modelUrl);
+
+    await this.page.getByRole('button', { name: 'Next' }).click();
+
+    await this.expectModelImportSuccess(modelName);
+    await this.page.getByRole('button', { name: 'Finish' }).click();
+  }
+
+  async importModelViaCsv(csvImport) {
+    await this.importModelButton.click();
+    await this.page.getByRole('heading', { name: 'CSV Import' }).click();
+
+    await this.page.getByRole('button', { name: 'Next' }).click();
+
+    await this.fileInput.setInputFiles(csvImport.Models);
+    await this.page.getByRole('button', { name: 'Next' }).click();
+    await this.fileInput.setInputFiles(csvImport.Components);
+    await this.page.getByRole('button', { name: 'Next' }).click();
+    await this.fileInput.setInputFiles(csvImport.Relationships);
+
+    await this.page.getByRole('button', { name: 'Generate' }).click();
+
+    await this.expectModelImportSuccess(csvImport.Model_Name);
+    await this.page.getByRole('button', { name: 'Finish' }).click();
+  }
+
+  async expectModelImportSuccess(modelName) {
+    await expect(
+      this.page.getByTestId(`ModelImportedSection-ModelHeader-${modelName}`),
+    ).toBeVisible();
+    await expect(this.page.getByTestId('ModelImportMessages-Wrapper')).toBeVisible();
+  }
+}

--- a/ui/tests/e2e/pages/ModelsPage.js
+++ b/ui/tests/e2e/pages/ModelsPage.js
@@ -34,9 +34,17 @@ export class ModelsPage {
     this.searchIcon = page.getByTestId('search-icon');
     this.searchInput = page.locator('#searchClick');
     this.exportModelButton = page.getByTestId('export-model-button');
-    this.statusCombobox = page.getByRole('combobox', { name: 'enabled' });
+    this.statusCombobox = page.locator('[aria-labelledby="entity-status-select-label"]');
 
     this.fileInput = page.locator('input[type="file"]');
+
+    this.importFileHeading = page.getByRole('heading', { name: 'File Import' });
+    this.importUrlHeading = page.getByRole('heading', { name: 'URL Import' });
+    this.importCsvHeading = page.getByRole('heading', { name: 'CSV Import' });
+    this.importUrlInput = page.getByRole('textbox', { name: 'URL' });
+    this.importNextButton = page.getByRole('button', { name: 'Next' });
+    this.importGenerateButton = page.getByRole('button', { name: 'Generate' });
+    this.importFinishButton = page.getByRole('button', { name: 'Finish' });
   }
 
   async navigateToRegistrySettings() {
@@ -97,49 +105,48 @@ export class ModelsPage {
   async setModelStatus(statusLabel) {
     await this.statusCombobox.click();
     await this.page.getByRole('option', { name: statusLabel }).click();
-    await expect(this.page.getByRole('combobox', { name: statusLabel })).toBeVisible();
+    await expect(this.statusCombobox).toHaveText(new RegExp(statusLabel, 'i'));
   }
 
   async importModelViaFile(filePath, modelName) {
     await this.importModelButton.click();
-    await this.page.getByRole('heading', { name: 'File Import' }).click();
+    await this.importFileHeading.click();
 
     await this.fileInput.setInputFiles(filePath);
-    await this.page.getByRole('button', { name: 'Next' }).click();
+    await this.importNextButton.click();
 
     await this.expectModelImportSuccess(modelName);
-    await this.page.getByRole('button', { name: 'Finish' }).click();
+    await this.importFinishButton.click();
   }
 
   async importModelViaUrl(modelUrl, modelName) {
     await this.importModelButton.click();
-    await this.page.getByRole('heading', { name: 'URL Import' }).click();
+    await this.importUrlHeading.click();
 
-    await this.page.getByRole('textbox', { name: 'URL' }).click();
-    await this.page.getByRole('textbox', { name: 'URL' }).fill(modelUrl);
+    await this.importUrlInput.fill(modelUrl);
 
-    await this.page.getByRole('button', { name: 'Next' }).click();
+    await this.importNextButton.click();
 
     await this.expectModelImportSuccess(modelName);
-    await this.page.getByRole('button', { name: 'Finish' }).click();
+    await this.importFinishButton.click();
   }
 
   async importModelViaCsv(csvImport) {
     await this.importModelButton.click();
-    await this.page.getByRole('heading', { name: 'CSV Import' }).click();
+    await this.importCsvHeading.click();
 
-    await this.page.getByRole('button', { name: 'Next' }).click();
+    await this.importNextButton.click();
 
     await this.fileInput.setInputFiles(csvImport.Models);
-    await this.page.getByRole('button', { name: 'Next' }).click();
+    await this.importNextButton.click();
     await this.fileInput.setInputFiles(csvImport.Components);
-    await this.page.getByRole('button', { name: 'Next' }).click();
+    await this.importNextButton.click();
     await this.fileInput.setInputFiles(csvImport.Relationships);
 
-    await this.page.getByRole('button', { name: 'Generate' }).click();
+    await this.importGenerateButton.click();
 
     await this.expectModelImportSuccess(csvImport.Model_Name);
-    await this.page.getByRole('button', { name: 'Finish' }).click();
+    await this.importFinishButton.click();
   }
 
   async expectModelImportSuccess(modelName) {


### PR DESCRIPTION
Refactored models.spec.js to follow the Page Object Model design pattern by creating ModelsPage class with encapsulated locators and methods.

Fixes #15372

**Notes for Reviewers**

- This PR fixes #15372

**[Signed commits](https://github.com/meshery/meshery/blob/master/CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [x] Yes, I signed my commits.

<!--
Thank you for contributing to Meshery! 

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. Sign your commits.
4. Include before and after screenshots/terminal output.

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.
-->
