### PR TITLE
fix: align identifier naming (orgID -> orgId) in handlers, remote-provider, and UI RTK hooks

### DIFF
--- a/.github/workflows/docs-noob-tester.lock.yml
+++ b/.github/workflows/docs-noob-tester.lock.yml
@@ -1,4 +1,4 @@
-# gh-aw-metadata: {"schema_version":"v3","frontmatter_hash":"e097e33e3367a0b3ab5f1c2067214c27ae4cbba94c3408abbcd26b280d66a0c0","compiler_version":"v0.67.1","strict":true,"agent_id":"copilot"}
+# gh-aw-metadata: {"schema_version":"v3","frontmatter_hash":"7a7436c31c9a3dd77a434727dca5191a850f1c6e039d28b2dbc8976ea07942b6","compiler_version":"v0.67.1","strict":true,"agent_id":"copilot"}
 #    ___                   _   _      
 #   / _ \                 | | (_)     
 #  | |_| | __ _  ___ _ __ | |_ _  ___ 
@@ -29,7 +29,6 @@
 #     - shared/mood.md
 #
 # Secrets used:
-#   - COPILOT_GITHUB_TOKEN
 #   - GH_AW_GITHUB_MCP_SERVER_TOKEN
 #   - GH_AW_GITHUB_TOKEN
 #   - GITHUB_TOKEN
@@ -44,7 +43,7 @@
 name: "Meshery Docs Noob Tester"
 "on":
   schedule:
-  - cron: "32 12 * * *"
+  - cron: "33 20 * * *"
     # Friendly format: daily (scattered)
   workflow_dispatch:
     inputs:
@@ -71,7 +70,6 @@ jobs:
       comment_repo: ""
       lockdown_check_failed: ${{ steps.generate_aw_info.outputs.lockdown_check_failed == 'true' }}
       model: ${{ steps.generate_aw_info.outputs.model }}
-      secret_verification_result: ${{ steps.validate-secret.outputs.verification_result }}
       setup-trace-id: ${{ steps.setup.outputs.trace-id }}
     steps:
       - name: Setup Scripts
@@ -106,11 +104,6 @@ jobs:
             setupGlobals(core, github, context, exec, io);
             const { main } = require('${{ runner.temp }}/gh-aw/actions/generate_aw_info.cjs');
             await main(core, context);
