### PR TITLE
[Models] Add relationships for AWS ElastiCache controller

### DIFF
--- a/server/meshmodel/aws-elasticache-controller/v1.3.3/v1.0.0/relationships/edge_mount_ReplicationGroup_S3Bucket.json
+++ b/server/meshmodel/aws-elasticache-controller/v1.3.3/v1.0.0/relationships/edge_mount_ReplicationGroup_S3Bucket.json
@@ -1,0 +1,41 @@
+{
+  "schemaVersion": "core.meshery.io/v1alpha2",
+  "version": "v1.0.0",
+  "kind": "Edge",
+  "type": "Binding",
+  "subType": "Mount",
+  "metadata": {
+    "description": "A ReplicationGroup can be seeded from a snapshot stored in Amazon S3. During creation, ElastiCache reads the RDB (Redis Database) snapshot file from the specified S3 bucket to populate the initial cache state. The S3 bucket must be in the same region as the ReplicationGroup."
+  },
+  "model": "aws-elasticache-controller",
+  "selectors": [
+    {
+      "allow": {
+        "from": [
+          {
+            "kind": "ReplicationGroup",
+            "model": "aws-elasticache-controller",
+            "patch": {
+              "patchStrategy": "replace",
+              "mutatorRef": [["settings", "snapshotARNs", "_"]],
+              "description": "The ReplicationGroup references the S3 ARN of a snapshot file to seed the initial dataset."
+            }
+          }
+        ],
+        "to": [
+          {
+            "kind": "Bucket",
+            "model": "aws-s3-controller",
+            "patch": {
+              "patchStrategy": "replace",
+              "mutatedRef": [["settings", "arn"]],
+              "description": "The S3 Bucket stores the RDB snapshot file used to seed the ReplicationGroup."
+            }
+          }
+        ]
+      },
+      "deny": {}
+    }
+  ],
+  "evaluationQuery": "edge_mount_relationship"
+}

--- a/server/meshmodel/aws-elasticache-controller/v1.3.3/v1.0.0/relationships/edge_mount_ReplicationGroup_S3Bucket.json
+++ b/server/meshmodel/aws-elasticache-controller/v1.3.3/v1.0.0/relationships/edge_mount_ReplicationGroup_S3Bucket.json
@@ -1,41 +1,96 @@
 {
-  "schemaVersion": "core.meshery.io/v1alpha2",
-  "version": "v1.0.0",
-  "kind": "Edge",
-  "type": "Binding",
-  "subType": "Mount",
+  "id": "00000000-0000-0000-0000-000000000000",
+  "evaluationQuery": "edge_mount_relationship",
+  "kind": "edge",
   "metadata": {
-    "description": "A ReplicationGroup can be seeded from a snapshot stored in Amazon S3. During creation, ElastiCache reads the RDB (Redis Database) snapshot file from the specified S3 bucket to populate the initial cache state. The S3 bucket must be in the same region as the ReplicationGroup."
+    "description": "A ReplicationGroup can be seeded from a snapshot stored in Amazon S3. During creation, ElastiCache reads the RDB (Redis Database) snapshot file from the specified S3 bucket to populate the initial cache state. The S3 bucket must be in the same region as the ReplicationGroup.",
+    "styles": {
+      "primaryColor": "",
+      "svgColor": "",
+      "svgWhite": ""
+    },
+    "isAnnotation": false
   },
-  "model": "aws-elasticache-controller",
+  "model": {
+    "version": "",
+    "name": "aws-elasticache-controller",
+    "displayName": "",
+    "id": "00000000-0000-0000-0000-000000000000",
+    "registrant": {
+      "kind": ""
+    },
+    "model": {
+      "version": "v1.3.3"
+    }
+  },
+  "schemaVersion": "relationships.meshery.io/v1alpha3",
   "selectors": [
     {
       "allow": {
         "from": [
           {
+            "id": null,
             "kind": "ReplicationGroup",
-            "model": "aws-elasticache-controller",
+            "match": {},
+            "match_strategy_matrix": null,
+            "model": {
+              "version": "",
+              "name": "aws-elasticache-controller",
+              "displayName": "",
+              "id": "00000000-0000-0000-0000-000000000000",
+              "registrant": {
+                "kind": "github"
+              },
+              "model": {
+                "version": ""
+              }
+            },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [["settings", "snapshotARNs", "_"]],
-              "description": "The ReplicationGroup references the S3 ARN of a snapshot file to seed the initial dataset."
+              "mutatorRef": [
+                [
+                  "configuration",
+                  "spec",
+                  "snapshotARNs"
+                ]
+              ]
             }
           }
         ],
         "to": [
           {
+            "id": null,
             "kind": "Bucket",
-            "model": "aws-s3-controller",
+            "match": {},
+            "match_strategy_matrix": null,
+            "model": {
+              "version": "",
+              "name": "aws-s3-controller",
+              "displayName": "",
+              "id": "00000000-0000-0000-0000-000000000000",
+              "registrant": {
+                "kind": "github"
+              },
+              "model": {
+                "version": ""
+              }
+            },
             "patch": {
               "patchStrategy": "replace",
-              "mutatedRef": [["settings", "arn"]],
-              "description": "The S3 Bucket stores the RDB snapshot file used to seed the ReplicationGroup."
+              "mutatedRef": [
+                [
+                  "displayName"
+                ]
+              ]
             }
           }
         ]
       },
-      "deny": {}
+      "deny": null
     }
   ],
-  "evaluationQuery": "edge_mount_relationship"
+  "subType": "mount",
+  "status": "enabled",
+  "type": "binding",
+  "version": "v1.0.0"
 }

--- a/server/meshmodel/aws-elasticache-controller/v1.3.3/v1.0.0/relationships/edge_mount_ServerlessCache_S3Bucket.json
+++ b/server/meshmodel/aws-elasticache-controller/v1.3.3/v1.0.0/relationships/edge_mount_ServerlessCache_S3Bucket.json
@@ -1,0 +1,41 @@
+{
+  "schemaVersion": "core.meshery.io/v1alpha2",
+  "version": "v1.0.0",
+  "kind": "Edge",
+  "type": "Binding",
+  "subType": "Mount",
+  "metadata": {
+    "description": "A ServerlessCache can be restored from a snapshot stored in Amazon S3. The S3 bucket holds point-in-time RDB snapshot data that is loaded into the serverless cache during provisioning, enabling data migration and disaster recovery workflows."
+  },
+  "model": "aws-elasticache-controller",
+  "selectors": [
+    {
+      "allow": {
+        "from": [
+          {
+            "kind": "ServerlessCache",
+            "model": "aws-elasticache-controller",
+            "patch": {
+              "patchStrategy": "replace",
+              "mutatorRef": [["settings", "snapshotARNsToRestore", "_"]],
+              "description": "The ServerlessCache references the S3 ARN of snapshot data to restore from."
+            }
+          }
+        ],
+        "to": [
+          {
+            "kind": "Bucket",
+            "model": "aws-s3-controller",
+            "patch": {
+              "patchStrategy": "replace",
+              "mutatedRef": [["settings", "arn"]],
+              "description": "The S3 Bucket holds snapshot data used to restore the ServerlessCache."
+            }
+          }
+        ]
+      },
+      "deny": {}
+    }
+  ],
+  "evaluationQuery": "edge_mount_relationship"
+}

--- a/server/meshmodel/aws-elasticache-controller/v1.3.3/v1.0.0/relationships/edge_mount_ServerlessCache_S3Bucket.json
+++ b/server/meshmodel/aws-elasticache-controller/v1.3.3/v1.0.0/relationships/edge_mount_ServerlessCache_S3Bucket.json
@@ -1,41 +1,96 @@
 {
-  "schemaVersion": "core.meshery.io/v1alpha2",
-  "version": "v1.0.0",
-  "kind": "Edge",
-  "type": "Binding",
-  "subType": "Mount",
+  "id": "00000000-0000-0000-0000-000000000000",
+  "evaluationQuery": "edge_mount_relationship",
+  "kind": "edge",
   "metadata": {
-    "description": "A ServerlessCache can be restored from a snapshot stored in Amazon S3. The S3 bucket holds point-in-time RDB snapshot data that is loaded into the serverless cache during provisioning, enabling data migration and disaster recovery workflows."
+    "description": "A ServerlessCache can be restored from a snapshot stored in Amazon S3. The S3 bucket holds point-in-time RDB snapshot data that is loaded into the serverless cache during provisioning, enabling data migration and disaster recovery workflows.",
+    "styles": {
+      "primaryColor": "",
+      "svgColor": "",
+      "svgWhite": ""
+    },
+    "isAnnotation": false
   },
-  "model": "aws-elasticache-controller",
+  "model": {
+    "version": "",
+    "name": "aws-elasticache-controller",
+    "displayName": "",
+    "id": "00000000-0000-0000-0000-000000000000",
+    "registrant": {
+      "kind": ""
+    },
+    "model": {
+      "version": "v1.3.3"
+    }
+  },
+  "schemaVersion": "relationships.meshery.io/v1alpha3",
   "selectors": [
     {
       "allow": {
         "from": [
           {
+            "id": null,
             "kind": "ServerlessCache",
-            "model": "aws-elasticache-controller",
+            "match": {},
+            "match_strategy_matrix": null,
+            "model": {
+              "version": "",
+              "name": "aws-elasticache-controller",
+              "displayName": "",
+              "id": "00000000-0000-0000-0000-000000000000",
+              "registrant": {
+                "kind": "github"
+              },
+              "model": {
+                "version": ""
+              }
+            },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [["settings", "snapshotARNsToRestore", "_"]],
-              "description": "The ServerlessCache references the S3 ARN of snapshot data to restore from."
+              "mutatorRef": [
+                [
+                  "configuration",
+                  "spec",
+                  "snapshotARNsToRestore"
+                ]
+              ]
             }
           }
         ],
         "to": [
           {
+            "id": null,
             "kind": "Bucket",
-            "model": "aws-s3-controller",
+            "match": {},
+            "match_strategy_matrix": null,
+            "model": {
+              "version": "",
+              "name": "aws-s3-controller",
+              "displayName": "",
+              "id": "00000000-0000-0000-0000-000000000000",
+              "registrant": {
+                "kind": "github"
+              },
+              "model": {
+                "version": ""
+              }
+            },
             "patch": {
               "patchStrategy": "replace",
-              "mutatedRef": [["settings", "arn"]],
-              "description": "The S3 Bucket holds snapshot data used to restore the ServerlessCache."
+              "mutatedRef": [
+                [
+                  "displayName"
+                ]
+              ]
             }
           }
         ]
       },
-      "deny": {}
+      "deny": null
     }
   ],
-  "evaluationQuery": "edge_mount_relationship"
+  "subType": "mount",
+  "status": "enabled",
+  "type": "binding",
+  "version": "v1.0.0"
 }

--- a/server/meshmodel/aws-elasticache-controller/v1.3.3/v1.0.0/relationships/edge_network_CacheCluster_SNSTopic.json
+++ b/server/meshmodel/aws-elasticache-controller/v1.3.3/v1.0.0/relationships/edge_network_CacheCluster_SNSTopic.json
@@ -1,0 +1,41 @@
+{
+  "schemaVersion": "core.meshery.io/v1alpha2",
+  "version": "v1.0.0",
+  "kind": "Edge",
+  "type": "Non-Binding",
+  "subType": "Network",
+  "metadata": {
+    "description": "A CacheCluster can be configured to send event notifications to an AWS SNS Topic. This allows operational events such as node failures, reboots, and scaling activities to be published for downstream monitoring or automation workflows."
+  },
+  "model": "aws-elasticache-controller",
+  "selectors": [
+    {
+      "allow": {
+        "from": [
+          {
+            "kind": "CacheCluster",
+            "model": "aws-elasticache-controller",
+            "patch": {
+              "patchStrategy": "replace",
+              "mutatorRef": [["settings", "notificationTopicARN"]],
+              "description": "The CacheCluster holds the SNS Topic ARN to publish ElastiCache event notifications."
+            }
+          }
+        ],
+        "to": [
+          {
+            "kind": "Topic",
+            "model": "aws-sns-controller",
+            "patch": {
+              "patchStrategy": "replace",
+              "mutatedRef": [["settings", "topicARN"]],
+              "description": "The SNS Topic receives ElastiCache operational event notifications from the CacheCluster."
+            }
+          }
+        ]
+      },
+      "deny": {}
+    }
+  ],
+  "evaluationQuery": "edge_network_relationship"
+}

