### PR TITLE
ui: replace hardcoded honeycomb colors with Sistent tokens

### DIFF
--- a/ui/components/Dashboard/style.ts
+++ b/ui/components/Dashboard/style.ts
@@ -72,7 +72,10 @@ export const HoneycombContainer = styled('ul')(({ columnSize, columns, rowSize }
 }));
 
 export const HexagonWrapper = styled('div')(({ theme }) => ({
-  backgroundColor: theme.palette.mode === 'dark' ? '#363636' : '#e9eff1', // TODO: this is the honeycomb color add this token in sistent
+  backgroundColor:
+    theme.palette.mode === 'dark'
+      ? theme.palette.background.constant?.table
+      : theme.palette.background.code,
   position: 'absolute',
   inset: '3.5px',
   display: 'flex',
@@ -106,7 +109,10 @@ export const SelectedHexagon = styled('div')({
 export const SkeletonHexagon = styled('div')(({ theme }) => ({
   display: 'flex',
   height: '95%',
-  backgroundColor: theme.palette.mode === 'dark' ? '#363636' : '#e9eff1', // TODO: this is the honeycomb color add this token in sistent
+  backgroundColor:
+    theme.palette.mode === 'dark'
+      ? theme.palette.background.constant?.table
+      : theme.palette.background.code,
   justifyContent: 'center',
   alignItems: 'center',
   opacity: 0.5,


### PR DESCRIPTION

<img width="1346" height="386" alt="Screenshot 2026-02-17 124605" src="https://github.com/user-attachments/assets/299fee2c-40eb-4b81-8851-516fd4d349bc" />
<img width="1325" height="350" alt="Screenshot 2026-02-17 124626" src="https://github.com/user-attachments/assets/39e91035-db39-4876-818f-a72c09406143" />
**Notes for Reviewers**

- This PR fixes #

**[Signed commits](https://github.com/meshery/meshery/blob/master/CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [ ] Yes, I signed my commits.

<!--
Thank you for contributing to Meshery! 

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. Sign your commits.
4. Include before and after screenshots/terminal output.

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.
-->
