### PR TITLE
[Models] Add hierarchical relationships for AWS APIGatewayV2 controller

### DIFF
--- a/server/meshmodel/aws-apigatewayv2-controller/v1.2.1/v1.0.0/relationships/hierarchical-inventory-apimapping-api.json
+++ b/server/meshmodel/aws-apigatewayv2-controller/v1.2.1/v1.0.0/relationships/hierarchical-inventory-apimapping-api.json
@@ -1,0 +1,157 @@
+{
+  "id": "00000000-0000-0000-0000-000000000000",
+  "evaluationQuery": "",
+  "kind": "hierarchical",
+  "metadata": {
+    "description": "API Mapping connects a custom domain path to a specific API.",
+    "styles": {
+      "primaryColor": "",
+      "svgColor": "",
+      "svgWhite": ""
+    },
+    "isAnnotation": false
+  },
+  "model": {
+    "version": "",
+    "name": "aws-apigatewayv2-controller",
+    "displayName": "",
+    "id": "00000000-0000-0000-0000-000000000000",
+    "registrant": {
+      "kind": ""
+    },
+    "model": {
+      "version": "v1.2.1"
+    }
+  },
+  "schemaVersion": "relationships.meshery.io/v1alpha3",
+  "selectors": [
+    {
+      "allow": {
+        "from": [
+          {
+            "id": null,
+            "kind": "APIMapping",
+            "match": {
+              "from": [
+                {
+                  "id": null,
+                  "kind": "APIMapping",
+                  "mutatedRef": [
+                    [
+                      "configuration",
+                      "spec",
+                      "apiID"
+                    ]
+                  ]
+                }
+              ],
+              "to": [
+                {
+                  "id": null,
+                  "kind": "API",
+                  "mutatorRef": [
+                    [
+                      "displayName"
+                    ]
+                  ]
+                }
+              ]
+            },
+            "match_strategy_matrix": [
+              [
+                "to_contains_from"
+              ]
+            ],
+            "model": {
+              "version": "",
+              "name": "aws-apigatewayv2-controller",
+              "displayName": "",
+              "id": "00000000-0000-0000-0000-000000000000",
+              "registrant": {
+                "kind": "github"
+              },
+              "model": {
+                "version": ""
+              }
+            },
+            "patch": {
+              "patchStrategy": "replace",
+              "mutatorRef": [
+                [
+                  "configuration",
+                  "spec",
+                  "apiID"
+                ]
+              ]
+            }
+          }
+        ],
+        "to": [
+          {
+            "id": null,
+            "kind": "API",
+            "match": {
+              "from": [
+                {
+                  "id": null,
+                  "kind": "APIMapping",
+                  "mutatedRef": [
+                    [
+                      "configuration",
+                      "spec",
+                      "apiID"
+                    ]
+                  ]
+                }
+              ],
+              "to": [
+                {
+                  "id": null,
+                  "kind": "self",
+                  "mutatorRef": [
+                    [
+                      "displayName"
+                    ]
+                  ]
+                }
+              ]
+            },
+            "match_strategy_matrix": [
+              [
+                "to_contains_from"
+              ]
+            ],
+            "model": {
+              "version": "",
+              "name": "aws-apigatewayv2-controller",
+              "displayName": "",
+              "id": "00000000-0000-0000-0000-000000000000",
+              "registrant": {
+                "kind": "github"
+              },
+              "model": {
+                "version": ""
+              }
+            },
+            "patch": {
+              "patchStrategy": "replace",
+              "mutatedRef": [
+                [
+                  "displayName"
+                ]
+              ]
+            }
+          }
+        ]
+      },
+      "deny": {
+        "from": [],
+        "to": []
+      }
+    }
+  ],
+  "subType": "inventory",
+  "status": "enabled",
+  "type": "parent",
+  "version": "v1.0.0"
+}

--- a/server/meshmodel/aws-apigatewayv2-controller/v1.2.1/v1.0.0/relationships/hierarchical-inventory-apimapping-api.json
+++ b/server/meshmodel/aws-apigatewayv2-controller/v1.2.1/v1.0.0/relationships/hierarchical-inventory-apimapping-api.json
@@ -51,7 +51,9 @@
                   "kind": "API",
                   "mutatorRef": [
                     [
-                      "displayName"
+                      "configuration",
+                      "spec",
+                      "name"
                     ]
                   ]
                 }