--- a/server/meshmodel/aws-elasticache-controller/v1.3.3/v1.0.0/relationships/edge_network_CacheCluster_SNSTopic.json
+++ b/server/meshmodel/aws-elasticache-controller/v1.3.3/v1.0.0/relationships/edge_network_CacheCluster_SNSTopic.json
@@ -1,41 +1,96 @@
 {
-  "schemaVersion": "core.meshery.io/v1alpha2",
-  "version": "v1.0.0",
-  "kind": "Edge",
-  "type": "Non-Binding",
-  "subType": "Network",
+  "id": "00000000-0000-0000-0000-000000000000",
+  "evaluationQuery": "edge_network_relationship",
+  "kind": "edge",
   "metadata": {
-    "description": "A CacheCluster can be configured to send event notifications to an AWS SNS Topic. This allows operational events such as node failures, reboots, and scaling activities to be published for downstream monitoring or automation workflows."
+    "description": "A CacheCluster can be configured to send event notifications to an AWS SNS Topic. This allows operational events such as node failures, reboots, and scaling activities to be published for downstream monitoring or automation workflows.",
+    "styles": {
+      "primaryColor": "",
+      "svgColor": "",
+      "svgWhite": ""
+    },
+    "isAnnotation": false
   },
-  "model": "aws-elasticache-controller",
+  "model": {
+    "version": "",
+    "name": "aws-elasticache-controller",
+    "displayName": "",
+    "id": "00000000-0000-0000-0000-000000000000",
+    "registrant": {
+      "kind": ""
+    },
+    "model": {
+      "version": "v1.3.3"
+    }
+  },
+  "schemaVersion": "relationships.meshery.io/v1alpha3",
   "selectors": [
     {
       "allow": {
         "from": [
           {
+            "id": null,
             "kind": "CacheCluster",
-            "model": "aws-elasticache-controller",
+            "match": {},
+            "match_strategy_matrix": null,
+            "model": {
+              "version": "",
+              "name": "aws-elasticache-controller",
+              "displayName": "",
+              "id": "00000000-0000-0000-0000-000000000000",
+              "registrant": {
+                "kind": "github"
+              },
+              "model": {
+                "version": ""
+              }
+            },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [["settings", "notificationTopicARN"]],
-              "description": "The CacheCluster holds the SNS Topic ARN to publish ElastiCache event notifications."
+              "mutatorRef": [
+                [
+                  "configuration",
+                  "spec",
+                  "notificationTopicARN"
+                ]
+              ]
             }
           }
         ],
         "to": [
           {
+            "id": null,
             "kind": "Topic",
-            "model": "aws-sns-controller",
+            "match": {},
+            "match_strategy_matrix": null,
+            "model": {
+              "version": "",
+              "name": "aws-sns-controller",
+              "displayName": "",
+              "id": "00000000-0000-0000-0000-000000000000",
+              "registrant": {
+                "kind": "github"
+              },
+              "model": {
+                "version": ""
+              }
+            },
             "patch": {
               "patchStrategy": "replace",
-              "mutatedRef": [["settings", "topicARN"]],
-              "description": "The SNS Topic receives ElastiCache operational event notifications from the CacheCluster."
+              "mutatedRef": [
+                [
+                  "displayName"
+                ]
+              ]
             }
           }
         ]
       },
-      "deny": {}
+      "deny": null
     }
   ],
-  "evaluationQuery": "edge_network_relationship"
+  "subType": "network",
+  "status": "enabled",
+  "type": "non-binding",
+  "version": "v1.0.0"
 }

--- a/server/meshmodel/aws-elasticache-controller/v1.3.3/v1.0.0/relationships/edge_network_CacheCluster_SecurityGroup.json
+++ b/server/meshmodel/aws-elasticache-controller/v1.3.3/v1.0.0/relationships/edge_network_CacheCluster_SecurityGroup.json
@@ -1,0 +1,41 @@
+{
+  "schemaVersion": "core.meshery.io/v1alpha2",
+  "version": "v1.0.0",
+  "kind": "Edge",
+  "type": "Non-Binding",
+  "subType": "Network",
+  "metadata": {
+    "description": "A CacheCluster is associated with one or more EC2 Security Groups to control inbound and outbound network traffic to the cache nodes. Security groups act as virtual firewalls, typically allowing access only from specific application servers or subnets on the ElastiCache port (e.g., 6379 for Redis, 11211 for Memcached)."
+  },
+  "model": "aws-elasticache-controller",
+  "selectors": [
+    {
+      "allow": {
+        "from": [
+          {
+            "kind": "CacheCluster",
+            "model": "aws-elasticache-controller",
+            "patch": {
+              "patchStrategy": "replace",
+              "mutatorRef": [["settings", "securityGroupIDs", "_"]],
+              "description": "The CacheCluster references security group IDs that control its network access."
+            }
+          }
+        ],
+        "to": [
+          {
+            "kind": "SecurityGroup",
+            "model": "aws-ec2-controller",
+            "patch": {
+              "patchStrategy": "replace",
+              "mutatedRef": [["settings", "groupID"]],
+              "description": "The EC2 SecurityGroup provides its group ID to control network access to the CacheCluster."
+            }
+          }
+        ]
+      },
+      "deny": {}
+    }
+  ],
+  "evaluationQuery": "edge_network_relationship"
+}

--- a/server/meshmodel/aws-elasticache-controller/v1.3.3/v1.0.0/relationships/edge_network_CacheCluster_SecurityGroup.json
+++ b/server/meshmodel/aws-elasticache-controller/v1.3.3/v1.0.0/relationships/edge_network_CacheCluster_SecurityGroup.json
@@ -1,41 +1,96 @@
 {
-  "schemaVersion": "core.meshery.io/v1alpha2",
-  "version": "v1.0.0",
-  "kind": "Edge",
-  "type": "Non-Binding",
-  "subType": "Network",
+  "id": "00000000-0000-0000-0000-000000000000",
+  "evaluationQuery": "edge_network_relationship",
+  "kind": "edge",
   "metadata": {
-    "description": "A CacheCluster is associated with one or more EC2 Security Groups to control inbound and outbound network traffic to the cache nodes. Security groups act as virtual firewalls, typically allowing access only from specific application servers or subnets on the ElastiCache port (e.g., 6379 for Redis, 11211 for Memcached)."
+    "description": "A CacheCluster is associated with one or more EC2 Security Groups to control inbound and outbound network traffic to the cache nodes. Security groups act as virtual firewalls, typically allowing access only from specific application servers on the ElastiCache port.",
+    "styles": {
+      "primaryColor": "",
+      "svgColor": "",
+      "svgWhite": ""
+    },
+    "isAnnotation": false
   },
-  "model": "aws-elasticache-controller",
+  "model": {
+    "version": "",
+    "name": "aws-elasticache-controller",
+    "displayName": "",
+    "id": "00000000-0000-0000-0000-000000000000",
+    "registrant": {
+      "kind": ""
+    },
+    "model": {
+      "version": "v1.3.3"
+    }
+  },
+  "schemaVersion": "relationships.meshery.io/v1alpha3",
   "selectors": [
     {
       "allow": {
         "from": [
           {
+            "id": null,
             "kind": "CacheCluster",
-            "model": "aws-elasticache-controller",
+            "match": {},
+            "match_strategy_matrix": null,
+            "model": {
+              "version": "",
+              "name": "aws-elasticache-controller",
+              "displayName": "",
+              "id": "00000000-0000-0000-0000-000000000000",
+              "registrant": {
+                "kind": "github"
+              },
+              "model": {
+                "version": ""
+              }
+            },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [["settings", "securityGroupIDs", "_"]],
-              "description": "The CacheCluster references security group IDs that control its network access."
+              "mutatorRef": [
+                [
+                  "configuration",
+                  "spec",
+                  "securityGroupIDs"
+                ]
+              ]
             }
           }
         ],
         "to": [
           {
+            "id": null,
             "kind": "SecurityGroup",
-            "model": "aws-ec2-controller",
+            "match": {},
+            "match_strategy_matrix": null,
+            "model": {
+              "version": "",
+              "name": "aws-ec2-controller",
+              "displayName": "",
+              "id": "00000000-0000-0000-0000-000000000000",
+              "registrant": {
+                "kind": "github"
+              },
+              "model": {
+                "version": ""
+              }
+            },
             "patch": {
               "patchStrategy": "replace",
-              "mutatedRef": [["settings", "groupID"]],
-              "description": "The EC2 SecurityGroup provides its group ID to control network access to the CacheCluster."
+              "mutatedRef": [
+                [
+                  "displayName"
+                ]
+              ]
             }
           }
         ]
       },
-      "deny": {}
+      "deny": null
     }
   ],
-  "evaluationQuery": "edge_network_relationship"
+  "subType": "network",
+  "status": "enabled",
+  "type": "non-binding",
+  "version": "v1.0.0"
 }

--- a/server/meshmodel/aws-elasticache-controller/v1.3.3/v1.0.0/relationships/edge_network_ReplicationGroup_SNSTopic.json
+++ b/server/meshmodel/aws-elasticache-controller/v1.3.3/v1.0.0/relationships/edge_network_ReplicationGroup_SNSTopic.json
@@ -1,0 +1,41 @@
+{
+  "schemaVersion": "core.meshery.io/v1alpha2",
+  "version": "v1.0.0",
+  "kind": "Edge",
+  "type": "Non-Binding",
+  "subType": "Network",
+  "metadata": {
+    "description": "A ReplicationGroup can send event notifications to an AWS SNS Topic. ElastiCache publishes cluster events (e.g., failovers, node additions/removals, parameter group changes) to the specified SNS topic, enabling downstream subscribers to react to infrastructure state changes."
+  },
+  "model": "aws-elasticache-controller",
+  "selectors": [
+    {
+      "allow": {
+        "from": [
+          {
+            "kind": "ReplicationGroup",
+            "model": "aws-elasticache-controller",
+            "patch": {
+              "patchStrategy": "replace",
+              "mutatorRef": [["settings", "notificationTopicARN"]],
+              "description": "The ReplicationGroup holds the SNS Topic ARN to route ElastiCache event notifications."
+            }
+          }
+        ],
+        "to": [
+          {
+            "kind": "Topic",
+            "model": "aws-sns-controller",
+            "patch": {
+              "patchStrategy": "replace",
+              "mutatedRef": [["settings", "topicARN"]],
+              "description": "The SNS Topic receives ElastiCache event notifications from the ReplicationGroup."
+            }
+          }
+        ]
+      },
+      "deny": {}
+    }
+  ],
+  "evaluationQuery": "edge_network_relationship"
+}

--- a/server/meshmodel/aws-elasticache-controller/v1.3.3/v1.0.0/relationships/edge_network_ReplicationGroup_SNSTopic.json
+++ b/server/meshmodel/aws-elasticache-controller/v1.3.3/v1.0.0/relationships/edge_network_ReplicationGroup_SNSTopic.json
@@ -1,41 +1,96 @@
 {
-  "schemaVersion": "core.meshery.io/v1alpha2",
-  "version": "v1.0.0",
-  "kind": "Edge",
-  "type": "Non-Binding",
-  "subType": "Network",
+  "id": "00000000-0000-0000-0000-000000000000",
+  "evaluationQuery": "edge_network_relationship",
+  "kind": "edge",
   "metadata": {
-    "description": "A ReplicationGroup can send event notifications to an AWS SNS Topic. ElastiCache publishes cluster events (e.g., failovers, node additions/removals, parameter group changes) to the specified SNS topic, enabling downstream subscribers to react to infrastructure state changes."
+    "description": "A ReplicationGroup can send event notifications to an AWS SNS Topic. ElastiCache publishes cluster events such as failovers, node additions/removals, and parameter group changes to the specified SNS topic.",
+    "styles": {
+      "primaryColor": "",
+      "svgColor": "",
+      "svgWhite": ""
+    },
+    "isAnnotation": false
   },
-  "model": "aws-elasticache-controller",
+  "model": {
+    "version": "",
+    "name": "aws-elasticache-controller",
+    "displayName": "",
+    "id": "00000000-0000-0000-0000-000000000000",
+    "registrant": {
+      "kind": ""
+    },
+    "model": {
+      "version": "v1.3.3"
+    }
+  },
+  "schemaVersion": "relationships.meshery.io/v1alpha3",
   "selectors": [
     {
       "allow": {
         "from": [
           {
+            "id": null,
             "kind": "ReplicationGroup",
-            "model": "aws-elasticache-controller",
+            "match": {},
+            "match_strategy_matrix": null,
+            "model": {
+              "version": "",
+              "name": "aws-elasticache-controller",
+              "displayName": "",
+              "id": "00000000-0000-0000-0000-000000000000",
+              "registrant": {
+                "kind": "github"
+              },
+              "model": {
+                "version": ""
+              }
+            },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [["settings", "notificationTopicARN"]],
-              "description": "The ReplicationGroup holds the SNS Topic ARN to route ElastiCache event notifications."
+              "mutatorRef": [
+                [
+                  "configuration",
+                  "spec",
+                  "notificationTopicARN"
+                ]
+              ]
             }
           }
         ],
         "to": [
           {
+            "id": null,
             "kind": "Topic",
-            "model": "aws-sns-controller",
+            "match": {},
+            "match_strategy_matrix": null,
+            "model": {
+              "version": "",
+              "name": "aws-sns-controller",
+              "displayName": "",
+              "id": "00000000-0000-0000-0000-000000000000",
+              "registrant": {
+                "kind": "github"
+              },
+              "model": {
+                "version": ""
+              }
+            },
             "patch": {
               "patchStrategy": "replace",
-              "mutatedRef": [["settings", "topicARN"]],
-              "description": "The SNS Topic receives ElastiCache event notifications from the ReplicationGroup."
+              "mutatedRef": [
+                [
+                  "displayName"
+                ]
+              ]
             }
           }
         ]
       },
-      "deny": {}
+      "deny": null
     }
   ],
