### PR TITLE
fix(docs): quote unquoted alt attribute in relationships shortcode

### DIFF
--- a/docs/layouts/shortcodes/relationships.html
+++ b/docs/layouts/shortcodes/relationships.html
@@ -5,7 +5,7 @@
 </style>
 <details open>
     <summary>Example Visual Representations</summary>
-    <details close><summary>Kind: Hierarchical</summary>
+    <details><summary>Kind: Hierarchical</summary>
         <figure>
             <figcaption>subType: Parent | Namespace (Parent) and ConfigMap (child), Role (Child)<a target="_blank" href="https://playground.meshery.io/extension/meshmap?mode=design&design=6370ffcd-13a6-4a65-b426-30f1e63dc381"> (open in playground)</a></figcaption>
         </figure>
@@ -16,11 +16,11 @@
         </figure>
         <img alt="Hierarchical - Parent: Namespace to other components" src="/concepts/logical/relationships/images/hierarchical_inventory_relationship.svg"/>
     </details>
-    <details close><summary>Kind: Edge</summary>
+    <details><summary>Kind: Edge</summary>
         <figure>
             <figcaption>Type: `Non-Binding`, subType: `Permission`: Cluster Role with Cluster Role Binding to Service Account<a target="_blank" href="https://playground.meshery.io/extension/meshmap?mode=design&design=7dd39d30-7b14-4f9f-a66c-06ba3e5000fa"> (open in playground)</a></figcaption>
         </figure>
-        <img alt=Binding src="/concepts/logical/relationships/images/edge_permission_relationship_cluster_role_service_account.svg"/>
+        <img alt="Binding" src="/concepts/logical/relationships/images/edge_permission_relationship_cluster_role_service_account.svg"/>
         <figure>
             <figcaption>Type: `Binding`, subType: `Mount`: Pod to Persistent volume via Persistent volume claim<a target="_blank" href="https://playground.meshery.io/extension/meshmap?mode=design&design=43d5fdfe-25f8-4c2c-be9d-30861bbc2a08"> (open in playground)</a> </figcaption>
         </figure>


### PR DESCRIPTION
## Problem

`docs/layouts/shortcodes/relationships.html` has an `<img>` tag with an unquoted `alt` attribute (`alt=Binding`), which is invalid HTML5.

## Solution

Added proper double quotes: `alt="Binding"`.

## Files Changed

- `docs/layouts/shortcodes/relationships.html` — line 23

Closes #18415