@@ -76,7 +78,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "spec",
@@ -110,7 +112,9 @@
                   "kind": "self",
                   "mutatorRef": [
                     [
-                      "displayName"
+                      "configuration",
+                      "spec",
+                      "name"
                     ]
                   ]
                 }
@@ -135,9 +139,11 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatedRef": [
+              "mutatorRef": [
                 [
-                  "displayName"
+                  "configuration",
+                  "spec",
+                  "name"
                 ]
               ]
             }

--- a/server/meshmodel/aws-apigatewayv2-controller/v1.2.1/v1.0.0/relationships/hierarchical-inventory-apimapping-domainname.json
+++ b/server/meshmodel/aws-apigatewayv2-controller/v1.2.1/v1.0.0/relationships/hierarchical-inventory-apimapping-domainname.json
@@ -51,7 +51,9 @@
                   "kind": "DomainName",
                   "mutatorRef": [
                     [
-                      "displayName"
+                      "configuration",
+                      "spec",
+                      "domainName"
                     ]
                   ]
                 }
@@ -76,7 +78,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "spec",
@@ -110,7 +112,9 @@
                   "kind": "self",
                   "mutatorRef": [
                     [
-                      "displayName"
+                      "configuration",
+                      "spec",
+                      "domainName"
                     ]
                   ]
                 }
@@ -135,9 +139,11 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatedRef": [
+              "mutatorRef": [
                 [
-                  "displayName"
+                  "configuration",
+                  "spec",
+                  "domainName"
                 ]
               ]
             }

--- a/server/meshmodel/aws-apigatewayv2-controller/v1.2.1/v1.0.0/relationships/hierarchical-inventory-apimapping-domainname.json
+++ b/server/meshmodel/aws-apigatewayv2-controller/v1.2.1/v1.0.0/relationships/hierarchical-inventory-apimapping-domainname.json
@@ -1,0 +1,157 @@
+{
+  "id": "00000000-0000-0000-0000-000000000000",
+  "evaluationQuery": "",
+  "kind": "hierarchical",
+  "metadata": {
+    "description": "API Mapping is logically contained within an API Gateway Domain Name.",
+    "styles": {
+      "primaryColor": "",
+      "svgColor": "",
+      "svgWhite": ""
+    },
+    "isAnnotation": false
+  },
+  "model": {
+    "version": "",
+    "name": "aws-apigatewayv2-controller",
+    "displayName": "",
+    "id": "00000000-0000-0000-0000-000000000000",
+    "registrant": {
+      "kind": ""
+    },
+    "model": {
+      "version": "v1.2.1"
+    }
+  },
+  "schemaVersion": "relationships.meshery.io/v1alpha3",
+  "selectors": [
+    {
+      "allow": {
+        "from": [
+          {
+            "id": null,
+            "kind": "APIMapping",
+            "match": {
+              "from": [
+                {
+                  "id": null,
+                  "kind": "APIMapping",
+                  "mutatedRef": [
+                    [
+                      "configuration",
+                      "spec",
+                      "domainName"
+                    ]
+                  ]
+                }
+              ],
+              "to": [
+                {
+                  "id": null,
+                  "kind": "DomainName",
+                  "mutatorRef": [
+                    [
+                      "displayName"
+                    ]
+                  ]
+                }
+              ]
+            },
+            "match_strategy_matrix": [
+              [
+                "to_contains_from"
+              ]
+            ],
+            "model": {
+              "version": "",
+              "name": "aws-apigatewayv2-controller",
+              "displayName": "",
+              "id": "00000000-0000-0000-0000-000000000000",
+              "registrant": {
+                "kind": "github"
+              },
+              "model": {
+                "version": ""
+              }
+            },
+            "patch": {
+              "patchStrategy": "replace",
+              "mutatorRef": [
+                [
+                  "configuration",
+                  "spec",
+                  "domainName"
+                ]
+              ]
+            }
+          }
+        ],
+        "to": [
+          {
+            "id": null,
+            "kind": "DomainName",
+            "match": {
+              "from": [
+                {
+                  "id": null,
+                  "kind": "APIMapping",
+                  "mutatedRef": [
+                    [
+                      "configuration",
+                      "spec",
+                      "domainName"
+                    ]
+                  ]
+                }
+              ],
+              "to": [
+                {
+                  "id": null,
+                  "kind": "self",
+                  "mutatorRef": [
+                    [
+                      "displayName"
+                    ]
+                  ]
+                }
+              ]
+            },
+            "match_strategy_matrix": [
+              [
+                "to_contains_from"
+              ]
+            ],
+            "model": {
+              "version": "",
+              "name": "aws-apigatewayv2-controller",
+              "displayName": "",
+              "id": "00000000-0000-0000-0000-000000000000",
+              "registrant": {
+                "kind": "github"
+              },
+              "model": {
+                "version": ""
+              }
+            },
+            "patch": {
+              "patchStrategy": "replace",
+              "mutatedRef": [
+                [
+                  "displayName"
+                ]
+              ]
+            }
+          }
+        ]
+      },
+      "deny": {
+        "from": [],
+        "to": []
+      }
+    }
+  ],
+  "subType": "inventory",
+  "status": "enabled",
+  "type": "parent",
+  "version": "v1.0.0"
+}