-  "evaluationQuery": "edge_network_relationship"
+  "subType": "network",
+  "status": "enabled",
+  "type": "non-binding",
+  "version": "v1.0.0"
 }

--- a/server/meshmodel/aws-elasticache-controller/v1.3.3/v1.0.0/relationships/edge_network_ReplicationGroup_SecurityGroup.json
+++ b/server/meshmodel/aws-elasticache-controller/v1.3.3/v1.0.0/relationships/edge_network_ReplicationGroup_SecurityGroup.json
@@ -1,0 +1,41 @@
+{
+  "schemaVersion": "core.meshery.io/v1alpha2",
+  "version": "v1.0.0",
+  "kind": "Edge",
+  "type": "Non-Binding",
+  "subType": "Network",
+  "metadata": {
+    "description": "A ReplicationGroup is associated with one or more EC2 Security Groups to control network access to the Redis/Valkey cluster endpoints. Security groups restrict which resources (e.g., EC2 instances, Lambda functions, ECS tasks) can connect to the primary and reader endpoints."
+  },
+  "model": "aws-elasticache-controller",
+  "selectors": [
+    {
+      "allow": {
+        "from": [
+          {
+            "kind": "ReplicationGroup",
+            "model": "aws-elasticache-controller",
+            "patch": {
+              "patchStrategy": "replace",
+              "mutatorRef": [["settings", "securityGroupIDs", "_"]],
+              "description": "The ReplicationGroup references security group IDs that govern its network access."
+            }
+          }
+        ],
+        "to": [
+          {
+            "kind": "SecurityGroup",
+            "model": "aws-ec2-controller",
+            "patch": {
+              "patchStrategy": "replace",
+              "mutatedRef": [["settings", "groupID"]],
+              "description": "The EC2 SecurityGroup provides network access control to the ReplicationGroup."
+            }
+          }
+        ]
+      },
+      "deny": {}
+    }
+  ],
+  "evaluationQuery": "edge_network_relationship"
+}

--- a/server/meshmodel/aws-elasticache-controller/v1.3.3/v1.0.0/relationships/edge_network_ReplicationGroup_SecurityGroup.json
+++ b/server/meshmodel/aws-elasticache-controller/v1.3.3/v1.0.0/relationships/edge_network_ReplicationGroup_SecurityGroup.json
@@ -1,41 +1,96 @@
 {
-  "schemaVersion": "core.meshery.io/v1alpha2",
-  "version": "v1.0.0",
-  "kind": "Edge",
-  "type": "Non-Binding",
-  "subType": "Network",
+  "id": "00000000-0000-0000-0000-000000000000",
+  "evaluationQuery": "edge_network_relationship",
+  "kind": "edge",
   "metadata": {
-    "description": "A ReplicationGroup is associated with one or more EC2 Security Groups to control network access to the Redis/Valkey cluster endpoints. Security groups restrict which resources (e.g., EC2 instances, Lambda functions, ECS tasks) can connect to the primary and reader endpoints."
+    "description": "A ReplicationGroup is associated with one or more EC2 Security Groups to control network access to the Redis/Valkey cluster endpoints. Security groups restrict which resources can connect to the primary and reader endpoints.",
+    "styles": {
+      "primaryColor": "",
+      "svgColor": "",
+      "svgWhite": ""
+    },
+    "isAnnotation": false
   },
-  "model": "aws-elasticache-controller",
+  "model": {
+    "version": "",
+    "name": "aws-elasticache-controller",
+    "displayName": "",
+    "id": "00000000-0000-0000-0000-000000000000",
+    "registrant": {
+      "kind": ""
+    },
+    "model": {
+      "version": "v1.3.3"
+    }
+  },
+  "schemaVersion": "relationships.meshery.io/v1alpha3",
   "selectors": [
     {
       "allow": {
         "from": [
           {
+            "id": null,
             "kind": "ReplicationGroup",
-            "model": "aws-elasticache-controller",
+            "match": {},
+            "match_strategy_matrix": null,
+            "model": {
+              "version": "",
+              "name": "aws-elasticache-controller",
+              "displayName": "",
+              "id": "00000000-0000-0000-0000-000000000000",
+              "registrant": {
+                "kind": "github"
+              },
+              "model": {
+                "version": ""
+              }
+            },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [["settings", "securityGroupIDs", "_"]],
-              "description": "The ReplicationGroup references security group IDs that govern its network access."
+              "mutatorRef": [
+                [
+                  "configuration",
+                  "spec",
+                  "securityGroupIDs"
+                ]
+              ]
             }
           }
         ],
         "to": [
           {
+            "id": null,
             "kind": "SecurityGroup",
-            "model": "aws-ec2-controller",
+            "match": {},
+            "match_strategy_matrix": null,
+            "model": {
+              "version": "",
+              "name": "aws-ec2-controller",
+              "displayName": "",
+              "id": "00000000-0000-0000-0000-000000000000",
+              "registrant": {
+                "kind": "github"
+              },
+              "model": {
+                "version": ""
+              }
+            },
             "patch": {
               "patchStrategy": "replace",
-              "mutatedRef": [["settings", "groupID"]],
-              "description": "The EC2 SecurityGroup provides network access control to the ReplicationGroup."
+              "mutatedRef": [
+                [
+                  "displayName"
+                ]
+              ]
             }
           }
         ]
       },
-      "deny": {}
+      "deny": null
     }
   ],
-  "evaluationQuery": "edge_network_relationship"
+  "subType": "network",
+  "status": "enabled",
+  "type": "non-binding",
+  "version": "v1.0.0"
 }

--- a/server/meshmodel/aws-elasticache-controller/v1.3.3/v1.0.0/relationships/edge_network_ServerlessCache_SecurityGroup.json
+++ b/server/meshmodel/aws-elasticache-controller/v1.3.3/v1.0.0/relationships/edge_network_ServerlessCache_SecurityGroup.json
@@ -1,0 +1,41 @@
+{
+  "schemaVersion": "core.meshery.io/v1alpha2",
+  "version": "v1.0.0",
+  "kind": "Edge",
+  "type": "Non-Binding",
+  "subType": "Network",
+  "metadata": {
+    "description": "A ServerlessCache is associated with EC2 Security Groups that restrict network access to the serverless cache endpoint. This controls which VPC resources are permitted to connect to the cache."
+  },
+  "model": "aws-elasticache-controller",
+  "selectors": [
+    {
+      "allow": {
+        "from": [
+          {
+            "kind": "ServerlessCache",
+            "model": "aws-elasticache-controller",
+            "patch": {
+              "patchStrategy": "replace",
+              "mutatorRef": [["settings", "securityGroupIDs", "_"]],
+              "description": "The ServerlessCache references security group IDs for network access control."
+            }
+          }
+        ],
+        "to": [
+          {
+            "kind": "SecurityGroup",
+            "model": "aws-ec2-controller",
+            "patch": {
+              "patchStrategy": "replace",
+              "mutatedRef": [["settings", "groupID"]],
+              "description": "The EC2 SecurityGroup controls inbound network access to the ServerlessCache."
+            }
+          }
+        ]
+      },
+      "deny": {}
+    }
+  ],
+  "evaluationQuery": "edge_network_relationship"
+}

--- a/server/meshmodel/aws-elasticache-controller/v1.3.3/v1.0.0/relationships/edge_network_ServerlessCache_SecurityGroup.json
+++ b/server/meshmodel/aws-elasticache-controller/v1.3.3/v1.0.0/relationships/edge_network_ServerlessCache_SecurityGroup.json
@@ -1,41 +1,96 @@
 {
-  "schemaVersion": "core.meshery.io/v1alpha2",
-  "version": "v1.0.0",
-  "kind": "Edge",
-  "type": "Non-Binding",
-  "subType": "Network",
+  "id": "00000000-0000-0000-0000-000000000000",
+  "evaluationQuery": "edge_network_relationship",
+  "kind": "edge",
   "metadata": {
-    "description": "A ServerlessCache is associated with EC2 Security Groups that restrict network access to the serverless cache endpoint. This controls which VPC resources are permitted to connect to the cache."
+    "description": "A ServerlessCache is associated with EC2 Security Groups that restrict network access to the serverless cache endpoint. This controls which VPC resources are permitted to connect to the cache.",
+    "styles": {
+      "primaryColor": "",
+      "svgColor": "",
+      "svgWhite": ""
+    },
+    "isAnnotation": false
   },
-  "model": "aws-elasticache-controller",
+  "model": {
+    "version": "",
+    "name": "aws-elasticache-controller",
+    "displayName": "",
+    "id": "00000000-0000-0000-0000-000000000000",
+    "registrant": {
+      "kind": ""
+    },
+    "model": {
+      "version": "v1.3.3"
+    }
+  },
+  "schemaVersion": "relationships.meshery.io/v1alpha3",
   "selectors": [
     {
       "allow": {
         "from": [
           {
+            "id": null,
             "kind": "ServerlessCache",
-            "model": "aws-elasticache-controller",
+            "match": {},
+            "match_strategy_matrix": null,
+            "model": {
+              "version": "",
+              "name": "aws-elasticache-controller",
+              "displayName": "",
+              "id": "00000000-0000-0000-0000-000000000000",
+              "registrant": {
+                "kind": "github"
+              },
+              "model": {
+                "version": ""
+              }
+            },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [["settings", "securityGroupIDs", "_"]],
-              "description": "The ServerlessCache references security group IDs for network access control."
+              "mutatorRef": [
+                [
+                  "configuration",
+                  "spec",
+                  "securityGroupIDs"
+                ]
+              ]
             }
           }
         ],
         "to": [
           {
+            "id": null,
             "kind": "SecurityGroup",
-            "model": "aws-ec2-controller",
+            "match": {},
+            "match_strategy_matrix": null,
+            "model": {
+              "version": "",
+              "name": "aws-ec2-controller",
+              "displayName": "",
+              "id": "00000000-0000-0000-0000-000000000000",
+              "registrant": {
+                "kind": "github"
+              },
+              "model": {
+                "version": ""
+              }
+            },
             "patch": {
               "patchStrategy": "replace",
-              "mutatedRef": [["settings", "groupID"]],
-              "description": "The EC2 SecurityGroup controls inbound network access to the ServerlessCache."
+              "mutatedRef": [
+                [
+                  "displayName"
+                ]
+              ]
             }
           }
         ]
       },
-      "deny": {}
+      "deny": null
     }
   ],
-  "evaluationQuery": "edge_network_relationship"
+  "subType": "network",
+  "status": "enabled",
+  "type": "non-binding",
+  "version": "v1.0.0"
 }

--- a/server/meshmodel/aws-elasticache-controller/v1.3.3/v1.0.0/relationships/edge_permission_ReplicationGroup_KMSKey.json
+++ b/server/meshmodel/aws-elasticache-controller/v1.3.3/v1.0.0/relationships/edge_permission_ReplicationGroup_KMSKey.json
@@ -1,0 +1,41 @@
+{
+  "schemaVersion": "core.meshery.io/v1alpha2",
+  "version": "v1.0.0",
+  "kind": "Edge",
+  "type": "Non-Binding",
+  "subType": "Permission",
+  "metadata": {
+    "description": "A ReplicationGroup can use a customer-managed AWS KMS Key for at-rest encryption of the cache data. The KMS Key governs access to the encrypted data, and IAM policies on the key control which services and roles can encrypt/decrypt the ReplicationGroup's data."
+  },
+  "model": "aws-elasticache-controller",
+  "selectors": [
+    {
+      "allow": {
+        "from": [
+          {
+            "kind": "ReplicationGroup",
+            "model": "aws-elasticache-controller",
+            "patch": {
+              "patchStrategy": "replace",
+              "mutatorRef": [["settings", "kmsKeyID"]],
+              "description": "The ReplicationGroup references the KMS Key ID to enable at-rest encryption."
+            }
+          }
+        ],
+        "to": [
+          {
+            "kind": "Key",
+            "model": "aws-kms-controller",
+            "patch": {
+              "patchStrategy": "replace",
+              "mutatedRef": [["settings", "keyID"]],
+              "description": "The KMS Key provides encryption-at-rest capability for the ReplicationGroup."
+            }
+          }
+        ]
+      },
+      "deny": {}
+    }
+  ],
+  "evaluationQuery": "edge_permission_relationship"
+}

