### PR TITLE
[mesheryctl] Fix typo and incorrect documentation references in workspace commands

### DIFF
--- a/mesheryctl/internal/cli/root/workspaces/create.go
+++ b/mesheryctl/internal/cli/root/workspaces/create.go
@@ -35,7 +35,7 @@ var createWorkspaceCmd = &cobra.Command{
 	Use:   "create",
 	Short: "Create a new workspace under an organization",
 	Long: `Create a new workspace by providing the name, description, and organization ID
-Documentation for models can be found at https://docs.meshery.io/reference/mesheryctl/exp/workspace/create`,
+Documentation for workspaces can be found at https://docs.meshery.io/reference/mesheryctl/exp/workspace/create`,
 	Example: `
 // Create a new workspace in an organization
 mesheryctl exp workspace create --orgId [orgId] --name [name] --description [description]

--- a/mesheryctl/internal/cli/root/workspaces/list.go
+++ b/mesheryctl/internal/cli/root/workspaces/list.go
@@ -30,7 +30,7 @@ var listWorkspaceCmd = &cobra.Command{
 	Use:   "list",
 	Short: "List registered workspaces",
 	Long: `List name of all registered workspaces
-Documentation for models can be found at https://docs.meshery.io/reference/mesheryctl/exp/workspace/list`,
+Documentation for workspaces can be found at https://docs.meshery.io/reference/mesheryctl/exp/workspace/list`,
 	Example: `
 // List of workspace under a specific organization
 mesheryctl exp workspace list --orgId [orgId]

--- a/mesheryctl/internal/cli/root/workspaces/workspace.go
+++ b/mesheryctl/internal/cli/root/workspaces/workspace.go
@@ -29,9 +29,9 @@ var (
 
 var WorkSpaceCmd = &cobra.Command{
 	Use:   "workspace",
-	Short: "Managge workspaces under an organization",
+	Short: "Manage workspaces under an organization",
 	Long: `Create, list of workspaces under an organization
-Documentation for models can be found at https://docs.meshery.io/reference/mesheryctl/exp/workspace`,
+Documentation for workspaces can be found at https://docs.meshery.io/reference/mesheryctl/exp/workspace`,
 	Example: `
 
 // To view a list workspaces


### PR DESCRIPTION
## Description
Fixes a typo and incorrect documentation references in mesheryctl workspace commands.

## Changes
- Fixed `Managge` → `Manage` in workspace.go
- Fixed "Documentation for models" → "Documentation for workspaces" in workspace.go
- Fixed "Documentation for models" → "Documentation for workspaces" in list.go
- Fixed "Documentation for models" → "Documentation for workspaces" in create.go

## Notes for Reviewers
- This PR fixes #17623

## Signed commits
- [x] Yes, I signed my commits.