### PR TITLE
fix: handle empty sessionStorage value to prevent JSON parse error

### DIFF
--- a/ui/pages/_app.tsx
+++ b/ui/pages/_app.tsx
@@ -426,7 +426,7 @@ const MesheryApp = ({ Component, pageProps, relayEnvironment }) => {
   const loadAbility = useCallback(
     async (orgID, reFetchKeys) => {
       const storedKeys = sessionStorage.getItem('keys');
-      if (storedKeys !== null && !reFetchKeys && storedKeys !== 'undefined') {
+      if (storedKeys !== null && storedKeys !== '' && !reFetchKeys && storedKeys !== 'undefined') {
         setState((prevState) => ({ ...prevState, keys: JSON.parse(storedKeys) }));
         updateAbility();
       } else {


### PR DESCRIPTION
## Description

Fixes an "Unexpected end of JSON input" crash that occurs when navigating to `/extension/meshmap?mode=design` in design mode.

### Root Cause

In [ui/pages/_app.tsx](cci:7://file:///d:/meshery/meshery/ui/pages/_app.tsx:0:0-0:0), the `loadAbility` function reads `keys` from `sessionStorage` and passes it directly to `JSON.parse`:

```js
const storedKeys = sessionStorage.getItem('keys');
if (storedKeys !== null && !reFetchKeys && storedKeys !== 'undefined') {
  setState((prevState) => ({ ...prevState, keys: JSON.parse(storedKeys) }));
  sessionStorage.getItem('keys') can return an empty string "" in edge cases (e.g., race condition on page load, or a corrupt prior session). The guard checked for null and "undefined" but not for an empty string — and JSON.parse("") throws "Unexpected end of JSON input", crashing the page.

Fix
Added storedKeys !== '' to the guard condition so the app safely falls back to re-fetching keys from the API instead of crashing:

diff
- if (storedKeys !== null && !reFetchKeys && storedKeys !== 'undefined') {
+ if (storedKeys !== null && storedKeys !== '' && !reFetchKeys && storedKeys !== 'undefined') {
Type of change
 Bug fix (non-breaking change which fixes an issue)
 ```