### PR TITLE
[Server] Fix silent error suppression in delete persisters and add transaction for bulk pattern delete

### DIFF
--- a/server/models/meshery_filter_persister.go
+++ b/server/models/meshery_filter_persister.go
@@ -153,7 +153,9 @@ func (mfp *MesheryFilterPersister) CloneMesheryFilter(filterID string, cloneFilt
 // DeleteMesheryFilter takes in a profile id and delete it if it already exists
 func (mfp *MesheryFilterPersister) DeleteMesheryFilter(id core.Uuid) ([]byte, error) {
 	filter := MesheryFilter{ID: &id}
-	mfp.DB.Delete(&filter)
+	if err := mfp.DB.Delete(&filter).Error; err != nil {
+		return nil, ErrDBDelete(err, "")
+	}
 
 	return marshalMesheryFilter(&filter), nil
 }

--- a/server/models/meshery_k8scontext_persister.go
+++ b/server/models/meshery_k8scontext_persister.go
@@ -59,7 +59,9 @@ func (mkcp *MesheryK8sContextPersister) GetMesheryK8sContexts(search, order stri
 // DeleteMesheryK8sContext takes in an application id and delete it if it already exists
 func (mkcp *MesheryK8sContextPersister) DeleteMesheryK8sContext(id string) (K8sContext, error) {
 	context := K8sContext{ID: id}
-	mkcp.DB.Delete(&context)
+	if err := mkcp.DB.Delete(&context).Error; err != nil {
+		return K8sContext{}, ErrDBDelete(err, "")
+	}
 
 	return context, nil
 }

--- a/server/models/meshery_pattern_persister.go
+++ b/server/models/meshery_pattern_persister.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/gofrs/uuid"
 	"gopkg.in/yaml.v2"
+	"gorm.io/gorm"
 
 	"github.com/meshery/meshkit/database"
 	"github.com/meshery/meshkit/models/patterns"
@@ -156,22 +157,43 @@ func (mpp *MesheryPatternPersister) CloneMesheryPattern(patternID string, cloneP
 // DeleteMesheryPattern takes in a profile id and delete it if it already exists
 func (mpp *MesheryPatternPersister) DeleteMesheryPattern(id core.Uuid) ([]byte, error) {
 	pattern := MesheryPattern{ID: &id}
-	mpp.DB.Delete(&pattern)
+	if err := mpp.DB.Delete(&pattern).Error; err != nil {
+		return nil, ErrDBDelete(err, "")
+	}
 
 	return marshalMesheryPattern(&pattern), nil
 }
 
 // DeleteMesheryPatterns takes in a meshery-patterns and delete those if exist
 func (mpp *MesheryPatternPersister) DeleteMesheryPatterns(patterns MesheryPatternDeleteRequestBody) ([]byte, error) {
-	var deletedMaptterns []MesheryPattern
-	for _, pObj := range patterns.Patterns {
-		id := uuid.FromStringOrNil(pObj.ID)
-		pattern := MesheryPattern{ID: &id}
-		mpp.DB.Delete(&pattern)
-		deletedMaptterns = append(deletedMaptterns, pattern)
+	var deletedPatterns []MesheryPattern
+	var meshkitErr error
+
+	err := mpp.DB.Transaction(func(tx *gorm.DB) error {
+		for _, pObj := range patterns.Patterns {
+			id, err := uuid.FromString(pObj.ID)
+			if err != nil {
+				meshkitErr = ErrGenerateUUID(err)
+				return meshkitErr
+			}
+			pattern := MesheryPattern{ID: &id}
+			if err := tx.Delete(&pattern).Error; err != nil {
+				meshkitErr = ErrDBDelete(err, "")
+				return meshkitErr
+			}
+			deletedPatterns = append(deletedPatterns, pattern)
+		}
+		return nil
+	})
+
+	if err != nil {
+		if meshkitErr != nil {
+			return nil, meshkitErr
+		}
+		return nil, ErrDBDelete(err, "")
 	}
 
-	return marshalMesheryPatterns(deletedMaptterns), nil
+	return marshalMesheryPatterns(deletedPatterns), nil
 }
 
 func (mpp *MesheryPatternPersister) SaveMesheryPattern(pattern *MesheryPattern) ([]byte, error) {

--- a/server/models/performance_profile_persister.go
+++ b/server/models/performance_profile_persister.go
@@ -78,7 +78,9 @@ func (ppp *PerformanceProfilePersister) GetPerformanceProfiles(_, search, order 
 // DeletePerformanceProfile takes in a profile id and delete it if it already exists
 func (ppp *PerformanceProfilePersister) DeletePerformanceProfile(id core.Uuid) ([]byte, error) {
 	profile := PerformanceProfile{ID: &id}
-	ppp.DB.Delete(profile)
+	if err := ppp.DB.Delete(&profile).Error; err != nil {
+		return nil, ErrDBDelete(err, "")
+	}
 
 	return marshalPerformanceProfile(&profile), nil
 }


### PR DESCRIPTION
**Notes for Reviewers**

- This PR fixes #18132

### What this PR does

**Primary fix — `DeleteMesheryPatterns` (bulk delete):**
Wraps the entire delete loop in a `DB.Transaction()` so that if any individual delete fails, the full batch is rolled back automatically. Previously, each delete ran independently outside a transaction, allowing partial data deletion with no error signal.

**Secondary fix — silent error suppression in single-item deletes:**
Captures and returns the `.Error` from `DB.Delete()` in four persister functions that previously discarded it:
- `DeleteMesheryPattern` (`meshery_pattern_persister.go`)
- `DeleteMesheryFilter` (`meshery_filter_persister.go`)
- `DeletePerformanceProfile` (`performance_profile_persister.go`)
- `DeleteMesheryK8sContext` (`meshery_k8scontext_persister.go`)

**Additional fixes:**
- `DeletePerformanceProfile` was passing a value instead of a pointer to `DB.Delete()` — corrected to `&profile`.
- Fixed typo: `deletedMaptterns` → `deletedPatterns`.

### Impact

| Area | Before | After |
|------|--------|-------|
| Data consistency | Partial deletes possible on failure | Full atomicity via transaction |
| Error visibility | Silent `nil` error always returned | Actual DB errors propagated to caller |
| HTTP response accuracy | `200 OK` even on DB failure | Correct error status on failure |

The fix is non-breaking — only the error path changes. Successful operations behave identically.

**[Signed commits](https://github.com/meshery/meshery/blob/master/CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [x] Yes, I signed my commits.