### PR TITLE
fix(docs): replace literal "undefined" SVG stroke attributes with valid values

### DIFF
--- a/docs/layouts/partials/footer.html
+++ b/docs/layouts/partials/footer.html
@@ -60,7 +60,7 @@
           <path
             d="M3.5 0a.5.5 0 0 1 .5.5V1h8V.5a.5.5 0 0 1 1 0V1h1a2 2 0 0 1 2 2v11a2 2 0 0 1-2 2H2a2 2 0 0 1-2-2V3a2 2 0 0 1 2-2h1V.5a.5.5 0 0 1 .5-.5zM1 4v10a1 1 0 0 0 1 1h12a1 1 0 0 0 1-1V4H1z"
           />
-          <g stroke-linecap="undefined" stroke-linejoin="undefined">
+          <g stroke-linecap="round" stroke-linejoin="round">
             <path d="M-3.468 8.168h-.033m25.313-4.242l-.063-.254M7.858 4.814v9.387" />
             <path d="M1.833 9.507h12.051" />
           </g>


### PR DESCRIPTION
## Problem

`docs/layouts/partials/footer.html` contains an inline SVG where `stroke-linecap` and `stroke-linejoin` are set to the literal string `"undefined"`, which is not a valid SVG value.

## Solution

Replaced both attributes with `"round"`, which is valid for both `stroke-linecap` and `stroke-linejoin`.

## Files Changed

- `docs/layouts/partials/footer.html` — line 63

Closes #18417