### PR TITLE
[Docs] Add Hugo shortcode for member-form

### DIFF
--- a/docs/content/en/project/contributing/contributing-cli.md
+++ b/docs/content/en/project/contributing/contributing-cli.md
@@ -7,6 +7,7 @@ categories: [contributing]
 `mesheryctl` is written in Golang or the Go Programming Language. For development use [Go version 1.25+](https://go.dev/dl/). `mesheryctl` uses the [Cobra](https://github.com/spf13/cobra) framework. A good first-step towards contributing to `mesheryctl` would be to familiarize yourself with the [Cobra concepts](https://github.com/spf13/cobra#concepts). For manipulating config files, `mesheryctl` uses [Viper](https://github.com/spf13/viper).
 
 {{% alert color="info" title="Meshery CLI Reference Documents" %}}<ul><li><a href="https://docs.google.com/spreadsheets/d/1q63sIGAuCnIeDs8PeM-0BAkNj8BBgPUXhLbe1Y-318o/edit#gid=0">Meshery Command Tracker</a>: Status of mesheryctl command implementation and platform compatibility.</li>
+
 <li><a href="https://docs.google.com/document/d/1xRlFpElRmybJ3WacgPKXgCSiQ2poJl3iCCV1dAalf0k/edit#">Meshery CLI Commands and Documentation</a>: Detailed documentation of the `mesheryctl` commands.</li>
 <li><a href="https://docs.google.com/spreadsheets/d/13Ir4gfaKoAX9r8qYjAFFl_U9ntke4X5ndREY1T7bnVs/edit?gid=1907616946#gid=1907616946">Meshery Test Plan</a>: Test cases for end-to-end testing of Meshery functionality.</li>
 <li><a href="https://github.com/meshery/meshery/labels/component%2Fmesheryctl">mesheryctl open issues and pull requests</a>: Matching the "component/mesheryctl" label.</li></ul>{{% /alert %}}

--- a/docs/content/en/project/contributing/contributing-cli.md
+++ b/docs/content/en/project/contributing/contributing-cli.md
@@ -40,10 +40,10 @@ The documentation pages for `mesheryctl` reference are made with the help of the
 - Then, edit the Cobra macro variables present in the each file. An example is given below for reference.
 
 {{< code code=`var startCmd = &cobra.Command{
-Use: "start",
-Short: "Start Meshery",
-Long: 'Start Meshery and each of its components.',
-Args: cobra.NoArgs,
+    Use:   "start",
+    Short: "Start Meshery",
+    Long:  'Start Meshery and each of its components.',
+    Args:  cobra.NoArgs,
 Example:
 // Start meshery
 mesheryctl system start
@@ -58,8 +58,8 @@ The variables present in above sample will be used in creating the doc pages for
 Also, if the screenshot is present in the command, an `Annotation` macro variable (of `map[string]string` type) containing the `link` and the `caption` has to be added at the bottom of the `Examples` field in the command file. The image file has to be included in the `docs/content/en/reference/images` folder in **PNG** format. The screenshot field is given for reference below
 
 {{< code code=`var linkDocPatternApply = map[string]string{
-"link": "![pattern-apply-usage](/reference/images/patternApply.png)",
-"caption": "Usage of mesheryctl design apply",
+    "link":    "![pattern-apply-usage](/reference/images/patternApply.png)",
+    "caption": "Usage of mesheryctl design apply",
 }
 ...
 Example:

--- a/docs/content/en/project/contributing/contributing-cli.md
+++ b/docs/content/en/project/contributing/contributing-cli.md
@@ -7,14 +7,15 @@ categories: [contributing]
 `mesheryctl` is written in Golang or the Go Programming Language. For development use [Go version 1.25+](https://go.dev/dl/). `mesheryctl` uses the [Cobra](https://github.com/spf13/cobra) framework. A good first-step towards contributing to `mesheryctl` would be to familiarize yourself with the [Cobra concepts](https://github.com/spf13/cobra#concepts). For manipulating config files, `mesheryctl` uses [Viper](https://github.com/spf13/viper).
 
 {{% alert color="info" title="Meshery CLI Reference Documents" %}}<ul><li><a href="https://docs.google.com/spreadsheets/d/1q63sIGAuCnIeDs8PeM-0BAkNj8BBgPUXhLbe1Y-318o/edit#gid=0">Meshery Command Tracker</a>: Status of mesheryctl command implementation and platform compatibility.</li>
-    <li><a href="https://docs.google.com/document/d/1xRlFpElRmybJ3WacgPKXgCSiQ2poJl3iCCV1dAalf0k/edit#">Meshery CLI Commands and Documentation</a>: Detailed documentation of the `mesheryctl` commands.</li>
-    <li><a href="https://docs.google.com/spreadsheets/d/13Ir4gfaKoAX9r8qYjAFFl_U9ntke4X5ndREY1T7bnVs/edit?gid=1907616946#gid=1907616946">Meshery Test Plan</a>: Test cases for end-to-end testing of Meshery functionality.</li>
-	<li><a href="https://github.com/meshery/meshery/labels/component%2Fmesheryctl">mesheryctl open issues and pull requests</a>: Matching the "component/mesheryctl" label.</li></ul>{{% /alert %}}
+<li><a href="https://docs.google.com/document/d/1xRlFpElRmybJ3WacgPKXgCSiQ2poJl3iCCV1dAalf0k/edit#">Meshery CLI Commands and Documentation</a>: Detailed documentation of the `mesheryctl` commands.</li>
+<li><a href="https://docs.google.com/spreadsheets/d/13Ir4gfaKoAX9r8qYjAFFl_U9ntke4X5ndREY1T7bnVs/edit?gid=1907616946#gid=1907616946">Meshery Test Plan</a>: Test cases for end-to-end testing of Meshery functionality.</li>
+<li><a href="https://github.com/meshery/meshery/labels/component%2Fmesheryctl">mesheryctl open issues and pull requests</a>: Matching the "component/mesheryctl" label.</li></ul>{{% /alert %}}
 
+{{< member-form >}}
 
 ### Designing Commands
 
-The [Meshery CLI Style Guide](/project/contributing/contributing-cli-guide) outlines the process by which new commands are designed and contains a collection of principles and conventions that need to be followed while designing `mesheryctl` commands. `mesheryctl` might be the interface that the users first have with Meshery. As such, `mesheryctl` needs to provide a great UX. 
+The [Meshery CLI Style Guide](/project/contributing/contributing-cli-guide) outlines the process by which new commands are designed and contains a collection of principles and conventions that need to be followed while designing `mesheryctl` commands. `mesheryctl` might be the interface that the users first have with Meshery. As such, `mesheryctl` needs to provide a great UX.
 
 ### Building CLI
 
@@ -38,10 +39,10 @@ The documentation pages for `mesheryctl` reference are made with the help of the
 - Then, edit the Cobra macro variables present in the each file. An example is given below for reference.
 
 {{< code code=`var startCmd = &cobra.Command{
-Use:   "start",
+Use: "start",
 Short: "Start Meshery",
-Long:  'Start Meshery and each of its components.',
-Args:  cobra.NoArgs,
+Long: 'Start Meshery and each of its components.',
+Args: cobra.NoArgs,
 Example:
 // Start meshery
 mesheryctl system start
@@ -51,13 +52,13 @@ mesheryctl system context create k8s -p kubernetes -s,
 Annotations: linkScreenshot,
 ...` >}}
 
-  The variables present in above sample will be used in creating the doc pages for the specific command
+The variables present in above sample will be used in creating the doc pages for the specific command
 
 Also, if the screenshot is present in the command, an `Annotation` macro variable (of `map[string]string` type) containing the `link` and the `caption` has to be added at the bottom of the `Examples` field in the command file. The image file has to be included in the `docs/content/en/reference/images` folder in **PNG** format. The screenshot field is given for reference below
 
 {{< code code=`var linkDocPatternApply = map[string]string{
-	"link":    "![pattern-apply-usage](/reference/images/patternApply.png)",
-	"caption": "Usage of mesheryctl design apply",
+"link": "![pattern-apply-usage](/reference/images/patternApply.png)",
+"caption": "Usage of mesheryctl design apply",
 }
 ...
 Example:
@@ -76,10 +77,10 @@ Annotations: linkDocPatternApply,
 Though the command page is generated automatically by the Cobra CLI library, there are chances where the command does not appear in the [reference index page](/reference/mesheryctl). In such cases, the command details must be manually added to the reference index YAML file. This is generally done by editing the below two files:
 
 - [cmds.yml](https://github.com/meshery/meshery/blob/master/docs/data/mesheryctlcommands/cmds.yml) - The YAML file containing the data about the commands
-- [_index.md](https://github.com/meshery/meshery/blob/master/docs/content/en/reference/mesheryctl/_index.md) - The markdown page of the command reference documentation
+- [\_index.md](https://github.com/meshery/meshery/blob/master/docs/content/en/reference/mesheryctl/_index.md) - The markdown page of the command reference documentation
 
 ### Preserving Manually Added Documentation
-	
+
 `mesheryctl` uses Cobra CLI library and GitHub Actions to automate the generation of command documentation pages. On occasion, additional documentation beyond that included in the `mesheryctl` Golang files is ideal to capture and include in the CLI reference pages. Contributors are encouraged to add more usage examples, screenshots to any of the CLI reference pages. To protect any manually added content and ensure it remains intact after regeneration, create a separate Hugo `shortcode` file. Follow file naming scheme outlined below:
 
 If your mesheryctl docs end like this, add a shortcode at the end of the file. An example is given below
@@ -92,6 +93,7 @@ mesheryctl design apply -f [file | URL]
 mesheryctl design apply [design-name],
 Annotations: linkDocPatternApply,
 ...
+
 <pre class='codeblock-pre'>
 <div class='codeblock'>
       --config string   path to config file (default "/home/runner/.meshery/config.yaml")
@@ -100,6 +102,7 @@ Annotations: linkDocPatternApply,
 
 </div>
 </pre>
+
 {{< permalink-of-file >}}` >}}
 
 ## Quality

--- a/docs/content/en/project/contributing/contributing-cli.md
+++ b/docs/content/en/project/contributing/contributing-cli.md
@@ -7,16 +7,15 @@ categories: [contributing]
 `mesheryctl` is written in Golang or the Go Programming Language. For development use [Go version 1.25+](https://go.dev/dl/). `mesheryctl` uses the [Cobra](https://github.com/spf13/cobra) framework. A good first-step towards contributing to `mesheryctl` would be to familiarize yourself with the [Cobra concepts](https://github.com/spf13/cobra#concepts). For manipulating config files, `mesheryctl` uses [Viper](https://github.com/spf13/viper).
 
 {{% alert color="info" title="Meshery CLI Reference Documents" %}}<ul><li><a href="https://docs.google.com/spreadsheets/d/1q63sIGAuCnIeDs8PeM-0BAkNj8BBgPUXhLbe1Y-318o/edit#gid=0">Meshery Command Tracker</a>: Status of mesheryctl command implementation and platform compatibility.</li>
-
-<li><a href="https://docs.google.com/document/d/1xRlFpElRmybJ3WacgPKXgCSiQ2poJl3iCCV1dAalf0k/edit#">Meshery CLI Commands and Documentation</a>: Detailed documentation of the `mesheryctl` commands.</li>
-<li><a href="https://docs.google.com/spreadsheets/d/13Ir4gfaKoAX9r8qYjAFFl_U9ntke4X5ndREY1T7bnVs/edit?gid=1907616946#gid=1907616946">Meshery Test Plan</a>: Test cases for end-to-end testing of Meshery functionality.</li>
-<li><a href="https://github.com/meshery/meshery/labels/component%2Fmesheryctl">mesheryctl open issues and pull requests</a>: Matching the "component/mesheryctl" label.</li></ul>{{% /alert %}}
+    <li><a href="https://docs.google.com/document/d/1xRlFpElRmybJ3WacgPKXgCSiQ2poJl3iCCV1dAalf0k/edit#">Meshery CLI Commands and Documentation</a>: Detailed documentation of the `mesheryctl` commands.</li>
+    <li><a href="https://docs.google.com/spreadsheets/d/13Ir4gfaKoAX9r8qYjAFFl_U9ntke4X5ndREY1T7bnVs/edit?gid=1907616946#gid=1907616946">Meshery Test Plan</a>: Test cases for end-to-end testing of Meshery functionality.</li>
+	<li><a href="https://github.com/meshery/meshery/labels/component%2Fmesheryctl">mesheryctl open issues and pull requests</a>: Matching the "component/mesheryctl" label.</li></ul>{{% /alert %}}
 
 {{< member-form >}}
 
 ### Designing Commands
 
-The [Meshery CLI Style Guide](/project/contributing/contributing-cli-guide) outlines the process by which new commands are designed and contains a collection of principles and conventions that need to be followed while designing `mesheryctl` commands. `mesheryctl` might be the interface that the users first have with Meshery. As such, `mesheryctl` needs to provide a great UX.
+The [Meshery CLI Style Guide](/project/contributing/contributing-cli-guide) outlines the process by which new commands are designed and contains a collection of principles and conventions that need to be followed while designing `mesheryctl` commands. `mesheryctl` might be the interface that the users first have with Meshery. As such, `mesheryctl` needs to provide a great UX. 
 
 ### Building CLI
 
@@ -40,10 +39,10 @@ The documentation pages for `mesheryctl` reference are made with the help of the
 - Then, edit the Cobra macro variables present in the each file. An example is given below for reference.
 
 {{< code code=`var startCmd = &cobra.Command{
-    Use:   "start",
-    Short: "Start Meshery",
-    Long:  'Start Meshery and each of its components.',
-    Args:  cobra.NoArgs,
+Use:   "start",
+Short: "Start Meshery",
+Long:  'Start Meshery and each of its components.',
+Args:  cobra.NoArgs,
 Example:
 // Start meshery
 mesheryctl system start
@@ -53,13 +52,13 @@ mesheryctl system context create k8s -p kubernetes -s,
 Annotations: linkScreenshot,
 ...` >}}
 
-The variables present in above sample will be used in creating the doc pages for the specific command
+  The variables present in above sample will be used in creating the doc pages for the specific command
 
 Also, if the screenshot is present in the command, an `Annotation` macro variable (of `map[string]string` type) containing the `link` and the `caption` has to be added at the bottom of the `Examples` field in the command file. The image file has to be included in the `docs/content/en/reference/images` folder in **PNG** format. The screenshot field is given for reference below
 
 {{< code code=`var linkDocPatternApply = map[string]string{
-    "link":    "![pattern-apply-usage](/reference/images/patternApply.png)",
-    "caption": "Usage of mesheryctl design apply",
+	"link":    "![pattern-apply-usage](/reference/images/patternApply.png)",
+	"caption": "Usage of mesheryctl design apply",
 }
 ...
 Example:
@@ -78,10 +77,10 @@ Annotations: linkDocPatternApply,
 Though the command page is generated automatically by the Cobra CLI library, there are chances where the command does not appear in the [reference index page](/reference/mesheryctl). In such cases, the command details must be manually added to the reference index YAML file. This is generally done by editing the below two files:
 
 - [cmds.yml](https://github.com/meshery/meshery/blob/master/docs/data/mesheryctlcommands/cmds.yml) - The YAML file containing the data about the commands
-- [\_index.md](https://github.com/meshery/meshery/blob/master/docs/content/en/reference/mesheryctl/_index.md) - The markdown page of the command reference documentation
+- [_index.md](https://github.com/meshery/meshery/blob/master/docs/content/en/reference/mesheryctl/_index.md) - The markdown page of the command reference documentation
 
 ### Preserving Manually Added Documentation
-
+	
 `mesheryctl` uses Cobra CLI library and GitHub Actions to automate the generation of command documentation pages. On occasion, additional documentation beyond that included in the `mesheryctl` Golang files is ideal to capture and include in the CLI reference pages. Contributors are encouraged to add more usage examples, screenshots to any of the CLI reference pages. To protect any manually added content and ensure it remains intact after regeneration, create a separate Hugo `shortcode` file. Follow file naming scheme outlined below:
 
 If your mesheryctl docs end like this, add a shortcode at the end of the file. An example is given below
@@ -94,7 +93,6 @@ mesheryctl design apply -f [file | URL]
 mesheryctl design apply [design-name],
 Annotations: linkDocPatternApply,
 ...
-
 <pre class='codeblock-pre'>
 <div class='codeblock'>
       --config string   path to config file (default "/home/runner/.meshery/config.yaml")
@@ -103,7 +101,6 @@ Annotations: linkDocPatternApply,
 
 </div>
 </pre>
-
 {{< permalink-of-file >}}` >}}
 
 ## Quality

--- a/docs/layouts/shortcodes/member-form.html
+++ b/docs/layouts/shortcodes/member-form.html
@@ -1,0 +1,4 @@
+<div class="alert alert-dark" role="alert">
+    <h4 class="alert-heading">Resource Access</h4>
+    Fill-in a <a href="https://meshery.io/newcomers">community member form</a> to gain access to community resources.
+</div>


### PR DESCRIPTION
**Notes for Reviewers**

This PR restores the `member-form` "Resource Access" alert box that was originally present in the Jekyll documentation but was lost during the recent migration to Hugo.

**Changes introduced:**
- Created a new Hugo shortcode at [layouts/shortcodes/member-form.html](cci:7://file:///home/umesh/oss/meshery/docs/layouts/shortcodes/member-form.html:0:0-0:0) containing the original alert box HTML.
- Injected the `{{< member-form >}}` shortcode into the [contributing-cli.md](cci:7://file:///home/umesh/oss/meshery/docs/content/en/project/contributing/contributing-cli.md:0:0-0:0) page right before the "Designing Commands" section.

- This PR fixes #17639

**[Signed commits](https://github.com/meshery/meshery/blob/master/CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [x] Yes, I signed my commits.

## Screenshots
<!! Drag and drop the screenshot you took of the local server rendering right here !!>

<!--
Thank you for contributing to Meshery! 

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. Sign your commits.
4. Include before and after screenshots/terminal output.

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.
-->
