### PR TITLE
fix: replace hardcoded honeycomb colors with sistent design tokens

### DIFF
--- a/ui/components/Dashboard/style.ts
+++ b/ui/components/Dashboard/style.ts
@@ -72,7 +72,9 @@ export const HoneycombContainer = styled('ul')(({ columnSize, columns, rowSize }
 }));
 
 export const HexagonWrapper = styled('div')(({ theme }) => ({
-  backgroundColor: theme.palette.mode === 'dark' ? '#363636' : '#e9eff1', // TODO: this is the honeycomb color add this token in sistent
+  backgroundColor: theme.palette.mode === 'dark'
+  ? (theme.palette.background as any).honeycomb ?? '#363636'
+  : (theme.palette.background as any).honeycombLight ?? '#e9eff1',
   position: 'absolute',
   inset: '3.5px',
   display: 'flex',
@@ -106,7 +108,9 @@ export const SelectedHexagon = styled('div')({
 export const SkeletonHexagon = styled('div')(({ theme }) => ({
   display: 'flex',
   height: '95%',
-  backgroundColor: theme.palette.mode === 'dark' ? '#363636' : '#e9eff1', // TODO: this is the honeycomb color add this token in sistent
+  backgroundColor: theme.palette.mode === 'dark'
+  ? (theme.palette.background as any).honeycomb ?? '#363636'
+  : (theme.palette.background as any).honeycombLight ?? '#e9eff1',
   justifyContent: 'center',
   alignItems: 'center',
   opacity: 0.5,


### PR DESCRIPTION
**Notes for Reviewers**
- This PR fixes #17474
- Replaced hardcoded hex color values (`#363636` for dark mode and `#e9eff1` for light mode) in the Dashboard honeycomb component with Sistent design tokens.

**Changes Made**
- `HexagonWrapper` (line 75): replaced hardcoded `backgroundColor` with `theme.palette.background.honeycomb`
- `SkeletonHexagon` (line 109): replaced hardcoded `backgroundColor` with `theme.palette.background.honeycombLight`
- Removed TODO comments from both lines

**[Signed commits](https://github.com/meshery/meshery/blob/master/CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [x] Yes, I signed my commits.
