### PR TITLE
fix(server): serve /_next static assets without auth, accept HEAD on UI routes

### DIFF
--- a/server/router/server.go
+++ b/server/router/server.go
@@ -458,7 +458,8 @@ func NewRouter(_ context.Context, h models.HandlerInterface, port int, g http.Ha
 	gMux.PathPrefix("/_next").
 		Handler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			h.ServeUI(w, r, "", "../../ui/out/")
-		}))
+		})).
+		Methods("GET", "HEAD")
 
 	gMux.PathPrefix("/").
 		Handler(h.ProviderMiddleware(h.AuthMiddleware(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/server/router/server.go
+++ b/server/router/server.go
@@ -446,12 +446,25 @@ func NewRouter(_ context.Context, h models.HandlerInterface, port int, g http.Ha
 	gMux.HandleFunc("/healthz/ready", h.K8sHealthzHandler).Methods("GET")
 
 	fs := http.FileServer(http.Dir("../../ui"))
-	gMux.PathPrefix("/ui/public/static/img/meshmodels").Handler(http.StripPrefix("/ui/", fs)).Methods("GET")
+	gMux.PathPrefix("/ui/public/static/img/meshmodels").Handler(http.StripPrefix("/ui/", fs)).Methods("GET", "HEAD")
+
+	// Serve Next.js build artifacts (/_next/data/<buildId>/<route>.json,
+	// /_next/static/*) without the auth middleware. Next.js client-side
+	// route transitions fetch the <route>.json blob to hydrate page props;
+	// when that fetch is gated by AuthMiddleware and auth fails, the 302
+	// redirect HTML cannot be parsed as JSON and the SPA navigation
+	// silently breaks (e.g. clicking through to /extension/meshmap).
+	// This mirrors the existing /provider/_next passthrough above.
+	gMux.PathPrefix("/_next").
+		Handler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			h.ServeUI(w, r, "", "../../ui/out/")
+		}))
+
 	gMux.PathPrefix("/").
 		Handler(h.ProviderMiddleware(h.AuthMiddleware(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			h.ServeUI(w, r, "", "../../ui/out/")
 		}), models.ProviderAuth))).
-		Methods("GET")
+		Methods("GET", "HEAD")
 
 	return &Router{
 		S:    gMux,


### PR DESCRIPTION
## Summary

Two router defects in `server/router/server.go` broke client-side navigation to extension routes (including the Kanvas Designer at `/extension/meshmap`) for unauthenticated or stale-session visitors, producing the console error:

```
[Error] Failed to load resource: the server responded with a status of 405 (Method Not Allowed) (meshmap.json, line 0)
```

## Root cause

### Defect 1 — `/_next/data/*.json` gated by auth middleware

When a user clicks a Next.js `<Link>` to an extension route, Next.js fetches `/_next/data/<buildId>/extension/meshmap.json` to hydrate `pageProps`. That file is a static `getStaticProps` build artifact — it contains only `{"pageProps":{"component":["meshmap"]},"__N_SSG":true}`, no session data, no secrets.

Today it's routed through the catch-all handler at `server/router/server.go:450-454`, which is wrapped in `ProviderMiddleware` + `AuthMiddleware`. When auth fails (missing or expired cookie) the middleware returns a 302 redirect to `/provider`. Next.js's data loader expects JSON, cannot parse the redirect HTML, and silently aborts the SPA transition. A hard refresh papers over the symptom because full-page navigation takes `ServeUI` + the pre-rendered HTML shell instead — but the next client-side `Link` hover/prefetch re-triggers the failure.

The existing `/provider/_next` passthrough at `server.go:49-52` was added for exactly this reason on the provider-ui tree. This PR mirrors that pattern for the main `ui/out/` tree.

### Defect 2 — `.Methods("GET")` is strict in gorilla/mux; HEAD returns 405

The catch-all UI handler was registered with `.Methods("GET")`, which in `gorilla/mux` is a *matcher* — HEAD requests fall through to `MethodNotAllowedHandler` and return 405. Browsers (notably Safari) and some Next.js prefetch paths issue HEAD to validate cached resources, producing the spurious 405 console error even on pages that otherwise loaded fine.

`http.ServeFile` (which `ServeUI` uses internally) already handles HEAD correctly. The only thing blocking it was the router-level method matcher.

## Reproduction (before this PR)

```
$ curl -is -X HEAD   "http://localhost:9081/_next/data/<buildId>/extension/meshmap.json"
HTTP/1.1 405 Method Not Allowed

$ curl -is -X GET    "http://localhost:9081/_next/data/<buildId>/extension/meshmap.json"
HTTP/1.1 302 Found
Location: /provider?ref=...

$ curl -is -X OPTIONS "http://localhost:9081/_next/data/<buildId>/extension/meshmap.json"
HTTP/1.1 405 Method Not Allowed
```

## Changes

`server/router/server.go`:

1. **Add `/_next` passthrough** (new, between the meshmodels FileServer and the catch-all) that serves `ui/out/` without the auth middleware. Mirrors the existing `/provider/_next` pattern from earlier in the same file.

2. **Add HEAD to the catch-all UI route's `.Methods(...)`.** `http.ServeFile` inside `ServeUI` already handles HEAD → this just stops the router from 405'ing before it's reached.

3. **Add HEAD to `/ui/public/static/img/meshmodels`** — same reasoning; these are pure static files served via `http.FileServer`, which already handles HEAD.

No changes to auth semantics for any `/api/*` route. Only the Next.js build-artifact tree loses its (always-spurious) auth gate, and only static UI paths gain HEAD support.

## Test plan

- [ ] `go build ./server/router/` — compiles clean ✅ (already verified locally)
- [ ] `make server` (or equivalent) — full server build succeeds
- [ ] `curl -is -X GET    http://localhost:9081/_next/data/<buildId>/extension/meshmap.json` → `200 OK` with JSON body, even when unauthenticated
- [ ] `curl -is -X HEAD   http://localhost:9081/_next/data/<buildId>/extension/meshmap.json` → `200 OK`, no body
- [ ] `curl -is -X HEAD   http://localhost:9081/extension/meshmap` → `200 OK` (catch-all HEAD support)
- [ ] Click `/extension/meshmap` from the Meshery UI (authenticated) → Kanvas Designer loads via client-side nav, no 405 in console
- [ ] Click `/extension/meshmap` from the Meshery UI (unauthenticated) → redirects cleanly to `/provider` via the full-page navigation, not via a broken JSON fetch
- [ ] `/api/*` routes unchanged — still enforce auth for all methods they declared before
- [ ] `/provider/_next` passthrough still works (not touched by this PR)

## Follow-ups (not in this PR)

- The same class of HEAD-405 issue likely affects `/provider/favicon.ico` (line 46), `/provider` (line 54), `/auth/login`, and `/auth/redirect` — all declared with `.Methods("GET")`. Worth a sweep, but kept out of scope here to keep the diff focused on the reported bug.
- Consider adding a `router_test.go` integration test that boots `NewRouter` against a fake handler and asserts the route matrix (GET/HEAD/OPTIONS on `/_next`, `/extension/*`, `/api/*`). The existing `server_test.go` is effectively empty.