--- a/server/meshmodel/aws-apigatewayv2-controller/v1.2.1/v1.0.0/relationships/hierarchical-inventory-authorizer-api.json
+++ b/server/meshmodel/aws-apigatewayv2-controller/v1.2.1/v1.0.0/relationships/hierarchical-inventory-authorizer-api.json
@@ -1,0 +1,157 @@
+{
+  "id": "00000000-0000-0000-0000-000000000000",
+  "evaluationQuery": "",
+  "kind": "hierarchical",
+  "metadata": {
+    "description": "API Gateway v2 Authorizer is logically contained within an API.",
+    "styles": {
+      "primaryColor": "",
+      "svgColor": "",
+      "svgWhite": ""
+    },
+    "isAnnotation": false
+  },
+  "model": {
+    "version": "",
+    "name": "aws-apigatewayv2-controller",
+    "displayName": "",
+    "id": "00000000-0000-0000-0000-000000000000",
+    "registrant": {
+      "kind": ""
+    },
+    "model": {
+      "version": "v1.2.1"
+    }
+  },
+  "schemaVersion": "relationships.meshery.io/v1alpha3",
+  "selectors": [
+    {
+      "allow": {
+        "from": [
+          {
+            "id": null,
+            "kind": "Authorizer",
+            "match": {
+              "from": [
+                {
+                  "id": null,
+                  "kind": "Authorizer",
+                  "mutatedRef": [
+                    [
+                      "configuration",
+                      "spec",
+                      "apiID"
+                    ]
+                  ]
+                }
+              ],
+              "to": [
+                {
+                  "id": null,
+                  "kind": "API",
+                  "mutatorRef": [
+                    [
+                      "displayName"
+                    ]
+                  ]
+                }
+              ]
+            },
+            "match_strategy_matrix": [
+              [
+                "to_contains_from"
+              ]
+            ],
+            "model": {
+              "version": "",
+              "name": "aws-apigatewayv2-controller",
+              "displayName": "",
+              "id": "00000000-0000-0000-0000-000000000000",
+              "registrant": {
+                "kind": "github"
+              },
+              "model": {
+                "version": ""
+              }
+            },
+            "patch": {
+              "patchStrategy": "replace",
+              "mutatorRef": [
+                [
+                  "configuration",
+                  "spec",
+                  "apiID"
+                ]
+              ]
+            }
+          }
+        ],
+        "to": [
+          {
+            "id": null,
+            "kind": "API",
+            "match": {
+              "from": [
+                {
+                  "id": null,
+                  "kind": "Authorizer",
+                  "mutatedRef": [
+                    [
+                      "configuration",
+                      "spec",
+                      "apiID"
+                    ]
+                  ]
+                }
+              ],
+              "to": [
+                {
+                  "id": null,
+                  "kind": "self",
+                  "mutatorRef": [
+                    [
+                      "displayName"
+                    ]
+                  ]
+                }
+              ]
+            },
+            "match_strategy_matrix": [
+              [
+                "to_contains_from"
+              ]
+            ],
+            "model": {
+              "version": "",
+              "name": "aws-apigatewayv2-controller",
+              "displayName": "",
+              "id": "00000000-0000-0000-0000-000000000000",
+              "registrant": {
+                "kind": "github"
+              },
+              "model": {
+                "version": ""
+              }
+            },
+            "patch": {
+              "patchStrategy": "replace",
+              "mutatedRef": [
+                [
+                  "displayName"
+                ]
+              ]
+            }
+          }
+        ]
+      },
+      "deny": {
+        "from": [],
+        "to": []
+      }
+    }
+  ],
+  "subType": "inventory",
+  "status": "enabled",
+  "type": "parent",
+  "version": "v1.0.0"
+}

