### PR TITLE
docs: Add text note on biweekly CI/CD meetings section

### DIFF
--- a/docs/content/en/project/contributing/build-and-release.md
+++ b/docs/content/en/project/contributing/build-and-release.md
@@ -486,6 +486,9 @@ For older releases we have to travel back in time. Using the `Tags` in github we
 
 If you are passionate about CI/CD pipelines, DevOps, automated testing, managing deployments, or if you want to learn how to use Meshery and its features, you are invited to join the bi-weekly Build and Release meetings. Find meeting details and agenda in the [community calendar](https://meshery.io/calendar) and the [meeting minutes document](https://docs.google.com/document/d/1GrVdGHZAYeu6wHNLLoiaKNqBtk7enXE9XeDRCvdA4bY/edit#). The meetings are open to everyone and recorded for later viewing. We hope to see you there!
 
+Note: This biweekly meeting series is currently on hiatus. We'll share an update when it resumes. Thank you for your patience!
+  
+
 <div class="training-video">
   <iframe width="560" height="315"
     src="https://www.youtube.com/embed/dlr_nzJV16Q"


### PR DESCRIPTION
## Summary

Added a note to clarify that the meetings are currently on hiatus and will resume at a later date.

## Changes

Add text "Note: This biweekly meeting series is currently on hiatus. We’ll share an update when it resumes. Thank you for your patience!" under Bi-Weekly Meetings section.

Closes: https://github.com/meshery/meshery/issues/18616

**Notes for Reviewers**

- This PR fixes #18616

**[Signed commits](https://github.com/meshery/meshery/blob/master/CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [x] Yes, I signed my commits.

<!--
Thank you for contributing to Meshery! 

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. Sign your commits.
4. Include before and after screenshots/terminal output.

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.
-->
