### PR TITLE
[models] Add ECS TaskDefinition to Cluster hierarchical relationship for aws-ecs-controller   

### DIFF
--- a/server/meshmodel/aws-ecs-controller/v1.2.1/v1.0.0/relationships/hierarchical-parent-inventory-97b1c.json
+++ b/server/meshmodel/aws-ecs-controller/v1.2.1/v1.0.0/relationships/hierarchical-parent-inventory-97b1c.json
@@ -1,0 +1,83 @@
+{
+  "id": "00000000-0000-0000-0000-000000000000",
+  "evaluationQuery": "",
+  "kind": "hierarchical",
+  "metadata": {
+    "description": "ECS TaskDefinition is registered within an ECS Cluster, establishing a hierarchical parent-child relationship where the Cluster manages the execution environment for tasks.",
+    "styles": {
+      "primaryColor": "",
+      "svgColor": "",
+      "svgWhite": ""
+    },
+    "isAnnotation": false
+  },
+  "model": {
+    "version": "",
+    "name": "aws-ecs-controller",
+    "displayName": "",
+    "id": "00000000-0000-0000-0000-000000000000",
+    "registrant": {
+      "kind": ""
+    },
+    "model": {
+      "version": "v1.2.1"
+    }
+  },
+  "schemaVersion": "relationships.meshery.io/v1alpha3",
+  "selectors": [
+    {
+      "allow": {
+        "from": [
+          {
+            "id": null,
+            "kind": "TaskDefinition",
+            "match": {},
+            "match_strategy_matrix": null,
+            "model": {
+              "version": "",
+              "name": "aws-ecs-controller",
+              "displayName": "",
+              "id": "00000000-0000-0000-0000-000000000000",
+              "registrant": {
+                "kind": "github"
+              },
+              "model": {
+                "version": ""
+              }
+            },
+            "patch": {}
+          }
+        ],
+        "to": [
+          {
+            "id": null,
+            "kind": "Cluster",
+            "match": {},
+            "match_strategy_matrix": null,
+            "model": {
+              "version": "",
+              "name": "aws-ecs-controller",
+              "displayName": "",
+              "id": "00000000-0000-0000-0000-000000000000",
+              "registrant": {
+                "kind": "github"
+              },
+              "model": {
+                "version": ""
+              }
+            },
+            "patch": {}
+          }
+        ]
+      },
+      "deny": {
+        "from": [],
+        "to": []
+      }
+    }
+  ],
+  "subType": "inventory",
+  "status": "enabled",
+  "type": "parent",
+  "version": "v1.0.0"
+}

--- a/server/meshmodel/aws-ecs-controller/v1.2.1/v1.0.0/relationships/hierarchical-parent-inventory-97b1c.json
+++ b/server/meshmodel/aws-ecs-controller/v1.2.1/v1.0.0/relationships/hierarchical-parent-inventory-97b1c.json
@@ -45,7 +45,15 @@
                 "version": ""
               }
             },
-            "patch": {}
+            "patch": {
+              "patchStrategy": "replace",
+              "mutatorRef": [
+                [
+                  "displayName"
+                ]
+              ],
+              "description": "TaskDefinition is registered within an ECS Cluster for task execution."
+            }
           }
         ],
         "to": [
@@ -66,7 +74,15 @@
                 "version": ""
               }
             },
-            "patch": {}
+            "patch": {
+              "patchStrategy": "replace",
+              "mutatedRef": [
+                [
+                  "displayName"
+                ]
+              ],
+              "description": "Cluster manages the execution environment for the TaskDefinition."
+            }
           }
         ]
       },


### PR DESCRIPTION
## Summary

  Adds a new hierarchical parent-inventory relationship defining how an ECS TaskDefinition is registered within an ECS Cluster. The Cluster acts  as the parent that manages the execution environment for tasks defined by the TaskDefinition. Assigned under #17548.

  ## Relationship Details

  | FROM (child) | TO (parent) | Kind/Type/SubType |
  |---|---|---|
  | TaskDefinition (aws-ecs-controller) | Cluster (aws-ecs-controller) | hierarchical/parent/inventory |

  - **match_strategy_matrix**: `null` (non-auto-populating)
  - **patch**: empty `{}` — consistent with existing hierarchical relationships in this directory
  - Follows the exact same structure as the existing `Service → Cluster` relationship (`hierarchical-parent-inventory-onlnx.json`) in the same
  directory

  ## Kanvas Validation

  Tested locally by running Meshery via `mesheryctl`, injecting the relationship file into the container, and validating in Kanvas.
  TaskDefinition successfully nests inside Cluster as a parent-child relationship.

<img width="956" height="621" alt="Screenshot from 2026-03-06 17-02-07" src="https://github.com/user-attachments/assets/f2dfbbb9-6d63-456a-9102-64d7d026df7a" />

  ## No Overlap

  - Verified against all open relationship PRs (#17632, #17656, #17655, #17640, #17617, #17619)
  - No other PR touches TaskDefinition → Cluster hierarchical relationship
  - Previously closed #17659 (batch PR with 4 relationships) in favor of submitting individually with proper Kanvas validation

  ## Context

  This is part of my work on #17548 (ECS controller relationships). The `aws-ecs-controller` currently has only 3 relationships this brings it   to 4. I initially tried a batch approach (#17659) but decided to submit each relationship individually with Kanvas-tested screenshots for  quality.

  cc @YASHMAHAKAL

  ## Test plan

  - [x] JSON schema validation passed
  - [x] Structure matches existing `hierarchical-parent-inventory-onlnx.json` in same directory
  - [x] Hierarchical containment renders correctly in Kanvas
  - [ ] Reviewer approval

  Closes part of #17548
