### PR TITLE
[Docs] Remove outdated note on deletion from Creating Models page

### DIFF
--- a/docs/content/en/guides/configuration-management/creating-models/index.md
+++ b/docs/content/en/guides/configuration-management/creating-models/index.md
@@ -115,11 +115,6 @@ When a model is marked for visual annotation only, it means the model will be us
     <p>Once the model is successfully generated, a confirmation message will appear. You'll be able to view the model along with its components and relationships directly in the Registry page.</p>
     <p>If any issues occur, Meshery will display an error message detailing what went wrong so you can correct it and try again.</p>
     <p>A notification will also appear in the <a href="/guides/events-management">Notification Center</a> to confirm whether the operation succeeded or failed, providing additional context if needed.</p>
-
-{{% alert color="warning" title="Note on Deletion" %}}
-Once a model is generated, it cannot be deleted from the Meshery UI. If you no longer wish to use it, you may mark it as ignored instead.
-{{% /alert %}}
-    
   </section>
 
   <!-- Second Level Tab: mesheryctl -->

--- a/docs/content/en/guides/configuration-management/creating-models/index.md
+++ b/docs/content/en/guides/configuration-management/creating-models/index.md
@@ -115,6 +115,11 @@ When a model is marked for visual annotation only, it means the model will be us
     <p>Once the model is successfully generated, a confirmation message will appear. You'll be able to view the model along with its components and relationships directly in the Registry page.</p>
     <p>If any issues occur, Meshery will display an error message detailing what went wrong so you can correct it and try again.</p>
     <p>A notification will also appear in the <a href="/guides/events-management">Notification Center</a> to confirm whether the operation succeeded or failed, providing additional context if needed.</p>
+
+{{% alert color="info" title="Note on Deletion" %}}
+Models cannot be deleted from the Meshery UI. To delete a model, use mesheryctl. For more information, refer to the <a href="/reference/mesheryctl/model">mesheryctl model command reference</a>.
+{{% /alert %}}
+    
   </section>
 
   <!-- Second Level Tab: mesheryctl -->


### PR DESCRIPTION
**Notes for Reviewers**
- This PR fixes #18277

Removed the outdated alert note on deletion from the Creating Models documentation. The note created confusion for users comparing the Meshery UI to mesheryctl, as deletion via CLI is now supported but not yet available in the UI.

**Signed commits**
- [x] Yes, I signed my commits.