### PR TITLE
fix(mesheryctl): system provider return proper error, remove logrus, …

### DIFF
--- a/mesheryctl/internal/cli/root/system/common_test.go
+++ b/mesheryctl/internal/cli/root/system/common_test.go
@@ -18,7 +18,7 @@ func BreakupFunc() {
 	channelCmd.Flags().VisitAll(setFlagValueAsUndefined)
 	SystemCmd.PersistentFlags().VisitAll(setFlagValueAsUndefined)
 	showForAllContext = false
-	showProviderForAllContext = false
+	providerViewFlags.All = false
 	tempContext = ""
 	utils.SilentFlag = false
 }

--- a/mesheryctl/internal/cli/root/system/provider.go
+++ b/mesheryctl/internal/cli/root/system/provider.go
@@ -16,27 +16,30 @@ package system
 
 import (
 	"fmt"
-	"sort"
 	mesheryctlflags "github.com/meshery/meshery/mesheryctl/internal/cli/pkg/flags"
 	"github.com/meshery/meshery/mesheryctl/internal/cli/root/config"
 	"github.com/meshery/meshery/mesheryctl/pkg/utils"
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
+	"sort"
 )
 
 var (
-	MesheryProvider           = "Layer5"
-	NoneProvider              = "None"
+	MesheryProvider = "Layer5"
+	NoneProvider    = "None"
 )
+
 type cmdProviderViewFlags struct {
-    All bool `json:"all" validate:"boolean"`
+	All bool `json:"all" validate:"boolean"`
 }
 type cmdProviderSetFlags struct {
-    Force bool `json:"force" validate:"boolean"`
+	Force bool `json:"force" validate:"boolean"`
 }
+
 var providerViewFlags cmdProviderViewFlags
 var providerSetFlags cmdProviderSetFlags
+
 // PrintProviderToStdout to return provider details for a context
 func PrintProviderToStdout(ctx config.Context, contextName string) string {
 	return fmt.Sprintf("Context: %v\nProvider: %v", contextName, ctx.Provider)
@@ -59,7 +62,7 @@ mesheryctl system provider view
 		}
 		mctlCfg, err := config.GetMesheryCtl(viper.GetViper())
 		if err != nil {
-			return err 
+			return err
 		}
 		focusedContext := focusedSystemContext(cmd, mctlCfg.CurrentContext)
 
@@ -174,7 +177,7 @@ mesheryctl system provider set [provider]
 		}
 		return nil
 	},
