### PR TITLE
ui: replace console.log with console.error in WorkspaceModalContext

### DIFF
--- a/ui/utils/context/WorkspaceModalContextProvider.tsx
+++ b/ui/utils/context/WorkspaceModalContextProvider.tsx
@@ -56,11 +56,13 @@ const WorkspaceModalContextProvider = ({ children }) => {
           id: '',
           name: '',
         },
-        org: { id: '' },
+        org: {
+          id: '',
+          name: '',
+        },
       });
       return;
     }
-
     try {
       const resource = {
         id,

--- a/ui/utils/context/WorkspaceModalContextProvider.tsx
+++ b/ui/utils/context/WorkspaceModalContextProvider.tsx
@@ -50,7 +50,14 @@ const WorkspaceModalContextProvider = ({ children }) => {
 
   const onLoadResource = async ({ id, workspaceId, orgId }) => {
     if (!workspaceId && !orgId) {
-      setCurrentLoadedResource({ id, workspace: { id: '' }, org: { id: '' } });
+      setCurrentLoadedResource({
+        id,
+        workspace: {
+          id: '',
+          name: '',
+        },
+        org: { id: '' },
+      });
       return;
     }
 
@@ -77,7 +84,7 @@ const WorkspaceModalContextProvider = ({ children }) => {
       console.log('onloadResource', workspaceId, orgId, resource);
       setCurrentLoadedResource(resource);
     } catch (e) {
-      console.log('[onLoadResource] failed set orgWorkspace context', e);
+      console.error('[onLoadResource] failed set orgWorkspace context', e);
     }
   };
 


### PR DESCRIPTION
### Notes for Reviewers

- **Fixes:** #17772
- **Observability:** Replaced `console.log` with `console.error` in `onLoadResource` to ensure context resolution failures are visible and include stack traces.


**[Signed commits](https://github.com/meshery/meshery/blob/master/CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [x] Yes, I signed my commits.