### PR TITLE
[mesheryctl] Fix GetPageQueryParameter to convert to zero-indexed page

### DIFF
--- a/mesheryctl/pkg/utils/helpers.go
+++ b/mesheryctl/pkg/utils/helpers.go
@@ -1287,7 +1287,7 @@ func GetPageQueryParameter(cmd *cobra.Command, page int) string {
 	if !cmd.Flags().Changed("page") {
 		return "pagesize=all"
 	}
-	return fmt.Sprintf("page=%d", page)
+	return fmt.Sprintf("page=%d", page-1)
 }
 func IsValidUrl(path string) bool {
 	u, err := url.Parse(path)


### PR DESCRIPTION

**Notes for Reviewers**

- This PR fixes #17490 

**Before**
<img width="1625" height="298" alt="image" src="https://github.com/user-attachments/assets/bd2ecdcd-618d-45ac-9e03-148e2e662127" />

**After**
<img width="1849" height="275" alt="image" src="https://github.com/user-attachments/assets/ad16ce46-7698-4d84-b608-26b3a53410ed" />


**[Signed commits](https://github.com/meshery/meshery/blob/master/CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [x] Yes, I signed my commits.



<!--
Thank you for contributing to Meshery! 

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. Sign your commits.
4. Include before and after screenshots/terminal output.

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.
-->
