### PR TITLE
[Server] Fix unauthenticated file read endpoints

### DIFF
--- a/server/handlers/common_handlers.go
+++ b/server/handlers/common_handlers.go
@@ -168,7 +168,7 @@ func (h *Handler) serveAllowedFile(responseWriter http.ResponseWriter, request *
 
 	if _, err = io.Copy(responseWriter, file); err != nil {
 		h.log.Error(err)
-		http.Error(responseWriter, "failed to stream requested file", http.StatusInternalServerError)
+		return
 	}
 }
 
@@ -276,7 +276,7 @@ func pathWithinAllowedRoots(path string, allowedRoots []string) (bool, error) {
 		if err != nil {
 			return false, fmt.Errorf("resolve relative path from %q to %q: %w", allowedRoot, path, err)
 		}
-		if relPath == "." || (relPath != ".." && !strings.HasPrefix(relPath, ".."+string(os.PathSeparator))) {
+		if !strings.HasPrefix(relPath, "..") {
 			return true, nil
 		}
 	}

--- a/server/handlers/common_handlers.go
+++ b/server/handlers/common_handlers.go
@@ -3,15 +3,23 @@ package handlers
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
-	"net/url"
 	"os"
 	"path/filepath"
+	"strings"
 
 	"github.com/meshery/meshery/server/core"
 	"github.com/meshery/meshery/server/models"
+	"github.com/spf13/viper"
+)
+
+var (
+	errMissingFilePath     = errors.New("missing file query parameter")
+	errFileAccessDenied    = errors.New("requested file is not available")
+	errUnsupportedFileType = errors.New("requested path must point to a file")
 )
 
 // swagger:route GET /user/login UserAPI idGetUserLogin
