### PR TITLE
[models] Add ECR Repository to ECS TaskDefinition relationship for aws-ecs-controller  

### DIFF
--- a/server/meshmodel/aws-ecs-controller/v1.2.1/v1.0.0/relationships/edge-non-binding-reference-tywcz.json
+++ b/server/meshmodel/aws-ecs-controller/v1.2.1/v1.0.0/relationships/edge-non-binding-reference-tywcz.json
@@ -1,0 +1,103 @@
+{
+  "id": "00000000-0000-0000-0000-000000000000",
+  "evaluationQuery": "",
+  "kind": "edge",
+  "metadata": {
+    "description": "A relationship that defines how an ECS TaskDefinition references an ECR Repository to specify the container image to use for task execution.",
+    "styles": {
+      "primaryColor": "",
+      "svgColor": "",
+      "svgWhite": ""
+    },
+    "isAnnotation": false
+  },
+  "model": {
+    "version": "",
+    "name": "aws-ecs-controller",
+    "displayName": "",
+    "id": "00000000-0000-0000-0000-000000000000",
+    "registrant": {
+      "kind": ""
+    },
+    "model": {
+      "version": "v1.2.1"
+    }
+  },
+  "schemaVersion": "relationships.meshery.io/v1alpha3",
+  "selectors": [
+    {
+      "allow": {
+        "from": [
+          {
+            "id": null,
+            "kind": "Repository",
+            "match": {},
+            "match_strategy_matrix": null,
+            "model": {
+              "version": "",
+              "name": "aws-ecr-controller",
+              "displayName": "",
+              "id": "00000000-0000-0000-0000-000000000000",
+              "registrant": {
+                "kind": "github"
+              },
+              "model": {
+                "version": ""
+              }
+            },
+            "patch": {
+              "patchStrategy": "replace",
+              "mutatorRef": [
+                [
+                  "displayName"
+                ]
+              ],
+              "description": "ECR Repository provides the container image for ECS TaskDefinitions."
+            }
+          }
+        ],
+        "to": [
+          {
+            "id": null,
+            "kind": "TaskDefinition",
+            "match": {},
+            "match_strategy_matrix": null,
+            "model": {
+              "version": "",
+              "name": "aws-ecs-controller",
+              "displayName": "",
+              "id": "00000000-0000-0000-0000-000000000000",
+              "registrant": {
+                "kind": "github"
+              },
+              "model": {
+                "version": ""
+              }
+            },
+            "patch": {
+              "patchStrategy": "replace",
+              "mutatedRef": [
+                [
+                  "configuration",
+                  "spec",
+                  "containerDefinitions",
+                  "0",
+                  "image"
+                ]
+              ],
+              "description": "TaskDefinition specifies the ECR repository image URI in the container definitions."
+            }
+          }
+        ]
+      },
+      "deny": {
+        "from": [],
+        "to": []
+      }
+    }
+  ],
+  "subType": "reference",
+  "status": "enabled",
+  "type": "non-binding",
+  "version": "v1.0.0"
+}


### PR DESCRIPTION
**Notes for Reviewers**                                                                                                                           
                                                                                                                                                    
  - This PR addresses #17548                                                                                                                        

  Adds an `edge/non-binding/reference` relationship between ECR Repository (`aws-ecr-controller`) and ECS TaskDefinition (`aws-ecs-controller`).

<img width="985" height="657" alt="Screenshot from 2026-02-26 23-58-10" src="https://github.com/user-attachments/assets/b11567f5-65ed-4a77-8df6-6f1ce92b3ccc" />


  **What it does:**
  - When connected in Kanvas, Repository's `displayName` auto-populates TaskDefinition's `containerDefinitions[0].image`
  - Mirrors the existing ECR Repository → K8s Deployment relationship pattern (PR #17175) but targets ECS TaskDefinition instead

  **Details:**
  - **File:** `server/meshmodel/aws-ecs-controller/v1.2.1/v1.0.0/relationships/edge-non-binding-reference-tywcz.json`
  - **Schema:** `relationships.meshery.io/v1alpha3`
  - **FROM:** Repository (aws-ecr-controller) → mutatorRef: `displayName`
  - **TO:** TaskDefinition (aws-ecs-controller) → mutatedRef: `containerDefinitions[0].image`
  - **Patch strategy:** replace

  **Validation:**
  - JSON syntax valid
  - Structure matches existing ECS controller relationships (same top-level keys, metadata, model format)
  - Direction matches proven ECR→K8s Deployment pattern exactly
  - Component kinds (`Repository`, `TaskDefinition`) verified against existing component definitions
  - Field path `containerDefinitions[0].image` maps to real AWS ECS API field

  **[Signed commits](https://github.com/meshery/meshery/blob/master/CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
  - [ X] Yes, I signed my commits.
