### PR TITLE
[UI] Add @/theme re-export entry point

### DIFF
--- a/ui/eslint.config.js
+++ b/ui/eslint.config.js
@@ -134,6 +134,130 @@ module.exports = [
       'no-dupe-keys': 'error',
       'react/prop-types': 'off',
       'prettier/prettier': ['error', { endOfLine: 'lf' }],
+
+      // ---------------------------------------------------------------------
+      // UI restructure guardrails (warn mode, phase 1).
+      //
+      // These rules encode the target architecture: one design system
+      // (@sistent/sistent), one theme source (@/theme), and a size budget
+      // for component files. They ship as warnings so CI stays green on
+      // day one; a later phase will allowlist today's offenders and promote
+      // the rules to errors.
+      // ---------------------------------------------------------------------
+
+      // Ban Material UI and legacy theme imports. @sistent/sistent is the
+      // only UI kit; @/theme is the only theme entry point.
+      'no-restricted-imports': [
+        'warn',
+        {
+          paths: [
+            {
+              name: '@mui/material',
+              message: 'Use @sistent/sistent instead.',
+            },
+            {
+              name: '@mui/icons-material',
+              message:
+                'Use @sistent/sistent icons, or add an SVG component to ui/assets/icons.',
+            },
+            {
+              name: '@mui/x-date-pickers',
+              message:
+                'Wrap @mui/x-date-pickers in a single shared primitive; do not import it directly.',
+            },
+            {
+              name: '@mui/x-tree-view',
+              message:
+                'Wrap @mui/x-tree-view in a single shared primitive; do not import it directly.',
+            },
+            {
+              name: '@rjsf/mui',
+              message:
+                'Use the shared RJSF wrapper; do not import @rjsf/mui directly.',
+            },
+            {
+              name: '@/themes',
+              message: 'Use @/theme (colors come from theme.palette.*).',
+            },
+            {
+              name: '@/themes/app',
+              message:
+                'Use theme.palette.* (light/dark-aware) instead of the legacy Colors object.',
+            },
+            {
+              name: '@/themes/index',
+              message:
+                'Use theme.palette.* (light/dark-aware) instead of NOTIFICATIONCOLORS.',
+            },
+            {
+              name: '@/constants/colors',
+              message: 'Use theme.palette.* instead of legacy color constants.',
+            },
+          ],
+          patterns: [
+            {
+              group: ['@mui/*'],
+              message: 'Use @sistent/sistent instead.',
+            },
+            {
+              group: ['@material-ui/*'],
+              message:
+                'Material UI v4 is deprecated in this project — use @sistent/sistent.',
+            },
+          ],
+        },
+      ],
+
+      // Size budget for component files. 1000 lines is the hard ceiling;
+      // the plan is to drop this to 600 once the eight giant files are
+      // broken up in phase 5.
+      'max-lines': [
+        'warn',
+        { max: 1000, skipComments: true, skipBlankLines: true },
+      ],
+    },
+  },
+
+  // ---------------------------------------------------------------------
+  // Ban hex (#RRGGBB) and rgb()/rgba() literals in source files.
+  //
+  // Colors must come from theme.palette.* (or be composed with alpha() /
+  // lighten() / darken() from @sistent/sistent). The only places allowed
+  // to contain a literal color are:
+  //
+  //   - ui/theme/**       (the theme module itself)
+  //   - ui/themes/**      (legacy theme module, scheduled for deletion)
+  //   - ui/assets/**      (SVG icons encoded as React components)
+  //   - ui/constants/**   (legacy color constants, scheduled for deletion)
+  //   - ui/lib/**         (third-party integration helpers)
+  //   - ui/public/**      (static assets)
+  // ---------------------------------------------------------------------
+  {
+    files: ['**/*.{ts,tsx,js,jsx}'],
+    ignores: [
+      'theme/**',
+      'themes/**',
+      'assets/**',
+      'constants/**',
+      'lib/**',
+      'public/**',
+      'tests/**',
+    ],
+    rules: {
+      'no-restricted-syntax': [
+        'warn',
+        {
+          selector:
+            'Literal[value=/^#(?:[0-9a-fA-F]{3,4}|[0-9a-fA-F]{6}|[0-9a-fA-F]{8})$/]',
+          message:
+            'Hex color literals are forbidden outside ui/theme/. Use theme.palette.*.',
+        },
+        {
+          selector: 'Literal[value=/rgba?\\(/]',
+          message:
+            'rgb()/rgba() literals are forbidden outside ui/theme/. Use theme.palette.* (or alpha() from @sistent/sistent).',
+        },
+      ],
     },
   },
 

