### PR TITLE
feat(mesheryctl): add organization view command

### DIFF
--- a/mesheryctl/internal/cli/root/organizations/fixtures/view.organization.api.response.golden
+++ b/mesheryctl/internal/cli/root/organizations/fixtures/view.organization.api.response.golden
@@ -1,0 +1,1 @@
+{"id":"3a4b5c6d-7e8f-9a0b-1c2d-3e4f5a6b7c8d","name":"test-organization","description":"test organization description","owner":"1a2b3c4d-5e6f-7a8b-9c0d-1e2f3a4b5c6d","created_at":"2024-05-01T14:24:26.84361Z","updated_at":"2024-05-01T14:24:26.84362Z","deleted_at":{"Time":"0001-01-01T00:00:00Z","Valid":false},"country":"","region":"","metadata":{"preferences":{}}}

--- a/mesheryctl/internal/cli/root/organizations/organization.go
+++ b/mesheryctl/internal/cli/root/organizations/organization.go
@@ -11,24 +11,29 @@ import (
 )
 
 var (
-	availableSubcommands = []*cobra.Command{listOrgCmd}
+	availableSubcommands = []*cobra.Command{listOrgCmd, viewOrgCmd}
 	organizationsApiPath = "api/identity/orgs"
 	count                bool
 )
 
 var OrgCmd = &cobra.Command{
-
 	Use:   "organization",
 	Short: "Interact with registered organizations",
 	Long: `Interact with registered organizations to display detailed information
 Find more information at: https://docs.meshery.io/reference/mesheryctl/organizations`,
 	Example: `
-// Number of  registered orgs
+// Number of registered organizations
 mesheryctl organization --count
 
-// List registerd orgs
+// List registered organizations
 mesheryctl organization list
-	`,
+
+// View details of a specific organization
+mesheryctl organization view [organization-id]
+
+// View details of a specific organization by name
+mesheryctl organization view [organization-name]
+`,
 	Args: func(cmd *cobra.Command, args []string) error {
 		count, _ = cmd.Flags().GetBool("count")
 		if len(args) == 0 && !count {
@@ -60,5 +65,4 @@ mesheryctl organization list
 func init() {
 	OrgCmd.Flags().BoolP("count", "", false, "total number of registered organizations")
 	OrgCmd.AddCommand(availableSubcommands...)
-
 }

--- a/mesheryctl/internal/cli/root/organizations/testdata/view.organization.output.golden
+++ b/mesheryctl/internal/cli/root/organizations/testdata/view.organization.output.golden
@@ -1,0 +1,27 @@
+country: ""
+created_at: 2024-05-01T14:24:26.84361Z
+description: test organization description
+domain: null
+id: 3a4b5c6d-7e8f-9a0b-1c2d-3e4f5a6b7c8d
+metadata:
+    preferences:
+        dashboard: {}
+        theme:
+            id: ""
+            logo:
+                dark_desktop_view:
+                    location: ""
+                    svg: ""
+                dark_mobile_view:
+                    location: ""
+                    svg: ""
+                desktop_view:
+                    location: ""
+                    svg: ""
+                mobile_view:
+                    location: ""
+                    svg: ""
+name: test-organization
+owner: 1a2b3c4d-5e6f-7a8b-9c0d-1e2f3a4b5c6d
+region: ""
+updated_at: 2024-05-01T14:24:26.84362Z

--- a/mesheryctl/internal/cli/root/organizations/view.go
+++ b/mesheryctl/internal/cli/root/organizations/view.go
@@ -1,0 +1,139 @@
+package organizations
+
+import (
+	"fmt"
+	"net/url"
+	"path/filepath"
+	"strings"
+
+	"github.com/meshery/meshery/mesheryctl/internal/cli/pkg/display"
+	mesheryctlflags "github.com/meshery/meshery/mesheryctl/internal/cli/pkg/flags"
+	"github.com/meshery/meshery/mesheryctl/pkg/utils"
+	"github.com/meshery/meshery/server/models"
+	"github.com/meshery/schemas/models/v1beta1/organization"
+	"github.com/spf13/cobra"
+)
+
+type orgViewFlags struct {
+	OutputFormat string `json:"output-format" validate:"required,oneof=json yaml"`
+	Save         bool   `json:"save" validate:"boolean"`
+}
+
+var orgViewFlagsProvided orgViewFlags
+
+func formatOrgLabel(rows []organization.Organization) []string {
+	labels := []string{}
+	for _, o := range rows {
+		labels = append(labels, fmt.Sprintf("%s (ID: %s)", o.Name, o.ID.String()))
+	}
+	return labels
+}
+
+var viewOrgCmd = &cobra.Command{
+	Use:   "view [organization-name|organization-id]",
+	Short: "View an organization",
+	Long: `View an organization by its ID or name.
+Find more information at: https://docs.meshery.io/reference/mesheryctl/organizations/view`,
+	Example: `// View details of a specific organization by ID
+mesheryctl organization view [organization-id]
+
+// View details of a specific organization by name
+mesheryctl organization view [organization-name]
+
+// View details of a specific organization in JSON format
+mesheryctl organization view [organization-id] --output-format json
+
+// View details of a specific organization and save it to a file
+mesheryctl organization view [organization-id] --output-format json --save`,
+	PreRunE: func(cmd *cobra.Command, args []string) error {
+		return mesheryctlflags.ValidateCmdFlags(cmd, &orgViewFlagsProvided)
+	},
+	Args: func(cmd *cobra.Command, args []string) error {
+		const errMsg = "Usage: mesheryctl organization view [organization-name|organization-id]\nRun 'mesheryctl organization view --help' to see detailed help message"
+		if len(args) != 1 {
+			return utils.ErrInvalidArgument(fmt.Errorf("please provide exactly one organization name or ID\n\n%v", errMsg))
+		}
+		return nil
+	},
+	RunE: func(cmd *cobra.Command, args []string) error {
+		orgNameOrID := args[0]
+		selectedOrg := new(organization.Organization)
+		var urlPath string
+		var displayData display.DisplayDataAsync
+
+		if utils.IsUUID(orgNameOrID) {
+			urlPath = fmt.Sprintf("%s/%s", organizationsApiPath, url.PathEscape(orgNameOrID))
+			displayData = display.DisplayDataAsync{UrlPath: urlPath}
+			err := display.PromptAsyncPagination(
+				displayData,
+				formatOrgLabel,
+				func(data *organization.Organization) ([]organization.Organization, int64) {
+					return []organization.Organization{*data}, 1
+				},
+				selectedOrg,
+			)
+			if err != nil {
+				return err
+			}
+		} else {
+			viewUrlValue := url.Values{}
+			viewUrlValue.Add("search", orgNameOrID)
+			urlPath = fmt.Sprintf("%s?%s", organizationsApiPath, viewUrlValue.Encode())
+			displayData = display.DisplayDataAsync{
+				UrlPath:    urlPath,
+				SearchTerm: orgNameOrID,
+			}
+			err := display.PromptAsyncPagination(
+				displayData,
+				formatOrgLabel,
+				func(data *models.OrganizationsPage) ([]organization.Organization, int64) {
+					orgs := make([]organization.Organization, len(data.Organizations))
+					for i, o := range data.Organizations {
+						orgs[i] = *o
+					}
+					return orgs, int64(data.TotalCount)
+				},
+				selectedOrg,
+			)
+			if err != nil {
+				return err
+			}
+		}
+
+		outputFormatterFactory := display.OutputFormatterFactory[organization.Organization]{}
+		outputFormatter, err := outputFormatterFactory.New(orgViewFlagsProvided.OutputFormat, *selectedOrg)
+		if err != nil {
+			return err
+		}
+
+		outputFormatter = outputFormatter.WithOutput(cmd.OutOrStdout())
+		err = outputFormatter.Display()
+		if err != nil {
+			return err
+		}
+
+		if orgViewFlagsProvided.Save {
+			orgString := strings.ReplaceAll(selectedOrg.Name, " ", "_")
+			if orgString == "" {
+				orgString = selectedOrg.ID.String()
+			}
+			fileName := filepath.Join(utils.MesheryFolder, fmt.Sprintf("organization_%s.%s", orgString, orgViewFlagsProvided.OutputFormat))
+			outputFormatterSaverFactory := display.OutputFormatterSaverFactory[organization.Organization]{}
+			outputFormatterSaver, err := outputFormatterSaverFactory.New(orgViewFlagsProvided.OutputFormat, outputFormatter)
+			if err != nil {
+				return err
+			}
+			outputFormatterSaver = outputFormatterSaver.WithFilePath(fileName)
+			err = outputFormatterSaver.Save()
+			if err != nil {
+				return err
+			}
+		}
+		return nil
+	},
+}
+
+func init() {
+	viewOrgCmd.Flags().StringVarP(&orgViewFlagsProvided.OutputFormat, "output-format", "o", "yaml", "(optional) format to display in [json|yaml]")
+	viewOrgCmd.Flags().BoolVarP(&orgViewFlagsProvided.Save, "save", "s", false, "(optional) save output as a JSON/YAML file")
+}

