### PR TITLE
[Docs] Update mesheryctl install script URL

### DIFF
--- a/docs/_includes/mesheryctl/installation-bash.md
+++ b/docs/_includes/mesheryctl/installation-bash.md
@@ -6,7 +6,7 @@ To install or upgrade `mesheryctl` using `bash`, execute anyone of the following
  <pre class="codeblock-pre">
  <div class="codeblock">
  <div class="clipboardjs">
-  $ curl -L https://meshery.io/install | DEPLOY_MESHERY=false bash -
+  $ curl -L https://get.meshery.io | DEPLOY_MESHERY=false bash -
  </div></div>
  </pre>
 <br />
@@ -16,7 +16,7 @@ To install or upgrade `mesheryctl` using `bash`, execute anyone of the following
  <pre class="codeblock-pre">
  <div class="codeblock">
  <div class="clipboardjs">
-  $ curl -L https://meshery.io/install | PLATFORM=docker bash -
+  $ curl -L https://get.meshery.io | PLATFORM=docker bash -
  </div></div>
  </pre>
 <br />
@@ -26,7 +26,7 @@ To install or upgrade `mesheryctl` using `bash`, execute anyone of the following
  <pre class="codeblock-pre">
  <div class="codeblock">
  <div class="clipboardjs">
-  $ curl -L https://meshery.io/install | PLATFORM=kubernetes bash -
+  $ curl -L https://get.meshery.io | PLATFORM=kubernetes bash -
  </div></div>
  </pre>
 <br />
@@ -38,7 +38,7 @@ Install `mesheryctl` binary and include one or more [adapters]({{ site.baseurl }
  <pre class="codeblock-pre">
  <div class="codeblock">
  <div class="clipboardjs">
-  $ curl -L https://meshery.io/install | ADAPTERS=consul PLATFORM=kubernetes bash -
+  $ curl -L https://get.meshery.io | ADAPTERS=consul PLATFORM=kubernetes bash -
  </div></div>
  </pre>
 <br />


### PR DESCRIPTION
This PR updates the mesheryctl installation script URL from meshery.io/install to get.meshery.io.

Fixes #12503


**[Signed commits](https://github.com/meshery/meshery/blob/master/CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [ ] Yes, I signed my commits.

<!--
Thank you for contributing to Meshery! 

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. Sign your commits.
4. Include before and after screenshots/terminal output.

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.
-->