-	PreRunE: func(cmd *cobra.Command, args []string) error{
+	PreRunE: func(cmd *cobra.Command, args []string) error {
 		return mesheryctlflags.ValidateCmdFlags(cmd, &providerSetFlags)
 	},
 	RunE: func(cmd *cobra.Command, args []string) error {
@@ -208,14 +211,12 @@ mesheryctl system provider set [provider]
 				return ErrProviderInfo(err)
 			}
 
-			keys := make([]string, 0, len(availableProviders))
 			isValidProvider := false
 
 			for k := range availableProviders {
 				if provider == k {
 					isValidProvider = true
 				}
-				keys = append(keys, k)
 			}
 
 			if !isValidProvider {
@@ -270,7 +271,7 @@ mesheryctl system provider switch [provider]
 	RunE: func(cmd *cobra.Command, args []string) error {
 		userResponse := false
 
-		mctlCfg, err = config.GetMesheryCtl(viper.GetViper())
+		mctlCfg, err := config.GetMesheryCtl(viper.GetViper())
 		if err != nil {
 			return err
 		}

--- a/mesheryctl/internal/cli/root/system/provider.go
+++ b/mesheryctl/internal/cli/root/system/provider.go
@@ -33,12 +33,8 @@ var (
 type cmdProviderViewFlags struct {
 	All bool `json:"all" validate:"boolean"`
 }
-type cmdProviderSetFlags struct {
-	Force bool `json:"force" validate:"boolean"`
-}
 
 var providerViewFlags cmdProviderViewFlags
-var providerSetFlags cmdProviderSetFlags
 
 // PrintProviderToStdout to return provider details for a context
 func PrintProviderToStdout(ctx config.Context, contextName string) string {
@@ -159,6 +155,12 @@ mesheryctl system provider list
 		return nil
 	},
 }
+
+type cmdProviderSetFlags struct {
+	Force bool `json:"force" validate:"boolean"`
+}
+
+var providerSetFlags cmdProviderSetFlags
 
 var setProviderCmd = &cobra.Command{
 	Use:   "set [provider]",

--- a/mesheryctl/internal/cli/root/system/provider.go
+++ b/mesheryctl/internal/cli/root/system/provider.go
@@ -16,9 +16,8 @@ package system
 
 import (
 	"fmt"
-	"os"
 	"sort"
-
+	mesheryctlflags "github.com/meshery/meshery/mesheryctl/internal/cli/pkg/flags"
 	"github.com/meshery/meshery/mesheryctl/internal/cli/root/config"
 	"github.com/meshery/meshery/mesheryctl/pkg/utils"
 	"github.com/pkg/errors"
@@ -27,12 +26,17 @@ import (
 )
 
 var (
-	showProviderForAllContext bool
-	forceSetProvider          bool
 	MesheryProvider           = "Layer5"
 	NoneProvider              = "None"
 )
-
+type cmdProviderViewFlags struct {
+    All bool `json:"all" validate:"boolean"`
+}
+type cmdProviderSetFlags struct {
+    Force bool `json:"force" validate:"boolean"`
+}
+var providerViewFlags cmdProviderViewFlags
+var providerSetFlags cmdProviderSetFlags
 // PrintProviderToStdout to return provider details for a context
 func PrintProviderToStdout(ctx config.Context, contextName string) string {
 	return fmt.Sprintf("Context: %v\nProvider: %v", contextName, ctx.Provider)
@@ -46,18 +50,20 @@ var viewProviderCmd = &cobra.Command{
 // View current provider
 mesheryctl system provider view
 	`,
+	PreRunE: func(cmd *cobra.Command, args []string) error {
+		return mesheryctlflags.ValidateCmdFlags(cmd, &providerViewFlags)
+	},
 	RunE: func(cmd *cobra.Command, args []string) error {
 		if len(args) != 0 {
 			return errors.New(utils.SystemProviderSubError("this command takes no arguments\n", "view"))
 		}
 		mctlCfg, err := config.GetMesheryCtl(viper.GetViper())
 		if err != nil {
-			utils.Log.Error(err)
-			return nil
+			return err 
 		}
 		focusedContext := focusedSystemContext(cmd, mctlCfg.CurrentContext)
 
-		if showProviderForAllContext {
+		if providerViewFlags.All {
 			keys := make([]string, 0, len(mctlCfg.Contexts))
 			for contextName := range mctlCfg.Contexts {
 				keys = append(keys, contextName)
@@ -73,14 +79,12 @@ mesheryctl system provider view
 
 		err = mctlCfg.SetCurrentContext(focusedContext)
 		if err != nil {
-			utils.Log.Error(ErrSetCurrentContext(err))
-			return nil
+			return ErrSetCurrentContext(err)
 		}
 
 		currCtx, err := mctlCfg.GetCurrentContext()
 		if err != nil {
-			utils.Log.Error(ErrGetCurrentContext(err))
-			return nil
+			return ErrGetCurrentContext(err)
 		}
 		utils.Log.Infof("%s\n", PrintProviderToStdout(*currCtx, focusedContext))
 		return nil
@@ -104,8 +108,7 @@ mesheryctl system provider list
 
 		mctlCfg, err := config.GetMesheryCtl(viper.GetViper())
 		if err != nil {
-			utils.Log.Error(err)
-			return nil
+			return err
 		}
 
 		focusedContext := tempContext
@@ -115,21 +118,19 @@ mesheryctl system provider list
 
 		err = mctlCfg.SetCurrentContext(focusedContext)
 		if err != nil {
-			utils.Log.Error(ErrSetCurrentContext(err))
-			return nil
+			return ErrSetCurrentContext(err)
 		}
 
 		currCtx, err := mctlCfg.GetCurrentContext()
 		if err != nil {
-			utils.Log.Error(ErrGetCurrentContext(err))
-			return nil
+			return ErrGetCurrentContext(err)
 		}
 
 		utils.Log.Infof("Current provider: %s", currCtx.Provider)
 
 		providers, err := utils.GetProviderInfo(mctlCfg)
 		if err != nil {
-			utils.Log.Fatalf("could not fetch providers as Meshery server was unreachable\nStart Meshery to list available providers")
+			return err
 		}
 
 		utils.Log.Info("Available providers:\n")
@@ -173,11 +174,14 @@ mesheryctl system provider set [provider]
 		}
 		return nil
 	},
+	PreRunE: func(cmd *cobra.Command, args []string) error{
+		return mesheryctlflags.ValidateCmdFlags(cmd, &providerSetFlags)
+	},
 	RunE: func(cmd *cobra.Command, args []string) error {
 
 		mctlCfg, err := config.GetMesheryCtl(viper.GetViper())
 		if err != nil {
-			utils.Log.Error(err)
+			return err
 		}
 
 		focusedContext := tempContext
@@ -187,23 +191,21 @@ mesheryctl system provider set [provider]
 
 		err = mctlCfg.SetCurrentContext(focusedContext)
 		if err != nil {
-			utils.Log.Error(ErrSetCurrentContext(err))
-			return nil
+			return ErrSetCurrentContext(err)
 		}
 
 		currCtx, err := mctlCfg.GetCurrentContext()
 		if err != nil {
-			utils.Log.Error(ErrGetCurrentContext(err))
-			return nil
+			return ErrGetCurrentContext(err)
 		}
 
 		provider := args[0]
 
-		if !forceSetProvider {
+		if !providerSetFlags.Force {
 			// Verify provider
 			availableProviders, err := utils.GetProviderInfo(mctlCfg)
 			if err != nil {
-				utils.Log.Error(ErrProviderInfo(err))
+				return ErrProviderInfo(err)
 			}
 
 			keys := make([]string, 0, len(availableProviders))
@@ -217,15 +219,7 @@ mesheryctl system provider set [provider]
 			}
 
 			if !isValidProvider {
-				utils.Log.Error(ErrValidProvider())
-
-				utils.Log.Info("Available providers:\n")
-				//sorting the contexts to get a consistent order on each subsequent run
-				sort.Strings(keys)
-				for _, k := range keys {
-					utils.Log.Infof("- %s", k)
-				}
-				os.Exit(1)
+				return ErrValidProvider()
 			}
 		}
 
@@ -235,8 +229,7 @@ mesheryctl system provider set [provider]
 		viper.Set("contexts", mctlCfg.Contexts)
 		err = viper.WriteConfig()
 		if err != nil {
-			utils.Log.Error(ErrWriteConfig(err))
-			return nil
+			return ErrWriteConfig(err)
 		}
 
 		utils.Log.Infof("Provider set to %s", currCtx.Provider)
@@ -270,8 +263,7 @@ mesheryctl system provider switch [provider]
 		}
 		hc, err := NewHealthChecker(hcOptions)
 		if err != nil {
-			utils.Log.Error(err)
-			return nil
+			return ErrHealthCheckFailed(err)
 		}
 		return hc.RunPreflightHealthChecks()
 	},
@@ -280,7 +272,7 @@ mesheryctl system provider switch [provider]
 
 		mctlCfg, err = config.GetMesheryCtl(viper.GetViper())
 		if err != nil {
-			utils.Log.Error(err)
+			return err
 		}
 
 		focusedContext := tempContext
@@ -329,7 +321,7 @@ mesheryctl system provider reset
 
 		mctlCfg, err := config.GetMesheryCtl(viper.GetViper())
 		if err != nil {
-			utils.Log.Error(err)
+			return err
 		}
 
 		focusedContext := tempContext
@@ -339,14 +331,12 @@ mesheryctl system provider reset
 
 		err = mctlCfg.SetCurrentContext(focusedContext)
 		if err != nil {
-			utils.Log.Error(ErrSetCurrentContext(err))
-			return nil
+			return ErrSetCurrentContext(err)
 		}
 
 		currCtx, err := mctlCfg.GetCurrentContext()
 		if err != nil {
-			utils.Log.Error(ErrGetCurrentContext(err))
-			return nil
+			return ErrGetCurrentContext(err)
 		}
 
 		currCtx.Provider = ""
@@ -355,8 +345,7 @@ mesheryctl system provider reset
 		viper.Set("contexts", mctlCfg.Contexts)
 		err = viper.WriteConfig()
 		if err != nil {
-			utils.Log.Error(ErrWriteConfig(err))
-			return nil
+			return ErrWriteConfig(err)
 		}
 
 		utils.Log.Info("Provider has been reset. You will be prompted to select a provider on next Meshery start. If not, log out or clear existing browser sessions.")
@@ -390,7 +379,7 @@ mesheryctl system provider reset
 		}
 		_, err := config.GetMesheryCtl(viper.GetViper())
 		if err != nil {
-			utils.Log.Error(err)
+			return err
 		}
 		err = viewProviderCmd.RunE(cmd, args)
 		if err != nil {
@@ -405,7 +394,7 @@ mesheryctl system provider reset
 }
 
 func init() {
-	viewProviderCmd.Flags().BoolVarP(&showProviderForAllContext, "all", "a", false, "Show provider for all contexts")
-	setProviderCmd.Flags().BoolVarP(&forceSetProvider, "force", "f", false, "Force set provider")
+	viewProviderCmd.Flags().BoolVarP(&providerViewFlags.All, "all", "a", false, "Show provider for all contexts")
+	setProviderCmd.Flags().BoolVarP(&providerSetFlags.Force, "force", "f", false, "Force set provider")
 	providerCmd.AddCommand(viewProviderCmd, listProviderCmd, setProviderCmd, switchProviderCmd, resetProviderCmd)
 }

--- a/mesheryctl/internal/cli/root/system/provider_test.go
+++ b/mesheryctl/internal/cli/root/system/provider_test.go
@@ -5,11 +5,13 @@ import (
 	"strings"
 	"testing"
 
+	mesheryctlflags "github.com/meshery/meshery/mesheryctl/internal/cli/pkg/flags"
 	"github.com/stretchr/testify/assert"
 )
 
 func TestViewProviderCmd(t *testing.T) {
 	setupContextTestEnv(t)
+	mesheryctlflags.InitValidators(SystemCmd)
 	tests := []CmdTestInput{
 		{
 			Name:             "given provider context when provider view then display provided provider",


### PR DESCRIPTION
Fixes #18281 

## Testing

Before fix: `--all` and `--force` flags accepted any value silently (no validation)

After fix:

$ ./mesheryctl system provider view --all=invalid
Error: invalid argument "invalid" for "-a, --all" flag: strconv.ParseBool: parsing "invalid": invalid syntax

$ ./mesheryctl system provider set --force=invalid Meshery
Error: invalid argument "invalid" for "-f, --force" flag: strconv.ParseBool: parsing "invalid": invalid syntax

Valid usage:

$ ./mesheryctl system provider view
Context: local
Provider:

$ ./mesheryctl system provider view --all
Context: local
Provider:
Current Context: local


- [x] Yes, I signed my commits.
