### PR TITLE
Docs: improve clarity of local setup instructions

### DIFF
--- a/docs/content/en/project/contributing/contributing-docs.md
+++ b/docs/content/en/project/contributing/contributing-docs.md
@@ -76,6 +76,17 @@ In case of any installation issues, use the [discussion forum](https://meshery.i
 
   This runs `hugo server -D -F`, which serves the site with draft and future content enabled. The site will be available at `http://localhost:1313`.
 
+       ### Beginner Note
+
+       Though the recommended way to run the Meshery documentation is:
+
+      ```bash
+      make setup
+      make site
+
+      some users may attempt to run npm commands directly. In such cases ensure that Go is installed, as it is required for Hugo modules.otherwise u may encounter errors like:
+      "binary with name 'go' not found in PATH"
+
 - To build the site without serving:
 
   <pre class="codeblock-pre"><div class="codeblock">


### PR DESCRIPTION
**Notes for Reviewers**
## Description
Added a beginner note to clarify setup instructions so as to avoid confusion and prevent common errors when running Meshery docs locally.

## Changes
- Added clarification about using make commands
- Highlighted Go dependency for Hugo modules


- This PR fixes #18367 

**[Signed commits](https://github.com/meshery/meshery/blob/master/CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [ ] Yes, I signed my commits.

<!--
Thank you for contributing to Meshery! 

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. Sign your commits.
4. Include before and after screenshots/terminal output.

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.
-->
