### PR TITLE
[UI] Fix Kubernetes cluster status tooltip copy

### DIFF
--- a/ui/components/Dashboard/charts/KubernetesConnectionChart.tsx
+++ b/ui/components/Dashboard/charts/KubernetesConnectionChart.tsx
@@ -95,7 +95,7 @@ export default function KubernetesConnectionStatsChart() {
             </Typography>
           </div>
           <div onClick={(e) => e.stopPropagation()}>
-            <CustomTextTooltip title="This chart shows the status of your connections to Kubernetes clusters.">
+            <CustomTextTooltip title="This chart shows the status of connections to your Kubernetes clusters.">
               <div>
                 <InfoOutlined
                   color={theme.palette.icon.default}


### PR DESCRIPTION
**Notes for Reviewers**

- This PR fixes #17819
- Updates tooltip copy in ui/components/Dashboard/charts/KubernetesConnectionChart.tsx
 - Replaces:
      - `This chart shows the status of the connections status to your Kubernetes clusters`.
        with:
      - `This chart shows the status of connections to your Kubernetes clusters.`.
- Scope is limited to UI text only (no behavior changes).

**[Signed commits](https://github.com/meshery/meshery/blob/master/CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [x] Yes, I signed my commits.

<!--
Thank you for contributing to Meshery! 

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. Sign your commits.
4. Include before and after screenshots/terminal output.

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.
-->
