### PR TITLE
[Docs] Fix Build warning '.params.ui.footer_about_disable'

### DIFF
--- a/docs/hugo.toml
+++ b/docs/hugo.toml
@@ -159,8 +159,8 @@ prism_syntax_highlighting = false
 [params.ui]
 #  Set to true to disable breadcrumb navigation.
 breadcrumb_disable = false
-# Set to true to disable the About link in the site footer
-footer_about_disable = false
+# Set to true to enable the About link in the site footer
+footer_about_enable = true
 # Set to false if you don't want to display a logo (/assets/icons/logo.svg) in the top navbar
 navbar_logo = true
 # Set to true if you don't want the top navbar to be translucent when over a `block/cover`, like on the homepage.


### PR DESCRIPTION
### Description
- .params.ui.footer_about_disable has been deprecated 
- .params.ui.footer_about_enable has been introduced to offer similar functionality. 
- There is a warning showing on the incremental build `WARN  Config parameter '.params.ui.footer_about_disable' is DEPRECATED, use '.params.ui.footer_about_enable' instead.`
- This warning shown only when there is an incremental build is happening. It does't show in the default build. 
- The fix is to use the .params.ui.footer_about_enable and set the values accordingly.

### Issue
- Closes #18010

### Testing
- Tested locally and verified that the incremental build doesn't show any warning

cc: @leecalcote 