### PR TITLE
docs(docs-new): migrate eks warning alert to hugo shortcode

### DIFF
--- a/docs-new/content/en/installation/kubernetes/eks.md
+++ b/docs-new/content/en/installation/kubernetes/eks.md
@@ -68,7 +68,9 @@ You're ready to use Meshery! Open your browser and navigate to the Meshery UI.
 
 # Out-of-cluster Installation
 
-{% include alert.html title='Out-of-cluster EKS deployments not currently supported' type="warning" alert='Out-of-cluster support for EKS is still beta and on <a href="https://github.com/meshery/meshery/blob/master/ROADMAP.md">roadmap</a>.' %}
+{{% alert title="Out-of-cluster EKS deployments not currently supported" color="warning" %}}
+Out-of-cluster support for EKS is still beta and on the [roadmap](https://github.com/meshery/meshery/blob/master/ROADMAP.md).
+{{% /alert %}}
 
 Install Meshery on Docker (out-of-cluster) and connect it to your EKS cluster.
 


### PR DESCRIPTION
**Description**
This PR continues the Jekyll-to-Hugo migration within the `docs-new` architecture by translating the legacy `{% include alert.html %}` component on the Amazon EKS installation page into a native Docsy `{{% alert %}}` shortcode. 

**Key Improvements:**
* Fixed the broken rendering of the warning banner in the new Hugo architecture.
* Removed raw HTML injection (`<a>` tags) previously required inside the Jekyll string parameter.
* Utilized the `{{% %}}` delimiter to enable native Markdown rendering inside the alert block (e.g., `[roadmap](...)`).
* Mapped the legacy `type="warning"` attribute to the Docsy standard `color="warning"`.

-- Before
<img width="1529" height="357" alt="Screenshot 2026-02-24 at 10 44 14 PM" src="https://github.com/user-attachments/assets/e8f84e41-0fc7-4f4d-9372-334af8f86a61" />

-- After
<img width="1529" height="357" alt="Screenshot 2026-02-24 at 10 45 10 PM" src="https://github.com/user-attachments/assets/5aa979e1-6312-4d8f-bcb1-59fb77e30aeb" />



**[Signed commits](https://github.com/meshery/meshery/blob/master/CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [x] Yes, I signed my commits.