--- a/server/meshmodel/aws-elasticache-controller/v1.3.3/v1.0.0/relationships/edge_permission_ReplicationGroup_KMSKey.json
+++ b/server/meshmodel/aws-elasticache-controller/v1.3.3/v1.0.0/relationships/edge_permission_ReplicationGroup_KMSKey.json
@@ -1,41 +1,96 @@
 {
-  "schemaVersion": "core.meshery.io/v1alpha2",
-  "version": "v1.0.0",
-  "kind": "Edge",
-  "type": "Non-Binding",
-  "subType": "Permission",
+  "id": "00000000-0000-0000-0000-000000000000",
+  "evaluationQuery": "edge_permission_relationship",
+  "kind": "edge",
   "metadata": {
-    "description": "A ReplicationGroup can use a customer-managed AWS KMS Key for at-rest encryption of the cache data. The KMS Key governs access to the encrypted data, and IAM policies on the key control which services and roles can encrypt/decrypt the ReplicationGroup's data."
+    "description": "A ServerlessCache can use a customer-managed AWS KMS Key for at-rest encryption. The KMS Key controls access to the encrypted serverless cache data.",
+    "styles": {
+      "primaryColor": "",
+      "svgColor": "",
+      "svgWhite": ""
+    },
+    "isAnnotation": false
   },
-  "model": "aws-elasticache-controller",
+  "model": {
+    "version": "",
+    "name": "aws-elasticache-controller",
+    "displayName": "",
+    "id": "00000000-0000-0000-0000-000000000000",
+    "registrant": {
+      "kind": ""
+    },
+    "model": {
+      "version": "v1.3.3"
+    }
+  },
+  "schemaVersion": "relationships.meshery.io/v1alpha3",
   "selectors": [
     {
       "allow": {
         "from": [
           {
-            "kind": "ReplicationGroup",
-            "model": "aws-elasticache-controller",
+            "id": null,
+            "kind": "ServerlessCache",
+            "match": {},
+            "match_strategy_matrix": null,
+            "model": {
+              "version": "",
+              "name": "aws-elasticache-controller",
+              "displayName": "",
+              "id": "00000000-0000-0000-0000-000000000000",
+              "registrant": {
+                "kind": "github"
+              },
+              "model": {
+                "version": ""
+              }
+            },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [["settings", "kmsKeyID"]],
-              "description": "The ReplicationGroup references the KMS Key ID to enable at-rest encryption."
+              "mutatorRef": [
+                [
+                  "configuration",
+                  "spec",
+                  "kmsKeyID"
+                ]
+              ]
             }
           }
         ],
         "to": [
           {
+            "id": null,
             "kind": "Key",
-            "model": "aws-kms-controller",
+            "match": {},
+            "match_strategy_matrix": null,
+            "model": {
+              "version": "",
+              "name": "aws-kms-controller",
+              "displayName": "",
+              "id": "00000000-0000-0000-0000-000000000000",
+              "registrant": {
+                "kind": "github"
+              },
+              "model": {
+                "version": ""
+              }
+            },
             "patch": {
               "patchStrategy": "replace",
-              "mutatedRef": [["settings", "keyID"]],
-              "description": "The KMS Key provides encryption-at-rest capability for the ReplicationGroup."
+              "mutatedRef": [
+                [
+                  "displayName"
+                ]
+              ]
             }
           }
         ]
       },
-      "deny": {}
+      "deny": null
     }
   ],
-  "evaluationQuery": "edge_permission_relationship"
+  "subType": "permission",
+  "status": "enabled",
+  "type": "non-binding",
+  "version": "v1.0.0"
 }

--- a/server/meshmodel/aws-elasticache-controller/v1.3.3/v1.0.0/relationships/edge_permission_ServerlessCache_KMSKey.json
+++ b/server/meshmodel/aws-elasticache-controller/v1.3.3/v1.0.0/relationships/edge_permission_ServerlessCache_KMSKey.json
@@ -1,0 +1,41 @@
+{
+  "schemaVersion": "core.meshery.io/v1alpha2",
+  "version": "v1.0.0",
+  "kind": "Edge",
+  "type": "Non-Binding",
+  "subType": "Permission",
+  "metadata": {
+    "description": "A ServerlessCache can use a customer-managed AWS KMS Key for at-rest encryption. The KMS Key controls access to the encrypted serverless cache data, providing an additional layer of data security beyond default AWS-managed encryption."
+  },
+  "model": "aws-elasticache-controller",
+  "selectors": [
+    {
+      "allow": {
+        "from": [
+          {
+            "kind": "ServerlessCache",
+            "model": "aws-elasticache-controller",
+            "patch": {
+              "patchStrategy": "replace",
+              "mutatorRef": [["settings", "kmsKeyID"]],
+              "description": "The ServerlessCache references the KMS Key ID for at-rest encryption."
+            }
+          }
+        ],
+        "to": [
+          {
+            "kind": "Key",
+            "model": "aws-kms-controller",
+            "patch": {
+              "patchStrategy": "replace",
+              "mutatedRef": [["settings", "keyID"]],
+              "description": "The KMS Key provides encryption capability for the ServerlessCache."
+            }
+          }
+        ]
+      },
+      "deny": {}
+    }
+  ],
+  "evaluationQuery": "edge_permission_relationship"
+}

--- a/server/meshmodel/aws-elasticache-controller/v1.3.3/v1.0.0/relationships/edge_permission_ServerlessCache_KMSKey.json
+++ b/server/meshmodel/aws-elasticache-controller/v1.3.3/v1.0.0/relationships/edge_permission_ServerlessCache_KMSKey.json
@@ -1,41 +1,96 @@
 {
-  "schemaVersion": "core.meshery.io/v1alpha2",
-  "version": "v1.0.0",
-  "kind": "Edge",
-  "type": "Non-Binding",
-  "subType": "Permission",
+  "id": "00000000-0000-0000-0000-000000000000",
+  "evaluationQuery": "edge_permission_relationship",
+  "kind": "edge",
   "metadata": {
-    "description": "A ServerlessCache can use a customer-managed AWS KMS Key for at-rest encryption. The KMS Key controls access to the encrypted serverless cache data, providing an additional layer of data security beyond default AWS-managed encryption."
+    "description": "A ServerlessCache can use a customer-managed AWS KMS Key for at-rest encryption. The KMS Key controls access to the encrypted serverless cache data.",
+    "styles": {
+      "primaryColor": "",
+      "svgColor": "",
+      "svgWhite": ""
+    },
+    "isAnnotation": false
   },
-  "model": "aws-elasticache-controller",
+  "model": {
+    "version": "",
+    "name": "aws-elasticache-controller",
+    "displayName": "",
+    "id": "00000000-0000-0000-0000-000000000000",
+    "registrant": {
+      "kind": ""
+    },
+    "model": {
+      "version": "v1.3.3"
+    }
+  },
+  "schemaVersion": "relationships.meshery.io/v1alpha3",
   "selectors": [
     {
       "allow": {
         "from": [
           {
+            "id": null,
             "kind": "ServerlessCache",
-            "model": "aws-elasticache-controller",
+            "match": {},
+            "match_strategy_matrix": null,
+            "model": {
+              "version": "",
+              "name": "aws-elasticache-controller",
+              "displayName": "",
+              "id": "00000000-0000-0000-0000-000000000000",
+              "registrant": {
+                "kind": "github"
+              },
+              "model": {
+                "version": ""
+              }
+            },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [["settings", "kmsKeyID"]],
-              "description": "The ServerlessCache references the KMS Key ID for at-rest encryption."
+              "mutatorRef": [
+                [
+                  "configuration",
+                  "spec",
+                  "kmsKeyID"
+                ]
+              ]
             }
           }
         ],
         "to": [
           {
+            "id": null,
             "kind": "Key",
-            "model": "aws-kms-controller",
+            "match": {},
+            "match_strategy_matrix": null,
+            "model": {
+              "version": "",
+              "name": "aws-kms-controller",
+              "displayName": "",
+              "id": "00000000-0000-0000-0000-000000000000",
+              "registrant": {
+                "kind": "github"
+              },
+              "model": {
+                "version": ""
+              }
+            },
             "patch": {
               "patchStrategy": "replace",
-              "mutatedRef": [["settings", "keyID"]],
-              "description": "The KMS Key provides encryption capability for the ServerlessCache."
+              "mutatedRef": [
+                [
+                  "displayName"
+                ]
+              ]
             }
           }
         ]
       },
-      "deny": {}
+      "deny": null
     }
   ],
-  "evaluationQuery": "edge_permission_relationship"
+  "subType": "permission",
+  "status": "enabled",
+  "type": "non-binding",
+  "version": "v1.0.0"
 }

--- a/server/meshmodel/aws-elasticache-controller/v1.3.3/v1.0.0/relationships/edge_permission_UserGroup_ReplicationGroup.json
+++ b/server/meshmodel/aws-elasticache-controller/v1.3.3/v1.0.0/relationships/edge_permission_UserGroup_ReplicationGroup.json
@@ -1,0 +1,41 @@
+{
+  "schemaVersion": "core.meshery.io/v1alpha2",
+  "version": "v1.0.0",
+  "kind": "Edge",
+  "type": "Non-Binding",
+  "subType": "Permission",
+  "metadata": {
+    "description": "A UserGroup is associated with a ReplicationGroup to enforce Role-Based Access Control (RBAC) for Redis/Valkey. When linked, the ReplicationGroup only allows connections authenticated by Users that belong to the associated UserGroup, controlling which users (and their permissions) can access the cache."
+  },
+  "model": "aws-elasticache-controller",
+  "selectors": [
+    {
+      "allow": {
+        "from": [
+          {
+            "kind": "UserGroup",
+            "model": "aws-elasticache-controller",
+            "patch": {
+              "patchStrategy": "replace",
+              "mutatorRef": [["settings", "userGroupID"]],
+              "description": "The UserGroup provides its ID to be attached to the ReplicationGroup for RBAC enforcement."
+            }
+          }
+        ],
+        "to": [
+          {
+            "kind": "ReplicationGroup",
+            "model": "aws-elasticache-controller",
+            "patch": {
+              "patchStrategy": "replace",
+              "mutatedRef": [["settings", "userGroupIDs", "_"]],
+              "description": "The ReplicationGroup references the UserGroup ID to enable RBAC access control."
+            }
+          }
+        ]
+      },
+      "deny": {}
+    }
+  ],
+  "evaluationQuery": "edge_permission_relationship"
+}

--- a/server/meshmodel/aws-elasticache-controller/v1.3.3/v1.0.0/relationships/edge_permission_UserGroup_ReplicationGroup.json
+++ b/server/meshmodel/aws-elasticache-controller/v1.3.3/v1.0.0/relationships/edge_permission_UserGroup_ReplicationGroup.json
@@ -1,41 +1,96 @@
 {
-  "schemaVersion": "core.meshery.io/v1alpha2",
-  "version": "v1.0.0",
-  "kind": "Edge",
-  "type": "Non-Binding",
-  "subType": "Permission",
+  "id": "00000000-0000-0000-0000-000000000000",
+  "evaluationQuery": "edge_permission_relationship",
+  "kind": "edge",
   "metadata": {
-    "description": "A UserGroup is associated with a ReplicationGroup to enforce Role-Based Access Control (RBAC) for Redis/Valkey. When linked, the ReplicationGroup only allows connections authenticated by Users that belong to the associated UserGroup, controlling which users (and their permissions) can access the cache."
+    "description": "A UserGroup is associated with a ReplicationGroup to enforce Role-Based Access Control (RBAC) for Redis/Valkey. The ReplicationGroup only allows connections authenticated by Users that belong to the associated UserGroup.",
+    "styles": {
+      "primaryColor": "",
+      "svgColor": "",
+      "svgWhite": ""
+    },
+    "isAnnotation": false
   },
-  "model": "aws-elasticache-controller",
+  "model": {
+    "version": "",
+    "name": "aws-elasticache-controller",
+    "displayName": "",
+    "id": "00000000-0000-0000-0000-000000000000",
+    "registrant": {
+      "kind": ""
+    },
+    "model": {
+      "version": "v1.3.3"
+    }
+  },
+  "schemaVersion": "relationships.meshery.io/v1alpha3",
   "selectors": [
     {
       "allow": {
         "from": [
           {
-            "kind": "UserGroup",
-            "model": "aws-elasticache-controller",
+            "id": null,
+            "kind": "ReplicationGroup",
+            "match": {},
+            "match_strategy_matrix": null,
+            "model": {
+              "version": "",
+              "name": "aws-elasticache-controller",
+              "displayName": "",
+              "id": "00000000-0000-0000-0000-000000000000",
+              "registrant": {
+                "kind": "github"
+              },
+              "model": {
+                "version": ""
+              }
+            },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [["settings", "userGroupID"]],
-              "description": "The UserGroup provides its ID to be attached to the ReplicationGroup for RBAC enforcement."
+              "mutatorRef": [
+                [
+                  "configuration",
+                  "spec",
+                  "userGroupIDs"
+                ]
+              ]
             }
           }
         ],
         "to": [
           {
-            "kind": "ReplicationGroup",
-            "model": "aws-elasticache-controller",
+            "id": null,
+            "kind": "UserGroup",
+            "match": {},
+            "match_strategy_matrix": null,
+            "model": {
+              "version": "",
+              "name": "aws-elasticache-controller",
+              "displayName": "",
+              "id": "00000000-0000-0000-0000-000000000000",
+              "registrant": {
+                "kind": "github"
+              },
+              "model": {
+                "version": ""
+              }
+            },
             "patch": {
               "patchStrategy": "replace",
-              "mutatedRef": [["settings", "userGroupIDs", "_"]],
-              "description": "The ReplicationGroup references the UserGroup ID to enable RBAC access control."
+              "mutatedRef": [
+                [
+                  "displayName"
+                ]
+              ]
             }
           }
         ]
       },
-      "deny": {}
+      "deny": null
     }
   ],
