### PR TITLE
[Server] Ensure exported Models and Designs are compressed and tarred (.tar.gz)

### DIFF
--- a/server/handlers/component_handler.go
+++ b/server/handlers/component_handler.go
@@ -1767,25 +1767,38 @@ func (h *Handler) ExportModel(rw http.ResponseWriter, r *http.Request) {
 	if fileTypes == "oci" {
 		img, err := meshkitOci.BuildImage(modelDir)
 		if err != nil {
-			h.log.Error(err) // TODO: Add appropriate meshkit error
+			h.log.Error(err)
 			http.Error(rw, err.Error(), http.StatusInternalServerError)
 			return
 		}
-
-		// Save OCI artifact into a tar file
-		tarfileName := filepath.Join(modelDir, "model.tar")
+		// Step 1: create temporary .tar
+		tarfileName = filepath.Join(modelDir, "model.tar")
 		err = meshkitOci.SaveOCIArtifact(img, tarfileName, model.Name)
 		if err != nil {
 			h.log.Error(err)
 			http.Error(rw, err.Error(), http.StatusInternalServerError)
 			return
 		}
-
-		// 3. Send response
-		byt, _ = os.ReadFile(tarfileName)
-		rw.Header().Add("Content-Type", "application/x-tar")
-		rw.Header().Set("Content-Disposition", fmt.Sprintf("attachment; filename=\"%s.tar\"", model.Name))
-		rw.Header().Set("Content-Length", fmt.Sprintf("%d", len(byt)))
+		// Step 2: compress to .tar.gz
+		var gzipBuffer bytes.Buffer
+		err = meshkitutils.Compress(modelDir, &gzipBuffer)
+		if err != nil {
+			h.log.Error(err)
+			http.Error(rw, err.Error(), http.StatusInternalServerError)
+			return
+		}
+		// Step 3: write compressed file
+		tarGzFile := filepath.Join(modelDir, "model.tar.gz")
+		err = os.WriteFile(tarGzFile, gzipBuffer.Bytes(), 0644)
+		if err != nil {
+			h.log.Error(err)
+			http.Error(rw, err.Error(), http.StatusInternalServerError)
+			return
+		}
+		// Step 4: prepare response
+		byt, _ = os.ReadFile(tarGzFile)
+		rw.Header().Set("Content-Type", "application/gzip")
+		rw.Header().Set("Content-Disposition", fmt.Sprintf("attachment; filename=\"%s.tar.gz\"", model.Name))
 	} else {
 		var tarData bytes.Buffer
 		err := meshkitutils.Compress(modelDir, &tarData)
@@ -1802,9 +1815,8 @@ func (h *Handler) ExportModel(rw http.ResponseWriter, r *http.Request) {
 			return
 		}
 		byt, _ = os.ReadFile(tarfileName)
-		rw.Header().Add("Content-Type", "application/gzip")
+		rw.Header().Set("Content-Type", "application/gzip")
 		rw.Header().Set("Content-Disposition", fmt.Sprintf("attachment; filename=\"%s.tar.gz\"", model.Name))
-
 	}
 
 	// 3. Send response

--- a/server/handlers/meshery_pattern_handler.go
+++ b/server/handlers/meshery_pattern_handler.go
@@ -2,6 +2,7 @@ package handlers
 
 import (
 	"bytes"
+	"compress/gzip"
 	"context"
 	"database/sql"
 	"encoding/json"
@@ -1006,6 +1007,23 @@ func (h *Handler) DownloadMesheryPatternHandler(
 		if err != nil {
 			h.log.Error(ErrIOReader(err))
 			http.Error(rw, ErrIOReader(err).Error(), http.StatusInternalServerError)
+			return
+		}
+
+		var gzipBuffer bytes.Buffer
+		gzipWriter := gzip.NewWriter(&gzipBuffer)
+
+		_, err = gzipWriter.Write(content)
+		if err != nil {
+			h.log.Error(err)
+			http.Error(rw, err.Error(), http.StatusInternalServerError)
+			return
+		}
+
+		gzipWriter.Close()
+		if err != nil {
+			h.log.Error(ErrIOReader(err))
+			http.Error(rw, ErrIOReader(err).Error(), http.StatusInternalServerError)
 			event := eventBuilder.WithSeverity(events.Error).WithMetadata(map[string]interface{}{
 				"error": ErrIOReader(err),
 			}).WithDescription(fmt.Sprintf("Failed to read contents of OCI artifact %s", tmpOCITarFilePath)).Build()
@@ -1022,10 +1040,48 @@ func (h *Handler) DownloadMesheryPatternHandler(
 		go h.config.EventBroadcaster.Publish(userID, event)
 		_ = provider.PersistEvent(*event, nil)
 
-		rw.Header().Set("Content-Type", "application/tar")
-		rw.Header().Add("Content-Disposition", fmt.Sprintf("attachment;filename=%s.tar", pattern.Name))
+		rw.Header().Set("Content-Type", "application/gzip")
+		rw.Header().Set("Content-Disposition", fmt.Sprintf("attachment; filename=%s.tar.gz", pattern.Name))
 
-		reader := bytes.NewReader(content)
+		content, err = io.ReadAll(file)
+		if err != nil {
+			h.log.Error(ErrIOReader(err))
+			http.Error(rw, ErrIOReader(err).Error(), http.StatusInternalServerError)
+			return
+		}
+
+		gzipWriter = gzip.NewWriter(&gzipBuffer)
+
+		_, err = gzipWriter.Write(content)
+		if err != nil {
+			h.log.Error(err)
+			http.Error(rw, err.Error(), http.StatusInternalServerError)
+			return
+		}
+
+		err = gzipWriter.Close()
+		if err != nil {
+			h.log.Error(err)
+			http.Error(rw, err.Error(), http.StatusInternalServerError)
+			return
+		}
+
+		// Logging (keep as is)
+		h.log.Info("OCI Artifact saved at: ", tmpOCITarFilePath)
+
+		eventBuilder.WithSeverity(events.Informational).WithDescription(
+			fmt.Sprintf("OCI Artifact temporarily saved at: %s", tmpOCITarFilePath),
+		)
+		event = eventBuilder.Build()
+		go h.config.EventBroadcaster.Publish(userID, event)
+		_ = provider.PersistEvent(*event, nil)
+
+		// Headers
+		rw.Header().Set("Content-Type", "application/gzip")
+		rw.Header().Set("Content-Disposition", fmt.Sprintf("attachment; filename=%s.tar.gz", pattern.Name))
+
+		// Send response (KEEP io.Copy style)
+		reader := bytes.NewReader(gzipBuffer.Bytes())
 		if _, err := io.Copy(rw, reader); err != nil {
 			http.Error(rw, ErrIOReader(err).Error(), http.StatusInternalServerError)
 			event := eventBuilder.WithSeverity(events.Error).WithMetadata(map[string]interface{}{


### PR DESCRIPTION
## Overview
This PR ensures that all exported Meshery Models and Designs are both tarred and compressed (`.tar.gz`), addressing issue 

## Problem
Previously, exported artifacts (Models and Designs) were only packaged as `.tar` files in certain flows (especially OCI-based exports). This resulted in larger file sizes and inconsistency across export mechanisms.

## Solution
- Added gzip compression layer on top of existing tar packaging.
- Ensured `.tar.gz` output for:
  - Meshery Server APIs (Model export, Design export)
- Updated response headers:
  - `Content-Type: application/gzip`
  - `Content-Disposition: attachment; filename=<name>.tar.gz`

## Key Implementation Details
- OCI artifacts are first generated as `.tar`
- The resulting tar is compressed using gzip before being sent in the response
- Existing streaming logic (`io.Copy`) and event handling were preserved to minimize impact
- Compression logic added without altering existing directory structure or OCI packaging

## Validation

### 1. CLI Export
Executed:

<img width="1690" height="1124" alt="image" src="https://github.com/user-attachments/assets/ef566fbb-35ab-48f9-a020-937cb9fd4b02" />



Fixes #11605
