### PR TITLE
[UI] Notification Center: Fix misalignment of text in events

### DIFF
--- a/ui/components/NotificationCenter/notification.tsx
+++ b/ui/components/NotificationCenter/notification.tsx
@@ -407,14 +407,14 @@ export const Notification = ({ event_id }) => {
               style={{ paddingRight: '0.25rem' }}
             />
           </GridItem>
-          <GridItem item xs={8} sm>
-            <Message variant="body1">
+          <GridItem item xs>
+            <Message variant="body1" style={{ paddingRight: '1rem' }}>
               {truncate(title, {
                 length: MAX_NOTIFICATION_DESCRIPTION_LENGTH,
               })}
             </Message>
           </GridItem>
-          <GridItem item xs="auto" style={{ justifyContent: 'end', gap: '0rem' }}>
+          <GridItem item xs="auto" style={{ gap: '0.5rem', marginLeft: 'auto', flexShrink: 0 }}>
             <Box sx={{ display: { xs: 'none', sm: 'block' } }}>
               <FormattedTime date={event.created_at} />
             </Box>

--- a/ui/components/NotificationCenter/notificationCenter.style.tsx
+++ b/ui/components/NotificationCenter/notificationCenter.style.tsx
@@ -259,4 +259,5 @@ export const Summary = styled(Grid)(({ notificationcolor }) => ({
   paddingBlock: '0.5rem',
   cursor: 'pointer',
   backgroundColor: alpha(notificationcolor, 0.2),
+  alignItems: 'center',
 }));


### PR DESCRIPTION
## Description

Fixes the misalignment of text, timestamp, and menu icon 
in the Notification Center event rows.

**Notes for Reviewers**
- This PR fixes #18844

## What was wrong?

### `ui/components/NotificationCenter/notificationCenter.style.tsx`
- `Summary` Grid container was missing `alignItems: 'center'`
  — due to this, text, timestamp and ⋮ icon were not 
  vertically centered in each notification row

### `ui/components/NotificationCenter/notification.tsx`
- Right `GridItem` had `gap: '0rem'` 
  — due to this, timestamp and ⋮ icon were stuck together 
  with no spacing
- Right `GridItem` was missing `marginLeft: 'auto'`
  — due to this, timestamp and ⋮ icon were not pushed 
  to the right edge of the row
- Message `GridItem` had fixed width `xs={8}` 
  — due to this, message text was not flexible 
  and could overflow on different screen sizes
- Message `GridItem` was missing `paddingRight: '1rem'`
  — due to this, message text was touching the timestamp

## What was fixed?

### `ui/components/NotificationCenter/notificationCenter.style.tsx`
- Added `alignItems: 'center'` to `Summary` styled component
  — so all items in notification row are vertically centered

### `ui/components/NotificationCenter/notification.tsx`
- Changed `gap: '0rem'` to `gap: '0.5rem'` in right GridItem
  — so timestamp and ⋮ icon have proper spacing between them
- Added `marginLeft: 'auto'` to right GridItem
  — so timestamp and ⋮ icon are pushed to the right edge
- Added `flexShrink: 0` to right GridItem
  — so timestamp and ⋮ icon never get squished
- Changed `xs={8} sm` to `xs` in message GridItem
  — so message takes flexible width on all screen sizes
- Added `paddingRight: '1rem'` to message GridItem
  — so message text has proper spacing from timestamp

**[Signed commits](https://github.com/meshery/meshery/blob/master/CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [x] Yes, I signed my commits.