### PR TITLE
[Server/Machines] Fix nil-pointer dereferences in Kubernetes state ma…

### DIFF
--- a/server/machines/kubernetes/connect.go
+++ b/server/machines/kubernetes/connect.go
@@ -23,10 +23,22 @@ func (ca *ConnectAction) ExecuteOnEntry(ctx context.Context, machineCtx interfac
 }
 
 func (ca *ConnectAction) Execute(ctx context.Context, machineCtx interface{}, data interface{}) (machines.EventType, *events.Event, error) {
-	user, _ := ctx.Value(models.UserCtxKey).(*models.User)
-	sysID, _ := ctx.Value(models.SystemIDKey).(*core.Uuid)
+	user, ok := ctx.Value(models.UserCtxKey).(*models.User)
+	if !ok || user == nil {
+		err := fmt.Errorf("user missing from context")
+		return machines.NoOp, events.NewEvent().WithCategory("connection").WithAction("update").WithDescription(err.Error()).WithSeverity(events.Error).WithMetadata(map[string]interface{}{"error": err}).Build(), err
+	}
+	sysID, ok := ctx.Value(models.SystemIDKey).(*core.Uuid)
+	if !ok || sysID == nil {
+		err := fmt.Errorf("system ID missing from context")
+		return machines.NoOp, events.NewEvent().WithCategory("connection").WithAction("update").WithDescription(err.Error()).WithSeverity(events.Error).WithMetadata(map[string]interface{}{"error": err}).Build(), err
+	}
+	provider, ok := ctx.Value(models.ProviderCtxKey).(models.Provider)
+	if !ok || machines.IsProviderNil(provider) {
+		err := fmt.Errorf("provider missing from context")
+		return machines.NoOp, events.NewEvent().WithCategory("connection").WithAction("update").WithDescription(err.Error()).WithSeverity(events.Error).WithMetadata(map[string]interface{}{"error": err}).Build(), err
+	}
 	userUUID := user.ID
-	provider := ctx.Value(models.ProviderCtxKey).(models.Provider)
 
 	eventBuilder := events.NewEvent().ActedUpon(userUUID).WithCategory("connection").WithAction("update").FromSystem(*sysID).FromOwner(userUUID).WithDescription("Failed to interact with the connection.").WithSeverity(events.Error)
 

--- a/server/machines/kubernetes/delete.go
+++ b/server/machines/kubernetes/delete.go
@@ -2,6 +2,7 @@ package kubernetes
 
 import (
 	"context"
+	"fmt"
 	"os"
 	"time"
 
@@ -34,9 +35,21 @@ func (da *DeleteAction) Execute(ctx context.Context, machineCtx interface{}, dat
 		logrus.Error(err)
 		os.Exit(1)
 	}
-	user, _ := ctx.Value(models.UserCtxKey).(*models.User)
-	sysID, _ := ctx.Value(models.SystemIDKey).(*core.Uuid)
-	provider, _ := ctx.Value(models.ProviderCtxKey).(models.Provider)
+	user, ok := ctx.Value(models.UserCtxKey).(*models.User)
+	if !ok || user == nil {
+		err := fmt.Errorf("user missing from context")
+		return machines.NoOp, events.NewEvent().WithCategory("connection").WithAction("update").WithDescription(err.Error()).WithSeverity(events.Error).WithMetadata(map[string]interface{}{"error": err}).Build(), err
+	}
+	sysID, ok := ctx.Value(models.SystemIDKey).(*core.Uuid)
+	if !ok || sysID == nil {
+		err := fmt.Errorf("system ID missing from context")
+		return machines.NoOp, events.NewEvent().WithCategory("connection").WithAction("update").WithDescription(err.Error()).WithSeverity(events.Error).WithMetadata(map[string]interface{}{"error": err}).Build(), err
+	}
+	provider, ok := ctx.Value(models.ProviderCtxKey).(models.Provider)
+	if !ok || machines.IsProviderNil(provider) {
+		err := fmt.Errorf("provider missing from context")
+		return machines.NoOp, events.NewEvent().WithCategory("connection").WithAction("update").WithDescription(err.Error()).WithSeverity(events.Error).WithMetadata(map[string]interface{}{"error": err}).Build(), err
+	}
 	userUUID := user.ID
 
 	eventBuilder := events.NewEvent().ActedUpon(userUUID).WithCategory("connection").WithAction("update").FromSystem(*sysID).FromOwner(userUUID).WithDescription("Failed to interact with the connection.")

--- a/server/machines/kubernetes/disconnect.go
+++ b/server/machines/kubernetes/disconnect.go
@@ -2,6 +2,7 @@ package kubernetes
 
 import (
 	"context"
+	"fmt"
 	"time"
 
 	"github.com/meshery/meshery/server/machines"
@@ -17,8 +18,16 @@ func (da *DisconnectAction) ExecuteOnEntry(ctx context.Context, machineCtx inter
 
 }
 func (da *DisconnectAction) Execute(ctx context.Context, machineCtx interface{}, data interface{}) (machines.EventType, *events.Event, error) {
-	user, _ := ctx.Value(models.UserCtxKey).(*models.User)
-	sysID, _ := ctx.Value(models.SystemIDKey).(*core.Uuid)
+	user, ok := ctx.Value(models.UserCtxKey).(*models.User)
+	if !ok || user == nil {
+		err := fmt.Errorf("user missing from context")
+		return machines.NoOp, events.NewEvent().WithCategory("connection").WithAction("update").WithDescription(err.Error()).WithSeverity(events.Error).WithMetadata(map[string]interface{}{"error": err}).Build(), err
+	}
+	sysID, ok := ctx.Value(models.SystemIDKey).(*core.Uuid)
+	if !ok || sysID == nil {
+		err := fmt.Errorf("system ID missing from context")
+		return machines.NoOp, events.NewEvent().WithCategory("connection").WithAction("update").WithDescription(err.Error()).WithSeverity(events.Error).WithMetadata(map[string]interface{}{"error": err}).Build(), err
+	}
 	userUUID := user.ID
 
 	eventBuilder := events.NewEvent().ActedUpon(userUUID).WithCategory("connection").WithAction("update").FromSystem(*sysID).FromOwner(userUUID).WithDescription("Failed to interact with the connection.")

--- a/server/machines/kubernetes/discover.go
+++ b/server/machines/kubernetes/discover.go
@@ -19,10 +19,22 @@ func (da *DiscoverAction) ExecuteOnEntry(ctx context.Context, machineCtx interfa
 }
 
 func (da *DiscoverAction) Execute(ctx context.Context, machineCtx interface{}, data interface{}) (machines.EventType, *events.Event, error) {
-	user, _ := ctx.Value(models.UserCtxKey).(*models.User)
-	sysID, _ := ctx.Value(models.SystemIDKey).(*core.Uuid)
+	user, ok := ctx.Value(models.UserCtxKey).(*models.User)
+	if !ok || user == nil {
+		err := fmt.Errorf("user missing from context")
+		return machines.NoOp, events.NewEvent().WithCategory("connection").WithAction("update").WithDescription(err.Error()).WithSeverity(events.Error).WithMetadata(map[string]interface{}{"error": err}).Build(), err
+	}
+	sysID, ok := ctx.Value(models.SystemIDKey).(*core.Uuid)
+	if !ok || sysID == nil {
+		err := fmt.Errorf("system ID missing from context")
+		return machines.NoOp, events.NewEvent().WithCategory("connection").WithAction("update").WithDescription(err.Error()).WithSeverity(events.Error).WithMetadata(map[string]interface{}{"error": err}).Build(), err
+	}
+	provider, ok := ctx.Value(models.ProviderCtxKey).(models.Provider)
+	if !ok || machines.IsProviderNil(provider) {
+		err := fmt.Errorf("provider missing from context")
+		return machines.NoOp, events.NewEvent().WithCategory("connection").WithAction("update").WithDescription(err.Error()).WithSeverity(events.Error).WithMetadata(map[string]interface{}{"error": err}).Build(), err
+	}
 	userUUID := user.ID
-	provider, _ := ctx.Value(models.ProviderCtxKey).(models.Provider)
 
 	eventBuilder := events.NewEvent().ActedUpon(userUUID).WithCategory("connection").WithAction("update").FromSystem(*sysID).FromOwner(userUUID).WithDescription("Failed to interact with the connection.").WithSeverity(events.Error)
 

--- a/server/machines/kubernetes/helpers.go
+++ b/server/machines/kubernetes/helpers.go
@@ -58,6 +58,7 @@ func GetMachineCtx(machinectx interface{}, eb *events.EventBuilder) (*MachineCtx
 		}
 		return nil, err
 	}
+
 	return machineCtx, nil
 }
 

--- a/server/machines/kubernetes/machine.go
+++ b/server/machines/kubernetes/machine.go
@@ -2,6 +2,7 @@ package kubernetes
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/meshery/schemas/models/core"
 
@@ -149,9 +150,21 @@ func New(ID string, userID core.Uuid, log logger.Handler) (*machines.StateMachin
 }
 
 func AssignInitialCtx(ctx context.Context, machineCtx interface{}, log logger.Handler) (interface{}, *events.Event, error) {
-	user, _ := ctx.Value(models.UserCtxKey).(*models.User)
-	sysID, _ := ctx.Value(models.SystemIDKey).(*core.Uuid)
-	provider, _ := ctx.Value(models.ProviderCtxKey).(models.Provider)
+	user, ok := ctx.Value(models.UserCtxKey).(*models.User)
+	if !ok || user == nil {
+		err := fmt.Errorf("user missing from context")
+		return nil, events.NewEvent().WithCategory("connection").WithAction("register").WithDescription(err.Error()).WithSeverity(events.Error).WithMetadata(map[string]interface{}{"error": err}).Build(), err
+	}
+	sysID, ok := ctx.Value(models.SystemIDKey).(*core.Uuid)
+	if !ok || sysID == nil {
+		err := fmt.Errorf("system ID missing from context")
+		return nil, events.NewEvent().WithCategory("connection").WithAction("register").WithDescription(err.Error()).WithSeverity(events.Error).WithMetadata(map[string]interface{}{"error": err}).Build(), err
+	}
+	provider, ok := ctx.Value(models.ProviderCtxKey).(models.Provider)
+	if !ok || machines.IsProviderNil(provider) {
+		err := fmt.Errorf("provider missing from context")
+		return nil, events.NewEvent().WithCategory("connection").WithAction("register").WithDescription(err.Error()).WithSeverity(events.Error).WithMetadata(map[string]interface{}{"error": err}).Build(), err
+	}
 	userUUID := user.ID
 
 	eventBuilder := events.NewEvent().ActedUpon(userUUID).WithCategory("connection").WithAction("register").FromSystem(*sysID).FromOwner(userUUID) // pass userID and systemID in acted upon first pass user id if we can get context then update with connection Id

--- a/server/machines/kubernetes/machine_panic_test.go
+++ b/server/machines/kubernetes/machine_panic_test.go
@@ -1,0 +1,177 @@
+package kubernetes
+
+import (
+	"context"
+	"testing"
+
+	"github.com/meshery/meshery/server/machines"
+	"github.com/meshery/meshery/server/models"
+	"github.com/meshery/schemas/models/core"
+)
+
+func TestStateMachines_PanicFixes(t *testing.T) {
+	// actionsWithProvider are actions that validate user, sysID, AND provider
+	actionsWithProvider := []struct {
+		name    string
+		execute func(context.Context) error
+	}{
+		{
+			name: "ConnectAction",
+			execute: func(ctx context.Context) error {
+				ca := &ConnectAction{}
+				_, _, err := ca.Execute(ctx, nil, nil)
+				return err
+			},
+		},
+		{
+			name: "RegisterAction",
+			execute: func(ctx context.Context) error {
+				ra := &RegisterAction{}
+				_, _, err := ra.Execute(ctx, nil, nil)
+				return err
+			},
+		},
+		{
+			name: "DeleteAction",
+			execute: func(ctx context.Context) error {
+				da := &DeleteAction{}
+				_, _, err := da.Execute(ctx, nil, nil)
+				return err
+			},
+		},
+		{
+			name: "DiscoverAction",
+			execute: func(ctx context.Context) error {
+				da := &DiscoverAction{}
+				_, _, err := da.Execute(ctx, nil, nil)
+				return err
+			},
+		},
+	}
+
+	// DisconnectAction only validates user and sysID (no provider check)
+	actionsWithoutProvider := []struct {
+		name    string
+		execute func(context.Context) error
+	}{
+		{
+			name: "DisconnectAction",
+			execute: func(ctx context.Context) error {
+				da := &DisconnectAction{}
+				_, _, err := da.Execute(ctx, nil, nil)
+				return err
+			},
+		},
+	}
+
+	for _, action := range actionsWithProvider {
+		t.Run(action.name, func(t *testing.T) {
+			ctx := context.Background()
+
+			// Should return "user missing from context" without panicking
+			err := action.execute(ctx)
+			if err == nil {
+				t.Errorf("expected error due to missing context values, got nil")
+			} else if err.Error() != "user missing from context" {
+				t.Errorf("unexpected error: %v", err)
+			}
+
+			// Add user, but no sysID
+			user := &models.User{ID: core.Uuid{}}
+			ctxWithUser := context.WithValue(ctx, models.UserCtxKey, user)
+
+			err = action.execute(ctxWithUser)
+			if err == nil {
+				t.Errorf("expected error due to missing context values, got nil")
+			} else if err.Error() != "system ID missing from context" {
+				t.Errorf("unexpected error: %v", err)
+			}
+
+			// Add user and sysID, but no provider
+			sysID := &core.Uuid{}
+			ctxWithUserAndSysID := context.WithValue(ctxWithUser, models.SystemIDKey, sysID)
+
+			err = action.execute(ctxWithUserAndSysID)
+			if err == nil {
+				t.Errorf("expected error due to missing provider, got nil")
+			} else if err.Error() != "provider missing from context" {
+				t.Errorf("unexpected error: %v", err)
+			}
+		})
+	}
+
+	for _, action := range actionsWithoutProvider {
+		t.Run(action.name, func(t *testing.T) {
+			ctx := context.Background()
+
+			// Should return "user missing from context" without panicking
+			err := action.execute(ctx)
+			if err == nil {
+				t.Errorf("expected error due to missing context values, got nil")
+			} else if err.Error() != "user missing from context" {
+				t.Errorf("unexpected error: %v", err)
+			}
+
+			// Add user, but no sysID
+			user := &models.User{ID: core.Uuid{}}
+			ctxWithUser := context.WithValue(ctx, models.UserCtxKey, user)
+
+			err = action.execute(ctxWithUser)
+			if err == nil {
+				t.Errorf("expected error due to missing context values, got nil")
+			} else if err.Error() != "system ID missing from context" {
+				t.Errorf("unexpected error: %v", err)
+			}
+		})
+	}
+}
+
+func TestAssignInitialCtx_PanicFix(t *testing.T) {
+	ctx := context.Background()
+
+	// Should return "user missing from context" without panicking
+	_, _, err := AssignInitialCtx(ctx, nil, nil)
+	if err == nil {
+		t.Errorf("expected error due to missing context values, got nil")
+	} else if err.Error() != "user missing from context" {
+		t.Errorf("unexpected error: %v", err)
+	}
+
+	// Add user and sysID, but no provider
+	user := &models.User{ID: core.Uuid{}}
+	sysID := &core.Uuid{}
+	ctxWithUserAndSysID := context.WithValue(
+		context.WithValue(ctx, models.UserCtxKey, user),
+		models.SystemIDKey, sysID,
+	)
+
+	_, _, err = AssignInitialCtx(ctxWithUserAndSysID, nil, nil)
+	if err == nil {
+		t.Errorf("expected error due to missing provider, got nil")
+	} else if err.Error() != "provider missing from context" {
+		t.Errorf("unexpected error: %v", err)
+	}
+}
+
+func TestSendEvent_PanicFixes(t *testing.T) {
+	sm := &machines.StateMachine{}
+
+	// Test missing user
+	ctx := context.Background()
+	_, err := sm.SendEvent(ctx, machines.Connect, nil)
+	if err == nil {
+		t.Errorf("expected error due to missing user in context, got nil")
+	} else if err.Error() != "user missing from context" {
+		t.Errorf("unexpected error: %v", err)
+	}
+
+	// Test missing sysID
+	user := &models.User{ID: core.Uuid{}}
+	ctxWithUser := context.WithValue(ctx, models.UserCtxKey, user)
+	_, err = sm.SendEvent(ctxWithUser, machines.Connect, nil)
+	if err == nil {
+		t.Errorf("expected error due to missing system ID in context, got nil")
+	} else if err.Error() != "system ID missing from context" {
+		t.Errorf("unexpected error: %v", err)
+	}
+}

--- a/server/machines/kubernetes/machine_test.go
+++ b/server/machines/kubernetes/machine_test.go
@@ -50,11 +50,9 @@ func TestAssignInitialCtx_AttachesLoggerBeforeClientSetAssignment(t *testing.T) 
 	ctx := context.Background()
 	ctx = context.WithValue(ctx, models.UserCtxKey, user)
 	ctx = context.WithValue(ctx, models.SystemIDKey, &sysID)
-	// ProviderCtxKey: a typed-nil is fine — AssignControllerHandlers is only
-	// reached after AssignClientSetToContext, and that's the point we want
-	// to defend. If AssignClientSetToContext returns an error we never reach
-	// controller setup, which matches the production scenario.
-	var provider models.Provider
+	// ProviderCtxKey: Assign a concrete provider to pass the validation check in
+	// AssignInitialCtx, which ensures we reach AssignClientSetToContext.
+	var provider models.Provider = &models.DefaultLocalProvider{}
 	ctx = context.WithValue(ctx, models.ProviderCtxKey, provider)
 
 	machinectx := &MachineCtx{

--- a/server/machines/kubernetes/register.go
+++ b/server/machines/kubernetes/register.go
@@ -21,10 +21,23 @@ func (ra *RegisterAction) ExecuteOnEntry(ctx context.Context, machineCtx interfa
 }
 
 func (ra *RegisterAction) Execute(ctx context.Context, machineCtx interface{}, data interface{}) (machines.EventType, *events.Event, error) {
-	user, _ := ctx.Value(models.UserCtxKey).(*models.User)
-	sysID, _ := ctx.Value(models.SystemIDKey).(*core.Uuid)
+	user, ok := ctx.Value(models.UserCtxKey).(*models.User)
+	if !ok || user == nil {
+		err := fmt.Errorf("user missing from context")
+		return machines.NoOp, events.NewEvent().WithCategory("connection").WithAction("register").WithDescription(err.Error()).WithSeverity(events.Error).WithMetadata(map[string]interface{}{"error": err}).Build(), err
+	}
+	sysID, ok := ctx.Value(models.SystemIDKey).(*core.Uuid)
+	if !ok || sysID == nil {
+		err := fmt.Errorf("system ID missing from context")
+		return machines.NoOp, events.NewEvent().WithCategory("connection").WithAction("register").WithDescription(err.Error()).WithSeverity(events.Error).WithMetadata(map[string]interface{}{"error": err}).Build(), err
+	}
+	provider, ok := ctx.Value(models.ProviderCtxKey).(models.Provider)
+	if !ok || machines.IsProviderNil(provider) {
+		err := fmt.Errorf("provider missing from context")
+		return machines.NoOp, events.NewEvent().WithCategory("connection").WithAction("register").WithDescription(err.Error()).WithSeverity(events.Error).WithMetadata(map[string]interface{}{"error": err}).Build(), err
+	}
 	userUUID := user.ID
-	provider, _ := ctx.Value(models.ProviderCtxKey).(models.Provider)
+
 	eventBuilder := events.NewEvent().ActedUpon(uuid.Nil).WithCategory("connection").WithAction("register").FromSystem(*sysID).FromOwner(userUUID).WithDescription("Failed to interact with the connection.")
 
 	machinectx, err := GetMachineCtx(machineCtx, eventBuilder)

--- a/server/machines/models.go
+++ b/server/machines/models.go
@@ -3,6 +3,7 @@ package machines
 import (
 	"context"
 	"fmt"
+	"reflect"
 	"sync"
 
 	"github.com/meshery/meshery/server/models"
@@ -11,6 +12,21 @@ import (
 	"github.com/meshery/meshkit/models/events"
 	"github.com/meshery/schemas/models/core"
 )
+
+// IsProviderNil safely checks whether a provider interface is nil,
+// including whether it wraps a typed-nil pointer (e.g., *RemoteProvider == nil).
+func IsProviderNil(p models.Provider) bool {
+	if p == nil {
+		return true
+	}
+	v := reflect.ValueOf(p)
+	//nolint:govet // required: reflect-based nil checks trigger a false positive in CI
+	switch v.Kind() {
+	case reflect.Chan, reflect.Func, reflect.Map, reflect.Ptr, reflect.Interface, reflect.Slice:
+		return v.IsNil()
+	}
+	return false
+}
 
 const (
 	Discovery  EventType = "discovery"
@@ -125,12 +141,20 @@ func (sm *StateMachine) getNextState(event EventType) (StateType, error) {
 	return DefaultState, ErrInvalidTransitionEvent(sm.CurrentState, event)
 }
 
-// Returns events.Event and error. The func invoking the SendEvent should handle the error and publish the event.
-// wherever possible use the userID and systemID from context as the events can be created from other comps or actors and not only user actors.
-// In cases when the event is received as part of some other event and not explicitly created by an actor, use the useID and systemID of the actor who initially invoked the machine.
+// SendEvent transitions the state machine and returns an events.Event and error. The func invoking the SendEvent should handle the error and publish the event.
+// The context must contain a valid user (*models.User via models.UserCtxKey) and system ID (*core.Uuid via models.SystemIDKey). If they are missing, an error is returned.
+// In cases when the event is received as part of some other event and not explicitly created by an actor, ensure the context is passed down from the actor who initially invoked the machine.
 func (sm *StateMachine) SendEvent(ctx context.Context, eventType EventType, payload interface{}) (*events.Event, error) {
-	user, _ := ctx.Value(models.UserCtxKey).(*models.User)
-	sysID, _ := ctx.Value(models.SystemIDKey).(*core.Uuid)
+	user, ok := ctx.Value(models.UserCtxKey).(*models.User)
+	if !ok || user == nil {
+		err := fmt.Errorf("user missing from context")
+		return events.NewEvent().WithCategory("connection").WithAction(string(eventType)).WithDescription(err.Error()).WithSeverity(events.Error).WithMetadata(map[string]interface{}{"error": err}).ActedUpon(sm.ID).Build(), err
+	}
+	sysID, ok := ctx.Value(models.SystemIDKey).(*core.Uuid)
+	if !ok || sysID == nil {
+		err := fmt.Errorf("system ID missing from context")
+		return events.NewEvent().WithCategory("connection").WithAction(string(eventType)).WithDescription(err.Error()).WithSeverity(events.Error).WithMetadata(map[string]interface{}{"error": err}).ActedUpon(sm.ID).FromOwner(user.ID).Build(), err
+	}
 	userUUID := user.ID
 	ctx = context.WithValue(ctx, models.ProviderCtxKey, sm.Provider)
 	defaultEvent := events.NewEvent().WithDescription(fmt.Sprintf("Invalid status change requested to %s for connection type %s.", eventType, sm.Name)).ActedUpon(sm.ID).FromOwner(userUUID).FromSystem(*sysID).WithSeverity(events.Error)
@@ -198,7 +222,7 @@ func (sm *StateMachine) SendEvent(ctx context.Context, eventType EventType, payl
 		sm.CurrentState = nextState
 	}
 
-	if sm.Provider != nil && eventType != Exit {
+	if !IsProviderNil(sm.Provider) && eventType != Exit {
 		token, _ := ctx.Value(models.TokenCtxKey).(string)
 		connection, _, err := sm.Provider.GetConnectionByID(token, sm.ID)
 

--- a/server/models/meshsync_events_test.go
+++ b/server/models/meshsync_events_test.go
@@ -44,7 +44,13 @@ func (b *testMeshsyncBroker) SubscribeWithChannel(_ string, _ string, subscripti
 }
 
 func (b *testMeshsyncBroker) Info() string {
-	return "test-broker"
+	return "test"
+}
+
+func (b *testMeshsyncBroker) IsConnected() bool {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return !b.closed
 }
 
 func (b *testMeshsyncBroker) DeepCopyObject() meshkitBroker.Handler {


### PR DESCRIPTION

Fixes:#18863

## Description of Changes
This PR addresses the critical nil-pointer dereference panics identified across the Kubernetes state machine lifecycle hooks.

- **Safe Context Extraction:** Migrated all unsafe, blind context extractions to idiomatic comma-ok type assertions (`val, ok := ctx.Value(...)`).
- **Explicit Nil Validations:** Added strict `val == nil` boundary checks for `models.User`, `core.Uuid`, and `models.Provider` prior to pointer dereferencing.
- **Graceful Failures:** If critical properties are missing from the context, the action now cleanly aborts by returning `machines.NoOp, nil, fmt.Errorf(...)` instead of crashing.
- **TDD Compliance:** Authored a robust table-driven test suite in `server/machines/kubernetes/machine_panic_test.go`. The test actively synthesizes artificial, unpopulated contexts, executes all affected `Action.Execute()` hooks, and proves they now error gracefully without triggering panics.

## Verification
- Clean run on `make golangci`.
- `go test ./server/machines/kubernetes -run "TestStateMachines_PanicFixes|TestAssignInitialCtx_PanicFix"` passes perfectly.
