### PR TITLE
[Provider UI] Fix Next.js 16 production build

### DIFF
--- a/provider-ui/next.config.js
+++ b/provider-ui/next.config.js
@@ -6,9 +6,6 @@ module.exports = (phase) => {
   return {
     reactStrictMode: true,
     assetPrefix: isDev ? '/' : '/provider',
-    eslint: {
-      ignoreDuringBuilds: true,
-    },
     output: 'export',
   };
 };

--- a/provider-ui/package.json
+++ b/provider-ui/package.json
@@ -5,7 +5,7 @@
   "main": "index.js",
   "scripts": {
     "dev": "node ui_dev_server.js",
-    "build": "npm run clean && next build",
+    "build": "npm run clean && next build --webpack",
     "start": "NODE_ENV=production node server.js",
     "lint": "eslint . --cache",
     "lint:fix": "eslint . --cache --fix",


### PR DESCRIPTION
## Summary
- switch provider-ui production builds to `next build --webpack` so builds succeed when Turbopack native bindings are unavailable
- remove the deprecated `eslint` block from `provider-ui/next.config.js` now that Next.js 16 rejects it

## Validation
- cd provider-ui && npm run lint
- cd provider-ui && npm run build