### PR TITLE
[Models] Add edge relationships for AWS APIGatewayV2 controller

### DIFF
--- a/server/meshmodel/aws-apigatewayv2-controller/v1.2.1/v1.0.0/relationships/edge-non-binding-network-integration-lambda.json
+++ b/server/meshmodel/aws-apigatewayv2-controller/v1.2.1/v1.0.0/relationships/edge-non-binding-network-integration-lambda.json
@@ -45,12 +45,11 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
-                  "status",
-                  "ackResourceMetadata",
-                  "arn"
+                  "spec",
+                  "integrationUri"
                 ]
               ]
             }
@@ -74,11 +73,12 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatedRef": [
+              "mutatorRef": [
                 [
                   "configuration",
-                  "spec",
-                  "integrationUri"
+                  "status",
+                  "ackResourceMetadata",
+                  "arn"
                 ]
               ]
             }

--- a/server/meshmodel/aws-apigatewayv2-controller/v1.2.1/v1.0.0/relationships/edge-non-binding-network-integration-lambda.json
+++ b/server/meshmodel/aws-apigatewayv2-controller/v1.2.1/v1.0.0/relationships/edge-non-binding-network-integration-lambda.json
@@ -45,11 +45,12 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatedRef": [
+              "mutatorRef": [
                 [
                   "configuration",
-                  "spec",
-                  "integrationUri"
+                  "status",
+                  "ackResourceMetadata",
+                  "arn"
                 ]
               ]
             }
@@ -73,12 +74,11 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
-                  "status",
-                  "ackResourceMetadata",
-                  "arn"
+                  "spec",
+                  "integrationUri"
                 ]
               ]
             }

