### PR TITLE
[UI] Fix back tooltip position in design configurator

### DIFF
--- a/ui/components/configuratorComponents/MeshModel/index.tsx
+++ b/ui/components/configuratorComponents/MeshModel/index.tsx
@@ -24,7 +24,6 @@ import LazyComponentForm from './LazyComponentForm';
 import useDesignLifecycle from './hooks/useDesignLifecycle';
 import { useRouter } from 'next/router';
 import { ArrowBack } from '@mui/icons-material';
-import TooltipButton from '../../../utils/TooltipButton';
 import { SaveAs as SaveAsIcon } from '@mui/icons-material';
 import CAN from '@/utils/can';
 import { keys } from '@/utils/permission_constants';
@@ -80,11 +79,11 @@ export default function DesignConfigurator() {
 
   return (
     <NoSsr>
-      <TooltipButton title="Back" placement="left">
+      <CustomTooltip title="Back" placement="right">
         <IconButton onClick={() => router.back()}>
           <ArrowBack />
         </IconButton>
-      </TooltipButton>
+      </CustomTooltip>
       <AppBarComponent position="static" elevation={0} data-testid="design-configurator-app-bar">
         <Toolbar>
           <div style={{ flexGrow: 1 }}>


### PR DESCRIPTION
**Notes for Reviewers**

-  This PR fixes the Back tooltip placement in catalog/design edit mode. The tooltip is now anchored to the actual back icon button, so it appears next to the button instead of the center.

**Before**
<img width="500" height="400" alt="Screenshot from 2026-04-15 09-47-18" src="https://github.com/user-attachments/assets/68173a19-89de-4c8a-917d-f0e01e321933" />

**After**
<img width="500" height="400" alt="image" src="https://github.com/user-attachments/assets/ac67969c-5537-4555-a0c6-ded6fbd310ef" />


**[Signed commits](https://github.com/meshery/meshery/blob/master/CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [x] Yes, I signed my commits.

<!--
Thank you for contributing to Meshery! 

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. Sign your commits.
4. Include before and after screenshots/terminal output.

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.
-->
