### PR TITLE
[Docs] Fix URL for related discussions include section

### DIFF
--- a/docs/_includes/related-discussions.html
+++ b/docs/_includes/related-discussions.html
@@ -29,7 +29,7 @@
   <!-- -->
   <li class="post">
     <span class="post-date"> {{ post.created_at | date: "%b %d" }} | </span>
-    <a href="http://discuss.layer5.io/t/{{ post.slug }}/{{ post.id }}"> {{ post.title }}</a>
+    <a href="https://discuss.layer5.io/t/{{ post.slug }}/{{ post.id }}"> {{ post.title }}</a>
     <span class="poost-author">
       {%for user in users%} {% if(post.posters[0].user_id == user.id)%} {%assign author = user.name%} {%break%}
       {%endif%} {%endfor%} by {{author}}


### PR DESCRIPTION
**Notes for Reviewers**

- This PR fixes #17489

**Summary**

This PR updates the incorrect discuss URL in the `related-discussions.html` include file.

Replaced:
http://discuss.meshery.io

With:
http://discuss.layer5.io

This resolves the SSL error encountered when clicking related discussion links.

**[Signed commits](https://github.com/meshery/meshery/blob/master/CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [x] Yes, I signed my commits.
