### PR TITLE
[CI] Globally disable ST1005 staticcheck lint rule

### DIFF
--- a/.github/.golangci.yml
+++ b/.github/.golangci.yml
@@ -9,4 +9,9 @@ linters:
     paths:
       - server/handlers/doc.go
       - server/models/meshmodel/core/register.go
- 
+
+linters-settings:
+  staticcheck:
+    checks:
+      - "all"
+      - "-ST1005"


### PR DESCRIPTION
## Description

Disables the `ST1005` lint check (error strings should not be capitalized) across the entire Go codebase by configuring `staticcheck` in `.github/.golangci.yml`.

**Resolves #16867**

## Changes

Modified `.github/.golangci.yml` to add:
```yaml
settings:
  staticcheck:
    checks:
      - "all"
      -       - "-ST1005"
      - ```
This uses the standard golangci-lint v2 approach: `"all"` enables all staticcheck checks, and `"-ST1005"` explicitly disables the ST1005 rule.

## Rationale

The Meshery project prefers capitalized error strings for better readability. The ST1005 rule causes unnecessary CI failures and contributor friction, as noted in the issue.

## Testing

- The configuration syntax follows golangci-lint v2 format, which is already used by the project
- - The existing `go-testing-ci.yml` workflow will validate this config automatically on this PR
- 