--- a/server/meshmodel/aws-apigatewayv2-controller/v1.2.1/v1.0.0/relationships/hierarchical-inventory-authorizer-api.json
+++ b/server/meshmodel/aws-apigatewayv2-controller/v1.2.1/v1.0.0/relationships/hierarchical-inventory-authorizer-api.json
@@ -51,7 +51,9 @@
                   "kind": "API",
                   "mutatorRef": [
                     [
-                      "displayName"
+                      "configuration",
+                      "spec",
+                      "name"
                     ]
                   ]
                 }
@@ -76,7 +78,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "spec",
@@ -110,7 +112,9 @@
                   "kind": "self",
                   "mutatorRef": [
                     [
-                      "displayName"
+                      "configuration",
+                      "spec",
+                      "name"
                     ]
                   ]
                 }
@@ -135,9 +139,11 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatedRef": [
+              "mutatorRef": [
                 [
-                  "displayName"
+                  "configuration",
+                  "spec",
+                  "name"
                 ]
               ]
             }

--- a/server/meshmodel/aws-apigatewayv2-controller/v1.2.1/v1.0.0/relationships/hierarchical-inventory-deployment-api.json
+++ b/server/meshmodel/aws-apigatewayv2-controller/v1.2.1/v1.0.0/relationships/hierarchical-inventory-deployment-api.json
@@ -51,7 +51,9 @@
                   "kind": "API",
                   "mutatorRef": [
                     [
-                      "displayName"
+                      "configuration",
+                      "spec",
+                      "name"
                     ]
                   ]
                 }
@@ -76,7 +78,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "spec",
@@ -110,7 +112,9 @@
                   "kind": "self",
                   "mutatorRef": [
                     [
-                      "displayName"
+                      "configuration",
+                      "spec",
+                      "name"
                     ]
                   ]
                 }
@@ -135,9 +139,11 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatedRef": [
+              "mutatorRef": [
                 [
-                  "displayName"
+                  "configuration",
+                  "spec",
+                  "name"
                 ]
               ]
             }

--- a/server/meshmodel/aws-apigatewayv2-controller/v1.2.1/v1.0.0/relationships/hierarchical-inventory-deployment-api.json
+++ b/server/meshmodel/aws-apigatewayv2-controller/v1.2.1/v1.0.0/relationships/hierarchical-inventory-deployment-api.json
@@ -1,0 +1,157 @@
+{
+  "id": "00000000-0000-0000-0000-000000000000",
+  "evaluationQuery": "",
+  "kind": "hierarchical",
+  "metadata": {
+    "description": "API Gateway v2 Deployment is logically contained within an API.",
+    "styles": {
+      "primaryColor": "",
+      "svgColor": "",
+      "svgWhite": ""
+    },
+    "isAnnotation": false
+  },
+  "model": {
+    "version": "",
+    "name": "aws-apigatewayv2-controller",
+    "displayName": "",
+    "id": "00000000-0000-0000-0000-000000000000",
+    "registrant": {
+      "kind": ""
+    },
+    "model": {
+      "version": "v1.2.1"
+    }
+  },
+  "schemaVersion": "relationships.meshery.io/v1alpha3",
+  "selectors": [
+    {
+      "allow": {
+        "from": [
+          {
+            "id": null,
+            "kind": "Deployment",
+            "match": {
+              "from": [
+                {
+                  "id": null,
+                  "kind": "Deployment",
+                  "mutatedRef": [
+                    [
+                      "configuration",
+                      "spec",
+                      "apiID"
+                    ]
+                  ]
+                }
+              ],
+              "to": [
+                {
+                  "id": null,
+                  "kind": "API",
+                  "mutatorRef": [
+                    [
+                      "displayName"
+                    ]
+                  ]
+                }
+              ]
+            },
+            "match_strategy_matrix": [
+              [
+                "to_contains_from"
+              ]
+            ],
+            "model": {
+              "version": "",
+              "name": "aws-apigatewayv2-controller",
+              "displayName": "",
+              "id": "00000000-0000-0000-0000-000000000000",
+              "registrant": {
+                "kind": "github"
+              },
+              "model": {
+                "version": ""
+              }
+            },
+            "patch": {
+              "patchStrategy": "replace",
+              "mutatorRef": [
+                [
+                  "configuration",
+                  "spec",
+                  "apiID"
+                ]
+              ]
+            }
+          }
+        ],
+        "to": [
+          {
+            "id": null,
+            "kind": "API",
+            "match": {
+              "from": [
+                {
+                  "id": null,
+                  "kind": "Deployment",
+                  "mutatedRef": [
+                    [
+                      "configuration",
+                      "spec",
+                      "apiID"
+                    ]
+                  ]
+                }
+              ],
+              "to": [
+                {
+                  "id": null,
+                  "kind": "self",
+                  "mutatorRef": [
+                    [
+                      "displayName"
+                    ]
+                  ]
+                }
+              ]
+            },
+            "match_strategy_matrix": [
+              [
+                "to_contains_from"
+              ]
+            ],
+            "model": {
+              "version": "",
+              "name": "aws-apigatewayv2-controller",
+              "displayName": "",
+              "id": "00000000-0000-0000-0000-000000000000",
+              "registrant": {
+                "kind": "github"
+              },
+              "model": {
+                "version": ""
+              }
+            },
+            "patch": {
+              "patchStrategy": "replace",
+              "mutatedRef": [
+                [
+                  "displayName"
+                ]
+              ]
+            }
+          }
+        ]
+      },
+      "deny": {
+        "from": [],
+        "to": []
+      }
+    }
+  ],
+  "subType": "inventory",
+  "status": "enabled",
+  "type": "parent",
+  "version": "v1.0.0"
+}

