### PR TITLE
Remove the site.baseURL at the beginning of urls

### DIFF
--- a/docs-new/content/en/concepts/architectural/architecture/images/index.md
+++ b/docs-new/content/en/concepts/architectural/architecture/images/index.md
@@ -21,7 +21,7 @@ Meshery and its components are written using the following languages and technol
 | [Meshery CLI](#meshery-cli)                                          | Golang                                                                            |
 | --- [Extensions](/extensions) ---                                    |                                                                                   |
 | [Meshery Adapters](/concepts/architecture/adapters)                  | Golang, gRPC, [CloudEvents](https://cloudevents.io/)                              |
-| [Meshery Remote Providers](/extensibility/providers)                 | _any_ - must adhere to Meshery [Extension Points]({{site.baseurl}}/extensibility) |
+| [Meshery Remote Providers](/extensibility/providers)                 | _any_ - must adhere to Meshery [Extension Points](/extensibility) |
 | [Envoy WASM Filters](https://github.com/layer5io/wasm-filters)     | Rust and C++                                                                      |
 
 ## Deployments
@@ -91,20 +91,20 @@ See the [**Operator**](/concepts/architecture/operator) section for more informa
 
 Meshery Server's database is responsible for collecting and centralizing the state of all elements under management, including infrastructure, application, and Meshery's own components. Meshery's database, while persisted to file, is treated as a cache.
 
-<a href="{{ site.baseurl }}/assets/img/architecture/meshery-database.webp" class="lightbox-image">
-<img src="{{ site.baseurl }}/assets/img/architecture/meshery-database.webp" width="50%" /></a>
+<a href="/assets/img/architecture/meshery-database.webp" class="lightbox-image">
+<img src="/assets/img/architecture/meshery-database.webp" width="50%" /></a>
 <figure>
   <figcaption>Figure: Meshery Docker Extension</figcaption>
 </figure>
 
-_See the [**Database**]({{ site.baseurl }}/concepts/architecture/database) section for more information on the function of the database._
+_See the [**Database**](/concepts/architecture/database) section for more information on the function of the database._
 
 ## Meshery Docker Extension
 
 Meshery's Docker extension provides a simple and flexible way to design and operate cloud native infrastructure on top of Kubernetes using Docker containers. The architecture of this extension is designed to be modular and extensible, with each component serving a specific purpose within the overall deployment process.
 
-<a href="{{ site.baseurl }}/assets/img/architecture/meshery-docker-extension.svg" class="lightbox-image">
-<img src="{{ site.baseurl }}/assets/img/architecture/meshery-docker-extension.svg" width="50%" /></a>
+<a href="/assets/img/architecture/meshery-docker-extension.svg" class="lightbox-image">
+<img src="/assets/img/architecture/meshery-docker-extension.svg" width="50%" /></a>
 <figure>
   <figcaption>Figure: Meshery Docker Extension</figcaption>
 </figure>
@@ -155,9 +155,9 @@ Meshery uses the following list of network ports to interface with its various c
 | <img src="{{ adapter.image }}" style="width:20px" data-logo-for-dark="{{ adapter.white_image }}" data-logo-for-light="{{ adapter.image }}" id="logo-dark-light" loading="lazy"/> [{{ adapter.name }}]({{ site.baseurl }}{{ adapter.url }}) | {{ adapter.port }} | Communication with Meshery Server |
 {% endif -%}
 {% endfor -%}
-| [Meshery Perf]({{ site.baseurl }}/guides/performance-management/managing-performance) | 10013/gRPC    | Performance Management|
+| [Meshery Perf](/guides/performance-management/managing-performance) | 10013/gRPC    | Performance Management|
 
-See the [**Adapters**]({{ site.baseurl }}/concepts/architecture/adapters) section for more information on the function of an adapter.
+See the [**Adapters**](/concepts/architecture/adapters) section for more information on the function of an adapter.
 
 ### **Meshery Connections and their Actions**
 

--- a/docs-new/content/en/concepts/architectural/architecture/index.md
+++ b/docs-new/content/en/concepts/architectural/architecture/index.md
@@ -21,7 +21,7 @@ Meshery and its components are written using the following languages and technol
 | [Meshery CLI](#meshery-cli)                                          | Golang                                                                            |
 | --- [Extensions](/extensions) ---                                    |                                                                                   |
 | [Meshery Adapters](/concepts/architecture/adapters)                  | Golang, gRPC, [CloudEvents](https://cloudevents.io/)                              |
-| [Meshery Remote Providers](/extensibility/providers)                 | _any_ - must adhere to Meshery [Extension Points]({{site.baseurl}}/extensibility) |
+| [Meshery Remote Providers](/extensibility/providers)                 | _any_ - must adhere to Meshery [Extension Points](/extensibility) |
 | [Envoy WASM Filters](https://github.com/layer5io/wasm-filters)     | Rust and C++                                                                      |
 
 ## Deployments
@@ -97,7 +97,7 @@ Meshery Server's database is responsible for collecting and centralizing the sta
   <figcaption>Figure: Meshery Docker Extension</figcaption>
 </figure>
 
-_See the [**Database**]({{ site.baseurl }}/concepts/architecture/database) section for more information on the function of the database._
+_See the [**Database**](/concepts/architecture/database) section for more information on the function of the database._
 
 ## Meshery Docker Extension
 
@@ -155,9 +155,9 @@ Meshery uses the following list of network ports to interface with its various c
 | <img src="{{ adapter.image }}" style="width:20px" data-logo-for-dark="{{ adapter.white_image }}" data-logo-for-light="{{ adapter.image }}" id="logo-dark-light" loading="lazy"/> [{{ adapter.name }}]({{ site.baseurl }}{{ adapter.url }}) | {{ adapter.port }} | Communication with Meshery Server |
 {% endif -%}
 {% endfor -%}
-| [Meshery Perf]({{ site.baseurl }}/guides/performance-management/managing-performance) | 10013/gRPC    | Performance Management|
+| [Meshery Perf](/guides/performance-management/managing-performance) | 10013/gRPC    | Performance Management|
 
-See the [**Adapters**]({{ site.baseurl }}/concepts/architecture/adapters) section for more information on the function of an adapter.
+See the [**Adapters**](/concepts/architecture/adapters) section for more information on the function of an adapter.
 
 ### **Meshery Connections and their Actions**
 

--- a/docs-new/content/en/concepts/architecture/_index.md
+++ b/docs-new/content/en/concepts/architecture/_index.md
@@ -21,7 +21,7 @@ Meshery and its components are written using the following languages and technol
 | [Meshery CLI](#meshery-cli)                                          | Golang                                                                            |
 | --- [Extensions](/extensions) ---                                    |                                                                                   |
 | [Meshery Adapters](/concepts/architecture/adapters)                  | Golang, gRPC, [CloudEvents](https://cloudevents.io/)                              |
-| [Meshery Remote Providers](/extensibility/providers)                 | _any_ - must adhere to Meshery [Extension Points]({{site.baseurl}}/extensibility) |
+| [Meshery Remote Providers](/extensibility/providers)                 | _any_ - must adhere to Meshery [Extension Points](/extensibility) |
 | [Envoy WASM Filters](https://github.com/layer5io/wasm-filters)     | Rust and C++                                                                      |
 
 ## Deployments
@@ -155,9 +155,9 @@ Meshery uses the following list of network ports to interface with its various c
 | <img src="{{ adapter.image }}" style="width:20px" data-logo-for-dark="{{ adapter.white_image }}" data-logo-for-light="{{ adapter.image }}" id="logo-dark-light" loading="lazy"/> [{{ adapter.name }}]({{ site.baseurl }}{{ adapter.url }}) | {{ adapter.port }} | Communication with Meshery Server |
 {% endif -%}
 {% endfor -%}
-| [Meshery Perf]({{ site.baseurl }}/guides/performance-management/managing-performance) | 10013/gRPC    | Performance Management|
+| [Meshery Perf](/guides/performance-management/managing-performance) | 10013/gRPC    | Performance Management|
 
-See the [**Adapters**]({{ site.baseurl }}/concepts/architecture/adapters) section for more information on the function of an adapter.
+See the [**Adapters**](/concepts/architecture/adapters) section for more information on the function of an adapter.
 
 ### **Meshery Connections and their Actions**
 

--- a/docs-new/content/en/concepts/logical/components/index.md
+++ b/docs-new/content/en/concepts/logical/components/index.md
@@ -47,8 +47,8 @@ Once registered with Meshery Server (in the [Registry](./registry)), components 
 
 Components having the same `kind`, `apiVersion` and `model.name` attributes are considered duplicates.
 
-<!-- [![Meshery Components]({{ site.baseurl }}/assets/img/architecture/meshery-components.svg
-)]({{ site.baseurl }}/assets/img/architecture/meshery-components.svg) -->
+<!-- [![Meshery Components](/assets/img/architecture/meshery-components.svg
+)](/assets/img/architecture/meshery-components.svg) -->
 <!-- 
  @leecalcote - This is mumbo jumbo to users and needs to be re-written.
 

--- a/docs-new/content/en/extensions/_index.md
+++ b/docs-new/content/en/extensions/_index.md
@@ -13,7 +13,7 @@ Extensions in Meshery are additional plugins or add-ons that provide extra funct
 <ul>
     {% for item in sorted_pages %}
     {% if item.type=="extensions" and item.language=="en" -%}
-      <li><a href="{{ site.baseurl }}{{ item.url }}">{{ item.title }}</a>
+      <li><a href="{{ item.url }}">{{ item.title }}</a>
       {% if item.abstract != " " %}
         -  {{ item.abstract }}
       {% endif %}

--- a/docs-new/content/en/guides/configuration-management/configuration-management/index.md
+++ b/docs-new/content/en/guides/configuration-management/configuration-management/index.md
@@ -61,7 +61,7 @@ mesheryctl design apply BookInfoApp
 
 This will apply the pattern BookInfoApp, which has already been imported into Meshery.
 
-See [mesheryctl design subcommand section]({{ site.baseurl }}/reference/mesheryctl/#cloud-native-pattern-configuration-and-management) for more details on the `design` subcommand.
+See [mesheryctl design subcommand section](/reference/mesheryctl/#cloud-native-pattern-configuration-and-management) for more details on the `design` subcommand.
 
 ## WASM Filters
 
@@ -75,7 +75,7 @@ Like patterns, Meshery also comes with some sample WebAssembly Filters for you t
 
 You can also import these filters manually to your provider from the [wasm-filters](https://github.com/layer5io/wasm-filters) repo.
 
-Meshery's sample application [ImageHub]({{ site.baseurl }}/guides/infrastructure-management/sample-apps) will let you test out configuring these filters out-of-the-box.
+Meshery's sample application [ImageHub](/guides/infrastructure-management/sample-apps) will let you test out configuring these filters out-of-the-box.
 
 You can onboard ImageHub to an installed service mesh as shown below.
 

--- a/docs-new/content/en/guides/tutorials/exploring-kubernetes-cronjobs.md
+++ b/docs-new/content/en/guides/tutorials/exploring-kubernetes-cronjobs.md
@@ -144,7 +144,7 @@ Use Meshery Playground to visualize the changes and observe the impact on the sc
     Within the design canvas, find the representation of the CronJob you wish to delete. It should be labeled as "CronJob" or have a specific icon associated with CronJobs.
 2. Select the CronJob Component:
     Click on the CronJob component to open the tooltip. This action will enable access to the delete icon. Click to delete the CronJob.
-    [![Save CronJob]({{site.baseurl}}/assets/img/kanvas/delete.png)]({{site.baseurl}}/assets/img/kanvas/delete.png)
+    [![Save CronJob](/assets/img/kanvas/delete.png)](/assets/img/kanvas/delete.png)
 3. Save Changes:
     After deleting the CronJob, save the changes made within the Kanvas Designer interface to reflect the cleanup.
     [![Save CronJob](/guides/tutorials/images/save-app.png)](/guides/tutorials/images/save-app.png)


### PR DESCRIPTION
**Notes for Reviewers**
This PR remove the leading site.baseURL on urls inside the docs-new folder.
This PR did not touch or remove the site.baseURL whenener it is concatenated (not starting a url) with another variable like adapter.name. Because I thought that on that part the site.baseURL should be updated with the adapter variable, and handle accordingly.
This PR did not also touch or update the Site.BaseURL (with the capital **S** on Site and **B** on BaseURL)

- This PR fixes #17465

**[Signed commits](https://github.com/meshery/meshery/blob/master/CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [x] Yes, I signed my commits.

<!--
Thank you for contributing to Meshery! 

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. Sign your commits.
4. Include before and after screenshots/terminal output.

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.
-->
