### PR TITLE
[Docs] fix: constrain TOC sidebar height for independent scrolling

### DIFF
--- a/docs-new/assets/scss/_table-of-content.scss
+++ b/docs-new/assets/scss/_table-of-content.scss
@@ -4,6 +4,9 @@
   box-shadow: var(--box-shadow-primary);
   z-index: 9;
   height: fit-content;
+  max-height: calc(100vh - var(--navbar-height) - 6rem);
+  overflow-y: auto;
+  scrollbar-width: none; // Firefox
   top: calc(var(--navbar-height) + 5rem);
   position: sticky;
   margin: 0 0 0 auto;
@@ -11,6 +14,10 @@
   border-radius: 7px;
   width: 90%;
   max-width: 200px;
+
+  &::-webkit-scrollbar {
+    display: none; // Chrome, Safari, Edge
+  }
 }
 
 .content-table {
@@ -28,6 +35,7 @@
     flex: 0 0 23%;
     // overflow-x: scroll;
   }
+
   @media (max-width: 56.25em) {
     display: none;
   }
@@ -41,6 +49,7 @@
     border-radius: 11px;
     overflow: hidden;
   }
+
   &::-webkit-scrollbar-thumb {
     background: #868e96;
     width: 0.2rem;
@@ -55,15 +64,18 @@
   &__editable {
     display: flex;
     flex-direction: column;
-    
+
     & a:first-of-type {
       margin-bottom: 4px;
     }
+
     & a:last-of-type {
       margin-top: 4px;
     }
+
     & a {
       color: var(--color-secondary-medium);
+
       &:hover {
         text-decoration: underline;
       }
@@ -77,14 +89,17 @@
     // gap: 10px;
     .selected {
       font-weight: 600;
+
       &:hover {
         text-decoration: none;
       }
     }
+
     & ul {
       font-size: .9rem;
       padding-inline-start: 0px;
       margin-bottom: 0;
+
       & li {
         list-style: none !important;
 
@@ -96,14 +111,14 @@
             text-decoration: underline;
           }
 
+        }
       }
-    }
 
-    & .md-nav {
-      display: flex;
-      flex-direction: column;
-      gap: 4px;
-    }
+      & .md-nav {
+        display: flex;
+        flex-direction: column;
+        gap: 4px;
+      }
 
     }
   }

--- a/docs/_sass/table-of-content.scss
+++ b/docs/_sass/table-of-content.scss
@@ -4,6 +4,9 @@
   box-shadow: var(--box-shadow-primary);
   z-index: 9;
   height: fit-content;
+  max-height: calc(100vh - var(--navbar-height) - 6rem);
+  overflow-y: auto;
+  scrollbar-width: none; // Firefox
   top: calc(var(--navbar-height) + 5rem);
   position: sticky;
   margin: 0 0 0 auto;
@@ -11,6 +14,10 @@
   border-radius: 7px;
   width: 90%;
   max-width: 200px;
+
+  &::-webkit-scrollbar {
+    display: none; // Chrome, Safari, Edge
+  }
 }
 
 .content-table {
@@ -28,6 +35,7 @@
     flex: 0 0 23%;
     // overflow-x: scroll;
   }
+
   @media (max-width: 56.25em) {
     display: none;
   }
@@ -41,6 +49,7 @@
     border-radius: 11px;
     overflow: hidden;
   }
+
   &::-webkit-scrollbar-thumb {
     background: #868e96;
     width: 0.2rem;
@@ -55,15 +64,18 @@
   &__editable {
     display: flex;
     flex-direction: column;
-    
+
     & a:first-of-type {
       margin-bottom: 4px;
     }
+
     & a:last-of-type {
       margin-top: 4px;
     }
+
     & a {
       color: var(--color-secondary-medium);
+
       &:hover {
         text-decoration: underline;
       }
@@ -77,14 +89,17 @@
     // gap: 10px;
     .selected {
       font-weight: 600;
+
       &:hover {
         text-decoration: none;
       }
     }
+
     & ul {
       font-size: .9rem;
       padding-inline-start: 0px;
       margin-bottom: 0;
+
       & li {
         list-style: none !important;
 
@@ -96,14 +111,14 @@
             text-decoration: underline;
           }
 
+        }
       }
-    }
 
-    & .md-nav {
-      display: flex;
-      flex-direction: column;
-      gap: 4px;
-    }
+      & .md-nav {
+        display: flex;
+        flex-direction: column;
+        gap: 4px;
+      }
 
     }
   }


### PR DESCRIPTION
**Notes for Reviewers**
Fixed the intra-page TOC sidebar overflow on content-heavy pages. Previously, the TOC grew taller than the viewport with no bound, requiring users to scroll the main page to see lower TOC entries.


- This PR fixes #17755 
-  [docs/_sass/table-of-content.scss](cci:7://file:///home/yash/meshery/docs/_sass/table-of-content.scss:0:0-0:0) — constrained TOC wrapper height to viewport and enabled independent scrolling
- [docs-new/assets/scss/_table-of-content.scss](cci:7://file:///home/yash/meshery/docs-new/assets/scss/_table-of-content.scss:0:0-0:0) — same fix applied to Hugo docs

**[Signed commits](https://github.com/meshery/meshery/blob/master/CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [x] Yes, I signed my commits.

<!--
Thank you for contributing to Meshery! 

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. Sign your commits.
4. Include before and after screenshots/terminal output.

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.
-->
