### PR TITLE
Prune old PR previews

### DIFF
--- a/.github/workflows/build-and-preview-docs.yml
+++ b/.github/workflows/build-and-preview-docs.yml
@@ -27,6 +27,7 @@ jobs:
     runs-on: ubuntu-24.04
     env:
       HUGO_VERSION: 0.157.0
+      PREVIEW_RETENTION_LIMIT: 6
 
     steps:
       - name: Checkout PR code
@@ -92,6 +93,47 @@ jobs:
           umbrella-dir: pr-preview
           action: auto
           comment: false
+
+      - name: Checkout gh-pages for preview retention
+        if: github.event.action != 'closed'
+        uses: actions/checkout@v6
+        with:
+          ref: gh-pages
+          fetch-depth: 0
+          path: gh-pages-maintenance
+
+      - name: Prune old PR previews
+        if: github.event.action != 'closed'
+        run: |
+          cd gh-pages-maintenance
+          mkdir -p pr-preview
+
+          mapfile -t previews < <(
+            while IFS= read -r preview; do
+              timestamp="$(git log -1 --format=%ct -- "pr-preview/$preview" 2>/dev/null || echo 0)"
+              printf '%s %s\n' "$timestamp" "$preview"
+            done < <(find pr-preview -mindepth 1 -maxdepth 1 -type d -name 'pr-*' -printf '%f\n') \
+              | sort -nr \
+              | awk '{print $2}'
+          )
+
+          if (( ${#previews[@]} <= PREVIEW_RETENTION_LIMIT )); then
+            exit 0
+          fi
+
+          for preview in "${previews[@]:PREVIEW_RETENTION_LIMIT}"; do
+            rm -rf "pr-preview/$preview"
+          done
+
+          if git diff --quiet -- pr-preview; then
+            exit 0
+          fi
+
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add pr-preview
+          git commit -m "Prune old PR previews"
+          git push
 
       - name: Comment PR with Preview URL
         if: github.event.action != 'closed'


### PR DESCRIPTION
**Notes for Reviewers**
- Will fix https://github.com/meshery/meshery/actions/runs/24359264346

- Prune Old Preview (current limit is set to 6)
- Only 6 previews are kept at any given point of time now, based on which PRs were updated most recently.
 Example: If an older PR is updated now, it stays, while a newer but inactive PR can be removed as we keep the current 6 active PRs in the window.

**[Signed commits](https://github.com/meshery/meshery/blob/master/CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [x] Yes, I signed my commits.

<!--
Thank you for contributing to Meshery! 

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. Sign your commits.
4. Include before and after screenshots/terminal output.

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.
-->