-  "evaluationQuery": "edge_permission_relationship"
+  "subType": "permission",
+  "status": "enabled",
+  "type": "non-binding",
+  "version": "v1.0.0"
 }

--- a/server/meshmodel/aws-elasticache-controller/v1.3.3/v1.0.0/relationships/hierarchical_inventory_CacheParameterGroup_CacheCluster.json
+++ b/server/meshmodel/aws-elasticache-controller/v1.3.3/v1.0.0/relationships/hierarchical_inventory_CacheParameterGroup_CacheCluster.json
@@ -1,0 +1,41 @@
+{
+  "schemaVersion": "core.meshery.io/v1alpha2",
+  "version": "v1.0.0",
+  "kind": "Hierarchical",
+  "type": "Inventory",
+  "subType": "Inventory",
+  "metadata": {
+    "description": "A CacheCluster inherits engine configuration from a CacheParameterGroup. The parameter group defines settings such as maxmemory-policy, timeout, and other engine-level options. The cluster's runtime behavior is governed by the parameter group it references."
+  },
+  "model": "aws-elasticache-controller",
+  "selectors": [
+    {
+      "allow": {
+        "from": [
+          {
+            "kind": "CacheParameterGroup",
+            "model": "aws-elasticache-controller",
+            "patch": {
+              "patchStrategy": "replace",
+              "mutatorRef": [["settings", "cacheParameterGroupName"]],
+              "description": "The CacheParameterGroup provides its name so the CacheCluster can reference it."
+            }
+          }
+        ],
+        "to": [
+          {
+            "kind": "CacheCluster",
+            "model": "aws-elasticache-controller",
+            "patch": {
+              "patchStrategy": "replace",
+              "mutatedRef": [["settings", "cacheParameterGroupName"]],
+              "description": "The CacheCluster uses the CacheParameterGroup name to inherit engine parameters."
+            }
+          }
+        ]
+      },
+      "deny": {}
+    }
+  ],
+  "evaluationQuery": "hierarchical_inventory_relationship"
+}

--- a/server/meshmodel/aws-elasticache-controller/v1.3.3/v1.0.0/relationships/hierarchical_inventory_CacheParameterGroup_CacheCluster.json
+++ b/server/meshmodel/aws-elasticache-controller/v1.3.3/v1.0.0/relationships/hierarchical_inventory_CacheParameterGroup_CacheCluster.json
@@ -1,41 +1,96 @@
 {
-  "schemaVersion": "core.meshery.io/v1alpha2",
-  "version": "v1.0.0",
-  "kind": "Hierarchical",
-  "type": "Inventory",
-  "subType": "Inventory",
+  "id": "00000000-0000-0000-0000-000000000000",
+  "evaluationQuery": "hierarchical_inventory_relationship",
+  "kind": "hierarchical",
   "metadata": {
-    "description": "A CacheCluster inherits engine configuration from a CacheParameterGroup. The parameter group defines settings such as maxmemory-policy, timeout, and other engine-level options. The cluster's runtime behavior is governed by the parameter group it references."
+    "description": "A CacheCluster inherits engine configuration from a CacheParameterGroup. The parameter group defines settings such as maxmemory-policy, timeout, and other engine-level options.",
+    "styles": {
+      "primaryColor": "",
+      "svgColor": "",
+      "svgWhite": ""
+    },
+    "isAnnotation": false
   },
-  "model": "aws-elasticache-controller",
+  "model": {
+    "version": "",
+    "name": "aws-elasticache-controller",
+    "displayName": "",
+    "id": "00000000-0000-0000-0000-000000000000",
+    "registrant": {
+      "kind": ""
+    },
+    "model": {
+      "version": "v1.3.3"
+    }
+  },
+  "schemaVersion": "relationships.meshery.io/v1alpha3",
   "selectors": [
     {
       "allow": {
         "from": [
           {
+            "id": null,
             "kind": "CacheParameterGroup",
-            "model": "aws-elasticache-controller",
+            "match": {},
+            "match_strategy_matrix": null,
+            "model": {
+              "version": "",
+              "name": "aws-elasticache-controller",
+              "displayName": "",
+              "id": "00000000-0000-0000-0000-000000000000",
+              "registrant": {
+                "kind": "github"
+              },
+              "model": {
+                "version": ""
+              }
+            },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [["settings", "cacheParameterGroupName"]],
-              "description": "The CacheParameterGroup provides its name so the CacheCluster can reference it."
+              "mutatorRef": [
+                [
+                  "configuration",
+                  "spec",
+                  "cacheParameterGroupName"
+                ]
+              ]
             }
           }
         ],
         "to": [
           {
+            "id": null,
             "kind": "CacheCluster",
-            "model": "aws-elasticache-controller",
+            "match": {},
+            "match_strategy_matrix": null,
+            "model": {
+              "version": "",
+              "name": "aws-elasticache-controller",
+              "displayName": "",
+              "id": "00000000-0000-0000-0000-000000000000",
+              "registrant": {
+                "kind": "github"
+              },
+              "model": {
+                "version": ""
+              }
+            },
             "patch": {
               "patchStrategy": "replace",
-              "mutatedRef": [["settings", "cacheParameterGroupName"]],
-              "description": "The CacheCluster uses the CacheParameterGroup name to inherit engine parameters."
+              "mutatedRef": [
+                [
+                  "displayName"
+                ]
+              ]
             }
           }
         ]
       },
-      "deny": {}
+      "deny": null
     }
   ],
-  "evaluationQuery": "hierarchical_inventory_relationship"
+  "subType": "inventory",
+  "status": "enabled",
+  "type": "non-binding",
+  "version": "v1.0.0"
 }

--- a/server/meshmodel/aws-elasticache-controller/v1.3.3/v1.0.0/relationships/hierarchical_inventory_CacheParameterGroup_ReplicationGroup.json
+++ b/server/meshmodel/aws-elasticache-controller/v1.3.3/v1.0.0/relationships/hierarchical_inventory_CacheParameterGroup_ReplicationGroup.json
@@ -1,0 +1,41 @@
+{
+  "schemaVersion": "core.meshery.io/v1alpha2",
+  "version": "v1.0.0",
+  "kind": "Hierarchical",
+  "type": "Inventory",
+  "subType": "Inventory",
+  "metadata": {
+    "description": "A ReplicationGroup inherits Redis/Valkey engine configuration from a CacheParameterGroup. All nodes in the replication group share the same parameter group settings, ensuring consistent behaviour across primary and replica nodes."
+  },
+  "model": "aws-elasticache-controller",
+  "selectors": [
+    {
+      "allow": {
+        "from": [
+          {
+            "kind": "CacheParameterGroup",
+            "model": "aws-elasticache-controller",
+            "patch": {
+              "patchStrategy": "replace",
+              "mutatorRef": [["settings", "cacheParameterGroupName"]],
+              "description": "The CacheParameterGroup provides its name for the ReplicationGroup to reference."
+            }
+          }
+        ],
+        "to": [
+          {
+            "kind": "ReplicationGroup",
+            "model": "aws-elasticache-controller",
+            "patch": {
+              "patchStrategy": "replace",
+              "mutatedRef": [["settings", "cacheParameterGroupName"]],
+              "description": "The ReplicationGroup uses the CacheParameterGroup name to inherit engine parameters."
+            }
+          }
+        ]
+      },
+      "deny": {}
+    }
+  ],
+  "evaluationQuery": "hierarchical_inventory_relationship"
+}

--- a/server/meshmodel/aws-elasticache-controller/v1.3.3/v1.0.0/relationships/hierarchical_inventory_CacheParameterGroup_ReplicationGroup.json
+++ b/server/meshmodel/aws-elasticache-controller/v1.3.3/v1.0.0/relationships/hierarchical_inventory_CacheParameterGroup_ReplicationGroup.json
@@ -1,41 +1,96 @@
 {
-  "schemaVersion": "core.meshery.io/v1alpha2",
-  "version": "v1.0.0",
-  "kind": "Hierarchical",
-  "type": "Inventory",
-  "subType": "Inventory",
+  "id": "00000000-0000-0000-0000-000000000000",
+  "evaluationQuery": "hierarchical_inventory_relationship",
+  "kind": "hierarchical",
   "metadata": {
-    "description": "A ReplicationGroup inherits Redis/Valkey engine configuration from a CacheParameterGroup. All nodes in the replication group share the same parameter group settings, ensuring consistent behaviour across primary and replica nodes."
+    "description": "A ReplicationGroup inherits Redis/Valkey engine configuration from a CacheParameterGroup. All nodes in the replication group share the same parameter group settings, ensuring consistent behaviour across primary and replica nodes.",
+    "styles": {
+      "primaryColor": "",
+      "svgColor": "",
+      "svgWhite": ""
+    },
+    "isAnnotation": false
   },
-  "model": "aws-elasticache-controller",
+  "model": {
+    "version": "",
+    "name": "aws-elasticache-controller",
+    "displayName": "",
+    "id": "00000000-0000-0000-0000-000000000000",
+    "registrant": {
+      "kind": ""
+    },
+    "model": {
+      "version": "v1.3.3"
+    }
+  },
+  "schemaVersion": "relationships.meshery.io/v1alpha3",
   "selectors": [
     {
       "allow": {
         "from": [
           {
+            "id": null,
             "kind": "CacheParameterGroup",
-            "model": "aws-elasticache-controller",
+            "match": {},
+            "match_strategy_matrix": null,
+            "model": {
+              "version": "",
+              "name": "aws-elasticache-controller",
+              "displayName": "",
+              "id": "00000000-0000-0000-0000-000000000000",
+              "registrant": {
+                "kind": "github"
+              },
+              "model": {
+                "version": ""
+              }
+            },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [["settings", "cacheParameterGroupName"]],
-              "description": "The CacheParameterGroup provides its name for the ReplicationGroup to reference."
+              "mutatorRef": [
+                [
+                  "configuration",
+                  "spec",
+                  "cacheParameterGroupName"
+                ]
+              ]
             }
           }
         ],
         "to": [
           {
+            "id": null,
             "kind": "ReplicationGroup",
-            "model": "aws-elasticache-controller",
+            "match": {},
+            "match_strategy_matrix": null,
+            "model": {
+              "version": "",
+              "name": "aws-elasticache-controller",
+              "displayName": "",
+              "id": "00000000-0000-0000-0000-000000000000",
+              "registrant": {
+                "kind": "github"
+              },
+              "model": {
+                "version": ""
+              }
+            },
             "patch": {
               "patchStrategy": "replace",
-              "mutatedRef": [["settings", "cacheParameterGroupName"]],
-              "description": "The ReplicationGroup uses the CacheParameterGroup name to inherit engine parameters."
+              "mutatedRef": [
+                [
+                  "displayName"
+                ]
+              ]
             }
           }
         ]
       },
-      "deny": {}
+      "deny": null
     }
   ],
-  "evaluationQuery": "hierarchical_inventory_relationship"
+  "subType": "inventory",
+  "status": "enabled",
+  "type": "non-binding",
+  "version": "v1.0.0"
 }

