### PR TITLE
[UI] Resolve Redux serializability warnings and fix middleware typos

### DIFF
--- a/ui/store/slices/events.ts
+++ b/ui/store/slices/events.ts
@@ -1,6 +1,5 @@
 import { createEntityAdapter, createSlice } from '@reduxjs/toolkit';
 import { SEVERITY, STATUS } from '../../components/NotificationCenter/constants';
-import { BellIcon } from '@sistent/sistent';
 
 const initialState = {
   current_view: {
@@ -24,7 +23,7 @@ const initialState = {
     history_mode: false, // used to determine if the notification center is in history mode . so we render in a different way
     title: 'Notifications', // title of the operation center
     empty_message: 'No notifications found', // message to show when there are no notifications
-    icon: BellIcon,
+    icon: 'BellIcon',
   },
   isNotificationCenterOpen: false,
 };
@@ -131,9 +130,15 @@ export const eventsSlice = createSlice({
       }
 
       if (action.payload.ui) {
+        const sanitizedUi = { ...action.payload.ui };
+
+        if (typeof sanitizedUi.icon === 'function') {
+          sanitizedUi.icon = sanitizedUi.icon.name || 'BellIcon';
+        }
+
         state.ui = {
           ...state.ui,
-          ...action.payload.ui,
+          ...sanitizedUi,
         };
       }
     },

--- a/ui/store/slices/mesheryUi.ts
+++ b/ui/store/slices/mesheryUi.ts
@@ -72,7 +72,14 @@ const coreSlice = createSlice({
       state.capabilitiesRegistry = action.payload.capabilitiesRegistry;
     },
     setConnectionMetadata: (state, action) => {
-      state.connectionMetadataState = action.payload.connectionMetadataState;
+      try {
+        state.connectionMetadataState = JSON.parse(
+          JSON.stringify(action.payload.connectionMetadataState),
+        );
+      } catch (e) {
+        console.error('Failed to serialize connectionMetadataState:', e);
+        state.connectionMetadataState = {};
+      }
     },
     setOrganization: (state, action) => {
       state.organization = action.payload.organization;
@@ -126,6 +133,7 @@ export const setK8sContexts = (payload) => (dispatch) => {
 export const updateProgress = (progressData) => {
   store.dispatch(updateProgressAction(progressData));
 };
+
 // Core middleware configuration
 export const coreMiddleware = (getDefaultMiddleware) =>
   getDefaultMiddleware({
@@ -133,14 +141,9 @@ export const coreMiddleware = (getDefaultMiddleware) =>
       // Ignore these action types
       ignoredActions: ['core/updateGrafanaConfig', 'core/updatePrometheusConfig'],
       // Ignore these field paths in all actions
-      ignoredActionPaths: ['payload.grafana.ts', 'payload.prometheus.ts'],
+      ignoredActionPaths: ['payload.grafana', 'payload.prometheus'],
       // Ignore these paths in the state
-      ignoredPaths: [
-        'core.grafana.ts',
-        'core.prometheus.ts',
-        'core.loadTestPref.ts',
-        'core.meshAdaptersts',
-      ],
+      ignoredPaths: ['core.grafana', 'core.prometheus', 'core.loadTestPref', 'core.meshAdapters'],
     },
   });
 


### PR DESCRIPTION
Description
This PR addresses persistent middleware warnings regarding non-serializable values in the Redux state, specifically within the events.ui.icon path. It also corrects typographical errors in the coreMiddleware configuration that prevented proper state path filtering.

Changes

Sanitized State: Modified ui/store/slices/events.ts to store icon identifiers as strings instead of raw React components/functions.

Data Validation: Added a sanitization check in the openNotificationCenter and setConnectionMetadata reducers to ensure only serializable data is persisted to the store.

Middleware Correction: Fixed typographical errors in ui/store/slices/mesheryUi.ts (e.g., corrected core.meshAdaptersts to core.meshAdapters) and removed accidental .ts file extensions from state paths.

Performance: Improved the reliability of the serializableCheck middleware by ensuring the ignoredPaths accurately match the state structure.

Testing Provider

Run the UI locally: npm run dev.

Open the browser console and observe that the "non-serializable value" warnings no longer appear when interacting with notifications or connection metadata.

Verify that the Notification Center still renders the correct icons based on the string identifiers.

Closes: #17740