### PR TITLE
fix(pattern): resolve variable shadowing bug causing silent design import failure

### DIFF
--- a/server/handlers/meshery_pattern_handler.go
+++ b/server/handlers/meshery_pattern_handler.go
@@ -272,7 +272,8 @@ func (h *Handler) VerifyAndConvertToDesign(
 		sourceContent := mesheryPattern.SourceContent
 		if len(mesheryPattern.SourceContent) == 0 {
 			h.log.Info("Pattern file doesn't contain SourceContent, fetching from remote provider")
-			sourceContent, err := provider.GetDesignSourceContent(token, mesheryPattern.ID.String())
+			var err error
+			sourceContent, err = provider.GetDesignSourceContent(token, mesheryPattern.ID.String())
 			if err != nil {
 				return ErrDesignSourceContent(err, "get ")
 			}

--- a/server/handlers/meshery_pattern_handler_shadowing_test.go
+++ b/server/handlers/meshery_pattern_handler_shadowing_test.go
@@ -1,0 +1,74 @@
+package handlers
+
+import (
+	"context"
+	"testing"
+	"bytes"
+
+	"github.com/gofrs/uuid"
+	"github.com/meshery/meshery/server/models"
+	coreV1 "github.com/meshery/schemas/models/v1alpha1/core"
+	"github.com/meshery/meshkit/logger"
+	"database/sql"
+)
+
+// shadowingMockProvider implementation for testing VerifyAndConvertToDesign
+type shadowingMockProvider struct {
+	models.Provider // Embed the interface so we don't have to implement all methods
+	
+	fetchedSourceContent []byte
+	fetchError           error
+	
+	savedPattern         *models.MesheryPattern
+	saveError            error
+	saveResp             []byte
+}
+
+func (m *shadowingMockProvider) GetDesignSourceContent(token, patternID string) ([]byte, error) {
+	return m.fetchedSourceContent, m.fetchError
+}
+
+func (m *shadowingMockProvider) SaveMesheryPattern(token string, pattern *models.MesheryPattern) ([]byte, error) {
+	m.savedPattern = pattern
+	return m.saveResp, m.saveError
+}
+
+func TestVerifyAndConvertToDesign_VariableShadowing(t *testing.T) {
+	log, _ := logger.New("test", logger.Options{})
+	
+	h := &Handler{
+		log: log,
+		// registryManager can be nil if ConvertFileToDesign doesn't crash, 
+		// but ConvertFileToDesign requires a valid filename with extension.
+	}
+	
+	patternID, _ := uuid.NewV4()
+	pattern := &models.MesheryPattern{
+		ID:   &patternID,
+		Name: "test-helm-chart.tgz", // needs extension for conversion to work without error
+		Type: sql.NullString{String: string(coreV1.HelmChart), Valid: true},
+		SourceContent: []byte{}, // empty initially
+		PatternFile: "", // empty initially
+	}
+	
+	expectedBytes := []byte("mocked helm chart content")
+	
+	provider := &shadowingMockProvider{
+		fetchedSourceContent: expectedBytes,
+		saveResp: []byte(`[]`), // mock successful json response from save
+	}
+	
+	ctx := context.WithValue(context.Background(), models.TokenCtxKey, "mock-token")
+	
+	// ConvertFileToDesign will likely fail without a valid registry or actual valid helm chart,
+	// but the bug was in assigning `mesheryPattern.SourceContent = sourceContent` before `ConvertFileToDesign` is called.
+	// So we can still assert that `mesheryPattern.SourceContent` gets populated correctly even if the function returns an error later.
+	
+	_ = h.VerifyAndConvertToDesign(ctx, pattern, provider)
+	
+	// Verify that the SourceContent was updated with the fetched bytes.
+	// This would fail before the bug fix because of the variable shadowing bug.
+	if !bytes.Equal(pattern.SourceContent, expectedBytes) {
+		t.Errorf("Expected pattern.SourceContent to be %q, but got %q (variable shadowing bug still present)", expectedBytes, pattern.SourceContent)
+	}
+}


### PR DESCRIPTION
### Description
This PR fixes issue #17661 where importing non-Design patterns (such as Helm charts, Kubernetes manifests, or Docker Compose files) would silently fail. 

The bug was caused by variable shadowing in [server/handlers/meshery_pattern_handler.go](cci:7://file:///d:/meshery/meshery/server/handlers/meshery_pattern_handler.go:0:0-0:0) ([VerifyAndConvertToDesign](cci:1://file:///d:/meshery/meshery/server/handlers/meshery_pattern_handler.go:258:0-312:1)). When fetching source content remotely, the `:=` operator was mistakenly used inside the [if](cci:1://file:///d:/meshery/meshery/server/models/pattern/core/pattern.go:26:0-32:1) block, preventing the outer `sourceContent` variable from being populated. Consequently, an empty byte slice was passed to the conversion function, resulting in corrupted or empty patterned files without any error being surfaced to the user.

**Changes made:**
- Changed `:=` to `=` when assigning `sourceContent` to properly update the outer scope variable.
- Added a new unit test [TestVerifyAndConvertToDesign_VariableShadowing](cci:1://file:///d:/meshery/meshery/server/handlers/meshery_pattern_handler_shadowing_test.go:35:0-73:1) in [server/handlers/meshery_pattern_handler_shadowing_test.go](cci:7://file:///d:/meshery/meshery/server/handlers/meshery_pattern_handler_shadowing_test.go:0:0-0:0) that mocks the provider to ensure source content is correctly populated and regressions are prevented.

### Notes for Reviewers
- This PR fixes #17661
- A regression test using a mock [Provider](cci:2://file:///d:/meshery/meshery/server/models/providers.go:353:0-514:1) was included to validate the fix.

### Signed commits
- [x] Yes, I signed my commits.
