### PR TITLE
Fix broken Discourse badge URL in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ alt="Meshery Logo" width="70%" /></picture></a><br /><br /></p>
   <img src="https://img.shields.io/github/actions/workflow/status/meshery/meshery/release-drafter.yml" /></a>
 <a href="https://bestpractices.coreinfrastructure.org/projects/3564" alt="CLI Best Practices">
   <img src="https://bestpractices.coreinfrastructure.org/projects/3564/badge" /></a>
-<a href="https://meshery.io/community#discussion-forums" alt="Discussion Forum">
+<a href="https://discuss.layer5.io" alt="Discussion Forum">
   <img src="https://img.shields.io/discourse/users?label=discuss&logo=discourse&server=https%3A%2F%2Fdiscuss.layer5.io" /></a>
 <a href="https://slack.meshery.io" alt="Join Slack">
   <img src="https://img.shields.io/badge/Slack-@meshery.svg?logo=slack" /></a>


### PR DESCRIPTION
  The Discourse users badge in README was pointing to `meshery.io/community` as the Discourse server URL, which is not a valid Discourse instance and returns a "not found" badge. 
  Updated it to point to `discuss.layer5.io` which is the actual Discourse forum.    

before :
<img width="915" height="345" alt="Screenshot from 2026-02-28 22-32-22" src="https://github.com/user-attachments/assets/48a0d24e-eea9-4f1d-9cde-26bc826cd4ac" />

after(my markdown previewer in VS is in light mode :) :
<img width="915" height="345" alt="Screenshot from 2026-02-28 22-42-22" src="https://github.com/user-attachments/assets/4d3f9091-0dad-4cbb-976f-9d9264442f9a" />

cc: @saurabhraghuvanshii  
