### PR TITLE
fix: prevent server panic due to send on closed channel in SSE event streamer

### DIFF
--- a/server/handlers/events_streamer.go
+++ b/server/handlers/events_streamer.go
@@ -350,15 +350,20 @@ func (h *Handler) EventStreamHandler(w http.ResponseWriter, req *http.Request, p
 	}()
 	go listenForCoreEvents(req.Context(), h.EventsBuffer, respChan, h.log, p)
 	go func(flusher http.Flusher) {
-		for data := range respChan {
-			h.log.Debug("received new data on response channel")
-			_, _ = fmt.Fprintf(w, "data: %s\n\n", data)
-			if flusher != nil {
-				flusher.Flush()
-				h.log.Debug("Flushed the messages on the wire...")
+		for {
+			select {
+			case data := <-respChan:
+				h.log.Debug("received new data on response channel")
+				_, _ = fmt.Fprintf(w, "data: %s\n\n", data)
+				if flusher != nil {
+					flusher.Flush()
+					h.log.Debug("Flushed the messages on the wire...")
+				}
+			case <-notify.Done():
+				h.log.Debug("response channel closed/context cancelled")
+				return
 			}
 		}
-		h.log.Debug("response channel closed")
 	}(flusherMap[client])
 
 STOP:
@@ -405,7 +410,6 @@ STOP:
 		}
 		time.Sleep(5 * time.Second)
 	}
-	close(respChan)
 	defer h.log.Debug("events handler closed")
 }
 func listenForCoreEvents(ctx context.Context, eb *_events.EventStreamer, resp chan []byte, log logger.Handler, _ models.Provider) {
@@ -423,7 +427,11 @@ func listenForCoreEvents(ctx context.Context, eb *_events.EventStreamer, resp ch
 				log.Error(models.ErrMarshal(err, "event"))
 				continue
 			}
-			resp <- data
+			select {
+			case resp <- data:
+			case <-ctx.Done():
+				return
+			}
 
 		case <-ctx.Done():
 			return
@@ -477,7 +485,11 @@ func listenForAdapterEvents(ctx context.Context, mClient *meshes.MeshClient, res
 			log.Error(models.ErrMarshal(err, "event"))
 			return
 		}
-		respChan <- data
+		select {
+		case respChan <- data:
+		case <-ctx.Done():
+			return
+		}
 	}
 }
 

--- a/server/handlers/events_streamer_test.go
+++ b/server/handlers/events_streamer_test.go
@@ -1,0 +1,31 @@
+package handlers
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/meshery/meshkit/logger"
+	_events "github.com/meshery/meshkit/utils/events"
+)
+
+// TestListenForCoreEvents_Cancellation checks that the goroutine stops and does not panic when the context is cancelled.
+func TestListenForCoreEvents_Cancellation(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	respChan := make(chan []byte)
+
+	log, _ := logger.New("test", logger.Options{})
+	eb := _events.NewEventStreamer()
+
+	// Run the core events listener in a goroutine
+	go listenForCoreEvents(ctx, eb, respChan, log, nil)
+
+	// Simulate context cancellation, which is what happens when the HTTP client disconnects
+	cancel()
+
+	// Wait briefly to allow the goroutine to process the cancellation
+	time.Sleep(100 * time.Millisecond)
+
+	// We verify that it doesn't panic. If it does, the test suite will fail.
+	// Since the select block uses ctx.Done(), the goroutine will exit cleanly.
+}


### PR DESCRIPTION
##  Bug Summary

The SSE handler in `events_streamer.go` had a race condition where multiple goroutines were sending events to a shared channel (`respChan`) while the main handler closed it on client disconnect.

If a client disconnected while events were still being produced, a goroutine could attempt to send on a **closed channel**, causing a **fatal panic (`send on closed channel`)** and crashing the entire Meshery Server.

This made the system fragile—normal user actions like refreshing the UI or losing network connection during event streaming could bring down the entire management plane.

---

##  Fix

- Removed `close(respChan)` to avoid unsafe channel closure
- Updated the response loop to exit using `req.Context().Done()` instead of relying on channel closure
- Wrapped all producer sends in `select` blocks with `ctx.Done()` to safely handle cancellation

```go
select {
case respChan <- data:
case <-ctx.Done():
	return
}
```

##  Impact
- Eliminates server crashes caused by "send on closed channel" panic
- Fixes race condition between event producers and client disconnects
- Improves stability of SSE event streaming under real-world conditions
- Ensures Meshery remains reliable even during UI refreshes or network interruptions
- Strengthens production readiness of the event streaming pipeline