### PR TITLE
server: replace http.Error with structured meshkit error in GetProvid…

### DIFF
--- a/server/models/default_local_provider.go
+++ b/server/models/default_local_provider.go
@@ -140,7 +140,6 @@ func (l *DefaultLocalProvider) GetProviderCapabilities(w http.ResponseWriter, _ 
 	}
 }
 
-
 // InitiateLogin - initiates login flow and returns a true to indicate the handler to "return" or false to continue
 func (l *DefaultLocalProvider) InitiateLogin(_ http.ResponseWriter, _ *http.Request, _ bool) {
 	// l.issueSession(w, r, fromMiddleWare)


### PR DESCRIPTION
This PR fixes #12438

This change replaces generic http.Error usage with structured meshkit error handling in GetProviderCapabilities to maintain consistency across server error responses.
