### PR TITLE
Add night and light mode toggle functionality

### DIFF
--- a/docs-new/layouts/_default/baseof.html
+++ b/docs-new/layouts/_default/baseof.html
@@ -3,19 +3,12 @@
   <head>
     {{ partialCached "head.html" (dict "Title" .Title "Description" .Params.abstract "Site" .Site) .RelPermalink }}
     {{ partialCached "header.html" . .RelPermalink }}
+    <script src="{{ "js/mode-toggle.js" | relURL }}"></script>
     <script src="https://cdn.jsdelivr.net/npm/clipboard@1/dist/clipboard.min.js"></script>
     <script src="{{ .Site.BaseURL }}assets/js/error-code-handler.js"></script>
   </head>
 
   <body class="td-{{ .Kind }} dark-mode {{ with .Params.body_class }}{{ . }}{{ end }}">
-    <script>
-      if (localStorage.getItem("mode") === "light-mode") {
-        document.body.classList.remove("dark-mode");
-        document.querySelectorAll("#logo-dark-light").forEach(e => {
-          e.src = e.dataset.logoForLight;
-        });
-      }
-    </script>
 
     {{ partialCached "scripts/google-tagmanager-body.html" . }}
 

--- a/docs-new/layouts/partials/header.html
+++ b/docs-new/layouts/partials/header.html
@@ -89,9 +89,9 @@
       <button class="nav-mode-icon" id="mode-toggle-btn">
         <img
           id="logo-dark-light"
-          src="{{ .Site.BaseURL }}images/nav-icons/mode-toggle-icon-moon.png"
-          data-logo-for-dark="{{ .Site.BaseURL }}images/nav-icons/mode-toggle-icon-moon.png"
-          data-logo-for-light="{{ .Site.BaseURL }}images/nav-icons/mode-toggle-icon-sun.png"
+          src="{{ "images/nav-icons/mode-toggle-icon-moon.png" | relURL }}"
+          data-logo-for-dark="{{ "images/nav-icons/mode-toggle-icon-moon.png" | relURL }}"
+          data-logo-for-light="{{ "images/nav-icons/mode-toggle-icon-sun.png" | relURL }}"
         />
       </button>
     </div>

--- a/docs-new/static/js/mode-toggle.js
+++ b/docs-new/static/js/mode-toggle.js
@@ -1,0 +1,40 @@
+document.addEventListener("DOMContentLoaded", function () {
+  const toggleBtn = document.getElementById("mode-toggle-btn");
+  const logo = document.getElementById("logo-dark-light");
+  const body = document.querySelector("body");
+
+  // Load saved theme if available
+  let savedTheme = localStorage.getItem("mode");
+  let isDark;
+
+  if (savedTheme === "dark") {
+    body.classList.add("dark-mode");
+    logo.src = logo.dataset.logoForDark;
+    isDark = true;
+  } else if (savedTheme === "light") {
+    body.classList.remove("dark-mode");
+    logo.src = logo.dataset.logoForLight;
+    isDark = false;
+  } else {
+    // No saved theme — fallback to OS preference
+    const osPrefersDark = window.matchMedia('(prefers-color-scheme: dark)').matches;
+    if (osPrefersDark) {
+      body.classList.add("dark-mode");
+      logo.src = logo.dataset.logoForDark;
+      isDark = true;
+    } else {
+      body.classList.remove("dark-mode");
+      logo.src = logo.dataset.logoForLight;
+      isDark = false;
+    }
+  }
+
+  // Toggle button
+  toggleBtn.addEventListener("click", function () {
+    isDark = !isDark;
+    body.classList.toggle("dark-mode");
+    logo.src = isDark ? logo.dataset.logoForDark : logo.dataset.logoForLight;
+    localStorage.setItem("mode", isDark ? "dark" : "light");
+  });
+});
+


### PR DESCRIPTION
**Notes for Reviewers**

The migration from Jekyll to Hugo still on process.
The new docs (Hugo) does not support the light/night mode toggle functionality yet.
This PR aims to add that functionality.

Here is the video reflecting the change

https://github.com/user-attachments/assets/aa2d7d15-f492-49f8-b07e-fd6719423563



- This PR fixes #17492

**[Signed commits](https://github.com/meshery/meshery/blob/master/CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [x] Yes, I signed my commits.

<!--
Thank you for contributing to Meshery! 

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. Sign your commits.
4. Include before and after screenshots/terminal output.

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.
-->
