### PR TITLE
feat(api): add /api/registry routes and update clients (backward compatible)

### DIFF
--- a/docs/_data/notes/meshery-model-generation.md
+++ b/docs/_data/notes/meshery-model-generation.md
@@ -136,7 +136,7 @@ Generating Models does not require Meshery Server
     Flow: Dynamically Generated Components
     Import and Export of Models
 13. Dynamic generation and registration occurs upon initial connection[b] to each supported platform (e.g. a Kubernetes context transitions to Discovered state)
-14. [Adapter] pushes its specific capabilities to Meshery Server. In order to register capabilities, Adapters will send a POST request to/api/meshmodel/components/register.
+14. [Adapter] pushes its specific capabilities to Meshery Server. In order to register capabilities, Adapters will send a POST request to /api/registry/components/register.
 15. [Meshery Server] Components can be registered with the server by interfacing with MeshModel APIs, mesheryctl and Meshery UI are two clients (will be) capable of invoking generation and registration. User imports a Meshery Application as a single file reference, folder reference (to be recursively searched), or a git repository to be walked.
     Flow: Importing Designs
     Importing Designs requires Meshery Server, so that your Design can be associated with your account.

--- a/docs/_data/notes/meshery-models.md
+++ b/docs/_data/notes/meshery-models.md
@@ -546,7 +546,7 @@ _Note: The Tier-2 eval results can override Tier-1 eval results._
 
 #### Tier-2: (First Part of Tier-2 eval) Server side eval:
 
