### PR TITLE
server: properly handle json.Marshal error in database summary handler

### DIFF
--- a/server/handlers/database_handlers.go
+++ b/server/handlers/database_handlers.go
@@ -7,7 +7,6 @@ import (
 	"os"
 	"path"
 	"time"
-	"log"
 
 	"github.com/meshery/meshery/server/models"
 	"github.com/meshery/meshkit/models/meshmodel/registry"

--- a/server/handlers/database_handlers.go
+++ b/server/handlers/database_handlers.go
@@ -81,13 +81,13 @@ func (h *Handler) GetSystemDatabase(w http.ResponseWriter, r *http.Request, _ *m
 
 	w.Header().Set("Content-Type", "application/json")
 
-val, err := json.Marshal(databaseSummary)
-if err != nil {
-    log.Printf("failed to serialize database summary: %v", err)
-    http.Error(w, "failed to serialize database summary", http.StatusInternalServerError)
-    return
-}
-w.Write(val)
+	val, err := json.Marshal(databaseSummary)
+	if err != nil {
+		h.log.Error(models.ErrMarshal(err, "database summary"))
+		http.Error(w, "failed to serialize database summary", http.StatusInternalServerError)
+		return
+	}
+	w.Write(val)
 }
 // swagger:route DELETE /api/system/database/reset ResetSystemDatabase
 // Reset the system database to its initial state.

--- a/server/handlers/database_handlers.go
+++ b/server/handlers/database_handlers.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"path"
 	"time"
+	"log"
 
 	"github.com/meshery/meshery/server/models"
 	"github.com/meshery/meshkit/models/meshmodel/registry"
@@ -82,10 +83,10 @@ func (h *Handler) GetSystemDatabase(w http.ResponseWriter, r *http.Request, _ *m
 
 val, err := json.Marshal(databaseSummary)
 if err != nil {
+    log.Printf("failed to serialize database summary: %v", err)
     http.Error(w, "failed to serialize database summary", http.StatusInternalServerError)
     return
 }
-
 w.Write(val)
 }
 // swagger:route DELETE /api/system/database/reset ResetSystemDatabase

--- a/server/handlers/database_handlers.go
+++ b/server/handlers/database_handlers.go
@@ -2,7 +2,6 @@ package handlers
 
 import (
 	"encoding/json"
-	"fmt"
 	"io"
 	"net/http"
 	"os"
@@ -81,13 +80,14 @@ func (h *Handler) GetSystemDatabase(w http.ResponseWriter, r *http.Request, _ *m
 
 	w.Header().Set("Content-Type", "application/json")
 
-	val, err := json.Marshal(databaseSummary)
-	if err != nil {
-		fmt.Println(err)
-	}
-	fmt.Fprint(w, string(val))
+val, err := json.Marshal(databaseSummary)
+if err != nil {
+    http.Error(w, "failed to serialize database summary", http.StatusInternalServerError)
+    return
 }
 
+w.Write(val)
+}
 // swagger:route DELETE /api/system/database/reset ResetSystemDatabase
 // Reset the system database to its initial state.
 //
@@ -196,6 +196,6 @@ func (h *Handler) ResetSystemDatabase(w http.ResponseWriter, r *http.Request, _ 
 			krh.SeedKeys(viper.GetString("KEYS_PATH"))
 		}()
 		w.Header().Set("Content-Type", "application/json")
-		fmt.Fprint(w, "Database reset successful")
+		w.Write([]byte("Database reset successful"))
 	}
 }


### PR DESCRIPTION
## Summary

Improves error handling in the database summary handler.

Previously, if `json.Marshal` failed, the error was printed to stdout and execution continued. This change ensures:

- Proper HTTP 500 response is returned
- Execution stops on serialization failure
- No partial or invalid response is written
- Removes unnecessary stdout noise

Additionally replaces `fmt.Fprint` with `w.Write([]byte(...))` to remove an unnecessary dependency.

## Impact
- Improves HTTP error handling correctness
- No functional behavior change for successful requests