### PR TITLE
[Docs] Improve next/previous pagination continuity across doc sections

### DIFF
--- a/docs/assets/scss/_pagination.scss
+++ b/docs/assets/scss/_pagination.scss
@@ -1,49 +1,69 @@
 .toc-pagination-wrapper {
-  display: flex;
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
   gap: 1rem;
   margin-top: 3rem;
 }
 
 .toc-card {
-  border: 1px solid #7a848e;
-  border-radius: 0.4rem;
+  border: 1px solid rgba(122, 132, 142, 0.45);
+  border-radius: 0.75rem;
   display: block;
   height: 100%;
   width: 100%;
-  line-height: 1.25;
-  padding: 1rem;
-  background: transparent;
+  line-height: 1.35;
+  padding: 1.1rem 1.25rem;
+  background: rgba(255, 255, 255, 0.02);
   text-decoration: none;
-  transition: border-color 200ms cubic-bezier(.08,.52,.52,1);
+  transition: border-color 180ms ease, background-color 180ms ease, transform 180ms ease;
 
   &:hover {
     border-color: var(--brand-color-secondary);
+    background: rgba(255, 255, 255, 0.06);
+    transform: translateY(-2px);
   }
 }
 
 .toc-label {
-  color: var(--color-white);
-  font-size: 0.875rem;
-  margin-bottom: 0.5rem;
+  color: #a9b2ba;
+  font-size: 0.76rem;
+  margin-bottom: 0.45rem;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  font-weight: 600;
 }
 
 .toc-title {
   color: var(--brand-color-secondary);
-  font-size: 1rem;
+  font-size: 1.35rem;
   font-weight: 600;
   display: flex;
-  align-items: center;
+  align-items: flex-start;
   gap: 0.5rem;
+
+  .toc-title-text {
+    display: inline-block;
+  }
+
   .fa-chevron-right::before, .fa-chevron-left::before {
     color: var(--brand-color-secondary);
-    font-size: 1rem;
+    font-size: 1.05rem;
   }
-  &:hover {
-    .fa-chevron-right::before, .fa-chevron-left::before {
-        color: var(--color-white);
-    }
-    color: var(--color-white);
-  }
+}
+
+.toc-card:hover .toc-title {
+  color: var(--color-white);
+}
+
+.toc-card:hover .fa-chevron-right::before,
+.toc-card:hover .fa-chevron-left::before {
+  color: var(--color-white);
+}
+
+.toc-context {
+  color: #a9b2ba;
+  font-size: 0.86rem;
+  margin-top: 0.65rem;
 }
 
 .toc-card.next {
@@ -51,5 +71,15 @@
 
   .toc-title {
     justify-content: flex-end;
+  }
+}
+
+@media (max-width: 900px) {
+  .toc-pagination-wrapper {
+    grid-template-columns: 1fr;
+  }
+
+  .toc-title {
+    font-size: 1.15rem;
   }
 }

--- a/docs/layouts/partials/pagination.html
+++ b/docs/layouts/partials/pagination.html
@@ -1,31 +1,31 @@
 {{ $nav := site.Data.toc }}
 {{ $pages := slice }}
 
-{{ range $nav }}
+{{ range $section := $nav }}
 
   {{/* ADD TOP LEVEL PAGE */}}
-  {{ if .url }}
-    {{ $pages = $pages | append (dict "title" .title "url" .url) }}
+  {{ if $section.url }}
+    {{ $pages = $pages | append (dict "title" $section.title "url" $section.url "section" $section.title) }}
   {{ end }}
 
-  {{ with .links }}
+  {{ with $section.links }}
     {{ range . }}
 
       {{ if .url }}
-        {{ $pages = $pages | append (dict "title" .title "url" .url) }}
+        {{ $pages = $pages | append (dict "title" .title "url" .url "section" $section.title) }}
       {{ end }}
 
       {{ with .children }}
         {{ range . }}
 
           {{ if .url }}
-            {{ $pages = $pages | append (dict "title" .title "url" .url) }}
+            {{ $pages = $pages | append (dict "title" .title "url" .url "section" $section.title) }}
           {{ end }}
 
           {{ with .grandchildren }}
             {{ range . }}
               {{ if .url }}
-                {{ $pages = $pages | append (dict "title" .title "url" .url) }}
+                {{ $pages = $pages | append (dict "title" .title "url" .url "section" $section.title) }}
               {{ end }}
             {{ end }}
           {{ end }}
@@ -49,28 +49,31 @@
 {{ end }}
 
 {{ if ge $index 0 }}
+{{ $currentPageData := index $pages $index }}
 
 <div class="toc-pagination-wrapper">
 
   {{ if gt $index 0 }}
     {{ $prev := index $pages (sub $index 1) }}
     <a class="toc-card prev" href="{{ $prev.url | relURL }}">   
-      <div class="toc-label">Previous</div>
+      <div class="toc-label">{{ if ne $prev.section $currentPageData.section }}Previous section{{ else }}Previous{{ end }}</div>
       <div class="toc-title">
         <span class="arrow"><i class="fa-solid fa-chevron-left"></i></span>
-        {{ replaceRE "\\s*[ↆ↓]$" "" (replaceRE "^[^a-zA-Z0-9]+" "" $prev.title) }}
+        <span class="toc-title-text">{{ replaceRE "\\s*[ↆ↓]$" "" (replaceRE "^[^a-zA-Z0-9]+" "" $prev.title) }}</span>
       </div>
+      <div class="toc-context">{{ replaceRE "\\s*[ↆ↓]$" "" (replaceRE "^[^a-zA-Z0-9]+" "" $prev.section) }}</div>
     </a>
   {{ end }}
 
   {{ if lt $index (sub (len $pages) 1) }}
     {{ $next := index $pages (add $index 1) }}
     <a class="toc-card next" href="{{ $next.url | relURL }}">
-      <div class="toc-label">Next</div>
+      <div class="toc-label">{{ if ne $next.section $currentPageData.section }}Next section{{ else }}Next{{ end }}</div>
       <div class="toc-title">
-        {{ replaceRE "\\s*[ↆ↓]$" "" (replaceRE "^[^a-zA-Z0-9]+" "" $next.title) }}
+        <span class="toc-title-text">{{ replaceRE "\\s*[ↆ↓]$" "" (replaceRE "^[^a-zA-Z0-9]+" "" $next.title) }}</span>
         <span class="arrow"><i class="fa-solid fa-chevron-right"></i></span>
       </div>
+      <div class="toc-context">{{ replaceRE "\\s*[ↆ↓]$" "" (replaceRE "^[^a-zA-Z0-9]+" "" $next.section) }}</div>
     </a>
   {{ end }}
 


### PR DESCRIPTION
  **Notes for Reviewers**

  - This PR fixes #18015

  ### Changes
  - Updated pagination logic to detect section transitions.
  - Shows:
    - `Previous` / `Next` for same-section navigation
    - `Previous section` / `Next section` when crossing sections
  - Improved pagination UI hierarchy for clearer scanning.
  - Added section context text beneath each navigation target.
  - Kept layout responsive for smaller screens.

<img width="1104" height="239" alt="Screenshot 2026-03-17 at 06 51 02" src="https://github.com/user-attachments/assets/f4f2fec1-18da-456a-8e66-7b4b15615f8c" />


  **[Signed commits](https://github.com/meshery/meshery/blob/master/CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
  - [x] Yes, I signed my commits.