### PR TITLE
[Models] Add relationships for AWS APIGatewayV2 controller

### DIFF
--- a/server/meshmodel/aws-apigatewayv2-controller/v1.2.1/v1.0.0/relationships/edge-binding-reference-b9r1t.json
+++ b/server/meshmodel/aws-apigatewayv2-controller/v1.2.1/v1.0.0/relationships/edge-binding-reference-b9r1t.json
@@ -12,7 +12,7 @@
     "isAnnotation": false
   },
   "model": {
-    "version": "v1.2.1",
+    "version": "",
     "name": "aws-apigatewayv2-controller",
     "displayName": "AWS API Gateway v2",
     "id": "00000000-0000-0000-0000-000000000000",
@@ -33,7 +33,7 @@
             "kind": "APIMapping",
             "model": {
               "name": "aws-apigatewayv2-controller",
-              "version": "v1.2.1"
+              "version": ""
             },
             "patch": {
               "patchStrategy": "replace",
@@ -54,7 +54,7 @@
             "kind": "Stage",
             "model": {
               "name": "aws-apigatewayv2-controller",
-              "version": "v1.2.1"
+              "version": ""
             },
             "patch": {
               "patchStrategy": "replace",

--- a/server/meshmodel/aws-apigatewayv2-controller/v1.2.1/v1.0.0/relationships/edge-binding-reference-b9r1t.json
+++ b/server/meshmodel/aws-apigatewayv2-controller/v1.2.1/v1.0.0/relationships/edge-binding-reference-b9r1t.json
@@ -1,0 +1,77 @@
+{
+  "id": "00000000-0000-0000-0000-000000000000",
+  "evaluationQuery": "",
+  "kind": "edge",
+  "metadata": {
+    "description": "You are linking an API Mapping to a specific Stage to establish the environment for the custom domain.",
+    "styles": {
+      "primaryColor": "",
+      "svgColor": "",
+      "svgWhite": ""
+    },
+    "isAnnotation": false
+  },
+  "model": {
+    "version": "v1.2.1",
+    "name": "aws-apigatewayv2-controller",
+    "displayName": "AWS API Gateway v2",
+    "id": "00000000-0000-0000-0000-000000000000",
+    "registrant": {
+      "kind": "github"
+    },
+    "model": {
+      "version": "v1.2.1"
+    }
+  },
+  "schemaVersion": "relationships.meshery.io/v1alpha3",
+  "selectors": [
+    {
+      "allow": {
+        "from": [
+          {
+            "id": null,
+            "kind": "APIMapping",
+            "model": {
+              "name": "aws-apigatewayv2-controller",
+              "version": "v1.2.1"
+            },
+            "patch": {
+              "patchStrategy": "replace",
+              "mutatedRef": [
+                [
+                  "configuration",
+                  "spec",
+                  "stage"
+                ]
+              ],
+              "description": "The API Mapping receives the Stage name."
+            }
+          }
+        ],
+        "to": [
+          {
+            "id": null,
+            "kind": "Stage",
+            "model": {
+              "name": "aws-apigatewayv2-controller",
+              "version": "v1.2.1"
+            },
+            "patch": {
+              "patchStrategy": "replace",
+              "mutatorRef": [
+                [
+                  "displayName"
+                ]
+              ],
+              "description": "Providing the Stage identity to the Mapping."
+            }
+          }
+        ]
+      }
+    }
+  ],
+  "subType": "reference",
+  "status": "enabled",
+  "type": "non-binding",
+  "version": "v1.0.0"
+}

--- a/server/meshmodel/aws-apigatewayv2-controller/v1.2.1/v1.0.0/relationships/edge-binding-reference-m7j3k.json
+++ b/server/meshmodel/aws-apigatewayv2-controller/v1.2.1/v1.0.0/relationships/edge-binding-reference-m7j3k.json
@@ -12,7 +12,7 @@
     "isAnnotation": false
   },
   "model": {
-    "version": "v1.2.1",
+    "version": "",
     "name": "aws-apigatewayv2-controller",
     "displayName": "AWS API Gateway v2",
     "id": "00000000-0000-0000-0000-000000000000",
@@ -33,7 +33,7 @@
             "kind": "APIMapping",
             "model": {
               "name": "aws-apigatewayv2-controller",
-              "version": "v1.2.1"
+              "version": ""
             },
             "patch": {
               "patchStrategy": "replace",
@@ -54,7 +54,7 @@
             "kind": "API",
             "model": {
               "name": "aws-apigatewayv2-controller",
-              "version": "v1.2.1"
+              "version": ""
             },
             "patch": {
               "patchStrategy": "replace",

--- a/server/meshmodel/aws-apigatewayv2-controller/v1.2.1/v1.0.0/relationships/edge-binding-reference-m7j3k.json
+++ b/server/meshmodel/aws-apigatewayv2-controller/v1.2.1/v1.0.0/relationships/edge-binding-reference-m7j3k.json
@@ -3,7 +3,7 @@
   "evaluationQuery": "",
   "kind": "edge",
   "metadata": {
-    "description": "Connects a Custom Domain Mapping to an API.",
+    "description": "You are binding an API Mapping to a specific API resource to establish the functional link for custom domain routing.",
     "styles": {
       "primaryColor": "",
       "svgColor": "",
@@ -12,12 +12,12 @@
     "isAnnotation": false
   },
   "model": {
-    "version": "",
+    "version": "v1.2.1",
     "name": "aws-apigatewayv2-controller",
-    "displayName": "",
+    "displayName": "AWS API Gateway v2",
     "id": "00000000-0000-0000-0000-000000000000",
     "registrant": {
-      "kind": ""
+      "kind": "github"
     },
     "model": {
       "version": "v1.2.1"
@@ -31,28 +31,20 @@
           {
             "id": null,
             "kind": "APIMapping",
-            "match": {},
-            "match_strategy_matrix": null,
             "model": {
-              "version": "",
               "name": "aws-apigatewayv2-controller",
-              "displayName": "",
-              "id": "00000000-0000-0000-0000-000000000000",
-              "registrant": {
-                "kind": "github"
-              },
-              "model": {
-                "version": ""
-              }
+              "version": "v1.2.1"
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
-                  "status",
+                  "configuration",
+                  "spec",
                   "apiID"
                 ]
-              ]
+              ],
+              "description": "The API Mapping is mutated to include the target API's identifier."
             }
           }
         ],
@@ -60,28 +52,20 @@
           {
             "id": null,
             "kind": "API",
-            "match": {},
-            "match_strategy_matrix": null,
             "model": {
-              "version": "",
               "name": "aws-apigatewayv2-controller",
-              "displayName": "",
-              "id": "00000000-0000-0000-0000-000000000000",
-              "registrant": {
-                "kind": "github"
-              },
-              "model": {
-                "version": ""
-              }
+              "version": "v1.2.1"
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatedRef": [
+              "mutatorRef": [
                 [
-                  "spec",
+                  "configuration",
+                  "status",
                   "apiID"
                 ]
-              ]
+              ],
+              "description": "The API acts as the mutator, providing its status-level apiID to the mapping."
             }
           }
         ]
@@ -92,7 +76,7 @@
       }
     }
   ],