--- a/server/meshmodel/aws-elasticache-controller/v1.3.3/v1.0.0/relationships/hierarchical_inventory_UserGroup_User.json
+++ b/server/meshmodel/aws-elasticache-controller/v1.3.3/v1.0.0/relationships/hierarchical_inventory_UserGroup_User.json
@@ -1,0 +1,41 @@
+{
+  "schemaVersion": "core.meshery.io/v1alpha2",
+  "version": "v1.0.0",
+  "kind": "Hierarchical",
+  "type": "Inventory",
+  "subType": "Inventory",
+  "metadata": {
+    "description": "A UserGroup is a collection of User resources. In ElastiCache RBAC for Redis/Valkey, User objects (with specific command/key permissions) are grouped into UserGroups, which are then associated with ReplicationGroups. The UserGroup configuration inherits its access rules from all its member Users."
+  },
+  "model": "aws-elasticache-controller",
+  "selectors": [
+    {
+      "allow": {
+        "from": [
+          {
+            "kind": "User",
+            "model": "aws-elasticache-controller",
+            "patch": {
+              "patchStrategy": "replace",
+              "mutatorRef": [["settings", "userID"]],
+              "description": "The User provides its userID to be enrolled in the UserGroup."
+            }
+          }
+        ],
+        "to": [
+          {
+            "kind": "UserGroup",
+            "model": "aws-elasticache-controller",
+            "patch": {
+              "patchStrategy": "replace",
+              "mutatedRef": [["settings", "userIDs", "_"]],
+              "description": "The UserGroup holds an array of userIDs referencing member User resources."
+            }
+          }
+        ]
+      },
+      "deny": {}
+    }
+  ],
+  "evaluationQuery": "hierarchical_inventory_relationship"
+}

--- a/server/meshmodel/aws-elasticache-controller/v1.3.3/v1.0.0/relationships/hierarchical_inventory_UserGroup_User.json
+++ b/server/meshmodel/aws-elasticache-controller/v1.3.3/v1.0.0/relationships/hierarchical_inventory_UserGroup_User.json
@@ -1,41 +1,96 @@
 {
-  "schemaVersion": "core.meshery.io/v1alpha2",
-  "version": "v1.0.0",
-  "kind": "Hierarchical",
-  "type": "Inventory",
-  "subType": "Inventory",
+  "id": "00000000-0000-0000-0000-000000000000",
+  "evaluationQuery": "hierarchical_inventory_relationship",
+  "kind": "hierarchical",
   "metadata": {
-    "description": "A UserGroup is a collection of User resources. In ElastiCache RBAC for Redis/Valkey, User objects (with specific command/key permissions) are grouped into UserGroups, which are then associated with ReplicationGroups. The UserGroup configuration inherits its access rules from all its member Users."
+    "description": "A UserGroup is a collection of User resources. In ElastiCache RBAC for Redis/Valkey, User objects with specific command/key permissions are grouped into UserGroups, which are then associated with ReplicationGroups.",
+    "styles": {
+      "primaryColor": "",
+      "svgColor": "",
+      "svgWhite": ""
+    },
+    "isAnnotation": false
   },
-  "model": "aws-elasticache-controller",
+  "model": {
+    "version": "",
+    "name": "aws-elasticache-controller",
+    "displayName": "",
+    "id": "00000000-0000-0000-0000-000000000000",
+    "registrant": {
+      "kind": ""
+    },
+    "model": {
+      "version": "v1.3.3"
+    }
+  },
+  "schemaVersion": "relationships.meshery.io/v1alpha3",
   "selectors": [
     {
       "allow": {
         "from": [
           {
+            "id": null,
             "kind": "User",
-            "model": "aws-elasticache-controller",
+            "match": {},
+            "match_strategy_matrix": null,
+            "model": {
+              "version": "",
+              "name": "aws-elasticache-controller",
+              "displayName": "",
+              "id": "00000000-0000-0000-0000-000000000000",
+              "registrant": {
+                "kind": "github"
+              },
+              "model": {
+                "version": ""
+              }
+            },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [["settings", "userID"]],
-              "description": "The User provides its userID to be enrolled in the UserGroup."
+              "mutatorRef": [
+                [
+                  "configuration",
+                  "spec",
+                  "userID"
+                ]
+              ]
             }
           }
         ],
         "to": [
           {
+            "id": null,
             "kind": "UserGroup",
-            "model": "aws-elasticache-controller",
+            "match": {},
+            "match_strategy_matrix": null,
+            "model": {
+              "version": "",
+              "name": "aws-elasticache-controller",
+              "displayName": "",
+              "id": "00000000-0000-0000-0000-000000000000",
+              "registrant": {
+                "kind": "github"
+              },
+              "model": {
+                "version": ""
+              }
+            },
             "patch": {
               "patchStrategy": "replace",
-              "mutatedRef": [["settings", "userIDs", "_"]],
-              "description": "The UserGroup holds an array of userIDs referencing member User resources."
+              "mutatedRef": [
+                [
+                  "displayName"
+                ]
+              ]
             }
           }
         ]
       },
-      "deny": {}
+      "deny": null
     }
   ],
-  "evaluationQuery": "hierarchical_inventory_relationship"
+  "subType": "inventory",
+  "status": "enabled",
+  "type": "non-binding",
+  "version": "v1.0.0"
 }

--- a/server/meshmodel/aws-elasticache-controller/v1.3.3/v1.0.0/relationships/hierarchical_parent_CacheSubnetGroup_CacheCluster.json
+++ b/server/meshmodel/aws-elasticache-controller/v1.3.3/v1.0.0/relationships/hierarchical_parent_CacheSubnetGroup_CacheCluster.json
@@ -1,0 +1,41 @@
+{
+  "schemaVersion": "core.meshery.io/v1alpha2",
+  "version": "v1.0.0",
+  "kind": "Hierarchical",
+  "type": "Parent",
+  "subType": "Parent",
+  "metadata": {
+    "description": "A CacheCluster must be placed inside a CacheSubnetGroup to operate within a VPC. The CacheSubnetGroup defines which VPC subnets the cluster nodes can be placed in, making it a prerequisite (parent) for the CacheCluster (child)."
+  },
+  "model": "aws-elasticache-controller",
+  "selectors": [
+    {
+      "allow": {
+        "from": [
+          {
+            "kind": "CacheCluster",
+            "model": "aws-elasticache-controller",
+            "patch": {
+              "patchStrategy": "replace",
+              "mutatorRef": [["settings", "cacheSubnetGroupName"]],
+              "description": "The CacheCluster references the CacheSubnetGroup by name to determine VPC subnet placement."
+            }
+          }
+        ],
+        "to": [
+          {
+            "kind": "CacheSubnetGroup",
+            "model": "aws-elasticache-controller",
+            "patch": {
+              "patchStrategy": "replace",
+              "mutatedRef": [["settings", "cacheSubnetGroupName"]],
+              "description": "The CacheSubnetGroup provides its name for CacheCluster to reference."
+            }
+          }
+        ]
+      },
+      "deny": {}
+    }
+  ],
+  "evaluationQuery": "hierarchical_parent_relationship"
+}

--- a/server/meshmodel/aws-elasticache-controller/v1.3.3/v1.0.0/relationships/hierarchical_parent_CacheSubnetGroup_CacheCluster.json
+++ b/server/meshmodel/aws-elasticache-controller/v1.3.3/v1.0.0/relationships/hierarchical_parent_CacheSubnetGroup_CacheCluster.json
@@ -1,41 +1,96 @@
 {
-  "schemaVersion": "core.meshery.io/v1alpha2",
-  "version": "v1.0.0",
-  "kind": "Hierarchical",
-  "type": "Parent",
-  "subType": "Parent",
+  "id": "00000000-0000-0000-0000-000000000000",
+  "evaluationQuery": "hierarchical_parent_relationship",
+  "kind": "hierarchical",
   "metadata": {
-    "description": "A CacheCluster must be placed inside a CacheSubnetGroup to operate within a VPC. The CacheSubnetGroup defines which VPC subnets the cluster nodes can be placed in, making it a prerequisite (parent) for the CacheCluster (child)."
+    "description": "A CacheCluster must be placed inside a CacheSubnetGroup to operate within a VPC. The CacheSubnetGroup defines which VPC subnets the cluster nodes can be placed in, making it a prerequisite (parent) for the CacheCluster (child).",
+    "styles": {
+      "primaryColor": "",
+      "svgColor": "",
+      "svgWhite": ""
+    },
+    "isAnnotation": false
   },
-  "model": "aws-elasticache-controller",
+  "model": {
+    "version": "",
+    "name": "aws-elasticache-controller",
+    "displayName": "",
+    "id": "00000000-0000-0000-0000-000000000000",
+    "registrant": {
+      "kind": ""
+    },
+    "model": {
+      "version": "v1.3.3"
+    }
+  },
+  "schemaVersion": "relationships.meshery.io/v1alpha3",
   "selectors": [
     {
       "allow": {
         "from": [
           {
+            "id": null,
             "kind": "CacheCluster",
-            "model": "aws-elasticache-controller",
+            "match": {},
+            "match_strategy_matrix": null,
+            "model": {
+              "version": "",
+              "name": "aws-elasticache-controller",
+              "displayName": "",
+              "id": "00000000-0000-0000-0000-000000000000",
+              "registrant": {
+                "kind": "github"
+              },
+              "model": {
+                "version": ""
+              }
+            },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [["settings", "cacheSubnetGroupName"]],
-              "description": "The CacheCluster references the CacheSubnetGroup by name to determine VPC subnet placement."
+              "mutatorRef": [
+                [
+                  "configuration",
+                  "spec",
+                  "cacheSubnetGroupName"
+                ]
+              ]
             }
           }
         ],
         "to": [
           {
+            "id": null,
             "kind": "CacheSubnetGroup",
-            "model": "aws-elasticache-controller",
+            "match": {},
+            "match_strategy_matrix": null,
+            "model": {
+              "version": "",
+              "name": "aws-elasticache-controller",
+              "displayName": "",
+              "id": "00000000-0000-0000-0000-000000000000",
+              "registrant": {
+                "kind": "github"
+              },
+              "model": {
+                "version": ""
+              }
+            },
             "patch": {
               "patchStrategy": "replace",
-              "mutatedRef": [["settings", "cacheSubnetGroupName"]],
-              "description": "The CacheSubnetGroup provides its name for CacheCluster to reference."
+              "mutatedRef": [
+                [
+                  "displayName"
+                ]
+              ]
             }
           }
         ]
       },
-      "deny": {}
+      "deny": null
     }
   ],
-  "evaluationQuery": "hierarchical_parent_relationship"
+  "subType": "parent",
+  "status": "enabled",
+  "type": "non-binding",
+  "version": "v1.0.0"
 }

--- a/server/meshmodel/aws-elasticache-controller/v1.3.3/v1.0.0/relationships/hierarchical_parent_CacheSubnetGroup_ReplicationGroup.json
+++ b/server/meshmodel/aws-elasticache-controller/v1.3.3/v1.0.0/relationships/hierarchical_parent_CacheSubnetGroup_ReplicationGroup.json
@@ -1,0 +1,41 @@
+{
+  "schemaVersion": "core.meshery.io/v1alpha2",
+  "version": "v1.0.0",
+  "kind": "Hierarchical",
+  "type": "Parent",
+  "subType": "Parent",
+  "metadata": {
+    "description": "A ReplicationGroup must be placed inside a CacheSubnetGroup to operate within a VPC. The CacheSubnetGroup defines which subnets the ReplicationGroup's node groups and shards are deployed into."
+  },
+  "model": "aws-elasticache-controller",
+  "selectors": [
+    {
+      "allow": {
+        "from": [
+          {
+            "kind": "ReplicationGroup",
+            "model": "aws-elasticache-controller",
+            "patch": {
+              "patchStrategy": "replace",
+              "mutatorRef": [["settings", "cacheSubnetGroupName"]],
+              "description": "The ReplicationGroup references the CacheSubnetGroup by name for VPC subnet placement."
+            }
+          }
+        ],
+        "to": [
+          {
+            "kind": "CacheSubnetGroup",
+            "model": "aws-elasticache-controller",
+            "patch": {
+              "patchStrategy": "replace",
+              "mutatedRef": [["settings", "cacheSubnetGroupName"]],
+              "description": "The CacheSubnetGroup provides its name to the ReplicationGroup."
+            }
+          }
+        ]
+      },
+      "deny": {}
+    }
+  ],
+  "evaluationQuery": "hierarchical_parent_relationship"
+}