--- a/server/meshmodel/aws-apigatewayv2-controller/v1.2.1/v1.0.0/relationships/edge-non-binding-network-integration-lambda.json
+++ b/server/meshmodel/aws-apigatewayv2-controller/v1.2.1/v1.0.0/relationships/edge-non-binding-network-integration-lambda.json
@@ -3,7 +3,7 @@
   "evaluationQuery": "",
   "kind": "edge",
   "metadata": {
-    "description": "You are connecting an API Gateway Integration to a Lambda Function to enable serverless backend execution.",
+    "description": "You are connecting an API Integration to a Lambda Function to enable serverless backend execution.",
     "styles": {
       "primaryColor": "",
       "svgColor": "",
@@ -31,8 +31,6 @@
           {
             "id": null,
             "kind": "Integration",
-            "match": {},
-            "match_strategy_matrix": null,
             "model": {
               "version": "",
               "name": "aws-apigatewayv2-controller",
@@ -42,12 +40,12 @@
                 "kind": "github"
               },
               "model": {
-                "version": "v1.2.1"
+                "version": ""
               }
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "spec",
@@ -61,8 +59,6 @@
           {
             "id": null,
             "kind": "Function",
-            "match": {},
-            "match_strategy_matrix": null,
             "model": {
               "version": "",
               "name": "aws-lambda-controller",
@@ -77,9 +73,12 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatedRef": [
+              "mutatorRef": [
                 [
-                  "displayName"
+                  "configuration",
+                  "status",
+                  "ackResourceMetadata",
+                  "arn"
                 ]
               ]
             }

--- a/server/meshmodel/aws-apigatewayv2-controller/v1.2.1/v1.0.0/relationships/edge-non-binding-network-integration-lambda.json
+++ b/server/meshmodel/aws-apigatewayv2-controller/v1.2.1/v1.0.0/relationships/edge-non-binding-network-integration-lambda.json
@@ -1,0 +1,99 @@
+{
+  "id": "00000000-0000-0000-0000-000000000000",
+  "evaluationQuery": "",
+  "kind": "edge",
+  "metadata": {
+    "description": "You are connecting an API Gateway Integration to a Lambda Function to enable serverless backend execution.",
+    "styles": {
+      "primaryColor": "",
+      "svgColor": "",
+      "svgWhite": ""
+    },
+    "isAnnotation": false
+  },
+  "model": {
+    "version": "",
+    "name": "aws-apigatewayv2-controller",
+    "displayName": "",
+    "id": "00000000-0000-0000-0000-000000000000",
+    "registrant": {
+      "kind": "github"
+    },
+    "model": {
+      "version": "v1.2.1"
+    }
+  },
+  "schemaVersion": "relationships.meshery.io/v1alpha3",
+  "selectors": [
+    {
+      "allow": {
+        "from": [
+          {
+            "id": null,
+            "kind": "Integration",
+            "match": {},
+            "match_strategy_matrix": null,
+            "model": {
+              "version": "",
+              "name": "aws-apigatewayv2-controller",
+              "displayName": "",
+              "id": "00000000-0000-0000-0000-000000000000",
+              "registrant": {
+                "kind": "github"
+              },
+              "model": {
+                "version": "v1.2.1"
+              }
+            },
+            "patch": {
+              "patchStrategy": "replace",
+              "mutatorRef": [
+                [
+                  "configuration",
+                  "spec",
+                  "integrationUri"
+                ]
+              ]
+            }
+          }
+        ],
+        "to": [
+          {
+            "id": null,
+            "kind": "Function",
+            "match": {},
+            "match_strategy_matrix": null,
+            "model": {
+              "version": "",
+              "name": "aws-lambda-controller",
+              "displayName": "",
+              "id": "00000000-0000-0000-0000-000000000000",
+              "registrant": {
+                "kind": "github"
+              },
+              "model": {
+                "version": ""
+              }
+            },
+            "patch": {
+              "patchStrategy": "replace",
+              "mutatedRef": [
+                [
+                  "displayName"
+                ]
+              ]
+            }
+          }
+        ]
+      },
+      "deny": {
+        "from": [],
+        "to": []
+      }
+    }
+  ],
+  "subType": "network",
+  "status": "enabled",
+  "type": "non-binding",
+  "version": "v1.0.0"
+}

--- a/server/meshmodel/aws-apigatewayv2-controller/v1.2.1/v1.0.0/relationships/edge-non-binding-network-integration-service.json
+++ b/server/meshmodel/aws-apigatewayv2-controller/v1.2.1/v1.0.0/relationships/edge-non-binding-network-integration-service.json
@@ -45,11 +45,10 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatedRef": [
+              "mutatorRef": [
                 [
-                  "configuration",
-                  "spec",
-                  "integrationUri"
+                  "metadata",
+                  "name"
                 ]
               ]
             }
@@ -73,9 +72,10 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
-                  "metadata",
+                  "spec",
+                  "integrationRef",
                   "name"
                 ]
               ]

--- a/server/meshmodel/aws-apigatewayv2-controller/v1.2.1/v1.0.0/relationships/edge-non-binding-network-integration-service.json
+++ b/server/meshmodel/aws-apigatewayv2-controller/v1.2.1/v1.0.0/relationships/edge-non-binding-network-integration-service.json
@@ -3,7 +3,7 @@
   "evaluationQuery": "",
   "kind": "edge",
   "metadata": {
-    "description": "You are linking an API Integration to a Kubernetes Service to route traffic into your cluster via VPC Link.",
+    "description": "You are linking an API Integration to a Kubernetes Service to route traffic into your cluster.",
     "styles": {
       "primaryColor": "",
       "svgColor": "",
@@ -31,8 +31,6 @@
           {
             "id": null,
             "kind": "Integration",
-            "match": {},
-            "match_strategy_matrix": null,
             "model": {
               "version": "",
               "name": "aws-apigatewayv2-controller",
@@ -42,14 +40,16 @@
                 "kind": "github"
               },
               "model": {
-                "version": "v1.2.1"
+                "version": ""
               }
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
-                  "displayName"
+                  "configuration",
+                  "spec",
+                  "integrationUri"
                 ]
               ]
             }
@@ -59,8 +59,6 @@
           {
             "id": null,
             "kind": "Service",
-            "match": {},
-            "match_strategy_matrix": null,
             "model": {
               "version": "",
               "name": "kubernetes",
@@ -75,11 +73,10 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatedRef": [
+              "mutatorRef": [
                 [
                   "metadata",
-                  "annotations",
-                  "meshery.io/api-integration-id"
+                  "name"
                 ]
               ]
             }

--- a/server/meshmodel/aws-apigatewayv2-controller/v1.2.1/v1.0.0/relationships/edge-non-binding-network-integration-service.json
+++ b/server/meshmodel/aws-apigatewayv2-controller/v1.2.1/v1.0.0/relationships/edge-non-binding-network-integration-service.json
@@ -1,0 +1,99 @@
+{
+  "id": "00000000-0000-0000-0000-000000000000",
+  "evaluationQuery": "",
+  "kind": "edge",
+  "metadata": {
+    "description": "You are linking an API Integration to a Kubernetes Service to route traffic into your cluster via VPC Link.",
+    "styles": {
+      "primaryColor": "",
+      "svgColor": "",
+      "svgWhite": ""
+    },
+    "isAnnotation": false
+  },
+  "model": {
+    "version": "",
+    "name": "aws-apigatewayv2-controller",
+    "displayName": "",
+    "id": "00000000-0000-0000-0000-000000000000",
+    "registrant": {
+      "kind": "github"
+    },
+    "model": {
+      "version": "v1.2.1"
+    }
+  },
+  "schemaVersion": "relationships.meshery.io/v1alpha3",
+  "selectors": [
+    {
+      "allow": {
+        "from": [
+          {
+            "id": null,
+            "kind": "Integration",
+            "match": {},
+            "match_strategy_matrix": null,
+            "model": {
+              "version": "",
+              "name": "aws-apigatewayv2-controller",
+              "displayName": "",
+              "id": "00000000-0000-0000-0000-000000000000",
+              "registrant": {
+                "kind": "github"
+              },
+              "model": {
+                "version": "v1.2.1"
+              }
+            },
+            "patch": {
+              "patchStrategy": "replace",
+              "mutatorRef": [
+                [
+                  "displayName"
+                ]
+              ]
+            }
+          }
+        ],
+        "to": [
+          {
+            "id": null,
+            "kind": "Service",
+            "match": {},
+            "match_strategy_matrix": null,
+            "model": {
+              "version": "",
+              "name": "kubernetes",
+              "displayName": "",
+              "id": "00000000-0000-0000-0000-000000000000",
+              "registrant": {
+                "kind": "github"
+              },
+              "model": {
+                "version": ""
+              }
+            },
+            "patch": {
+              "patchStrategy": "replace",
+              "mutatedRef": [
+                [
+                  "metadata",
+                  "annotations",
+                  "meshery.io/api-integration-id"
+                ]
+              ]
+            }
+          }
+        ]
+      },
+      "deny": {
+        "from": [],
+        "to": []
+      }
+    }
+  ],
+  "subType": "network",
+  "status": "enabled",
+  "type": "non-binding",
+  "version": "v1.0.0"
+}

--- a/server/meshmodel/aws-apigatewayv2-controller/v1.2.1/v1.0.0/relationships/edge-non-binding-network-vpclink-subnet.json
+++ b/server/meshmodel/aws-apigatewayv2-controller/v1.2.1/v1.0.0/relationships/edge-non-binding-network-vpclink-subnet.json
@@ -3,7 +3,7 @@
   "evaluationQuery": "",
   "kind": "edge",
   "metadata": {
-    "description": "You are connecting a VPC Link to a Subnet, ensuring private connectivity for your API resources.",
+    "description": "You are connecting a VPC Link to a Subnet to ensure private cloud connectivity.",
     "styles": {
       "primaryColor": "",
       "svgColor": "",
@@ -31,8 +31,6 @@
           {
             "id": null,
             "kind": "VPCLink",
-            "match": {},
-            "match_strategy_matrix": null,
             "model": {
               "version": "",
               "name": "aws-apigatewayv2-controller",
@@ -42,12 +40,12 @@
                 "kind": "github"
               },
               "model": {
-                "version": "v1.2.1"
+                "version": ""
               }
             },
             "patch": {
               "patchStrategy": "add",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "spec",
@@ -61,8 +59,6 @@
           {
             "id": null,
             "kind": "Subnet",
-            "match": {},
-            "match_strategy_matrix": null,
             "model": {
               "version": "",
               "name": "aws-ec2-controller",
@@ -77,9 +73,12 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatedRef": [
+              "mutatorRef": [
                 [
-                  "displayName"
+                  "configuration",
+                  "status",
+                  "ackResourceMetadata",
+                  "arn"
                 ]
               ]
             }

--- a/server/meshmodel/aws-apigatewayv2-controller/v1.2.1/v1.0.0/relationships/edge-non-binding-network-vpclink-subnet.json
+++ b/server/meshmodel/aws-apigatewayv2-controller/v1.2.1/v1.0.0/relationships/edge-non-binding-network-vpclink-subnet.json
@@ -1,0 +1,99 @@
+{
+  "id": "00000000-0000-0000-0000-000000000000",
+  "evaluationQuery": "",
+  "kind": "edge",
+  "metadata": {
+    "description": "You are connecting a VPC Link to a Subnet, ensuring private connectivity for your API resources.",
+    "styles": {
+      "primaryColor": "",
+      "svgColor": "",
+      "svgWhite": ""
+    },
+    "isAnnotation": false
+  },
+  "model": {
+    "version": "",
+    "name": "aws-apigatewayv2-controller",
+    "displayName": "",
+    "id": "00000000-0000-0000-0000-000000000000",
+    "registrant": {
+      "kind": "github"
+    },
+    "model": {
+      "version": "v1.2.1"
+    }
+  },
+  "schemaVersion": "relationships.meshery.io/v1alpha3",
+  "selectors": [
+    {
+      "allow": {
+        "from": [
+          {
+            "id": null,
+            "kind": "VPCLink",
+            "match": {},
+            "match_strategy_matrix": null,
+            "model": {
+              "version": "",
+              "name": "aws-apigatewayv2-controller",
+              "displayName": "",
+              "id": "00000000-0000-0000-0000-000000000000",
+              "registrant": {
+                "kind": "github"
+              },
+              "model": {
+                "version": "v1.2.1"
+              }
+            },
+            "patch": {
+              "patchStrategy": "add",
+              "mutatorRef": [
+                [
+                  "configuration",
+                  "spec",
+                  "subnetIDs"
+                ]
+              ]
+            }
+          }
+        ],
+        "to": [
+          {
+            "id": null,
+            "kind": "Subnet",
+            "match": {},
+            "match_strategy_matrix": null,
+            "model": {
+              "version": "",
+              "name": "aws-ec2-controller",
+              "displayName": "",
+              "id": "00000000-0000-0000-0000-000000000000",
+              "registrant": {
+                "kind": "github"
+              },
+              "model": {
+                "version": ""
+              }
+            },
+            "patch": {
+              "patchStrategy": "replace",
+              "mutatedRef": [
+                [
+                  "displayName"
+                ]
+              ]
+            }
+          }
+        ]
+      },
+      "deny": {
+        "from": [],
+        "to": []
+      }
+    }
+  ],
+  "subType": "network",
+  "status": "enabled",
+  "type": "non-binding",
+  "version": "v1.0.0"
+}

--- a/server/meshmodel/aws-apigatewayv2-controller/v1.2.1/v1.0.0/relationships/edge-non-binding-network-vpclink-subnet.json
+++ b/server/meshmodel/aws-apigatewayv2-controller/v1.2.1/v1.0.0/relationships/edge-non-binding-network-vpclink-subnet.json
@@ -45,7 +45,7 @@
             },
             "patch": {
               "patchStrategy": "add",
-              "mutatedRef": [
+              "mutatorRef": [
                 [
                   "configuration",
                   "spec",
@@ -73,7 +73,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "status",

--- a/server/meshmodel/aws-apigatewayv2-controller/v1.2.1/v1.0.0/relationships/edge-non-binding-reference-stage-deployment.json
+++ b/server/meshmodel/aws-apigatewayv2-controller/v1.2.1/v1.0.0/relationships/edge-non-binding-reference-stage-deployment.json
@@ -1,0 +1,99 @@
+{
+  "id": "00000000-0000-0000-0000-000000000000",
+  "evaluationQuery": "",
+  "kind": "edge",
+  "metadata": {
+    "description": "You are linking an API Stage to a Deployment snapshot to establish the environment configuration version.",
+    "styles": {
+      "primaryColor": "",
+      "svgColor": "",
+      "svgWhite": ""
+    },
+    "isAnnotation": false
+  },
+  "model": {
+    "version": "",
+    "name": "aws-apigatewayv2-controller",
+    "displayName": "",
+    "id": "00000000-0000-0000-0000-000000000000",
+    "registrant": {
+      "kind": "github"
+    },
+    "model": {
+      "version": "v1.2.1"
+    }
+  },
+  "schemaVersion": "relationships.meshery.io/v1alpha3",
+  "selectors": [
+    {
+      "allow": {
+        "from": [
+          {
+            "id": null,
+            "kind": "Stage",
+            "match": {},
+            "match_strategy_matrix": null,
+            "model": {
+              "version": "",
+              "name": "aws-apigatewayv2-controller",
+              "displayName": "",
+              "id": "00000000-0000-0000-0000-000000000000",
+              "registrant": {
+                "kind": "github"
+              },
+              "model": {
+                "version": "v1.2.1"
+              }
+            },
+            "patch": {
+              "patchStrategy": "replace",
+              "mutatorRef": [
+                [
+                  "configuration",
+                  "spec",
+                  "deploymentID"
+                ]
+              ]
+            }
+          }
+        ],
+        "to": [
+          {
+            "id": null,
+            "kind": "Deployment",
+            "match": {},
+            "match_strategy_matrix": null,
+            "model": {
+              "version": "",
+              "name": "aws-apigatewayv2-controller",
+              "displayName": "",
+              "id": "00000000-0000-0000-0000-000000000000",
+              "registrant": {
+                "kind": "github"
+              },
+              "model": {
+                "version": "v1.2.1"
+              }
+            },
+            "patch": {
+              "patchStrategy": "replace",
+              "mutatedRef": [
+                [
+                  "displayName"
+                ]
+              ]
+            }
+          }
+        ]
+      },
+      "deny": {
+        "from": [],
+        "to": []
+      }
+    }
+  ],
+  "subType": "reference",
+  "status": "enabled",
+  "type": "non-binding",
+  "version": "v1.0.0"
+}

--- a/server/meshmodel/aws-apigatewayv2-controller/v1.2.1/v1.0.0/relationships/edge-non-binding-reference-stage-deployment.json
+++ b/server/meshmodel/aws-apigatewayv2-controller/v1.2.1/v1.0.0/relationships/edge-non-binding-reference-stage-deployment.json
@@ -31,8 +31,6 @@
           {
             "id": null,
             "kind": "Stage",
-            "match": {},
-            "match_strategy_matrix": null,
             "model": {
               "version": "",
               "name": "aws-apigatewayv2-controller",
@@ -42,12 +40,12 @@
                 "kind": "github"
               },
               "model": {
-                "version": "v1.2.1"
+                "version": ""
               }
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "spec",
@@ -61,8 +59,6 @@
           {
             "id": null,
             "kind": "Deployment",
-            "match": {},
-            "match_strategy_matrix": null,
             "model": {
               "version": "",
               "name": "aws-apigatewayv2-controller",
@@ -72,14 +68,16 @@
                 "kind": "github"
               },
               "model": {
-                "version": "v1.2.1"
+                "version": ""
               }
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatedRef": [
+              "mutatorRef": [
                 [
-                  "displayName"
+                  "configuration",
+                  "status",
+                  "deploymentID"
                 ]
               ]
             }

--- a/server/meshmodel/aws-apigatewayv2-controller/v1.2.1/v1.0.0/relationships/edge-non-binding-reference-stage-deployment.json
+++ b/server/meshmodel/aws-apigatewayv2-controller/v1.2.1/v1.0.0/relationships/edge-non-binding-reference-stage-deployment.json
@@ -45,7 +45,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatedRef": [
+              "mutatorRef": [
                 [
                   "configuration",
                   "spec",


### PR DESCRIPTION
## What does this PR do?

Adds **AWS API Gateway v2 edge network relationships** to Meshery, enabling visualization of external integrations (Lambda, K8s Services) and infrastructure dependencies (VPC Links → Subnets) for API Gateway deployments.

## Related Issue

**Contributes to #17503, #17096** (Relationships for AWS Services)

## Changes

Added **4 new edge relationships** for the **`aws-apigatewayv2-controller/v1.2.1`** model:

1. **`Integration → Lambda Function `** (`edge-non-binding-network-integration-lambda.json`)
   - Connects API backend integrations to AWS Lambda functions
   
2. **`Integration → K8s Service `** (`edge-non-binding-network-integration-service.json`)
   - Links API integrations to Kubernetes Services for hybrid workloads
   
3. **`VPC Link  → Subnet `** (`edge-non-binding-network-vpclink-subnet.json`)
   - Maps private VPC Links to target subnets
   
4. **`Stage→ Deployment `** (`edge-non-binding-reference-stage-deployment.json`)
   - References API stage configurations to deployments

**All follow `relationships.meshery.io/v1alpha3` schema with `non-binding-network` and `non-binding-reference` types.**

## Testing

- [x] **Kanvas Validation**:
  - Integration → Lambda Function
  - Integration → K8s Service  
  - VPC Link → Subnet
  - Stage → Deployment


**Screenshot Proof:**

<img width="1920" height="1080" alt="Screenshot from 2026-02-21 04-08-00" src="https://github.com/user-attachments/assets/4153ba93-0fcc-4d89-b553-7bf388df9b04" />



<img width="1920" height="1080" alt="Screenshot from 2026-02-21 04-15-19" src="https://github.com/user-attachments/assets/c17e08ae-9e51-4bca-9d2a-aa6407f7c038" />


---

**[Signed commits](https://github.com/meshery/meshery/blob/master/CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [x] Yes, I signed my commits.