-  "subType": "Binding",
+  "subType": "reference",
   "status": "enabled",
   "type": "non-binding",
   "version": "v1.0.0"

--- a/server/meshmodel/aws-apigatewayv2-controller/v1.2.1/v1.0.0/relationships/edge-binding-reference-m7j3k.json
+++ b/server/meshmodel/aws-apigatewayv2-controller/v1.2.1/v1.0.0/relationships/edge-binding-reference-m7j3k.json
@@ -1,0 +1,99 @@
+{
+  "id": "00000000-0000-0000-0000-000000000000",
+  "evaluationQuery": "",
+  "kind": "edge",
+  "metadata": {
+    "description": "Connects a Custom Domain Mapping to an API.",
+    "styles": {
+      "primaryColor": "",
+      "svgColor": "",
+      "svgWhite": ""
+    },
+    "isAnnotation": false
+  },
+  "model": {
+    "version": "",
+    "name": "aws-apigatewayv2-controller",
+    "displayName": "",
+    "id": "00000000-0000-0000-0000-000000000000",
+    "registrant": {
+      "kind": ""
+    },
+    "model": {
+      "version": "v1.2.1"
+    }
+  },
+  "schemaVersion": "relationships.meshery.io/v1alpha3",
+  "selectors": [
+    {
+      "allow": {
+        "from": [
+          {
+            "id": null,
+            "kind": "APIMapping",
+            "match": {},
+            "match_strategy_matrix": null,
+            "model": {
+              "version": "",
+              "name": "aws-apigatewayv2-controller",
+              "displayName": "",
+              "id": "00000000-0000-0000-0000-000000000000",
+              "registrant": {
+                "kind": "github"
+              },
+              "model": {
+                "version": ""
+              }
+            },
+            "patch": {
+              "patchStrategy": "replace",
+              "mutatorRef": [
+                [
+                  "status",
+                  "apiID"
+                ]
+              ]
+            }
+          }
+        ],
+        "to": [
+          {
+            "id": null,
+            "kind": "API",
+            "match": {},
+            "match_strategy_matrix": null,
+            "model": {
+              "version": "",
+              "name": "aws-apigatewayv2-controller",
+              "displayName": "",
+              "id": "00000000-0000-0000-0000-000000000000",
+              "registrant": {
+                "kind": "github"
+              },
+              "model": {
+                "version": ""
+              }
+            },
+            "patch": {
+              "patchStrategy": "replace",
+              "mutatedRef": [
+                [
+                  "spec",
+                  "apiID"
+                ]
+              ]
+            }
+          }
+        ]
+      },
+      "deny": {
+        "from": [],
+        "to": []
+      }
+    }
+  ],
+  "subType": "Binding",
+  "status": "enabled",
+  "type": "non-binding",
+  "version": "v1.0.0"
+}