@@ -102,32 +110,7 @@ func (h *Handler) TokenHandler(w http.ResponseWriter, r *http.Request, p models.
 
 // ViewHandler handles viewing the file content.
 func (h *Handler) ViewHandler(responseWriter http.ResponseWriter, request *http.Request) {
-	filePath, err := url.QueryUnescape(request.URL.Query().Get("file"))
-
-	if err != nil {
-		http.Error(responseWriter, err.Error(), http.StatusBadRequest)
-		return
-	}
-	file, err := os.Open(filePath)
-	if err != nil {
-		http.Error(responseWriter, err.Error(), http.StatusInternalServerError)
-		return
-	}
-	defer func() {
-		if err := file.Close(); err != nil {
-			h.log.Error(err)
-		}
-	}()
-
-	// Set the content type to plain text
-	responseWriter.Header().Set("Content-Type", "text/plain")
-
-	// Copy the file content to the response writer
-	_, err = io.Copy(responseWriter, file)
-	if err != nil {
-		http.Error(responseWriter, err.Error(), http.StatusInternalServerError)
-		return
-	}
+	h.serveAllowedFile(responseWriter, request, false)
 }
 
 // swagger:route GET /api/system/downloadFile system downloadFile idDownloadFile
@@ -141,15 +124,35 @@ func (h *Handler) ViewHandler(responseWriter http.ResponseWriter, request *http.
 
 // DownloadHandler handles downloading the file.
 func (h *Handler) DownloadHandler(responseWriter http.ResponseWriter, request *http.Request) {
-	filePath, err := url.QueryUnescape(request.URL.Query().Get("file"))
+	h.serveAllowedFile(responseWriter, request, true)
+}
+
+func (h *Handler) serveAllowedFile(responseWriter http.ResponseWriter, request *http.Request, download bool) {
+	filePath, err := validateMesheryLogFilePath(request.URL.Query().Get("file"))
 	if err != nil {
-		http.Error(responseWriter, err.Error(), http.StatusBadRequest)
+		switch {
+		case errors.Is(err, errMissingFilePath), errors.Is(err, errUnsupportedFileType):
+			http.Error(responseWriter, err.Error(), http.StatusBadRequest)
+		case errors.Is(err, errFileAccessDenied):
+			http.Error(responseWriter, err.Error(), http.StatusForbidden)
+		case errors.Is(err, os.ErrNotExist):
+			http.Error(responseWriter, "requested file was not found", http.StatusNotFound)
+		default:
+			h.log.Error(err)
+			http.Error(responseWriter, "failed to process requested file", http.StatusInternalServerError)
+		}
 		return
 	}
 
 	file, err := os.Open(filePath)
 	if err != nil {
-		http.Error(responseWriter, err.Error(), http.StatusInternalServerError)
+		if errors.Is(err, os.ErrNotExist) {
+			http.Error(responseWriter, "requested file was not found", http.StatusNotFound)
+			return
+		}
+
+		h.log.Error(err)
+		http.Error(responseWriter, "failed to open requested file", http.StatusInternalServerError)
 		return
 	}
 	defer func() {
@@ -158,15 +161,127 @@ func (h *Handler) DownloadHandler(responseWriter http.ResponseWriter, request *h
 		}
 	}()
 
-	fileName := filepath.Base(filePath)
 	responseWriter.Header().Set("Content-Type", "text/plain")
-	responseWriter.Header().Set("Content-Disposition", fmt.Sprintf("attachment; filename=\"%s\"", fileName))
-
-	_, err = io.Copy(responseWriter, file)
-	if err != nil {
-		http.Error(responseWriter, err.Error(), http.StatusInternalServerError)
-		return
+	if download {
+		responseWriter.Header().Set("Content-Disposition", fmt.Sprintf("attachment; filename=\"%s\"", filepath.Base(filePath)))
 	}
+
+	if _, err = io.Copy(responseWriter, file); err != nil {
+		h.log.Error(err)
+		http.Error(responseWriter, "failed to stream requested file", http.StatusInternalServerError)
+	}
+}
+
+func validateMesheryLogFilePath(filePath string) (string, error) {
+	if filePath == "" {
+		return "", errMissingFilePath
+	}
+
+	if !filepath.IsAbs(filePath) {
+		return "", errFileAccessDenied
+	}
+
+	allowedRoots, err := mesheryLogRoots()
+	if err != nil {
+		return "", err
+	}
+
+	cleanFilePath := filepath.Clean(filePath)
+	isAllowed, err := pathWithinAllowedRoots(cleanFilePath, allowedRoots)
+	if err != nil {
+		return "", err
+	}
+	if !isAllowed {
+		return "", errFileAccessDenied
+	}
+
+	resolvedFilePath, err := filepath.EvalSymlinks(cleanFilePath)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return "", err
+		}
+		return "", fmt.Errorf("resolve requested file path: %w", err)
+	}
+
+	isAllowed, err = pathWithinAllowedRoots(resolvedFilePath, allowedRoots)
+	if err != nil {
+		return "", err
+	}
+	if !isAllowed {
+		return "", errFileAccessDenied
+	}
+
+	info, err := os.Stat(resolvedFilePath)
+	if err != nil {
+		return "", err
+	}
+	if !info.Mode().IsRegular() {
+		return "", errUnsupportedFileType
+	}
+
+	return resolvedFilePath, nil
+}
+
+func mesheryLogRoots() ([]string, error) {
+	homeDir, err := os.UserHomeDir()
+	if err != nil {
+		return nil, fmt.Errorf("determine home directory: %w", err)
+	}
+
+	rootCandidates := []string{
+		filepath.Join(homeDir, ".meshery", "logs"),
+	}
+
+	if registryLogFile := viper.GetString("REGISTRY_LOG_FILE"); registryLogFile != "" {
+		rootCandidates = append(rootCandidates, filepath.Dir(registryLogFile))
+	}
+
+	roots := make([]string, 0, len(rootCandidates))
+	seen := make(map[string]struct{}, len(rootCandidates))
+	for _, rootCandidate := range rootCandidates {
+		resolvedRoot, err := normalizeAllowedRoot(rootCandidate)
+		if err != nil {
+			return nil, err
+		}
+		if _, ok := seen[resolvedRoot]; ok {
+			continue
+		}
+		seen[resolvedRoot] = struct{}{}
+		roots = append(roots, resolvedRoot)
+	}
+
+	return roots, nil
+}
+
+func normalizeAllowedRoot(root string) (string, error) {
+	absRoot, err := filepath.Abs(root)
+	if err != nil {
+		return "", fmt.Errorf("resolve allowed file root %q: %w", root, err)
+	}
+
+	resolvedRoot, err := filepath.EvalSymlinks(absRoot)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return absRoot, nil
+		}
+		return "", fmt.Errorf("resolve allowed file root %q: %w", root, err)
+	}
+
+	return resolvedRoot, nil
+}
+
+func pathWithinAllowedRoots(path string, allowedRoots []string) (bool, error) {
+	for _, allowedRoot := range allowedRoots {
+		relPath, err := filepath.Rel(allowedRoot, path)
+		if err != nil {
+			return false, fmt.Errorf("resolve relative path from %q to %q: %w", allowedRoot, path, err)
+		}
+		if relPath == "." || (relPath != ".." && !strings.HasPrefix(relPath, ".."+string(os.PathSeparator))) {
+			return true, nil
+		}
+	}
+
+	return false, nil
 }
 
 // Deep-link and redirect support to land user on their originally requested page post authentication instead of dropping user on the root (home) page.

