### PR TITLE
[UI] Avoid anonymous token fetch redirects

### DIFF
--- a/ui/components/Header.tsx
+++ b/ui/components/Header.tsx
@@ -57,6 +57,7 @@ import {
 import {
   getUserAccessToken,
   getUserProfile,
+  useGetLoggedInUserQuery,
   useGetProviderCapabilitiesQuery,
 } from '@/rtk-query/user';
 import { useGetConnectionsQuery } from '@/rtk-query/connection';
@@ -440,6 +441,7 @@ const Header = ({
     isError: isProviderCapabilitiesError,
     error: providerCapabilitiesError,
   } = useGetProviderCapabilitiesQuery();
+  const { data: currentUser } = useGetLoggedInUserQuery();
 
   if (isProviderCapabilitiesError) {
     notify({
@@ -451,6 +453,8 @@ const Header = ({
 
   const remoteProviderUrl = providerCapabilities?.provider_url;
   const collaboratorExtensionUri = providerCapabilities?.extensions?.collaborator?.[0]?.component;
+  const collaboratorAccessTokenGetter =
+    currentUser?.status === 'anonymous' ? undefined : getUserAccessToken;
 
   const loaderType = 'circular';
   return (
@@ -497,7 +501,7 @@ const Header = ({
                       url={{ url: createPathForRemoteComponent(collaboratorExtensionUri) }}
                       loaderType={loaderType}
                       providerUrl={remoteProviderUrl}
-                      getUserAccessToken={getUserAccessToken}
+                      getUserAccessToken={collaboratorAccessTokenGetter}
                       getUserProfile={getUserProfile}
                       onOpenWorkspace={openModal}
                     />

--- a/ui/components/Header.tsx
+++ b/ui/components/Header.tsx
@@ -454,7 +454,7 @@ const Header = ({
   const remoteProviderUrl = providerCapabilities?.provider_url;
   const collaboratorExtensionUri = providerCapabilities?.extensions?.collaborator?.[0]?.component;
   const collaboratorAccessTokenGetter =
-    currentUser?.status === 'anonymous' ? undefined : getUserAccessToken;
+    currentUser?.status && currentUser.status !== 'anonymous' ? getUserAccessToken : undefined;
 
   const loaderType = 'circular';
   return (

--- a/ui/components/SpacesSwitcher/MainDesignsContent.tsx
+++ b/ui/components/SpacesSwitcher/MainDesignsContent.tsx
@@ -268,9 +268,11 @@ const MainDesignsContent = ({
   const { capabilitiesRegistry } = useSelector((state) => state.ui);
   const { organization: currentOrganization } = useSelector((state) => state.ui);
   const providerUrl = capabilitiesRegistry?.provider_url;
+  const roomActivityAccessTokenGetter =
+    currentUser?.status === 'anonymous' ? undefined : getUserAccessToken;
   const [activeUsers] = useRoomActivity({
     provider_url: providerUrl,
-    getUserAccessToken: getUserAccessToken,
+    getUserAccessToken: roomActivityAccessTokenGetter,
     getUserProfile: getUserProfile,
   });
   const [assignDesignToWorkspace] = useAssignDesignToWorkspaceMutation();

--- a/ui/components/SpacesSwitcher/MainDesignsContent.tsx
+++ b/ui/components/SpacesSwitcher/MainDesignsContent.tsx
@@ -269,7 +269,7 @@ const MainDesignsContent = ({
   const { organization: currentOrganization } = useSelector((state) => state.ui);
   const providerUrl = capabilitiesRegistry?.provider_url;
   const roomActivityAccessTokenGetter =
-    currentUser?.status === 'anonymous' ? undefined : getUserAccessToken;
+    currentUser?.status && currentUser.status !== 'anonymous' ? getUserAccessToken : undefined;
   const [activeUsers] = useRoomActivity({
     provider_url: providerUrl,
     getUserAccessToken: roomActivityAccessTokenGetter,

--- a/ui/components/SpacesSwitcher/MainViewsContent.tsx
+++ b/ui/components/SpacesSwitcher/MainViewsContent.tsx
@@ -204,7 +204,7 @@ const MainViewsContent = ({
   const { organization: currentOrganization } = useSelector((state) => state.ui);
   const providerUrl = capabilitiesRegistry?.provider_url;
   const roomActivityAccessTokenGetter =
-    currentUser?.status === 'anonymous' ? undefined : getUserAccessToken;
+    currentUser?.status && currentUser.status !== 'anonymous' ? getUserAccessToken : undefined;
   const [activeUsers] = useRoomActivity({
     provider_url: providerUrl,
     getUserAccessToken: roomActivityAccessTokenGetter,

--- a/ui/components/SpacesSwitcher/MainViewsContent.tsx
+++ b/ui/components/SpacesSwitcher/MainViewsContent.tsx
@@ -203,9 +203,11 @@ const MainViewsContent = ({
   const { capabilitiesRegistry } = useSelector((state) => state.ui);
   const { organization: currentOrganization } = useSelector((state) => state.ui);
   const providerUrl = capabilitiesRegistry?.provider_url;
+  const roomActivityAccessTokenGetter =
+    currentUser?.status === 'anonymous' ? undefined : getUserAccessToken;
   const [activeUsers] = useRoomActivity({
     provider_url: providerUrl,
-    getUserAccessToken: getUserAccessToken,
+    getUserAccessToken: roomActivityAccessTokenGetter,
     getUserProfile: getUserProfile,
   });
   const [assignDesignToWorkspace] = useAssignDesignToWorkspaceMutation();

--- a/ui/components/User.tsx
+++ b/ui/components/User.tsx
@@ -3,6 +3,7 @@ import { Avatar, Button } from '@sistent/sistent';
 import NoSsr from '@mui/material/NoSsr';
 import Link from 'next/link';
 import { useGetLoggedInUserQuery } from '@/rtk-query/user';
+import { mesheryApiPath } from '../rtk-query/index';
 import ExtensionPointSchemaValidator from '../utils/ExtensionPointSchemaValidator';
 import { useNotification } from '@/utils/hooks/useNotification';
 import { EVENT_TYPES } from 'lib/event-types';
@@ -63,7 +64,7 @@ const User = (props) => {
 
   const { color } = props;
 
-  const source = new URL('/api/user/token', window.location.origin);
+  const source = new URL(mesheryApiPath('user/token'), window.location.origin);
   const sourceURL = btoa(source.toString());
   const refURL = btoa(window.location.href);
 

--- a/ui/rtk-query/user.ts
+++ b/ui/rtk-query/user.ts
@@ -43,7 +43,7 @@ export const userApi = api
         invalidatesTags: [Tags.LOAD_TEST_PREF],
       }),
       getToken: builder.query({
-        query: () => `/api/user/token`,
+        query: () => mesheryApiPath('user/token'),
         method: 'GET',
       }),
       getUserPref: builder.query({
@@ -223,7 +223,7 @@ export const userApi = api
       }),
       getAccessToken: builder.query({
         query: () => ({
-          url: `/api/user/token`,
+          url: mesheryApiPath('user/token'),
         }),
         transformResponse: (response) => {
           return response?.token;


### PR DESCRIPTION
## Summary
- stop passing `getUserAccessToken` into collaboration entry points for anonymous sessions
- avoid browser-side OAuth redirect fetches that fail with credentialed CORS errors
- normalize user token URL construction through `mesheryApiPath`

## Validation
- `cd ui && npm run lint -- components/User.tsx components/Header.tsx components/SpacesSwitcher/MainViewsContent.tsx components/SpacesSwitcher/MainDesignsContent.tsx rtk-query/user.ts`
- `cd ui && npm run build`