### PR TITLE
docs: restructure steps and update troubleshooting link (#9387 follow-up)

### DIFF
--- a/docs-new/content/en/guides/getting-started-creating-a-design-from-template.md
+++ b/docs-new/content/en/guides/getting-started-creating-a-design-from-template.md
@@ -1,0 +1,37 @@
+---
+title: "Getting Started: Creating a Design from Template"
+description: "A step-by-step guide for cloning a design from Meshery Catalog templates."
+---
+
+# Getting Started: Creating a Design from Template
+
+Meshery offers a wide array of templates within its catalog to help users jumpstart their projects. Cloning a design from these templates is an easy way to leverage pre-configured settings and configurations. This guide walks you through the process step-by-step.
+
+## Prerequisites
+
+- Access to a Meshery instance.
+- Basic familiarity with Meshery's interface.
+
+## Steps to Clone a Design from Template
+
+### Step 1: Accessing the Meshery Catalog
+1. **Login**: Log in to your Meshery instance.
+2. **Navigate to Catalog**: Locate and click on the "Catalog" or "Templates" section in the navigation menu.
+
+### Step 2: Exploring and Cloning a Template
+1. **Browse Templates**: Explore the available templates based on categories, tags, or search keywords.
+2. **Select Template**: Click on the desired template to view its details and configurations.
+3. **Clone Template**: Look for the "Clone" or "Use Template" option on the template's page.
+4. **Customize Settings** (if available): Configure any settings or parameters based on your project requirements, if prompted.
+5. **Confirm Cloning**: Meshery might prompt a confirmation dialog. Review and confirm the cloning process.
+
+### Step 3: Accessing the Cloned Design
+1. **Navigate to Cloned Design**: Once the cloning process completes, access the cloned design from your project list or a designated area.
+
+## Troubleshooting Tips
+
+### Common Issues
+- **Failed Cloning**: If the cloning process fails, check your internet connection and try again. If the issue persists, seek help from the [Meshery community](https://layer5.io/community).
+
+### Additional Assistance
+- **Meshery Community**: Visit the [Meshery community forums](https://layer5.io/community) for help and discussion.


### PR DESCRIPTION
This pull request enhances the "Getting Started: Creating a Design from Template" guide by implementing suggested improvements from the previous review:

**- Restructured the steps for better logical flow and consistency:**
  - Step 2, 3, and 4 are now combined into a single logical section: Exploring and Cloning a Template.
  - Step 5 now clearly focuses on accessing the cloned design.
  - Numbered lists applied consistently for all steps and sub-steps.

**- Updated the troubleshooting section:**
  - Replaced the vague "Meshery support" reference with a direct link to the [Meshery community](https://layer5.io/community) for more specific assistance.

This contribution is a follow-up to issue #9387 and improves clarity, usability, and guidance for users cloning designs from Meshery Catalog templates.