### PR TITLE
fix(extensions): forward upstream responses and return JSON errors

### DIFF
--- a/server/handlers/extensions.go
+++ b/server/handlers/extensions.go
@@ -106,7 +106,10 @@ func (h *Handler) ExtensionsVersionHandler(w http.ResponseWriter, _ *http.Reques
 func (h *Handler) ExtensionsHandler(w http.ResponseWriter, req *http.Request, _ *models.Preference, _ *models.User, provider models.Provider) {
 	resp, err := provider.ExtensionProxy(req)
 	if err != nil {
-		http.Error(w, fmt.Sprintf("Error: %v", err.Error()), http.StatusInternalServerError)
+		h.log.Error(err)
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusInternalServerError)
+		_ = json.NewEncoder(w).Encode(map[string]string{"error": err.Error()})
 		return
 	}
 

--- a/server/models/remote_provider.go
+++ b/server/models/remote_provider.go
@@ -4363,13 +4363,12 @@ func (l *RemoteProvider) ExtensionProxy(req *http.Request) (*ExtensionProxyRespo
 		StatusCode: resp.StatusCode,
 	}
 
-	// check for all success status codes
-	statusOK := response.StatusCode >= 200 && response.StatusCode < 300
-	if statusOK {
+	if response.StatusCode < 200 || response.StatusCode >= 300 {
+		l.Log.Warn(ErrFetch(fmt.Errorf("remote provider returned status %d", resp.StatusCode), string(bdr), resp.StatusCode))
+	} else {
 		l.Log.Info("response retrieved from remote provider.")
-		return response, nil
 	}
-	return nil, ErrFetch(fmt.Errorf("failed to communicate with remote provider. "), string(bdr), resp.StatusCode)
+	return response, nil
 }
 
 func (l *RemoteProvider) SaveConnection(conn *connections.ConnectionPayload, token string, skipTokenCheck bool) (*connections.Connection, error) {

--- a/ui/components/Dashboard/widgets/WorkspaceActivityWidget.tsx
+++ b/ui/components/Dashboard/widgets/WorkspaceActivityWidget.tsx
@@ -12,7 +12,11 @@ const WorkspaceActivityWidget = () => {
   );
 
   const [selectedWorkspace, setSelectedWorkspace] = useState('');
-  const { data: events, isLoading: isEventsLoading } = useGetEventsOfWorkspaceQuery(
+  const {
+    data: events,
+    isLoading: isEventsLoading,
+    isError: isEventsError,
+  } = useGetEventsOfWorkspaceQuery(
     {
       workspaceId: selectedWorkspace,
       pagesize: 5,
@@ -34,7 +38,7 @@ const WorkspaceActivityWidget = () => {
     <WorkspaceActivityCard
       selectedWorkspace={selectedWorkspace}
       handleWorkspaceChange={handleWorkspaceChange}
-      activities={events?.data}
+      activities={isEventsError ? [] : events?.data}
       workspaces={workspaces?.workspaces}
       isEventsLoading={isEventsLoading}
       workspacePagePath="/management/workspaces"


### PR DESCRIPTION
## Summary

- `ExtensionProxy` now returns the remote provider's response faithfully for all status codes instead of dropping non-2xx bodies and wrapping them in a generic error.
- `ExtensionsHandler` now returns transport failures as `{"error": "..."}` JSON instead of a plain-text `Error: ...` body, so clients using `fetch`/RTK Query can parse it.
- `WorkspaceActivityWidget` reads `isError` and renders an empty activity list on failure instead of leaving `activities` undefined.

## Why

Reported error in the browser:

```
GET /api/extensions/api/workspaces/<id>/events?pagesize=5 → 500
[RTK Query] getEventsOfWorkspace failed: SyntaxError: Unexpected token 'E', "Error: ..." is not valid JSON
```

Tracing the path:
1. The remote provider returns a 500 with a meaningful body (e.g. `"Unable to get events of workspace"`).
2. `ExtensionProxy` discarded that body because status wasn't 2xx (`server/models/remote_provider.go`) and returned `ErrFetch(...)` instead.
3. `ExtensionsHandler` then wrote `http.Error(w, "Error: <wrapped>", 500)` as plain text.
4. RTK Query tried to JSON-parse the body and threw `SyntaxError: Unexpected token 'E'`, masking the real upstream error.

After this PR, the upstream body and status flow through verbatim, and the only branch that still synthesizes a body (true transport failure) returns parseable JSON.

## Test plan

- [ ] Reproduce the 500 from the original endpoint and confirm the client sees the upstream body (`Unable to get events of workspace` or whatever meshery-cloud emits) with the upstream status, not `Error: ...`.
- [ ] Confirm `WorkspaceActivityWidget` on the dashboard renders an empty state rather than logging `Unexpected token 'E'` when the events endpoint 500s.
- [ ] Successful extension calls (`/api/extensions/...` returning 2xx JSON) continue to work unchanged.
- [ ] Simulate an unreachable remote provider and confirm the client receives `{"error": "..."}` JSON with status 500.

## Follow-ups (not in this PR)

The underlying meshery-cloud 500 for that workspace is still unfixed. Once this PR is merged, the real upstream error will be visible to the client and in logs — my best guess is `server/dao/workspace.go:GetEventsOfWorkspace`'s inner `JOIN users` failing when an event row references a missing user. I'll open a separate PR in meshery-cloud after confirming from logs.