### PR TITLE
Add ElasticsearchDomain and Cloudwatch LogGroup relationship

### DIFF
--- a/server/meshmodel/aws-elasticsearchservice-controller/v0.0.2/v1.0.0/relationships/edge-non-binding-reference-syebd.json
+++ b/server/meshmodel/aws-elasticsearchservice-controller/v0.0.2/v1.0.0/relationships/edge-non-binding-reference-syebd.json
@@ -1,0 +1,111 @@
+{
+  "id": "00000000-0000-0000-0000-000000000000",
+  "evaluationQuery": "",
+  "kind": "edge",
+  "metadata": {
+    "description": "ElasticsearchDomain and Cloudwatch LogGroup relationship",
+    "isAnnotation": false,
+    "styles": {
+      "primaryColor": "",
+      "svgColor": "",
+      "svgWhite": ""
+    }
+  },
+  "model": {
+    "displayName": "",
+    "id": "00000000-0000-0000-0000-000000000000",
+    "model": {
+      "version": "v0.0.2"
+    },
+    "name": "aws-elasticsearchservice-controller",
+    "registrant": {
+      "kind": ""
+    },
+    "version": ""
+  },
+  "schemaVersion": "relationships.meshery.io/v1alpha3",
+  "selectors": [
+    {
+        "allow": {
+            "from": [
+                {
+                    "id": null,
+                    "kind": "ElasticsearchDomain",
+                    "match": {},
+                    "match_strategy_matrix": null,
+                    "model": {
+                        "displayName": "",
+                        "id": "00000000-0000-0000-0000-000000000000",
+                        "model": {
+                            "version": ""
+                        },
+                        "name": "aws-elasticsearchservice-controller",
+                        "registrant": {
+                            "kind": "github"
+                        },
+                        "version": ""
+                    },
+                    "patch": {
+                        "patchStrategy": "replace",
+                        "mutatorRef": [
+                            [
+                            "configuration",
+                            "spec",
+                            "logPublishingOptions",
+                            "cloudWatchLogsLogGroupArn"
+                            ]
+                        ],
+                        "description": "The Elasticsearch configuration path where the CloudWatch Log Group ARN will be located within the mutatorRef"
+                    }
+                }
+        ],
+            "to": [
+                {
+                    "id": null,
+                    "kind": "LogGroup",
+                    "match": {},
+                    "match_strategy_matrix": null,
+                    "model": {
+                        "displayName": "",
+                        "id": "00000000-0000-0000-0000-000000000000",
+                        "model": {
+                            "version": ""
+                        },
+                        "name": "aws-cloudwatchlogs-controller",
+                        "registrant": {
+                            "kind": "github"
+                        },
+                        "version": ""
+                },
+                "patch": {
+                    "patchStrategy": "replace",
+                    "mutatedRef": [
+                    [
+                        "configuration",
+                        "status",
+                        "ackResourceMetadata",
+                        "arn"
+                    ]
+              ]
+            }
+        }
+        ]
+      },
+      "deny": {
+        "from": [],
+        "to": []
+      }
+    }
+    ],
+    "subType": "reference",
+    "status": "enabled",
+    "type": "non-binding",
+    "version": "v1.0.0"
+}
+ 
+
+
+
+        
+                    
+  


### PR DESCRIPTION
**Notes for Reviewers**

- This PR fixes #18148

- This PR adds a new Edge-Reference relationship between AWS Elasticsearch and AWS CloudWatch Log Group.
- The goal is to automate the logging configuration. This relationship automatically retrieves the CloudWatch Log Group ARN and patches it into the Elasticsearch Domain configuration. 

**[Signed commits](https://github.com/meshery/meshery/blob/master/CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [X] Yes, I signed my commits.

<!--
Thank you for contributing to Meshery! 

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. Sign your commits.
4. Include before and after screenshots/terminal output.

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.
-->
