### PR TITLE
chore(deps): bump @meshery/schemas to ^1.1.0

### DIFF
--- a/provider-ui/package-lock.json
+++ b/provider-ui/package-lock.json
@@ -13,7 +13,7 @@
         "@emotion/react": "^11.14.0",
         "@emotion/server": "^11.11.0",
         "@emotion/styled": "^11.14.1",
-        "@meshery/schemas": "^1.0.1",
+        "@meshery/schemas": "^1.1.0",
         "@mui/icons-material": "^7.3.9",
         "@sistent/sistent": "^0.18.2",
         "http-proxy": "^1.18.1",
@@ -1344,9 +1344,9 @@
       }
     },
     "node_modules/@meshery/schemas": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@meshery/schemas/-/schemas-1.0.1.tgz",
-      "integrity": "sha512-Xd+t3VXE/9XL6gOEuW74RfuL1RSz5MYm6+TqZURqCQ1GoOCz75ylOcPTDdKeOMJFiwkt1gOj9gb81fDItR60FA==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@meshery/schemas/-/schemas-1.1.0.tgz",
+      "integrity": "sha512-WsgW2iCE5dq7HC+VHJeyTnH/4L8OFVJ2FszfyV7WS6WCfLZO8qMjvNb1PNbR4NMUpZMSTaZ1jnhF6cl9DtcoHA==",
       "license": "ISC",
       "peerDependencies": {
         "@reduxjs/toolkit": "^2.8.1",

--- a/provider-ui/package.json
+++ b/provider-ui/package.json
@@ -20,7 +20,7 @@
     "@emotion/react": "^11.14.0",
     "@emotion/server": "^11.11.0",
     "@emotion/styled": "^11.14.1",
-    "@meshery/schemas": "^1.0.1",
+    "@meshery/schemas": "^1.1.0",
     "@mui/icons-material": "^7.3.9",
     "@sistent/sistent": "^0.18.2",
     "http-proxy": "^1.18.1",

--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -21,7 +21,7 @@
         "@emotion/react": "^11.14.0",
         "@emotion/server": "^11.11.0",
         "@emotion/styled": "^11.14.1",
-        "@meshery/schemas": "^1.0.5",
+        "@meshery/schemas": "^1.1.0",
         "@microlink/react-json-view": "^1.31.14",
         "@mui/icons-material": "^7.3.9",
         "@mui/material": "^7.3.9",
@@ -2457,9 +2457,9 @@
       "license": "MIT"
     },
     "node_modules/@meshery/schemas": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/@meshery/schemas/-/schemas-1.0.5.tgz",
-      "integrity": "sha512-4/xhvPUqpoMB+/+X2GsAHLqx5z7Q3et+OJ7aTkDiZjS+K6/2e1qHOBibfdSKtZ22xs0ve7CbKcJPZhZX6Opgrw==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@meshery/schemas/-/schemas-1.1.0.tgz",
+      "integrity": "sha512-WsgW2iCE5dq7HC+VHJeyTnH/4L8OFVJ2FszfyV7WS6WCfLZO8qMjvNb1PNbR4NMUpZMSTaZ1jnhF6cl9DtcoHA==",
       "license": "ISC",
       "peerDependencies": {
         "@reduxjs/toolkit": "^2.8.1",

--- a/ui/package.json
+++ b/ui/package.json
@@ -46,7 +46,7 @@
     "@emotion/react": "^11.14.0",
     "@emotion/server": "^11.11.0",
     "@emotion/styled": "^11.14.1",
-    "@meshery/schemas": "^1.0.5",
+    "@meshery/schemas": "^1.1.0",
     "@microlink/react-json-view": "^1.31.14",
     "@mui/icons-material": "^7.3.9",
     "@mui/material": "^7.3.9",


### PR DESCRIPTION
## Summary

Bump `@meshery/schemas` to `^1.1.0` on both workspaces: `ui/package.json` and `provider-ui/package.json`. Regenerate both `package-lock.json` files; each workspace's `node_modules/@meshery/schemas` now resolves to `1.1.0`.

## Why

`@meshery/schemas@1.1.0` is the first release carrying the canonical camelCase-wire schemas published by Phase 3 of the identifier-naming migration — all 22 resources from the plan's inventory have been version-bumped (see [`docs/identifier-naming-impact-report.md`](https://github.com/meshery/schemas/blob/master/docs/identifier-naming-impact-report.md) on the schemas repo for the per-resource PR list).

Bumping the pin explicitly signals the intent to migrate and makes the new `v1beta3` / `v1beta2` canonical target-version types available to any code that wants to consume them. The existing `v1beta1` types remain importable — this is additive, not a breaking upgrade.

## Changes

- `ui/package.json` — `"@meshery/schemas": "^1.0.5"` → `"^1.1.0"`
- `provider-ui/package.json` — `"@meshery/schemas": "^1.0.1"` → `"^1.1.0"`
- `ui/package-lock.json` — regenerated, resolves to 1.1.0
- `provider-ui/package-lock.json` — regenerated, resolves to 1.1.0

No code changes in this PR. Per-resource consumer repoint PRs (e.g., workspace / environment / design handlers and UI hooks moving from `v1beta1` to `v1beta3`) will follow under the Phase 3 consumer-migration track.

## Tests

- `npm install --package-lock-only` in each workspace completes clean.
- Lockfile inspection confirms `node_modules/@meshery/schemas => 1.1.0` in both workspaces.

No code depends on removed v1beta1 exports; 1.1.0 is strictly additive.

## Migration impact

Additive dependency bump only. The schemas package's 1.0.x types continue to be re-exported from 1.1.0; no downstream import paths break.

## Rollback

Revert this commit and re-run \`npm install\` in each workspace.

## Test plan

- [x] \`git commit -s\` (DCO signed)
- [x] Both \`package-lock.json\` files regenerated and resolve to 1.1.0
- [ ] CI: \`UI build\`, \`UI end-to-end tests\`, \`runner / eslint\` green