-REST API: POST request to `/api/meshmodels/relationships/evaluate`
+REST API: POST request to `/api/registry/relationships/evaluate`
 
 ```
 Body: {

--- a/docs/_data/openapi.yml
+++ b/docs/_data/openapi.yml
@@ -21361,7 +21361,7 @@ paths:
                 type: string
       security:
         - keychain_jwt: []
-  /api/meshmodels/register:
+  /api/registry/register:
     servers: []
     post:
       summary: Register mesh models

--- a/docs/_data/swagger.yml
+++ b/docs/_data/swagger.yml
@@ -7799,7 +7799,7 @@ paths:
             summary: Handle GET request for getting all connections status
             tags:
                 - GetConnectionsStatus
-    /api/meshmodel/components/register:
+    /api/registry/components/register:
         post:
             description: Validate the given value with the given schema
             operationId: idPostMeshModelValidate
@@ -7809,7 +7809,7 @@ paths:
             summary: Handle POST request for registering meshmodel components.
             tags:
                 - MeshmodelValidate
-    /api/meshmodel/generate:
+    /api/registry/generate:
         post:
             description: Generates Meshery Components for the given payload
             operationId: idPostMeshModelComponentGenerate
@@ -7819,7 +7819,7 @@ paths:
             summary: Handle POST request for component generation
             tags:
                 - MeshmodelComponentGenerate
-    /api/meshmodel/update/status:
+    /api/registry/{entityType}/status:
         post:
             description: Update the ignore status of a model based on the provided parameters.
             operationId: idPostMeshModelUpdateEntityStatus
@@ -7829,7 +7829,7 @@ paths:
             summary: Handle POST request for updating the ignore status of a model.
             tags:
                 - MeshModelUpdateEntityStatus
-    /api/meshmodel/validate:
+    /api/registry/validate:
         post:
             description: Validate the given value with the given schema
             operationId: idPostMeshModelValidate
@@ -7839,7 +7839,7 @@ paths:
             summary: Handle POST request for validate
             tags:
                 - MeshmodelValidate
-    /api/meshmodels/categories:
+    /api/registry/categories:
         get:
             description: |-
                 ```?order={field}``` orders on the passed field
@@ -7858,7 +7858,7 @@ paths:
             summary: Handle GET request for getting all meshmodel categories
             tags:
                 - GetMeshmodelCategories
-    /api/meshmodels/categories/{category}:
+    /api/registry/categories/{category}:
         get:
             description: |-
                 ```?order={field}``` orders on the passed field
@@ -7877,7 +7877,7 @@ paths:
             summary: Handle GET request for getting all meshmodel categories of a given name
             tags:
                 - GetMeshmodelCategoriesByName
-    /api/meshmodels/categories/{category}/components:
+    /api/registry/categories/{category}/components:
         get:
             description: |-
                 # Components can be further filtered through query parameter
@@ -7906,10 +7906,10 @@ paths:
             summary: Handle GET request for getting meshmodel components of a specific model and category.
             tags:
                 - GetMeshmodelComponentByCategory
-    /api/meshmodels/categories/{category}/components/{name}:
+    /api/registry/categories/{category}/components/{name}:
         get:
             description: |-
-                Example: ```/api/meshmodels/categories/Orchestration``` and Management/components/Namespace
+                Example: ```/api/registry/categories/Orchestration``` and Management/components/Namespace
                 Components can be further filtered through query parameter
 
                 ```?model={model}``` If model is unspecified then all models are returned
@@ -7936,7 +7936,7 @@ paths:
             summary: Handle GET request for getting meshmodel components of a specific type category.
             tags:
                 - GetMeshmodelComponentsByNameByCategory
-    /api/meshmodels/categories/{category}/models:
+    /api/registry/categories/{category}/models:
         get:
             description: |-
                 ```?version={version}``` If version is unspecified then all models are returned
@@ -7958,7 +7958,7 @@ paths:
             summary: Handle GET request for getting all meshmodel models for a given category. The component type/model name should be lowercase like "kubernetes", "istio"
             tags:
                 - GetMeshmodelModelsByCategories
-    /api/meshmodels/categories/{category}/models/{model}:
+    /api/registry/categories/{category}/models/{model}:
         get:
             description: |-
                 ```?version={version}``` If version is unspecified then all models are returned
@@ -7979,10 +7979,10 @@ paths:
             summary: Handle GET request for getting all meshmodel models for a given category. The component type/model name should be lowercase like "kubernetes", "istio"
             tags:
                 - GetMeshmodelModelsByCategoriesByModel
-    /api/meshmodels/categories/{category}/models/{model}/components:
+    /api/registry/categories/{category}/models/{model}/components:
         get:
             description: |-
-                Example: ```/api/meshmodels/categories/Orchestration``` and Management/models/kubernetes/components
+                Example: ```/api/registry/categories/Orchestration``` and Management/models/kubernetes/components
                 Components can be further filtered through query parameter
 
                 ```?version={version}```
@@ -8009,10 +8009,10 @@ paths:
             summary: Handle GET request for getting meshmodel components of a specific model and category. The component type/model name should be lowercase like "kubernetes", "istio"
             tags:
                 - GetMeshmodelComponentByModelByCategory
-    /api/meshmodels/categories/{category}/models/{model}/components/{name}:
+    /api/registry/categories/{category}/models/{model}/components/{name}:
         get:
             description: |-
-                Example: ```/api/meshmodels/categories/Orchestration``` and Management/models/kubernetes/components/Namespace
+                Example: ```/api/registry/categories/Orchestration``` and Management/models/kubernetes/components/Namespace
                 Components can be further filtered through query parameter
 
                 ```?version={version}``` If version is unspecified then all model versions are returned
@@ -8037,7 +8037,7 @@ paths:
             summary: Handle GET request for getting meshmodel components of a specific type by model and category.
             tags:
                 - GetMeshmodelComponentsByNameByModelByCategory
-    /api/meshmodels/components:
+    /api/registry/components:
         get:
             description: |-
                 # Components can be further filtered through query parameter
@@ -8066,10 +8066,10 @@ paths:
             summary: Handle GET request for getting meshmodel components across all models and categories
             tags:
                 - GetAllMeshmodelComponents
-    /api/meshmodels/components/{name}:
+    /api/registry/components/{name}:
         get:
             description: |-
-                Example: ```/api/meshmodels/components/Namespace```
+                Example: ```/api/registry/components/Namespace```
                 Components can be further filtered through query parameter
 
                 ```?model={model}``` If model is unspecified then all models are returned
@@ -8098,7 +8098,7 @@ paths:
             summary: Handle GET request for getting meshmodel components of a specific type by name across all models and categories
             tags:
                 - GetAllMeshmodelComponentsByName
-    /api/meshmodels/export:
+    /api/registry/export:
         get:
             description: |-
                 # Export model with the given id in the output format specified
@@ -8112,7 +8112,7 @@ paths:
             summary: Handle GET request for exporting a model.
             tags:
                 - ExportModel
-    /api/meshmodels/models:
+    /api/registry/models:
         get:
             description: |-
                 # Returns a list of registered models across all categories
@@ -8135,7 +8135,7 @@ paths:
             summary: Handle GET request for getting all meshmodel models
             tags:
                 - GetMeshmodelModels
-    /api/meshmodels/models/{model}:
+    /api/registry/models/{model}:
         get:
             description: |-
                 # Returns a list of registered models across all categories
@@ -8158,10 +8158,10 @@ paths:
             summary: Handle GET request for getting all meshmodel models. The component type/model name should be lowercase like "kubernetes", "istio"
             tags:
                 - GetMeshmodelModelsByName
-    /api/meshmodels/models/{model}/components:
+    /api/registry/models/{model}/components:
         get:
             description: |-
-                Example: ```/api/meshmodels/models/kubernetes/components```
+                Example: ```/api/registry/models/kubernetes/components```
                 Components can be further filtered through query parameter
 
                 ```?version={version}```
@@ -8188,10 +8188,10 @@ paths:
             summary: Handle GET request for getting meshmodel components of a specific model. The component type/model name should be lowercase like "kubernetes", "istio"
             tags:
                 - GetMeshmodelComponentByModel
-    /api/meshmodels/models/{model}/components/{name}:
+    /api/registry/models/{model}/components/{name}:
         get:
             description: |-
-                Example: ```/api/meshmodels/models/kubernetes/components/Namespace```
+                Example: ```/api/registry/models/kubernetes/components/Namespace```
                 Components can be further filtered through query parameter
 
                 ```?version={version}``` If version is unspecified then all model versions are returned
@@ -8216,10 +8216,10 @@ paths:
             summary: Handle GET request for getting meshmodel components of a specific  model.
             tags:
                 - GetMeshmodelComponentsByNameByModel
-    /api/meshmodels/models/{model}/policies/:
+    /api/registry/models/{model}/policies/:
         get:
             description: |-
-                Example: ```/api/meshmodels/models/kubernetes/policies```
+                Example: ```/api/registry/models/kubernetes/policies```
 
                 ```?order={field}``` orders on the passed field
 
@@ -8237,10 +8237,10 @@ paths:
             summary: Handle GET request for getting meshmodel policies of a specific model by name.
             tags:
                 - GetMeshmodelPolicies
-    /api/meshmodels/models/{model}/policies/{name}:
+    /api/registry/models/{model}/policies/{name}:
         get:
             description: |-
-                Example: ```/api/meshmodels/models/kubernetes/policies/{name}```
+                Example: ```/api/registry/models/kubernetes/policies/{name}```
 
                 ```?order={field}``` orders on the passed field
 
@@ -8258,10 +8258,10 @@ paths:
             summary: Handle GET request for getting meshmodel policies of a specific model by name.
             tags:
                 - GetMeshmodelPoliciesByName
-    /api/meshmodels/models/{model}/relationships:
+    /api/registry/models/{model}/relationships:
         get:
             description: |-
-                Example: ```/api/meshmodel/model/kubernetes/relationship```
+                Example: ```/api/registry/model/kubernetes/relationship```
 
                 # Relationships can be further filtered through query parameter
 
@@ -8281,10 +8281,10 @@ paths:
             summary: Handle GET request for getting meshmodel relationships of a specific model
             tags:
                 - GetAllMeshmodelRelationships
-    /api/meshmodels/models/{model}/relationships/{name}:
+    /api/registry/models/{model}/relationships/{name}:
         get:
             description: |-
-                Example: ```/api/meshmodels/models/kubernetes/relationships/Edge```
+                Example: ```/api/registry/models/kubernetes/relationships/Edge```
 
                 # Relationships can be further filtered through query parameter
 
@@ -8306,7 +8306,7 @@ paths:
             summary: Handle GET request for getting meshmodel relationships of a specific model by name.
             tags:
                 - GetMeshmodelRelationshipByName
-    /api/meshmodels/register:
+    /api/registry/register:
         post:
             description: Register model based on their Schema Version.
             operationId: idRegisterMeshmodels
@@ -8316,7 +8316,7 @@ paths:
             summary: Handle POST request for registering entites like components and relationships model.
             tags:
                 - RegisterMeshmodels
-    /api/meshmodels/registrants:
+    /api/registry/registrants:
         get:
             description: |-
                 # Returns a list of registrants and summary count of its models, components, and relationships
@@ -8335,7 +8335,7 @@ paths:
                 "200":
                     $ref: '#/responses/meshmodelRegistrantsResponseWrapper'
             summary: Handle GET request for getting all meshmodel registrants
-    /api/meshmodels/relationships:
+    /api/registry/relationships:
         get:
             description: |-
                 # Relationships can be further filtered through query parameter
@@ -8356,7 +8356,7 @@ paths:
             summary: Handle GET request for getting all meshmodel relationships
             tags:
                 - GetAllMeshmodelRelationships
-    /api/meshmodels/relationships/evaluate:
+    /api/registry/relationships/evaluate:
         post:
             description: Handle POST request for evaluating relationships in the provided design file by running a set of provided evaluation queries on the design file
             operationId: relationshipPolicyEvalPayloadWrapper

--- a/docs/_data/swagger.yml
+++ b/docs/_data/swagger.yml
@@ -8261,7 +8261,7 @@ paths:
     /api/registry/models/{model}/relationships:
         get:
             description: |-
-                Example: ```/api/registry/model/kubernetes/relationship```
+                Example: ```/api/registry/models/kubernetes/relationships```
 
                 # Relationships can be further filtered through query parameter
 

--- a/server/handlers/component_generation.go
+++ b/server/handlers/component_generation.go
@@ -31,7 +31,7 @@ type componentGenerationResponseDataItem struct {
 	Errors     []string                        `json:"errors"`
 }
 
-// swagger:route POST /api/meshmodel/generate MeshmodelComponentGenerate idPostMeshModelComponentGenerate
+// swagger:route POST /api/registry/generate MeshmodelComponentGenerate idPostMeshModelComponentGenerate
 // Handle POST request for component generation
 //
 // Generates Meshery Components for the given payload

--- a/server/handlers/component_handler.go
+++ b/server/handlers/component_handler.go
@@ -46,7 +46,7 @@ import (
 /**Meshmodel endpoints **/
 const DefaultPageSizeForMeshModelComponents = 25
 
-// swagger:route GET /api/meshmodels/categories/{category}/models GetMeshmodelModelsByCategories idGetMeshmodelModelsByCategories
+// swagger:route GET /api/registry/categories/{category}/models GetMeshmodelModelsByCategories idGetMeshmodelModelsByCategories
 //
 // Handle GET request for getting all meshmodel models for a given category. The component type/model name should be lowercase like "kubernetes", "istio"
 //
@@ -119,7 +119,7 @@ func (h *Handler) GetMeshmodelModelsByCategories(rw http.ResponseWriter, r *http
 	}
 }
 
-// swagger:route GET /api/meshmodels/categories/{category}/models/{model} GetMeshmodelModelsByCategoriesByModel idGetMeshmodelModelsByCategoriesByModel
+// swagger:route GET /api/registry/categories/{category}/models/{model} GetMeshmodelModelsByCategoriesByModel idGetMeshmodelModelsByCategoriesByModel
 //
 // Handle GET request for getting all meshmodel models for a given category. The component type/model name should be lowercase like "kubernetes", "istio"
 //
@@ -194,7 +194,7 @@ func (h *Handler) GetMeshmodelModelsByCategoriesByModel(rw http.ResponseWriter, 
 	}
 }
 
-// swagger:route GET /api/meshmodels/models GetMeshmodelModels idGetMeshmodelModels
+// swagger:route GET /api/registry/models GetMeshmodelModels idGetMeshmodelModels
 // Handle GET request for getting all meshmodel models
 //
 // # Returns a list of registered models across all categories
@@ -274,7 +274,7 @@ func (h *Handler) GetMeshmodelModels(rw http.ResponseWriter, r *http.Request) {
 	}
 }
 
-// swagger:route GET /api/meshmodels/models/{model} GetMeshmodelModelsByName idGetMeshmodelModelsByName
+// swagger:route GET /api/registry/models/{model} GetMeshmodelModelsByName idGetMeshmodelModelsByName
 // Handle GET request for getting all meshmodel models. The component type/model name should be lowercase like "kubernetes", "istio"
 //
 // # Returns a list of registered models across all categories
@@ -351,7 +351,7 @@ func (h *Handler) GetMeshmodelModelsByName(rw http.ResponseWriter, r *http.Reque
 	}
 }
 
-// swagger:route GET /api/meshmodels/categories GetMeshmodelCategories idGetMeshmodelCategories
+// swagger:route GET /api/registry/categories GetMeshmodelCategories idGetMeshmodelCategories
 // Handle GET request for getting all meshmodel categories
 //
 // ```?order={field}``` orders on the passed field
@@ -407,7 +407,7 @@ func (h *Handler) GetMeshmodelCategories(rw http.ResponseWriter, r *http.Request
 	}
 }
 
-// swagger:route GET /api/meshmodels/categories/{category} GetMeshmodelCategoriesByName idGetMeshmodelCategoriesByName
+// swagger:route GET /api/registry/categories/{category} GetMeshmodelCategoriesByName idGetMeshmodelCategoriesByName
 // Handle GET request for getting all meshmodel categories of a given name
 //
 // ```?order={field}``` orders on the passed field
@@ -464,10 +464,10 @@ func (h *Handler) GetMeshmodelCategoriesByName(rw http.ResponseWriter, r *http.R
 	}
 }
 
-// swagger:route GET /api/meshmodels/categories/{category}/models/{model}/components/{name} GetMeshmodelComponentsByNameByModelByCategory idGetMeshmodelComponentsByNameByModelByCategory
+// swagger:route GET /api/registry/categories/{category}/models/{model}/components/{name} GetMeshmodelComponentsByNameByModelByCategory idGetMeshmodelComponentsByNameByModelByCategory
 // Handle GET request for getting meshmodel components of a specific type by model and category.
 //
-// Example: ```/api/meshmodels/categories/Orchestration``` and Management/models/kubernetes/components/Namespace
+// Example: ```/api/registry/categories/Orchestration``` and Management/models/kubernetes/components/Namespace
 // Components can be further filtered through query parameter
 //
 // ```?version={version}``` If version is unspecified then all model versions are returned
@@ -541,10 +541,10 @@ func (h *Handler) GetMeshmodelComponentsByNameByModelByCategory(rw http.Response
 	}
 }
 
-// swagger:route GET /api/meshmodels/categories/{category}/components/{name} GetMeshmodelComponentsByNameByCategory idGetMeshmodelComponentsByNameByCategory
+// swagger:route GET /api/registry/categories/{category}/components/{name} GetMeshmodelComponentsByNameByCategory idGetMeshmodelComponentsByNameByCategory
 // Handle GET request for getting meshmodel components of a specific type category.
 //
-// Example: ```/api/meshmodels/categories/Orchestration``` and Management/components/Namespace
+// Example: ```/api/registry/categories/Orchestration``` and Management/components/Namespace
 // Components can be further filtered through query parameter
 //
 // ```?model={model}``` If model is unspecified then all models are returned
@@ -619,10 +619,10 @@ func (h *Handler) GetMeshmodelComponentsByNameByCategory(rw http.ResponseWriter,
 	}
 }
 
-// swagger:route GET /api/meshmodels/models/{model}/components/{name} GetMeshmodelComponentsByNameByModel idGetMeshmodelComponentsByNameByModel
+// swagger:route GET /api/registry/models/{model}/components/{name} GetMeshmodelComponentsByNameByModel idGetMeshmodelComponentsByNameByModel
 // Handle GET request for getting meshmodel components of a specific  model.
 //
-// Example: ```/api/meshmodels/models/kubernetes/components/Namespace```
+// Example: ```/api/registry/models/kubernetes/components/Namespace```
 // Components can be further filtered through query parameter
 //
 // ```?version={version}``` If version is unspecified then all model versions are returned
@@ -696,10 +696,10 @@ func (h *Handler) GetMeshmodelComponentsByNameByModel(rw http.ResponseWriter, r 
 	}
 }
 
-// swagger:route GET /api/meshmodels/components/{name} GetAllMeshmodelComponentsByName idGetAllMeshmodelComponentsByName
+// swagger:route GET /api/registry/components/{name} GetAllMeshmodelComponentsByName idGetAllMeshmodelComponentsByName
 // Handle GET request for getting meshmodel components of a specific type by name across all models and categories
 //
-// Example: ```/api/meshmodels/components/Namespace```
+// Example: ```/api/registry/components/Namespace```
 // Components can be further filtered through query parameter
 //
 // ```?model={model}``` If model is unspecified then all models are returned
@@ -774,10 +774,10 @@ func (h *Handler) GetAllMeshmodelComponentsByName(rw http.ResponseWriter, r *htt
 	}
 }
 
-// swagger:route GET /api/meshmodels/models/{model}/components GetMeshmodelComponentByModel idGetMeshmodelComponentByModel
+// swagger:route GET /api/registry/models/{model}/components GetMeshmodelComponentByModel idGetMeshmodelComponentByModel
 // Handle GET request for getting meshmodel components of a specific model. The component type/model name should be lowercase like "kubernetes", "istio"
 //
-// Example: ```/api/meshmodels/models/kubernetes/components```
+// Example: ```/api/registry/models/kubernetes/components```
 // Components can be further filtered through query parameter
 //
 // ```?version={version}```
@@ -850,11 +850,11 @@ func (h *Handler) GetMeshmodelComponentByModel(rw http.ResponseWriter, r *http.R
 	}
 }
 
-// swagger:route GET /api/meshmodels/categories/{category}/models/{model}/components GetMeshmodelComponentByModelByCategory idGetMeshmodelComponentByModelByCategory
+// swagger:route GET /api/registry/categories/{category}/models/{model}/components GetMeshmodelComponentByModelByCategory idGetMeshmodelComponentByModelByCategory
 //
 // Handle GET request for getting meshmodel components of a specific model and category. The component type/model name should be lowercase like "kubernetes", "istio"
 //
-// Example: ```/api/meshmodels/categories/Orchestration``` and Management/models/kubernetes/components
+// Example: ```/api/registry/categories/Orchestration``` and Management/models/kubernetes/components
 // Components can be further filtered through query parameter
 //
 // ```?version={version}```
@@ -927,7 +927,7 @@ func (h *Handler) GetMeshmodelComponentByModelByCategory(rw http.ResponseWriter,
 	}
 }
 
-// swagger:route GET /api/meshmodels/categories/{category}/components GetMeshmodelComponentByCategory idGetMeshmodelComponentByCategory
+// swagger:route GET /api/registry/categories/{category}/components GetMeshmodelComponentByCategory idGetMeshmodelComponentByCategory
 // Handle GET request for getting meshmodel components of a specific model and category.
 //
 // # Components can be further filtered through query parameter
@@ -1001,7 +1001,7 @@ func (h *Handler) GetMeshmodelComponentByCategory(rw http.ResponseWriter, r *htt
 	}
 }
 
-// swagger:route GET /api/meshmodels/components GetAllMeshmodelComponents idGetAllMeshmodelComponents
+// swagger:route GET /api/registry/components GetAllMeshmodelComponents idGetAllMeshmodelComponents
 // Handle GET request for getting meshmodel components across all models and categories
 //
 // # Components can be further filtered through query parameter
@@ -1077,7 +1077,7 @@ func (h *Handler) GetAllMeshmodelComponents(rw http.ResponseWriter, r *http.Requ
 	}
 }
 
-// swagger:route POST /api/meshmodel/components/register MeshmodelValidate idPostMeshModelValidate
+// swagger:route POST /api/registry/components/register MeshmodelValidate idPostMeshModelValidate
 // Handle POST request for registering meshmodel components.
 //
 // Validate the given value with the given schema
@@ -1119,7 +1119,7 @@ func (h *Handler) RegisterMeshmodelComponents(rw http.ResponseWriter, r *http.Re
 	go h.config.MeshModelSummaryChannel.Publish()
 }
 
-// swagger:route GET /api/meshmodels/registrants GetMeshmodelRegistrants
+// swagger:route GET /api/registry/registrants GetMeshmodelRegistrants
 // Handle GET request for getting all meshmodel registrants
 //
 // # Returns a list of registrants and summary count of its models, components, and relationships
@@ -1182,7 +1182,7 @@ func (h *Handler) GetMeshmodelRegistrants(rw http.ResponseWriter, r *http.Reques
 	}
 }
 
-// swagger:route POST /api/meshmodel/update/status MeshModelUpdateEntityStatus idPostMeshModelUpdateEntityStatus
+// swagger:route POST /api/registry/{entityType}/status MeshModelUpdateEntityStatus idPostMeshModelUpdateEntityStatus
 // Handle POST request for updating the ignore status of a model.
 //
 // Update the ignore status of a model based on the provided parameters.
@@ -1249,7 +1249,7 @@ func processComponentDefinitions(entities []entity.Entity) []component.Component
 	return comps
 }
 
-// swagger:route POST /api/meshmodels/register RegisterMeshmodels idRegisterMeshmodels
+// swagger:route POST /api/registry/register RegisterMeshmodels idRegisterMeshmodels
 // Handle POST request for registering entites like components and relationships model.
 //
 // Register model based on thier Schema Version.
@@ -1600,7 +1600,7 @@ func (h *Handler) RegisterMeshmodels(rw http.ResponseWriter, r *http.Request, _ 
 
 }
 
-// swagger:route GET /api/meshmodels/export ExportModel idExportModel
+// swagger:route GET /api/registry/export ExportModel idExportModel
 // Handle GET request for exporting a model.
 //
 // # Export model with the given id in the output format specified
@@ -1851,7 +1851,7 @@ func RegisterEntity(content []byte, entityType entity.EntityType, h *Handler) er
 	return meshkitutils.ErrInvalidSchemaVersion
 }
 
-// swagger:route DELETE /api/meshmodels/models/{id} MeshmodelAPI idDeleteModel
+// swagger:route DELETE /api/registry/models/{id} MeshmodelAPI idDeleteModel
 // Handle DELETE request for a model by ID
 //
 // Deletes a model and its associated registry entries from the database.

--- a/server/handlers/policy_relationship_handler.go
+++ b/server/handlers/policy_relationship_handler.go
@@ -343,7 +343,7 @@ func processEvaluationResponse(registryManager *registry.RegistryManager, evalPa
 	return unknownComponents
 }
 
-// swagger:route POST /api/meshmodels/relationships/evaluate EvaluateRelationshipPolicy relationshipPolicyEvalPayloadWrapper
+// swagger:route POST /api/registry/relationships/evaluate EvaluateRelationshipPolicy relationshipPolicyEvalPayloadWrapper
 // Handle POST request for evaluating relationships in the provided design file by running a set of provided evaluation queries on the design file
 //
 // responses:
@@ -469,10 +469,10 @@ func (h *Handler) EvaluateRelationshipPolicy(
 // 	return
 // }
 
-// swagger:route GET /api/meshmodels/models/{model}/policies/{name} GetMeshmodelPoliciesByName idGetMeshmodelPoliciesByName
+// swagger:route GET /api/registry/models/{model}/policies/{name} GetMeshmodelPoliciesByName idGetMeshmodelPoliciesByName
 // Handle GET request for getting meshmodel policies of a specific model by name.
 //
-// Example: ```/api/meshmodels/models/kubernetes/policies/{name}```
+// Example: ```/api/registry/models/kubernetes/policies/{name}```
 //
 // ```?order={field}``` orders on the passed field
 //
@@ -529,10 +529,10 @@ func (h *Handler) GetAllMeshmodelPoliciesByName(rw http.ResponseWriter, r *http.
 	}
 }
 
-// swagger:route GET /api/meshmodels/models/{model}/policies/ GetMeshmodelPolicies idGetMeshmodelPolicies
+// swagger:route GET /api/registry/models/{model}/policies/ GetMeshmodelPolicies idGetMeshmodelPolicies
 // Handle GET request for getting meshmodel policies of a specific model by name.
 //
-// Example: ```/api/meshmodels/models/kubernetes/policies```
+// Example: ```/api/registry/models/kubernetes/policies```
 //
 // // ```?order={field}``` orders on the passed field
 //

--- a/server/handlers/relationship_handlers.go
+++ b/server/handlers/relationship_handlers.go
@@ -13,10 +13,10 @@ import (
 	"github.com/meshery/schemas/models/v1alpha3/relationship"
 )
 
-// swagger:route GET /api/meshmodels/models/{model}/relationships/{name} GetMeshmodelRelationshipByName idGetMeshmodelRelationshipByName
+// swagger:route GET /api/registry/models/{model}/relationships/{name} GetMeshmodelRelationshipByName idGetMeshmodelRelationshipByName
 // Handle GET request for getting meshmodel relationships of a specific model by name.
 //
-// Example: ```/api/meshmodels/models/kubernetes/relationships/Edge```
+// Example: ```/api/registry/models/kubernetes/relationships/Edge```
 //
 // # Relationships can be further filtered through query parameter
 //
@@ -79,7 +79,7 @@ func (h *Handler) GetMeshmodelRelationshipByName(rw http.ResponseWriter, r *http
 	}
 }
 
-// swagger:route GET /api/meshmodels/relationships GetAllMeshmodelRelationships idGetAllMeshmodelRelationships
+// swagger:route GET /api/registry/relationships GetAllMeshmodelRelationships idGetAllMeshmodelRelationships
 // Handle GET request for getting all meshmodel relationships
 //
 // # Relationships can be further filtered through query parameter
@@ -102,7 +102,7 @@ func (h *Handler) GetMeshmodelRelationshipByName(rw http.ResponseWriter, r *http
 // ```?type={type}```  Filters relationship based type
 //	200: meshmodelRelationshipsResponseWrapper
 
-// swagger:route GET /api/meshmodels/models/{model}/relationships GetAllMeshmodelRelationships idGetAllMeshmodelRelationshipsByModel
+// swagger:route GET /api/registry/models/{model}/relationships GetAllMeshmodelRelationships idGetAllMeshmodelRelationshipsByModel
 // Handle GET request for getting meshmodel relationships of a specific model
 //
 // Example: ```/api/meshmodel/model/kubernetes/relationship```

--- a/server/handlers/validate.go
+++ b/server/handlers/validate.go
@@ -40,7 +40,7 @@ type jsonSchemaValidationType struct {
 	Schema string `json:"$schema,omitempty"`
 }
 
-// swagger:route POST /api/meshmodel/validate MeshmodelValidate idPostMeshModelValidate
+// swagger:route POST /api/registry/validate MeshmodelValidate idPostMeshModelValidate
 // Handle POST request for validate
 //
 // Validate the given value with the given schema

--- a/server/router/server.go
+++ b/server/router/server.go
@@ -117,6 +117,9 @@ func NewRouter(_ context.Context, h models.HandlerInterface, port int, g http.Ha
 	gMux.Handle("/api/system/adapters", h.ProviderMiddleware(h.AuthMiddleware(h.SessionInjectorMiddleware(h.AdaptersHandler), models.ProviderAuth)))
 	gMux.Handle("/api/system/availableAdapters", http.HandlerFunc(h.AvailableAdaptersHandler)).
 		Methods("GET")
+	// Canonical registry API routes
+	gMux.Handle("/api/registry/export", h.ProviderMiddleware(h.AuthMiddleware(http.HandlerFunc(h.ExportModel), models.NoAuth))).Methods("GET")
+	// Deprecated: use /api/registry/export
 	gMux.Handle("/api/meshmodels/export", h.ProviderMiddleware(h.AuthMiddleware(http.HandlerFunc(h.ExportModel), models.NoAuth))).Methods("GET")
 
 	gMux.Handle("/api/system/events", h.ProviderMiddleware(h.AuthMiddleware(h.SessionInjectorMiddleware(h.ClientEventHandler), models.ProviderAuth))).
@@ -195,21 +198,48 @@ func NewRouter(_ context.Context, h models.HandlerInterface, port int, g http.Ha
 	gMux.Handle("/api/schema/resource/{resourceName}", h.ProviderMiddleware(h.AuthMiddleware(http.HandlerFunc(h.HandleResourceSchemas), models.NoAuth))).
 		Methods("GET")
 
+	// Canonical registry API routes
+	gMux.Handle("/api/registry/validate", h.ProviderMiddleware(h.AuthMiddleware(http.HandlerFunc(h.ValidationHandler), models.NoAuth))).Methods("POST")
+	gMux.Handle("/api/registry/components", h.ProviderMiddleware(h.AuthMiddleware(http.HandlerFunc(h.RegisterMeshmodelComponents), models.NoAuth))).Methods("POST")
+	gMux.Handle("/api/registry/{entityType}/status", h.ProviderMiddleware(h.AuthMiddleware(h.SessionInjectorMiddleware(h.UpdateEntityStatus), models.NoAuth))).Methods("POST")
+	gMux.Handle("/api/registry/components", h.ProviderMiddleware(h.AuthMiddleware(http.HandlerFunc(h.GetAllMeshmodelComponents), models.NoAuth))).Methods("GET")
+	gMux.Handle("/api/registry/categories", h.ProviderMiddleware(h.AuthMiddleware(http.HandlerFunc(h.GetMeshmodelCategories), models.NoAuth))).Methods("GET")
+	gMux.Handle("/api/registry/models", h.ProviderMiddleware(h.AuthMiddleware(http.HandlerFunc(h.GetMeshmodelModels), models.NoAuth))).Methods("GET")
+	gMux.Handle("/api/registry/models/{model}", h.ProviderMiddleware(h.AuthMiddleware(http.HandlerFunc(h.GetMeshmodelModelsByName), models.NoAuth))).Methods("GET")
+	gMux.Handle("/api/registry/models/{id}", h.ProviderMiddleware(h.AuthMiddleware(h.SessionInjectorMiddleware(h.DeleteModel), models.ProviderAuth))).Methods("DELETE")
+	gMux.Handle("/api/registry/registrants", h.ProviderMiddleware(h.AuthMiddleware(http.HandlerFunc(h.GetMeshmodelRegistrants), models.NoAuth))).Methods("GET")
+	gMux.Handle("/api/registry/register", h.ProviderMiddleware(h.AuthMiddleware(h.SessionInjectorMiddleware(h.RegisterMeshmodels), models.ProviderAuth))).Methods("POST")
+	gMux.Handle("/api/registry/categories/{category}", h.ProviderMiddleware(h.AuthMiddleware(http.HandlerFunc(h.GetMeshmodelCategoriesByName), models.NoAuth))).Methods("GET")
+	gMux.Handle("/api/registry/categories/{category}/models", h.ProviderMiddleware(h.AuthMiddleware(http.HandlerFunc(h.GetMeshmodelModelsByCategories), models.NoAuth))).Methods("GET")
+	gMux.Handle("/api/registry/categories/{category}/models/{model}", h.ProviderMiddleware(h.AuthMiddleware(http.HandlerFunc(h.GetMeshmodelModelsByCategoriesByModel), models.NoAuth))).Methods("GET")
+	gMux.Handle("/api/registry/categories/{category}/models/{model}/components", h.ProviderMiddleware(h.AuthMiddleware(http.HandlerFunc(h.GetMeshmodelComponentByModelByCategory), models.NoAuth))).Methods("GET")
+	gMux.Handle("/api/registry/categories/{category}/models/{model}/components/{name}", h.ProviderMiddleware(h.AuthMiddleware(http.HandlerFunc(h.GetMeshmodelComponentsByNameByModelByCategory), models.NoAuth))).Methods("GET")
+	gMux.Handle("/api/registry/categories/{category}/components", h.ProviderMiddleware(h.AuthMiddleware(http.HandlerFunc(h.GetMeshmodelComponentByCategory), models.NoAuth))).Methods("GET")
+	gMux.Handle("/api/registry/categories/{category}/components/{name}", h.ProviderMiddleware(h.AuthMiddleware(http.HandlerFunc(h.GetMeshmodelComponentsByNameByCategory), models.NoAuth))).Methods("GET")
+	gMux.Handle("/api/registry/components/{name}", h.ProviderMiddleware(h.AuthMiddleware(http.HandlerFunc(h.GetAllMeshmodelComponentsByName), models.NoAuth))).Methods("GET")
+	gMux.Handle("/api/registry/generate", h.ProviderMiddleware(h.AuthMiddleware(http.HandlerFunc(h.MeshModelGenerationHandler), models.NoAuth))).Methods("POST")
+	gMux.Handle("/api/registry/relationships", h.ProviderMiddleware(h.AuthMiddleware(http.HandlerFunc(h.GetAllMeshmodelRelationships), models.NoAuth))).Methods("GET")
+	gMux.Handle("/api/registry/models/{model}/components", h.ProviderMiddleware(h.AuthMiddleware(http.HandlerFunc(h.GetMeshmodelComponentByModel), models.NoAuth))).Methods("GET")
+	gMux.Handle("/api/registry/models/{model}/components/{name}", h.ProviderMiddleware(h.AuthMiddleware(http.HandlerFunc(h.GetMeshmodelComponentsByNameByModel), models.NoAuth))).Methods("GET")
+	gMux.Handle("/api/registry/models/{model}/relationships", h.ProviderMiddleware(h.AuthMiddleware(http.HandlerFunc(h.GetAllMeshmodelRelationships), models.NoAuth))).Methods("GET")
+	gMux.Handle("/api/registry/models/{model}/relationships/{name}", h.ProviderMiddleware(h.AuthMiddleware(http.HandlerFunc(h.GetMeshmodelRelationshipByName), models.NoAuth))).Methods("GET")
+	gMux.Handle("/api/registry/relationships", h.ProviderMiddleware(h.AuthMiddleware(http.HandlerFunc(h.RegisterMeshmodelRelationships), models.NoAuth))).Methods("POST")
+	gMux.Handle("/api/registry/relationships/evaluate", h.ProviderMiddleware(h.AuthMiddleware(h.SessionInjectorMiddleware(h.EvaluateRelationshipPolicy), models.ProviderAuth))).Methods("POST")
+	gMux.Handle("/api/registry/models/{model}/policies", h.ProviderMiddleware(h.AuthMiddleware(http.HandlerFunc(h.GetAllMeshmodelPolicies), models.NoAuth))).Methods("GET")
+	gMux.Handle("/api/registry/models/{model}/policies{name}", h.ProviderMiddleware(h.AuthMiddleware(http.HandlerFunc(h.GetAllMeshmodelPoliciesByName), models.NoAuth))).Methods("GET")
+
+	// Deprecated meshmodels routes (backward compatibility)
 	gMux.Handle("/api/meshmodels/validate", h.ProviderMiddleware(h.AuthMiddleware(http.HandlerFunc(h.ValidationHandler), models.NoAuth))).Methods("POST")
-	gMux.Handle("/api/meshmodels/components", h.ProviderMiddleware(h.AuthMiddleware(http.HandlerFunc(h.RegisterMeshmodelComponents), models.NoAuth))).Methods("POST") //This should also be left with NoAuth
-	gMux.Handle("/api/meshmodel/components/register", h.ProviderMiddleware((http.HandlerFunc(h.RegisterMeshmodelComponents)))).Methods("POST")                        //For backwards compatibility with previous registrants
+	gMux.Handle("/api/meshmodels/components", h.ProviderMiddleware(h.AuthMiddleware(http.HandlerFunc(h.RegisterMeshmodelComponents), models.NoAuth))).Methods("POST")
+	gMux.Handle("/api/meshmodel/components/register", h.ProviderMiddleware((http.HandlerFunc(h.RegisterMeshmodelComponents)))).Methods("POST")
 	gMux.Handle("/api/meshmodels/{entityType}/status", h.ProviderMiddleware(h.AuthMiddleware(h.SessionInjectorMiddleware(h.UpdateEntityStatus), models.NoAuth))).Methods("POST")
 	gMux.Handle("/api/meshmodels/components", h.ProviderMiddleware(h.AuthMiddleware(http.HandlerFunc(h.GetAllMeshmodelComponents), models.NoAuth))).Methods("GET")
-
 	gMux.Handle("/api/meshmodels/categories", h.ProviderMiddleware(h.AuthMiddleware(http.HandlerFunc(h.GetMeshmodelCategories), models.NoAuth))).Methods("GET")
 	gMux.Handle("/api/meshmodels/models", h.ProviderMiddleware(h.AuthMiddleware(http.HandlerFunc(h.GetMeshmodelModels), models.NoAuth))).Methods("GET")
 	gMux.Handle("/api/meshmodels/models/{model}", h.ProviderMiddleware(h.AuthMiddleware(http.HandlerFunc(h.GetMeshmodelModelsByName), models.NoAuth))).Methods("GET")
 	gMux.Handle("/api/meshmodels/models/{id}", h.ProviderMiddleware(h.AuthMiddleware(h.SessionInjectorMiddleware(h.DeleteModel), models.ProviderAuth))).Methods("DELETE")
-
 	gMux.Handle("/api/meshmodels/registrants", h.ProviderMiddleware(h.AuthMiddleware(http.HandlerFunc(h.GetMeshmodelRegistrants), models.NoAuth))).Methods("GET")
-
-	gMux.Handle("/api/meshmodels/register", h.ProviderMiddleware(h.AuthMiddleware(h.SessionInjectorMiddleware(h.RegisterMeshmodels), models.ProviderAuth))).
-		Methods("POST")
+	gMux.Handle("/api/meshmodels/register", h.ProviderMiddleware(h.AuthMiddleware(h.SessionInjectorMiddleware(h.RegisterMeshmodels), models.ProviderAuth))).Methods("POST")
 	gMux.Handle("/api/meshmodels/categories/{category}", h.ProviderMiddleware(h.AuthMiddleware(http.HandlerFunc(h.GetMeshmodelCategoriesByName), models.NoAuth))).Methods("GET")
 	gMux.Handle("/api/meshmodels/categories/{category}/models", h.ProviderMiddleware(h.AuthMiddleware(http.HandlerFunc(h.GetMeshmodelModelsByCategories), models.NoAuth))).Methods("GET")
 	gMux.Handle("/api/meshmodels/categories/{category}/models/{model}", h.ProviderMiddleware(h.AuthMiddleware(http.HandlerFunc(h.GetMeshmodelModelsByCategoriesByModel), models.NoAuth))).Methods("GET")
@@ -217,21 +247,15 @@ func NewRouter(_ context.Context, h models.HandlerInterface, port int, g http.Ha
 	gMux.Handle("/api/meshmodels/categories/{category}/models/{model}/components/{name}", h.ProviderMiddleware(h.AuthMiddleware(http.HandlerFunc(h.GetMeshmodelComponentsByNameByModelByCategory), models.NoAuth))).Methods("GET")
 	gMux.Handle("/api/meshmodels/categories/{category}/components", h.ProviderMiddleware(h.AuthMiddleware(http.HandlerFunc(h.GetMeshmodelComponentByCategory), models.NoAuth))).Methods("GET")
 	gMux.Handle("/api/meshmodels/categories/{category}/components/{name}", h.ProviderMiddleware(h.AuthMiddleware(http.HandlerFunc(h.GetMeshmodelComponentsByNameByCategory), models.NoAuth))).Methods("GET")
-
 	gMux.Handle("/api/meshmodels/components/{name}", h.ProviderMiddleware(h.AuthMiddleware(http.HandlerFunc(h.GetAllMeshmodelComponentsByName), models.NoAuth))).Methods("GET")
 	gMux.Handle("/api/meshmodels/generate", h.ProviderMiddleware(h.AuthMiddleware(http.HandlerFunc(h.MeshModelGenerationHandler), models.NoAuth))).Methods("POST")
 	gMux.Handle("/api/meshmodels/relationships", h.ProviderMiddleware(h.AuthMiddleware(http.HandlerFunc(h.GetAllMeshmodelRelationships), models.NoAuth))).Methods("GET")
-
 	gMux.Handle("/api/meshmodels/models/{model}/components", h.ProviderMiddleware(h.AuthMiddleware(http.HandlerFunc(h.GetMeshmodelComponentByModel), models.NoAuth))).Methods("GET")
 	gMux.Handle("/api/meshmodels/models/{model}/components/{name}", h.ProviderMiddleware(h.AuthMiddleware(http.HandlerFunc(h.GetMeshmodelComponentsByNameByModel), models.NoAuth))).Methods("GET")
-
 	gMux.Handle("/api/meshmodels/models/{model}/relationships", h.ProviderMiddleware(h.AuthMiddleware(http.HandlerFunc(h.GetAllMeshmodelRelationships), models.NoAuth))).Methods("GET")
 	gMux.Handle("/api/meshmodels/models/{model}/relationships/{name}", h.ProviderMiddleware(h.AuthMiddleware(http.HandlerFunc(h.GetMeshmodelRelationshipByName), models.NoAuth))).Methods("GET")
-	gMux.Handle("/api/meshmodels/relationships", h.ProviderMiddleware(h.AuthMiddleware(http.HandlerFunc(h.RegisterMeshmodelRelationships), models.NoAuth))).Methods("POST") //This should also be left with NoAuth
-
-	gMux.Handle("/api/meshmodels/relationships/evaluate", h.ProviderMiddleware(h.AuthMiddleware(h.SessionInjectorMiddleware(h.EvaluateRelationshipPolicy), models.ProviderAuth))).
-		Methods("POST")
-
+	gMux.Handle("/api/meshmodels/relationships", h.ProviderMiddleware(h.AuthMiddleware(http.HandlerFunc(h.RegisterMeshmodelRelationships), models.NoAuth))).Methods("POST")
+	gMux.Handle("/api/meshmodels/relationships/evaluate", h.ProviderMiddleware(h.AuthMiddleware(h.SessionInjectorMiddleware(h.EvaluateRelationshipPolicy), models.ProviderAuth))).Methods("POST")
 	gMux.Handle("/api/meshmodels/models/{model}/policies", h.ProviderMiddleware(h.AuthMiddleware(http.HandlerFunc(h.GetAllMeshmodelPolicies), models.NoAuth))).Methods("GET")
 	gMux.Handle("/api/meshmodels/models/{model}/policies{name}", h.ProviderMiddleware(h.AuthMiddleware(http.HandlerFunc(h.GetAllMeshmodelPoliciesByName), models.NoAuth))).Methods("GET")
 

--- a/server/router/server.go
+++ b/server/router/server.go
@@ -201,6 +201,7 @@ func NewRouter(_ context.Context, h models.HandlerInterface, port int, g http.Ha
 	// Canonical registry API routes
 	gMux.Handle("/api/registry/validate", h.ProviderMiddleware(h.AuthMiddleware(http.HandlerFunc(h.ValidationHandler), models.NoAuth))).Methods("POST")
 	gMux.Handle("/api/registry/components", h.ProviderMiddleware(h.AuthMiddleware(http.HandlerFunc(h.RegisterMeshmodelComponents), models.NoAuth))).Methods("POST")
+	gMux.Handle("/api/registry/components/register", h.ProviderMiddleware((http.HandlerFunc(h.RegisterMeshmodelComponents)))).Methods("POST")
 	gMux.Handle("/api/registry/{entityType}/status", h.ProviderMiddleware(h.AuthMiddleware(h.SessionInjectorMiddleware(h.UpdateEntityStatus), models.NoAuth))).Methods("POST")
 	gMux.Handle("/api/registry/components", h.ProviderMiddleware(h.AuthMiddleware(http.HandlerFunc(h.GetAllMeshmodelComponents), models.NoAuth))).Methods("GET")
 	gMux.Handle("/api/registry/categories", h.ProviderMiddleware(h.AuthMiddleware(http.HandlerFunc(h.GetMeshmodelCategories), models.NoAuth))).Methods("GET")
@@ -225,8 +226,8 @@ func NewRouter(_ context.Context, h models.HandlerInterface, port int, g http.Ha
 	gMux.Handle("/api/registry/models/{model}/relationships/{name}", h.ProviderMiddleware(h.AuthMiddleware(http.HandlerFunc(h.GetMeshmodelRelationshipByName), models.NoAuth))).Methods("GET")
 	gMux.Handle("/api/registry/relationships", h.ProviderMiddleware(h.AuthMiddleware(http.HandlerFunc(h.RegisterMeshmodelRelationships), models.NoAuth))).Methods("POST")
 	gMux.Handle("/api/registry/relationships/evaluate", h.ProviderMiddleware(h.AuthMiddleware(h.SessionInjectorMiddleware(h.EvaluateRelationshipPolicy), models.ProviderAuth))).Methods("POST")
-	gMux.Handle("/api/registry/models/{model}/policies", h.ProviderMiddleware(h.AuthMiddleware(http.HandlerFunc(h.GetAllMeshmodelPolicies), models.NoAuth))).Methods("GET")
-	gMux.Handle("/api/registry/models/{model}/policies{name}", h.ProviderMiddleware(h.AuthMiddleware(http.HandlerFunc(h.GetAllMeshmodelPoliciesByName), models.NoAuth))).Methods("GET")
+	gMux.Handle("/api/registry/models/{model}/policies/", h.ProviderMiddleware(h.AuthMiddleware(http.HandlerFunc(h.GetAllMeshmodelPolicies), models.NoAuth))).Methods("GET")
+	gMux.Handle("/api/registry/models/{model}/policies/{name}", h.ProviderMiddleware(h.AuthMiddleware(http.HandlerFunc(h.GetAllMeshmodelPoliciesByName), models.NoAuth))).Methods("GET")
 
 	// Deprecated meshmodels routes (backward compatibility)
 	gMux.Handle("/api/meshmodels/validate", h.ProviderMiddleware(h.AuthMiddleware(http.HandlerFunc(h.ValidationHandler), models.NoAuth))).Methods("POST")
@@ -257,7 +258,7 @@ func NewRouter(_ context.Context, h models.HandlerInterface, port int, g http.Ha
 	gMux.Handle("/api/meshmodels/relationships", h.ProviderMiddleware(h.AuthMiddleware(http.HandlerFunc(h.RegisterMeshmodelRelationships), models.NoAuth))).Methods("POST")
 	gMux.Handle("/api/meshmodels/relationships/evaluate", h.ProviderMiddleware(h.AuthMiddleware(h.SessionInjectorMiddleware(h.EvaluateRelationshipPolicy), models.ProviderAuth))).Methods("POST")
 	gMux.Handle("/api/meshmodels/models/{model}/policies", h.ProviderMiddleware(h.AuthMiddleware(http.HandlerFunc(h.GetAllMeshmodelPolicies), models.NoAuth))).Methods("GET")
-	gMux.Handle("/api/meshmodels/models/{model}/policies{name}", h.ProviderMiddleware(h.AuthMiddleware(http.HandlerFunc(h.GetAllMeshmodelPoliciesByName), models.NoAuth))).Methods("GET")
+	gMux.Handle("/api/meshmodels/models/{model}/policies/{name}", h.ProviderMiddleware(h.AuthMiddleware(http.HandlerFunc(h.GetAllMeshmodelPoliciesByName), models.NoAuth))).Methods("GET")
 
 	gMux.Handle("/api/filter/deploy", h.ProviderMiddleware(h.AuthMiddleware(h.SessionInjectorMiddleware(h.KubernetesMiddleware(h.FilterFileHandler)), models.ProviderAuth))).
 		Methods("POST", "DELETE")

--- a/ui/api/meshmodel.ts
+++ b/ui/api/meshmodel.ts
@@ -65,7 +65,7 @@ export async function getRelationshipFromModelApi(model, pageSize = 'all', trim 
 }
 
 export async function getDuplicateModels(model, version) {
-  return await promisifiedDataFetch(`${MESHMODEL_ENDPOINT}/${model}?version=${version}      `);
+  return await promisifiedDataFetch(`${MESHMODEL_ENDPOINT}/${model}?version=${version}`);
 }
 
 export async function getDuplicateComponents(componentKind, apiVersion, modelName) {
@@ -76,7 +76,7 @@ export async function getDuplicateComponents(componentKind, apiVersion, modelNam
 
 export async function getMeshModelRegistrants(page = 1, pageSize = 'all') {
   return await promisifiedDataFetch(
-    `/api/registry/registrants?page=${page}&pageSize=${pageSize}`,
+    `/api/registry/registrants?page=${page}&pagesize=${pageSize}`,
   );
 }
 
@@ -170,9 +170,7 @@ export async function searchModels(queryString, options = defaultOptions) {
 
 export async function searchComponents(queryString, options = defaultOptions) {
   return promisifiedDataFetch(
-    `/api/registry/components?search=${encodeURI(queryString)}&${optionToQueryConvertor(
-      options,
-    )}`,
+    `/api/registry/components?search=${encodeURI(queryString)}&${optionToQueryConvertor(options)}`,
   );
 }
 

--- a/ui/api/meshmodel.ts
+++ b/ui/api/meshmodel.ts
@@ -6,8 +6,8 @@ import {
   SORT,
 } from '../constants/endpoints';
 
-const COMPONENTS_ENDPOINT = '/api/meshmodels/components';
-const CATEGORIES_ENDPOINT = '/api/meshmodels/categories';
+const COMPONENTS_ENDPOINT = '/api/registry/components';
+const CATEGORIES_ENDPOINT = '/api/registry/categories';
 
 /**
  * @typedef {{
@@ -76,7 +76,7 @@ export async function getDuplicateComponents(componentKind, apiVersion, modelNam
 
 export async function getMeshModelRegistrants(page = 1, pageSize = 'all') {
   return await promisifiedDataFetch(
-    `/api/meshmodels/registrants?page=${page}&pageSize=${pageSize}`,
+    `/api/registry/registrants?page=${page}&pageSize=${pageSize}`,
   );
 }
 
@@ -98,14 +98,14 @@ export async function getComponentsDetailWithPageSize(
   order = '',
 ) {
   return await promisifiedDataFetch(
-    `api/meshmodels/components?page=${page}&pagesize=${pageSize}&order=${encodeURIComponent(
+    `/api/registry/components?page=${page}&pagesize=${pageSize}&order=${encodeURIComponent(
       order,
     )}&sort=${sort}`,
   );
 }
 
 export async function getComponentsDetail(page) {
-  return await promisifiedDataFetch(`api/meshmodels/components?page=${page}`);
+  return await promisifiedDataFetch(`/api/registry/components?page=${page}`);
 }
 
 export async function getModelsDetail(page) {
@@ -119,14 +119,14 @@ export async function getRelationshipsDetailWithPageSize(
   order = '',
 ) {
   return await promisifiedDataFetch(
-    `api/meshmodels/relationships?page=${page}&pagesize=${pageSize}&sort=${sort}&order=${encodeURIComponent(
+    `/api/registry/relationships?page=${page}&pagesize=${pageSize}&sort=${sort}&order=${encodeURIComponent(
       order,
     )}`,
   );
 }
 
 export async function getRelationshipsDetail(page) {
-  return await promisifiedDataFetch(`api/meshmodels/relationships?page=${page}`);
+  return await promisifiedDataFetch(`/api/registry/relationships?page=${page}`);
 }
 
 export async function getMeshModelComponent(model, component, version, apiVersion) {
@@ -170,7 +170,7 @@ export async function searchModels(queryString, options = defaultOptions) {
 
 export async function searchComponents(queryString, options = defaultOptions) {
   return promisifiedDataFetch(
-    `/api/meshmodels/components?search=${encodeURI(queryString)}&${optionToQueryConvertor(
+    `/api/registry/components?search=${encodeURI(queryString)}&${optionToQueryConvertor(
       options,
     )}`,
   );

--- a/ui/components/Settings/Registry/MeshModelDetails.tsx
+++ b/ui/components/Settings/Registry/MeshModelDetails.tsx
@@ -191,7 +191,7 @@ const ModelContents = ({ modelDef }: { modelDef: any }) => {
   };
   const handleExport = () => {
     const a = document.createElement('a');
-    a.href = '/api/meshmodels/export?id=' + modelDef.id;
+    a.href = '/api/registry/export?id=' + modelDef.id;
     document.body.appendChild(a);
     a.click();
     a.remove();

--- a/ui/components/Settings/Registry/MeshModelDetails.tsx
+++ b/ui/components/Settings/Registry/MeshModelDetails.tsx
@@ -424,6 +424,7 @@ const TitleWithImg = ({ displayName, iconSrc }: { displayName?: string; iconSrc?
     {iconSrc && (
       <img
         src={iconSrc}
+        alt={displayName ? `${displayName} icon` : 'Model or component icon'}
         height="32px"
         width="32px"
         style={{ objectFit: 'contain', marginRight: '0.6rem' }}

--- a/ui/components/Settings/Registry/MesheryTreeViewItem.tsx
+++ b/ui/components/Settings/Registry/MesheryTreeViewItem.tsx
@@ -36,7 +36,7 @@ const MesheryTreeViewItem = ({
       top
       labelText={
         <StyledTreeItemDiv>
-          {imgSrc ? <img src={imgSrc} style={{ height: '24px', width: '24px' }} /> : null}
+          {imgSrc ? <img src={imgSrc} alt="" style={{ height: '24px', width: '24px' }} /> : null}
           <StyledTreeItemNameDiv>
             {modelDef.displayName ? modelDef.displayName : modelDef.name}
           </StyledTreeItemNameDiv>

--- a/ui/constants/endpoints.ts
+++ b/ui/constants/endpoints.ts
@@ -1,9 +1,9 @@
 //  The constants for API endpoints
 // Meshery Extension Point
 // See Meshery Docs to have your Remote Provider listed here
-export const MESHMODEL_ENDPOINT = '/api/meshmodels/models';
-export const MESHMODEL_COMPONENT_ENDPOINT = '/api/meshmodels';
-export const MESHMODEL_RELATIONSHIPS_ENDPOINT = '/api/meshmodels/models/core/relationships';
+export const MESHMODEL_ENDPOINT = '/api/registry/models';
+export const MESHMODEL_COMPONENT_ENDPOINT = '/api/registry';
+export const MESHMODEL_RELATIONSHIPS_ENDPOINT = '/api/registry/models/core/relationships';
 export const MESHERY_CLOUD_PROD = 'https://cloud.layer5.io';
 export const MESHERY_DOCS_URL = 'https://docs.meshery.io';
 export const PATTERN_ENDPOINT = '/api/pattern';

--- a/ui/tests/e2e/extensions.spec.js
+++ b/ui/tests/e2e/extensions.spec.js
@@ -32,6 +32,7 @@ test.describe('Extensions Section Tests', () => {
   });
 
   test('Verify Kanvas Details', async ({ context }) => {
+    await expect(extensionsPage.kanvasSignupHeading).toBeVisible({ timeout: 15000 });
     await extensionsPage.verifyKanvasSignupUI();
     await extensionsPage.verifyNewTab(context, extensionsPage.kanvasSignupBtn, URLS.KANVAS.DOCS);
   });

--- a/ui/tests/e2e/models.spec.js
+++ b/ui/tests/e2e/models.spec.js
@@ -2,6 +2,9 @@ import { test, expect } from '@playwright/test';
 import path from 'path';
 import { DashboardPage } from './pages/DashboardPage';
 
+// Resolve asset paths from project root (ui/). CI runs e2e from ui/ via make ui-test-e2e-ci.
+const E2E_ASSETS = path.join(process.cwd(), 'tests', 'e2e', 'assets');
+
 const model = {
   MODEL_URL: 'git://github.com/aws-controllers-k8s/apigatewayv2-controller/main/helm',
   MODEL_NAME: `test-model-${Date.now()}`,
@@ -12,12 +15,12 @@ const model_import = {
   MODEL_NAME: `test`,
   MODEL_URL_IMPORT:
     'https://raw.githubusercontent.com/meshery/meshery/master/ui/tests/e2e/assets/test.tar',
-  MODEL_FILE_IMPORT: path.resolve('tests/e2e/assets/test.tar'),
+  MODEL_FILE_IMPORT: path.join(E2E_ASSETS, 'test.tar'),
   MODEL_CSV_IMPORT: {
     Model_Name: 'couchbase',
-    Models: path.resolve('tests/e2e/assets/models.csv'),
-    Components: path.resolve('tests/e2e/assets/components.csv'),
-    Relationships: path.resolve('tests/e2e/assets/relationships.csv'),
+    Models: path.join(E2E_ASSETS, 'models.csv'),
+    Components: path.join(E2E_ASSETS, 'components.csv'),
+    Relationships: path.join(E2E_ASSETS, 'relationships.csv'),
   },
 };
 
@@ -93,8 +96,8 @@ test.describe.serial('Model Workflow Tests', () => {
 
     await expect(
       page.getByTestId(`ModelImportedSection-ModelHeader-${model_import.MODEL_NAME}`),
-    ).toBeVisible();
-    await expect(page.getByTestId('ModelImportMessages-Wrapper')).toBeVisible();
+    ).toBeVisible({ timeout: 60000 });
+    await expect(page.getByTestId('ModelImportMessages-Wrapper')).toBeVisible({ timeout: 10000 });
     await page.getByRole('button', { name: 'Finish' }).click();
   });
 

--- a/ui/tests/e2e/pages/ExtensionsPage.js
+++ b/ui/tests/e2e/pages/ExtensionsPage.js
@@ -59,8 +59,11 @@ export class ExtensionsPage {
   }
 
   async verifyNewTab(context, locator, expectedUrl) {
-    const [newPage] = await Promise.all([context.waitForEvent('page'), locator.click()]);
-    await expect(newPage).toHaveURL(expectedUrl);
+    const [newPage] = await Promise.all([
+      context.waitForEvent('page', { timeout: 15000 }),
+      locator.click(),
+    ]);
+    await expect(newPage).toHaveURL(expectedUrl, { timeout: 10000 });
     await newPage.close();
   }
 }

--- a/ui/tests/e2e/relationship_evaluation.spec.js
+++ b/ui/tests/e2e/relationship_evaluation.spec.js
@@ -45,7 +45,7 @@ test.describe('Relationship Evaluation', { tag: '@relationship' }, () => {
       const designToTest = { ...design, relationships: [] };
 
       const response = await request.post(
-        `${ENV.MESHERY_SERVER_URL}/api/meshmodels/relationships/evaluate`,
+        `${ENV.MESHERY_SERVER_URL}/api/registry/relationships/evaluate`,
         {
           data: {
             design: designToTest,


### PR DESCRIPTION
Implements: Rename meshmodel API routes to /api/registry with backward compatibility
- Adds canonical /api/registry routes; keeps /api/meshmodels as deprecated aliases
- Updates UI, Swagger/OpenAPI, and docs to use /api/registry
Closes #17965