### PR TITLE
[UI] Fix release link icon color in sidebar

### DIFF
--- a/ui/components/Navigator.tsx
+++ b/ui/components/Navigator.tsx
@@ -408,7 +408,10 @@ const Navigator_ = () => {
               title={`Newer version of Meshery available: ${latest}`}
               placement="right"
             >
-              <OpenInNewIcon style={{ width: '0.85rem', verticalAlign: 'middle' }} />
+              <OpenInNewIcon
+                fill={theme.palette.background.constant.white}
+                style={{ width: '0.85rem', verticalAlign: 'middle' }}
+              />
             </CustomTextTooltip>
           </a>
         </span>
@@ -428,7 +431,10 @@ const Navigator_ = () => {
           rel="noreferrer"
           style={{ color: 'white' }}
         >
-          <OpenInNewIcon style={{ width: '0.85rem', verticalAlign: 'middle' }} />
+          <OpenInNewIcon
+            fill={theme.palette.background.constant.white}
+            style={{ width: '0.85rem', verticalAlign: 'middle' }}
+          />
         </a>
       );
 
@@ -439,7 +445,10 @@ const Navigator_ = () => {
         rel="noreferrer"
         style={{ color: 'white' }}
       >
-        <OpenInNewIcon style={{ width: '0.85rem', verticalAlign: 'middle' }} />
+        <OpenInNewIcon
+          fill={theme.palette.background.constant.white}
+          style={{ width: '0.85rem', verticalAlign: 'middle' }}
+        />
       </a>
     );
   };


### PR DESCRIPTION
**Notes for Reviewers**

-  Set the release link icons near version text to theme white so they are visible on dark background.

**Before :**

<img width="287" height="117" alt="Screenshot from 2026-04-21 19-42-47" src="https://github.com/user-attachments/assets/750955b0-9b9d-4cb8-9eae-03340d3918ea" /><br>
**After :** 

<img width="287" height="117" alt="Screenshot from 2026-04-21 19-42-50" src="https://github.com/user-attachments/assets/303a8ef2-eee3-45cf-bb41-a0649ad9baa3" />

**[Signed commits](https://github.com/meshery/meshery/blob/master/CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [x] Yes, I signed my commits.

<!--
Thank you for contributing to Meshery! 

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. Sign your commits.
4. Include before and after screenshots/terminal output.

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.
-->
