### PR TITLE
[Models] Improve relationships for ms-catalogs-worker component

### DIFF
--- a/server/meshmodel/components/ms-catalogs-worker.yaml
+++ b/server/meshmodel/components/ms-catalogs-worker.yaml
@@ -37,4 +37,29 @@ components:
       selector:
         app: ms-catalogs-worker
 
-relationships: []
+relationships:
+  - kind: Edge
+    type: "exposes"
+    from:
+      kind: Deployment
+      name: ms-catalogs-worker
+    to:
+      kind: Service
+      name: ms-catalogs-worker-service
+
+  - kind: Edge
+    type: "selects"
+    from:
+      kind: Service
+      name: ms-catalogs-worker-service
+    to:
+      kind: Pod
+      name: ms-catalogs-worker
+
+  - kind: Edge
+    type: "runs"
+    from:
+      kind: Pod
+      name: ms-catalogs-worker
+    to:
+      kind: Node


### PR DESCRIPTION
## Description

This PR enhances the relationship definitions for the ms-catalogs-worker MeshModel component.

### Changes:
- Added Deployment → Service relationship (exposes)
- Added Service → Pod relationship (selects)
- Added Pod → Node relationship (runs)

These improvements provide better representation of Kubernetes workload interactions and infrastructure mapping.

## Checklist
- [x] Relationships updated
- [x] YAML validated
- [x] Signed-off commits included


Related to #15531