### PR TITLE
[Models]Add AWS relationships for IAM Role → EKS Cluster / NodeGroup

### DIFF
--- a/server/meshmodel/aws-iam-controller/v1.6.1/v1.0.0/relationships/edge-binding-permission-role-cluster.json
+++ b/server/meshmodel/aws-iam-controller/v1.6.1/v1.0.0/relationships/edge-binding-permission-role-cluster.json
@@ -1,0 +1,98 @@
+{
+  "id": "00000000-0000-0000-0000-000000000000",
+  "evaluationQuery": "edge_binding_permission_relationship",
+  "kind": "edge",
+  "metadata": {
+    "description": "Defines the permission relationship between an AWS IAM Role and an Amazon EKS Cluster. The IAM Role must be attached to the EKS Cluster as its cluster IAM role (roleARN), granting the Kubernetes control plane the necessary permissions to make AWS API calls on your behalf.",
+    "styles": {
+      "primaryColor": "",
+      "svgColor": "",
+      "svgWhite": ""
+    },
+    "isAnnotation": false
+  },
+  "model": {
+    "version": "",
+    "name": "aws-iam-controller",
+    "displayName": "AWS IAM Controller",
+    "id": "00000000-0000-0000-0000-000000000000",
+    "registrant": {
+      "kind": "artifacthub"
+    },
+    "model": {
+      "version": "v1.6.1"
+    }
+  },
+  "schemaVersion": "relationships.meshery.io/v1alpha3",
+  "selectors": [
+    {
+      "allow": {
+        "from": [
+          {
+            "id": null,
+            "kind": "Role",
+            "match": {},
+            "match_strategy_matrix": null,
+            "model": {
+              "name": "aws-iam-controller",
+              "registrant": {
+                "kind": "artifacthub"
+              },
+              "model": {
+                "version": ""
+              }
+            },
+            "patch": {
+              "patchStrategy": "replace",
+              "mutatorRef": [
+                [
+                  "configuration",
+                  "status",
+                  "ackResourceMetadata",
+                  "arn"
+                ]
+              ],
+              "description": "The IAM Role whose ARN will be assigned to the EKS Cluster as its cluster IAM role. This grants the Kubernetes control plane the necessary permissions to make AWS API calls on your behalf."
+            }
+          }
+        ],
+        "to": [
+          {
+            "id": null,
+            "kind": "Cluster",
+            "match": {},
+            "match_strategy_matrix": null,
+            "model": {
+              "name": "aws-eks-controller",
+              "registrant": {
+                "kind": "artifacthub"
+              },
+              "model": {
+                "version": ""
+              }
+            },
+            "patch": {
+              "patchStrategy": "replace",
+              "mutatedRef": [
+                [
+                  "configuration",
+                  "spec",
+                  "roleARN"
+                ]
+              ],
+              "description": "The EKS Cluster that receives the IAM Role ARN in its spec.roleARN field (or the role name in spec.roleRef.from.name), authorising the control plane to make AWS API calls."
+            }
+          }
+        ]
+      },
+      "deny": {
+        "from": [],
+        "to": []
+      }
+    }
+  ],
+  "subType": "permission",
+  "status": "enabled",
+  "type": "non-binding",
+  "version": "v1.0.0"
+}

--- a/server/meshmodel/aws-iam-controller/v1.6.1/v1.0.0/relationships/edge-binding-permission-role-nodegroup.json
+++ b/server/meshmodel/aws-iam-controller/v1.6.1/v1.0.0/relationships/edge-binding-permission-role-nodegroup.json
@@ -1,0 +1,98 @@
+{
+  "id": "00000000-0000-0000-0000-000000000000",
+  "evaluationQuery": "edge_binding_permission_relationship",
+  "kind": "edge",
+  "metadata": {
+    "description": "Defines the permission relationship between an AWS IAM Role and an Amazon EKS NodeGroup. The IAM Role must be attached to the NodeGroup as its node IAM role (nodeRole ARN), granting worker nodes the permissions required to register with the cluster and make AWS API calls via the kubelet.",
+    "styles": {
+      "primaryColor": "",
+      "svgColor": "",
+      "svgWhite": ""
+    },
+    "isAnnotation": false
+  },
+  "model": {
+    "version": "",
+    "name": "aws-iam-controller",
+    "displayName": "AWS IAM Controller",
+    "id": "00000000-0000-0000-0000-000000000000",
+    "registrant": {
+      "kind": "artifacthub"
+    },
+    "model": {
+      "version": "v1.6.1"
+    }
+  },
+  "schemaVersion": "relationships.meshery.io/v1alpha3",
+  "selectors": [
+    {
+      "allow": {
+        "from": [
+          {
+            "id": null,
+            "kind": "Role",
+            "match": {},
+            "match_strategy_matrix": null,
+            "model": {
+              "name": "aws-iam-controller",
+              "registrant": {
+                "kind": "artifacthub"
+              },
+              "model": {
+                "version": ""
+              }
+            },
+            "patch": {
+              "patchStrategy": "replace",
+              "mutatorRef": [
+                [
+                  "configuration",
+                  "status",
+                  "ackResourceMetadata",
+                  "arn"
+                ]
+              ],
+              "description": "The IAM Role whose ARN will be assigned to the EKS NodeGroup as its node instance role. This grants worker nodes the permissions needed to register with the cluster and make AWS API calls via the kubelet daemon."
+            }
+          }
+        ],
+        "to": [
+          {
+            "id": null,
+            "kind": "Nodegroup",
+            "match": {},
+            "match_strategy_matrix": null,
+            "model": {
+              "name": "aws-eks-controller",
+              "registrant": {
+                "kind": "artifacthub"
+              },
+              "model": {
+                "version": ""
+              }
+            },
+            "patch": {
+              "patchStrategy": "replace",
+              "mutatedRef": [
+                [
+                  "configuration",
+                  "spec",
+                  "nodeRole"
+                ]
+              ],
+              "description": "The EKS NodeGroup that receives the IAM Role ARN in its spec.nodeRole field (or the role name in spec.nodeRoleRef.from.name), authorising the worker nodes to make AWS API calls."
+            }
+          }
+        ]
+      },
+      "deny": {
+        "from": [],
+        "to": []
+      }
+    }
+  ],
+  "subType": "permission",
+  "status": "enabled",
+  "type": "non-binding",
+  "version": "v1.0.0"
+}


### PR DESCRIPTION
## What does this PR do?

Adds **AWS IAM EKS Infrastructure binding relationships** to Meshery, enabling the assignment of **IAM Roles to EKS Clusters and Node Groups** for proper control plane and worker node authorization.

## Related Issue

**Contributes to #17096** (Relationships for AWS Services)

## Changes

Added **2 new binding relationships** between **`aws-iam-controller`** and **`aws-eks-controller`**:

1. **`IAM Role → EKS Cluster`** (`edge-binding-permission-role-cluster.json`)
   - Binds the Service Role ARN to `spec.roleArn`.
2. **`IAM Role → EKS NodeGroup`** (`edge-binding-permission-role-nodegroup.json`)
   - Binds the Worker Node Role ARN to `nodeRole`.

**All follow `relationships.meshery.io/v1alpha3` schema**


## Testing

- [x] **Kanvas Validation**: 
  - IAM Role → EKS Cluster
  - IAM Role → EKS NodeGroup

**Screenshot Proof:**


<img width="1920" height="1080" alt="Screenshot from 2026-02-19 00-29-50" src="https://github.com/user-attachments/assets/5889b2b2-61bf-46a0-8138-1753db63a88e" />