### PR TITLE
fix(server): nil logger panic in K8s machine init when kube context unreachable

### DIFF
--- a/server/machines/kubernetes/machine.go
+++ b/server/machines/kubernetes/machine.go
@@ -159,11 +159,16 @@ func AssignInitialCtx(ctx context.Context, machineCtx interface{}, log logger.Ha
 	if err != nil {
 		return nil, eventBuilder.Build(), err
 	}
+	// Attach the logger before any action that may log on an error path.
+	// AssignClientSetToContext threads machinectx.log into GenerateK8sClientSet,
+	// which log.Warn()s when the kube handler cannot be constructed (e.g. the
+	// persisted context's API server is unreachable from this machine). A nil
+	// logger.Handler there causes an interface-method-on-nil panic.
+	machinectx.log = log
 	err = AssignClientSetToContext(machinectx, eventBuilder)
 	if err != nil {
 		return nil, eventBuilder.Build(), err
 	}
-	machinectx.log = log
 	AssignControllerHandlers(machinectx, sysID, provider)
 	return machinectx, nil, nil
 }

--- a/server/machines/kubernetes/machine_test.go
+++ b/server/machines/kubernetes/machine_test.go
@@ -25,19 +25,25 @@ import (
 // This test exercises AssignInitialCtx with a K8sContext whose API server
 // is unreachable, which forces the error path previously responsible for
 // the nil-deref panic. The assertions:
-//   - no panic
-//   - machinectx.log is the logger we passed (proving the attach happened
-//     before any action could consume it)
+//   - no panic on the error path
+//   - AssignInitialCtx surfaces the underlying AssignClientSetToContext error
+//     (so the caller can handle it) and does not return a populated context
+//   - machinectx.log is the exact logger we passed (proving the attach
+//     happened before any action could consume it)
 func TestAssignInitialCtx_AttachesLoggerBeforeClientSetAssignment(t *testing.T) {
 	log, err := logger.New("test", logger.Options{})
 	if err != nil {
 		t.Fatalf("failed to build test logger: %v", err)
 	}
 
-	user := &models.User{}
-	if userID, err := uuid.NewV4(); err == nil {
-		user.ID = core.Uuid(userID)
+	// Fail fast on UUID generation so the event builder always sees a valid
+	// user ID and the test setup is deterministic; silently leaving user.ID
+	// unset would change the code path we're exercising.
+	userID, err := uuid.NewV4()
+	if err != nil {
+		t.Fatalf("failed to generate user UUID: %v", err)
 	}
+	user := &models.User{ID: core.Uuid(userID)}
 
 	sysID := core.Uuid(uuid.FromStringOrNil("00000000-0000-0000-0000-000000000000"))
 
@@ -66,13 +72,22 @@ func TestAssignInitialCtx_AttachesLoggerBeforeClientSetAssignment(t *testing.T) 
 
 	result, _, err := AssignInitialCtx(ctx, machinectx, log)
 
-	// The production repro errors out of AssignClientSetToContext; we accept
-	// any error or nil here — what we're asserting is *the absence of a
-	// panic* and that the log attachment happened before that error path ran.
-	_ = err
-	_ = result
+	// AssignClientSetToContext must fail for an unreachable/invalid context —
+	// that's the exact production regression we're guarding. If this ever
+	// returns nil here, either the test lost its repro or GenerateK8sClientSet
+	// started tolerating unreachable servers, both of which invalidate this
+	// guard.
+	if err == nil {
+		t.Fatal("expected AssignInitialCtx to return an error for an unreachable K8s context, got nil — the regression guard is no longer exercising the panicking path")
+	}
+	if result != nil {
+		t.Fatalf("expected nil machine context on AssignClientSetToContext error, got %#v", result)
+	}
 
-	if machinectx.log == nil {
-		t.Fatal("expected machinectx.log to be populated before AssignClientSetToContext runs; it was nil — the very ordering bug that produced the login panic")
+	// Logger must be the exact instance we passed in: equality (not just
+	// non-nil) proves the attach happened before AssignClientSetToContext
+	// ran, which is the invariant the ordering fix establishes.
+	if machinectx.log != log {
+		t.Fatal("expected machinectx.log to be the logger passed into AssignInitialCtx and assigned before AssignClientSetToContext; a different or nil value reintroduces the login-panic ordering bug")
 	}
 }

--- a/server/machines/kubernetes/machine_test.go
+++ b/server/machines/kubernetes/machine_test.go
@@ -1,0 +1,78 @@
+package kubernetes
+
+import (
+	"context"
+	"testing"
+
+	"github.com/gofrs/uuid"
+	"github.com/meshery/meshery/server/models"
+	"github.com/meshery/meshkit/logger"
+	"github.com/meshery/schemas/models/core"
+)
+
+// TestAssignInitialCtx_AttachesLoggerBeforeClientSetAssignment guards against
+// a nil-pointer panic on login when a persisted K8s context can't be reached:
+// GenerateKubeHandler errors → GenerateK8sClientSet hits its log.Warn path →
+// interface-method-on-nil panic.
+//
+// The bug was an ordering mistake in AssignInitialCtx: machinectx.log was
+// assigned AFTER AssignClientSetToContext, which threaded the still-nil
+// log through GenerateClientSetAction → GenerateK8sClientSet. Any persisted
+// context whose API server wasn't reachable (common: stale contexts from a
+// remote provider pointing at clusters this host can't route to) produced
+// the panic on every /api request that went through K8sFSMMiddleware.
+//
+// This test exercises AssignInitialCtx with a K8sContext whose API server
+// is unreachable, which forces the error path previously responsible for
+// the nil-deref panic. The assertions:
+//   - no panic
+//   - machinectx.log is the logger we passed (proving the attach happened
+//     before any action could consume it)
+func TestAssignInitialCtx_AttachesLoggerBeforeClientSetAssignment(t *testing.T) {
+	log, err := logger.New("test", logger.Options{})
+	if err != nil {
+		t.Fatalf("failed to build test logger: %v", err)
+	}
+
+	user := &models.User{}
+	if userID, err := uuid.NewV4(); err == nil {
+		user.ID = core.Uuid(userID)
+	}
+
+	sysID := core.Uuid(uuid.FromStringOrNil("00000000-0000-0000-0000-000000000000"))
+
+	ctx := context.Background()
+	ctx = context.WithValue(ctx, models.UserCtxKey, user)
+	ctx = context.WithValue(ctx, models.SystemIDKey, &sysID)
+	// ProviderCtxKey: a typed-nil is fine — AssignControllerHandlers is only
+	// reached after AssignClientSetToContext, and that's the point we want
+	// to defend. If AssignClientSetToContext returns an error we never reach
+	// controller setup, which matches the production scenario.
+	var provider models.Provider
+	ctx = context.WithValue(ctx, models.ProviderCtxKey, provider)
+
+	machinectx := &MachineCtx{
+		K8sContext: models.K8sContext{
+			// Deliberately empty: any unreachable/invalid kubeconfig is fine.
+			// The point is to force GenerateKubeHandler to fail so the
+			// previously panicking log.Warn path runs.
+			Name:         "unreachable-test-context",
+			Server:       "https://127.0.0.1:1", // RFC-reserved, refused instantly
+			ConnectionID: uuid.Must(uuid.NewV4()).String(),
+		},
+		// clientset left nil to force AssignClientSetToContext to attempt
+		// GenerateClientSetAction (the panicking path).
+	}
+
+	result, _, err := AssignInitialCtx(ctx, machinectx, log)
+
+	// The production repro errors out of AssignClientSetToContext; we accept
+	// any error or nil here — what we're asserting is *the absence of a
+	// panic* and that the log attachment happened before that error path ran.
+	_ = err
+	_ = result
+
+	if machinectx.log == nil {
+		t.Fatal("expected machinectx.log to be populated before AssignClientSetToContext runs; it was nil — the very ordering bug that produced the login panic")
+	}
+}


### PR DESCRIPTION
## Summary

Fixes a server-wide panic triggered on login (and on every request passing through \`K8sFSMMiddleware\`) when a persisted K8s context has an unreachable API server.

- \`server/machines/kubernetes/machine.go\` — move \`machinectx.log = log\` above the \`AssignClientSetToContext\` call in \`AssignInitialCtx\`.
- \`server/machines/kubernetes/machine_test.go\` — new unit test \`TestAssignInitialCtx_AttachesLoggerBeforeClientSetAssignment\` that reproduces the production panic stack when the fix is reverted.

## Root cause

\`AssignInitialCtx\` assigned \`machinectx.log\` **after** \`AssignClientSetToContext\` ran:

\`\`\`go
machinectx, err := GetMachineCtx(machineCtx, eventBuilder)
…
err = AssignClientSetToContext(machinectx, eventBuilder)  // uses machinectx.log (nil)
…
machinectx.log = log  // assigned too late
\`\`\`

\`AssignClientSetToContext\` threads \`machinectx.log\` into \`GenerateClientSetAction\` → \`models.GenerateK8sClientSet\`. On the error path in \`models/k8s_context.go:639\`:

\`\`\`go
log.Warn(ErrGenerateK8sHandler(err, context.Name))
\`\`\`

If \`GenerateKubeHandler\` returns an error — exactly what happens when the persisted context's API server isn't reachable from this machine (stale contexts pointing at clusters this host can't route to are common) — calling \`.Warn()\` on the still-nil \`logger.Handler\` interface causes an interface-method-on-nil panic.

Because every API request routed through \`K8sFSMMiddleware\` hits this path (including \`/api/*\` requests on login), the panic was user-visible and persistent.

## Fix

Attach the logger before any action that might consume it:

\`\`\`go
machinectx.log = log
err = AssignClientSetToContext(machinectx, eventBuilder)
\`\`\`

No behavior change in the leaf function — the contract that \`machinectx.log\` must be set before actions run is now honored at the single entry point that was violating it.

## Test plan

- [x] Added \`TestAssignInitialCtx_AttachesLoggerBeforeClientSetAssignment\` that drives \`AssignInitialCtx\` with a deliberately unreachable K8s context (\`https://127.0.0.1:1\`). Reverting the fix causes the test to reproduce the exact production panic stack (\`k8s_context.go:639 → helpers.go:28 → helpers.go:58 → machine.go:162\`). With the fix it passes.
- [x] Full \`go test ./...\` in \`server/\` passes.

## Observed production trace this fixes

\`\`\`
http: panic serving: runtime error: invalid memory address or nil pointer dereference
    models.GenerateK8sClientSet … k8s_context.go:639
    kubernetes.GenerateClientSetAction … helpers.go:28
    kubernetes.AssignClientSetToContext … helpers.go:58
    kubernetes.AssignInitialCtx … machine.go:162
    handlers.K8sFSMMiddleware … middlewares.go:359
\`\`\`

## Note

This change was originally part of PR #18855; splitting it out here because it is surgical, independent, and blocking users on login.