### PR TITLE
[Docs] Rename "Integrations" to "Models" on homepage #18811

### DIFF
--- a/docs/content/en/_index.md
+++ b/docs/content/en/_index.md
@@ -149,11 +149,11 @@ linkTitle: Documentation
     <details>
       <summary>
         <p style="display:inline">
-          <a href="/extensibility/integrations" class="text-black">Integrations</a>
+          <a href="/extensibility/integrations" class="text-black">Models</a>
         </p>
       </summary>
       <ul class="section-title">
-        <li>See all <a href="/extensions/models">{{< model-count >}} integrations</a></li>
+        <li>See all <a href="/extensions/models">{{< model-count >}} models</a></li>
       </ul>
     </details>
   </div>

--- a/docs/content/en/_index.md
+++ b/docs/content/en/_index.md
@@ -149,7 +149,7 @@ linkTitle: Documentation
     <details>
       <summary>
         <p style="display:inline">
-          <a href="/extensibility/integrations" class="text-black">Models</a>
+<a href="/extensions/models" class="text-black">Models</a>
         </p>
       </summary>
       <ul class="section-title">


### PR DESCRIPTION
**Notes for Reviewers**
- This PR fixes #18811
- Renamed the collapsible summary label from "Integrations" to "Models" in the Integrations & Extensions section on the documentation homepage.
- Updated "See all X integrations" link text to "See all X models".

**[Signed commits](https://github.com/meshery/meshery/blob/master/CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [ ] Yes, I signed my commits.