### PR TITLE
fix(ui): host tippy.js + xterm CSS subpaths for extensions

### DIFF
--- a/ui/pages/_app.tsx
+++ b/ui/pages/_app.tsx
@@ -21,6 +21,33 @@ import { api } from '../rtk-query';
 import { useLazyGetConnectionsQuery } from '../rtk-query/connection';
 import 'react-grid-layout/css/styles.css';
 import 'react-resizable/css/styles.css';
+// Host-side CSS for packages shared with extensions via remote-component.
+// Next.js (pages router) only permits global CSS imports from _app; remote
+// plugins cannot inject their own global stylesheets through the bundler
+// pipeline. Import the full set of tippy.js themes/animations and xterm CSS
+// here so any extension that references them via remote-component-stubbed
+// subpaths (see remote-component.config.js) has the styles already on-page.
+import 'tippy.js/dist/tippy.css';
+import 'tippy.js/dist/svg-arrow.css';
+import 'tippy.js/dist/border.css';
+import 'tippy.js/dist/backdrop.css';
+import 'tippy.js/themes/light.css';
+import 'tippy.js/themes/light-border.css';
+import 'tippy.js/themes/material.css';
+import 'tippy.js/themes/translucent.css';
+import 'tippy.js/animations/shift-away.css';
+import 'tippy.js/animations/shift-away-subtle.css';
+import 'tippy.js/animations/shift-away-extreme.css';
+import 'tippy.js/animations/shift-toward.css';
+import 'tippy.js/animations/shift-toward-subtle.css';
+import 'tippy.js/animations/shift-toward-extreme.css';
+import 'tippy.js/animations/scale.css';
+import 'tippy.js/animations/scale-subtle.css';
+import 'tippy.js/animations/scale-extreme.css';
+import 'tippy.js/animations/perspective.css';
+import 'tippy.js/animations/perspective-subtle.css';
+import 'tippy.js/animations/perspective-extreme.css';
+import '@xterm/xterm/css/xterm.css';
 import { getConnectionIDsFromContextIds, getK8sConfigIdsFromK8sConfig } from '../utils/multi-ctx';
 import './../public/static/style/index.css';
 import './styles/AnimatedFilter.css';

--- a/ui/remote-component.config.js
+++ b/ui/remote-component.config.js
@@ -186,12 +186,43 @@ module.exports = {
     '@xterm/xterm': require('@xterm/xterm'),
     '@xterm/addon-fit': require('@xterm/addon-fit'),
     '@xterm/addon-search': require('@xterm/addon-search'),
+    // CSS subpath stub — the actual stylesheet is injected globally in
+    // pages/_app.tsx. Remote plugins still call `require(...)` on the subpath,
+    // so a key must exist here or remote-component throws
+    // "does not exist in dependencies". The value is irrelevant because
+    // plugin-side imports are side-effect only.
+    '@xterm/xterm/css/xterm.css': {},
 
     // Extension Point: Shared runtime for extensions
     '@dnd-kit/core': require('@dnd-kit/core'),
     '@dnd-kit/utilities': require('@dnd-kit/utilities'),
     '@tippyjs/react': require('@tippyjs/react'),
     'tippy.js': require('tippy.js'),
+    // tippy.js CSS subpath stubs — stylesheets are injected globally in
+    // pages/_app.tsx. These keys exist only so remote plugins that
+    // `require('tippy.js/...css')` don't trip remote-component's resolver.
+    // Listed greedily (every shipped theme + animation) so we don't have to
+    // chase each new extension's subpath request one-by-one.
+    'tippy.js/dist/tippy.css': {},
+    'tippy.js/dist/svg-arrow.css': {},
+    'tippy.js/dist/border.css': {},
+    'tippy.js/dist/backdrop.css': {},
+    'tippy.js/themes/light.css': {},
+    'tippy.js/themes/light-border.css': {},
+    'tippy.js/themes/material.css': {},
+    'tippy.js/themes/translucent.css': {},
+    'tippy.js/animations/shift-away.css': {},
+    'tippy.js/animations/shift-away-subtle.css': {},
+    'tippy.js/animations/shift-away-extreme.css': {},
+    'tippy.js/animations/shift-toward.css': {},
+    'tippy.js/animations/shift-toward-subtle.css': {},
+    'tippy.js/animations/shift-toward-extreme.css': {},
+    'tippy.js/animations/scale.css': {},
+    'tippy.js/animations/scale-subtle.css': {},
+    'tippy.js/animations/scale-extreme.css': {},
+    'tippy.js/animations/perspective.css': {},
+    'tippy.js/animations/perspective-subtle.css': {},
+    'tippy.js/animations/perspective-extreme.css': {},
     '@reactour/tour': require('@reactour/tour'),
     'react-mentions': require('react-mentions'),
     'hotkeys-js': require('hotkeys-js'),


### PR DESCRIPTION
## Summary

Kanvas (and any other Meshery extension) loads at runtime through `@paciolan/remote-component`, which resolves imports via this repo's `ui/remote-component.config.js`. The `resolve` map currently exposes package roots only — so an extension that imports a CSS subpath like `tippy.js/animations/shift-away.css` or `@xterm/xterm/css/xterm.css` hits:

```
Could not require 'tippy.js/animations/shift-away-extreme.css'.
'tippy.js/animations/shift-away-extreme.css' does not exist in dependencies.
```

...and fails to load the plugin. We've been patching this by forcing the extension to bundle the CSS locally (layer5labs/meshery-extensions#4200, #4201), which:
- leaks host responsibility into every extension,
- requires a plugin rebuild each time a new subpath is referenced,
- defeats the point of sharing the singleton.

Fix it on the host so extensions stay thin.

## Changes

- `pages/_app.tsx` — side-effect CSS imports for every shipped `tippy.js` theme and animation, the other stylesheets in `tippy.js/dist/`, and `@xterm/xterm/css/xterm.css`. Next.js (pages router) only permits global CSS imports from `_app`, so this is the only valid injection point.
- `remote-component.config.js` — stub `{}` entries for the same subpath keys. `@paciolan/remote-component`'s resolver only does `key in deps`, so inert stubs satisfy the extension's `require(...)`-as-side-effect while the actual stylesheet is already on the page from `_app`.

The list is intentionally greedy — every tippy.js theme/animation the package publishes, even if no extension currently references it — so future extensions don't hit the same wall.

## Follow-up

After this lands in a deployed Meshery UI, the plugin-side `BUNDLED_SUBPATHS` entries in `layer5labs/meshery-extensions`' `meshmap/externalDeps.js` for tippy.js + xterm can be reverted so the extension re-externalizes those imports.

## Test plan

- [x] `node --check remote-component.config.js` — syntax OK
- [ ] Local Meshery UI build succeeds (`cd ui && npm run build`)
- [ ] Run Meshery with Kanvas loaded; verify no `Could not require 'tippy.js/...'` or `'@xterm/xterm/css/xterm.css'` errors in the console
- [ ] Tooltips (Kanvas designer edge color picker, second-level tippy) render with the expected animation and border theme
- [ ] The custom terminal in Kanvas renders with proper xterm styling