--- a/server/meshmodel/aws-elasticache-controller/v1.3.3/v1.0.0/relationships/hierarchical_parent_CacheSubnetGroup_ReplicationGroup.json
+++ b/server/meshmodel/aws-elasticache-controller/v1.3.3/v1.0.0/relationships/hierarchical_parent_CacheSubnetGroup_ReplicationGroup.json
@@ -1,41 +1,96 @@
 {
-  "schemaVersion": "core.meshery.io/v1alpha2",
-  "version": "v1.0.0",
-  "kind": "Hierarchical",
-  "type": "Parent",
-  "subType": "Parent",
+  "id": "00000000-0000-0000-0000-000000000000",
+  "evaluationQuery": "hierarchical_parent_relationship",
+  "kind": "hierarchical",
   "metadata": {
-    "description": "A ReplicationGroup must be placed inside a CacheSubnetGroup to operate within a VPC. The CacheSubnetGroup defines which subnets the ReplicationGroup's node groups and shards are deployed into."
+    "description": "A ReplicationGroup must be placed inside a CacheSubnetGroup to operate within a VPC. The CacheSubnetGroup defines which subnets the ReplicationGroup's node groups and shards are deployed into.",
+    "styles": {
+      "primaryColor": "",
+      "svgColor": "",
+      "svgWhite": ""
+    },
+    "isAnnotation": false
   },
-  "model": "aws-elasticache-controller",
+  "model": {
+    "version": "",
+    "name": "aws-elasticache-controller",
+    "displayName": "",
+    "id": "00000000-0000-0000-0000-000000000000",
+    "registrant": {
+      "kind": ""
+    },
+    "model": {
+      "version": "v1.3.3"
+    }
+  },
+  "schemaVersion": "relationships.meshery.io/v1alpha3",
   "selectors": [
     {
       "allow": {
         "from": [
           {
+            "id": null,
             "kind": "ReplicationGroup",
-            "model": "aws-elasticache-controller",
+            "match": {},
+            "match_strategy_matrix": null,
+            "model": {
+              "version": "",
+              "name": "aws-elasticache-controller",
+              "displayName": "",
+              "id": "00000000-0000-0000-0000-000000000000",
+              "registrant": {
+                "kind": "github"
+              },
+              "model": {
+                "version": ""
+              }
+            },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [["settings", "cacheSubnetGroupName"]],
-              "description": "The ReplicationGroup references the CacheSubnetGroup by name for VPC subnet placement."
+              "mutatorRef": [
+                [
+                  "configuration",
+                  "spec",
+                  "cacheSubnetGroupName"
+                ]
+              ]
             }
           }
         ],
         "to": [
           {
+            "id": null,
             "kind": "CacheSubnetGroup",
-            "model": "aws-elasticache-controller",
+            "match": {},
+            "match_strategy_matrix": null,
+            "model": {
+              "version": "",
+              "name": "aws-elasticache-controller",
+              "displayName": "",
+              "id": "00000000-0000-0000-0000-000000000000",
+              "registrant": {
+                "kind": "github"
+              },
+              "model": {
+                "version": ""
+              }
+            },
             "patch": {
               "patchStrategy": "replace",
-              "mutatedRef": [["settings", "cacheSubnetGroupName"]],
-              "description": "The CacheSubnetGroup provides its name to the ReplicationGroup."
+              "mutatedRef": [
+                [
+                  "displayName"
+                ]
+              ]
             }
           }
         ]
       },
-      "deny": {}
+      "deny": null
     }
   ],
-  "evaluationQuery": "hierarchical_parent_relationship"
+  "subType": "parent",
+  "status": "enabled",
+  "type": "non-binding",
+  "version": "v1.0.0"
 }

--- a/server/meshmodel/aws-elasticache-controller/v1.3.3/v1.0.0/relationships/hierarchical_parent_CacheSubnetGroup_ServerlessCache.json
+++ b/server/meshmodel/aws-elasticache-controller/v1.3.3/v1.0.0/relationships/hierarchical_parent_CacheSubnetGroup_ServerlessCache.json
@@ -1,0 +1,41 @@
+{
+  "schemaVersion": "core.meshery.io/v1alpha2",
+  "version": "v1.0.0",
+  "kind": "Hierarchical",
+  "type": "Parent",
+  "subType": "Parent",
+  "metadata": {
+    "description": "A ServerlessCache must be placed inside a CacheSubnetGroup. The CacheSubnetGroup determines VPC subnet placement for the serverless cache's internal resources."
+  },
+  "model": "aws-elasticache-controller",
+  "selectors": [
+    {
+      "allow": {
+        "from": [
+          {
+            "kind": "ServerlessCache",
+            "model": "aws-elasticache-controller",
+            "patch": {
+              "patchStrategy": "replace",
+              "mutatorRef": [["settings", "subnetIds"]],
+              "description": "The ServerlessCache references subnet IDs from the CacheSubnetGroup."
+            }
+          }
+        ],
+        "to": [
+          {
+            "kind": "CacheSubnetGroup",
+            "model": "aws-elasticache-controller",
+            "patch": {
+              "patchStrategy": "replace",
+              "mutatedRef": [["settings", "subnetIds"]],
+              "description": "The CacheSubnetGroup provides subnet IDs for the ServerlessCache."
+            }
+          }
+        ]
+      },
+      "deny": {}
+    }
+  ],
+  "evaluationQuery": "hierarchical_parent_relationship"
+}

--- a/server/meshmodel/aws-elasticache-controller/v1.3.3/v1.0.0/relationships/hierarchical_parent_CacheSubnetGroup_ServerlessCache.json
+++ b/server/meshmodel/aws-elasticache-controller/v1.3.3/v1.0.0/relationships/hierarchical_parent_CacheSubnetGroup_ServerlessCache.json
@@ -1,41 +1,96 @@
 {
-  "schemaVersion": "core.meshery.io/v1alpha2",
-  "version": "v1.0.0",
-  "kind": "Hierarchical",
-  "type": "Parent",
-  "subType": "Parent",
+  "id": "00000000-0000-0000-0000-000000000000",
+  "evaluationQuery": "hierarchical_parent_relationship",
+  "kind": "hierarchical",
   "metadata": {
-    "description": "A ServerlessCache must be placed inside a CacheSubnetGroup. The CacheSubnetGroup determines VPC subnet placement for the serverless cache's internal resources."
+    "description": "A ServerlessCache must be placed inside a CacheSubnetGroup. The CacheSubnetGroup determines VPC subnet placement for the serverless cache's internal resources.",
+    "styles": {
+      "primaryColor": "",
+      "svgColor": "",
+      "svgWhite": ""
+    },
+    "isAnnotation": false
   },
-  "model": "aws-elasticache-controller",
+  "model": {
+    "version": "",
+    "name": "aws-elasticache-controller",
+    "displayName": "",
+    "id": "00000000-0000-0000-0000-000000000000",
+    "registrant": {
+      "kind": ""
+    },
+    "model": {
+      "version": "v1.3.3"
+    }
+  },
+  "schemaVersion": "relationships.meshery.io/v1alpha3",
   "selectors": [
     {
       "allow": {
         "from": [
           {
+            "id": null,
             "kind": "ServerlessCache",
-            "model": "aws-elasticache-controller",
+            "match": {},
+            "match_strategy_matrix": null,
+            "model": {
+              "version": "",
+              "name": "aws-elasticache-controller",
+              "displayName": "",
+              "id": "00000000-0000-0000-0000-000000000000",
+              "registrant": {
+                "kind": "github"
+              },
+              "model": {
+                "version": ""
+              }
+            },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [["settings", "subnetIds"]],
-              "description": "The ServerlessCache references subnet IDs from the CacheSubnetGroup."
+              "mutatorRef": [
+                [
+                  "configuration",
+                  "spec",
+                  "subnetIDs"
+                ]
+              ]
             }
           }
         ],
         "to": [
           {
+            "id": null,
             "kind": "CacheSubnetGroup",
-            "model": "aws-elasticache-controller",
+            "match": {},
+            "match_strategy_matrix": null,
+            "model": {
+              "version": "",
+              "name": "aws-elasticache-controller",
+              "displayName": "",
+              "id": "00000000-0000-0000-0000-000000000000",
+              "registrant": {
+                "kind": "github"
+              },
+              "model": {
+                "version": ""
+              }
+            },
             "patch": {
               "patchStrategy": "replace",
-              "mutatedRef": [["settings", "subnetIds"]],
-              "description": "The CacheSubnetGroup provides subnet IDs for the ServerlessCache."
+              "mutatedRef": [
+                [
+                  "displayName"
+                ]
+              ]
             }
           }
         ]
       },
-      "deny": {}
+      "deny": null
     }
   ],
-  "evaluationQuery": "hierarchical_parent_relationship"
+  "subType": "parent",
+  "status": "enabled",
+  "type": "non-binding",
+  "version": "v1.0.0"
 }

--- a/server/meshmodel/aws-elasticache-controller/v1.3.3/v1.0.0/relationships/hierarchical_parent_GlobalReplicationGroup_ReplicationGroup.json
+++ b/server/meshmodel/aws-elasticache-controller/v1.3.3/v1.0.0/relationships/hierarchical_parent_GlobalReplicationGroup_ReplicationGroup.json
@@ -1,0 +1,41 @@
+{
+  "schemaVersion": "core.meshery.io/v1alpha2",
+  "version": "v1.0.0",
+  "kind": "Hierarchical",
+  "type": "Parent",
+  "subType": "Parent",
+  "metadata": {
+    "description": "A GlobalReplicationGroup acts as the parent of multiple regional ReplicationGroups, enabling cross-region active-active replication for Redis/Valkey. One ReplicationGroup is designated the primary (source), and additional ReplicationGroups in other AWS regions become secondary members. The GlobalReplicationGroup must exist before secondary regional clusters can join it."
+  },
+  "model": "aws-elasticache-controller",
+  "selectors": [
+    {
+      "allow": {
+        "from": [
+          {
+            "kind": "ReplicationGroup",
+            "model": "aws-elasticache-controller",
+            "patch": {
+              "patchStrategy": "replace",
+              "mutatorRef": [["settings", "globalReplicationGroupID"]],
+              "description": "The ReplicationGroup references a GlobalReplicationGroup ID to join the cross-region replication topology."
+            }
+          }
+        ],
+        "to": [
+          {
+            "kind": "GlobalReplicationGroup",
+            "model": "aws-elasticache-controller",
+            "patch": {
+              "patchStrategy": "replace",
+              "mutatedRef": [["settings", "globalReplicationGroupID"]],
+              "description": "The GlobalReplicationGroup provides its ID for regional ReplicationGroups to reference."
+            }
+          }
+        ]
+      },
+      "deny": {}
+    }
+  ],
+  "evaluationQuery": "hierarchical_parent_relationship"
+}

--- a/server/meshmodel/aws-elasticache-controller/v1.3.3/v1.0.0/relationships/hierarchical_parent_GlobalReplicationGroup_ReplicationGroup.json
+++ b/server/meshmodel/aws-elasticache-controller/v1.3.3/v1.0.0/relationships/hierarchical_parent_GlobalReplicationGroup_ReplicationGroup.json
@@ -1,41 +1,96 @@
 {
-  "schemaVersion": "core.meshery.io/v1alpha2",
-  "version": "v1.0.0",
-  "kind": "Hierarchical",
-  "type": "Parent",
-  "subType": "Parent",
+  "id": "00000000-0000-0000-0000-000000000000",
+  "evaluationQuery": "hierarchical_parent_relationship",
+  "kind": "hierarchical",
   "metadata": {
-    "description": "A GlobalReplicationGroup acts as the parent of multiple regional ReplicationGroups, enabling cross-region active-active replication for Redis/Valkey. One ReplicationGroup is designated the primary (source), and additional ReplicationGroups in other AWS regions become secondary members. The GlobalReplicationGroup must exist before secondary regional clusters can join it."
+    "description": "A GlobalReplicationGroup acts as the parent of multiple regional ReplicationGroups, enabling cross-region active-active replication for Redis/Valkey. The GlobalReplicationGroup must exist before secondary regional clusters can join it.",
+    "styles": {
+      "primaryColor": "",
+      "svgColor": "",
+      "svgWhite": ""
+    },
+    "isAnnotation": false
   },
-  "model": "aws-elasticache-controller",
+  "model": {
+    "version": "",
+    "name": "aws-elasticache-controller",
+    "displayName": "",
+    "id": "00000000-0000-0000-0000-000000000000",
+    "registrant": {
+      "kind": ""
+    },
+    "model": {
+      "version": "v1.3.3"
+    }
+  },
+  "schemaVersion": "relationships.meshery.io/v1alpha3",
   "selectors": [
     {
       "allow": {
         "from": [
           {
+            "id": null,
             "kind": "ReplicationGroup",
-            "model": "aws-elasticache-controller",
+            "match": {},
+            "match_strategy_matrix": null,
+            "model": {
+              "version": "",
+              "name": "aws-elasticache-controller",
+              "displayName": "",
+              "id": "00000000-0000-0000-0000-000000000000",
+              "registrant": {
+                "kind": "github"
+              },
+              "model": {
+                "version": ""
+              }
+            },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [["settings", "globalReplicationGroupID"]],
-              "description": "The ReplicationGroup references a GlobalReplicationGroup ID to join the cross-region replication topology."
+              "mutatorRef": [
+                [
+                  "configuration",
+                  "spec",
+                  "globalReplicationGroupID"
+                ]
+              ]
             }
           }
         ],
         "to": [
           {
+            "id": null,
             "kind": "GlobalReplicationGroup",
-            "model": "aws-elasticache-controller",
+            "match": {},
+            "match_strategy_matrix": null,
+            "model": {
+              "version": "",
+              "name": "aws-elasticache-controller",
+              "displayName": "",
+              "id": "00000000-0000-0000-0000-000000000000",
+              "registrant": {
+                "kind": "github"
+              },
+              "model": {
+                "version": ""
+              }
+            },
             "patch": {
               "patchStrategy": "replace",
-              "mutatedRef": [["settings", "globalReplicationGroupID"]],
-              "description": "The GlobalReplicationGroup provides its ID for regional ReplicationGroups to reference."
+              "mutatedRef": [
+                [
+                  "displayName"
+                ]
+              ]
             }
           }
         ]
       },
-      "deny": {}
+      "deny": null
     }
   ],