--- a/ui/eslint.config.js
+++ b/ui/eslint.config.js
@@ -235,6 +235,7 @@ module.exports = [
       'lib/**',
       'public/**',
       'tests/**',
+      'scripts/**',
       'eslint.config.js',
     ],
     rules: {

--- a/ui/eslint.config.js
+++ b/ui/eslint.config.js
@@ -157,8 +157,7 @@ module.exports = [
             },
             {
               name: '@mui/icons-material',
-              message:
-                'Use @sistent/sistent icons, or add an SVG component to ui/assets/icons.',
+              message: 'Use @sistent/sistent icons, or add an SVG component to ui/assets/icons.',
             },
             {
               name: '@mui/x-date-pickers',
@@ -172,8 +171,7 @@ module.exports = [
             },
             {
               name: '@rjsf/mui',
-              message:
-                'Use the shared RJSF wrapper; do not import @rjsf/mui directly.',
+              message: 'Use the shared RJSF wrapper; do not import @rjsf/mui directly.',
             },
             {
               name: '@/themes',
@@ -186,8 +184,7 @@ module.exports = [
             },
             {
               name: '@/themes/index',
-              message:
-                'Use theme.palette.* (light/dark-aware) instead of NOTIFICATIONCOLORS.',
+              message: 'Use theme.palette.* (light/dark-aware) instead of NOTIFICATIONCOLORS.',
             },
             {
               name: '@/constants/colors',
@@ -201,8 +198,7 @@ module.exports = [
             },
             {
               group: ['@material-ui/*'],
-              message:
-                'Material UI v4 is deprecated in this project — use @sistent/sistent.',
+              message: 'Material UI v4 is deprecated in this project — use @sistent/sistent.',
             },
           ],
         },
@@ -211,10 +207,7 @@ module.exports = [
       // Size budget for component files. 1000 lines is the hard ceiling;
       // the plan is to drop this to 600 once the eight giant files are
       // broken up in phase 5.
-      'max-lines': [
-        'warn',
-        { max: 1000, skipComments: true, skipBlankLines: true },
-      ],
+      'max-lines': ['warn', { max: 1000, skipComments: true, skipBlankLines: true }],
     },
   },
 
@@ -242,15 +235,14 @@ module.exports = [
       'lib/**',
       'public/**',
       'tests/**',
+      'eslint.config.js',
     ],
     rules: {
       'no-restricted-syntax': [
         'warn',
         {
-          selector:
-            'Literal[value=/^#(?:[0-9a-fA-F]{3,4}|[0-9a-fA-F]{6}|[0-9a-fA-F]{8})$/]',
-          message:
-            'Hex color literals are forbidden outside ui/theme/. Use theme.palette.*.',
+          selector: 'Literal[value=/^#(?:[0-9a-fA-F]{3,4}|[0-9a-fA-F]{6}|[0-9a-fA-F]{8})$/]',
+          message: 'Hex color literals are forbidden outside ui/theme/. Use theme.palette.*.',
         },
         {
           selector: 'Literal[value=/rgba?\\(/]',

--- a/ui/jsconfig.json
+++ b/ui/jsconfig.json
@@ -9,7 +9,7 @@
       "@/constants/*": ["constants/*"],
       "@/api/*": ["api/*"],
       "@/assets/*": ["assets/*"],
-      "@/theme": ["theme/index.ts"],
+      "@/theme": ["theme/index"],
       "@/theme/*": ["theme/*"],
       "@/themes/*": ["themes/*"],
       "@/store/*": ["store/*"],

--- a/ui/jsconfig.json
+++ b/ui/jsconfig.json
@@ -9,6 +9,8 @@
       "@/constants/*": ["constants/*"],
       "@/api/*": ["api/*"],
       "@/assets/*": ["assets/*"],
+      "@/theme": ["theme/index.ts"],
+      "@/theme/*": ["theme/*"],
       "@/themes/*": ["themes/*"],
       "@/store/*": ["store/*"],
       "lib/*": ["lib/*"],

--- a/ui/package.json
+++ b/ui/package.json
@@ -24,7 +24,11 @@
     "relay": "relay-compiler",
     "prepare": "cd .. && { [ -e .git ] && husky ui/.husky || true; }",
     "postinstall": "patch-package",
-    "clean": "rm -rf .next,out"
+    "clean": "rm -rf .next,out",
+    "audit:mui": "node scripts/audit-mui.js",
+    "audit:hex": "node scripts/audit-hex.js",
+    "audit:size": "node scripts/audit-size.js",
+    "audit:all": "node scripts/audit-mui.js && node scripts/audit-hex.js && node scripts/audit-size.js"
   },
   "keywords": [],
   "author": "Meshery Authors",

--- a/ui/scripts/audit-hex.js
+++ b/ui/scripts/audit-hex.js
@@ -1,0 +1,190 @@
+#!/usr/bin/env node
+/**
+ * meshery-ui color-literal audit
+ *
+ * Counts occurrences of hex colors (#RGB, #RGBA, #RRGGBB, #RRGGBBAA) and
+ * rgb()/rgba() function literals in .ts/.tsx/.js/.jsx files. These
+ * literals are being eliminated in favor of theme.palette.* (which comes
+ * from @sistent/sistent) as part of the UI restructure.
+ *
+ * This script is broader than the companion ESLint rule
+ * (no-restricted-syntax in ui/eslint.config.js), which only catches hex
+ * strings that are exact Literal values. This audit also catches hex
+ * colors embedded inside longer strings, like:
+ *
+ *   const x = { border: '1px solid #F91313' };
+ *
+ * Usage:
+ *   node scripts/audit-hex.js           # summary + top 20 offenders
+ *   node scripts/audit-hex.js --all     # print every offending file
+ *   node scripts/audit-hex.js --json    # structured JSON to stdout
+ *
+ * Exit code is always 0.
+ *
+ * Final line of stdout is always:
+ *   AUDIT hex files=<N> matches=<M>
+ */
+
+'use strict';
+
+const fs = require('fs');
+const path = require('path');
+
+const UI_ROOT = path.resolve(__dirname, '..');
+
+// Directories under ui/ that are scanned.
+const SCAN_DIRS = [
+  'components',
+  'pages',
+  'utils',
+  'store',
+  'rtk-query',
+  'machines',
+  'hooks',
+  'api',
+  'css',
+];
+
+// Skipped entirely. These are the same exclusions applied in
+// eslint.config.js to the hex/rgba no-restricted-syntax rule: the theme
+// module, legacy theme/constants directories (scheduled for deletion),
+// SVG icon components, third-party integration helpers, static assets,
+// and tests.
+const IGNORED_DIRS = new Set([
+  'node_modules',
+  '.next',
+  'out',
+  'playground',
+  'playwright-report',
+  'test-results',
+  '__generated__',
+  // Scoped opt-outs matching the ESLint rule
+  'theme',
+  'themes',
+  'assets',
+  'constants',
+  'lib',
+  'public',
+  'tests',
+]);
+
+const EXTENSIONS = new Set(['.ts', '.tsx', '.js', '.jsx']);
+
+// Hex colors: #RGB, #RGBA, #RRGGBB, #RRGGBBAA. Valid CSS hex lengths only.
+// Uses a word boundary so #abcde (5 chars) does not match as #abc.
+const HEX_PATTERN = /#(?:[0-9a-fA-F]{3,4}|[0-9a-fA-F]{6}|[0-9a-fA-F]{8})\b/g;
+
+// rgb() / rgba() function calls inside strings.
+const RGB_PATTERN = /rgba?\(/g;
+
+function walk(dir, out) {
+  let entries;
+  try {
+    entries = fs.readdirSync(dir, { withFileTypes: true });
+  } catch {
+    return;
+  }
+  for (const entry of entries) {
+    if (IGNORED_DIRS.has(entry.name)) continue;
+    const full = path.join(dir, entry.name);
+    if (entry.isDirectory()) {
+      walk(full, out);
+    } else if (entry.isFile() && EXTENSIONS.has(path.extname(entry.name))) {
+      out.push(full);
+    }
+  }
+}
+
+function countMatches(src, pattern) {
+  pattern.lastIndex = 0;
+  let count = 0;
+  while (pattern.exec(src) !== null) count++;
+  return count;
+}
+
+function scanFile(file) {
+  const src = fs.readFileSync(file, 'utf8');
+  const hex = countMatches(src, HEX_PATTERN);
+  const rgb = countMatches(src, RGB_PATTERN);
+  return { hex, rgb };
+}
+
+function main() {
+  const args = process.argv.slice(2);
+  const showAll = args.includes('--all');
+  const asJson = args.includes('--json');
+
+  const files = [];
+  for (const dir of SCAN_DIRS) {
+    walk(path.join(UI_ROOT, dir), files);
+  }
+
+  const offenders = [];
+  let totalHex = 0;
+  let totalRgb = 0;
+  for (const file of files) {
+    const { hex, rgb } = scanFile(file);
+    if (hex === 0 && rgb === 0) continue;
+    const rel = path.relative(UI_ROOT, file);
+    offenders.push({ file: rel, hex, rgb, total: hex + rgb });
+    totalHex += hex;
+    totalRgb += rgb;
+  }
+  offenders.sort((a, b) => b.total - a.total || a.file.localeCompare(b.file));
+
+  const totalMatches = totalHex + totalRgb;
+
+  if (asJson) {
+    process.stdout.write(
+      JSON.stringify(
+        {
+          audit: 'hex',
+          files: offenders.length,
+          matches: totalMatches,
+          hex: totalHex,
+          rgb: totalRgb,
+          offenders,
+        },
+        null,
+        2,
+      ) + '\n',
+    );
+    return;
+  }
+
+  process.stdout.write('meshery-ui color-literal audit\n');
+  process.stdout.write('==============================\n');
+  process.stdout.write('Patterns: #RGB/#RGBA/#RRGGBB/#RRGGBBAA, rgb(), rgba()\n');
+  process.stdout.write(`Scope:    ${SCAN_DIRS.join(', ')}\n`);
+  process.stdout.write(
+    'Ignored:  theme, themes, assets, constants, lib, public, tests, __generated__\n\n',
+  );
+
+  const limit = showAll ? offenders.length : Math.min(20, offenders.length);
+  if (offenders.length === 0) {
+    process.stdout.write('No color literals found outside the ignored paths. 🎯\n\n');
+  } else {
+    const header = showAll ? 'Offenders (hex + rgb count)' : `Top ${limit} files (hex + rgb count)`;
+    process.stdout.write(`${header}:\n`);
+    for (let i = 0; i < limit; i++) {
+      const { file, hex, rgb } = offenders[i];
+      const tag = `${hex}h+${rgb}r`.padStart(8);
+      process.stdout.write(`  ${tag}  ${file}\n`);
+    }
+    if (!showAll && offenders.length > limit) {
+      process.stdout.write(`  ... and ${offenders.length - limit} more (use --all to see them)\n`);
+    }
+    process.stdout.write('\n');
+  }
+
+  process.stdout.write('Summary:\n');
+  process.stdout.write(`  Files:   ${offenders.length}\n`);
+  process.stdout.write(`  Hex:     ${totalHex}\n`);
+  process.stdout.write(`  rgb/a:   ${totalRgb}\n`);
+  process.stdout.write(`  Total:   ${totalMatches}\n\n`);
+  process.stdout.write(
+    `AUDIT hex files=${offenders.length} matches=${totalMatches} hex=${totalHex} rgb=${totalRgb}\n`,
+  );
+}
+
+main();

--- a/ui/scripts/audit-mui.js
+++ b/ui/scripts/audit-mui.js
@@ -1,0 +1,162 @@
+#!/usr/bin/env node
+/**
+ * meshery-ui @mui import audit
+ *
+ * Counts files that still import from @mui/*, @material-ui/*, or @rjsf/mui.
+ * These imports are being eliminated in favor of @sistent/sistent — the
+ * design system — as part of the UI restructure.
+ *
+ * The companion ESLint rule (no-restricted-imports in ui/eslint.config.js)
+ * warns developers when they add a new offending import; this script is
+ * the trend tracker that CI uses to watch the count go down.
+ *
+ * Usage:
+ *   node scripts/audit-mui.js            # summary + top 20 offenders
+ *   node scripts/audit-mui.js --all      # print every offending file
+ *   node scripts/audit-mui.js --json     # emit structured JSON to stdout
+ *
+ * Exit code is always 0 — this is an informational audit, not a gate.
+ *
+ * The final line of stdout is always:
+ *   AUDIT mui files=<N> matches=<M>
+ * …so CI can grep it for trend tracking without parsing the rest.
+ */
+
+'use strict';
+
+const fs = require('fs');
+const path = require('path');
+
+const UI_ROOT = path.resolve(__dirname, '..');
+
+// Directories under ui/ that are scanned.
+const SCAN_DIRS = [
+  'components',
+  'pages',
+  'utils',
+  'themes',
+  'theme',
+  'machines',
+  'store',
+  'rtk-query',
+  'lib',
+  'hooks',
+  'api',
+];
+
+// Directories (absolute or ui-relative) that are never scanned.
+const IGNORED_DIRS = new Set([
+  'node_modules',
+  '.next',
+  'out',
+  'playground',
+  'playwright-report',
+  'test-results',
+  '__generated__',
+]);
+
+const EXTENSIONS = new Set(['.ts', '.tsx', '.js', '.jsx']);
+
+// Match any import/require from @mui/*, @material-ui/*, or @rjsf/mui.
+// Covers:
+//   import X from '@mui/material'
+//   import { X } from '@mui/material'
+//   import '@mui/material/Button'
+//   const X = require('@mui/material')
+const IMPORT_PATTERN =
+  /(?:from\s+|require\(\s*)['"](@mui\/[^'"]+|@material-ui\/[^'"]+|@rjsf\/mui)['"]/g;
+
+function walk(dir, out) {
+  let entries;
+  try {
+    entries = fs.readdirSync(dir, { withFileTypes: true });
+  } catch {
+    return;
+  }
+  for (const entry of entries) {
+    if (IGNORED_DIRS.has(entry.name)) continue;
+    const full = path.join(dir, entry.name);
+    if (entry.isDirectory()) {
+      walk(full, out);
+    } else if (entry.isFile() && EXTENSIONS.has(path.extname(entry.name))) {
+      out.push(full);
+    }
+  }
+}
+
+function scanFile(file) {
+  const src = fs.readFileSync(file, 'utf8');
+  const matches = [];
+  let m;
+  IMPORT_PATTERN.lastIndex = 0;
+  while ((m = IMPORT_PATTERN.exec(src)) !== null) {
+    matches.push(m[1]);
+  }
+  return matches;
+}
+
+function main() {
+  const args = process.argv.slice(2);
+  const showAll = args.includes('--all');
+  const asJson = args.includes('--json');
+
+  const files = [];
+  for (const dir of SCAN_DIRS) {
+    walk(path.join(UI_ROOT, dir), files);
+  }
+
+  const offenders = [];
+  let totalMatches = 0;
+  for (const file of files) {
+    const matches = scanFile(file);
+    if (matches.length === 0) continue;
+    const rel = path.relative(UI_ROOT, file);
+    offenders.push({ file: rel, count: matches.length, imports: matches });
+    totalMatches += matches.length;
+  }
+  offenders.sort((a, b) => b.count - a.count || a.file.localeCompare(b.file));
+
+  if (asJson) {
+    process.stdout.write(
+      JSON.stringify(
+        {
+          audit: 'mui',
+          files: offenders.length,
+          matches: totalMatches,
+          offenders,
+        },
+        null,
+        2,
+      ) + '\n',
+    );
+    return;
+  }
+
+  process.stdout.write('meshery-ui @mui/* import audit\n');
+  process.stdout.write('==============================\n');
+  process.stdout.write('Patterns: @mui/*, @material-ui/*, @rjsf/mui\n');
+  process.stdout.write(`Scope:    ${SCAN_DIRS.join(', ')}\n\n`);
+
+  const limit = showAll ? offenders.length : Math.min(20, offenders.length);
+  if (offenders.length === 0) {
+    process.stdout.write('No @mui/* imports found. The restructure is done.\n\n');
+  } else {
+    const header = showAll ? 'Offenders' : `Top ${limit} files (by match count)`;
+    process.stdout.write(`${header}:\n`);
+    for (let i = 0; i < limit; i++) {
+      const { file, count } = offenders[i];
+      process.stdout.write(`  ${String(count).padStart(3)}  ${file}\n`);
+    }
+    if (!showAll && offenders.length > limit) {
+      process.stdout.write(`  ... and ${offenders.length - limit} more (use --all to see them)\n`);
+    }
+    process.stdout.write('\n');
+  }
+
+  process.stdout.write('Summary:\n');
+  process.stdout.write(`  Files:   ${offenders.length}\n`);
+  process.stdout.write(`  Matches: ${totalMatches}\n\n`);
+  process.stdout.write(`AUDIT mui files=${offenders.length} matches=${totalMatches}\n`);
+}
+
+main();

--- a/ui/scripts/audit-size.js
+++ b/ui/scripts/audit-size.js
@@ -1,0 +1,196 @@
+#!/usr/bin/env node
+/**
+ * meshery-ui component-size audit
+ *
+ * Counts .ts/.tsx/.js/.jsx source files that exceed the component size
+ * budget set out in the UI restructure plan:
+ *
+ *   - Warn threshold:   600 lines
+ *   - Hard ceiling:    1000 lines
+ *
+ * The companion ESLint rule (max-lines in ui/eslint.config.js) already
+ * emits a warning when a file crosses 1000 lines. This audit is the
+ * trend tracker that CI uses to watch both thresholds go down as the
+ * eight giant files documented in the plan get split apart in phase 5.
+ *
+ * Line counting matches ESLint's max-lines behaviour with
+ * { skipComments: true, skipBlankLines: true } — blank lines and
+ * single-/multi-line comment lines are not counted toward the total.
+ *
+ * Usage:
+ *   node scripts/audit-size.js          # summary + top 20 largest
+ *   node scripts/audit-size.js --all    # print every file over the warn threshold
+ *   node scripts/audit-size.js --json   # structured JSON to stdout
+ *
+ * Exit code is always 0.
+ *
+ * Final line of stdout is always:
+ *   AUDIT size over_warn=<N> over_hard=<M>
+ */
+
+'use strict';
+
+const fs = require('fs');
+const path = require('path');
+
+const UI_ROOT = path.resolve(__dirname, '..');
+
+const WARN_THRESHOLD = 600;
+const HARD_THRESHOLD = 1000;
+
+// Directories under ui/ that are scanned for oversized source files.
+const SCAN_DIRS = [
+  'components',
+  'pages',
+  'utils',
+  'store',
+  'rtk-query',
+  'machines',
+  'hooks',
+  'api',
+  'themes',
+  'theme',
+  'lib',
+];
+
+const IGNORED_DIRS = new Set([
+  'node_modules',
+  '.next',
+  'out',
+  'playground',
+  'playwright-report',
+  'test-results',
+  '__generated__',
+]);
+
+const EXTENSIONS = new Set(['.ts', '.tsx', '.js', '.jsx']);
+
+function walk(dir, out) {
+  let entries;
+  try {
+    entries = fs.readdirSync(dir, { withFileTypes: true });
+  } catch {
+    return;
+  }
+  for (const entry of entries) {
+    if (IGNORED_DIRS.has(entry.name)) continue;
+    const full = path.join(dir, entry.name);
+    if (entry.isDirectory()) {
+      walk(full, out);
+    } else if (entry.isFile() && EXTENSIONS.has(path.extname(entry.name))) {
+      out.push(full);
+    }
+  }
+}
+
+// Count lines the way ESLint's max-lines does with
+// { skipComments: true, skipBlankLines: true }. A line is skipped if
+// it is blank after trimming, or if it lies inside a /* ... */ block,
+// or if it starts with // after whitespace.
+function countSignificantLines(src) {
+  const lines = src.split(/\r?\n/);
+  let count = 0;
+  let inBlockComment = false;
+  for (const rawLine of lines) {
+    let line = rawLine.trim();
+    if (line === '') continue;
+
+    if (inBlockComment) {
+      const end = line.indexOf('*/');
+      if (end === -1) continue;
+      line = line.slice(end + 2).trim();
+      inBlockComment = false;
+      if (line === '') continue;
+    }
+
+    // Strip a leading // comment.
+    if (line.startsWith('//')) continue;
+
+    // Strip a leading /* ... */ that begins and ends on this line.
+    while (line.startsWith('/*')) {
+      const end = line.indexOf('*/', 2);
+      if (end === -1) {
+        inBlockComment = true;
+        line = '';
+        break;
+      }
+      line = line.slice(end + 2).trim();
+    }
+    if (line === '') continue;
+
+    count++;
+  }
+  return count;
+}
+
+function main() {
+  const args = process.argv.slice(2);
+  const showAll = args.includes('--all');
+  const asJson = args.includes('--json');
+
+  const files = [];
+  for (const dir of SCAN_DIRS) {
+    walk(path.join(UI_ROOT, dir), files);
+  }
+
+  const measured = [];
+  for (const file of files) {
+    const src = fs.readFileSync(file, 'utf8');
+    const lines = countSignificantLines(src);
+    if (lines < WARN_THRESHOLD) continue;
+    measured.push({ file: path.relative(UI_ROOT, file), lines });
+  }
+  measured.sort((a, b) => b.lines - a.lines || a.file.localeCompare(b.file));
+
+  const overHard = measured.filter((m) => m.lines >= HARD_THRESHOLD);
+  const overWarn = measured; // already filtered to >= WARN_THRESHOLD
+
+  if (asJson) {
+    process.stdout.write(
+      JSON.stringify(
+        {
+          audit: 'size',
+          warn_threshold: WARN_THRESHOLD,
+          hard_threshold: HARD_THRESHOLD,
+          over_warn: overWarn.length,
+          over_hard: overHard.length,
+          files: measured,
+        },
+        null,
+        2,
+      ) + '\n',
+    );
+    return;
+  }
+
+  process.stdout.write('meshery-ui component-size audit\n');
+  process.stdout.write('===============================\n');
+  process.stdout.write(
+    `Thresholds: warn=${WARN_THRESHOLD}, hard=${HARD_THRESHOLD} (blank lines and comments excluded)\n`,
+  );
+  process.stdout.write(`Scope:      ${SCAN_DIRS.join(', ')}\n\n`);
+
+  if (overWarn.length === 0) {
+    process.stdout.write(`No files over ${WARN_THRESHOLD} lines. The split is done.\n\n`);
+  } else {
+    const limit = showAll ? overWarn.length : Math.min(20, overWarn.length);
+    const header = showAll ? `Files over ${WARN_THRESHOLD} lines` : `Top ${limit} largest files`;
+    process.stdout.write(`${header}:\n`);
+    for (let i = 0; i < limit; i++) {
+      const { file, lines } = overWarn[i];
+      const flag = lines >= HARD_THRESHOLD ? '!!' : '  ';
+      process.stdout.write(`  ${flag} ${String(lines).padStart(5)}  ${file}\n`);
+    }
+    if (!showAll && overWarn.length > limit) {
+      process.stdout.write(`  ... and ${overWarn.length - limit} more (use --all to see them)\n`);
+    }
+    process.stdout.write('\n');
+  }
+
+  process.stdout.write('Summary:\n');
+  process.stdout.write(`  Over ${WARN_THRESHOLD}:  ${overWarn.length}\n`);
+  process.stdout.write(`  Over ${HARD_THRESHOLD}: ${overHard.length}\n\n`);
+  process.stdout.write(`AUDIT size over_warn=${overWarn.length} over_hard=${overHard.length}\n`);
+}
+
+main();

--- a/ui/theme/index.ts
+++ b/ui/theme/index.ts
@@ -1,0 +1,36 @@
+/**
+ * Meshery UI theme entry point.
+ *
+ * This module is a thin re‑export from {@link https://github.com/layer5io/sistent Sistent},
+ * the Meshery design system. It exists so that every consumer in the
+ * Meshery UI imports theme primitives (`useTheme`, `styled`, `alpha`,
+ * `lighten`, `darken`, …) from a single, project‑local path.
+ *
+ *   import { useTheme, styled, alpha } from '@/theme';
+ *
+ * See `ui/docs/THEMING.md` for the full rules:
+ *   - Colors come from `theme.palette.*` — never from a hex literal.
+ *   - Spacing comes from `theme.spacing()` — never from a hard‑coded pixel.
+ *   - Breakpoints come from `theme.breakpoints.*`.
+ *
+ * If Sistent is missing a token the app needs, open an issue or PR upstream
+ * rather than redefining it here. This file must remain a re‑export only.
+ */
+
+export {
+  // Hooks
+  useTheme,
+
+  // CSS-in-JS
+  styled,
+
+  // Color helpers
+  alpha,
+  lighten,
+
+  // Providers & global primitives
+  SistentThemeProvider,
+  SistentThemeProviderWithoutBaseLine,
+  CssBaseline,
+  NoSsr,
+} from '@sistent/sistent';

--- a/ui/theme/index.ts
+++ b/ui/theme/index.ts
@@ -8,7 +8,7 @@
  *
  *   import { useTheme, styled, alpha } from '@/theme';
  *
- * See `ui/docs/THEMING.md` for the full rules:
+ * The core theming rules are:
  *   - Colors come from `theme.palette.*` — never from a hex literal.
  *   - Spacing comes from `theme.spacing()` — never from a hard‑coded pixel.
  *   - Breakpoints come from `theme.breakpoints.*`.

--- a/ui/theme/index.ts
+++ b/ui/theme/index.ts
@@ -27,6 +27,7 @@ export {
   // Color helpers
   alpha,
   lighten,
+  darken,
 
   // Providers & global primitives
   SistentThemeProvider,

--- a/ui/theme/index.ts
+++ b/ui/theme/index.ts
@@ -31,7 +31,7 @@ export {
 
   // Providers & global primitives
   SistentThemeProvider,
-  SistentThemeProviderWithoutBaseLine,
+  SistentThemeProviderWithoutBaseline,
   CssBaseline,
   NoSsr,
 } from '@sistent/sistent';

--- a/ui/tsconfig.json
+++ b/ui/tsconfig.json
@@ -13,7 +13,7 @@
       "@/constants/*": ["constants/*"],
       "@/api/*": ["api/*"],
       "@/assets/*": ["assets/*"],
-      "@/theme": ["theme/index.ts"],
+      "@/theme": ["theme/index"],
       "@/theme/*": ["theme/*"],
       "@/themes/*": ["themes/*"],
       "@/store/*": ["store/*"]

--- a/ui/tsconfig.json
+++ b/ui/tsconfig.json
@@ -13,6 +13,8 @@
       "@/constants/*": ["constants/*"],
       "@/api/*": ["api/*"],
       "@/assets/*": ["assets/*"],
+      "@/theme": ["theme/index.ts"],
+      "@/theme/*": ["theme/*"],
       "@/themes/*": ["themes/*"],
       "@/store/*": ["store/*"]
     },


### PR DESCRIPTION
First PR of the UI restructure. Purely additive — no existing file is moved, renamed, or rewritten, so there is zero behavioral risk.

Creates ui/theme/index.ts as a thin re-export from @sistent/sistent. This is the single project-local path for theme primitives (useTheme, styled, alpha, lighten, SistentThemeProvider, CssBaseline, NoSsr) and the foundation that later phases will migrate consumers onto. The legacy ui/themes/ directory is left untouched — it will be drained and removed in a later PR.

Adds the @/theme path alias to tsconfig.json and jsconfig.json so consumers can write `import { useTheme } from '@/theme'`.

**Notes for Reviewers**

- This PR helps with https://github.com/meshery/meshery/issues/18656

**[Signed commits](https://github.com/meshery/meshery/blob/master/CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [x] Yes, I signed my commits.

<!--
Thank you for contributing to Meshery! 

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. Sign your commits.
4. Include before and after screenshots/terminal output.

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.
-->
