### PR TITLE
[AWS ElasticSearch Service] Fix invalid vpcOptions patch references in ElasticsearchDomain relationships

### DIFF
--- a/server/meshmodel/aws-elasticsearchservice-controller/v0.0.2/v1.0.0/relationships/edge-binding-network-vbebu.json
+++ b/server/meshmodel/aws-elasticsearchservice-controller/v0.0.2/v1.0.0/relationships/edge-binding-network-vbebu.json
@@ -45,17 +45,7 @@
               },
               "version": ""
             },
-            "patch": {
-              "mutatorRef": [
-                [
-                  "configuration",
-                  "spec",
-                  "vpcOptions",
-                  "vpcID"
-                ]
-              ],
-              "patchStrategy": "replace"
-            }
+            "patch": null
           }
         ],
         "to": [
@@ -76,14 +66,7 @@
               },
               "version": ""
             },
-            "patch": {
-              "mutatedRef": [
-                [
-                  "displayName"
-                ]
-              ],
-              "patchStrategy": "replace"
-            }
+            "patch": null
           }
         ]
       },

--- a/server/meshmodel/aws-elasticsearchservice-controller/v0.0.2/v1.0.0/relationships/hierarchical-parent-inventory-kmjea.json
+++ b/server/meshmodel/aws-elasticsearchservice-controller/v0.0.2/v1.0.0/relationships/hierarchical-parent-inventory-kmjea.json
@@ -89,14 +89,7 @@
               "components": null,
               "relationships": null
             },
-            "patch": {
-              "patchStrategy": "replace",
-              "mutatedRef": [
-                [
-                  "displayName"
-                ]
-              ]
-            }
+            "patch": null
           }
         ],
         "to": [
@@ -139,17 +132,7 @@
               "components": null,
               "relationships": null
             },
-            "patch": {
-              "patchStrategy": "replace",
-              "mutatorRef": [
-                [
-                  "configuration",
-                  "spec",
-                  "vpcOptions",
-                  "vpcID"
-                ]
-              ]
-            }
+            "patch": null
           }
         ]
       }


### PR DESCRIPTION
 **Notes for Reviewers**

 --This PR addresses relationship inconsistencies in the `aws-elasticsearchservice-controller` model, identified and confirmed with the Meshery community on Slack.

  **What is the problem?**

  Both `edge-binding-network-vbebu.json` and `hierarchical-parent-inventory-kmjea.json` had invalid `patch` configurations on both sides of the ElasticsearchDomain ↔ VPC
  relationship:

  1. The `ElasticsearchDomain` selector referenced `vpcOptions.vpcID` via `mutatorRef` — this field does not exist. The `vpcOptions` object in the ElasticsearchDomain CRD
  spec only contains `subnetIDs` and `securityGroupIDs`.

  2. The `VPC` selector had a `mutatedRef` pointing to `displayName` — but with no corresponding `mutatorRef` on the ElasticsearchDomain side to write to it, this
  reference is orphaned and serves no purpose.

  **What is the fix?**

  Set `patch: null` on both sides of both relationship files, removing all invalid and orphaned patch references and leaving the relationships as visual-only connections.

  **Files changed**
  - `server/meshmodel/aws-elasticsearchservice-controller/v0.0.2/v1.0.0/relationships/edge-binding-network-vbebu.json`
  - `server/meshmodel/aws-elasticsearchservice-controller/v0.0.2/v1.0.0/relationships/hierarchical-parent-inventory-kmjea.json`