### PR TITLE
ci: configure dependabot for docs-new architecture

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -55,3 +55,20 @@ updates:
   labels:
   - kind/chore
   - pr/dependencies
+- package-ecosystem: npm
+  directory: "/docs-new"
+  schedule:
+    interval: monthly
+  open-pull-requests-limit: 5
+  labels:
+  - kind/chore
+  - pr/dependencies
+- package-ecosystem: gomod
+  directory: "/docs-new"
+  schedule:
+    interval: monthly
+  open-pull-requests-limit: 5
+  labels:
+  - pr/dependencies
+  - kind/chore
+  - language/go

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -64,7 +64,7 @@ updates:
   - kind/chore
   - pr/dependencies
 - package-ecosystem: gomod
-  directory: "/docs-new"
+  directory: "/docs"
   schedule:
     interval: monthly
   open-pull-requests-limit: 5


### PR DESCRIPTION

- This PR fixes #17590
This PR updates the .github/dependabot.yml configuration to include the new docs-new Hugo architecture. It adds both npm and gomod ecosystem tracking to ensure the Dart Sass compiler and Hugo theme modules stay up to date.


**[Signed commits](https://github.com/meshery/meshery/blob/master/CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [x] Yes, I signed my commits.


