### PR TITLE
docs: resolve white flash by inlining theme detection logic

### DIFF
--- a/docs/layouts/partials/head.html
+++ b/docs/layouts/partials/head.html
@@ -72,6 +72,17 @@
   />
 
   <title>{{ .Title | default .Site.Title }} | Meshery</title>
+
+  <script>
+  (function () {
+    const mode = localStorage.getItem("mode");
+    const systemPrefersDark = window.matchMedia("(prefers-color-scheme: dark)").matches;
+    if (mode === "dark-mode" || (!mode && systemPrefersDark)) {
+      document.documentElement.setAttribute("data-theme", "dark");
+    }
+  })();
+</script>
+
   <meta property="og:title" content="{{ .Title | default .Site.Title }}" />
   <meta
     property="og:description"


### PR DESCRIPTION
**Notes for Reviewers**

- This PR fixes #17999

Description:
Added an inline theme-detection script in head.html that executes before the page is rendered. This script checks localStorage for the mode: dark-mode key (and falls back to system preferences) to apply the data-theme="dark" attribute to the <html> element instantly. This eliminates the "white flash" experienced during page transitions in dark mode.

**[Signed commits](https://github.com/meshery/meshery/blob/master/CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [x] Yes, I signed my commits.

<!--
Thank you for contributing to Meshery! 

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. Sign your commits.
4. Include before and after screenshots/terminal output.

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.
-->


[White Flash.webm](https://github.com/user-attachments/assets/073f0640-c6f9-42b0-9eb1-8f39a5ac62f8)