--- a/server/meshmodel/aws-apigatewayv2-controller/v1.2.1/v1.0.0/relationships/edge-binding-reference-p4q8z.json
+++ b/server/meshmodel/aws-apigatewayv2-controller/v1.2.1/v1.0.0/relationships/edge-binding-reference-p4q8z.json
@@ -33,7 +33,7 @@
             "kind": "Route",
             "model": {
               "name": "aws-apigatewayv2-controller",
-              "version": "v1.2.1"
+              "version": ""
             },
             "patch": {
               "patchStrategy": "replace",
@@ -54,7 +54,7 @@
             "kind": "Authorizer",
             "model": {
               "name": "aws-apigatewayv2-controller",
-              "version": "v1.2.1"
+              "version": ""
             },
             "patch": {
               "patchStrategy": "replace",

--- a/server/meshmodel/aws-apigatewayv2-controller/v1.2.1/v1.0.0/relationships/edge-binding-reference-p4q8z.json
+++ b/server/meshmodel/aws-apigatewayv2-controller/v1.2.1/v1.0.0/relationships/edge-binding-reference-p4q8z.json
@@ -1,0 +1,99 @@
+{
+  "id": "00000000-0000-0000-0000-000000000000",
+  "evaluationQuery": "",
+  "kind": "edge",
+  "metadata": {
+    "description": "Secures a Route with an Authorizer.",
+    "styles": {
+      "primaryColor": "",
+      "svgColor": "",
+      "svgWhite": ""
+    },
+    "isAnnotation": false
+  },
+  "model": {
+    "version": "",
+    "name": "aws-apigatewayv2-controller",
+    "displayName": "",
+    "id": "00000000-0000-0000-0000-000000000000",
+    "registrant": {
+      "kind": ""
+    },
+    "model": {
+      "version": "v1.2.1"
+    }
+  },
+  "schemaVersion": "relationships.meshery.io/v1alpha3",
+  "selectors": [
+    {
+      "allow": {
+        "from": [
+          {
+            "id": null,
+            "kind": "Route",
+            "match": {},
+            "match_strategy_matrix": null,
+            "model": {
+              "version": "",
+              "name": "aws-apigatewayv2-controller",
+              "displayName": "",
+              "id": "00000000-0000-0000-0000-000000000000",
+              "registrant": {
+                "kind": "github"
+              },
+              "model": {
+                "version": ""
+              }
+            },
+            "patch": {
+              "patchStrategy": "replace",
+              "mutatorRef": [
+                [
+                  "status",
+                  "authorizerID"
+                ]
+              ]
+            }
+          }
+        ],
+        "to": [
+          {
+            "id": null,
+            "kind": "Authorizer",
+            "match": {},
+            "match_strategy_matrix": null,
+            "model": {
+              "version": "",
+              "name": "aws-apigatewayv2-controller",
+              "displayName": "",
+              "id": "00000000-0000-0000-0000-000000000000",
+              "registrant": {
+                "kind": "github"
+              },
+              "model": {
+                "version": ""
+              }
+            },
+            "patch": {
+              "patchStrategy": "replace",
+              "mutatedRef": [
+                [
+                  "spec",
+                  "authorizerID"
+                ]
+              ]
+            }
+          }
+        ]
+      },
+      "deny": {
+        "from": [],
+        "to": []
+      }
+    }
+  ],
+  "subType": "Binding",
+  "status": "enabled",
+  "type": "non-binding",
+  "version": "v1.0.0"
+}

--- a/server/meshmodel/aws-apigatewayv2-controller/v1.2.1/v1.0.0/relationships/edge-binding-reference-p4q8z.json
+++ b/server/meshmodel/aws-apigatewayv2-controller/v1.2.1/v1.0.0/relationships/edge-binding-reference-p4q8z.json
@@ -3,7 +3,7 @@
   "evaluationQuery": "",
   "kind": "edge",
   "metadata": {
-    "description": "Secures a Route with an Authorizer.",
+    "description": "You are binding an Authorizer to a specific Route to enforce security and access control on the API endpoint.",
     "styles": {
       "primaryColor": "",
       "svgColor": "",
@@ -17,7 +17,7 @@
     "displayName": "",
     "id": "00000000-0000-0000-0000-000000000000",
     "registrant": {
-      "kind": ""
+      "kind": "github"
     },
     "model": {
       "version": "v1.2.1"
@@ -31,28 +31,20 @@
           {
             "id": null,
             "kind": "Route",
-            "match": {},
-            "match_strategy_matrix": null,
             "model": {
-              "version": "",
               "name": "aws-apigatewayv2-controller",
-              "displayName": "",
-              "id": "00000000-0000-0000-0000-000000000000",
-              "registrant": {
-                "kind": "github"
-              },
-              "model": {
-                "version": ""
-              }
+              "version": "v1.2.1"
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
-                  "status",
+                  "configuration",
+                  "spec",
                   "authorizerID"
                 ]
-              ]
+              ],
+              "description": "The Route is mutated to include the Authorizer's identifier."
             }
           }
         ],
@@ -60,28 +52,18 @@
           {
             "id": null,
             "kind": "Authorizer",
-            "match": {},
-            "match_strategy_matrix": null,
             "model": {
-              "version": "",
               "name": "aws-apigatewayv2-controller",
-              "displayName": "",
-              "id": "00000000-0000-0000-0000-000000000000",
-              "registrant": {
-                "kind": "github"
-              },
-              "model": {
-                "version": ""
-              }
+              "version": "v1.2.1"
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatedRef": [
+              "mutatorRef": [
                 [
-                  "spec",
-                  "authorizerID"
+                  "displayName"
                 ]
-              ]
+              ],
+              "description": "The Authorizer acts as the mutator, providing its identity to secure the Route."
             }
           }
         ]
@@ -92,7 +74,7 @@
       }
     }
   ],
-  "subType": "Binding",
+  "subType": "reference",
   "status": "enabled",
   "type": "non-binding",
   "version": "v1.0.0"

--- a/server/meshmodel/aws-apigatewayv2-controller/v1.2.1/v1.0.0/relationships/edge-binding-reference-v2w5n.json
+++ b/server/meshmodel/aws-apigatewayv2-controller/v1.2.1/v1.0.0/relationships/edge-binding-reference-v2w5n.json
@@ -1,0 +1,99 @@
+{
+  "id": "00000000-0000-0000-0000-000000000000",
+  "evaluationQuery": "",
+  "kind": "edge",
+  "metadata": {
+    "description": "Points a Stage to a specific Deployment snapshot.",
+    "styles": {
+      "primaryColor": "",
+      "svgColor": "",
+      "svgWhite": ""
+    },
+    "isAnnotation": false
+  },
+  "model": {
+    "version": "",
+    "name": "aws-apigatewayv2-controller",
+    "displayName": "",
+    "id": "00000000-0000-0000-0000-000000000000",
+    "registrant": {
+      "kind": ""
+    },
+    "model": {
+      "version": "v1.2.1"
+    }
+  },
+  "schemaVersion": "relationships.meshery.io/v1alpha3",
+  "selectors": [
+    {
+      "allow": {
+        "from": [
+          {
+            "id": null,
+            "kind": "Stage",
+            "match": {},
+            "match_strategy_matrix": null,
+            "model": {
+              "version": "",
+              "name": "aws-apigatewayv2-controller",
+              "displayName": "",
+              "id": "00000000-0000-0000-0000-000000000000",
+              "registrant": {
+                "kind": "github"
+              },
+              "model": {
+                "version": ""
+              }
+            },
+            "patch": {
+              "patchStrategy": "replace",
+              "mutatorRef": [
+                [
+                  "status",
+                  "deploymentID"
+                ]
+              ]
+            }
+          }
+        ],
+        "to": [
+          {
+            "id": null,
+            "kind": "Deployment",
+            "match": {},
+            "match_strategy_matrix": null,
+            "model": {
+              "version": "",
+              "name": "aws-apigatewayv2-controller",
+              "displayName": "",
+              "id": "00000000-0000-0000-0000-000000000000",
+              "registrant": {
+                "kind": "github"
+              },
+              "model": {
+                "version": ""
+              }
+            },
+            "patch": {
+              "patchStrategy": "replace",
+              "mutatedRef": [
+                [
+                  "spec",
+                  "deploymentID"
+                ]
+              ]
+            }
+          }
+        ]
+      },
+      "deny": {
+        "from": [],
+        "to": []
+      }
+    }
+  ],
+  "subType": "Binding",
+  "status": "enabled",
+  "type": "non-binding",
+  "version": "v1.0.0"
+}

