### PR TITLE
fix(docs): replace deprecated word-wrap with overflow-wrap

### DIFF
--- a/docs/assets/scss/_table.scss
+++ b/docs/assets/scss/_table.scss
@@ -26,7 +26,7 @@ table td {
   padding: 8px;
   text-align: left;
   max-width: 300px;
-  word-wrap: break-word;
+  overflow-wrap: break-word;
 }
 table td img {
   text-align: center;

--- a/docs/assets/scss/_table.scss
+++ b/docs/assets/scss/_table.scss
@@ -26,6 +26,7 @@ table td {
   padding: 8px;
   text-align: left;
   max-width: 300px;
+  word-wrap: break-word;
   overflow-wrap: break-word;
 }
 table td img {


### PR DESCRIPTION
## Problem

`docs/assets/scss/_table.scss` uses the deprecated `word-wrap` CSS property instead of the standardized `overflow-wrap`.

## Solution

Replaced `word-wrap: break-word;` with `overflow-wrap: break-word;` as specified in CSS Text Module Level 3.

## Files Changed

- `docs/assets/scss/_table.scss` — line 29

Closes #18418