### PR TITLE
feat(relationships): add ECS TaskDefinition → IAM Role permission relationships

### DIFF
--- a/server/meshmodel/aws-ecs-controller/v1.2.2/v1.0.0/relationships/edge-binding-permission-taskdef-execution-role.json
+++ b/server/meshmodel/aws-ecs-controller/v1.2.2/v1.0.0/relationships/edge-binding-permission-taskdef-execution-role.json
@@ -1,0 +1,102 @@
+{
+  "id": "00000000-0000-0000-0000-000000000000",
+  "evaluationQuery": "",
+  "kind": "edge",
+  "metadata": {
+    "description": "An ECS Task Definition references an IAM Role as its execution role, granting the ECS agent permission to pull container images and publish logs.",
+    "isAnnotation": false,
+    "styles": {
+      "primaryColor": "",
+      "svgColor": "",
+      "svgWhite": ""
+    }
+  },
+  "model": {
+    "displayName": "",
+    "id": "00000000-0000-0000-0000-000000000000",
+    "model": {
+      "version": "v1.2.2"
+    },
+    "name": "aws-ecs-controller",
+    "registrant": {
+      "kind": ""
+    },
+    "version": ""
+  },
+  "schemaVersion": "relationships.meshery.io/v1alpha3",
+  "selectors": [
+    {
+      "allow": {
+        "from": [
+          {
+            "id": null,
+            "kind": "Role",
+            "match": {},
+            "match_strategy_matrix": null,
+            "model": {
+              "displayName": "",
+              "id": "00000000-0000-0000-0000-000000000000",
+              "model": {
+                "version": ""
+              },
+              "name": "aws-iam-controller",
+              "registrant": {
+                "kind": "github"
+              },
+              "version": ""
+            },
+            "patch": {
+              "mutatorRef": [
+                [
+                  "configuration",
+                  "status",
+                  "ackResourceMetadata",
+                  "arn"
+                ]
+              ],
+              "patchStrategy": "replace"
+            }
+          }
+        ],
+        "to": [
+          {
+            "id": null,
+            "kind": "TaskDefinition",
+            "match": {},
+            "match_strategy_matrix": null,
+            "model": {
+              "displayName": "",
+              "id": "00000000-0000-0000-0000-000000000000",
+              "model": {
+                "version": ""
+              },
+              "name": "aws-ecs-controller",
+              "registrant": {
+                "kind": "github"
+              },
+              "version": ""
+            },
+            "patch": {
+              "mutatedRef": [
+                [
+                  "configuration",
+                  "spec",
+                  "executionRoleARN"
+                ]
+              ],
+              "patchStrategy": "replace"
+            }
+          }
+        ]
+      },
+      "deny": {
+        "from": [],
+        "to": []
+      }
+    }
+  ],
+  "subType": "permission",
+  "status": "enabled",
+  "type": "binding",
+  "version": "v1.0.0"
+}

--- a/server/meshmodel/aws-ecs-controller/v1.2.2/v1.0.0/relationships/edge-binding-permission-taskdef-task-role.json
+++ b/server/meshmodel/aws-ecs-controller/v1.2.2/v1.0.0/relationships/edge-binding-permission-taskdef-task-role.json
@@ -1,0 +1,102 @@
+{
+  "id": "00000000-0000-0000-0000-000000000000",
+  "evaluationQuery": "",
+  "kind": "edge",
+  "metadata": {
+    "description": "An ECS Task Definition references an IAM Role as its task role, granting containers in the task permission to call AWS APIs.",
+    "isAnnotation": false,
+    "styles": {
+      "primaryColor": "",
+      "svgColor": "",
+      "svgWhite": ""
+    }
+  },
+  "model": {
+    "displayName": "",
+    "id": "00000000-0000-0000-0000-000000000000",
+    "model": {
+      "version": "v1.2.2"
+    },
+    "name": "aws-ecs-controller",
+    "registrant": {
+      "kind": ""
+    },
+    "version": ""
+  },
+  "schemaVersion": "relationships.meshery.io/v1alpha3",
+  "selectors": [
+    {
+      "allow": {
+        "from": [
+          {
+            "id": null,
+            "kind": "Role",
+            "match": {},
+            "match_strategy_matrix": null,
+            "model": {
+              "displayName": "",
+              "id": "00000000-0000-0000-0000-000000000000",
+              "model": {
+                "version": ""
+              },
+              "name": "aws-iam-controller",
+              "registrant": {
+                "kind": "github"
+              },
+              "version": ""
+            },
+            "patch": {
+              "mutatorRef": [
+                [
+                  "configuration",
+                  "status",
+                  "ackResourceMetadata",
+                  "arn"
+                ]
+              ],
+              "patchStrategy": "replace"
+            }
+          }
+        ],
+        "to": [
+          {
+            "id": null,
+            "kind": "TaskDefinition",
+            "match": {},
+            "match_strategy_matrix": null,
+            "model": {
+              "displayName": "",
+              "id": "00000000-0000-0000-0000-000000000000",
+              "model": {
+                "version": ""
+              },
+              "name": "aws-ecs-controller",
+              "registrant": {
+                "kind": "github"
+              },
+              "version": ""
+            },
+            "patch": {
+              "mutatedRef": [
+                [
+                  "configuration",
+                  "spec",
+                  "taskRoleARN"
+                ]
+              ],
+              "patchStrategy": "replace"
+            }
+          }
+        ]
+      },
+      "deny": {
+        "from": [],
+        "to": []
+      }
+    }
+  ],
+  "subType": "permission",
+  "status": "enabled",
+  "type": "binding",
+  "version": "v1.0.0"
+}


### PR DESCRIPTION
Add two new cross-model permission relationships between aws-ecs-controller and aws-iam-controller, addressing a gap in ECS↔IAM coverage for issue #17096.

### New relationships

**Role → TaskDefinition (executionRoleARN)** (`edge/binding/permission`)
- Models the ECS task execution role that grants the ECS agent permission to pull container images and publish logs
- mutatorRef: `status.ackResourceMetadata.arn` (Role)
- mutatedRef: `spec.executionRoleARN` (TaskDefinition)

**Role → TaskDefinition (taskRoleARN)** (`edge/binding/permission`)
- Models the ECS task role that grants containers permission to call AWS APIs
- mutatorRef: `status.ackResourceMetadata.arn` (Role)
- mutatedRef: `spec.taskRoleARN` (TaskDefinition)

### Verification

- Confirmed no existing ECS↔IAM relationship in any version: `find server/meshmodel/aws-ecs-controller -name "*.json" -path "*/relationships/*" | xargs grep -l "Role"` returns empty
- Both follow the existing cross-model permission pattern from aws-eventbridge-controller (Role → EventBus)
- Registrant kind set to `github` on both sides, matching existing conventions

### Testing

- JSON schema validated against relationships.meshery.io/v1alpha3
- Field paths verified against actual component specs (TaskDefinition.spec.executionRoleARN, TaskDefinition.spec.taskRoleARN)
- Cross-model pattern matches existing merged relationship (aws-eventbridge-controller Role → EventBus)
- Kanvas visual validation to be done

Part of #17096

**Notes for Reviewers**
- This PR fixes #17096 (partial)

**Signed commits**
- [x] Yes, I signed my commits.