### PR TITLE
[UI] Align @/theme export surface with Sistent

### DIFF
--- a/ui/theme/index.ts
+++ b/ui/theme/index.ts
@@ -6,14 +6,17 @@ import type { Theme } from '@sistent/sistent';
  * This module is a thin wrapper around {@link https://github.com/layer5io/sistent Sistent},
  * the Meshery design system. It exists so that every consumer in the
  * Meshery UI imports theme primitives (`useTheme`, `styled`, `alpha`,
- * `lighten`, `darken`, ...) from a single, project-local path.
+ * `lighten`, ...) from a single, project-local path.
  *
  *   import { useTheme, styled, alpha } from '@/theme';
  *
- * The core theming rules are:
- *   - Colors come from `theme.palette.*` - never from a hex literal.
- *   - Spacing comes from `theme.spacing()` - never from a hard-coded pixel.
- *   - Breakpoints come from `theme.breakpoints.*`.
+ * Preferred theming conventions for new or touched UI code are:
+ *   - Prefer colors from `theme.palette.*` instead of introducing new hex literals.
+ *   - Prefer spacing from `theme.spacing()` instead of hard-coded pixel values where possible.
+ *   - Prefer breakpoints from `theme.breakpoints.*`.
+ *
+ * Some legacy theme files in the UI still contain literal color and spacing
+ * values; treat those as migration candidates rather than precedent for new code.
  *
  * If Sistent is missing a token the app needs, open an issue or PR upstream
  * rather than redefining it here. This file must remain a thin wrapper:
@@ -30,11 +33,10 @@ export {
   // Color helpers
   alpha,
   lighten,
-  darken,
 
   // Providers & global primitives
   SistentThemeProvider,
-  SistentThemeProviderWithoutBaseLine as SistentThemeProviderWithoutBaseline,
+  SistentThemeProviderWithoutBaseLine,
   CssBaseline,
   NoSsr,
 } from '@sistent/sistent';


### PR DESCRIPTION
## Summary
- remove the unsupported `darken` re-export from `ui/theme/index.ts`
- switch the baseline-free provider export back to Sistent's published `SistentThemeProviderWithoutBaseLine` name
- soften the wrapper guidance so it reflects the current migration state while preserving the already-merged local palette/type helpers and avoiding runtime behavior changes

Fixes #18757