### PR TITLE
[UI] Migrated deprecated MUI v6 TextField props to slotProps

### DIFF
--- a/ui/components/ConfirmationModal.tsx
+++ b/ui/components/ConfirmationModal.tsx
@@ -356,8 +356,10 @@ function ConfirmationMsg(props) {
                         backgroundColor: 'rgba(102, 102, 102, 0.12)',
                         margin: '1px 1px 8px ',
                       }}
-                      InputProps={{
-                        endAdornment: <Search style={iconMedium} />,
+                      slotProps={{
+                        input: {
+                          endAdornment: <Search style={iconMedium} />,
+                        },
                       }}
                       // margin="none"
                     />
@@ -514,8 +516,10 @@ export const SelectDeploymentTarget_ = ({ k8scontext, selectedK8sContexts }) => 
           backgroundColor: 'rgba(102, 102, 102, 0.12)',
           margin: '1px 1px 8px ',
         }}
-        InputProps={{
-          endAdornment: <Search style={iconMedium} />,
+        slotProps={{
+          input: {
+            endAdornment: <Search style={iconMedium} />,
+          },
         }}
         // margin="none"
       />

--- a/ui/components/Header.tsx
+++ b/ui/components/Header.tsx
@@ -352,8 +352,10 @@ function K8sContextMenu({
                         backgroundColor: 'rgba(102, 102, 102, 0.12)',
                         margin: '1px 0px',
                       }}
-                      InputProps={{
-                        endAdornment: <Search style={iconMedium} width={24} />,
+                      slotProps={{
+                        input: {
+                          endAdornment: <Search style={iconMedium} width={24} />,
+                        },
                       }}
                     />
                   </div>

--- a/ui/components/MesheryDateTimePicker.tsx
+++ b/ui/components/MesheryDateTimePicker.tsx
@@ -55,7 +55,7 @@ const MesheryDateTimePicker: React.FC<MesheryDateTimePickerProps> = ({
           value={dateVal}
           onChange={handleNativeChange}
           fullWidth
-          InputLabelProps={{ shrink: true }}
+          slotProps={{ inputLabel: { shrink: true } }}
         />
       </div>
     );

--- a/ui/components/MesheryMeshInterface/PatternService/RJSFCustomComponents/CustomBaseInput.tsx
+++ b/ui/components/MesheryMeshInterface/PatternService/RJSFCustomComponents/CustomBaseInput.tsx
@@ -91,50 +91,52 @@ const BaseInput = (props) => {
                       : e.target.value,
                 )
           }
-          InputLabelProps={{
-            style: getInputLabelStyle(),
-          }}
           onFocus={() => setIsFocused(true)}
           onBlur={() => setIsFocused(false)}
-          InputProps={{
-            style: { padding: props.multiline ? '10.5px 0px 10.5px 14px' : '0px' },
-            endAdornment: (
-              <InputAdornment position="start">
-                {props.rawErrors?.length > 0 && (
-                  <CustomTextTooltip
-                    bgColor={ERROR_COLOR}
-                    flag={props?.formContext?.overrideFlag}
-                    title={props.rawErrors?.join('  ')}
-                    interactive={true}
-                  >
-                    <IconButton component="span" size="small" tabIndex={-1}>
-                      <ErrorOutlineIcon
-                        width="14px"
-                        height="14px"
-                        fill="#B32700"
-                        style={{ verticalAlign: 'middle', ...iconSmall }}
-                      />
-                    </IconButton>
-                  </CustomTextTooltip>
-                )}
-                {props.schema?.description && (
-                  <CustomTextTooltip
-                    flag={props?.formContext?.overrideFlag}
-                    title={props.schema?.description}
-                    interactive={true}
-                  >
-                    <IconButton component="span" size="small" tabIndex={-1}>
-                      <HelpOutlineIcon
-                        width="14px"
-                        height="14px"
-                        fill={theme.palette.mode === 'dark' ? 'white' : 'gray'}
-                        style={{ verticalAlign: 'middle', ...iconSmall }}
-                      />
-                    </IconButton>
-                  </CustomTextTooltip>
-                )}
-              </InputAdornment>
-            ),
+          slotProps={{
+            inputLabel: {
+              style: getInputLabelStyle(),
+            },
+            input: {
+              style: { padding: props.multiline ? '10.5px 0px 10.5px 14px' : '0px' },
+              endAdornment: (
+                <InputAdornment position="start">
+                  {props.rawErrors?.length > 0 && (
+                    <CustomTextTooltip
+                      bgColor={ERROR_COLOR}
+                      flag={props?.formContext?.overrideFlag}
+                      title={props.rawErrors?.join('  ')}
+                      interactive={true}
+                    >
+                      <IconButton component="span" size="small" tabIndex={-1}>
+                        <ErrorOutlineIcon
+                          width="14px"
+                          height="14px"
+                          fill="#B32700"
+                          style={{ verticalAlign: 'middle', ...iconSmall }}
+                        />
+                      </IconButton>
+                    </CustomTextTooltip>
+                  )}
+                  {props.schema?.description && (
+                    <CustomTextTooltip
+                      flag={props?.formContext?.overrideFlag}
+                      title={props.schema?.description}
+                      interactive={true}
+                    >
+                      <IconButton component="span" size="small" tabIndex={-1}>
+                        <HelpOutlineIcon
+                          width="14px"
+                          height="14px"
+                          fill={theme.palette.mode === 'dark' ? 'white' : 'gray'}
+                          style={{ verticalAlign: 'middle', ...iconSmall }}
+                        />
+                      </IconButton>
+                    </CustomTextTooltip>
+                  )}
+                </InputAdornment>
+              ),
+            },
           }}
         />
       </div>

--- a/ui/components/MesheryMeshInterface/PatternService/RJSFCustomComponents/CustomSelectWidget.tsx
+++ b/ui/components/MesheryMeshInterface/PatternService/RJSFCustomComponents/CustomSelectWidget.tsx
@@ -83,51 +83,53 @@ export default function CustomSelectWidget({
         onBlur={_onBlur}
         onFocus={_onFocus}
         size="small"
-        InputProps={{
-          style: { paddingRight: '0px' },
-          endAdornment: (
-            <InputAdornment position="start" style={{ position: 'absolute', right: '1rem' }}>
-              {rawErrors?.length > 0 && (
-                <CustomTextTooltip
-                  bgColor={ERROR_COLOR}
-                  flag={formContext?.overrideFlag}
-                  title={rawErrors?.join('  ')}
-                  interactive={true}
-                >
-                  <IconButton component="span" size="small">
-                    <ErrorOutlineIcon
-                      width="14px"
-                      height="14px"
-                      fill={ERROR_COLOR}
-                      style={{ verticalAlign: 'middle', ...iconSmall }}
-                    />
-                  </IconButton>
-                </CustomTextTooltip>
-              )}
-              {schema?.description && (
-                <CustomTextTooltip
-                  flag={formContext?.overrideFlag}
-                  title={schema?.description}
-                  interactive={true}
-                >
-                  <IconButton component="span" size="small" style={{ marginRight: '4px' }}>
-                    <HelpOutlineIcon
-                      width="14px"
-                      height="14px"
-                      fill={theme.palette.mode === 'dark' ? 'white' : 'gray'}
-                      style={{ verticalAlign: 'middle', ...iconSmall }}
-                    />
-                  </IconButton>
-                </CustomTextTooltip>
-              )}
-            </InputAdornment>
-          ),
-        }}
         {...textFieldProps}
         select
-        InputLabelProps={{
-          ...textFieldProps.InputLabelProps,
-          shrink: !isEmpty,
+        slotProps={{
+          input: {
+            style: { paddingRight: '0px' },
+            endAdornment: (
+              <InputAdornment position="start" style={{ position: 'absolute', right: '1rem' }}>
+                {rawErrors?.length > 0 && (
+                  <CustomTextTooltip
+                    bgColor={ERROR_COLOR}
+                    flag={formContext?.overrideFlag}
+                    title={rawErrors?.join('  ')}
+                    interactive={true}
+                  >
+                    <IconButton component="span" size="small">
+                      <ErrorOutlineIcon
+                        width="14px"
+                        height="14px"
+                        fill={ERROR_COLOR}
+                        style={{ verticalAlign: 'middle', ...iconSmall }}
+                      />
+                    </IconButton>
+                  </CustomTextTooltip>
+                )}
+                {schema?.description && (
+                  <CustomTextTooltip
+                    flag={formContext?.overrideFlag}
+                    title={schema?.description}
+                    interactive={true}
+                  >
+                    <IconButton component="span" size="small" style={{ marginRight: '4px' }}>
+                      <HelpOutlineIcon
+                        width="14px"
+                        height="14px"
+                        fill={theme.palette.mode === 'dark' ? 'white' : 'gray'}
+                        style={{ verticalAlign: 'middle', ...iconSmall }}
+                      />
+                    </IconButton>
+                  </CustomTextTooltip>
+                )}
+              </InputAdornment>
+            ),
+          },
+          inputLabel: {
+            ...textFieldProps.InputLabelProps,
+            shrink: !isEmpty,
+          },
         }}
         SelectProps={{
           ...textFieldProps.SelectProps,

--- a/ui/components/MesherySettingsEnvButtons.tsx
+++ b/ui/components/MesherySettingsEnvButtons.tsx
@@ -152,13 +152,15 @@ const MesherySettingsEnvButtons = () => {
                 }}
                 data-testid={testIDs('uploadKubeConfig')}
                 margin="normal"
-                InputProps={{
-                  readOnly: true,
-                  endAdornment: (
-                    <InputAdornment position="end">
-                      <CloudUploadIcon />
-                    </InputAdornment>
-                  ),
+                slotProps={{
+                  input: {
+                    readOnly: true,
+                    endAdornment: (
+                      <InputAdornment position="end">
+                        <CloudUploadIcon />
+                      </InputAdornment>
+                    ),
+                  },
                 }}
               />
             </FormGroup>

--- a/ui/components/Performance/index.tsx
+++ b/ui/components/Performance/index.tsx
@@ -864,15 +864,17 @@ const MesheryPerformanceComponent_ = (props) => {
                     margin="normal"
                     variant="outlined"
                     onChange={handleChange('profileName')}
-                    inputProps={{
-                      maxLength: 300,
-                    }}
-                    InputProps={{
-                      endAdornment: (
-                        <CustomTooltip title="Create a profile providing a name, if a profile name is not provided, a random one will be generated for you.">
-                          <HelpOutlineOutlinedIcon style={{ color: '#929292' }} />
-                        </CustomTooltip>
-                      ),
+                    slotProps={{
+                      htmlInput: {
+                        maxLength: 300,
+                      },
+                      input: {
+                        endAdornment: (
+                          <CustomTooltip title="Create a profile providing a name, if a profile name is not provided, a random one will be generated for you.">
+                            <HelpOutlineOutlinedIcon style={{ color: '#929292' }} />
+                          </CustomTooltip>
+                        ),
+                      },
                     }}
                   />
                 </Grid2>
@@ -918,12 +920,14 @@ const MesheryPerformanceComponent_ = (props) => {
                     margin="normal"
                     variant="outlined"
                     onChange={handleChange('url')}
-                    InputProps={{
-                      endAdornment: (
-                        <CustomTooltip title="The Endpoint where the load will be generated and the performance test will run against.">
-                          <HelpOutlineOutlinedIcon style={{ color: '#929292' }} />
-                        </CustomTooltip>
-                      ),
+                    slotProps={{
+                      input: {
+                        endAdornment: (
+                          <CustomTooltip title="The Endpoint where the load will be generated and the performance test will run against.">
+                            <HelpOutlineOutlinedIcon style={{ color: '#929292' }} />
+                          </CustomTooltip>
+                        ),
+                      },
                     }}
                   />
                 </Grid2>
@@ -936,17 +940,19 @@ const MesheryPerformanceComponent_ = (props) => {
                     type="number"
                     fullWidth
                     value={cState}
-                    inputProps={{ min: '0', step: '1' }}
                     margin="normal"
                     variant="outlined"
                     onChange={handleChange('c')}
-                    InputLabelProps={{ shrink: true }}
-                    InputProps={{
-                      endAdornment: (
-                        <CustomTooltip title="Load Testing tool will create this many concurrent request against the endpoint.">
-                          <HelpOutlineOutlinedIcon style={{ color: '#929292' }} />
-                        </CustomTooltip>
-                      ),
+                    slotProps={{
+                      htmlInput: { min: '0', step: '1' },
+                      inputLabel: { shrink: true },
+                      input: {
+                        endAdornment: (
+                          <CustomTooltip title="Load Testing tool will create this many concurrent request against the endpoint.">
+                            <HelpOutlineOutlinedIcon style={{ color: '#929292' }} />
+                          </CustomTooltip>
+                        ),
+                      },
                     }}
                   />
                 </Grid2>
@@ -959,17 +965,19 @@ const MesheryPerformanceComponent_ = (props) => {
                     type="number"
                     fullWidth
                     value={qpsState}
-                    inputProps={{ min: '0', step: '1' }}
                     margin="normal"
                     variant="outlined"
                     onChange={handleChange('qps')}
-                    InputLabelProps={{ shrink: true }}
-                    InputProps={{
-                      endAdornment: (
-                        <CustomTooltip title="The Number of queries/second. If not provided then the MAX number of queries/second will be requested">
-                          <HelpOutlineOutlinedIcon style={{ color: '#929292' }} />
-                        </CustomTooltip>
-                      ),
+                    slotProps={{
+                      htmlInput: { min: '0', step: '1' },
+                      inputLabel: { shrink: true },
+                      input: {
+                        endAdornment: (
+                          <CustomTooltip title="The Number of queries/second. If not provided then the MAX number of queries/second will be requested">
+                            <HelpOutlineOutlinedIcon style={{ color: '#929292' }} />
+                          </CustomTooltip>
+                        ),
+                      },
                     }}
                   />
                 </Grid2>

--- a/ui/components/ReactSelectWrapper.tsx
+++ b/ui/components/ReactSelectWrapper.tsx
@@ -61,15 +61,17 @@ function Control(props) {
     <TextField
       fullWidth
       variant="outlined"
-      InputProps={{
-        inputComponent,
-        inputProps: {
-          style: {
-            display: 'flex',
+      slotProps={{
+        input: {
+          inputComponent,
+          inputProps: {
+            style: {
+              display: 'flex',
+            },
+            inputRef: props.innerRef,
+            children: props.children,
+            ...props.innerProps,
           },
-          inputRef: props.innerRef,
-          children: props.children,
-          ...props.innerProps,
         },
       }}
       {...props.selectProps.textFieldProps}

--- a/ui/components/Settings/MesherySettingsPerformanceComponent.tsx
+++ b/ui/components/Settings/MesherySettingsPerformanceComponent.tsx
@@ -140,11 +140,13 @@ const MesherySettingsPerformanceComponent = () => {
                 type="number"
                 fullWidth
                 value={c}
-                inputProps={{ min: '0', step: '1' }}
                 margin="normal"
                 variant="outlined"
                 onChange={handleChange('c')}
-                InputLabelProps={{ shrink: true }}
+                slotProps={{
+                  htmlInput: { min: '0', step: '1' },
+                  inputLabel: { shrink: true },
+                }}
               />
             </Grid2>
             <Grid2 size={{ xs: 12, lg: 4 }}>
@@ -156,11 +158,13 @@ const MesherySettingsPerformanceComponent = () => {
                 type="number"
                 fullWidth
                 value={qps}
-                inputProps={{ min: '0', step: '1' }}
                 margin="normal"
                 variant="outlined"
                 onChange={handleChange('qps')}
-                InputLabelProps={{ shrink: true }}
+                slotProps={{
+                  htmlInput: { min: '0', step: '1' },
+                  inputLabel: { shrink: true },
+                }}
               />
             </Grid2>
             <Grid2 size={{ xs: 12, lg: 4 }}>

--- a/ui/components/Settings/Registry/Stepper/CSVStepper.tsx
+++ b/ui/components/Settings/Registry/Stepper/CSVStepper.tsx
@@ -159,8 +159,10 @@ const CsvStepper = React.memo(({ handleClose }: CsvStepperProps) => {
                     required
                     id="model-csv-file"
                     type="file"
-                    inputProps={{
-                      accept: '.csv',
+                    slotProps={{
+                      input: {
+                        accept: '.csv',
+                      },
                     }}
                     onChange={handleModelCsvFileChange}
                     sx={{
@@ -216,8 +218,10 @@ const CsvStepper = React.memo(({ handleClose }: CsvStepperProps) => {
                     required
                     id="component-csv-file"
                     type="file"
-                    inputProps={{
-                      accept: '.csv',
+                    slotProps={{
+                      input: {
+                        accept: '.csv',
+                      },
                     }}
                     onChange={handleComponentCsvFileChange}
                     sx={{
@@ -278,8 +282,10 @@ const CsvStepper = React.memo(({ handleClose }: CsvStepperProps) => {
                     required
                     id="relationship-csv-file"
                     type="file"
-                    inputProps={{
-                      accept: '.csv',
+                    slotProps={{
+                      input: {
+                        accept: '.csv',
+                      },
                     }}
                     onChange={handleRelationshipCsvFileChange}
                     sx={{

--- a/ui/components/SpacesSwitcher/components.tsx
+++ b/ui/components/SpacesSwitcher/components.tsx
@@ -122,14 +122,16 @@ export const UserSearchAutoComplete = ({ handleAuthorChange }) => {
         <TextField
           {...params}
           label="Author"
-          InputProps={{
-            ...params.InputProps,
-            endAdornment: (
-              <>
-                {loading ? <CircularProgress color="inherit" size={20} /> : null}
-                {params.InputProps.endAdornment}
-              </>
-            ),
+          slotProps={{
+            input: {
+              ...params.InputProps,
+              endAdornment: (
+                <>
+                  {loading ? <CircularProgress color="inherit" size={20} /> : null}
+                  {params.InputProps.endAdornment}
+                </>
+              ),
+            },
           }}
         />
       )}

--- a/ui/components/TypingFilter/index.tsx
+++ b/ui/components/TypingFilter/index.tsx
@@ -303,7 +303,7 @@ const TypingFilter = ({ filterSchema, placeholder, handleFilter, defaultFilters 
               {...params}
               placeholder={placeholder}
               onKeyDown={handleKeyDown}
-              InputProps={customInputProps}
+              slotProps={{ input: customInputProps }}
             />
           );
         }}

--- a/ui/components/configuratorComponents/MeshModel/index.tsx
+++ b/ui/components/configuratorComponents/MeshModel/index.tsx
@@ -109,7 +109,7 @@ export default function DesignConfigurator() {
                   },
                   displayEmpty: true,
                 }}
-                InputProps={{ disableUnderline: true }}
+                slotProps={{ input: { disableUnderline: true } }}
                 labelId="category-selector"
                 id="category-selector"
                 data-testid="category-selector"
@@ -149,7 +149,7 @@ export default function DesignConfigurator() {
                     },
                     displayEmpty: true,
                   }}
-                  InputProps={{ disableUnderline: true }}
+                  slotProps={{ input: { disableUnderline: true } }}
                   labelId="model-selector"
                   id="model-selector"
                   data-testid="model-selector"


### PR DESCRIPTION
Replaced deprecated InputProps, inputProps, and InputLabelProps with the new slotProps API across all TextField and OutlinedInput usages:

- InputProps -> slotProps.input
- inputProps -> slotProps.htmlInput (TextField) / slotProps.input (OutlinedInput)
- InputLabelProps -> slotProps.inputLabel

Fixes meshery#17774


**[Signed commits](https://github.com/meshery/meshery/blob/master/CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [x] Yes, I signed my commits.

<!--
Thank you for contributing to Meshery! 

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. Sign your commits.
4. Include before and after screenshots/terminal output.

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.
-->
