### PR TITLE
[Server] Fix policy engine infinite loop on nil mutator values

### DIFF
--- a/server/policies/eval_rules.go
+++ b/server/policies/eval_rules.go
@@ -140,7 +140,7 @@ func patchMutatorsAction(rel *relationship.RelationshipDefinition, design *patte
 		for i := 0; i < count; i++ {
 			mutatorValue := configurationForComponentAtPath(mutatorRefs[i], mutatorComp, design)
 			oldValue := configurationForComponentAtPath(mutatedRefs[i], mutatedComp, design)
-			if deepEqual(mutatorValue, oldValue) || mutatorValue == nil {
+			if mutatorValue == nil || deepEqual(mutatorValue, oldValue) {
 				continue
 			}
 			actions = append(actions, newComponentUpdateAction(getComponentUpdateOp(mutatedRefs[i]), mutatedID, mutatedRefs[i], mutatorValue))

--- a/server/policies/eval_rules.go
+++ b/server/policies/eval_rules.go
@@ -140,7 +140,7 @@ func patchMutatorsAction(rel *relationship.RelationshipDefinition, design *patte
 		for i := 0; i < count; i++ {
 			mutatorValue := configurationForComponentAtPath(mutatorRefs[i], mutatorComp, design)
 			oldValue := configurationForComponentAtPath(mutatedRefs[i], mutatedComp, design)
-			if deepEqual(mutatorValue, oldValue) {
+			if deepEqual(mutatorValue, oldValue) || mutatorValue == nil {
 				continue
 			}
 			actions = append(actions, newComponentUpdateAction(getComponentUpdateOp(mutatedRefs[i]), mutatedID, mutatedRefs[i], mutatorValue))


### PR DESCRIPTION
**Notes for Reviewers**

- This PR relates to #17330 (Go policy engine port)

## Why

`patchMutatorsAction` keeps generating the same patch each iteration when a mutator field resolves to `nil`, because the convergence check only compares equality. On large designs this exhausts `MAX_RE_EVALUATION_DEPTH`, producing a timeout on `config patching correctness` (e.g. `meshery-design-fixture.json`).

`policy_binding.go:121` already guards with `|| mutatorValue == nil`. `patchMutatorsAction` (used by edge-non-binding, wallet, hierarchical policies) was missing the same guard.

## How

- Add `|| mutatorValue == nil` to the equality check in `patchMutatorsAction` so a nil mutator is treated as "nothing to patch", matching binding policy behavior.

**[Signed commits](https://github.com/meshery/meshery/blob/master/CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [x] Yes, I signed my commits.