### PR TITLE
[mesheryctl] Graduate `relationship` command from experimental to stable    

### DIFF
--- a/mesheryctl/internal/cli/root/experimental/experimental.go
+++ b/mesheryctl/internal/cli/root/experimental/experimental.go
@@ -17,7 +17,6 @@ package experimental
 import (
 	"fmt"
 
-	"github.com/meshery/meshery/mesheryctl/internal/cli/root/relationships"
 	"github.com/meshery/meshery/mesheryctl/internal/cli/root/workspaces"
 	"github.com/meshery/meshery/mesheryctl/pkg/utils"
 	"github.com/pkg/errors"
@@ -45,7 +44,7 @@ var ExpCmd = &cobra.Command{
 }
 
 func init() {
-	availableSubcommands = append(availableSubcommands, relationships.RelationshipCmd, workspaces.WorkSpaceCmd)
+	availableSubcommands = append(availableSubcommands, workspaces.WorkSpaceCmd)
 
 	ExpCmd.AddCommand(availableSubcommands...)
 }

--- a/mesheryctl/internal/cli/root/relationships/error.go
+++ b/mesheryctl/internal/cli/root/relationships/error.go
@@ -3,7 +3,7 @@ package relationships
 import "fmt"
 
 var (
-	viewUsageMsg           = "\n\nUsage: mesheryctl exp relationship view [model-name]\nRun 'mesheryctl exp relationship view --help' to see detailed help message"
+	viewUsageMsg           = "\n\nUsage: mesheryctl relationship view [model-name]\nRun 'mesheryctl relationship view --help' to see detailed help message"
 	errNoModelNameProvided = fmt.Errorf("[model-name] isn't specified%s", viewUsageMsg)
 	errTooManyArgs         = fmt.Errorf("too many arguments, only [model-name] is expected%s", viewUsageMsg)
 )

--- a/mesheryctl/internal/cli/root/relationships/generate.go
+++ b/mesheryctl/internal/cli/root/relationships/generate.go
@@ -39,11 +39,11 @@ var generateCmd = &cobra.Command{
 	Short: "Generate relationships documents",
 	Long:  "Generate relationships documents from the google spreadsheets",
 	Example: `
-// Generate relationships documentss
-mesheryctl exp relationship generate --spreadsheet-id [Spreadsheet ID] --spreadsheet-cred $CRED
+// Generate relationships documents
+mesheryctl relationship generate --spreadsheet-id [Spreadsheet ID] --spreadsheet-cred $CRED
 `,
 	Args: func(cmd *cobra.Command, args []string) error {
-		const errMsg = "[ Spreadsheet ID | Spreadsheet Credentials ] aren't specified\n\nUsage: mesheryctl exp relationship generate --spreadsheet-id [Spreadsheet ID] --spreadsheet-cred $CRED\nRun 'mesheryctl exp relationship generate --help' to see detailed help message"
+		const errMsg = "[ Spreadsheet ID | Spreadsheet Credentials ] aren't specified\n\nUsage: mesheryctl relationship generate --spreadsheet-id [Spreadsheet ID] --spreadsheet-cred $CRED\nRun 'mesheryctl relationship generate --help' to see detailed help message"
 
 		// Check if flag is set
 		if spreadsheeetID == "" || spreadsheeetCred == "" {

--- a/mesheryctl/internal/cli/root/relationships/list.go
+++ b/mesheryctl/internal/cli/root/relationships/list.go
@@ -24,14 +24,14 @@ import (
 	"github.com/spf13/cobra"
 )
 
-// represents the mesheryctl exp relationships list command
+// represents the mesheryctl relationship list command
 var listCmd = &cobra.Command{
 	Use:   "list",
 	Short: "List registered relationships",
 	Long:  "List all relationships registered in Meshery Server",
 	Example: `
 // List of relationships
-mesheryctl exp relationship list
+mesheryctl relationship list
 
 // List of relationships for a specified page
 mesheryctl relationship list --page [page-number]
@@ -40,7 +40,7 @@ mesheryctl relationship list --page [page-number]
 mesheryctl relationship list --count
 `,
 	Args: func(_ *cobra.Command, args []string) error {
-		const errMsg = "Usage: mesheryctl exp relationship list\nRun 'mesheryctl exp relationship list --help' to see detailed help message"
+		const errMsg = "Usage: mesheryctl relationship list\nRun 'mesheryctl relationship list --help' to see detailed help message"
 		if len(args) != 0 {
 			return utils.ErrInvalidArgument(errors.New(errMsg))
 		}
@@ -82,7 +82,7 @@ mesheryctl relationship list --count
 }
 
 func init() {
-	// Add the new exp relationship commands to the listRelationshipsCmd
+	// Add the relationship subcommands to the listRelationshipsCmd
 	listCmd.Flags().IntP("page", "p", 1, "(optional) List next set of relationships with --page (default = 1)")
 	listCmd.Flags().BoolP("count", "c", false, "(optional) Get the number of relationship(s) in total")
 }

--- a/mesheryctl/internal/cli/root/relationships/relationship.go
+++ b/mesheryctl/internal/cli/root/relationships/relationship.go
@@ -48,22 +48,22 @@ Meshery uses relationships to define how interconnected components interact.
 // Display number of available relationships in Meshery
 mesheryctl relationship --count
 
-// Generate a relationship documentation 
-mesheryctl exp relationship generate [flags]
+// Generate a relationship documentation
+mesheryctl relationship generate [flags]
 
 // List available relationship(s)
-mesheryctl exp relationship list [flags]
+mesheryctl relationship list [flags]
 
 // Search for a specific relationship
-mesheryctl exp relationship search [flags] [query-text]
+mesheryctl relationship search [flags] [query-text]
 
 // View a specific relationship
-mesheryctl exp relationship view [model-name]
+mesheryctl relationship view [model-name]
 	`,
 	Args: func(cmd *cobra.Command, args []string) error {
 		count, _ := cmd.Flags().GetBool("count")
 		if len(args) == 0 && !count {
-			errMsg := "Usage: mesheryctl exp relationship [subcommand]\nRun 'mesheryctl exp relationship --help' to see detailed help message"
+			errMsg := "Usage: mesheryctl relationship [subcommand]\nRun 'mesheryctl relationship --help' to see detailed help message"
 			return utils.ErrInvalidArgument(fmt.Errorf("no command specified. %s", errMsg))
 		}
 		return nil
@@ -83,7 +83,7 @@ mesheryctl exp relationship view [model-name]
 		}
 
 		if ok := utils.IsValidSubcommand(availableSubcommands, args[0]); !ok {
-			return errors.New(utils.RelationshipsError(fmt.Sprintf("'%s' is an invalid subcommand. Please provide required options from [view]. Use 'mesheryctl exp relationship --help' to display usage guide.\n", args[0]), "relationship"))
+			return errors.New(utils.RelationshipsError(fmt.Sprintf("'%s' is an invalid subcommand. Please provide required options from [view]. Use 'mesheryctl relationship --help' to display usage guide.\n", args[0]), "relationship"))
 		}
 		_, err := config.GetMesheryCtl(viper.GetViper())
 		if err != nil {

--- a/mesheryctl/internal/cli/root/relationships/search.go
+++ b/mesheryctl/internal/cli/root/relationships/search.go
@@ -33,17 +33,17 @@ var (
 	searchKind      string
 )
 
-// represents the mesheryctl exp relationship search [query-text] subcommand.
+// represents the mesheryctl relationship search [query-text] subcommand.
 var searchCmd = &cobra.Command{
 	Use:   "search",
 	Short: "Search registered relationship(s)",
 	Long:  "Search registred relationship(s) used by different models",
 	Example: `
 // Search for relationship using a query
-mesheryctl exp relationship search [--kind <kind>] [--type <type>] [--subtype <subtype>] [--model <model>] [query-text]`,
+mesheryctl relationship search [--kind <kind>] [--type <type>] [--subtype <subtype>] [--model <model>] [query-text]`,
 	Args: func(cmd *cobra.Command, args []string) error {
-		const usage = "mesheryctl exp relationship search [--kind <kind>] [--type <type>] [--subtype <subtype>] [--model <model>]"
-		errMsg := fmt.Errorf("[--kind, --subtype or --type or --model] and [query-text] are required\n\nUsage: %s\nRun 'mesheryctl exp relationship search --help'", usage)
+		const usage = "mesheryctl relationship search [--kind <kind>] [--type <type>] [--subtype <subtype>] [--model <model>]"
+		errMsg := fmt.Errorf("[--kind, --subtype or --type or --model] and [query-text] are required\n\nUsage: %s\nRun 'mesheryctl relationship search --help'", usage)
 
 		if searchKind == "" && searchSubType == "" && searchType == "" && searchModelName == "" {
 			err := utils.ErrInvalidArgument(errMsg)

--- a/mesheryctl/internal/cli/root/relationships/testdata/generate.relationship.output.without.spreadsheet.cred.golden
+++ b/mesheryctl/internal/cli/root/relationships/testdata/generate.relationship.output.without.spreadsheet.cred.golden
@@ -1,5 +1,5 @@
 [ Spreadsheet ID | Spreadsheet Credentials ] aren't specified
 
-Usage: mesheryctl exp relationship generate --spreadsheet-id [Spreadsheet ID] --spreadsheet-cred $CRED
-Run 'mesheryctl exp relationship generate --help' to see detailed help message
+Usage: mesheryctl relationship generate --spreadsheet-id [Spreadsheet ID] --spreadsheet-cred $CRED
+Run 'mesheryctl relationship generate --help' to see detailed help message
 See https://docs.meshery.io/reference/mesheryctl/relationships/generate for usage details

--- a/mesheryctl/internal/cli/root/relationships/testdata/generate.relationship.output.without.spreadsheet.id.golden
+++ b/mesheryctl/internal/cli/root/relationships/testdata/generate.relationship.output.without.spreadsheet.id.golden
@@ -1,5 +1,5 @@
 [ Spreadsheet ID | Spreadsheet Credentials ] aren't specified
 
-Usage: mesheryctl exp relationship generate --spreadsheet-id [Spreadsheet ID] --spreadsheet-cred $CRED
-Run 'mesheryctl exp relationship generate --help' to see detailed help message
+Usage: mesheryctl relationship generate --spreadsheet-id [Spreadsheet ID] --spreadsheet-cred $CRED
+Run 'mesheryctl relationship generate --help' to see detailed help message
 See https://docs.meshery.io/reference/mesheryctl/relationships/generate for usage details

--- a/mesheryctl/internal/cli/root/relationships/testdata/relationship.invalid.command.output.golden
+++ b/mesheryctl/internal/cli/root/relationships/testdata/relationship.invalid.command.output.golden
@@ -1,3 +1,3 @@
-'invalidCommand' is an invalid subcommand. Please provide required options from [view]. Use 'mesheryctl exp relationship --help' to display usage guide.
+'invalidCommand' is an invalid subcommand. Please provide required options from [view]. Use 'mesheryctl relationship --help' to display usage guide.
 
 See https://docs.meshery.io/reference/mesheryctl/relationships for usage details

--- a/mesheryctl/internal/cli/root/relationships/testdata/relationship.no.args.no.flag.output.golden
+++ b/mesheryctl/internal/cli/root/relationships/testdata/relationship.no.args.no.flag.output.golden
@@ -1,2 +1,2 @@
-no command specified. Usage: mesheryctl exp relationship [subcommand]
-Run 'mesheryctl exp relationship --help' to see detailed help message | Short Description: Invalid Argument | Probable Cause: Invalid Argument | Suggested Remediation: Please check the arguments passed
+no command specified. Usage: mesheryctl relationship [subcommand]
+Run 'mesheryctl relationship --help' to see detailed help message | Short Description: Invalid Argument | Probable Cause: Invalid Argument | Suggested Remediation: Please check the arguments passed

--- a/mesheryctl/internal/cli/root/relationships/testdata/search.missing.args.output.golden
+++ b/mesheryctl/internal/cli/root/relationships/testdata/search.missing.args.output.golden
@@ -1,4 +1,4 @@
 [--kind, --subtype or --type or --model] and [query-text] are required
 
-Usage: mesheryctl exp relationship search [--kind <kind>] [--type <type>] [--subtype <subtype>] [--model <model>]
-Run 'mesheryctl exp relationship search --help' | Short Description: Invalid Argument | Probable Cause: Invalid Argument | Suggested Remediation: Please check the arguments passed
+Usage: mesheryctl relationship search [--kind <kind>] [--type <type>] [--subtype <subtype>] [--model <model>]
+Run 'mesheryctl relationship search --help' | Short Description: Invalid Argument | Probable Cause: Invalid Argument | Suggested Remediation: Please check the arguments passed

--- a/mesheryctl/internal/cli/root/relationships/testdata/view.relationship.no.arguments.golden
+++ b/mesheryctl/internal/cli/root/relationships/testdata/view.relationship.no.arguments.golden
@@ -1,5 +1,5 @@
 [model-name] isn't specified
 
-Usage: mesheryctl exp relationship view [model-name]
-Run 'mesheryctl exp relationship view --help' to see detailed help message
+Usage: mesheryctl relationship view [model-name]
+Run 'mesheryctl relationship view --help' to see detailed help message
 See https://docs.meshery.io/reference/mesheryctl/relationships/view for usage details

--- a/mesheryctl/internal/cli/root/relationships/view.go
+++ b/mesheryctl/internal/cli/root/relationships/view.go
@@ -40,13 +40,13 @@ var viewCmd = &cobra.Command{
 	Long:  "view a relationship queried by the model name",
 	Example: `
 // View relationships of a model in default format yaml
-mesheryctl exp relationship view [model-name]
+mesheryctl relationship view [model-name]
 
 // View relationships of a model in JSON format
-mesheryctl exp relationship view [model-name] --output-format json
+mesheryctl relationship view [model-name] --output-format json
 
 // View relationships of a model in json format and save it to a file
-mesheryctl exp relationship view [model-name] --output-format json --save
+mesheryctl relationship view [model-name] --output-format json --save
 	`,
 	Args: func(cmd *cobra.Command, args []string) error {
 		if len(args) == 0 {

--- a/mesheryctl/internal/cli/root/root.go
+++ b/mesheryctl/internal/cli/root/root.go
@@ -32,6 +32,7 @@ import (
 	"github.com/meshery/meshery/mesheryctl/internal/cli/root/model"
 	"github.com/meshery/meshery/mesheryctl/internal/cli/root/perf"
 	"github.com/meshery/meshery/mesheryctl/internal/cli/root/registry"
+	"github.com/meshery/meshery/mesheryctl/internal/cli/root/relationships"
 	"github.com/meshery/meshery/mesheryctl/internal/cli/root/system"
 	"github.com/meshery/meshery/mesheryctl/pkg/utils"
 	logrus "github.com/sirupsen/logrus"
@@ -127,6 +128,7 @@ func init() {
 		model.ModelCmd,
 		environments.EnvironmentCmd,
 		connections.ConnectionsCmd,
+		relationships.RelationshipCmd,
 	}
 
 	RootCmd.AddCommand(availableSubcommands...)


### PR DESCRIPTION
## What does this PR do?

This PR graduates the `relationship` command from the experimental namespace to a stable, top-level command in `mesheryctl`.

* **Before:** `mesheryctl exp relationship [subcommand]`
* **After:**  `mesheryctl relationship [subcommand]`

This change reflects the stabilization of the `relationship` command and makes it directly accessible at the root level.

---

## Changes

* **`root.go`**

  * Registers `RelationshipCmd` as a root-level command.

* **`experimental.go`**

  * Removes `RelationshipCmd` from the `exp` namespace.

* **Relationship command files**

  * `relationship.go`
  * `list.go`
  * `view.go`
  * `search.go`
  * `generate.go`
  * `error.go`
  * Updates all usage examples, help text, and error messages from:

    * `mesheryctl exp relationship ...`
    * to `mesheryctl relationship ...`

* **Golden test files (`testdata/*.golden`)**

  * Updates expected CLI output to reflect the new stable command path.

No functional or behavioral changes are introduced. This PR strictly updates command wiring and related strings.

---

## How to Test

```bash
# Should work at root level
mesheryctl relationship --help
mesheryctl relationship list
mesheryctl relationship view [model-name]
mesheryctl relationship search --kind [kind]

# Should no longer appear under experimental namespace
mesheryctl exp --help
```

Expected behavior:

* `relationship` is available as a root-level command.
* `relationship` is no longer listed under `mesheryctl exp`.

---

## Related Issues

Closes #17701
Part of #17520
