### PR TITLE
[models] Add CloudWatch LogGroup to ECS TaskDefinition relationship for aws-ecs-controller

### DIFF
--- a/server/meshmodel/aws-ecs-controller/v1.2.1/v1.0.0/relationships/edge-non-binding-reference-vjbxu.json
+++ b/server/meshmodel/aws-ecs-controller/v1.2.1/v1.0.0/relationships/edge-non-binding-reference-vjbxu.json
@@ -1,0 +1,105 @@
+{
+  "id": "00000000-0000-0000-0000-000000000000",
+  "evaluationQuery": "",
+  "kind": "edge",
+  "metadata": {
+    "description": "ECS TaskDefinition references a CloudWatch LogGroup to route container logs via the awslogs log driver.",
+    "styles": {
+      "primaryColor": "",
+      "svgColor": "",
+      "svgWhite": ""
+    },
+    "isAnnotation": false
+  },
+  "model": {
+    "version": "",
+    "name": "aws-ecs-controller",
+    "displayName": "",
+    "id": "00000000-0000-0000-0000-000000000000",
+    "registrant": {
+      "kind": ""
+    },
+    "model": {
+      "version": "v1.2.1"
+    }
+  },
+  "schemaVersion": "relationships.meshery.io/v1alpha3",
+  "selectors": [
+    {
+      "allow": {
+        "from": [
+          {
+            "id": null,
+            "kind": "LogGroup",
+            "match": {},
+            "match_strategy_matrix": null,
+            "model": {
+              "version": "",
+              "name": "aws-cloudwatchlogs-controller",
+              "displayName": "",
+              "id": "00000000-0000-0000-0000-000000000000",
+              "registrant": {
+                "kind": "github"
+              },
+              "model": {
+                "version": ""
+              }
+            },
+            "patch": {
+              "patchStrategy": "replace",
+              "mutatorRef": [
+                [
+                  "displayName"
+                ]
+              ],
+              "description": "CloudWatch LogGroup provides the log destination for ECS container logs."
+            }
+          }
+        ],
+        "to": [
+          {
+            "id": null,
+            "kind": "TaskDefinition",
+            "match": {},
+            "match_strategy_matrix": null,
+            "model": {
+              "version": "",
+              "name": "aws-ecs-controller",
+              "displayName": "",
+              "id": "00000000-0000-0000-0000-000000000000",
+              "registrant": {
+                "kind": "github"
+              },
+              "model": {
+                "version": ""
+              }
+            },
+            "patch": {
+              "patchStrategy": "replace",
+              "mutatedRef": [
+                [
+                  "configuration",
+                  "spec",
+                  "containerDefinitions",
+                  "0",
+                  "logConfiguration",
+                  "options",
+                  "awslogs-group"
+                ]
+              ],
+              "description": "TaskDefinition receives the log group name in its container log configuration."
+            }
+          }
+        ]
+      },
+      "deny": {
+        "from": [],
+        "to": []
+      }
+    }
+  ],
+  "subType": "reference",
+  "status": "enabled",
+  "type": "non-binding",
+  "version": "v1.0.0"
+}


### PR DESCRIPTION
  ## Summary

  Adds a new relationship defining how an ECS TaskDefinition references a CloudWatch LogGroup for container log routing via the `awslogs` log driver. Assigned under #17548.

  ## Relationship Details

  | FROM | TO | Kind/Type/SubType |
  |---|---|---|
  | LogGroup (aws-cloudwatchlogs-controller) | TaskDefinition (aws-ecs-controller) | edge/non-binding/reference |

  - **Direction**: LogGroup provides the log destination name (mutatorRef: `displayName`) → TaskDefinition receives it in its container log configuration (mutatedRef:
  `containerDefinitions.0.logConfiguration.options.awslogs-group`)
  - **match_strategy_matrix**: `null` (non-auto-populating, manual edge only)
  - Follows the same FROM/TO pattern as existing relationships like ECR Repository → TaskDefinition and SecretsManager Secret → TaskDefinition

  ## Kanvas Validation

  Tested locally by running Meshery via `mesheryctl`, injecting the relationship file into the container, and validating in Kanvas. The reference edge between LogGroup and  TaskDefinition connects successfully.

<img width="1193" height="622" alt="Screenshot from 2026-02-28 23-47-19" src="https://github.com/user-attachments/assets/0c230a4a-eae6-4370-b973-7da07795c230" />

  ## Context

  I initially submitted a batch PR (#17659) with 4 relationships, but closed it after realizing one of them (Cluster → VPC) had an invalid field path that failed Kanvas testing.
  Instead of shipping untested relationships, I'm submitting them individually with proper Kanvas validation for each. Will pick up the pace as I get more comfortable with the  model system.

  ## No Overlap
  - Verified against all open PRs (#17632, #17656, #17655, #17640, #17617, #17619, #17181)
  - #17181 is `aws-cloudwatch-controller` (Dashboard/MetricAlarm), not `aws-cloudwatchlogs-controller` (LogGroup)
  - No other PR touches LogGroup → TaskDefinition

  ## Test plan

  - [x] JSON schema validation passed
  - [x] Reference edge connects in Kanvas
  - [ ] Reviewer approval

  Closes part of #17548

  cc @YASHMAHAKAL