### PR TITLE
[meshmodel] feat: add CloudWatch relationships for MetricAlarm, MetricStream and Dashboard

### DIFF
--- a/server/meshmodel/aws-cloudwatch-controller/v1.4.1/v1.0.0/model.json
+++ b/server/meshmodel/aws-cloudwatch-controller/v1.4.1/v1.0.0/model.json
@@ -1,4 +1,4 @@
--{
+{
   "id": "00000000-0000-0000-0000-000000000000",
   "schemaVersion": "models.meshery.io/v1beta1",
   "version": "v1.0.0",

--- a/server/meshmodel/aws-cloudwatch-controller/v1.4.1/v1.0.0/model.json
+++ b/server/meshmodel/aws-cloudwatch-controller/v1.4.1/v1.0.0/model.json
@@ -1,8 +1,8 @@
-{
+-{
   "id": "00000000-0000-0000-0000-000000000000",
   "schemaVersion": "models.meshery.io/v1beta1",
   "version": "v1.0.0",
-  "name": "aws-cloudwatch-controller",
+  "name": "aws-cloudwatch-controller-bhavya",
   "displayName": "AWS CloudWatch",
   "status": "enabled",
   "registrant": {

--- a/server/meshmodel/aws-cloudwatch-controller/v1.4.1/v1.0.0/model.json
+++ b/server/meshmodel/aws-cloudwatch-controller/v1.4.1/v1.0.0/model.json
@@ -2,7 +2,7 @@
   "id": "00000000-0000-0000-0000-000000000000",
   "schemaVersion": "models.meshery.io/v1beta1",
   "version": "v1.0.0",
-  "name": "aws-cloudwatch-controller-bhavya",
+  "name": "aws-cloudwatch-controller",
   "displayName": "AWS CloudWatch",
   "status": "enabled",
   "registrant": {

--- a/server/meshmodel/aws-cloudwatch-controller/v1.4.1/v1.0.0/relationships/edge-non-binding-control-MetricAlarm-AutoScaling.json
+++ b/server/meshmodel/aws-cloudwatch-controller/v1.4.1/v1.0.0/relationships/edge-non-binding-control-MetricAlarm-AutoScaling.json
@@ -1,6 +1,6 @@
 {
   "id": "00000000-0000-0000-0000-000000000004",
-  "evaluationQuery": "",
+  "evaluationQuery": "edge_non_binding_control_relationship",
   "kind": "edge",
   "metadata": {
     "description": "MetricAlarm triggers Auto Scaling Group scaling policies based on metric thresholds",

--- a/server/meshmodel/aws-cloudwatch-controller/v1.4.1/v1.0.0/relationships/edge-non-binding-control-MetricAlarm-AutoScaling.json
+++ b/server/meshmodel/aws-cloudwatch-controller/v1.4.1/v1.0.0/relationships/edge-non-binding-control-MetricAlarm-AutoScaling.json
@@ -1,0 +1,99 @@
+{
+  "id": "00000000-0000-0000-0000-000000000004",
+  "evaluationQuery": "",
+  "kind": "edge",
+  "metadata": {
+    "description": "MetricAlarm triggers Auto Scaling Group scaling policies based on metric thresholds",
+    "styles": {
+      "primaryColor": "",
+      "svgColor": "",
+      "svgWhite": ""
+    },
+    "isAnnotation": false
+  },
+  "model": {
+    "version": "",
+    "name": "aws-cloudwatch-controller",
+    "displayName": "",
+    "id": "00000000-0000-0000-0000-000000000000",
+    "registrant": {
+      "kind": ""
+    },
+    "model": {
+      "version": "v1.4.1"
+    }
+  },
+  "schemaVersion": "relationships.meshery.io/v1alpha3",
+  "selectors": [
+    {
+      "allow": {
+        "from": [
+          {
+            "id": null,
+            "kind": "MetricAlarm",
+            "match": {},
+            "match_strategy_matrix": null,
+            "model": {
+              "version": "",
+              "name": "aws-cloudwatch-controller",
+              "displayName": "",
+              "id": "00000000-0000-0000-0000-000000000000",
+              "registrant": {
+                "kind": "github"
+              },
+              "model": {
+                "version": ""
+              }
+            },
+            "patch": {
+              "patchStrategy": "replace",
+              "mutatorRef": [
+                [
+                  "configuration",
+                  "spec",
+                  "alarmActions"
+                ]
+              ]
+            }
+          }
+        ],
+        "to": [
+          {
+            "id": null,
+            "kind": "ScalingPolicy",
+            "match": {},
+            "match_strategy_matrix": null,
+            "model": {
+              "version": "",
+              "name": "aws-autoscaling-controller",
+              "displayName": "",
+              "id": "00000000-0000-0000-0000-000000000000",
+              "registrant": {
+                "kind": "github"
+              },
+              "model": {
+                "version": ""
+              }
+            },
+            "patch": {
+              "patchStrategy": "replace",
+              "mutatedRef": [
+                [
+                  "displayName"
+                ]
+              ]
+            }
+          }
+        ]
+      },
+      "deny": {
+        "from": [],
+        "to": []
+      }
+    }
+  ],
+  "subType": "control",
+  "status": "enabled",
+  "type": "non-binding",
+  "version": "v1.0.0"
+}

--- a/server/meshmodel/aws-cloudwatch-controller/v1.4.1/v1.0.0/relationships/edge-non-binding-control-MetricAlarm-AutoScaling.json
+++ b/server/meshmodel/aws-cloudwatch-controller/v1.4.1/v1.0.0/relationships/edge-non-binding-control-MetricAlarm-AutoScaling.json
@@ -1,6 +1,6 @@
 {
   "id": "00000000-0000-0000-0000-000000000004",
-  "evaluationQuery": "edge_non_binding_control_relationship",
+  "evaluationQuery": "",
   "kind": "edge",
   "metadata": {
     "description": "MetricAlarm triggers Auto Scaling Group scaling policies based on metric thresholds",

--- a/server/meshmodel/aws-cloudwatch-controller/v1.4.1/v1.0.0/relationships/edge-non-binding-network-Dashboard-EC2.json
+++ b/server/meshmodel/aws-cloudwatch-controller/v1.4.1/v1.0.0/relationships/edge-non-binding-network-Dashboard-EC2.json
@@ -1,6 +1,6 @@
 {
   "id": "00000000-0000-0000-0000-000000000006",
-  "evaluationQuery": "edge_non_binding_network_relationship",
+  "evaluationQuery": "",
   "kind": "edge",
   "metadata": {
     "description": "CloudWatch Dashboard visualizes metrics from EC2 instances for monitoring and observability",

--- a/server/meshmodel/aws-cloudwatch-controller/v1.4.1/v1.0.0/relationships/edge-non-binding-network-Dashboard-EC2.json
+++ b/server/meshmodel/aws-cloudwatch-controller/v1.4.1/v1.0.0/relationships/edge-non-binding-network-Dashboard-EC2.json
@@ -1,6 +1,6 @@
 {
   "id": "00000000-0000-0000-0000-000000000006",
-  "evaluationQuery": "",
+  "evaluationQuery": "edge_non_binding_network_relationship",
   "kind": "edge",
   "metadata": {
     "description": "CloudWatch Dashboard visualizes metrics from EC2 instances for monitoring and observability",

--- a/server/meshmodel/aws-cloudwatch-controller/v1.4.1/v1.0.0/relationships/edge-non-binding-network-Dashboard-EC2.json
+++ b/server/meshmodel/aws-cloudwatch-controller/v1.4.1/v1.0.0/relationships/edge-non-binding-network-Dashboard-EC2.json
@@ -1,0 +1,99 @@
+{
+  "id": "00000000-0000-0000-0000-000000000006",
+  "evaluationQuery": "",
+  "kind": "edge",
+  "metadata": {
+    "description": "CloudWatch Dashboard visualizes metrics from EC2 instances for monitoring and observability",
+    "styles": {
+      "primaryColor": "",
+      "svgColor": "",
+      "svgWhite": ""
+    },
+    "isAnnotation": false
+  },
+  "model": {
+    "version": "",
+    "name": "aws-cloudwatch-controller",
+    "displayName": "",
+    "id": "00000000-0000-0000-0000-000000000000",
+    "registrant": {
+      "kind": ""
+    },
+    "model": {
+      "version": "v1.4.1"
+    }
+  },
+  "schemaVersion": "relationships.meshery.io/v1alpha3",
+  "selectors": [
+    {
+      "allow": {
+        "from": [
+          {
+            "id": null,
+            "kind": "Dashboard",
+            "match": {},
+            "match_strategy_matrix": null,
+            "model": {
+              "version": "",
+              "name": "aws-cloudwatch-controller",
+              "displayName": "",
+              "id": "00000000-0000-0000-0000-000000000000",
+              "registrant": {
+                "kind": "github"
+              },
+              "model": {
+                "version": ""
+              }
+            },
+            "patch": {
+              "patchStrategy": "replace",
+              "mutatorRef": [
+                [
+                  "configuration",
+                  "spec",
+                  "dashboardBody"
+                ]
+              ]
+            }
+          }
+        ],
+        "to": [
+          {
+            "id": null,
+            "kind": "Instance",
+            "match": {},
+            "match_strategy_matrix": null,
+            "model": {
+              "version": "",
+              "name": "aws-ec2-controller",
+              "displayName": "",
+              "id": "00000000-0000-0000-0000-000000000000",
+              "registrant": {
+                "kind": "github"
+              },
+              "model": {
+                "version": ""
+              }
+            },
+            "patch": {
+              "patchStrategy": "replace",
+              "mutatedRef": [
+                [
+                  "displayName"
+                ]
+              ]
+            }
+          }
+        ]
+      },
+      "deny": {
+        "from": [],
+        "to": []
+      }
+    }
+  ],
+  "subType": "network",
+  "status": "enabled",
+  "type": "non-binding",
+  "version": "v1.0.0"
+}

--- a/server/meshmodel/aws-cloudwatch-controller/v1.4.1/v1.0.0/relationships/edge-non-binding-network-Dashboard-RDS.json
+++ b/server/meshmodel/aws-cloudwatch-controller/v1.4.1/v1.0.0/relationships/edge-non-binding-network-Dashboard-RDS.json
@@ -1,0 +1,99 @@
+{
+  "id": "00000000-0000-0000-0000-000000000007",
+  "evaluationQuery": "",
+  "kind": "edge",
+  "metadata": {
+    "description": "CloudWatch Dashboard visualizes metrics from RDS instances for database monitoring and observability",
+    "styles": {
+      "primaryColor": "",
+      "svgColor": "",
+      "svgWhite": ""
+    },
+    "isAnnotation": false
+  },
+  "model": {
+    "version": "",
+    "name": "aws-cloudwatch-controller",
+    "displayName": "",
+    "id": "00000000-0000-0000-0000-000000000000",
+    "registrant": {
+      "kind": ""
+    },
+    "model": {
+      "version": "v1.4.1"
+    }
+  },
+  "schemaVersion": "relationships.meshery.io/v1alpha3",
+  "selectors": [
+    {
+      "allow": {
+        "from": [
+          {
+            "id": null,
+            "kind": "Dashboard",
+            "match": {},
+            "match_strategy_matrix": null,
+            "model": {
+              "version": "",
+              "name": "aws-cloudwatch-controller",
+              "displayName": "",
+              "id": "00000000-0000-0000-0000-000000000000",
+              "registrant": {
+                "kind": "github"
+              },
+              "model": {
+                "version": ""
+              }
+            },
+            "patch": {
+              "patchStrategy": "replace",
+              "mutatorRef": [
+                [
+                  "configuration",
+                  "spec",
+                  "dashboardBody"
+                ]
+              ]
+            }
+          }
+        ],
+        "to": [
+          {
+            "id": null,
+            "kind": "DBInstance",
+            "match": {},
+            "match_strategy_matrix": null,
+            "model": {
+              "version": "",
+              "name": "aws-rds-controller",
+              "displayName": "",
+              "id": "00000000-0000-0000-0000-000000000000",
+              "registrant": {
+                "kind": "github"
+              },
+              "model": {
+                "version": ""
+              }
+            },
+            "patch": {
+              "patchStrategy": "replace",
+              "mutatedRef": [
+                [
+                  "displayName"
+                ]
+              ]
+            }
+          }
+        ]
+      },
+      "deny": {
+        "from": [],
+        "to": []
+      }
+    }
+  ],
+  "subType": "network",
+  "status": "enabled",
+  "type": "non-binding",
+  "version": "v1.0.0"
+}

--- a/server/meshmodel/aws-cloudwatch-controller/v1.4.1/v1.0.0/relationships/edge-non-binding-network-Dashboard-RDS.json
+++ b/server/meshmodel/aws-cloudwatch-controller/v1.4.1/v1.0.0/relationships/edge-non-binding-network-Dashboard-RDS.json
@@ -1,6 +1,6 @@
 {
   "id": "00000000-0000-0000-0000-000000000007",
-  "evaluationQuery": "edge_non_binding_network_relationship",
+  "evaluationQuery": "",
   "kind": "edge",
   "metadata": {
     "description": "CloudWatch Dashboard visualizes metrics from RDS instances for database monitoring and observability",

--- a/server/meshmodel/aws-cloudwatch-controller/v1.4.1/v1.0.0/relationships/edge-non-binding-network-Dashboard-RDS.json
+++ b/server/meshmodel/aws-cloudwatch-controller/v1.4.1/v1.0.0/relationships/edge-non-binding-network-Dashboard-RDS.json
@@ -1,6 +1,6 @@
 {
   "id": "00000000-0000-0000-0000-000000000007",
-  "evaluationQuery": "",
+  "evaluationQuery": "edge_non_binding_network_relationship",
   "kind": "edge",
   "metadata": {
     "description": "CloudWatch Dashboard visualizes metrics from RDS instances for database monitoring and observability",

--- a/server/meshmodel/aws-cloudwatch-controller/v1.4.1/v1.0.0/relationships/edge-non-binding-network-MetricAlarm-Lambda.json
+++ b/server/meshmodel/aws-cloudwatch-controller/v1.4.1/v1.0.0/relationships/edge-non-binding-network-MetricAlarm-Lambda.json
@@ -1,0 +1,99 @@
+{
+  "id": "00000000-0000-0000-0000-000000000002",
+  "evaluationQuery": "",
+  "kind": "edge",
+  "metadata": {
+    "description": "MetricAlarm triggers Lambda Function when alarm state changes",
+    "styles": {
+      "primaryColor": "",
+      "svgColor": "",
+      "svgWhite": ""
+    },
+    "isAnnotation": false
+  },
+  "model": {
+    "version": "",
+    "name": "aws-cloudwatch-controller",
+    "displayName": "",
+    "id": "00000000-0000-0000-0000-000000000000",
+    "registrant": {
+      "kind": ""
+    },
+    "model": {
+      "version": "v1.4.1"
+    }
+  },
+  "schemaVersion": "relationships.meshery.io/v1alpha3",
+  "selectors": [
+    {
+      "allow": {
+        "from": [
+          {
+            "id": null,
+            "kind": "MetricAlarm",
+            "match": {},
+            "match_strategy_matrix": null,
+            "model": {
+              "version": "",
+              "name": "aws-cloudwatch-controller",
+              "displayName": "",
+              "id": "00000000-0000-0000-0000-000000000000",
+              "registrant": {
+                "kind": "github"
+              },
+              "model": {
+                "version": ""
+              }
+            },
+            "patch": {
+              "patchStrategy": "replace",
+              "mutatorRef": [
+                [
+                  "configuration",
+                  "spec",
+                  "alarmActions"
+                ]
+              ]
+            }
+          }
+        ],
+        "to": [
+          {
+            "id": null,
+            "kind": "Function",
+            "match": {},
+            "match_strategy_matrix": null,
+            "model": {
+              "version": "",
+              "name": "aws-lambda-controller",
+              "displayName": "",
+              "id": "00000000-0000-0000-0000-000000000000",
+              "registrant": {
+                "kind": "github"
+              },
+              "model": {
+                "version": ""
+              }
+            },
+            "patch": {
+              "patchStrategy": "replace",
+              "mutatedRef": [
+                [
+                  "displayName"
+                ]
+              ]
+            }
+          }
+        ]
+      },
+      "deny": {
+        "from": [],
+        "to": []
+      }
+    }
+  ],
+  "subType": "network",
+  "status": "enabled",
+  "type": "non-binding",
+  "version": "v1.0.0"
+}

--- a/server/meshmodel/aws-cloudwatch-controller/v1.4.1/v1.0.0/relationships/edge-non-binding-network-MetricAlarm-Lambda.json
+++ b/server/meshmodel/aws-cloudwatch-controller/v1.4.1/v1.0.0/relationships/edge-non-binding-network-MetricAlarm-Lambda.json
@@ -1,6 +1,6 @@
 {
   "id": "00000000-0000-0000-0000-000000000002",
-  "evaluationQuery": "edge_non_binding_network_relationship",
+  "evaluationQuery": "",
   "kind": "edge",
   "metadata": {
     "description": "MetricAlarm triggers Lambda Function when alarm state changes",

--- a/server/meshmodel/aws-cloudwatch-controller/v1.4.1/v1.0.0/relationships/edge-non-binding-network-MetricAlarm-Lambda.json
+++ b/server/meshmodel/aws-cloudwatch-controller/v1.4.1/v1.0.0/relationships/edge-non-binding-network-MetricAlarm-Lambda.json
@@ -1,6 +1,6 @@
 {
   "id": "00000000-0000-0000-0000-000000000002",
-  "evaluationQuery": "",
+  "evaluationQuery": "edge_non_binding_network_relationship",
   "kind": "edge",
   "metadata": {
     "description": "MetricAlarm triggers Lambda Function when alarm state changes",

--- a/server/meshmodel/aws-cloudwatch-controller/v1.4.1/v1.0.0/relationships/edge-non-binding-network-MetricAlarm-SNS.json
+++ b/server/meshmodel/aws-cloudwatch-controller/v1.4.1/v1.0.0/relationships/edge-non-binding-network-MetricAlarm-SNS.json
@@ -1,6 +1,6 @@
 {
   "id": "00000000-0000-0000-0000-000000000001",
-  "evaluationQuery": "",
+  "evaluationQuery": "edge_non_binding_network_relationship",
   "kind": "edge",
   "metadata": {
     "description": "MetricAlarm sends notifications to SNS Topic when alarm state changes",

--- a/server/meshmodel/aws-cloudwatch-controller/v1.4.1/v1.0.0/relationships/edge-non-binding-network-MetricAlarm-SNS.json
+++ b/server/meshmodel/aws-cloudwatch-controller/v1.4.1/v1.0.0/relationships/edge-non-binding-network-MetricAlarm-SNS.json
@@ -1,6 +1,6 @@
 {
   "id": "00000000-0000-0000-0000-000000000001",
-  "evaluationQuery": "edge_non_binding_network_relationship",
+  "evaluationQuery": "",
   "kind": "edge",
   "metadata": {
     "description": "MetricAlarm sends notifications to SNS Topic when alarm state changes",

--- a/server/meshmodel/aws-cloudwatch-controller/v1.4.1/v1.0.0/relationships/edge-non-binding-network-MetricAlarm-SNS.json
+++ b/server/meshmodel/aws-cloudwatch-controller/v1.4.1/v1.0.0/relationships/edge-non-binding-network-MetricAlarm-SNS.json
@@ -1,0 +1,99 @@
+{
+  "id": "00000000-0000-0000-0000-000000000001",
+  "evaluationQuery": "",
+  "kind": "edge",
+  "metadata": {
+    "description": "MetricAlarm sends notifications to SNS Topic when alarm state changes",
+    "styles": {
+      "primaryColor": "",
+      "svgColor": "",
+      "svgWhite": ""
+    },
+    "isAnnotation": false
+  },
+  "model": {
+    "version": "",
+    "name": "aws-cloudwatch-controller",
+    "displayName": "",
+    "id": "00000000-0000-0000-0000-000000000000",
+    "registrant": {
+      "kind": ""
+    },
+    "model": {
+      "version": "v1.4.1"
+    }
+  },
+  "schemaVersion": "relationships.meshery.io/v1alpha3",
+  "selectors": [
+    {
+      "allow": {
+        "from": [
+          {
+            "id": null,
+            "kind": "MetricAlarm",
+            "match": {},
+            "match_strategy_matrix": null,
+            "model": {
+              "version": "",
+              "name": "aws-cloudwatch-controller",
+              "displayName": "",
+              "id": "00000000-0000-0000-0000-000000000000",
+              "registrant": {
+                "kind": "github"
+              },
+              "model": {
+                "version": ""
+              }
+            },
+            "patch": {
+              "patchStrategy": "replace",
+              "mutatorRef": [
+                [
+                  "configuration",
+                  "spec",
+                  "alarmActions"
+                ]
+              ]
+            }
+          }
+        ],
+        "to": [
+          {
+            "id": null,
+            "kind": "Topic",
+            "match": {},
+            "match_strategy_matrix": null,
+            "model": {
+              "version": "",
+              "name": "aws-sns-controller",
+              "displayName": "",
+              "id": "00000000-0000-0000-0000-000000000000",
+              "registrant": {
+                "kind": "github"
+              },
+              "model": {
+                "version": ""
+              }
+            },
+            "patch": {
+              "patchStrategy": "replace",
+              "mutatedRef": [
+                [
+                  "displayName"
+                ]
+              ]
+            }
+          }
+        ]
+      },
+      "deny": {
+        "from": [],
+        "to": []
+      }
+    }
+  ],
+  "subType": "network",
+  "status": "enabled",
+  "type": "non-binding",
+  "version": "v1.0.0"
+}

--- a/server/meshmodel/aws-cloudwatch-controller/v1.4.1/v1.0.0/relationships/edge-non-binding-network-MetricStream-Firehose.json
+++ b/server/meshmodel/aws-cloudwatch-controller/v1.4.1/v1.0.0/relationships/edge-non-binding-network-MetricStream-Firehose.json
@@ -1,0 +1,99 @@
+{
+  "id": "00000000-0000-0000-0000-000000000003",
+  "evaluationQuery": "",
+  "kind": "edge",
+  "metadata": {
+    "description": "MetricStream exports CloudWatch metrics to Kinesis Data Firehose for delivery pipeline",
+    "styles": {
+      "primaryColor": "",
+      "svgColor": "",
+      "svgWhite": ""
+    },
+    "isAnnotation": false
+  },
+  "model": {
+    "version": "",
+    "name": "aws-cloudwatch-controller",
+    "displayName": "",
+    "id": "00000000-0000-0000-0000-000000000000",
+    "registrant": {
+      "kind": ""
+    },
+    "model": {
+      "version": "v1.4.1"
+    }
+  },
+  "schemaVersion": "relationships.meshery.io/v1alpha3",
+  "selectors": [
+    {
+      "allow": {
+        "from": [
+          {
+            "id": null,
+            "kind": "MetricStream",
+            "match": {},
+            "match_strategy_matrix": null,
+            "model": {
+              "version": "",
+              "name": "aws-cloudwatch-controller",
+              "displayName": "",
+              "id": "00000000-0000-0000-0000-000000000000",
+              "registrant": {
+                "kind": "github"
+              },
+              "model": {
+                "version": ""
+              }
+            },
+            "patch": {
+              "patchStrategy": "replace",
+              "mutatorRef": [
+                [
+                  "configuration",
+                  "spec",
+                  "firehoseARN"
+                ]
+              ]
+            }
+          }
+        ],
+        "to": [
+          {
+            "id": null,
+            "kind": "DeliveryStream",
+            "match": {},
+            "match_strategy_matrix": null,
+            "model": {
+              "version": "",
+              "name": "aws-kinesis-firehose-controller",
+              "displayName": "",
+              "id": "00000000-0000-0000-0000-000000000000",
+              "registrant": {
+                "kind": "github"
+              },
+              "model": {
+                "version": ""
+              }
+            },
+            "patch": {
+              "patchStrategy": "replace",
+              "mutatedRef": [
+                [
+                  "displayName"
+                ]
+              ]
+            }
+          }
+        ]
+      },
+      "deny": {
+        "from": [],
+        "to": []
+      }
+    }
+  ],
+  "subType": "network",
+  "status": "enabled",
+  "type": "non-binding",
+  "version": "v1.0.0"
+}

--- a/server/meshmodel/aws-cloudwatch-controller/v1.4.1/v1.0.0/relationships/edge-non-binding-network-MetricStream-Firehose.json
+++ b/server/meshmodel/aws-cloudwatch-controller/v1.4.1/v1.0.0/relationships/edge-non-binding-network-MetricStream-Firehose.json
@@ -1,6 +1,6 @@
 {
   "id": "00000000-0000-0000-0000-000000000003",
-  "evaluationQuery": "edge_non_binding_network_relationship",
+  "evaluationQuery": "",
   "kind": "edge",
   "metadata": {
     "description": "MetricStream exports CloudWatch metrics to Kinesis Data Firehose for delivery pipeline",

--- a/server/meshmodel/aws-cloudwatch-controller/v1.4.1/v1.0.0/relationships/edge-non-binding-network-MetricStream-Firehose.json
+++ b/server/meshmodel/aws-cloudwatch-controller/v1.4.1/v1.0.0/relationships/edge-non-binding-network-MetricStream-Firehose.json
@@ -1,6 +1,6 @@
 {
   "id": "00000000-0000-0000-0000-000000000003",
-  "evaluationQuery": "",
+  "evaluationQuery": "edge_non_binding_network_relationship",
   "kind": "edge",
   "metadata": {
     "description": "MetricStream exports CloudWatch metrics to Kinesis Data Firehose for delivery pipeline",

--- a/server/meshmodel/aws-cloudwatch-controller/v1.4.1/v1.0.0/relationships/edge-non-binding-permission-MetricStream-KMS.json
+++ b/server/meshmodel/aws-cloudwatch-controller/v1.4.1/v1.0.0/relationships/edge-non-binding-permission-MetricStream-KMS.json
@@ -1,0 +1,99 @@
+{
+  "id": "00000000-0000-0000-0000-000000000005",
+  "evaluationQuery": "",
+  "kind": "edge",
+  "metadata": {
+    "description": "MetricStream uses KMS Key for server-side encryption of metric data",
+    "styles": {
+      "primaryColor": "",
+      "svgColor": "",
+      "svgWhite": ""
+    },
+    "isAnnotation": false
+  },
+  "model": {
+    "version": "",
+    "name": "aws-cloudwatch-controller",
+    "displayName": "",
+    "id": "00000000-0000-0000-0000-000000000000",
+    "registrant": {
+      "kind": ""
+    },
+    "model": {
+      "version": "v1.4.1"
+    }
+  },
+  "schemaVersion": "relationships.meshery.io/v1alpha3",
+  "selectors": [
+    {
+      "allow": {
+        "from": [
+          {
+            "id": null,
+            "kind": "MetricStream",
+            "match": {},
+            "match_strategy_matrix": null,
+            "model": {
+              "version": "",
+              "name": "aws-cloudwatch-controller",
+              "displayName": "",
+              "id": "00000000-0000-0000-0000-000000000000",
+              "registrant": {
+                "kind": "github"
+              },
+              "model": {
+                "version": ""
+              }
+            },
+            "patch": {
+              "patchStrategy": "replace",
+              "mutatorRef": [
+                [
+                  "configuration",
+                  "spec",
+                  "kmsKeyID"
+                ]
+              ]
+            }
+          }
+        ],
+        "to": [
+          {
+            "id": null,
+            "kind": "Key",
+            "match": {},
+            "match_strategy_matrix": null,
+            "model": {
+              "version": "",
+              "name": "aws-kms-controller",
+              "displayName": "",
+              "id": "00000000-0000-0000-0000-000000000000",
+              "registrant": {
+                "kind": "github"
+              },
+              "model": {
+                "version": ""
+              }
+            },
+            "patch": {
+              "patchStrategy": "replace",
+              "mutatedRef": [
+                [
+                  "displayName"
+                ]
+              ]
+            }
+          }
+        ]
+      },
+      "deny": {
+        "from": [],
+        "to": []
+      }
+    }
+  ],
+  "subType": "permission",
+  "status": "enabled",
+  "type": "non-binding",
+  "version": "v1.0.0"
+}

--- a/server/meshmodel/aws-cloudwatch-controller/v1.4.1/v1.0.0/relationships/edge-non-binding-permission-MetricStream-KMS.json
+++ b/server/meshmodel/aws-cloudwatch-controller/v1.4.1/v1.0.0/relationships/edge-non-binding-permission-MetricStream-KMS.json
@@ -1,6 +1,6 @@
 {
   "id": "00000000-0000-0000-0000-000000000005",
-  "evaluationQuery": "edge_non_binding_permission_relationship",
+  "evaluationQuery": "",
   "kind": "edge",
   "metadata": {
     "description": "MetricStream uses KMS Key for server-side encryption of metric data",

--- a/server/meshmodel/aws-cloudwatch-controller/v1.4.1/v1.0.0/relationships/edge-non-binding-permission-MetricStream-KMS.json
+++ b/server/meshmodel/aws-cloudwatch-controller/v1.4.1/v1.0.0/relationships/edge-non-binding-permission-MetricStream-KMS.json
@@ -1,6 +1,6 @@
 {
   "id": "00000000-0000-0000-0000-000000000005",
-  "evaluationQuery": "",
+  "evaluationQuery": "edge_non_binding_permission_relationship",
   "kind": "edge",
   "metadata": {
     "description": "MetricStream uses KMS Key for server-side encryption of metric data",


### PR DESCRIPTION

<img width="2940" height="1912" alt="Image 10-03-26 at 12 55 AM" src="https://github.com/user-attachments/assets/9fa08a73-3a08-4d30-8361-5d75de76cb42" />

Description
Adds meaningful cross-service relationships for aws-cloudwatch-controller components addressing the observability gap in Meshery's AWS coverage.

**MetricAlarm relationships:**
- MetricAlarm → SNS Topic (alarm notifications)
- MetricAlarm → Lambda Function (trigger actions)
- MetricAlarm → AutoScaling ScalingPolicy (scaling execution)

**MetricStream relationships:**
- MetricStream → Kinesis Firehose (metric export pipeline)
- MetricStream → KMS Key (encryption)

**Dashboard relationships:**
- Dashboard → EC2 Instance (visualization)
- Dashboard → RDS DBInstance (visualization)

## Testing
Tested locally by running Meshery via Docker and verified all 3 components (MetricAlarm, MetricStream, Dashboard) load correctly in Meshery Kanvas.

## Screenshots
<img>