### PR TITLE
UI: fix workspace API endpoint URLs

### DIFF
--- a/ui/rtk-query/workspace.ts
+++ b/ui/rtk-query/workspace.ts
@@ -22,7 +22,7 @@ const workspacesApi = api
           const { expandInfo, ...otherArgs } = queryArgs;
           const params = urlEncodeParams(otherArgs);
           const workspaces = await baseQuery({
-            url: `workspaces?${params}`,
+            url: `extensions/api/workspaces?${params}`,
             method: 'GET',
           });
 
@@ -81,7 +81,7 @@ const workspacesApi = api
 
       getEnvironmentsOfWorkspace: builder.query({
         query: (queryArg) => ({
-          url: `workspaces/${queryArg.workspaceId}/environments`,
+          url: `extensions/api/workspaces/${queryArg.workspaceId}/environments`,
           params: {
             search: queryArg.search,
             order: queryArg.order,
@@ -96,7 +96,7 @@ const workspacesApi = api
 
       assignEnvironmentToWorkspace: builder.mutation({
         query: (queryArg) => ({
-          url: `workspaces/${queryArg.workspaceId}/environments/${queryArg.environmentId}`,
+          url: `extensions/api/workspaces/${queryArg.workspaceId}/environments/${queryArg.environmentId}`,
           method: 'POST',
         }),
 
@@ -105,7 +105,7 @@ const workspacesApi = api
 
       unassignEnvironmentFromWorkspace: builder.mutation({
         query: (queryArg) => ({
-          url: `workspaces/${queryArg.workspaceId}/environments/${queryArg.environmentId}`,
+          url: `extensions/api/workspaces/${queryArg.workspaceId}/environments/${queryArg.environmentId}`,
           method: 'DELETE',
         }),
 
@@ -117,7 +117,7 @@ const workspacesApi = api
           const { expandUser, infiniteScroll: _infiniteScroll, ...otherArgs } = queryArgs;
           const params = urlEncodeParams(otherArgs);
           const designs = await baseQuery({
-            url: `workspaces/${queryArgs.workspaceId}/designs?${params}`,
+            url: `extensions/api/workspaces/${queryArgs.workspaceId}/designs?${params}`,
             method: 'GET',
           });
           if (expandUser && designs.data && !designs.error) {
@@ -171,14 +171,14 @@ const workspacesApi = api
       }),
       assignDesignToWorkspace: builder.mutation({
         query: (queryArg) => ({
-          url: `workspaces/${queryArg.workspaceId}/designs/${queryArg.designId}`,
+          url: `extensions/api/workspaces/${queryArg.workspaceId}/designs/${queryArg.designId}`,
           method: 'POST',
         }),
       }),
 
       unassignDesignFromWorkspace: builder.mutation({
         query: (queryArg) => ({
-          url: `workspaces/${queryArg.workspaceId}/designs/${queryArg.designId}`,
+          url: `extensions/api/workspaces/${queryArg.workspaceId}/designs/${queryArg.designId}`,
           method: 'DELETE',
         }),
       }),
@@ -299,7 +299,7 @@ const workspacesApi = api
 
       createWorkspace: builder.mutation({
         query: (queryArg) => ({
-          url: `workspaces`,
+          url: `extensions/api/workspaces`,
           method: 'POST',
           body: {
             name: queryArg.name,
@@ -312,7 +312,7 @@ const workspacesApi = api
 
       updateWorkspace: builder.mutation({
         query: (queryArg) => ({
-          url: `workspaces/${queryArg.id}`,
+          url: `extensions/api/workspaces/${queryArg.id}`,
           method: 'PUT',
           body: {
             name: queryArg.name,
@@ -325,7 +325,7 @@ const workspacesApi = api
 
       deleteWorkspace: builder.mutation({
         query: (queryArg) => ({
-          url: `workspaces/${queryArg.id}`,
+          url: `extensions/api/workspaces/${queryArg.id}`,
           method: 'DELETE',
         }),
         invalidatesTags: () => [{ type: TAGS.WORKSPACES }],


### PR DESCRIPTION
## Summary

- Fix workspace RTK query endpoints to use `extensions/api/workspaces/...` prefix consistently across all operations (list, create, update, delete, assign/unassign environments, designs)
- Skip `WorkspaceActivityWidget` workspace query when no org ID is set (prevents 404 on local provider)

## Root cause

The bare `workspaces/...` relative paths in RTK Query resolved page-relative: from `/extension/meshmap` they resolved to `/extension/workspaces/...` (200 but wrong content), and from `/` they resolved to `/workspaces/...` (404 on playground). The `extensions/api/workspaces/...` prefix already used by views, teams, and events endpoints is the correct cloud-layer route.

## Test plan

- [ ] Visit dashboard on playground.meshery.io — no 404 for `/workspaces`
- [ ] Workspace list, create, update, delete all route to `/extensions/api/workspaces/...`
- [ ] Dashboard `WorkspaceActivityWidget` does not fire on local provider (no orgID)