### PR TITLE
{AI Adapter]Add Ai config endpoint

### DIFF
--- a/server/handlers/ai_handler.go
+++ b/server/handlers/ai_handler.go
@@ -1,0 +1,31 @@
+package handlers
+
+import (
+	"encoding/json"
+	"net/http"
+)
+
+type AIRequest struct {
+	Prompt string `json:"prompt"`
+}
+
+type AIResponse struct {
+	Response string `json:"response"`
+}
+
+func HandleAITest(w http.ResponseWriter, r *http.Request) {
+	var req AIRequest
+
+	err := json.NewDecoder(r.Body).Decode(&req)
+	if err != nil {
+		http.Error(w, "Invalid request", http.StatusBadRequest)
+		return
+	}
+
+	resp := AIResponse{
+		Response: "Mock response for: " + req.Prompt,
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	json.NewEncoder(w).Encode(resp)
+}

--- a/server/handlers/ai_handler.go
+++ b/server/handlers/ai_handler.go
@@ -14,18 +14,27 @@ type AIResponse struct {
 }
 
 func HandleAITest(w http.ResponseWriter, r *http.Request) {
+	defer r.Body.Close()
+
 	var req AIRequest
 
-	err := json.NewDecoder(r.Body).Decode(&req)
-	if err != nil {
+	// Decode request
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
 		http.Error(w, "Invalid request", http.StatusBadRequest)
 		return
 	}
 
+	// Create response
 	resp := AIResponse{
 		Response: "Mock response for: " + req.Prompt,
 	}
 
+	// Set header
 	w.Header().Set("Content-Type", "application/json")
-	json.NewEncoder(w).Encode(resp)
+
+	// Encode response with error handling
+	if err := json.NewEncoder(w).Encode(resp); err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
 }

--- a/server/handlers/ai_handler.go
+++ b/server/handlers/ai_handler.go
@@ -13,6 +13,16 @@ type AIResponse struct {
 	Response string `json:"response"`
 }
 
+// NEW: AI Config struct
+type AIConfig struct {
+	Provider string `json:"provider"`
+	APIKey   string `json:"api_key"`
+}
+
+// NEW: Store config (in-memory)
+var aiConfig AIConfig
+
+// Existing test handler
 func HandleAITest(w http.ResponseWriter, r *http.Request) {
 	defer r.Body.Close()
 
@@ -32,9 +42,47 @@ func HandleAITest(w http.ResponseWriter, r *http.Request) {
 	// Set header
 	w.Header().Set("Content-Type", "application/json")
 
-	// Encode response with error handling
+	// Encode response
 	if err := json.NewEncoder(w).Encode(resp); err != nil {
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 		return
+	}
+}
+
+// NEW: AI Config handler
+func HandleAIConfig(w http.ResponseWriter, r *http.Request) {
+	defer r.Body.Close()
+
+	w.Header().Set("Content-Type", "application/json")
+
+	switch r.Method {
+
+	case http.MethodPost:
+		var config AIConfig
+
+		// Decode request
+		if err := json.NewDecoder(r.Body).Decode(&config); err != nil {
+			http.Error(w, "Invalid request", http.StatusBadRequest)
+			return
+		}
+
+		// Save config
+		aiConfig = config
+
+		// Return saved config
+		if err := json.NewEncoder(w).Encode(aiConfig); err != nil {
+			http.Error(w, err.Error(), http.StatusInternalServerError)
+			return
+		}
+
+	case http.MethodGet:
+		// Return current config
+		if err := json.NewEncoder(w).Encode(aiConfig); err != nil {
+			http.Error(w, err.Error(), http.StatusInternalServerError)
+			return
+		}
+
+	default:
+		http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
 	}
 }

--- a/server/router/server.go
+++ b/server/router/server.go
@@ -1,15 +1,16 @@
 package router
 
-import (
-	"context"
-	"fmt"
-	"net/http"
-	"time"
+import import (
+    "context"
+    "fmt"
+    "net/http"
+    "time"
 
-	"github.com/go-openapi/runtime/middleware"
-	"github.com/gorilla/mux"
-	"github.com/meshery/meshery/server/models"
-	"go.opentelemetry.io/contrib/instrumentation/github.com/gorilla/mux/otelmux"
+    "github.com/go-openapi/runtime/middleware"
+    "github.com/gorilla/mux"
+    "github.com/meshery/meshery/server/models"
+    "github.com/meshery/meshery/server/handlers"
+    "go.opentelemetry.io/contrib/instrumentation/github.com/gorilla/mux/otelmux"
 )
 
 // Router represents Meshery router
@@ -28,6 +29,7 @@ func NewRouter(_ context.Context, h models.HandlerInterface, port int, g http.Ha
 
 	gMux.HandleFunc("/api/system/version", h.ServerVersionHandler).
 		Methods("GET")
+	gMux.HandleFunc("/api/system/ai/test", handlers.HandleAITest).Methods("POST")
 	gMux.Handle("/api/extension/version", h.ProviderMiddleware(h.AuthMiddleware(h.SessionInjectorMiddleware(h.ExtensionsVersionHandler), models.ProviderAuth))).
 		Methods("GET")
 	gMux.Handle("/api/system/database", h.ProviderMiddleware(h.AuthMiddleware(h.SessionInjectorMiddleware(h.GetSystemDatabase), models.ProviderAuth))).

--- a/server/router/server.go
+++ b/server/router/server.go
@@ -33,6 +33,10 @@ func NewRouter(_ context.Context, h models.HandlerInterface, port int, g http.Ha
     "/api/system/ai/test",
     h.ProviderMiddleware(h.AuthMiddleware(h.HandleAITest)),
 ).Methods("POST")
+    gMux.Handle(
+	"/api/system/ai/config",
+	h.ProviderMiddleware(h.AuthMiddleware(h.HandleAIConfig)),
+).Methods("GET", "POST")
 	gMux.Handle("/api/extension/version", h.ProviderMiddleware(h.AuthMiddleware(h.SessionInjectorMiddleware(h.ExtensionsVersionHandler), models.ProviderAuth))).
 		Methods("GET")
 	gMux.Handle("/api/system/database", h.ProviderMiddleware(h.AuthMiddleware(h.SessionInjectorMiddleware(h.GetSystemDatabase), models.ProviderAuth))).

--- a/server/router/server.go
+++ b/server/router/server.go
@@ -1,6 +1,6 @@
 package router
 
-import import (
+import (
     "context"
     "fmt"
     "net/http"
@@ -29,7 +29,10 @@ func NewRouter(_ context.Context, h models.HandlerInterface, port int, g http.Ha
 
 	gMux.HandleFunc("/api/system/version", h.ServerVersionHandler).
 		Methods("GET")
-	gMux.HandleFunc("/api/system/ai/test", handlers.HandleAITest).Methods("POST")
+	gMux.Handle(
+    "/api/system/ai/test",
+    h.ProviderMiddleware(h.AuthMiddleware(h.HandleAITest)),
+).Methods("POST")
 	gMux.Handle("/api/extension/version", h.ProviderMiddleware(h.AuthMiddleware(h.SessionInjectorMiddleware(h.ExtensionsVersionHandler), models.ProviderAuth))).
 		Methods("GET")
 	gMux.Handle("/api/system/database", h.ProviderMiddleware(h.AuthMiddleware(h.SessionInjectorMiddleware(h.GetSystemDatabase), models.ProviderAuth))).


### PR DESCRIPTION
Adds a configuration endpoint for AI Adapter.

- Supports GET and POST methods
- Allows storing and retrieving AI provider configuration
- Extends AI adapter functionality