--- a/server/meshmodel/aws-apigatewayv2-controller/v1.2.1/v1.0.0/relationships/hierarchical-inventory-integration-api.json
+++ b/server/meshmodel/aws-apigatewayv2-controller/v1.2.1/v1.0.0/relationships/hierarchical-inventory-integration-api.json
@@ -1,0 +1,157 @@
+{
+  "id": "00000000-0000-0000-0000-000000000000",
+  "evaluationQuery": "",
+  "kind": "hierarchical",
+  "metadata": {
+    "description": "API Gateway v2 Integration is logically contained within an API.",
+    "styles": {
+      "primaryColor": "",
+      "svgColor": "",
+      "svgWhite": ""
+    },
+    "isAnnotation": false
+  },
+  "model": {
+    "version": "",
+    "name": "aws-apigatewayv2-controller",
+    "displayName": "",
+    "id": "00000000-0000-0000-0000-000000000000",
+    "registrant": {
+      "kind": ""
+    },
+    "model": {
+      "version": "v1.2.1"
+    }
+  },
+  "schemaVersion": "relationships.meshery.io/v1alpha3",
+  "selectors": [
+    {
+      "allow": {
+        "from": [
+          {
+            "id": null,
+            "kind": "Integration",
+            "match": {
+              "from": [
+                {
+                  "id": null,
+                  "kind": "Integration",
+                  "mutatedRef": [
+                    [
+                      "configuration",
+                      "spec",
+                      "apiID"
+                    ]
+                  ]
+                }
+              ],
+              "to": [
+                {
+                  "id": null,
+                  "kind": "API",
+                  "mutatorRef": [
+                    [
+                      "displayName"
+                    ]
+                  ]
+                }
+              ]
+            },
+            "match_strategy_matrix": [
+              [
+                "to_contains_from"
+              ]
+            ],
+            "model": {
+              "version": "",
+              "name": "aws-apigatewayv2-controller",
+              "displayName": "",
+              "id": "00000000-0000-0000-0000-000000000000",
+              "registrant": {
+                "kind": "github"
+              },
+              "model": {
+                "version": ""
+              }
+            },
+            "patch": {
+              "patchStrategy": "replace",
+              "mutatorRef": [
+                [
+                  "configuration",
+                  "spec",
+                  "apiID"
+                ]
+              ]
+            }
+          }
+        ],
+        "to": [
+          {
+            "id": null,
+            "kind": "API",
+            "match": {
+              "from": [
+                {
+                  "id": null,
+                  "kind": "Integration",
+                  "mutatedRef": [
+                    [
+                      "configuration",
+                      "spec",
+                      "apiID"
+                    ]
+                  ]
+                }
+              ],
+              "to": [
+                {
+                  "id": null,
+                  "kind": "self",
+                  "mutatorRef": [
+                    [
+                      "displayName"
+                    ]
+                  ]
+                }
+              ]
+            },
+            "match_strategy_matrix": [
+              [
+                "to_contains_from"
+              ]
+            ],
+            "model": {
+              "version": "",
+              "name": "aws-apigatewayv2-controller",
+              "displayName": "",
+              "id": "00000000-0000-0000-0000-000000000000",
+              "registrant": {
+                "kind": "github"
+              },
+              "model": {
+                "version": ""
+              }
+            },
+            "patch": {
+              "patchStrategy": "replace",
+              "mutatedRef": [
+                [
+                  "displayName"
+                ]
+              ]
+            }
+          }
+        ]
+      },
+      "deny": {
+        "from": [],
+        "to": []
+      }
+    }
+  ],
+  "subType": "inventory",
+  "status": "enabled",
+  "type": "parent",
+  "version": "v1.0.0"
+}