--- a/server/meshmodel/aws-apigatewayv2-controller/v1.2.1/v1.0.0/relationships/edge-binding-reference-v2w5n.json
+++ b/server/meshmodel/aws-apigatewayv2-controller/v1.2.1/v1.0.0/relationships/edge-binding-reference-v2w5n.json
@@ -3,7 +3,7 @@
   "evaluationQuery": "",
   "kind": "edge",
   "metadata": {
-    "description": "Points a Stage to a specific Deployment snapshot.",
+    "description": "You are binding an API Stage to a specific Deployment snapshot to establish the environment configuration version.",
     "styles": {
       "primaryColor": "",
       "svgColor": "",
@@ -17,7 +17,7 @@
     "displayName": "",
     "id": "00000000-0000-0000-0000-000000000000",
     "registrant": {
-      "kind": ""
+      "kind": "github"
     },
     "model": {
       "version": "v1.2.1"
@@ -31,8 +31,6 @@
           {
             "id": null,
             "kind": "Stage",
-            "match": {},
-            "match_strategy_matrix": null,
             "model": {
               "version": "",
               "name": "aws-apigatewayv2-controller",
@@ -42,14 +40,15 @@
                 "kind": "github"
               },
               "model": {
-                "version": ""
+                "version": "v1.2.1"
               }
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
-                  "status",
+                  "configuration",
+                  "spec",
                   "deploymentID"
                 ]
               ]
@@ -60,8 +59,6 @@
           {
             "id": null,
             "kind": "Deployment",
-            "match": {},
-            "match_strategy_matrix": null,
             "model": {
               "version": "",
               "name": "aws-apigatewayv2-controller",
@@ -71,14 +68,15 @@
                 "kind": "github"
               },
               "model": {
-                "version": ""
+                "version": "v1.2.1"
               }
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatedRef": [
+              "mutatorRef": [
                 [
-                  "spec",
+                  "configuration",
+                  "status",
                   "deploymentID"
                 ]
               ]
@@ -92,7 +90,7 @@
       }
     }
   ],
-  "subType": "Binding",
+  "subType": "reference",
   "status": "enabled",
   "type": "non-binding",
   "version": "v1.0.0"

