### PR TITLE
Add(Docs):MeshSync system check example

### DIFF
--- a/docs/pages/concepts/architectural/meshsync.md
+++ b/docs/pages/concepts/architectural/meshsync.md
@@ -82,7 +82,14 @@ The informer in MeshSync actively listens to changes in resources and updates th
 
 ### Synthetic Test of MeshSync
 
-_TODO: Include an example of how to invoke this built-in check._
+MeshSync health can be verified using Meshery's built-in system checks. For example, run:
+
+```bash
+mesheryctl system check --operator
+```
+
+This check reports the status of Meshery Operator and its controllers, including MeshSync and Broker.
+You can also trigger the same check from the UI by clicking the connection chip in the Connections view.
 
 ## Scalability and Performance
 

--- a/docs/pages/concepts/architectural/meshsync.md
+++ b/docs/pages/concepts/architectural/meshsync.md
@@ -89,7 +89,7 @@ mesheryctl system check --operator
 ```
 
 This check reports the status of Meshery Operator and its controllers, including MeshSync and Broker.
-You can also trigger the same check from the UI by clicking the connection chip in the Connections view.
+This check can also be triggered in the UI from the **Connections** view by clicking the **connection chip**
 
 ## Scalability and Performance
 

--- a/docs/pages/concepts/architectural/meshsync.md
+++ b/docs/pages/concepts/architectural/meshsync.md
@@ -89,7 +89,22 @@ mesheryctl system check --operator
 ```
 
 This check reports the status of Meshery Operator and its controllers, including MeshSync and Broker.
-This check can also be triggered in the UI from the **Connections** view by clicking the **connection chip**
+This check can also be triggered in the UI from the **Connections** view by clicking the **connection chip**.
+
+Example output:
+
+```text
+Meshery Operators
+--------------
+✓ Meshery Operator is running
+✓ Meshsync is running
+✓ Meshery Broker is running
+✓ Meshery Broker CR contains Status.Endpoint (External: <public-endpoint>, Internal: <cluster-endpoint>)
+```
+
+How to interpret:
+- A ✓ line means that component is healthy and reachable.
+- A "!!" line indicates the component is not running or a required status field is missing.
 
 ## Scalability and Performance
 


### PR DESCRIPTION
## Summary
Added a short, actionable example under “Synthetic Test of MeshSync” showing how to invoke the built‑in check.
- Add a concrete example for running the MeshSync built-in synthetic check.
- Mention the UI entry point for the same check.

### File updated

[meshsync.md](https://file+.vscode-resource.vscode-cdn.net/c%3A/Users/hp/.vscode/extensions/openai.chatgpt-26.5309.21912-win32-x64/webview/)