--- a/server/meshmodel/aws-apigatewayv2-controller/v1.2.1/v1.0.0/relationships/hierarchical-inventory-integration-api.json
+++ b/server/meshmodel/aws-apigatewayv2-controller/v1.2.1/v1.0.0/relationships/hierarchical-inventory-integration-api.json
@@ -51,7 +51,9 @@
                   "kind": "API",
                   "mutatorRef": [
                     [
-                      "displayName"
+                      "configuration",
+                      "spec",
+                      "name"
                     ]
                   ]
                 }
@@ -76,7 +78,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "spec",
@@ -110,7 +112,9 @@
                   "kind": "self",
                   "mutatorRef": [
                     [
-                      "displayName"
+                      "configuration",
+                      "spec",
+                      "name"
                     ]
                   ]
                 }
@@ -135,9 +139,11 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatedRef": [
+              "mutatorRef": [
                 [
-                  "displayName"
+                  "configuration",
+                  "spec",
+                  "name"
                 ]
               ]
             }


### PR DESCRIPTION
> **Note:** When defining Hierarchical relationships, remember that the `from` field represents the child component, while the `to` field represents the parent component.
> (Reference: [Meshery Contributing - Relationships Documentation](https://docs.meshery.io/project/contributing/contributing-relationships))


## What does this PR do?

Adds **AWS API Gateway v2 hierarchical inventory relationships** to Meshery, enabling the logical containment and organizational visualization of internal API components (Routes, Integrations, Authorizers, Stages, and Deployments) within the parent API resource.

## Related Issue

**Contributes to #17503 ,#17096** (Relationships for AWS Services)

## Changes

Added **5 new hierarchical inventory relationships** for the **`aws-apigatewayv2-controller/v1.2.1`** model using the branched mirror-match logic:


1. **`Integration (Child) → API (Parent)`** (`hierarchical-inventory-integration-api.json`)
   - Links backend service integrations to parent API via `apiId` reference
2. **`Authorizer (Child) → API (Parent)`** (`hierarchical-inventory-authorizer-api.json`)
   - Parents security authorizers to the specific API they protect.
3. **`Deployment (Child) → API (Parent)`** (`hierarchical-inventory-deployment-api.json`)
   - Groups API configuration snapshots under the logical API.
1. **`API Mapping (Child) → DomainName (Parent)`** (`hierarchical-inventory-apimapping-domainname.json`)
   - Maps API/stage to custom DomainName via `domainName`.
4. **`API Mapping (Child) → API (Parent)`** (`hierarchical-inventory-apimapping-api.json`)
   - Nests API mappings under parent API via `apiId`.

**All follow `relationships.meshery.io/v1alpha3` schema.**

## Testing

- [x] **Kanvas Validation**: 
  - Integration → API
  - Authorizer → API
  - Deployment → API
  - API Mapping → DomainName
  - API Mapping → API

**Screenshot Proof:**


**API Gateway v2 Component Hierarchy:**

<img width="1920" height="1080" alt="Screenshot from 2026-02-20 03-13-51" src="https://github.com/user-attachments/assets/ce927245-3852-4eea-b320-05da2ca1add6" />
<img width="1920" height="1080" alt="Screenshot from 2026-02-20 03-14-05" src="https://github.com/user-attachments/assets/c680a029-f701-43d9-9f07-0da84d25a2a1" />
---

**[Signed commits](https://github.com/meshery/meshery/blob/master/CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [x] Yes, I signed my commits.