--- a/server/meshmodel/aws-apigatewayv2-controller/v1.2.1/v1.0.0/relationships/edge-binding-reference-v2w5n.json
+++ b/server/meshmodel/aws-apigatewayv2-controller/v1.2.1/v1.0.0/relationships/edge-binding-reference-v2w5n.json
@@ -32,16 +32,8 @@
             "id": null,
             "kind": "Stage",
             "model": {
-              "version": "",
               "name": "aws-apigatewayv2-controller",
-              "displayName": "",
-              "id": "00000000-0000-0000-0000-000000000000",
-              "registrant": {
-                "kind": "github"
-              },
-              "model": {
-                "version": "v1.2.1"
-              }
+              "version": "v1.2.1"
             },
             "patch": {
               "patchStrategy": "replace",
@@ -60,16 +52,8 @@
             "id": null,
             "kind": "Deployment",
             "model": {
-              "version": "",
               "name": "aws-apigatewayv2-controller",
-              "displayName": "",
-              "id": "00000000-0000-0000-0000-000000000000",
-              "registrant": {
-                "kind": "github"
-              },
-              "model": {
-                "version": "v1.2.1"
-              }
+              "version": "v1.2.1"
             },
             "patch": {
               "patchStrategy": "replace",

--- a/server/meshmodel/aws-apigatewayv2-controller/v1.2.1/v1.0.0/relationships/edge-binding-reference-v2w5n.json
+++ b/server/meshmodel/aws-apigatewayv2-controller/v1.2.1/v1.0.0/relationships/edge-binding-reference-v2w5n.json
@@ -33,7 +33,7 @@
             "kind": "Stage",
             "model": {
               "name": "aws-apigatewayv2-controller",
-              "version": "v1.2.1"
+              "version": ""
             },
             "patch": {
               "patchStrategy": "replace",
@@ -53,7 +53,7 @@
             "kind": "Deployment",
             "model": {
               "name": "aws-apigatewayv2-controller",
-              "version": "v1.2.1"
+              "version": ""
             },
             "patch": {
               "patchStrategy": "replace",

--- a/server/meshmodel/aws-apigatewayv2-controller/v1.2.1/v1.0.0/relationships/edge-binding-reference-w3r9p.json
+++ b/server/meshmodel/aws-apigatewayv2-controller/v1.2.1/v1.0.0/relationships/edge-binding-reference-w3r9p.json
@@ -3,7 +3,7 @@
   "evaluationQuery": "",
   "kind": "edge",
   "metadata": {
-    "description": "Wires a VpcLink into an Integration for private backend connectivity.",
+    "description": "You are binding a VPC Link to an Integration to enable private backend connectivity.",
     "styles": {
       "primaryColor": "",
       "svgColor": "",
@@ -17,7 +17,7 @@
     "displayName": "",
     "id": "00000000-0000-0000-0000-000000000000",
     "registrant": {
-      "kind": ""
+      "kind": "github"
     },
     "model": {
       "version": "v1.2.1"
@@ -31,8 +31,6 @@
           {
             "id": null,
             "kind": "Integration",
-            "match": {},
-            "match_strategy_matrix": null,
             "model": {
               "version": "",
               "name": "aws-apigatewayv2-controller",
@@ -42,15 +40,16 @@
                 "kind": "github"
               },
               "model": {
-                "version": ""
+                "version": "v1.2.1"
               }
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
-                  "status",
-                  "vpcLinkID"
+                  "configuration",
+                  "spec",
+                  "connectionID"
                 ]
               ]
             }
@@ -60,8 +59,6 @@
           {
             "id": null,
             "kind": "VPCLink",
-            "match": {},
-            "match_strategy_matrix": null,
             "model": {
               "version": "",
               "name": "aws-apigatewayv2-controller",
@@ -71,15 +68,16 @@
                 "kind": "github"
               },
               "model": {
-                "version": ""
+                "version": "v1.2.1"
               }
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatedRef": [
+              "mutatorRef": [
                 [
-                  "spec",
-                  "connectionID"
+                  "configuration",
+                  "status",
+                  "vpcLinkID"
                 ]
               ]
             }
@@ -92,7 +90,7 @@
       }
     }
   ],
-  "subType": "Binding",
+  "subType": "reference",
   "status": "enabled",
   "type": "non-binding",
   "version": "v1.0.0"

--- a/server/meshmodel/aws-apigatewayv2-controller/v1.2.1/v1.0.0/relationships/edge-binding-reference-w3r9p.json
+++ b/server/meshmodel/aws-apigatewayv2-controller/v1.2.1/v1.0.0/relationships/edge-binding-reference-w3r9p.json
@@ -1,0 +1,99 @@
+{
+  "id": "00000000-0000-0000-0000-000000000000",
+  "evaluationQuery": "",
+  "kind": "edge",
+  "metadata": {
+    "description": "Wires a VpcLink into an Integration for private backend connectivity.",
+    "styles": {
+      "primaryColor": "",
+      "svgColor": "",
+      "svgWhite": ""
+    },
+    "isAnnotation": false
+  },
+  "model": {
+    "version": "",
+    "name": "aws-apigatewayv2-controller",
+    "displayName": "",
+    "id": "00000000-0000-0000-0000-000000000000",
+    "registrant": {
+      "kind": ""
+    },
+    "model": {
+      "version": "v1.2.1"
+    }
+  },
+  "schemaVersion": "relationships.meshery.io/v1alpha3",
+  "selectors": [
+    {
+      "allow": {
+        "from": [
+          {
+            "id": null,
+            "kind": "Integration",
+            "match": {},
+            "match_strategy_matrix": null,
+            "model": {
+              "version": "",
+              "name": "aws-apigatewayv2-controller",
+              "displayName": "",
+              "id": "00000000-0000-0000-0000-000000000000",
+              "registrant": {
+                "kind": "github"
+              },
+              "model": {
+                "version": ""
+              }
+            },
+            "patch": {
+              "patchStrategy": "replace",
+              "mutatorRef": [
+                [
+                  "status",
+                  "vpcLinkID"
+                ]
+              ]
+            }
+          }
+        ],
+        "to": [
+          {
+            "id": null,
+            "kind": "VPCLink",
+            "match": {},
+            "match_strategy_matrix": null,
+            "model": {
+              "version": "",
+              "name": "aws-apigatewayv2-controller",
+              "displayName": "",
+              "id": "00000000-0000-0000-0000-000000000000",
+              "registrant": {
+                "kind": "github"
+              },
+              "model": {
+                "version": ""
+              }
+            },
+            "patch": {
+              "patchStrategy": "replace",
+              "mutatedRef": [
+                [
+                  "spec",
+                  "connectionID"
+                ]
+              ]
+            }
+          }
+        ]
+      },
+      "deny": {
+        "from": [],
+        "to": []
+      }
+    }
+  ],
+  "subType": "Binding",
+  "status": "enabled",
+  "type": "non-binding",
+  "version": "v1.0.0"
+}

--- a/server/meshmodel/aws-apigatewayv2-controller/v1.2.1/v1.0.0/relationships/edge-binding-reference-w3r9p.json
+++ b/server/meshmodel/aws-apigatewayv2-controller/v1.2.1/v1.0.0/relationships/edge-binding-reference-w3r9p.json
@@ -40,7 +40,7 @@
                 "kind": "github"
               },
               "model": {
-                "version": "v1.2.1"
+                "version": ""
               }
             },
             "patch": {
@@ -68,7 +68,7 @@
                 "kind": "github"
               },
               "model": {
-                "version": "v1.2.1"
+                "version": ""
               }
             },
             "patch": {

--- a/server/meshmodel/aws-apigatewayv2-controller/v1.2.1/v1.0.0/relationships/edge-non-binding-firewall-t2y5m.json
+++ b/server/meshmodel/aws-apigatewayv2-controller/v1.2.1/v1.0.0/relationships/edge-non-binding-firewall-t2y5m.json
@@ -1,0 +1,99 @@
+{
+  "id": "00000000-0000-0000-0000-000000000000",
+  "evaluationQuery": "",
+  "kind": "edge",
+  "metadata": {
+    "description": "Attaches a Security Group to a VpcLink to control private network access.",
+    "styles": {
+      "primaryColor": "",
+      "svgColor": "",
+      "svgWhite": ""
+    },
+    "isAnnotation": false
+  },
+  "model": {
+    "version": "",
+    "name": "aws-apigatewayv2-controller",
+    "displayName": "",
+    "id": "00000000-0000-0000-0000-000000000000",
+    "registrant": {
+      "kind": ""
+    },
+    "model": {
+      "version": "v1.2.1"
+    }
+  },
+  "schemaVersion": "relationships.meshery.io/v1alpha3",
+  "selectors": [
+    {
+      "allow": {
+        "from": [
+          {
+            "id": null,
+            "kind": "VPCLink",
+            "match": {},
+            "match_strategy_matrix": null,
+            "model": {
+              "version": "",
+              "name": "aws-apigatewayv2-controller",
+              "displayName": "",
+              "id": "00000000-0000-0000-0000-000000000000",
+              "registrant": {
+                "kind": "github"
+              },
+              "model": {
+                "version": ""
+              }
+            },
+            "patch": {
+              "patchStrategy": "replace",
+              "mutatorRef": [
+                [
+                  "status",
+                  "groupID"
+                ]
+              ]
+            }
+          }
+        ],
+        "to": [
+          {
+            "id": null,
+            "kind": "SecurityGroup",
+            "match": {},
+            "match_strategy_matrix": null,
+            "model": {
+              "version": "",
+              "name": "aws-ec2-controller",
+              "displayName": "",
+              "id": "00000000-0000-0000-0000-000000000000",
+              "registrant": {
+                "kind": "github"
+              },
+              "model": {
+                "version": ""
+              }
+            },
+            "patch": {
+              "patchStrategy": "replace",
+              "mutatedRef": [
+                [
+                  "spec",
+                  "securityGroupIDs"
+                ]
+              ]
+            }
+          }
+        ]
+      },
+      "deny": {
+        "from": [],
+        "to": []
+      }
+    }
+  ],
+  "subType": "Binding",
+  "status": "enabled",
+  "type": "non-binding",
+  "version": "v1.0.0"
+}

--- a/server/meshmodel/aws-apigatewayv2-controller/v1.2.1/v1.0.0/relationships/edge-non-binding-firewall-t2y5m.json
+++ b/server/meshmodel/aws-apigatewayv2-controller/v1.2.1/v1.0.0/relationships/edge-non-binding-firewall-t2y5m.json
@@ -3,7 +3,7 @@
   "evaluationQuery": "",
   "kind": "edge",
   "metadata": {
-    "description": "Attaches a Security Group to a VpcLink to control private network access.",
+    "description": "You are binding a Security Group to a VPC Link to control private network access for your API.",
     "styles": {
       "primaryColor": "",
       "svgColor": "",
@@ -17,7 +17,7 @@
     "displayName": "",
     "id": "00000000-0000-0000-0000-000000000000",
     "registrant": {
-      "kind": ""
+      "kind": "github"
     },
     "model": {
       "version": "v1.2.1"
@@ -31,26 +31,17 @@
           {
             "id": null,
             "kind": "VPCLink",
-            "match": {},
-            "match_strategy_matrix": null,
             "model": {
-              "version": "",
               "name": "aws-apigatewayv2-controller",
-              "displayName": "",
-              "id": "00000000-0000-0000-0000-000000000000",
-              "registrant": {
-                "kind": "github"
-              },
-              "model": {
-                "version": ""
-              }
+              "version": "v1.2.1"
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
-                  "status",
-                  "groupID"
+                  "configuration",
+                  "spec",
+                  "securityGroupIDs"
                 ]
               ]
             }
@@ -60,26 +51,17 @@
           {
             "id": null,
             "kind": "SecurityGroup",
-            "match": {},
-            "match_strategy_matrix": null,
             "model": {
-              "version": "",
               "name": "aws-ec2-controller",
-              "displayName": "",
-              "id": "00000000-0000-0000-0000-000000000000",
-              "registrant": {
-                "kind": "github"
-              },
-              "model": {
-                "version": ""
-              }
+              "version": "v1.9.2"
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatedRef": [
+              "mutatorRef": [
                 [
-                  "spec",
-                  "securityGroupIDs"
+                  "configuration",
+                  "status",
+                  "id"
                 ]
               ]
             }
@@ -92,7 +74,7 @@
       }
     }
   ],
-  "subType": "Binding",
+  "subType": "firewall",
   "status": "enabled",
   "type": "non-binding",
   "version": "v1.0.0"

--- a/server/meshmodel/aws-apigatewayv2-controller/v1.2.1/v1.0.0/relationships/edge-non-binding-firewall-t2y5m.json
+++ b/server/meshmodel/aws-apigatewayv2-controller/v1.2.1/v1.0.0/relationships/edge-non-binding-firewall-t2y5m.json
@@ -33,7 +33,7 @@
             "kind": "VPCLink",
             "model": {
               "name": "aws-apigatewayv2-controller",
-              "version": "v1.2.1"
+              "version": ""
             },
             "patch": {
               "patchStrategy": "replace",
@@ -53,7 +53,7 @@
             "kind": "SecurityGroup",
             "model": {
               "name": "aws-ec2-controller",
-              "version": "v1.9.2"
+              "version": ""
             },
             "patch": {
               "patchStrategy": "replace",

--- a/server/meshmodel/aws-apigatewayv2-controller/v1.2.1/v1.0.0/relationships/edge-non-binding-reference-g8f3d.json
+++ b/server/meshmodel/aws-apigatewayv2-controller/v1.2.1/v1.0.0/relationships/edge-non-binding-reference-g8f3d.json
@@ -1,0 +1,101 @@
+{
+  "id": "00000000-0000-0000-0000-000000000000",
+  "evaluationQuery": "",
+  "kind": "edge",
+  "metadata": {
+    "description": "Connects a CloudWatch LogGroup to a Stage for access log delivery.",
+    "styles": {
+      "primaryColor": "",
+      "svgColor": "",
+      "svgWhite": ""
+    },
+    "isAnnotation": false
+  },
+  "model": {
+    "version": "",
+    "name": "aws-apigatewayv2-controller",
+    "displayName": "",
+    "id": "00000000-0000-0000-0000-000000000000",
+    "registrant": {
+      "kind": ""
+    },
+    "model": {
+      "version": "v1.2.1"
+    }
+  },
+  "schemaVersion": "relationships.meshery.io/v1alpha3",
+  "selectors": [
+    {
+      "allow": {
+        "from": [
+          {
+            "id": null,
+            "kind": "Stage",
+            "match": {},
+            "match_strategy_matrix": null,
+            "model": {
+              "version": "",
+              "name": "aws-apigatewayv2-controller",
+              "displayName": "",
+              "id": "00000000-0000-0000-0000-000000000000",
+              "registrant": {
+                "kind": "github"
+              },
+              "model": {
+                "version": ""
+              }
+            },
+            "patch": {
+              "patchStrategy": "replace",
+              "mutatorRef": [
+                [
+                  "status",
+                  "ackResourceMetadata",
+                  "arn"
+                ]
+              ]
+            }
+          }
+        ],
+        "to": [
+          {
+            "id": null,
+            "kind": "LogGroup",
+            "match": {},
+            "match_strategy_matrix": null,
+            "model": {
+              "version": "",
+              "name": "aws-cloudwatchlogs-controller",
+              "displayName": "",
+              "id": "00000000-0000-0000-0000-000000000000",
+              "registrant": {
+                "kind": "github"
+              },
+              "model": {
+                "version": ""
+              }
+            },
+            "patch": {
+              "patchStrategy": "replace",
+              "mutatedRef": [
+                [
+                  "spec",
+                  "accessLogSettings",
+                  "destinationArn"
+                ]
+              ]
+            }
+          }
+        ]
+      },
+      "deny": {
+        "from": [],
+        "to": []
+      }
+    }
+  ],
+  "subType": "Binding",
+  "status": "enabled",
+  "type": "non-binding",
+  "version": "v1.0.0"
+}

--- a/server/meshmodel/aws-apigatewayv2-controller/v1.2.1/v1.0.0/relationships/edge-non-binding-reference-g8f3d.json
+++ b/server/meshmodel/aws-apigatewayv2-controller/v1.2.1/v1.0.0/relationships/edge-non-binding-reference-g8f3d.json
@@ -3,7 +3,7 @@
   "evaluationQuery": "",
   "kind": "edge",
   "metadata": {
-    "description": "Connects a CloudWatch LogGroup to a Stage for access log delivery.",
+    "description": "You are linking an API Stage to a CloudWatch Log Group to enable automated delivery of access logs.",
     "styles": {
       "primaryColor": "",
       "svgColor": "",
@@ -17,7 +17,7 @@
     "displayName": "",
     "id": "00000000-0000-0000-0000-000000000000",
     "registrant": {
-      "kind": ""
+      "kind": "github"
     },
     "model": {
       "version": "v1.2.1"
@@ -31,27 +31,18 @@
           {
             "id": null,
             "kind": "Stage",
-            "match": {},
-            "match_strategy_matrix": null,
             "model": {
-              "version": "",
               "name": "aws-apigatewayv2-controller",
-              "displayName": "",
-              "id": "00000000-0000-0000-0000-000000000000",
-              "registrant": {
-                "kind": "github"
-              },
-              "model": {
-                "version": ""
-              }
+              "version": "v1.2.1"
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
-                  "status",
-                  "ackResourceMetadata",
-                  "arn"
+                  "configuration",
+                  "spec",
+                  "accessLogSettings",
+                  "destinationArn"
                 ]
               ]
             }
@@ -61,27 +52,18 @@
           {
             "id": null,
             "kind": "LogGroup",
-            "match": {},
-            "match_strategy_matrix": null,
             "model": {
-              "version": "",
               "name": "aws-cloudwatchlogs-controller",
-              "displayName": "",
-              "id": "00000000-0000-0000-0000-000000000000",
-              "registrant": {
-                "kind": "github"
-              },
-              "model": {
-                "version": ""
-              }
+              "version": "v1.2.1"
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatedRef": [
+              "mutatorRef": [
                 [
-                  "spec",
-                  "accessLogSettings",
-                  "destinationArn"
+                  "configuration",
+                  "status",
+                  "ackResourceMetadata",
+                  "arn"
                 ]
               ]
             }
@@ -94,7 +76,7 @@
       }
     }
   ],
-  "subType": "Binding",
+  "subType": "reference",
   "status": "enabled",
   "type": "non-binding",
   "version": "v1.0.0"

--- a/server/meshmodel/aws-apigatewayv2-controller/v1.2.1/v1.0.0/relationships/edge-non-binding-reference-g8f3d.json
+++ b/server/meshmodel/aws-apigatewayv2-controller/v1.2.1/v1.0.0/relationships/edge-non-binding-reference-g8f3d.json
@@ -33,7 +33,7 @@
             "kind": "Stage",
             "model": {
               "name": "aws-apigatewayv2-controller",
-              "version": "v1.2.1"
+              "version": ""
             },
             "patch": {
               "patchStrategy": "replace",
@@ -54,7 +54,7 @@
             "kind": "LogGroup",
             "model": {
               "name": "aws-cloudwatchlogs-controller",
-              "version": "v1.2.1"
+              "version": ""
             },
             "patch": {
               "patchStrategy": "replace",

--- a/server/meshmodel/aws-apigatewayv2-controller/v1.2.1/v1.0.0/relationships/edge-non-binding-reference-z1n4y.json
+++ b/server/meshmodel/aws-apigatewayv2-controller/v1.2.1/v1.0.0/relationships/edge-non-binding-reference-z1n4y.json
@@ -33,7 +33,7 @@
             "kind": "Authorizer",
             "model": {
               "name": "aws-apigatewayv2-controller",
-              "version": "v1.2.1",
+              "version": "",
               "registrant": {
                 "kind": "github"
               }
@@ -57,7 +57,7 @@
             "kind": "Function",
             "model": {
               "name": "aws-lambda-controller",
-              "version": "v1.10.1",
+              "version": "",
               "registrant": {
                 "kind": "github"
               }

--- a/server/meshmodel/aws-apigatewayv2-controller/v1.2.1/v1.0.0/relationships/edge-non-binding-reference-z1n4y.json
+++ b/server/meshmodel/aws-apigatewayv2-controller/v1.2.1/v1.0.0/relationships/edge-non-binding-reference-z1n4y.json
@@ -3,7 +3,7 @@
   "evaluationQuery": "",
   "kind": "edge",
   "metadata": {
-    "description": "Wires a Lambda Function as the backing Authorizer URI for request authorization.",
+    "description": "You are binding a Lambda Function to an API Authorizer to define the custom logic for request authorization.",
     "styles": {
       "primaryColor": "",
       "svgColor": "",
@@ -17,7 +17,7 @@
     "displayName": "",
     "id": "00000000-0000-0000-0000-000000000000",
     "registrant": {
-      "kind": ""
+      "kind": "github"
     },
     "model": {
       "version": "v1.2.1"
@@ -31,29 +31,23 @@
           {
             "id": null,
             "kind": "Authorizer",
-            "match": {},
-            "match_strategy_matrix": null,
             "model": {
-              "version": "",
               "name": "aws-apigatewayv2-controller",
-              "displayName": "",
-              "id": "00000000-0000-0000-0000-000000000000",
+              "version": "v1.2.1",
               "registrant": {
                 "kind": "github"
-              },
-              "model": {
-                "version": ""
               }
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
-                  "status",
-                  "ackResourceMetadata",
-                  "arn"
+                  "configuration",
+                  "spec",
+                  "authorizerUri"
                 ]
-              ]
+              ],
+              "description": "The Authorizer is mutated to include the backing Lambda Function's ARN."
             }
           }
         ],
@@ -61,28 +55,24 @@
           {
             "id": null,
             "kind": "Function",
-            "match": {},
-            "match_strategy_matrix": null,
             "model": {
-              "version": "",
               "name": "aws-lambda-controller",
-              "displayName": "",
-              "id": "00000000-0000-0000-0000-000000000000",
+              "version": "v1.10.1",
               "registrant": {
                 "kind": "github"
-              },
-              "model": {
-                "version": ""
               }
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatedRef": [
+              "mutatorRef": [
                 [
-                  "spec",
-                  "authorizerUri"
+                  "configuration",
+                  "status",
+                  "ackResourceMetadata",
+                  "arn"
                 ]
-              ]
+              ],
+              "description": "The Lambda Function provides its ARN to the Authorizer."
             }
           }
         ]
@@ -93,7 +83,7 @@
       }
     }
   ],
-  "subType": "Binding",
+  "subType": "reference",
   "status": "enabled",
   "type": "non-binding",
   "version": "v1.0.0"

--- a/server/meshmodel/aws-apigatewayv2-controller/v1.2.1/v1.0.0/relationships/edge-non-binding-reference-z1n4y.json
+++ b/server/meshmodel/aws-apigatewayv2-controller/v1.2.1/v1.0.0/relationships/edge-non-binding-reference-z1n4y.json
@@ -1,0 +1,100 @@
+{
+  "id": "00000000-0000-0000-0000-000000000000",
+  "evaluationQuery": "",
+  "kind": "edge",
+  "metadata": {
+    "description": "Wires a Lambda Function as the backing Authorizer URI for request authorization.",
+    "styles": {
+      "primaryColor": "",
+      "svgColor": "",
+      "svgWhite": ""
+    },
+    "isAnnotation": false
+  },
+  "model": {
+    "version": "",
+    "name": "aws-apigatewayv2-controller",
+    "displayName": "",
+    "id": "00000000-0000-0000-0000-000000000000",
+    "registrant": {
+      "kind": ""
+    },
+    "model": {
+      "version": "v1.2.1"
+    }
+  },
+  "schemaVersion": "relationships.meshery.io/v1alpha3",
+  "selectors": [
+    {
+      "allow": {
+        "from": [
+          {
+            "id": null,
+            "kind": "Authorizer",
+            "match": {},
+            "match_strategy_matrix": null,
+            "model": {
+              "version": "",
+              "name": "aws-apigatewayv2-controller",
+              "displayName": "",
+              "id": "00000000-0000-0000-0000-000000000000",
+              "registrant": {
+                "kind": "github"
+              },
+              "model": {
+                "version": ""
+              }
+            },
+            "patch": {
+              "patchStrategy": "replace",
+              "mutatorRef": [
+                [
+                  "status",
+                  "ackResourceMetadata",
+                  "arn"
+                ]
+              ]
+            }
+          }
+        ],
+        "to": [
+          {
+            "id": null,
+            "kind": "Function",
+            "match": {},
+            "match_strategy_matrix": null,
+            "model": {
+              "version": "",
+              "name": "aws-lambda-controller",
+              "displayName": "",
+              "id": "00000000-0000-0000-0000-000000000000",
+              "registrant": {
+                "kind": "github"
+              },
+              "model": {
+                "version": ""
+              }
+            },
+            "patch": {
+              "patchStrategy": "replace",
+              "mutatedRef": [
+                [
+                  "spec",
+                  "authorizerUri"
+                ]
+              ]
+            }
+          }
+        ]
+      },
+      "deny": {
+        "from": [],
+        "to": []
+      }
+    }
+  ],
+  "subType": "Binding",
+  "status": "enabled",
+  "type": "non-binding",
+  "version": "v1.0.0"
+}


### PR DESCRIPTION
## What does this PR do?

Adds **AWS API Gateway v2 functional edge relationships** to Meshery. These definitions enable the visualization and functional configuration of security authorization, private networking (VPC Links), observability (CloudWatch), and environmental mapping for API Gateway deployments.

## Related Issue

**Contributes to #17503, #17096** (Relationships for AWS Services)

## Changes

Added **8 new edge relationships** for the **`aws-apigatewayv2-controller/v1.2.1`** model:

### 1. Custom Domain & Environment Mapping
- **`APIMapping → Stage`** (`edge-binding-reference-b9r1t.json`)
  - Connects a custom domain mapping to a specific API environment (Stage).
- **`APIMapping → API`** (`edge-binding-reference-m7j3k.json`)
  - Links a custom domain mapping to the functional API resource.
- **`Stage → Deployment`** (`edge-binding-reference-v2w5n.json`)
  - Points an API Stage to a specific configuration snapshot (Deployment).

### 2. Backend & Private Connectivity
- **`Integration → VPCLink`** (`edge-binding-reference-w3r9p.json`)
  - Links backend integrations to VPC Links for private resource access.
- **`VPCLink → SecurityGroup`** (`edge-non-binding-firewall-t2y5m.json`)
  - Binds VPC Links to EC2 Security Groups for network traffic control.

### 3. Security & Authorization
- **`Route → Authorizer`** (`edge-binding-reference-p4q8z.json`)
  - Secures specific API routes by linking them to defined Authorizers.
- **`Authorizer → Function`** (`edge-non-binding-reference-z1n4y.json`)
  - Connects Lambda-based Authorizers to their underlying AWS Lambda functions.

### 4. Observability
- **`Stage → LogGroup`** (`edge-non-binding-reference-g8f3d.json`)
  - Enables access logging by routing API stage telemetry to AWS CloudWatch Log Groups.

**All follow `relationships.meshery.io/v1alpha3` schema with `reference`, `network`, `firewall`, and `permission` subtypes.**

## Testing

- [x] **Kanvas Validation**: 
  - APIMapping → Stage
  - APIMapping → API
  - Route → Authorizer
  - Stage → Deployment
  - Integration → VPCLink
  - VPCLink → SecurityGroup
  - Stage → LogGroup
  - Authorizer → Function

**Screenshot Proof:**
<img width="1034" height="641" alt="Screenshot from 2026-02-24 20-30-04" src="https://github.com/user-attachments/assets/261c7c92-af9c-4692-aaa3-c8ed42c249ce" />



<img width="1034" height="641" alt="Screenshot from 2026-02-24 20-32-45" src="https://github.com/user-attachments/assets/9ee9f44e-7d17-476d-91c4-df1faec3ed71" />




---

**[Signed commits](https://github.com/meshery/meshery/blob/master/CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [x] Yes, I signed my commits.