### PR TITLE
Fixed TOC for DOCS error-codes.md

### DIFF
--- a/docs/pages/reference/error-codes.md
+++ b/docs/pages/reference/error-codes.md
@@ -75,6 +75,8 @@ td {
     }
 </script>
 
+# Error Code Reference
+
 ## Error Codes and Troubleshooting
 
 Meshery and its components use a common framework (defined within MeshKit) to generate and document an event with a unique error code identifier as the combination of `[component type]-[component name]-[event moniker]-[numeric code]`. Each error code identifies the source component for the error and a standard set of information to describe the error and provide helpful details for troubleshooting the situation surrounding the specific error.


### PR DESCRIPTION
**Notes for Reviewers**
 - fixed broken TOC for error-codes.md
 - follows same pattern as error-codes.md from docs-new
 - added # h1 title only 


**[Signed commits](https://github.com/meshery/meshery/blob/master/CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [x] Yes, I signed my commits.

<!--
Thank you for contributing to Meshery! 

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. Sign your commits.
4. Include before and after screenshots/terminal output.

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.
-->
