### PR TITLE
docs(agents): identifier-naming mandate (Phase 4.C)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -26,6 +26,74 @@ performance management, and multi-tenancy capabilities across any cloud or on-pr
 - **/.github** – GitHub Actions workflows, issue templates, Copilot agent definitions, and community
   health files.
 
+## Identifier Naming Conventions — MANDATORY
+
+This repository adheres to the canonical camelCase-wire identifier-naming contract
+defined authoritatively in `meshery/schemas/AGENTS.md § Casing rules at a
+glance`. The contract is **not optional**; deviations block PRs via the
+schemas consumer-audit CI gate.
+
+### The rule in one sentence
+
+*Wire is camelCase everywhere; DB is snake_case; Go fields follow Go
+idiom; the ORM layer is the sole translation boundary.*
+
+### Per-layer canonical forms
+
+| Layer | Form |
+|---|---|
+| DB column / `db:` tag | `snake_case` — `user_id`, `org_id`, `created_at` |
+| Go struct field | `PascalCase` with Go-idiomatic initialisms — `UserID`, `OrgID`, `CreatedAt` |
+| JSON tag | `camelCase` — `json:"userId"`, `json:"orgId"`, `json:"createdAt"` |
+| URL query/path param | `camelCase + Id` — `{orgId}`, `?userId=...` |
+| TypeScript property | `camelCase` — `response.userId`, `queryArg.orgId` |
+| OpenAPI schema property | `camelCase` |
+| OpenAPI `operationId` | `lower camelCase verbNoun` — `getWorkspaces` |
+| `components/schemas` type name | `PascalCase` — `WorkspacePayload` |
+
+### Forbidden (MUST NOT)
+
+- MUST NOT introduce a `json:` tag that matches the `db:` tag on a new
+  DB-backed field. Wire is camel; DB is snake; they differ by design.
+- MUST NOT declare an RTK query endpoint hand-rolled when
+  `@meshery/schemas/{mesheryApi,cloudApi}` provides a canonical equivalent.
+- MUST NOT locally redeclare a Go type that has an equivalent in
+  `github.com/meshery/schemas/models/...`.
+- MUST NOT use `ID` (ALL CAPS) in URL query parameters, JSON tags, or
+  TypeScript properties. `Id` (camelCase) is canonical.
+- MUST NOT mix casing conventions within a single resource. If wire
+  format must change, introduce a new API version per
+  `schemas/AGENTS.md § Dual-Schema Pattern`.
+- MUST NOT import deprecated legacy schema versions in new code. When
+  importing from `@meshery/schemas`, consume the latest canonical-casing
+  version (v1beta3 where present, otherwise v1beta2). Deprecated
+  `v1beta1` constructs are kept for backward compatibility only; do not
+  reach for them in new server handlers, `mesheryctl` commands, or UI
+  RTK slices.
+
+### Required on every PR
+
+- MUST run the schemas validator locally before pushing:
+  `cd ../schemas && make validate-schemas && make consumer-audit`.
+- MUST include test updates for any casing or tag change.
+- MUST include doc updates for any user-visible API change.
+- MUST sign off commits (`git commit -s`).
+
+### Authority
+
+`meshery/schemas/AGENTS.md` is authoritative. On any conflict between
+this repo's documentation and the schemas AGENTS.md, schemas wins. File
+discrepancies as issues against `meshery/schemas`, not locally. All
+wire-format questions are resolved against `meshery/schemas`, not this
+downstream repo.
+
+### Migration
+
+The identifier-naming migration is tracked at
+`meshery/schemas/docs/identifier-naming-migration.md`. All
+contributors — human and AI agents — MUST read this plan before making
+any schema-aware change.
+
 ## Build & Development Commands
 
 ### Server (Go)

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -30,8 +30,12 @@ performance management, and multi-tenancy capabilities across any cloud or on-pr
 
 This repository adheres to the canonical camelCase-wire identifier-naming contract
 defined authoritatively in `meshery/schemas/AGENTS.md § Casing rules at a
-glance`. The contract is **not optional**; deviations block PRs via the
-schemas consumer-audit CI gate.
+glance`. The contract is **not optional**; deviations should be treated as
+repository policy and corrected before review or merge. The cross-repo
+consumer-audit gate lives in `meshery/schemas` and will flag divergence
+in this repo's server handlers and UI slices when Phase 2 and Phase 3 of
+the migration plan land — see `meshery/schemas/.github/workflows/schema-audit.yml`
+for the authoritative CI job.
 
 ### The rule in one sentence
 
@@ -45,7 +49,7 @@ idiom; the ORM layer is the sole translation boundary.*
 | DB column / `db:` tag | `snake_case` — `user_id`, `org_id`, `created_at` |
 | Go struct field | `PascalCase` with Go-idiomatic initialisms — `UserID`, `OrgID`, `CreatedAt` |
 | JSON tag | `camelCase` — `json:"userId"`, `json:"orgId"`, `json:"createdAt"` |
-| URL query/path param | `camelCase + Id` — `{orgId}`, `?userId=...` |
+| URL query/path param | `camelCase` — `{orgId}`, `?userId=...` |
 | TypeScript property | `camelCase` — `response.userId`, `queryArg.orgId` |
 | OpenAPI schema property | `camelCase` |
 | OpenAPI `operationId` | `lower camelCase verbNoun` — `getWorkspaces` |
@@ -63,7 +67,7 @@ idiom; the ORM layer is the sole translation boundary.*
   TypeScript properties. `Id` (camelCase) is canonical.
 - MUST NOT mix casing conventions within a single resource. If wire
   format must change, introduce a new API version per
-  `schemas/AGENTS.md § Dual-Schema Pattern`.
+  `meshery/schemas/AGENTS.md § Dual-Schema Pattern`.
 - MUST NOT import deprecated legacy schema versions in new code. When
   importing from `@meshery/schemas`, consume the latest canonical-casing
   version (v1beta3 where present, otherwise v1beta2). Deprecated
@@ -73,8 +77,12 @@ idiom; the ORM layer is the sole translation boundary.*
 
 ### Required on every PR
 
-- MUST run the schemas validator locally before pushing:
-  `cd ../schemas && make validate-schemas && make consumer-audit`.
+- MUST run the schemas validator locally before pushing. This command
+  assumes `meshery` and `schemas` are checked out as sibling directories
+  (for example, `../meshery` and `../schemas`):
+  `cd ../schemas && make validate-schemas && make consumer-audit`. If
+  `meshery/schemas` is cloned elsewhere, run the same targets from that
+  checkout instead — e.g. `cd /path/to/schemas && make validate-schemas && make consumer-audit`.
 - MUST include test updates for any casing or tag change.
 - MUST include doc updates for any user-visible API change.
 - MUST sign off commits (`git commit -s`).


### PR DESCRIPTION
## Summary

- Adds the canonical camelCase-wire identifier-naming contract to `AGENTS.md` as a self-contained MANDATORY section, placed between `## Repository Structure` and `## Build & Development Commands`.
- Follows the boilerplate prescribed by [`meshery/schemas/docs/identifier-naming-migration.md` §14](https://github.com/meshery/schemas/blob/master/docs/identifier-naming-migration.md#14-per-repo-agentsmd--claudemd-mandate), plus the Phase 4.C additions:
  - **MUST** consume the latest canonical-casing `@meshery/schemas` version (v1beta3 where present, otherwise v1beta2) in new server handlers, `mesheryctl` commands, and UI RTK slices. Deprecated `v1beta1` constructs are kept for backward compatibility only.
  - **Authority note:** all wire-format questions are resolved against `meshery/schemas`, not this downstream repo.

## Context

Phase 3 of the identifier-naming migration has landed all 22 resources on camelCase-wire API versions in [`meshery/schemas`](https://github.com/meshery/schemas). Phase 4.C ensures the same mandate is visible to every coding agent and contributor in each downstream repo's root `AGENTS.md` / `CLAUDE.md`. The contract in one sentence: *wire is camelCase everywhere; DB is snake_case; Go fields follow Go idiom; the ORM layer is the sole translation boundary.*

`meshery/schemas/AGENTS.md § Casing rules at a glance` remains the single authoritative source; this change is the local pointer + MUST/MUST NOT summary so contributors see it before diverging.

## Changes

- **Docs-only.** No code, schema, or generated-artifact changes.
- `AGENTS.md` gains a new `## Identifier Naming Conventions — MANDATORY` section with:
  - The one-sentence rule
  - A per-layer canonical-forms table (DB / Go / JSON / URL / TS / OpenAPI)
  - A Forbidden (MUST NOT) list, including the v1beta1 import prohibition
  - A Required-on-every-PR list
  - An Authority section pointing at `meshery/schemas/AGENTS.md`
  - A Migration pointer to `meshery/schemas/docs/identifier-naming-migration.md`

## Test plan

- [x] `AGENTS.md` renders as valid Markdown (GitHub preview)
- [x] Section headings match the charter's structure (§14 boilerplate)
- [x] New `## Identifier Naming Conventions — MANDATORY` section lands immediately after `## Repository Structure`, before the existing `## Build & Development Commands` — flow preserved
- [x] Commit is DCO-signed (`git commit -s`)
- [x] No other files modified

## Refs

- `meshery/schemas` docs/identifier-naming-migration.md §10 (Agent 4.C charter), §14 (boilerplate)