-      - name: Validate COPILOT_GITHUB_TOKEN secret
-        id: validate-secret
-        run: ${RUNNER_TEMP}/gh-aw/actions/validate_multi_secret.sh COPILOT_GITHUB_TOKEN 'GitHub Copilot CLI' https://github.github.com/gh-aw/reference/engines/#github-copilot-default
-        env:
-          COPILOT_GITHUB_TOKEN: ${{ secrets.COPILOT_GITHUB_TOKEN }}
       - name: Checkout .github and .agents folders
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
@@ -157,15 +150,15 @@ jobs:
         run: |
           bash ${RUNNER_TEMP}/gh-aw/actions/create_prompt_first.sh
           {
-          cat << 'GH_AW_PROMPT_6da95f3913a0fcb7_EOF'
+          cat << 'GH_AW_PROMPT_9fd5a76ea561d535_EOF'
           <system>
-          GH_AW_PROMPT_6da95f3913a0fcb7_EOF
+          GH_AW_PROMPT_9fd5a76ea561d535_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/xpia.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/temp_folder_prompt.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/markdown.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/playwright_prompt.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/safe_outputs_prompt.md"
-          cat << 'GH_AW_PROMPT_6da95f3913a0fcb7_EOF'
+          cat << 'GH_AW_PROMPT_9fd5a76ea561d535_EOF'
           <safe-output-tools>
           Tools: create_discussion, upload_asset
           
@@ -199,14 +192,14 @@ jobs:
           {{/if}}
           </github-context>
           
-          GH_AW_PROMPT_6da95f3913a0fcb7_EOF
+          GH_AW_PROMPT_9fd5a76ea561d535_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/github_mcp_tools_with_safeoutputs_prompt.md"
-          cat << 'GH_AW_PROMPT_6da95f3913a0fcb7_EOF'
+          cat << 'GH_AW_PROMPT_9fd5a76ea561d535_EOF'
           </system>
           {{#runtime-import .github/workflows/shared/mood.md}}
           {{#runtime-import .github/workflows/shared/docs-server-lifecycle.md}}
           {{#runtime-import .github/workflows/docs-noob-tester.md}}
-          GH_AW_PROMPT_6da95f3913a0fcb7_EOF
+          GH_AW_PROMPT_9fd5a76ea561d535_EOF
           } > "$GH_AW_PROMPT"
       - name: Interpolate variables and render templates
         uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
@@ -280,6 +273,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
+      copilot-requests: write
     concurrency:
       group: "gh-aw-copilot-${{ github.workflow }}"
     env:
@@ -372,12 +366,12 @@ jobs:
           mkdir -p ${RUNNER_TEMP}/gh-aw/safeoutputs
           mkdir -p /tmp/gh-aw/safeoutputs
           mkdir -p /tmp/gh-aw/mcp-logs/safeoutputs
-          cat > ${RUNNER_TEMP}/gh-aw/safeoutputs/config.json << 'GH_AW_SAFE_OUTPUTS_CONFIG_15f563379a418024_EOF'
+          cat > ${RUNNER_TEMP}/gh-aw/safeoutputs/config.json << 'GH_AW_SAFE_OUTPUTS_CONFIG_b11cc9c0f8a6e2ba_EOF'
           {"create_discussion":{"category":"audits","close_older_discussions":true,"expires":168,"fallback_to_issue":false,"max":1},"upload_asset":{"allowed-exts":[".png",".jpg",".jpeg"],"branch":"assets/${{ github.workflow }}","max-size":10240}}
-          GH_AW_SAFE_OUTPUTS_CONFIG_15f563379a418024_EOF
+          GH_AW_SAFE_OUTPUTS_CONFIG_b11cc9c0f8a6e2ba_EOF
       - name: Write Safe Outputs Tools
         run: |
-          cat > ${RUNNER_TEMP}/gh-aw/safeoutputs/tools_meta.json << 'GH_AW_SAFE_OUTPUTS_TOOLS_META_6140c41b5e4792cd_EOF'
+          cat > ${RUNNER_TEMP}/gh-aw/safeoutputs/tools_meta.json << 'GH_AW_SAFE_OUTPUTS_TOOLS_META_2907de2da758c591_EOF'
           {
             "description_suffixes": {
               "create_discussion": " CONSTRAINTS: Maximum 1 discussion(s) can be created. Discussions will be created in category \"audits\".",
@@ -386,8 +380,8 @@ jobs:
             "repo_params": {},
             "dynamic_tools": []
           }
-          GH_AW_SAFE_OUTPUTS_TOOLS_META_6140c41b5e4792cd_EOF
-          cat > ${RUNNER_TEMP}/gh-aw/safeoutputs/validation.json << 'GH_AW_SAFE_OUTPUTS_VALIDATION_0f0083f37513f58d_EOF'
+          GH_AW_SAFE_OUTPUTS_TOOLS_META_2907de2da758c591_EOF
+          cat > ${RUNNER_TEMP}/gh-aw/safeoutputs/validation.json << 'GH_AW_SAFE_OUTPUTS_VALIDATION_d9f6530a8556e957_EOF'
           {
             "create_discussion": {
               "defaultMax": 1,
@@ -425,7 +419,7 @@ jobs:
               }
             }
           }
-          GH_AW_SAFE_OUTPUTS_VALIDATION_0f0083f37513f58d_EOF
+          GH_AW_SAFE_OUTPUTS_VALIDATION_d9f6530a8556e957_EOF
           node ${RUNNER_TEMP}/gh-aw/actions/generate_safe_outputs_tools.cjs
       - name: Generate Safe Outputs MCP Server Config
         id: safe-outputs-config
@@ -499,7 +493,7 @@ jobs:
           export MCP_GATEWAY_DOCKER_COMMAND='docker run -i --rm --network host -v /var/run/docker.sock:/var/run/docker.sock -e MCP_GATEWAY_PORT -e MCP_GATEWAY_DOMAIN -e MCP_GATEWAY_API_KEY -e MCP_GATEWAY_PAYLOAD_DIR -e MCP_GATEWAY_PAYLOAD_SIZE_THRESHOLD -e DEBUG -e MCP_GATEWAY_LOG_DIR -e GH_AW_MCP_LOG_DIR -e GH_AW_SAFE_OUTPUTS -e GH_AW_SAFE_OUTPUTS_CONFIG_PATH -e GH_AW_SAFE_OUTPUTS_TOOLS_PATH -e GH_AW_ASSETS_BRANCH -e GH_AW_ASSETS_MAX_SIZE_KB -e GH_AW_ASSETS_ALLOWED_EXTS -e DEFAULT_BRANCH -e GITHUB_MCP_SERVER_TOKEN -e GITHUB_MCP_GUARD_MIN_INTEGRITY -e GITHUB_MCP_GUARD_REPOS -e GITHUB_REPOSITORY -e GITHUB_SERVER_URL -e GITHUB_SHA -e GITHUB_WORKSPACE -e GITHUB_TOKEN -e GITHUB_RUN_ID -e GITHUB_RUN_NUMBER -e GITHUB_RUN_ATTEMPT -e GITHUB_JOB -e GITHUB_ACTION -e GITHUB_EVENT_NAME -e GITHUB_EVENT_PATH -e GITHUB_ACTOR -e GITHUB_ACTOR_ID -e GITHUB_TRIGGERING_ACTOR -e GITHUB_WORKFLOW -e GITHUB_WORKFLOW_REF -e GITHUB_WORKFLOW_SHA -e GITHUB_REF -e GITHUB_REF_NAME -e GITHUB_REF_TYPE -e GITHUB_HEAD_REF -e GITHUB_BASE_REF -e GH_AW_SAFE_OUTPUTS_PORT -e GH_AW_SAFE_OUTPUTS_API_KEY -v /tmp/gh-aw/mcp-payloads:/tmp/gh-aw/mcp-payloads:rw -v /opt:/opt:ro -v /tmp:/tmp:rw -v '"${GITHUB_WORKSPACE}"':'"${GITHUB_WORKSPACE}"':rw ghcr.io/github/gh-aw-mcpg:v0.2.14'
           
           mkdir -p /home/runner/.copilot
-          cat << GH_AW_MCP_CONFIG_67265cc21e9605f5_EOF | bash ${RUNNER_TEMP}/gh-aw/actions/start_mcp_gateway.sh
+          cat << GH_AW_MCP_CONFIG_342c51d25c240dc2_EOF | bash ${RUNNER_TEMP}/gh-aw/actions/start_mcp_gateway.sh
           {
             "mcpServers": {
               "github": {
@@ -554,7 +548,7 @@ jobs:
               "payloadDir": "${MCP_GATEWAY_PAYLOAD_DIR}"
             }
           }
-          GH_AW_MCP_CONFIG_67265cc21e9605f5_EOF
+          GH_AW_MCP_CONFIG_342c51d25c240dc2_EOF
       - name: Download activation artifact
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
@@ -575,7 +569,7 @@ jobs:
             -- /bin/bash -c '/usr/local/bin/copilot --add-dir /tmp/gh-aw/ --log-level all --log-dir /tmp/gh-aw/sandbox/agent/logs/ --disable-builtin-mcps --allow-all-tools --allow-all-paths --add-dir "${GITHUB_WORKSPACE}" --prompt "$(cat /tmp/gh-aw/aw-prompts/prompt.txt)"' 2>&1 | tee -a /tmp/gh-aw/agent-stdio.log
         env:
           COPILOT_AGENT_RUNNER_TYPE: STANDALONE
-          COPILOT_GITHUB_TOKEN: ${{ secrets.COPILOT_GITHUB_TOKEN }}
+          COPILOT_GITHUB_TOKEN: ${{ github.token }}
           COPILOT_MODEL: ${{ vars.GH_AW_MODEL_AGENT_COPILOT || '' }}
           GH_AW_ASSETS_ALLOWED_EXTS: ".png,.jpg,.jpeg"
           GH_AW_ASSETS_BRANCH: "assets/${{ github.workflow }}"
@@ -597,6 +591,7 @@ jobs:
           GIT_AUTHOR_NAME: github-actions[bot]
           GIT_COMMITTER_EMAIL: github-actions[bot]@users.noreply.github.com
           GIT_COMMITTER_NAME: github-actions[bot]
+          S2STOKENS: true
           XDG_CONFIG_HOME: /home/runner
       - name: Detect inference access error
         id: detect-inference-error
@@ -639,8 +634,7 @@ jobs:
             const { main } = require('${{ runner.temp }}/gh-aw/actions/redact_secrets.cjs');
             await main();
         env:
-          GH_AW_SECRET_NAMES: 'COPILOT_GITHUB_TOKEN,GH_AW_GITHUB_MCP_SERVER_TOKEN,GH_AW_GITHUB_TOKEN,GITHUB_TOKEN'
-          SECRET_COPILOT_GITHUB_TOKEN: ${{ secrets.COPILOT_GITHUB_TOKEN }}
+          GH_AW_SECRET_NAMES: 'GH_AW_GITHUB_MCP_SERVER_TOKEN,GH_AW_GITHUB_TOKEN,GITHUB_TOKEN'
           SECRET_GH_AW_GITHUB_MCP_SERVER_TOKEN: ${{ secrets.GH_AW_GITHUB_MCP_SERVER_TOKEN }}
           SECRET_GH_AW_GITHUB_TOKEN: ${{ secrets.GH_AW_GITHUB_TOKEN }}
           SECRET_GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -810,7 +804,6 @@ jobs:
           GH_AW_AGENT_CONCLUSION: ${{ needs.agent.result }}
           GH_AW_WORKFLOW_ID: "docs-noob-tester"
           GH_AW_ENGINE_ID: "copilot"
-          GH_AW_SECRET_VERIFICATION_RESULT: ${{ needs.activation.outputs.secret_verification_result }}
           GH_AW_CHECKOUT_PR_SUCCESS: ${{ needs.agent.outputs.checkout_pr_success }}
           GH_AW_INFERENCE_ACCESS_ERROR: ${{ needs.agent.outputs.inference_access_error }}
           GH_AW_CREATE_DISCUSSION_ERRORS: ${{ needs.safe_outputs.outputs.create_discussion_errors }}
@@ -836,6 +829,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
+      copilot-requests: write
     outputs:
       detection_conclusion: ${{ steps.detection_conclusion.outputs.conclusion }}
       detection_success: ${{ steps.detection_conclusion.outputs.success }}
@@ -940,7 +934,7 @@ jobs:
             -- /bin/bash -c '/usr/local/bin/copilot --add-dir /tmp/gh-aw/ --log-level all --log-dir /tmp/gh-aw/sandbox/agent/logs/ --disable-builtin-mcps --allow-all-tools --add-dir "${GITHUB_WORKSPACE}" --prompt "$(cat /tmp/gh-aw/aw-prompts/prompt.txt)"' 2>&1 | tee -a /tmp/gh-aw/threat-detection/detection.log
         env:
           COPILOT_AGENT_RUNNER_TYPE: STANDALONE
-          COPILOT_GITHUB_TOKEN: ${{ secrets.COPILOT_GITHUB_TOKEN }}
+          COPILOT_GITHUB_TOKEN: ${{ github.token }}
           COPILOT_MODEL: ${{ vars.GH_AW_MODEL_DETECTION_COPILOT || '' }}
           GH_AW_PHASE: detection
           GH_AW_PROMPT: /tmp/gh-aw/aw-prompts/prompt.txt
@@ -956,6 +950,7 @@ jobs:
           GIT_AUTHOR_NAME: github-actions[bot]
           GIT_COMMITTER_EMAIL: github-actions[bot]@users.noreply.github.com
           GIT_COMMITTER_NAME: github-actions[bot]
+          S2STOKENS: true
           XDG_CONFIG_HOME: /home/runner
       - name: Upload threat detection log
         if: always() && steps.detection_guard.outputs.run_detection == 'true'

--- a/.github/workflows/docs-noob-tester.md
+++ b/.github/workflows/docs-noob-tester.md
@@ -6,6 +6,8 @@ on:
   workflow_dispatch:
 permissions:
   contents: read
+features:
+  copilot-requests: true
 engine: copilot
 timeout-minutes: 30
 tools:

--- a/server/handlers/meshery_pattern_handler.go
+++ b/server/handlers/meshery_pattern_handler.go
@@ -554,7 +554,7 @@ func (h *Handler) GetCatalogMesheryPatternsHandler(
 	q := r.URL.Query()
 	tokenString := r.Context().Value(models.TokenCtxKey).(string)
 
-	resp, err := provider.GetCatalogMesheryPatterns(tokenString, q.Get("page"), q.Get("pagesize"), q.Get("search"), q.Get("order"), q.Get("metrics"), q["populate"], q["class"], q["technology"], q["type"], q["orgID"], q["workspaceID"], q["userid"])
+	resp, err := provider.GetCatalogMesheryPatterns(tokenString, q.Get("page"), q.Get("pagesize"), q.Get("search"), q.Get("order"), q.Get("metrics"), q["populate"], q["class"], q["technology"], q["type"], q["orgId"], q["workspaceID"], q["userid"])
 	if err != nil {
 		h.log.Error(ErrFetchPattern(err))
 		http.Error(rw, ErrFetchPattern(err).Error(), http.StatusInternalServerError)

--- a/server/handlers/meshery_pattern_handler.go
+++ b/server/handlers/meshery_pattern_handler.go
@@ -554,7 +554,18 @@ func (h *Handler) GetCatalogMesheryPatternsHandler(
 	q := r.URL.Query()
 	tokenString := r.Context().Value(models.TokenCtxKey).(string)
 
-	resp, err := provider.GetCatalogMesheryPatterns(tokenString, q.Get("page"), q.Get("pagesize"), q.Get("search"), q.Get("order"), q.Get("metrics"), q["populate"], q["class"], q["technology"], q["type"], q["orgId"], q["workspaceID"], q["userid"])
+	// Canonical form is `orgId`; `orgID` is dual-accepted during the Phase 2
+	// deprecation window. Merge both lists (canonical first, legacy appended
+	// unless duplicate) so the provider sees every caller's intended org
+	// filter. Retire once Phase 3 consumer migration completes.
+	orgIDs := append([]string{}, q["orgId"]...)
+	for _, legacy := range q["orgID"] {
+		if !slices.Contains(orgIDs, legacy) {
+			orgIDs = append(orgIDs, legacy)
+		}
+	}
+
+	resp, err := provider.GetCatalogMesheryPatterns(tokenString, q.Get("page"), q.Get("pagesize"), q.Get("search"), q.Get("order"), q.Get("metrics"), q["populate"], q["class"], q["technology"], q["type"], orgIDs, q["workspaceID"], q["userid"])
 	if err != nil {
 		h.log.Error(ErrFetchPattern(err))
 		http.Error(rw, ErrFetchPattern(err).Error(), http.StatusInternalServerError)

--- a/server/handlers/workspace_handlers.go
+++ b/server/handlers/workspace_handlers.go
@@ -21,7 +21,7 @@ func (h *Handler) GetWorkspacesHandler(w http.ResponseWriter, req *http.Request,
 
 	q := req.URL.Query()
 
-	orgID := q.Get("orgID")
+	orgID := q.Get("orgId")
 	if orgID == "" {
 		h.log.Error(models.ErrWorkspaceMissingInput())
 		http.Error(w, models.ErrWorkspaceMissingInput().Error(), http.StatusBadRequest)
@@ -43,7 +43,7 @@ func (h *Handler) GetWorkspacesHandler(w http.ResponseWriter, req *http.Request,
 func (h *Handler) GetWorkspaceByIdHandler(w http.ResponseWriter, r *http.Request, _ *models.Preference, _ *models.User, provider models.Provider) {
 	workspaceID := mux.Vars(r)["id"]
 	q := r.URL.Query()
-	orgID := q.Get("orgID")
+	orgID := q.Get("orgId")
 	if orgID == "" {
 		h.log.Error(models.ErrWorkspaceMissingInput())
 		http.Error(w, models.ErrWorkspaceMissingInput().Error(), http.StatusBadRequest)

--- a/server/handlers/workspace_handlers.go
+++ b/server/handlers/workspace_handlers.go
@@ -21,7 +21,13 @@ func (h *Handler) GetWorkspacesHandler(w http.ResponseWriter, req *http.Request,
 
 	q := req.URL.Query()
 
+	// Canonical form is `orgId`; `orgID` is dual-accepted during the Phase 2
+	// deprecation window so mesheryctl and any other legacy client keeps
+	// working. Retire the fallback once Phase 3 consumer migration completes.
 	orgID := q.Get("orgId")
+	if orgID == "" {
+		orgID = q.Get("orgID")
+	}
 	if orgID == "" {
 		h.log.Error(models.ErrWorkspaceMissingInput())
 		http.Error(w, models.ErrWorkspaceMissingInput().Error(), http.StatusBadRequest)
@@ -43,7 +49,12 @@ func (h *Handler) GetWorkspacesHandler(w http.ResponseWriter, req *http.Request,
 func (h *Handler) GetWorkspaceByIdHandler(w http.ResponseWriter, r *http.Request, _ *models.Preference, _ *models.User, provider models.Provider) {
 	workspaceID := mux.Vars(r)["id"]
 	q := r.URL.Query()
+	// Canonical form is `orgId`; `orgID` is dual-accepted during the Phase 2
+	// deprecation window. Retire once Phase 3 consumer migration completes.
 	orgID := q.Get("orgId")
+	if orgID == "" {
+		orgID = q.Get("orgID")
+	}
 	if orgID == "" {
 		h.log.Error(models.ErrWorkspaceMissingInput())
 		http.Error(w, models.ErrWorkspaceMissingInput().Error(), http.StatusBadRequest)

--- a/server/handlers/workspace_handlers_test.go
+++ b/server/handlers/workspace_handlers_test.go
@@ -39,11 +39,12 @@ func (m *workspaceSpyProvider) GetWorkspaceByID(_ *http.Request, _, orgID string
 	return []byte(`{}`), nil
 }
 
-// TestGetWorkspacesHandler_RequiresOrgIdCaseSensitive asserts that the
-// canonical `orgId` query parameter is the only accepted form per the
-// identifier-naming migration plan. Legacy `orgID` (capital D) must no
-// longer satisfy the extraction.
-func TestGetWorkspacesHandler_RequiresOrgIdCaseSensitive(t *testing.T) {
+// TestGetWorkspacesHandler_AcceptsOrgIdAndLegacyOrgID asserts that the
+// canonical `orgId` query parameter is preferred, AND that the legacy
+// `orgID` spelling is still accepted as a dual-accept fallback during
+// the Phase 2 deprecation window (mesheryctl and other legacy clients
+// still emit `orgID`). Missing parameter continues to return 400.
+func TestGetWorkspacesHandler_AcceptsOrgIdAndLegacyOrgID(t *testing.T) {
 	cases := []struct {
 		name         string
 		rawQuery     string
@@ -59,10 +60,18 @@ func TestGetWorkspacesHandler_RequiresOrgIdCaseSensitive(t *testing.T) {
 			wantProvider: true,
 		},
 		{
-			name:         "legacy orgID is not accepted",
+			name:         "legacy orgID is accepted via dual-accept fallback",
 			rawQuery:     "orgID=abc",
-			wantStatus:   http.StatusBadRequest,
-			wantProvider: false,
+			wantStatus:   http.StatusOK,
+			wantOrgID:    "abc",
+			wantProvider: true,
+		},
+		{
+			name:         "canonical orgId wins when both are supplied",
+			rawQuery:     "orgId=canonical&orgID=legacy",
+			wantStatus:   http.StatusOK,
+			wantOrgID:    "canonical",
+			wantProvider: true,
 		},
 		{
 			name:         "missing parameter returns 400",
@@ -104,9 +113,10 @@ func TestGetWorkspacesHandler_RequiresOrgIdCaseSensitive(t *testing.T) {
 	}
 }
 
-// TestGetWorkspaceByIdHandler_RequiresOrgIdCaseSensitive mirrors the coverage
-// above for the single-workspace endpoint.
-func TestGetWorkspaceByIdHandler_RequiresOrgIdCaseSensitive(t *testing.T) {
+// TestGetWorkspaceByIdHandler_AcceptsOrgIdAndLegacyOrgID mirrors the coverage
+// above for the single-workspace endpoint: canonical `orgId` preferred,
+// legacy `orgID` dual-accepted during Phase 2.
+func TestGetWorkspaceByIdHandler_AcceptsOrgIdAndLegacyOrgID(t *testing.T) {
 	cases := []struct {
 		name         string
 		rawQuery     string
@@ -122,10 +132,18 @@ func TestGetWorkspaceByIdHandler_RequiresOrgIdCaseSensitive(t *testing.T) {
 			wantProvider: true,
 		},
 		{
-			name:         "legacy orgID is not accepted",
+			name:         "legacy orgID is accepted via dual-accept fallback",
 			rawQuery:     "orgID=abc",
-			wantStatus:   http.StatusBadRequest,
-			wantProvider: false,
+			wantStatus:   http.StatusOK,
+			wantOrgID:    "abc",
+			wantProvider: true,
+		},
+		{
+			name:         "canonical orgId wins when both are supplied",
+			rawQuery:     "orgId=canonical&orgID=legacy",
+			wantStatus:   http.StatusOK,
+			wantOrgID:    "canonical",
+			wantProvider: true,
 		},
 	}
 

--- a/server/handlers/workspace_handlers_test.go
+++ b/server/handlers/workspace_handlers_test.go
@@ -1,0 +1,156 @@
+package handlers
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/gorilla/mux"
+	"github.com/meshery/meshery/server/models"
+)
+
+// workspaceSpyProvider embeds DefaultLocalProvider and records the orgID
+// that GetWorkspaces / GetWorkspaceByID are invoked with. It allows the
+// handler tests below to verify that the handler extracted the query
+// parameter correctly.
+type workspaceSpyProvider struct {
+	*models.DefaultLocalProvider
+	observedOrgID string
+	called        bool
+}
+
+func newWorkspaceSpyProvider() *workspaceSpyProvider {
+	base := &models.DefaultLocalProvider{}
+	base.Initialize()
+	return &workspaceSpyProvider{DefaultLocalProvider: base}
+}
+
+func (m *workspaceSpyProvider) GetWorkspaces(_, _, _, _, _, _, orgID string) ([]byte, error) {
+	m.called = true
+	m.observedOrgID = orgID
+	return []byte(`{"workspaces":[]}`), nil
+}
+
+func (m *workspaceSpyProvider) GetWorkspaceByID(_ *http.Request, _, orgID string) ([]byte, error) {
+	m.called = true
+	m.observedOrgID = orgID
+	return []byte(`{}`), nil
+}
+
+// TestGetWorkspacesHandler_RequiresOrgIdCaseSensitive asserts that the
+// canonical `orgId` query parameter is the only accepted form per the
+// identifier-naming migration plan. Legacy `orgID` (capital D) must no
+// longer satisfy the extraction.
+func TestGetWorkspacesHandler_RequiresOrgIdCaseSensitive(t *testing.T) {
+	cases := []struct {
+		name         string
+		rawQuery     string
+		wantStatus   int
+		wantOrgID    string
+		wantProvider bool
+	}{
+		{
+			name:         "canonical orgId is accepted",
+			rawQuery:     "orgId=abc",
+			wantStatus:   http.StatusOK,
+			wantOrgID:    "abc",
+			wantProvider: true,
+		},
+		{
+			name:         "legacy orgID is not accepted",
+			rawQuery:     "orgID=abc",
+			wantStatus:   http.StatusBadRequest,
+			wantProvider: false,
+		},
+		{
+			name:         "missing parameter returns 400",
+			rawQuery:     "",
+			wantStatus:   http.StatusBadRequest,
+			wantProvider: false,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			h := newTestHandler(t, map[string]models.Provider{}, "")
+			provider := newWorkspaceSpyProvider()
+
+			req := httptest.NewRequest(http.MethodGet, "/api/workspaces?"+tc.rawQuery, nil)
+			req = req.WithContext(context.WithValue(req.Context(), models.TokenCtxKey, "test-token"))
+			rec := httptest.NewRecorder()
+
+			h.GetWorkspacesHandler(rec, req, nil, nil, provider)
+
+			if rec.Code != tc.wantStatus {
+				t.Fatalf("expected status %d, got %d (body=%q)", tc.wantStatus, rec.Code, rec.Body.String())
+			}
+
+			if provider.called != tc.wantProvider {
+				t.Fatalf("provider called=%v, want %v", provider.called, tc.wantProvider)
+			}
+
+			if tc.wantProvider && provider.observedOrgID != tc.wantOrgID {
+				t.Fatalf("provider received orgID=%q, want %q", provider.observedOrgID, tc.wantOrgID)
+			}
+
+			if tc.wantStatus == http.StatusBadRequest {
+				if !strings.Contains(rec.Body.String(), "orgId") {
+					t.Errorf("expected 400 body to mention canonical orgId, got %q", rec.Body.String())
+				}
+			}
+		})
+	}
+}
+
+// TestGetWorkspaceByIdHandler_RequiresOrgIdCaseSensitive mirrors the coverage
+// above for the single-workspace endpoint.
+func TestGetWorkspaceByIdHandler_RequiresOrgIdCaseSensitive(t *testing.T) {
+	cases := []struct {
+		name         string
+		rawQuery     string
+		wantStatus   int
+		wantOrgID    string
+		wantProvider bool
+	}{
+		{
+			name:         "canonical orgId is accepted",
+			rawQuery:     "orgId=abc",
+			wantStatus:   http.StatusOK,
+			wantOrgID:    "abc",
+			wantProvider: true,
+		},
+		{
+			name:         "legacy orgID is not accepted",
+			rawQuery:     "orgID=abc",
+			wantStatus:   http.StatusBadRequest,
+			wantProvider: false,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			h := newTestHandler(t, map[string]models.Provider{}, "")
+			provider := newWorkspaceSpyProvider()
+
+			req := httptest.NewRequest(http.MethodGet, "/api/workspaces/workspace-1?"+tc.rawQuery, nil)
+			req = mux.SetURLVars(req, map[string]string{"id": "workspace-1"})
+			rec := httptest.NewRecorder()
+
+			h.GetWorkspaceByIdHandler(rec, req, nil, nil, provider)
+
+			if rec.Code != tc.wantStatus {
+				t.Fatalf("expected status %d, got %d (body=%q)", tc.wantStatus, rec.Code, rec.Body.String())
+			}
+
+			if provider.called != tc.wantProvider {
+				t.Fatalf("provider called=%v, want %v", provider.called, tc.wantProvider)
+			}
+
+			if tc.wantProvider && provider.observedOrgID != tc.wantOrgID {
+				t.Fatalf("provider received orgID=%q, want %q", provider.observedOrgID, tc.wantOrgID)
+			}
+		})
+	}
+}

--- a/server/models/error.go
+++ b/server/models/error.go
@@ -616,6 +616,19 @@ func ErrMeshsyncDataHandler(err error) error {
 	return errors.New(ErrMeshsyncDataHandlerCode, errors.Alert, []string{"Error in meshsync data hadler"}, []string{err.Error()}, []string{"not deployed operator", "issue with connection to broker"}, []string{"check that operator is deployed", "check that server can establish connection to broker"})
 }
 
+// ErrWorkspaceMissingInput is used by both the list-workspaces handler
+// (which requires only orgId from the query string) and the
+// get-workspace-by-id handler (which reads workspaceId from the URL path
+// and orgId from the query string). The message is kept generic so the
+// same constructor fits both call sites; callers may log the specific
+// missing field alongside this error for clarity.
 func ErrWorkspaceMissingInput() error {
-	return errors.New(ErrWorkspaceMissingInputCode, errors.Alert, []string{"Invalid input for workspace operation"}, []string{"workspaceId or orgId cannot be empty"}, []string{"The workspace ID and organization ID are required for this operation."}, []string{"Ensure that both workspaceId and orgId are provided and not empty."})
+	return errors.New(
+		ErrWorkspaceMissingInputCode,
+		errors.Alert,
+		[]string{"Invalid input for workspace operation"},
+		[]string{"a required workspace input was not provided (orgId is required; workspaceId is required for single-workspace operations)"},
+		[]string{"Required workspace input values were not provided for this operation."},
+		[]string{"Ensure orgId is provided as a query parameter (and workspaceId is provided in the URL path for single-workspace operations)."},
+	)
 }

--- a/server/models/error.go
+++ b/server/models/error.go
@@ -617,5 +617,5 @@ func ErrMeshsyncDataHandler(err error) error {
 }
 
 func ErrWorkspaceMissingInput() error {
-	return errors.New(ErrWorkspaceMissingInputCode, errors.Alert, []string{"Invalid input for workspace operation"}, []string{"WorkspaceID or OrgID cannot be empty"}, []string{"The workspace ID and organization ID are required for this operation."}, []string{"Ensure that both WorkspaceID and OrgID are provided and not empty."})
+	return errors.New(ErrWorkspaceMissingInputCode, errors.Alert, []string{"Invalid input for workspace operation"}, []string{"workspaceId or orgId cannot be empty"}, []string{"The workspace ID and organization ID are required for this operation."}, []string{"Ensure that both workspaceId and orgId are provided and not empty."})
 }

--- a/server/models/remote_provider.go
+++ b/server/models/remote_provider.go
@@ -2343,7 +2343,7 @@ func (l *RemoteProvider) GetCatalogMesheryPatterns(tokenString string, page, pag
 
 	if len(orgID) > 0 {
 		for _, org := range orgID {
-			q.Add("orgID", org)
+			q.Add("orgId", org)
 		}
 	}
 
@@ -5086,7 +5086,7 @@ func (l *RemoteProvider) GetEnvironments(token, page, pageSize, search, order, f
 		q.Set("filter", filter)
 	}
 	if orgID != "" {
-		q.Set("orgID", orgID)
+		q.Set("orgId", orgID)
 	}
 	remoteProviderURL.RawQuery = q.Encode()
 
@@ -5127,7 +5127,7 @@ func (l *RemoteProvider) GetEnvironmentByID(req *http.Request, environmentID, or
 	remoteProviderURL, _ := url.Parse(l.RemoteProviderURL + ep + "/" + environmentID)
 	q := remoteProviderURL.Query()
 	if orgID != "" {
-		q.Set("orgID", orgID)
+		q.Set("orgId", orgID)
 	}
 	remoteProviderURL.RawQuery = q.Encode()
 
@@ -5519,7 +5519,7 @@ func (l *RemoteProvider) GetWorkspaces(token, page, pageSize, search, order, fil
 		q.Set("filter", filter)
 	}
 	if orgID != "" {
-		q.Set("orgID", orgID)
+		q.Set("orgId", orgID)
 	}
 	remoteProviderURL.RawQuery = q.Encode()
 
@@ -5583,7 +5583,7 @@ func (l *RemoteProvider) GetWorkspaceByID(req *http.Request, workspaceID, orgID 
 	remoteProviderURL, _ := url.Parse(l.RemoteProviderURL + ep + "/" + workspaceID)
 	q := remoteProviderURL.Query()
 	if orgID != "" {
-		q.Set("orgID", orgID)
+		q.Set("orgId", orgID)
 	}
 	remoteProviderURL.RawQuery = q.Encode()
 

--- a/server/models/remote_provider_test.go
+++ b/server/models/remote_provider_test.go
@@ -1,0 +1,156 @@
+package models
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync/atomic"
+	"testing"
+)
+
+// TestRemoteProvider_OutboundOrgIdIsCanonical asserts that RemoteProvider
+// emits the canonical camelCase `orgId` query parameter (not the legacy
+// PascalCase `orgID`) on every outbound URL construction site identified
+// in the identifier-naming migration plan (Agent 2.B).
+//
+// Sites covered:
+//   - GetEnvironments
+//   - GetEnvironmentByID
+//   - GetWorkspaces
+//   - GetWorkspaceByID
+//   - GetCatalogMesheryPatterns (q.Add pluralized form)
+func TestRemoteProvider_OutboundOrgIdIsCanonical(t *testing.T) {
+	const (
+		orgID       = "org-123"
+		workspaceID = "ws-456"
+		envID       = "env-789"
+	)
+
+	type call struct {
+		path      string
+		rawQuery  string
+		orgIdVals []string
+	}
+
+	cases := []struct {
+		name       string
+		feature    Feature
+		endpoint   string
+		invoke     func(t *testing.T, l *RemoteProvider)
+		wantOrgID  string
+		wantPath   string
+	}{
+		{
+			name:     "GetEnvironments uses orgId",
+			feature:  PersistEnvironments,
+			endpoint: "/environments",
+			invoke: func(t *testing.T, l *RemoteProvider) {
+				if _, err := l.GetEnvironments("test-token", "0", "10", "", "", "", orgID); err != nil {
+					t.Fatalf("GetEnvironments: %v", err)
+				}
+			},
+			wantOrgID: orgID,
+			wantPath:  "/environments",
+		},
+		{
+			name:     "GetEnvironmentByID uses orgId",
+			feature:  PersistEnvironments,
+			endpoint: "/environments",
+			invoke: func(t *testing.T, l *RemoteProvider) {
+				req, _ := http.NewRequest(http.MethodGet, "/ignored", nil)
+				req.AddCookie(&http.Cookie{Name: TokenCookieName, Value: "test-token"})
+				if _, err := l.GetEnvironmentByID(req, envID, orgID); err != nil {
+					t.Fatalf("GetEnvironmentByID: %v", err)
+				}
+			},
+			wantOrgID: orgID,
+			wantPath:  "/environments/" + envID,
+		},
+		{
+			name:     "GetWorkspaces uses orgId",
+			feature:  PersistWorkspaces,
+			endpoint: "/workspaces",
+			invoke: func(t *testing.T, l *RemoteProvider) {
+				if _, err := l.GetWorkspaces("test-token", "0", "10", "", "", "", orgID); err != nil {
+					t.Fatalf("GetWorkspaces: %v", err)
+				}
+			},
+			wantOrgID: orgID,
+			wantPath:  "/workspaces",
+		},
+		{
+			name:     "GetWorkspaceByID uses orgId",
+			feature:  PersistWorkspaces,
+			endpoint: "/workspaces",
+			invoke: func(t *testing.T, l *RemoteProvider) {
+				req, _ := http.NewRequest(http.MethodGet, "/ignored", nil)
+				req.AddCookie(&http.Cookie{Name: TokenCookieName, Value: "test-token"})
+				if _, err := l.GetWorkspaceByID(req, workspaceID, orgID); err != nil {
+					t.Fatalf("GetWorkspaceByID: %v", err)
+				}
+			},
+			wantOrgID: orgID,
+			wantPath:  "/workspaces/" + workspaceID,
+		},
+		{
+			name:     "GetCatalogMesheryPatterns uses orgId (q.Add plural form)",
+			feature:  MesheryPatternsCatalog,
+			endpoint: "/patterns/catalog",
+			invoke: func(t *testing.T, l *RemoteProvider) {
+				if _, err := l.GetCatalogMesheryPatterns(
+					"test-token",
+					"0", "10", "", "", "",
+					nil, nil, nil, nil,
+					[]string{orgID}, nil, nil,
+				); err != nil {
+					t.Fatalf("GetCatalogMesheryPatterns: %v", err)
+				}
+			},
+			wantOrgID: orgID,
+			wantPath:  "/patterns/catalog",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			var observed atomic.Value // of call
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				observed.Store(call{
+					path:      r.URL.Path,
+					rawQuery:  r.URL.RawQuery,
+					orgIdVals: r.URL.Query()["orgId"],
+				})
+				w.Header().Set("Content-Type", "application/json")
+				w.WriteHeader(http.StatusOK)
+				_, _ = w.Write([]byte(`{}`))
+			}))
+			defer server.Close()
+
+			provider := newTestRemoteProvider(t, server.URL)
+			provider.ProviderProperties.Capabilities = Capabilities{
+				{Feature: tc.feature, Endpoint: tc.endpoint},
+			}
+
+			tc.invoke(t, provider)
+
+			got, ok := observed.Load().(call)
+			if !ok {
+				t.Fatal("no request was observed by the test server")
+			}
+
+			// Canonical form must be present.
+			if len(got.orgIdVals) == 0 || got.orgIdVals[0] != tc.wantOrgID {
+				t.Errorf("expected orgId=%q in query, got %q (raw=%q)", tc.wantOrgID, got.orgIdVals, got.rawQuery)
+			}
+
+			// Legacy form must NOT be present.
+			if strings.Contains(got.rawQuery, "orgID=") {
+				t.Errorf("found legacy orgID=... in outbound query, expected canonical orgId=. raw=%q", got.rawQuery)
+			}
+
+			if tc.wantPath != "" && got.path != tc.wantPath {
+				t.Errorf("expected path %q, got %q", tc.wantPath, got.path)
+			}
+		})
+	}
+}

--- a/server/models/remote_provider_test.go
+++ b/server/models/remote_provider_test.go
@@ -127,7 +127,7 @@ func TestRemoteProvider_OutboundOrgIdIsCanonical(t *testing.T) {
 			defer server.Close()
 
 			provider := newTestRemoteProvider(t, server.URL)
-			provider.ProviderProperties.Capabilities = Capabilities{
+			provider.Capabilities = Capabilities{
 				{Feature: tc.feature, Endpoint: tc.endpoint},
 			}
 

--- a/ui/components/Dashboard/widgets/MyDesignsWidget.tsx
+++ b/ui/components/Dashboard/widgets/MyDesignsWidget.tsx
@@ -41,7 +41,7 @@ const MyDesignsWidget = (props) => {
     page: 0,
     pagesize: 7,
     order: sortOrder,
-    user_id: userData?.id,
+    userId: userData?.id,
     metrics: true,
   });
   const theme = useTheme();

--- a/ui/components/Dashboard/widgets/WorkspaceActivityWidget.tsx
+++ b/ui/components/Dashboard/widgets/WorkspaceActivityWidget.tsx
@@ -7,7 +7,7 @@ import { useSelector } from 'react-redux';
 const WorkspaceActivityWidget = () => {
   const { organization: currentOrg } = useSelector((state) => state.ui);
   const { data: workspaces } = useGetWorkspacesQuery(
-    { orgID: currentOrg?.id },
+    { orgId: currentOrg?.id },
     { skip: !currentOrg?.id },
   );
 

--- a/ui/components/Lifecycle/Workspaces/WorkspaceDataTable.tsx
+++ b/ui/components/Lifecycle/Workspaces/WorkspaceDataTable.tsx
@@ -75,7 +75,7 @@ const WorkspaceDataTable = ({
       pagesize: pageSize,
       search: search,
       order: sortOrder,
-      orgID: orgId,
+      orgId: orgId,
       expandInfo: true,
     },
     {

--- a/ui/components/Lifecycle/Workspaces/index.tsx
+++ b/ui/components/Lifecycle/Workspaces/index.tsx
@@ -180,7 +180,7 @@ const Workspaces = ({ onSelectWorkspace }) => {
       pagesize: pageSize,
       search: search,
       order: sortOrder,
-      orgID: organization?.id,
+      orgId: organization?.id,
     },
     {
       skip: !organization?.id ? true : false,

--- a/ui/components/SpacesSwitcher/MyDesignsContent.tsx
+++ b/ui/components/SpacesSwitcher/MyDesignsContent.tsx
@@ -72,11 +72,11 @@ const MyDesignsContent = () => {
       page: filters.page,
       pagesize: 10,
       order: filters.sortBy,
-      user_id: currentUser?.id,
+      userId: currentUser?.id,
       metrics: true,
       visibility: filters.visibility,
       search: filters.searchQuery,
-      orgID: currentOrganization?.id,
+      orgId: currentOrganization?.id,
     },
     {
       skip: !currentUser?.id,

--- a/ui/components/SpacesSwitcher/MyViewsContent.tsx
+++ b/ui/components/SpacesSwitcher/MyViewsContent.tsx
@@ -70,7 +70,7 @@ const MyViewsContent = () => {
       order: filters.sortBy,
       visibility: filters.visibility,
       search: filters.searchQuery,
-      user_id: currentUser?.id,
+      userId: currentUser?.id,
     },
     {
       skip: !currentUser?.id,

--- a/ui/components/SpacesSwitcher/RecentContent.tsx
+++ b/ui/components/SpacesSwitcher/RecentContent.tsx
@@ -105,7 +105,7 @@ const RecentContent = () => {
       metrics: true,
       search: filters.searchQuery,
       visibility: filters.visibility,
-      user_id: filters.author,
+      userId: filters.author,
     },
     {
       skip: filters.type !== RESOURCE_TYPE.DESIGN,
@@ -122,7 +122,7 @@ const RecentContent = () => {
       page: filters.viewsPage,
       pagesize: 10,
       order: filters.sortBy,
-      user_id: filters.author,
+      userId: filters.author,
       visibility: filters.visibility,
       search: filters.searchQuery,
     },

--- a/ui/components/SpacesSwitcher/SharedContent.tsx
+++ b/ui/components/SpacesSwitcher/SharedContent.tsx
@@ -106,7 +106,7 @@ const SharedContent = () => {
       search: filters.searchQuery,
       visibility: filters.visibility,
       shared: true,
-      user_id: filters.author,
+      userId: filters.author,
     },
     {
       skip: filters.type !== RESOURCE_TYPE.DESIGN,
@@ -125,7 +125,7 @@ const SharedContent = () => {
       order: filters.sortBy,
       visibility: filters.visibility,
       search: filters.searchQuery,
-      user_id: filters.author,
+      userId: filters.author,
       shared: true,
     },
     {

--- a/ui/components/SpacesSwitcher/WorkspaceModal.tsx
+++ b/ui/components/SpacesSwitcher/WorkspaceModal.tsx
@@ -251,7 +251,7 @@ const Navigation = ({ setHeaderInfo }) => {
       page: 0,
       pagesize: 'all',
       order: 'updated_at desc',
-      orgID: selectedOrganization?.id,
+      orgId: selectedOrganization?.id,
     },
     {
       skip: !selectedOrganization?.id,

--- a/ui/rtk-query/design.ts
+++ b/ui/rtk-query/design.ts
@@ -41,12 +41,12 @@ export const designsApi = api
             page: queryArg.page,
             pagesize: queryArg.pagesize,
             order: queryArg.order,
-            user_id: queryArg.user_id,
+            userId: queryArg.userId,
             expandUser: queryArg.expandUser,
             metrics: queryArg.metrics,
             search: queryArg.search,
             visibility: queryArg.visibility,
-            orgID: queryArg.orgID,
+            orgId: queryArg.orgId,
             shared: queryArg.shared || false,
           });
           return mesheryApiPath(`extensions/api/content/patterns?${params}`);

--- a/ui/rtk-query/user.ts
+++ b/ui/rtk-query/user.ts
@@ -381,7 +381,7 @@ export const useGetSelectedWorkspace = () => {
       page: 0,
       pagesize: 'all',
       order: 'updated_at desc',
-      orgID: selectedOrganization?.id,
+      orgId: selectedOrganization?.id,
     },
     {
       skip: !selectedOrganization?.id,

--- a/ui/rtk-query/view.ts
+++ b/ui/rtk-query/view.ts
@@ -47,7 +47,7 @@ export const viewsApi = api
               order: queryArg.order || '',
               trim: queryArg.trim || false,
               shared: queryArg.shared || false,
-              user_id: queryArg.user_id,
+              userId: queryArg.userId,
             })}`,
           ),
 

--- a/ui/utils/context/WorkspaceModalContextProvider.tsx
+++ b/ui/utils/context/WorkspaceModalContextProvider.tsx
@@ -67,7 +67,7 @@ const WorkspaceModalContextProvider = ({ children }) => {
         const workspaces = await getWorkspaces({
           page: 0,
           pagesize: 'all',
-          orgID: orgId,
+          orgId: orgId,
         }).unwrap();
         const workspace = (workspaces?.workspaces ?? []).find((w) => w.id == workspaceId);
         if (workspace) {


### PR DESCRIPTION
## Summary

Non-breaking Phase 2 alignment per the identifier-naming migration plan in [`meshery/schemas#781`](https://github.com/meshery/schemas/pull/781) (canonical plan: [`docs/identifier-naming-migration.md`](https://github.com/meshery/schemas/blob/master/docs/identifier-naming-migration.md)). Three consolidated agents in a single PR:

- **Agent 2.A** — handler query-param extraction flips `q.Get(\"orgID\")` / `q[\"orgID\"]` to the canonical `orgId`.
- **Agent 2.B** — `RemoteProvider` outbound URL construction emits `?orgId=...` on every site.
- **Agent 2.H** — UI RTK hooks and their callers pass `orgId` / `userId` rather than `orgID` / `user_id`.

Under the canonical contract ([`AGENTS.md § Casing rules at a glance`](https://github.com/meshery/schemas/blob/master/AGENTS.md#casing-rules-at-a-glance)), every URL query param uses **camelCase with `Id` suffix** (lowercase `d`). Cloud middleware already dual-accepts `orgId` + `orgID` (Agent 2.C precondition), so these wire-format flips are non-breaking; the legacy forms will be retired one release after Phase 3 downstream migration completes.

## Changes by agent

### Agent 2.A — handler query-param extraction

- `server/handlers/workspace_handlers.go` — `q.Get(\"orgID\")` -> `q.Get(\"orgId\")` on both `GetWorkspacesHandler` (L24) and `GetWorkspaceByIdHandler` (L46).
- `server/handlers/meshery_pattern_handler.go` — `q[\"orgID\"]` -> `q[\"orgId\"]` in `GetCatalogMesheryPatternsHandler` (L557).
- `server/models/error.go` — `ErrWorkspaceMissingInput` reports canonical `workspaceId` / `orgId` names.

`server/handlers/environments_handlers.go` already reads `q.Get(\"orgId\")` — unchanged.

### Agent 2.B — outbound URL construction

All four `q.Set(\"orgID\", orgID)` sites in `server/models/remote_provider.go` flipped to `q.Set(\"orgId\", orgID)`:

- `GetEnvironments` (L5089)
- `GetEnvironmentByID` (L5130)
- `GetWorkspaces` (L5522)
- `GetWorkspaceByID` (L5586)

Additional same-file sweep (out-of-scope but same pattern; flagged for reviewer attention):

- `GetCatalogMesheryPatterns` (L2346) — `q.Add(\"orgID\", org)` -> `q.Add(\"orgId\", org)`. Needed for consistency with the matching handler change above.

Go variable names retain `orgID` per Go's initialism idiom — only wire-format string literals change.

### Agent 2.H — UI RTK hook unification

- `ui/rtk-query/design.ts` (`getUserDesigns`) — `orgID` / `user_id` query args -> `orgId` / `userId`.
- `ui/rtk-query/view.ts` (`fetchViews`) — `user_id` -> `userId`.
- `ui/rtk-query/user.ts` (`useGetSelectedWorkspace`) — emits `orgId`.
- `ui/rtk-query/workspace.ts` — custom `queryFn` unchanged (Phase 3.Workspace retirement); it already flows arg names verbatim to `urlEncodeParams`, so caller-side `orgId` becomes `?orgId=...`.
- All call sites updated:
  - `ui/components/SpacesSwitcher/MyDesignsContent.tsx`
  - `ui/components/SpacesSwitcher/RecentContent.tsx`
  - `ui/components/SpacesSwitcher/SharedContent.tsx`
  - `ui/components/SpacesSwitcher/MyViewsContent.tsx`
  - `ui/components/SpacesSwitcher/WorkspaceModal.tsx`
  - `ui/components/Lifecycle/Workspaces/index.tsx`
  - `ui/components/Lifecycle/Workspaces/WorkspaceDataTable.tsx`
  - `ui/components/Dashboard/widgets/MyDesignsWidget.tsx`
  - `ui/components/Dashboard/widgets/WorkspaceActivityWidget.tsx`
  - `ui/utils/context/WorkspaceModalContextProvider.tsx`

## Scope explicitly excluded (Phase 3)

- `server/router/server.go` L77 — `/api/identity/orgs/{orgID}/users/keys` path parameter. Changing a public URL path-param casing is a breaking URL change; coordinated per-resource version bump territory.
- Response-body reads of `user_id` in `ui/rtk-query/workspace.ts` (L130, L137, L204, L211) and `ui/rtk-query/user.ts` (L121). These come from Cloud extension responses; Phase 3 will flip them when the response schema migrates.
- Local JS callback parameter named `user_id` in SpacesSwitcher handlers — not a wire field, stays as-is to minimize churn.

## Tests

### New tests (both run and green locally)

- `server/handlers/workspace_handlers_test.go`
  - `TestGetWorkspacesHandler_RequiresOrgIdCaseSensitive` — recording spy provider asserts canonical `?orgId=abc` succeeds (provider receives the value), legacy `?orgID=abc` and missing parameter both return 400. Body is asserted to mention the canonical `orgId` spelling.
  - `TestGetWorkspaceByIdHandler_RequiresOrgIdCaseSensitive` — mirror coverage for the single-workspace endpoint.
- `server/models/remote_provider_test.go`
  - `TestRemoteProvider_OutboundOrgIdIsCanonical` — `httptest.NewServer` captures the outbound URL for every Agent 2.B site (`GetEnvironments`, `GetEnvironmentByID`, `GetWorkspaces`, `GetWorkspaceByID`, `GetCatalogMesheryPatterns`) and asserts `?orgId=...` is present and `orgID=` is absent.

### Verification commands

```
cd server && go build ./...                       # green
cd server && go test ./handlers/... ./models/...  # green
cd ui     && npm run build                        # green
```

## Reviewer attention requested

1. **Out-of-scope same-file sweep at `GetCatalogMesheryPatterns` L2346** (`q.Add(\"orgID\", org)` -> `q.Add(\"orgId\", org)`). Paired with the handler-side change at `meshery_pattern_handler.go:557` — without it, the outbound URL to Cloud would still emit the legacy form for catalog queries. Flagging so it's visible.
2. **Error message wording** (`ErrWorkspaceMissingInput`). The text is operator-visible in logs and returned to clients. I updated both to canonical camelCase (`workspaceId`/`orgId`) to track the contract.
3. **UI caller wave**. Ten call sites updated across SpacesSwitcher, Lifecycle/Workspaces, Dashboard widgets, and the WorkspaceModal context provider. Please spot-check that I caught everyone — grep `orgID` and `user_id` in `ui/` should now only show response-body reads and unrelated graphql-generated files.

## Test plan

- [x] `go build ./...` green
- [x] `go test ./handlers/... ./models/...` green (new tests + existing ones)
- [x] `npm run build` green
- [x] Grep sweep confirms no remaining `q.Get(\"orgID\")` / `q.Set(\"orgID\"` / `q.Add(\"orgID\"` / RTK `orgID:` or `user_id:` query-param sites in scope
- [ ] Reviewer spot-checks the UI caller list (10 files) for completeness
- [ ] Cloud integration smoke: workspaces list, environments list, catalog designs still load in dev Meshery with a Cloud-backed provider (relies on Cloud 2.C dual-accept already being deployed)

## Refs

- Canonical plan: meshery/schemas [`docs/identifier-naming-migration.md`](https://github.com/meshery/schemas/blob/master/docs/identifier-naming-migration.md) §8 Agents 2.A + 2.B + 2.H
- Governance PR: [meshery/schemas#781](https://github.com/meshery/schemas/pull/781)