--- a/mesheryctl/internal/cli/root/organizations/view.go
+++ b/mesheryctl/internal/cli/root/organizations/view.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"net/url"
 	"path/filepath"
-	"strings"
 
 	"github.com/meshery/meshery/mesheryctl/internal/cli/pkg/display"
 	mesheryctlflags "github.com/meshery/meshery/mesheryctl/internal/cli/pkg/flags"
@@ -113,11 +112,7 @@ mesheryctl organization view [organization-id] --output-format json --save`,
 		}
 
 		if orgViewFlagsProvided.Save {
-			orgString := strings.ReplaceAll(selectedOrg.Name, " ", "_")
-			if orgString == "" {
-				orgString = selectedOrg.ID.String()
-			}
-			fileName := filepath.Join(utils.MesheryFolder, fmt.Sprintf("organization_%s.%s", orgString, orgViewFlagsProvided.OutputFormat))
+			fileName := filepath.Join(utils.MesheryFolder, fmt.Sprintf("organization_%s.%s", selectedOrg.ID.String(), orgViewFlagsProvided.OutputFormat))
 			outputFormatterSaverFactory := display.OutputFormatterSaverFactory[organization.Organization]{}
 			outputFormatterSaver, err := outputFormatterSaverFactory.New(orgViewFlagsProvided.OutputFormat, outputFormatter)
 			if err != nil {

--- a/mesheryctl/internal/cli/root/organizations/view_test.go
+++ b/mesheryctl/internal/cli/root/organizations/view_test.go
@@ -1,0 +1,78 @@
+package organizations
+
+import (
+	"fmt"
+	"path/filepath"
+	"runtime"
+	"testing"
+
+	mesheryctlflags "github.com/meshery/meshery/mesheryctl/internal/cli/pkg/flags"
+	"github.com/meshery/meshery/mesheryctl/pkg/utils"
+)
+
+func expectedOrgViewFlagError(outputFormat string) error {
+	fv := mesheryctlflags.GetFlagValidator()
+	return fv.Validate(&orgViewFlags{OutputFormat: outputFormat})
+}
+
+func TestViewOrganization(t *testing.T) {
+	_, filename, _, ok := runtime.Caller(0)
+	if !ok {
+		t.Fatal("Not able to get current working directory")
+	}
+	currDir := filepath.Dir(filename)
+	mesheryctlflags.InitValidators(OrgCmd)
+
+	testOrgID := "3a4b5c6d-7e8f-9a0b-1c2d-3e4f5a6b7c8d"
+
+	tests := []utils.MesheryCommandTest{
+		{
+			Name:             "given no arguments when running organization view then return error",
+			Args:             []string{"view"},
+			HttpMethod:       "GET",
+			HttpStatusCode:   200,
+			URL:              fmt.Sprintf("/%s", organizationsApiPath),
+			Fixture:          "view.organization.api.response.golden",
+			ExpectedResponse: "",
+			ExpectError:      true,
+			IsOutputGolden:   false,
+			ExpectedError:    utils.ErrInvalidArgument(fmt.Errorf("please provide exactly one organization name or ID\n\nUsage: mesheryctl organization view [organization-name|organization-id]\nRun 'mesheryctl organization view --help' to see detailed help message")),
+		},
+		{
+			Name:             "given too many arguments when running organization view then return error",
+			Args:             []string{"view", testOrgID, "extra-arg"},
+			HttpMethod:       "GET",
+			HttpStatusCode:   200,
+			URL:              fmt.Sprintf("/%s", organizationsApiPath),
+			Fixture:          "view.organization.api.response.golden",
+			ExpectedResponse: "",
+			ExpectError:      true,
+			IsOutputGolden:   false,
+			ExpectedError:    utils.ErrInvalidArgument(fmt.Errorf("please provide exactly one organization name or ID\n\nUsage: mesheryctl organization view [organization-name|organization-id]\nRun 'mesheryctl organization view --help' to see detailed help message")),
+		},
+		{
+			Name:             "given valid organization ID when running organization view then display organization details",
+			Args:             []string{"view", testOrgID},
+			HttpMethod:       "GET",
+			HttpStatusCode:   200,
+			URL:              fmt.Sprintf("/%s/%s", organizationsApiPath, testOrgID),
+			Fixture:          "view.organization.api.response.golden",
+			ExpectedResponse: "view.organization.output.golden",
+			ExpectError:      false,
+		},
+		{
+			Name:             "given invalid output format flag when running organization view then return error",
+			Args:             []string{"view", testOrgID, "--output-format", "invalid"},
+			HttpMethod:       "GET",
+			HttpStatusCode:   200,
+			URL:              fmt.Sprintf("/%s/%s", organizationsApiPath, testOrgID),
+			Fixture:          "view.organization.api.response.golden",
+			ExpectedResponse: "",
+			ExpectError:      true,
+			IsOutputGolden:   false,
+			ExpectedError:    expectedOrgViewFlagError("invalid"),
+		},
+	}
+
+	utils.InvokeMesheryctlTestCommand(t, update, OrgCmd, tests, currDir, "organization")
+}


### PR DESCRIPTION
## Description
This PR introduces the mesheryctl organization view command, enabling users to fetch and display details of a specific organization by UUID or name.

Changes:
view.go — new organization view subcommand with UUID and name lookup support
view_test.go — unit tests with golden file fixtures for CLI output and API response mocking
organization.go — register viewOrgCmd, fix typo (registerd → registered), add view examples to help text

Behavior:
UUID lookup: GET api/identity/orgs/{id}
Name lookup: GET api/identity/orgs?search={name} with PromptAsyncPagination
Output in YAML (default) or JSON via --output-format
Optional --save flag to persist output to file
Displays: id, name, description, owner, created_at, updated_at (cloud-only fields country, region, domain, teams excluded per Lee Calcote's guidance in #mesheryctl)

## Related Issue
Fixes #18130

