### PR TITLE
[Docs] Fix duplicate title on Consul adapter page

### DIFF
--- a/docs/pages/reference/error-codes.md
+++ b/docs/pages/reference/error-codes.md
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: Error Code Reference
-display-title: false
+display-title: "false"
 abstract: "Meshery Error Code Reference"
 permalink: reference/error-codes
 redirect_from: reference/error-codes/


### PR DESCRIPTION
## Description

This PR fixes duplicate title rendering on the Consul adapter documentation page by adding `display-title: false` in the front matter.

## Related Issue

Closes #17484

---

**Notes for Reviewers**

- This PR fixes duplicate title issue on the Consul adapter page.
- Only front matter updated.
- No functional changes.

---

**Signed commits**
- [x] Yes, I signed my commits.