-  "evaluationQuery": "hierarchical_parent_relationship"
+  "subType": "parent",
+  "status": "enabled",
+  "type": "non-binding",
+  "version": "v1.0.0"
 }

--- a/server/meshmodel/aws-elasticache-controller/v1.3.3/v1.0.0/relationships/hierarchical_parent_VPC_CacheSubnetGroup.json
+++ b/server/meshmodel/aws-elasticache-controller/v1.3.3/v1.0.0/relationships/hierarchical_parent_VPC_CacheSubnetGroup.json
@@ -1,0 +1,41 @@
+{
+  "schemaVersion": "core.meshery.io/v1alpha2",
+  "version": "v1.0.0",
+  "kind": "Hierarchical",
+  "type": "Parent",
+  "subType": "Parent",
+  "metadata": {
+    "description": "A CacheSubnetGroup must belong to a VPC. It groups subnets from within a single VPC so that ElastiCache clusters can be provisioned inside the network boundary of that VPC. The VPC must exist before the CacheSubnetGroup (and transitively any ElastiCache cluster using it) can be created."
+  },
+  "model": "aws-elasticache-controller",
+  "selectors": [
+    {
+      "allow": {
+        "from": [
+          {
+            "kind": "CacheSubnetGroup",
+            "model": "aws-elasticache-controller",
+            "patch": {
+              "patchStrategy": "replace",
+              "mutatorRef": [["settings", "subnetIDs", "_"]],
+              "description": "The CacheSubnetGroup references subnet IDs that belong to the VPC."
+            }
+          }
+        ],
+        "to": [
+          {
+            "kind": "VPC",
+            "model": "aws-ec2-controller",
+            "patch": {
+              "patchStrategy": "replace",
+              "mutatedRef": [["settings", "vpcID"]],
+              "description": "The VPC provides the network boundary within which the CacheSubnetGroup's subnets reside."
+            }
+          }
+        ]
+      },
+      "deny": {}
+    }
+  ],
+  "evaluationQuery": "hierarchical_parent_relationship"
+}

--- a/server/meshmodel/aws-elasticache-controller/v1.3.3/v1.0.0/relationships/hierarchical_parent_VPC_CacheSubnetGroup.json
+++ b/server/meshmodel/aws-elasticache-controller/v1.3.3/v1.0.0/relationships/hierarchical_parent_VPC_CacheSubnetGroup.json
@@ -1,41 +1,96 @@
 {
-  "schemaVersion": "core.meshery.io/v1alpha2",
-  "version": "v1.0.0",
-  "kind": "Hierarchical",
-  "type": "Parent",
-  "subType": "Parent",
+  "id": "00000000-0000-0000-0000-000000000000",
+  "evaluationQuery": "hierarchical_parent_relationship",
+  "kind": "hierarchical",
   "metadata": {
-    "description": "A CacheSubnetGroup must belong to a VPC. It groups subnets from within a single VPC so that ElastiCache clusters can be provisioned inside the network boundary of that VPC. The VPC must exist before the CacheSubnetGroup (and transitively any ElastiCache cluster using it) can be created."
+    "description": "A CacheSubnetGroup must belong to a VPC. It groups subnets from within a single VPC so that ElastiCache clusters can be provisioned inside the network boundary of that VPC.",
+    "styles": {
+      "primaryColor": "",
+      "svgColor": "",
+      "svgWhite": ""
+    },
+    "isAnnotation": false
   },
-  "model": "aws-elasticache-controller",
+  "model": {
+    "version": "",
+    "name": "aws-elasticache-controller",
+    "displayName": "",
+    "id": "00000000-0000-0000-0000-000000000000",
+    "registrant": {
+      "kind": ""
+    },
+    "model": {
+      "version": "v1.3.3"
+    }
+  },
+  "schemaVersion": "relationships.meshery.io/v1alpha3",
   "selectors": [
     {
       "allow": {
         "from": [
           {
+            "id": null,
             "kind": "CacheSubnetGroup",
-            "model": "aws-elasticache-controller",
+            "match": {},
+            "match_strategy_matrix": null,
+            "model": {
+              "version": "",
+              "name": "aws-elasticache-controller",
+              "displayName": "",
+              "id": "00000000-0000-0000-0000-000000000000",
+              "registrant": {
+                "kind": "github"
+              },
+              "model": {
+                "version": ""
+              }
+            },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [["settings", "subnetIDs", "_"]],
-              "description": "The CacheSubnetGroup references subnet IDs that belong to the VPC."
+              "mutatorRef": [
+                [
+                  "configuration",
+                  "spec",
+                  "subnetIDs"
+                ]
+              ]
             }
           }
         ],
         "to": [
           {
+            "id": null,
             "kind": "VPC",
-            "model": "aws-ec2-controller",
+            "match": {},
+            "match_strategy_matrix": null,
+            "model": {
+              "version": "",
+              "name": "aws-ec2-controller",
+              "displayName": "",
+              "id": "00000000-0000-0000-0000-000000000000",
+              "registrant": {
+                "kind": "github"
+              },
+              "model": {
+                "version": ""
+              }
+            },
             "patch": {
               "patchStrategy": "replace",
-              "mutatedRef": [["settings", "vpcID"]],
-              "description": "The VPC provides the network boundary within which the CacheSubnetGroup's subnets reside."
+              "mutatedRef": [
+                [
+                  "displayName"
+                ]
+              ]
             }
           }
         ]
       },
-      "deny": {}
+      "deny": null
     }
   ],
-  "evaluationQuery": "hierarchical_parent_relationship"
+  "subType": "parent",
+  "status": "enabled",
+  "type": "non-binding",
+  "version": "v1.0.0"
 }

--- a/server/meshmodel/aws-elasticache-controller/v1.3.3/v1.0.0/relationships/sibling_CacheCluster_CacheCluster.json
+++ b/server/meshmodel/aws-elasticache-controller/v1.3.3/v1.0.0/relationships/sibling_CacheCluster_CacheCluster.json
@@ -1,0 +1,31 @@
+{
+  "schemaVersion": "core.meshery.io/v1alpha2",
+  "version": "v1.0.0",
+  "kind": "Sibling",
+  "type": "Non-Binding",
+  "subType": "Sibling",
+  "metadata": {
+    "description": "In a Redis cluster mode disabled ReplicationGroup, individual CacheCluster nodes (one primary, up to 5 replicas) are siblings — they share the same ReplicationGroup parent, operate at the same hierarchical level, and replicate data between each other. Understanding this sibling relationship helps model the primary/replica topology within a single shard."
+  },
+  "model": "aws-elasticache-controller",
+  "selectors": [
+    {
+      "allow": {
+        "from": [
+          {
+            "kind": "CacheCluster",
+            "model": "aws-elasticache-controller"
+          }
+        ],
+        "to": [
+          {
+            "kind": "CacheCluster",
+            "model": "aws-elasticache-controller"
+          }
+        ]
+      },
+      "deny": {}
+    }
+  ],
+  "evaluationQuery": "sibling_relationship"
+}

--- a/server/meshmodel/aws-elasticache-controller/v1.3.3/v1.0.0/relationships/sibling_CacheCluster_CacheCluster.json
+++ b/server/meshmodel/aws-elasticache-controller/v1.3.3/v1.0.0/relationships/sibling_CacheCluster_CacheCluster.json
@@ -1,31 +1,80 @@
 {
-  "schemaVersion": "core.meshery.io/v1alpha2",
-  "version": "v1.0.0",
-  "kind": "Sibling",
-  "type": "Non-Binding",
-  "subType": "Sibling",
+  "id": "00000000-0000-0000-0000-000000000000",
+  "evaluationQuery": "sibling_relationship",
+  "kind": "sibling",
   "metadata": {
-    "description": "In a Redis cluster mode disabled ReplicationGroup, individual CacheCluster nodes (one primary, up to 5 replicas) are siblings — they share the same ReplicationGroup parent, operate at the same hierarchical level, and replicate data between each other. Understanding this sibling relationship helps model the primary/replica topology within a single shard."
+    "description": "In a Redis cluster mode disabled ReplicationGroup, individual CacheCluster nodes (one primary, up to 5 replicas) are siblings. They share the same ReplicationGroup parent, operate at the same hierarchical level, and replicate data between each other.",
+    "styles": {
+      "primaryColor": "",
+      "svgColor": "",
+      "svgWhite": ""
+    },
+    "isAnnotation": false
   },
-  "model": "aws-elasticache-controller",
+  "model": {
+    "version": "",
+    "name": "aws-elasticache-controller",
+    "displayName": "",
+    "id": "00000000-0000-0000-0000-000000000000",
+    "registrant": {
+      "kind": ""
+    },
+    "model": {
+      "version": "v1.3.3"
+    }
+  },
+  "schemaVersion": "relationships.meshery.io/v1alpha3",
   "selectors": [
     {
       "allow": {
         "from": [
           {
+            "id": null,
             "kind": "CacheCluster",
-            "model": "aws-elasticache-controller"
+            "match": {},
+            "match_strategy_matrix": null,
+            "model": {
+              "version": "",
+              "name": "aws-elasticache-controller",
+              "displayName": "",
+              "id": "00000000-0000-0000-0000-000000000000",
+              "registrant": {
+                "kind": "github"
+              },
+              "model": {
+                "version": ""
+              }
+            },
+            "patch": null
           }
         ],
         "to": [
           {
+            "id": null,
             "kind": "CacheCluster",
-            "model": "aws-elasticache-controller"
+            "match": {},
+            "match_strategy_matrix": null,
+            "model": {
+              "version": "",
+              "name": "aws-elasticache-controller",
+              "displayName": "",
+              "id": "00000000-0000-0000-0000-000000000000",
+              "registrant": {
+                "kind": "github"
+              },
+              "model": {
+                "version": ""
+              }
+            },
+            "patch": null
           }
         ]
       },
-      "deny": {}
+      "deny": null
     }
   ],
-  "evaluationQuery": "sibling_relationship"
+  "subType": "sibling",
+  "status": "enabled",
+  "type": "non-binding",
+  "version": "v1.0.0"
 }


### PR DESCRIPTION
**Notes for Reviewers**
- This PR fixes #17633

**[Signed commits](https://github.com/meshery/meshery/blob/master/CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [x] Yes, I signed my commits.

## Summary
Added 19 new relationship definitions for `aws-elasticache-controller` in `v1.3.3/v1.0.0/relationships/`

## Relationships Added

**Hierarchical - Parent (5):**
- VPC → CacheSubnetGroup
- CacheSubnetGroup → CacheCluster
- CacheSubnetGroup → ReplicationGroup
- CacheSubnetGroup → ServerlessCache
- GlobalReplicationGroup → ReplicationGroup

**Hierarchical - Inventory (3):**
- CacheParameterGroup → CacheCluster
- CacheParameterGroup → ReplicationGroup
- UserGroup ← User (RBAC)

**Edge - Permission (3):**
- UserGroup → ReplicationGroup (RBAC enforcement)
- ReplicationGroup → KMS Key (at-rest encryption)
- ServerlessCache → KMS Key (at-rest encryption)

**Edge - Network (5):**
- CacheCluster → SecurityGroup
- ReplicationGroup → SecurityGroup
- ServerlessCache → SecurityGroup
- CacheCluster → SNS Topic (event notifications)
- ReplicationGroup → SNS Topic (event notifications)

**Edge - Mount (2):**
- ReplicationGroup → S3 Bucket (snapshot restore)
- ServerlessCache → S3 Bucket (snapshot restore)

**Sibling (1):**
- CacheCluster ↔ CacheCluster (primary/replica nodes)


<!--
Thank you for contributing to Meshery! 

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. Sign your commits.
4. Include before and after screenshots/terminal output.

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.
-->