--- a/server/handlers/common_handlers_test.go
+++ b/server/handlers/common_handlers_test.go
@@ -1,0 +1,141 @@
+package handlers
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestViewHandlerServesAllowedMesheryLogFile(t *testing.T) {
+	homeDir := t.TempDir()
+	t.Setenv("HOME", homeDir)
+
+	logDir := filepath.Join(homeDir, ".meshery", "logs", "registry")
+	if err := os.MkdirAll(logDir, 0o755); err != nil {
+		t.Fatalf("failed to create log directory: %v", err)
+	}
+
+	filePath := filepath.Join(logDir, "registry-logs.log")
+	fileContents := "registry import failed"
+	if err := os.WriteFile(filePath, []byte(fileContents), 0o600); err != nil {
+		t.Fatalf("failed to write log file: %v", err)
+	}
+
+	h := newTestHandler(t, nil, "")
+	req := httptest.NewRequest(http.MethodGet, "/api/system/fileView?file="+url.QueryEscape(filePath), nil)
+	rec := httptest.NewRecorder()
+
+	h.ViewHandler(rec, req)
+
+	resp := rec.Result()
+	t.Cleanup(func() {
+		if err := resp.Body.Close(); err != nil {
+			t.Errorf("failed to close response body: %v", err)
+		}
+	})
+
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("expected 200 OK, got %d", resp.StatusCode)
+	}
+
+	if body := rec.Body.String(); body != fileContents {
+		t.Fatalf("expected response body %q, got %q", fileContents, body)
+	}
+
+	if contentType := resp.Header.Get("Content-Type"); contentType != "text/plain" {
+		t.Fatalf("expected text/plain content type, got %q", contentType)
+	}
+}
+
+func TestDownloadHandlerRejectsFileOutsideAllowedRoots(t *testing.T) {
+	homeDir := t.TempDir()
+	t.Setenv("HOME", homeDir)
+
+	outsideDir := t.TempDir()
+	filePath := filepath.Join(outsideDir, "secret.txt")
+	if err := os.WriteFile(filePath, []byte("secret"), 0o600); err != nil {
+		t.Fatalf("failed to write outside file: %v", err)
+	}
+
+	h := newTestHandler(t, nil, "")
+	req := httptest.NewRequest(http.MethodGet, "/api/system/fileDownload?file="+url.QueryEscape(filePath), nil)
+	rec := httptest.NewRecorder()
+
+	h.DownloadHandler(rec, req)
+
+	resp := rec.Result()
+	t.Cleanup(func() {
+		if err := resp.Body.Close(); err != nil {
+			t.Errorf("failed to close response body: %v", err)
+		}
+	})
+
+	if resp.StatusCode != http.StatusForbidden {
+		t.Fatalf("expected 403 Forbidden, got %d", resp.StatusCode)
+	}
+
+	if !strings.Contains(rec.Body.String(), errFileAccessDenied.Error()) {
+		t.Fatalf("expected forbidden response body to mention %q, got %q", errFileAccessDenied.Error(), rec.Body.String())
+	}
+}
+
+func TestViewHandlerRejectsSymlinkEscapingAllowedRoots(t *testing.T) {
+	homeDir := t.TempDir()
+	t.Setenv("HOME", homeDir)
+
+	logDir := filepath.Join(homeDir, ".meshery", "logs", "registry")
+	if err := os.MkdirAll(logDir, 0o755); err != nil {
+		t.Fatalf("failed to create log directory: %v", err)
+	}
+
+	outsideDir := t.TempDir()
+	outsideFile := filepath.Join(outsideDir, "secret.txt")
+	if err := os.WriteFile(outsideFile, []byte("secret"), 0o600); err != nil {
+		t.Fatalf("failed to write outside file: %v", err)
+	}
+
+	linkPath := filepath.Join(logDir, "registry-link.log")
+	if err := os.Symlink(outsideFile, linkPath); err != nil {
+		t.Fatalf("failed to create symlink: %v", err)
+	}
+
+	h := newTestHandler(t, nil, "")
+	req := httptest.NewRequest(http.MethodGet, "/api/system/fileView?file="+url.QueryEscape(linkPath), nil)
+	rec := httptest.NewRecorder()
+
+	h.ViewHandler(rec, req)
+
+	resp := rec.Result()
+	t.Cleanup(func() {
+		if err := resp.Body.Close(); err != nil {
+			t.Errorf("failed to close response body: %v", err)
+		}
+	})
+
+	if resp.StatusCode != http.StatusForbidden {
+		t.Fatalf("expected 403 Forbidden, got %d", resp.StatusCode)
+	}
+}
+
+func TestDownloadHandlerRejectsMissingFileQuery(t *testing.T) {
+	h := newTestHandler(t, nil, "")
+	req := httptest.NewRequest(http.MethodGet, "/api/system/fileDownload", nil)
+	rec := httptest.NewRecorder()
+
+	h.DownloadHandler(rec, req)
+
+	resp := rec.Result()
+	t.Cleanup(func() {
+		if err := resp.Body.Close(); err != nil {
+			t.Errorf("failed to close response body: %v", err)
+		}
+	})
+
+	if resp.StatusCode != http.StatusBadRequest {
+		t.Fatalf("expected 400 Bad Request, got %d", resp.StatusCode)
+	}
+}

