### PR TITLE
[mesheryctl] fix: schema-driven source-type flag for design commands

### DIFF
--- a/mesheryctl/internal/cli/root/design/design.go
+++ b/mesheryctl/internal/cli/root/design/design.go
@@ -18,9 +18,8 @@ import (
 	"slices"
 	"strings"
 
-	"github.com/meshery/meshery/mesheryctl/internal/cli/pkg/api"
 	"github.com/meshery/meshery/mesheryctl/pkg/utils"
-	"github.com/meshery/meshery/server/models"
+	coreV1 "github.com/meshery/schemas/models/v1alpha1/core"
 	"github.com/spf13/cobra"
 )
 
@@ -75,18 +74,14 @@ func init() {
 	DesignCmd.AddCommand(availableSubcommands...)
 }
 
-func getDesignSourceTypes() ([]string, error) {
-	apiResponse, err := api.Fetch[[]models.PatternSourceTypesAPIResponse]("api/pattern/types")
-	if err != nil {
-		return nil, err
+func getDesignSourceTypes() []string {
+	return []string{
+		string(coreV1.HelmChart),
+		string(coreV1.K8sManifest),
+		string(coreV1.DockerCompose),
+		string(coreV1.MesheryDesign),
+		string(coreV1.K8sKustomize),
 	}
-
-	sourceTypes := make([]string, 0, len(*apiResponse))
-	for _, sourceTypeResponse := range *apiResponse {
-		sourceTypes = append(sourceTypes, strings.ToLower(sourceTypeResponse.DesignType))
-	}
-
-	return sourceTypes, nil
 }
 
 func retrieveProvidedSourceType(sType string, validDesignSourceTypes []string) (string, error) {

--- a/mesheryctl/internal/cli/root/design/import.go
+++ b/mesheryctl/internal/cli/root/design/import.go
@@ -26,7 +26,6 @@ import (
 	"github.com/meshery/meshery/mesheryctl/pkg/utils"
 	"github.com/meshery/meshery/server/models"
 
-	coreV1 "github.com/meshery/schemas/models/v1alpha1/core"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 )
@@ -52,7 +51,7 @@ mesheryctl design import -f [file/URL] -s [source-type] -n [name]
 
 mesheryctl design import -f design.tar
 mesheryctl design import -f design.yml -n design-name
-mesheryctl design import -f design.yml -s "Kubernetes Manifest" -n design-name
+mesheryctl design import -f design.yml -s "k8s-manifest" -n design-name
 	`,
 	Args: func(_ *cobra.Command, args []string) error {
 		const errMsg = "Usage: mesheryctl design import -f [file/URL] -s [source-type] -n [name]\n"
@@ -74,25 +73,13 @@ mesheryctl design import -f design.yml -s "Kubernetes Manifest" -n design-name
 
 		// If pattern file is passed via flags
 		if sourceType != "" {
-			validSourceTypes, err := getDesignSourceTypes()
-			if err != nil {
-				return err
-			}
+			validSourceTypes := getDesignSourceTypes()
+			var err error
 			if sourceType, err = retrieveProvidedSourceType(sourceType, validSourceTypes); err != nil {
 				return err
 			}
 		}
 
-		switch sourceType {
-		case "Helm Chart":
-			sourceType = string(coreV1.HelmChart)
-		case "Kubernetes Manifest":
-			sourceType = string(coreV1.K8sManifest)
-		case "Meshery Design":
-			sourceType = string(coreV1.MesheryDesign)
-		case "Docker Compose":
-			sourceType = string(coreV1.DockerCompose)
-		}
 
 		pattern, err := importPattern(sourceType, file, patternURL, true)
 		if err != nil {
@@ -201,6 +188,6 @@ func importPattern(sourceType string, file string, patternURL string, save bool)
 
 func init() {
 	importCmd.Flags().StringVarP(&file, "file", "f", "", "Path/URL to design file")
-	importCmd.Flags().StringVarP(&sourceType, "source-type", "s", "", "Type of source file (ex. manifest / compose / helm / design)")
+	importCmd.Flags().StringVarP(&sourceType, "source-type", "s", "", "Type of source file (ex. helm-chart / k8s-manifest / docker-compose / meshery-design)")
 	importCmd.Flags().StringVarP(&name, "name", "n", "", "Name for the design file")
 }

--- a/mesheryctl/internal/cli/root/design/onboard.go
+++ b/mesheryctl/internal/cli/root/design/onboard.go
@@ -59,18 +59,15 @@ var onboardCmd = &cobra.Command{
 	Example: `
 // Onboard design by providing file path
 mesheryctl design onboard -f [filepath] -s [source type]
-mesheryctl design onboard -f ./pattern.yml -s "Kubernetes Manifest"
+mesheryctl design onboard -f ./pattern.yml -s "k8s-manifest"
 	`,
 	Annotations: linkDocpatternOnboard,
 	PreRunE: func(cmd *cobra.Command, args []string) error {
 
 		flagValidator := mesheryctlflags.NewFlagValidator()
-		designOnboardValidSourceTypes, err := getDesignSourceTypes()
-		if err != nil {
-			return err
-		}
+		designOnboardValidSourceTypes := getDesignSourceTypes()
 
-		err = flagValidator.Validator.RegisterValidation("design-source-type", func(fl validator.FieldLevel) bool {
+		err := flagValidator.Validator.RegisterValidation("design-source-type", func(fl validator.FieldLevel) bool {
 			if sourceType, ok := fl.Field().Interface().(string); ok {
 				for _, validType := range designOnboardValidSourceTypes {
 					if strings.EqualFold(sourceType, validType) {
@@ -210,5 +207,5 @@ func multiplepatternsConfirmation(profiles []models.MesheryPattern) int {
 func init() {
 	onboardCmd.Flags().StringVarP(&designOnboardFlags.File, "file", "f", "", "Path to design file")
 	onboardCmd.Flags().BoolVarP(&designOnboardFlags.SkipSave, "skip-save", "", false, "Skip saving a design")
-	onboardCmd.Flags().StringVarP(&designOnboardFlags.SourceType, "source-type", "s", "", "Type of source file (ex. manifest / compose / helm)")
+	onboardCmd.Flags().StringVarP(&designOnboardFlags.SourceType, "source-type", "s", "", "Type of source file (ex. helm-chart / k8s-manifest / docker-compose / meshery-design)")
 }


### PR DESCRIPTION
 This PR fixes #14443

**[Signed commits](https://github.com/meshery/meshery/blob/master/CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [x] Yes, I signed my commits.

### What changed
The `--source-type` flag for `design import` and `design onboard` had inconsistent terminology — help text used informal shorthands (`manifest / compose / helm`) while examples used human-readable titles (`"Kubernetes Manifest"`), neither matching the schema-defined values.

### Changes
- `getDesignSourceTypes()` now returns values from schema constants (`coreV1.HelmChart`, `coreV1.K8sManifest`, `coreV1.DockerCompose`, `coreV1.MesheryDesign`, `coreV1.K8sKustomize`) instead of making an API call
- Removed dead `switch sourceType` block in `import.go` (unreachable after `retrieveProvidedSourceType` lowercased the input)
- Updated flag help text and examples to use canonical schema values: `helm-chart`, `k8s-manifest`, `docker-compose`, `meshery-design`
