### PR TITLE
fix: replace deprecated word-wrap with overflow-wrap in table styles

### DIFF
--- a/docs/assets/scss/_table.scss
+++ b/docs/assets/scss/_table.scss
@@ -26,7 +26,7 @@ table td {
   padding: 8px;
   text-align: left;
   max-width: 300px;
-  word-wrap: break-word;
+  overflow-wrap:break-word;
 }
 table td img {
   text-align: center;

--- a/docs/assets/scss/_table.scss
+++ b/docs/assets/scss/_table.scss
@@ -26,7 +26,7 @@ table td {
   padding: 8px;
   text-align: left;
   max-width: 300px;
-  overflow-wrap:break-word;
+  overflow-wrap: break-word;
 }
 table td img {
   text-align: center;


### PR DESCRIPTION
## Description

This PR replaces the deprecated CSS property `word-wrap: break-word` with the standardized `overflow-wrap: break-word` in `docs/assets/scss/_table.scss`.

`word-wrap` is an older alias and is deprecated in favor of `overflow-wrap`, which is the canonical CSS property supported by modern browsers and stylelint rules.

This change preserves the existing behavior while improving standards compliance and maintainability.

Fixes #18418 

---

**[Signed commits]**
- [x] Yes, I signed my commits.