### PR TITLE
chore: remove trailing exp from relationship command

### DIFF
--- a/mesheryctl/internal/cli/root/relationships/list.go
+++ b/mesheryctl/internal/cli/root/relationships/list.go
@@ -33,7 +33,7 @@ type cmdRelationshipListFlags struct {
 
 var relationshipListFlags cmdRelationshipListFlags
 
-// represents the mesheryctl exp relationships list command.
+// represents the mesheryctl relationships list command.
 var listCmd = &cobra.Command{
 	Use:   "list",
 	Short: "List registered relationships",
@@ -58,7 +58,7 @@ mesheryctl relationship list --count
 
 	Args: func(_ *cobra.Command, args []string) error {
 		if len(args) != 0 {
-			errMsg := "Usage: mesheryctl exp relationship list\nRun 'mesheryctl exp relationship list --help' to see detailed help message"
+			errMsg := "Usage: mesheryctl relationship list\nRun 'mesheryctl relationship list --help' to see detailed help message"
 			return utils.ErrInvalidArgument(fmt.Errorf("too many arguments specified\n\n%s", errMsg))
 		}
 		return nil

--- a/mesheryctl/internal/cli/root/relationships/search.go
+++ b/mesheryctl/internal/cli/root/relationships/search.go
@@ -61,8 +61,8 @@ mesheryctl relationship search [--kind <kind>] [--page <int>]`,
 			searchRelationshipFlagsProvided.Model == "" {
 			return utils.ErrFlagsInvalid(fmt.Errorf(
 				"at least one of [--kind, --subtype, --type, --model] is required\n\n" +
-					"Usage: mesheryctl exp relationship search [--kind <kind>] [--type <type>] [--subtype <subtype>] [--model <model>]\n" +
-					"Run 'mesheryctl exp relationship search --help'",
+					"Usage: mesheryctl relationship search [--kind <kind>] [--type <type>] [--subtype <subtype>] [--model <model>]\n" +
+					"Run 'mesheryctl relationship search --help'",
 			))
 		}
 
@@ -71,7 +71,7 @@ mesheryctl relationship search [--kind <kind>] [--page <int>]`,
 
 	Args: func(_ *cobra.Command, args []string) error {
 		if len(args) != 0 {
-			errMsg := "Usage: mesheryctl exp relationship search\nRun 'mesheryctl exp relationship search --help' to see detailed help message"
+			errMsg := "Usage: mesheryctl relationship search\nRun 'mesheryctl relationship search --help' to see detailed help message"
 			return utils.ErrInvalidArgument(fmt.Errorf("too many arguments specified\n\n%s", errMsg))
 		}
 		return nil

--- a/mesheryctl/internal/cli/root/relationships/search_test.go
+++ b/mesheryctl/internal/cli/root/relationships/search_test.go
@@ -13,8 +13,8 @@ import (
 func expectedSearchMissingFlagsError() error {
 	return utils.ErrFlagsInvalid(fmt.Errorf(
 		"at least one of [--kind, --subtype, --type, --model] is required\n\n" +
-			"Usage: mesheryctl exp relationship search [--kind <kind>] [--type <type>] [--subtype <subtype>] [--model <model>]\n" +
-			"Run 'mesheryctl exp relationship search --help'",
+			"Usage: mesheryctl relationship search [--kind <kind>] [--type <type>] [--subtype <subtype>] [--model <model>]\n" +
+			"Run 'mesheryctl relationship search --help'",
 	))
 }
 


### PR DESCRIPTION
**Notes for Reviewers**
Minimal follow-up PR for cleaning up missed `exp` from the relationship command


- This PR fixes #

**[Signed commits](https://github.com/meshery/meshery/blob/master/CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [x] Yes, I signed my commits.

<!--
Thank you for contributing to Meshery! 

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. Sign your commits.
4. Include before and after screenshots/terminal output.

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.
-->