--- a/server/router/server.go
+++ b/server/router/server.go
@@ -113,8 +113,8 @@ func NewRouter(_ context.Context, h models.HandlerInterface, port int, g http.Ha
 		Methods("GET")
 	gMux.Handle("/api/smi/results/{id}", h.ProviderMiddleware(h.AuthMiddleware(h.SessionInjectorMiddleware(h.FetchSingleSmiResultHandler), models.ProviderAuth))).
 		Methods("GET")
-	gMux.Handle("/api/system/fileDownload", h.ProviderMiddleware(h.AuthMiddleware(http.HandlerFunc(h.DownloadHandler), models.NoAuth))).Methods("GET")
-	gMux.Handle("/api/system/fileView", h.ProviderMiddleware(h.AuthMiddleware(http.HandlerFunc(h.ViewHandler), models.NoAuth))).Methods("GET")
+	gMux.Handle("/api/system/fileDownload", h.ProviderMiddleware(h.AuthMiddleware(http.HandlerFunc(h.DownloadHandler), models.ProviderAuth))).Methods("GET")
+	gMux.Handle("/api/system/fileView", h.ProviderMiddleware(h.AuthMiddleware(http.HandlerFunc(h.ViewHandler), models.ProviderAuth))).Methods("GET")
 	gMux.Handle("/api/system/adapter/manage", h.ProviderMiddleware(h.AuthMiddleware(h.SessionInjectorMiddleware(h.KubernetesMiddleware(h.MeshAdapterConfigHandler)), models.ProviderAuth)))
 	gMux.Handle("/api/system/adapter/operation", h.ProviderMiddleware(h.AuthMiddleware(h.SessionInjectorMiddleware(h.KubernetesMiddleware(h.MeshOpsHandler)), models.ProviderAuth))).
 		Methods("POST")

--- a/server/router/server_test.go
+++ b/server/router/server_test.go
@@ -1,7 +1,18 @@
 package router
 
 import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"strings"
 	"testing"
+
+	"github.com/gofrs/uuid"
+	"github.com/meshery/meshery/server/handlers"
+	"github.com/meshery/meshery/server/models"
+	"github.com/meshery/meshkit/logger"
+	schemasConnection "github.com/meshery/schemas/models/v1beta1/connection"
+	"github.com/spf13/viper"
 )
 
 func TestClose(t *testing.T) {
@@ -15,4 +26,80 @@ func TestClose(t *testing.T) {
 	//	t.Errorf("Close() failed with error: %s", err)
 	//}
 }
-  
+
+func TestFileEndpointsRequireProviderAuth(t *testing.T) {
+	log, err := logger.New("test", logger.Options{})
+	if err != nil {
+		t.Fatalf("failed to create logger: %v", err)
+	}
+
+	instanceID, err := uuid.NewV4()
+	if err != nil {
+		t.Fatalf("failed to create instance id: %v", err)
+	}
+
+	previousInstanceID := viper.Get("INSTANCE_ID")
+	viper.Set("INSTANCE_ID", &instanceID)
+	t.Cleanup(func() {
+		viper.Set("INSTANCE_ID", previousInstanceID)
+	})
+
+	handler := handlers.NewHandlerInstance(
+		&models.HandlerConfig{
+			ProviderCookieName: "meshery-provider",
+			Providers:          map[string]models.Provider{},
+		},
+		nil,
+		log,
+		nil,
+		nil,
+		nil,
+		nil,
+		nil,
+		nil,
+		"",
+		nil,
+		nil,
+		schemasConnection.MeshsyncDeploymentMode(""),
+	)
+
+	router := NewRouter(context.Background(), handler, 0, http.NotFoundHandler(), http.NotFoundHandler())
+
+	testCases := []struct {
+		name string
+		path string
+	}{
+		{
+			name: "view endpoint",
+			path: "/api/system/fileView?file=/tmp/registry-logs.log",
+		},
+		{
+			name: "download endpoint",
+			path: "/api/system/fileDownload?file=/tmp/registry-logs.log",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			req := httptest.NewRequest(http.MethodGet, tc.path, nil)
+			rec := httptest.NewRecorder()
+
+			router.S.ServeHTTP(rec, req)
+
+			resp := rec.Result()
+			t.Cleanup(func() {
+				if err := resp.Body.Close(); err != nil {
+					t.Errorf("failed to close response body: %v", err)
+				}
+			})
+
+			if resp.StatusCode != http.StatusFound {
+				t.Fatalf("expected 302 Found, got %d", resp.StatusCode)
+			}
+
+			if location := resp.Header.Get("Location"); !strings.HasPrefix(location, "/provider") {
+				t.Fatalf("expected redirect to provider login, got %q", location)
+			}
+		})
+	}
+}


### PR DESCRIPTION
**Notes for Reviewers**

- This PR fixes #18375

**[Signed commits](https://github.com/meshery/meshery/blob/master/CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [x] Yes, I signed my commits.

## Summary
- require provider auth for `/api/system/fileView` and `/api/system/fileDownload`
- limit file serving to Meshery log roots and regular files only
- block outside-path access, missing `file`, and symlink escapes
- add focused handler and router regression tests

## Testing
- `go test ./server/handlers -run 'Test(ViewHandlerServesAllowedMesheryLogFile|DownloadHandlerRejectsFileOutsideAllowedRoots|ViewHandlerRejectsSymlinkEscapingAllowedRoots|DownloadHandlerRejectsMissingFileQuery)$' -count=1`
- `go test ./server/router -run 'Test(FileEndpointsRequireProviderAuth)$' -count=1`
