### PR TITLE
BUG: Fix the Footer not reacting to light mode(NEW DOCS)

### DIFF
--- a/docs-new/assets/scss/_footer.scss
+++ b/docs-new/assets/scss/_footer.scss
@@ -3,37 +3,35 @@ html {
   scroll-behavior: smooth;
 }
 .footer {
-  background: linear-gradient(to bottom,
-  #151515 5%,
-  #252525 20%,
-  #2f2f2f,
-  #303030,
-  #3d3d3d
-  );
+  background: var(--color-primary-medium);
+  border-top: 1px solid var(--color-grey-light);
   display: flex;
   flex-direction: column;
   padding: min(2vh, 2vw);
   gap: min(2vh, 5vw);
+  transition:
+    background 0.3s ease,
+    border-color 0.3s ease;
 
   @media (max-width: 600px) {
-    height: calc(var(--footer-height) - 4.0rem);
+    height: calc(var(--footer-height) - 4rem);
   }
 
-  @media (max: 1200px){
+  @media (max: 1200px) {
     height: var(--footer-height);
   }
 
   & * {
-    color: white;
+    color: var(--color-secondary-medium);
   }
 
   & .text-white {
-    color: #adb5bd;
+    color: var(--color-grey-dark);
     font-size: 1rem;
     text-align: center;
 
     @media (max-width: 600px) {
-      font-size: .8rem;
+      font-size: 0.8rem;
     }
   }
 
@@ -44,7 +42,7 @@ html {
     justify-content: center;
 
     @media (max-width: 600px) {
-      gap: .5rem;
+      gap: 0.5rem;
     }
 
     & .footer-icons {
@@ -100,10 +98,9 @@ html {
           fill: #000;
         }
         & svg.youtube:hover {
-          fill: #FF0000;
+          fill: #ff0000;
         }
       }
     }
   }
 }
-


### PR DESCRIPTION
**Notes for Reviewers**

- This PR fixes #17566 

### Summary Of PR 
- Updated footer styles to properly support light mode.
- Ensured background, text, and link colors adapt according to the active theme.

### Testing Performed
- Tested theme switching locally to confirm correct footer behavior in both light and dark modes.

### Screenshots
 - Before  
<img width="2938" height="1550" alt="image" src="https://github.com/user-attachments/assets/cf9374da-b195-42b5-8826-6353263f6733" />

- After 
<img width="2940" height="1644" alt="image" src="https://github.com/user-attachments/assets/bdd2bd7f-e695-4bb0-b7f9-7ed97e1f774a" />


**[Signed commits](https://github.com/meshery/meshery/blob/master/CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [x] Yes, I signed my commits.

<!--
Thank you for contributing to Meshery! 

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. Sign your commits.
4. Include before and after screenshots/terminal output.

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.
-->
