### PR TITLE
Fix/component search async pagination

### DIFF
--- a/mesheryctl/internal/cli/root/components/search.go
+++ b/mesheryctl/internal/cli/root/components/search.go
@@ -19,10 +19,8 @@ import (
 	"net/url"
 	"strings"
 
-	"github.com/meshery/meshery/mesheryctl/internal/cli/pkg/api"
 	"github.com/meshery/meshery/mesheryctl/internal/cli/pkg/display"
 	"github.com/meshery/meshery/mesheryctl/pkg/utils"
-	"github.com/meshery/meshery/server/models"
 	"github.com/spf13/cobra"
 )
 
@@ -37,6 +35,12 @@ Find more information at: https://docs.meshery.io/reference/mesheryctl/component
 	Example: `
 // Search for components using a query
 mesheryctl component search [query-text]
+
+// Search for components with a specified page number
+mesheryctl component search [query-text] --page [page-number]
+
+// Search for components with a specified page size
+mesheryctl component search [query-text] --pagesize [pagesize-number]
 	`,
 	Args: func(_ *cobra.Command, args []string) error {
 		if len(args) == 0 {
@@ -46,33 +50,24 @@ mesheryctl component search [query-text]
 	},
 	RunE: func(cmd *cobra.Command, args []string) error {
 		componentName := strings.Join(args, " ")
-		searchValue := url.Values{}
-		searchValue.Add("search", componentName)
-		searchValue.Add("pagesize", "all")
 
-		componentsResponse, err := api.Fetch[models.MeshmodelComponentsAPIResponse](fmt.Sprintf("%s?%s", componentApiPath, searchValue.Encode()))
-		if err != nil {
-			return err
+		page, _ := cmd.Flags().GetInt("page")
+		pageSize, _ := cmd.Flags().GetInt("pagesize")
+
+		componentData := display.DisplayDataAsync{
+			UrlPath:  fmt.Sprintf("%s?search=%s", componentApiPath, url.QueryEscape(componentName)),
+			DataType: "component",
+			Header:   []string{"ID", "Name", "Model", "Version"},
+			Page:     page,
+			PageSize: pageSize,
+			IsPage:   cmd.Flags().Changed("page"),
 		}
 
-		header := []string{"ID", "Name", "Model", "Version"}
-
-		rows, componentsCount := generateComponentDataToDisplay(componentsResponse)
-
-		dataToDisplay := display.DisplayedData{
-			DataType:         "components",
-			Header:           header,
-			Rows:             rows,
-			Count:            componentsCount,
-			DisplayCountOnly: false,
-			IsPage:           false,
-		}
-
-		err = display.List(dataToDisplay)
-		if err != nil {
-			return err
-		}
-
-		return nil
+		return display.ListAsyncPagination(componentData, generateComponentDataToDisplay)
 	},
+}
+
+func init() {
+	searchComponentsCmd.Flags().IntP("page", "p", 1, "(optional) List next set of components with --page (default = 1)")
+	searchComponentsCmd.Flags().IntP("pagesize", "s", 10, "(optional) List next set of components with --pagesize (default = 10)")
 }

--- a/mesheryctl/internal/cli/root/components/search_test.go
+++ b/mesheryctl/internal/cli/root/components/search_test.go
@@ -33,7 +33,7 @@ func TestSearchComponent(t *testing.T) {
 		{
 			Name:             "Search components with query parameter",
 			Args:             []string{"search", "Test"},
-			URL:              fmt.Sprintf("/%s?pagesize=all&search=Test", componentApiPath),
+			URL:              fmt.Sprintf("/%s?search=Test&page=0&pagesize=10", componentApiPath),
 			Fixture:          "components.api.response.golden",
 			ExpectedResponse: "components.search.output.golden",
 			ExpectError:      false,

--- a/mesheryctl/internal/cli/root/components/testdata/components.search.output.golden
+++ b/mesheryctl/internal/cli/root/components/testdata/components.search.output.golden
@@ -1,5 +1,4 @@
 Total number of components: 1
-[H[J
-
+Page: 1
 ID                                    NAME  MODEL             VERSION                             
 fda1c4e7-14ae-4435-8236-adfb9cea0395  Test  component-test-0  memorydb.aws.kubeform.com/v1alpha1  


### PR DESCRIPTION
**Notes for Reviewers**

- This PR  Fixes #17793

## Changes made:
  - Migrated `mesheryctl component search` from `display.List()` to             
  `display.ListAsyncPagination()` for server-side lazy pagination               
  - Removed `pagesize=all` parameter that fetched all data upfront              
  - Added `--page` and `--pagesize` flags for pagination control
  - Updated tests and golden files to reflect the new paginated output


  ## Test plan
  - [x] `go build ./mesheryctl/...` compiles without errors
  - [x] `TestSearchComponent` passes
  - [x] `TestListComponent` passes (no regressions)


**[Signed commits](https://github.com/meshery/meshery/blob/master/CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [x] Yes, I signed my commits.

<!--
Thank you for contributing to Meshery! 

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. Sign your commits.
4. Include before and after screenshots/terminal output.

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.
-->
