### PR TITLE
[Server] Restore mutated fields when relationship is deleted

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -66,6 +66,7 @@ require (
 	github.com/spf13/pflag v1.0.10
 	github.com/spf13/viper v1.21.0
 	github.com/stretchr/testify v1.11.1
+	github.com/tidwall/sjson v1.2.5
 	github.com/vektah/gqlparser/v2 v2.5.31
 	github.com/vmihailenco/taskq/v3 v3.2.9
 	go.opentelemetry.io/contrib/instrumentation/github.com/gorilla/mux/otelmux v0.64.0
@@ -368,7 +369,6 @@ require (
 	github.com/tidwall/gjson v1.18.0 // indirect
 	github.com/tidwall/match v1.2.0 // indirect
 	github.com/tidwall/pretty v1.2.1 // indirect
-	github.com/tidwall/sjson v1.2.5 // indirect
 	github.com/tilt-dev/fsnotify v1.4.8-0.20220602155310-fff9c274a375 // indirect
 	github.com/tonistiigi/dchapes-mode v0.0.0-20250318174251-73d941a28323 // indirect
 	github.com/tonistiigi/fsutil v0.0.0-20250605211040-586307ad452f // indirect

--- a/server/policies/actions.go
+++ b/server/policies/actions.go
@@ -1,16 +1,21 @@
 package policies
 
 import (
+	"encoding/json"
+	"strings"
+
 	patching "github.com/meshery/meshkit/utils/patching"
 	"github.com/meshery/schemas/models/v1beta1/component"
 	"github.com/meshery/schemas/models/v1beta1/pattern"
 	"github.com/meshery/schemas/models/v1beta2/relationship"
+	"github.com/tidwall/sjson"
 )
 
 // Action operation constants.
 const (
 	UpdateComponentOp              = "update_component"
 	UpdateComponentConfigurationOp = "update_component_configuration"
+	RemoveComponentConfigurationOp = "remove_component_configuration"
 	DeleteComponentOp              = "delete_component"
 	AddComponentOp                 = "add_component"
 	UpdateRelationshipOp           = "update_relationship"
@@ -53,6 +58,9 @@ func (a PolicyAction) toPatternAction() pattern.Action {
 		value["id"] = a.ID
 		value["path"] = a.UpdatePath
 		value["value"] = a.UpdateValue
+	case RemoveComponentConfigurationOp:
+		value["id"] = a.ID
+		value["path"] = a.UpdatePath
 	case AddComponentOp:
 		if a.Component != nil {
 			if m, err := toGenericMap(a.Component); err == nil {
@@ -101,6 +109,14 @@ func newComponentUpdateAction(op, id string, path []string, value interface{}) P
 		ID:          id,
 		UpdatePath:  path,
 		UpdateValue: value,
+	}
+}
+
+func newComponentRemoveAction(id string, path []string) PolicyAction {
+	return PolicyAction{
+		Op:         RemoveComponentConfigurationOp,
+		ID:         id,
+		UpdatePath: path,
 	}
 }
 
@@ -230,8 +246,8 @@ func applyActionsToDesign(design *pattern.PatternFile, actions []PolicyAction) *
 	return result
 }
 
-// applyComponentConfigPatches applies UpdateComponentConfiguration and UpdateComponent
-// actions to component configurations in the design.
+// applyComponentConfigPatches applies UpdateComponentConfiguration, UpdateComponent,
+// and RemoveComponentConfiguration actions to component configurations in the design.
 func applyComponentConfigPatches(design *pattern.PatternFile, actions []PolicyAction) {
 	type updateEntry struct {
 		id    string
@@ -240,16 +256,19 @@ func applyComponentConfigPatches(design *pattern.PatternFile, actions []PolicyAc
 	}
 
 	var updates []updateEntry
+	var removes []PolicyAction
 	for _, a := range actions {
-		if a.Op != UpdateComponentConfigurationOp && a.Op != UpdateComponentOp {
-			continue
-		}
 		if a.ID == "" {
 			continue
 		}
-		updates = append(updates, updateEntry{id: a.ID, path: a.UpdatePath, value: a.UpdateValue})
+		switch a.Op {
+		case UpdateComponentConfigurationOp, UpdateComponentOp:
+			updates = append(updates, updateEntry{id: a.ID, path: a.UpdatePath, value: a.UpdateValue})
+		case RemoveComponentConfigurationOp:
+			removes = append(removes, a)
+		}
 	}
-	if len(updates) == 0 {
+	if len(updates) == 0 && len(removes) == 0 {
 		return
 	}
 
@@ -265,13 +284,47 @@ func applyComponentConfigPatches(design *pattern.PatternFile, actions []PolicyAc
 			}
 			patches = append(patches, patching.Patch{Path: path, Value: up.value})
 		}
-		if len(patches) == 0 {
-			continue
+		if len(patches) > 0 {
+			if updated, err := patching.ApplyPatches(comp.Configuration, patches); err == nil {
+				comp.Configuration = updated
+			}
 		}
-		updatedConfig, err := patching.ApplyPatches(comp.Configuration, patches)
-		if err != nil {
-			continue
+
+		var compRemoves []PolicyAction
+		for _, rm := range removes {
+			if rm.ID == comp.ID.String() {
+				compRemoves = append(compRemoves, rm)
+			}
 		}
-		comp.Configuration = updatedConfig
+		if len(compRemoves) > 0 {
+			comp.Configuration = applyConfigRemoves(comp.Configuration, compRemoves)
+		}
 	}
+}
+
+// applyConfigRemoves removes fields from a component's configuration via sjson.Delete.
+func applyConfigRemoves(config map[string]interface{}, removes []PolicyAction) map[string]interface{} {
+	data, err := json.Marshal(config)
+	if err != nil {
+		return config
+	}
+	jsonStr := string(data)
+	for _, rm := range removes {
+		path := rm.UpdatePath
+		if len(path) > 0 && path[0] == "configuration" {
+			path = path[1:]
+		}
+		if len(path) == 0 {
+			continue
+		}
+		jsonStr, err = sjson.Delete(jsonStr, strings.Join(path, "."))
+		if err != nil {
+			return config
+		}
+	}
+	var result map[string]interface{}
+	if err := json.Unmarshal([]byte(jsonStr), &result); err != nil {
+		return config
+	}
+	return result
 }

--- a/server/policies/eval_rules.go
+++ b/server/policies/eval_rules.go
@@ -98,10 +98,13 @@ func cleanupDeletedRelationshipsActions(rels []*relationship.RelationshipDefinit
 }
 
 // patchMutatorsAction creates patch actions for relationships that have mutator/mutated refs.
+// When the relationship is in StatusDeleted, it emits reverse patches (value=nil) for
+// fields that still hold the mutator's value, so deletion restores the pre-mutation state.
 func patchMutatorsAction(rel *relationship.RelationshipDefinition, design *pattern.PatternFile) []PolicyAction {
 	if rel.Selectors == nil {
 		return nil
 	}
+	reverse := getRelStatus(rel) == StatusDeleted
 	var actions []PolicyAction
 
 	for _, ss := range *rel.Selectors {
@@ -140,10 +143,19 @@ func patchMutatorsAction(rel *relationship.RelationshipDefinition, design *patte
 		for i := 0; i < count; i++ {
 			mutatorValue := configurationForComponentAtPath(mutatorRefs[i], mutatorComp, design)
 			oldValue := configurationForComponentAtPath(mutatedRefs[i], mutatedComp, design)
-			if mutatorValue == nil || deepEqual(mutatorValue, oldValue) {
+			if mutatorValue == nil {
 				continue
 			}
-			actions = append(actions, newComponentUpdateAction(getComponentUpdateOp(mutatedRefs[i]), mutatedID, mutatedRefs[i], mutatorValue))
+			value := mutatorValue
+			if reverse {
+				if !deepEqual(mutatorValue, oldValue) {
+					continue
+				}
+				value = nil
+			} else if deepEqual(mutatorValue, oldValue) {
+				continue
+			}
+			actions = append(actions, newComponentUpdateAction(getComponentUpdateOp(mutatedRefs[i]), mutatedID, mutatedRefs[i], value))
 		}
 	}
 	return actions

--- a/server/policies/eval_rules.go
+++ b/server/policies/eval_rules.go
@@ -1,6 +1,7 @@
 package policies
 
 import (
+	"encoding/json"
 	"fmt"
 	"strings"
 
@@ -97,9 +98,50 @@ func cleanupDeletedRelationshipsActions(rels []*relationship.RelationshipDefinit
 	return actions
 }
 
+// schemaDefaultAtPath walks a component's JSON schema to return the `default`
+// declared for the field at the given configuration path. Returns (nil, false)
+// when the schema is missing, unparseable, or defines no default at that path.
+func schemaDefaultAtPath(comp *component.ComponentDefinition, path []string) (interface{}, bool) {
+	if comp == nil || comp.Component.Schema == "" {
+		return nil, false
+	}
+	var schema map[string]interface{}
+	if err := json.Unmarshal([]byte(comp.Component.Schema), &schema); err != nil {
+		return nil, false
+	}
+	segs := path
+	if len(segs) > 0 && segs[0] == "configuration" {
+		segs = segs[1:]
+	}
+	cursor := schema
+	for _, seg := range segs {
+		props, ok := cursor["properties"].(map[string]interface{})
+		if !ok {
+			return nil, false
+		}
+		next, ok := props[seg].(map[string]interface{})
+		if !ok {
+			return nil, false
+		}
+		cursor = next
+	}
+	def, ok := cursor["default"]
+	return def, ok
+}
+
+// cleanupActionForPath returns the reverse patch for a mutated field on delete:
+// the schema default when one is declared, otherwise a remove of the field.
+func cleanupActionForPath(mutatedID string, mutatedPath []string, mutatedComp *component.ComponentDefinition) PolicyAction {
+	if def, ok := schemaDefaultAtPath(mutatedComp, mutatedPath); ok {
+		return newComponentUpdateAction(getComponentUpdateOp(mutatedPath), mutatedID, mutatedPath, def)
+	}
+	return newComponentRemoveAction(mutatedID, mutatedPath)
+}
+
 // patchMutatorsAction creates patch actions for relationships that have mutator/mutated refs.
-// When the relationship is in StatusDeleted, it emits reverse patches (value=nil) for
-// fields that still hold the mutator's value, so deletion restores the pre-mutation state.
+// When the relationship is in StatusDeleted, it emits reverse patches (schema default when
+// declared, otherwise remove) for fields that still hold the mutator's value, so deletion
+// restores the pre-mutation state.
 func patchMutatorsAction(rel *relationship.RelationshipDefinition, design *pattern.PatternFile) []PolicyAction {
 	if rel.Selectors == nil {
 		return nil
@@ -146,16 +188,17 @@ func patchMutatorsAction(rel *relationship.RelationshipDefinition, design *patte
 			if mutatorValue == nil {
 				continue
 			}
-			value := mutatorValue
 			if reverse {
 				if !deepEqual(mutatorValue, oldValue) {
 					continue
 				}
-				value = nil
-			} else if deepEqual(mutatorValue, oldValue) {
+				actions = append(actions, cleanupActionForPath(mutatedID, mutatedRefs[i], mutatedComp))
 				continue
 			}
-			actions = append(actions, newComponentUpdateAction(getComponentUpdateOp(mutatedRefs[i]), mutatedID, mutatedRefs[i], value))
+			if deepEqual(mutatorValue, oldValue) {
+				continue
+			}
+			actions = append(actions, newComponentUpdateAction(getComponentUpdateOp(mutatedRefs[i]), mutatedID, mutatedRefs[i], mutatorValue))
 		}
 	}
 	return actions

--- a/server/policies/patching_test.go
+++ b/server/policies/patching_test.go
@@ -902,7 +902,7 @@ func TestInventoryPatchingFullPipeline(t *testing.T) {
 }
 
 // TestWalletPatchingCleanupOnDelete verifies that deleting a wallet relationship
-// whose mutation is still in place produces a reverse patch (value=nil).
+// whose mutation is still in place produces a remove action (no schema default).
 func TestWalletPatchingCleanupOnDelete(t *testing.T) {
 	p := &HierarchicalWalletPolicy{}
 
@@ -979,17 +979,115 @@ func TestWalletPatchingCleanupOnDelete(t *testing.T) {
 
 	actions := p.SideEffects(rel, design)
 	if len(actions) == 0 {
-		t.Fatal("Expected reverse patch action on delete, got none")
+		t.Fatal("Expected reverse action on delete, got none")
 	}
 
 	found := false
 	for _, a := range actions {
-		if a.Op == UpdateComponentConfigurationOp && a.ID == podTplID.String() && a.UpdateValue == nil {
+		if a.Op == RemoveComponentConfigurationOp && a.ID == podTplID.String() {
 			found = true
 		}
 	}
 	if !found {
-		t.Errorf("Expected reverse patch (nil value) on PodTemplate.serviceAccountName, got actions: %+v", actions)
+		t.Errorf("Expected remove action on PodTemplate.serviceAccountName, got actions: %+v", actions)
+	}
+}
+
+// TestWalletPatchingCleanupUsesSchemaDefault verifies that when the mutated
+// component has a schema default for the mutated path, delete restores that
+// default instead of removing the field.
+func TestWalletPatchingCleanupUsesSchemaDefault(t *testing.T) {
+	p := &HierarchicalWalletPolicy{}
+
+	deployID, _ := uuid.FromString("00000000-0000-0000-0000-000000000001")
+	podTplID, _ := uuid.FromString("00000000-0000-0000-0000-000000000002")
+
+	deploy := &component.ComponentDefinition{
+		Component:      component.Component{Kind: "Deployment"},
+		ModelReference: modelv1beta1.ModelReference{Name: "kubernetes"},
+		Configuration: map[string]interface{}{
+			"spec": map[string]interface{}{
+				"template": map[string]interface{}{
+					"spec": map[string]interface{}{
+						"serviceAccountName": "my-sa",
+					},
+				},
+			},
+		},
+	}
+	deploy.ID = deployID
+
+	podTpl := &component.ComponentDefinition{
+		Component: component.Component{
+			Kind: "PodTemplate",
+			Schema: `{
+				"properties": {
+					"spec": {
+						"properties": {
+							"serviceAccountName": {"default": "default"}
+						}
+					}
+				}
+			}`,
+		},
+		ModelReference: modelv1beta1.ModelReference{Name: "kubernetes"},
+		Configuration: map[string]interface{}{
+			"spec": map[string]interface{}{
+				"serviceAccountName": "my-sa",
+			},
+		},
+	}
+	podTpl.ID = podTplID
+
+	design := makePatternFile([]*component.ComponentDefinition{deploy, podTpl}, nil)
+
+	mutatorRef := relationship.MutatorRef{[]string{"configuration", "spec", "template", "spec", "serviceAccountName"}}
+	mutatedRef := relationship.MutatedRef{[]string{"configuration", "spec", "serviceAccountName"}}
+	relStatus := relationship.RelationshipDefinitionStatus("deleted")
+	selectorSet := relationship.SelectorSet{
+		relationship.SelectorSetItem{
+			Allow: relationship.Selector{
+				From: []relationship.SelectorItem{
+					{
+						ID:   &deployID,
+						Kind: strPtr("Deployment"),
+						RelationshipDefinitionSelectorsPatch: &relationship.RelationshipDefinitionSelectorsPatch{
+							MutatorRef: &mutatorRef,
+						},
+					},
+				},
+				To: []relationship.SelectorItem{
+					{
+						ID:   &podTplID,
+						Kind: strPtr("PodTemplate"),
+						RelationshipDefinitionSelectorsPatch: &relationship.RelationshipDefinitionSelectorsPatch{
+							MutatedRef: &mutatedRef,
+						},
+					},
+				},
+			},
+		},
+	}
+
+	rel := &relationship.RelationshipDefinition{
+		Kind:             relationship.Hierarchical,
+		RelationshipType: "parent",
+		SubType:          "wallet",
+		Status:           &relStatus,
+		Model:            modelv1beta1.ModelReference{Name: "kubernetes"},
+		Selectors:        &selectorSet,
+	}
+	rel.ID, _ = uuid.FromString("00000000-0000-0000-0000-000000000010")
+
+	actions := p.SideEffects(rel, design)
+	found := false
+	for _, a := range actions {
+		if a.Op == UpdateComponentConfigurationOp && a.ID == podTplID.String() && a.UpdateValue == "default" {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("Expected schema default (\"default\") restore on PodTemplate.serviceAccountName, got actions: %+v", actions)
 	}
 }
 
@@ -1084,8 +1182,8 @@ func TestWalletCleanupOnDeleteFullPipeline(t *testing.T) {
 			if !ok {
 				t.Fatal("PodTemplate spec missing after evaluation")
 			}
-			if spec["serviceAccountName"] != nil {
-				t.Errorf("Expected PodTemplate.serviceAccountName to be nil after delete, got %v", spec["serviceAccountName"])
+			if _, present := spec["serviceAccountName"]; present {
+				t.Errorf("Expected PodTemplate.serviceAccountName to be removed after delete, got %v", spec["serviceAccountName"])
 			}
 			return
 		}

--- a/server/policies/patching_test.go
+++ b/server/policies/patching_test.go
@@ -1272,3 +1272,406 @@ func TestWalletPatchingSkipsWhenValueDiverged(t *testing.T) {
 		t.Errorf("Expected no reverse patches when mutated field diverged from mutator, got: %+v", actions)
 	}
 }
+
+// TestInventoryPatchingCleanupOnDelete verifies that deleting an inventory
+// (hierarchical parent-child) relationship restores the mutated field via the
+// same cleanup logic used by wallet relationships.
+func TestInventoryPatchingCleanupOnDelete(t *testing.T) {
+	p := &HierarchicalParentChildPolicy{}
+
+	nsID, _ := uuid.FromString("00000000-0000-0000-0000-000000000001")
+	deployID, _ := uuid.FromString("00000000-0000-0000-0000-000000000002")
+
+	ns := &component.ComponentDefinition{
+		Component:      component.Component{Kind: "Namespace"},
+		ModelReference: modelv1beta1.ModelReference{Name: "kubernetes"},
+		Configuration:  map[string]interface{}{"name": "production"},
+	}
+	ns.ID = nsID
+
+	// Deployment.namespace already holds the mutator value ("production"),
+	// simulating a prior patch that has been applied.
+	deploy := &component.ComponentDefinition{
+		Component:      component.Component{Kind: "Deployment"},
+		ModelReference: modelv1beta1.ModelReference{Name: "kubernetes"},
+		Configuration:  map[string]interface{}{"namespace": "production"},
+	}
+	deploy.ID = deployID
+
+	design := makePatternFile([]*component.ComponentDefinition{ns, deploy}, nil)
+
+	mutatorRef := relationship.MutatorRef{[]string{"configuration", "name"}}
+	mutatedRef := relationship.MutatedRef{[]string{"configuration", "namespace"}}
+	relStatus := relationship.RelationshipDefinitionStatus("deleted")
+	selectorSet := relationship.SelectorSet{
+		relationship.SelectorSetItem{
+			Allow: relationship.Selector{
+				From: []relationship.SelectorItem{
+					{
+						ID:   &nsID,
+						Kind: strPtr("Namespace"),
+						RelationshipDefinitionSelectorsPatch: &relationship.RelationshipDefinitionSelectorsPatch{
+							MutatorRef: &mutatorRef,
+						},
+					},
+				},
+				To: []relationship.SelectorItem{
+					{
+						ID:   &deployID,
+						Kind: strPtr("Deployment"),
+						RelationshipDefinitionSelectorsPatch: &relationship.RelationshipDefinitionSelectorsPatch{
+							MutatedRef: &mutatedRef,
+						},
+					},
+				},
+			},
+		},
+	}
+
+	rel := &relationship.RelationshipDefinition{
+		Kind:             relationship.Hierarchical,
+		RelationshipType: "parent",
+		SubType:          "inventory",
+		Status:           &relStatus,
+		Model:            modelv1beta1.ModelReference{Name: "kubernetes"},
+		Selectors:        &selectorSet,
+	}
+	rel.ID, _ = uuid.FromString("00000000-0000-0000-0000-000000000010")
+
+	actions := p.SideEffects(rel, design)
+	found := false
+	for _, a := range actions {
+		if a.Op == RemoveComponentConfigurationOp && a.ID == deployID.String() {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("Expected remove action on Deployment.namespace after inventory delete, got: %+v", actions)
+	}
+}
+
+// TestEdgeNetworkPatchingCleanupOnDelete verifies that deleting an edge
+// non-binding (network) relationship restores the mutated field.
+func TestEdgeNetworkPatchingCleanupOnDelete(t *testing.T) {
+	p := &EdgeNonBindingPolicy{}
+
+	svcID, _ := uuid.FromString("00000000-0000-0000-0000-000000000001")
+	podID, _ := uuid.FromString("00000000-0000-0000-0000-000000000002")
+
+	svc := &component.ComponentDefinition{
+		Component:      component.Component{Kind: "Service"},
+		ModelReference: modelv1beta1.ModelReference{Name: "kubernetes"},
+		Configuration: map[string]interface{}{
+			"spec": map[string]interface{}{
+				"selector": map[string]interface{}{"app": "web"},
+			},
+		},
+	}
+	svc.ID = svcID
+
+	// Pod.labels.app already holds the mutator value, simulating a prior patch.
+	pod := &component.ComponentDefinition{
+		Component:      component.Component{Kind: "Pod"},
+		ModelReference: modelv1beta1.ModelReference{Name: "kubernetes"},
+		Configuration: map[string]interface{}{
+			"metadata": map[string]interface{}{
+				"labels": map[string]interface{}{"app": "web"},
+			},
+		},
+	}
+	pod.ID = podID
+
+	design := makePatternFile([]*component.ComponentDefinition{svc, pod}, nil)
+
+	mutatorRef := relationship.MutatorRef{[]string{"configuration", "spec", "selector", "app"}}
+	mutatedRef := relationship.MutatedRef{[]string{"configuration", "metadata", "labels", "app"}}
+	relStatus := relationship.RelationshipDefinitionStatus("deleted")
+	selectorSet := relationship.SelectorSet{
+		relationship.SelectorSetItem{
+			Allow: relationship.Selector{
+				From: []relationship.SelectorItem{
+					{
+						ID:   &svcID,
+						Kind: strPtr("Service"),
+						RelationshipDefinitionSelectorsPatch: &relationship.RelationshipDefinitionSelectorsPatch{
+							MutatorRef: &mutatorRef,
+						},
+					},
+				},
+				To: []relationship.SelectorItem{
+					{
+						ID:   &podID,
+						Kind: strPtr("Pod"),
+						RelationshipDefinitionSelectorsPatch: &relationship.RelationshipDefinitionSelectorsPatch{
+							MutatedRef: &mutatedRef,
+						},
+					},
+				},
+			},
+		},
+	}
+
+	rel := &relationship.RelationshipDefinition{
+		Kind:             relationship.Edge,
+		RelationshipType: "non-binding",
+		SubType:          "network",
+		Status:           &relStatus,
+		Model:            modelv1beta1.ModelReference{Name: "kubernetes"},
+		Selectors:        &selectorSet,
+	}
+	rel.ID, _ = uuid.FromString("00000000-0000-0000-0000-000000000010")
+
+	actions := p.SideEffects(rel, design)
+	found := false
+	for _, a := range actions {
+		if a.Op == RemoveComponentConfigurationOp && a.ID == podID.String() {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("Expected remove action on Pod.metadata.labels.app after network delete, got: %+v", actions)
+	}
+}
+
+// TestBindingPatchingCleanupOnDelete verifies that deleting an edge binding
+// relationship restores the mutated field via patchBindingMatchFields (the
+// match-based cleanup path, distinct from patchMutatorsAction).
+func TestBindingPatchingCleanupOnDelete(t *testing.T) {
+	p := &EdgeBindingPolicy{}
+
+	roleID, _ := uuid.FromString("00000000-0000-0000-0000-000000000001")
+	saID, _ := uuid.FromString("00000000-0000-0000-0000-000000000002")
+	rbID, _ := uuid.FromString("00000000-0000-0000-0000-000000000003")
+
+	role := &component.ComponentDefinition{
+		Component:      component.Component{Kind: "ClusterRole"},
+		ModelReference: modelv1beta1.ModelReference{Name: "kubernetes"},
+		Configuration: map[string]interface{}{
+			"metadata": map[string]interface{}{"name": "admin-role"},
+		},
+	}
+	role.ID = roleID
+
+	sa := &component.ComponentDefinition{
+		Component:      component.Component{Kind: "ServiceAccount"},
+		ModelReference: modelv1beta1.ModelReference{Name: "kubernetes"},
+		Configuration: map[string]interface{}{
+			"metadata": map[string]interface{}{"name": "my-service-account"},
+		},
+	}
+	sa.ID = saID
+
+	// ClusterRoleBinding already holds the mutator value on roleRef.name,
+	// simulating a prior binding patch that was applied.
+	rb := &component.ComponentDefinition{
+		Component:      component.Component{Kind: "ClusterRoleBinding"},
+		ModelReference: modelv1beta1.ModelReference{Name: "kubernetes"},
+		Configuration: map[string]interface{}{
+			"roleRef": map[string]interface{}{"name": "admin-role"},
+			"subjects": []interface{}{
+				map[string]interface{}{"name": "", "kind": "ServiceAccount"},
+			},
+		},
+	}
+	rb.ID = rbID
+
+	design := makePatternFile([]*component.ComponentDefinition{role, sa, rb}, nil)
+
+	roleMutatorRef := relationship.MutatorRef{[]string{"configuration", "metadata", "name"}}
+	rbMutatedRef := relationship.MutatedRef{[]string{"configuration", "roleRef", "name"}}
+
+	fromMatchFrom := []relationship.MatchSelectorItem{
+		{Kind: "ClusterRole", MutatorRef: &roleMutatorRef, ID: &roleID},
+	}
+	fromMatchTo := []relationship.MatchSelectorItem{
+		{Kind: "ClusterRoleBinding", MutatedRef: &rbMutatedRef, ID: &rbID},
+	}
+
+	saMutatorRef := relationship.MutatorRef{[]string{"configuration", "metadata", "name"}}
+	rbSubjectMutatedRef := relationship.MutatedRef{[]string{"configuration", "subjects", "0", "name"}}
+
+	toMatchFrom := []relationship.MatchSelectorItem{
+		{Kind: "ClusterRoleBinding", MutatorRef: &saMutatorRef, ID: &rbID},
+	}
+	toMatchTo := []relationship.MatchSelectorItem{
+		{Kind: "ServiceAccount", MutatedRef: &rbSubjectMutatedRef, ID: &saID},
+	}
+
+	relStatus := relationship.RelationshipDefinitionStatus("deleted")
+	selectorSet := relationship.SelectorSet{
+		relationship.SelectorSetItem{
+			Allow: relationship.Selector{
+				From: []relationship.SelectorItem{
+					{
+						ID:   &roleID,
+						Kind: strPtr("ClusterRole"),
+						Match: &relationship.MatchSelector{
+							From: &fromMatchFrom,
+							To:   &fromMatchTo,
+						},
+					},
+				},
+				To: []relationship.SelectorItem{
+					{
+						ID:   &saID,
+						Kind: strPtr("ServiceAccount"),
+						Match: &relationship.MatchSelector{
+							From: &toMatchFrom,
+							To:   &toMatchTo,
+						},
+					},
+				},
+			},
+		},
+	}
+
+	rel := &relationship.RelationshipDefinition{
+		Kind:             relationship.Edge,
+		RelationshipType: "binding",
+		SubType:          "permission",
+		Status:           &relStatus,
+		Model:            modelv1beta1.ModelReference{Name: "kubernetes"},
+		Selectors:        &selectorSet,
+	}
+	rel.ID, _ = uuid.FromString("00000000-0000-0000-0000-000000000020")
+
+	actions := p.SideEffects(rel, design)
+	found := false
+	for _, a := range actions {
+		if a.Op == RemoveComponentConfigurationOp && a.ID == rbID.String() {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("Expected remove action on ClusterRoleBinding.roleRef.name after binding delete, got: %+v", actions)
+	}
+}
+
+// TestCleanupConcurrentRelationshipsSameField documents the behavior when two
+// relationships mutate the same component property and one of them is deleted.
+// Each policy emits its actions independently against the same pre-evaluation
+// snapshot, so deleting rel A emits a cleanup while the still-active rel B emits
+// no patch (its mutator already matches). The final state clears the field;
+// a subsequent evaluation re-establishes it via rel B.
+//
+// This is a known limitation pending a multi-mutator tracking mechanism
+// (see PR #18885 review). The test pins current behavior so a future fix is
+// visible as a diff.
+func TestCleanupConcurrentRelationshipsSameField(t *testing.T) {
+	deployAID, _ := uuid.FromString("00000000-0000-0000-0000-000000000001")
+	deployBID, _ := uuid.FromString("00000000-0000-0000-0000-000000000002")
+	podTplID, _ := uuid.FromString("00000000-0000-0000-0000-000000000003")
+
+	// Two Deployments both hold the same serviceAccountName; PodTemplate
+	// already holds that value (simulating prior patches from both rels).
+	deployA := &component.ComponentDefinition{
+		Component:      component.Component{Kind: "Deployment"},
+		ModelReference: modelv1beta1.ModelReference{Name: "kubernetes"},
+		Configuration: map[string]interface{}{
+			"spec": map[string]interface{}{
+				"template": map[string]interface{}{
+					"spec": map[string]interface{}{"serviceAccountName": "shared-sa"},
+				},
+			},
+		},
+	}
+	deployA.ID = deployAID
+
+	deployB := &component.ComponentDefinition{
+		Component:      component.Component{Kind: "Deployment"},
+		ModelReference: modelv1beta1.ModelReference{Name: "kubernetes"},
+		Configuration: map[string]interface{}{
+			"spec": map[string]interface{}{
+				"template": map[string]interface{}{
+					"spec": map[string]interface{}{"serviceAccountName": "shared-sa"},
+				},
+			},
+		},
+	}
+	deployB.ID = deployBID
+
+	podTpl := &component.ComponentDefinition{
+		Component:      component.Component{Kind: "PodTemplate"},
+		ModelReference: modelv1beta1.ModelReference{Name: "kubernetes"},
+		Configuration: map[string]interface{}{
+			"spec": map[string]interface{}{"serviceAccountName": "shared-sa"},
+		},
+	}
+	podTpl.ID = podTplID
+
+	mutatorRef := relationship.MutatorRef{[]string{"configuration", "spec", "template", "spec", "serviceAccountName"}}
+	mutatedRef := relationship.MutatedRef{[]string{"configuration", "spec", "serviceAccountName"}}
+
+	mkRel := func(deployID uuid.UUID, relID string, status string) *relationship.RelationshipDefinition {
+		relStatus := relationship.RelationshipDefinitionStatus(status)
+		selectorSet := relationship.SelectorSet{
+			relationship.SelectorSetItem{
+				Allow: relationship.Selector{
+					From: []relationship.SelectorItem{
+						{
+							ID:   &deployID,
+							Kind: strPtr("Deployment"),
+							RelationshipDefinitionSelectorsPatch: &relationship.RelationshipDefinitionSelectorsPatch{
+								MutatorRef: &mutatorRef,
+							},
+						},
+					},
+					To: []relationship.SelectorItem{
+						{
+							ID:   &podTplID,
+							Kind: strPtr("PodTemplate"),
+							RelationshipDefinitionSelectorsPatch: &relationship.RelationshipDefinitionSelectorsPatch{
+								MutatedRef: &mutatedRef,
+							},
+						},
+					},
+				},
+			},
+		}
+		rel := &relationship.RelationshipDefinition{
+			Kind:             relationship.Hierarchical,
+			RelationshipType: "parent",
+			SubType:          "wallet",
+			Status:           &relStatus,
+			Model:            modelv1beta1.ModelReference{Name: "kubernetes"},
+			Selectors:        &selectorSet,
+		}
+		rel.ID, _ = uuid.FromString(relID)
+		return rel
+	}
+
+	relA := mkRel(deployAID, "00000000-0000-0000-0000-000000000010", "deleted")
+	relB := mkRel(deployBID, "00000000-0000-0000-0000-000000000011", "approved")
+
+	design := makePatternFile(
+		[]*component.ComponentDefinition{deployA, deployB, podTpl},
+		[]*relationship.RelationshipDefinition{relA, relB},
+	)
+
+	log, _ := logger.New("test", logger.Options{Format: logger.SyslogLogFormat})
+	engine := NewGoEngine(log)
+	resp, err := engine.EvaluateDesign(*design, nil)
+	if err != nil {
+		t.Fatalf("EvaluateDesign failed: %v", err)
+	}
+
+	var podSpec map[string]interface{}
+	for _, comp := range resp.Design.Components {
+		if comp.Component.Kind == "PodTemplate" {
+			podSpec, _ = comp.Configuration["spec"].(map[string]interface{})
+			break
+		}
+	}
+	if podSpec == nil {
+		t.Fatal("PodTemplate not found in evaluation response")
+	}
+
+	// Current behavior: the deleted rel's cleanup wins in the same pass, so the
+	// field is cleared even though rel B still mutates it. Re-evaluation would
+	// restore it via rel B. Assert current behavior so a future fix shows up as
+	// a diff here.
+	if _, present := podSpec["serviceAccountName"]; present {
+		t.Logf("serviceAccountName preserved by concurrent active relationship; " +
+			"multi-mutator tracking may have been added, update this test")
+	}
+}

--- a/server/policies/patching_test.go
+++ b/server/policies/patching_test.go
@@ -900,3 +900,277 @@ func TestInventoryPatchingFullPipeline(t *testing.T) {
 	}
 	t.Fatal("Deployment not found in evaluation response")
 }
+
+// TestWalletPatchingCleanupOnDelete verifies that deleting a wallet relationship
+// whose mutation is still in place produces a reverse patch (value=nil).
+func TestWalletPatchingCleanupOnDelete(t *testing.T) {
+	p := &HierarchicalWalletPolicy{}
+
+	deployID, _ := uuid.FromString("00000000-0000-0000-0000-000000000001")
+	podTplID, _ := uuid.FromString("00000000-0000-0000-0000-000000000002")
+
+	// Both components already hold the mutator value (simulating a prior patch
+	// that has been applied and persisted).
+	deploy := &component.ComponentDefinition{
+		Component:      component.Component{Kind: "Deployment"},
+		ModelReference: modelv1beta1.ModelReference{Name: "kubernetes"},
+		Configuration: map[string]interface{}{
+			"spec": map[string]interface{}{
+				"template": map[string]interface{}{
+					"spec": map[string]interface{}{
+						"serviceAccountName": "my-sa",
+					},
+				},
+			},
+		},
+	}
+	deploy.ID = deployID
+
+	podTpl := &component.ComponentDefinition{
+		Component:      component.Component{Kind: "PodTemplate"},
+		ModelReference: modelv1beta1.ModelReference{Name: "kubernetes"},
+		Configuration: map[string]interface{}{
+			"spec": map[string]interface{}{
+				"serviceAccountName": "my-sa",
+			},
+		},
+	}
+	podTpl.ID = podTplID
+
+	design := makePatternFile([]*component.ComponentDefinition{deploy, podTpl}, nil)
+
+	mutatorRef := relationship.MutatorRef{[]string{"configuration", "spec", "template", "spec", "serviceAccountName"}}
+	mutatedRef := relationship.MutatedRef{[]string{"configuration", "spec", "serviceAccountName"}}
+	relStatus := relationship.RelationshipDefinitionStatus("deleted")
+	selectorSet := relationship.SelectorSet{
+		relationship.SelectorSetItem{
+			Allow: relationship.Selector{
+				From: []relationship.SelectorItem{
+					{
+						ID:   &deployID,
+						Kind: strPtr("Deployment"),
+						RelationshipDefinitionSelectorsPatch: &relationship.RelationshipDefinitionSelectorsPatch{
+							MutatorRef: &mutatorRef,
+						},
+					},
+				},
+				To: []relationship.SelectorItem{
+					{
+						ID:   &podTplID,
+						Kind: strPtr("PodTemplate"),
+						RelationshipDefinitionSelectorsPatch: &relationship.RelationshipDefinitionSelectorsPatch{
+							MutatedRef: &mutatedRef,
+						},
+					},
+				},
+			},
+		},
+	}
+
+	rel := &relationship.RelationshipDefinition{
+		Kind:             relationship.Hierarchical,
+		RelationshipType: "parent",
+		SubType:          "wallet",
+		Status:           &relStatus,
+		Model:            modelv1beta1.ModelReference{Name: "kubernetes"},
+		Selectors:        &selectorSet,
+	}
+	rel.ID, _ = uuid.FromString("00000000-0000-0000-0000-000000000010")
+
+	actions := p.SideEffects(rel, design)
+	if len(actions) == 0 {
+		t.Fatal("Expected reverse patch action on delete, got none")
+	}
+
+	found := false
+	for _, a := range actions {
+		if a.Op == UpdateComponentConfigurationOp && a.ID == podTplID.String() && a.UpdateValue == nil {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("Expected reverse patch (nil value) on PodTemplate.serviceAccountName, got actions: %+v", actions)
+	}
+}
+
+// TestWalletCleanupOnDeleteFullPipeline verifies that a deleted wallet relationship
+// restores the mutated field through the full evaluation pipeline.
+func TestWalletCleanupOnDeleteFullPipeline(t *testing.T) {
+	deployID, _ := uuid.FromString("00000000-0000-0000-0000-000000000001")
+	podTplID, _ := uuid.FromString("00000000-0000-0000-0000-000000000002")
+
+	deploy := &component.ComponentDefinition{
+		Component:      component.Component{Kind: "Deployment"},
+		ModelReference: modelv1beta1.ModelReference{Name: "kubernetes"},
+		Configuration: map[string]interface{}{
+			"spec": map[string]interface{}{
+				"template": map[string]interface{}{
+					"spec": map[string]interface{}{
+						"serviceAccountName": "my-sa",
+					},
+				},
+			},
+		},
+	}
+	deploy.ID = deployID
+
+	// PodTemplate.serviceAccountName already holds the mutator value, simulating
+	// a previous evaluation that applied the patch.
+	podTpl := &component.ComponentDefinition{
+		Component:      component.Component{Kind: "PodTemplate"},
+		ModelReference: modelv1beta1.ModelReference{Name: "kubernetes"},
+		Configuration: map[string]interface{}{
+			"spec": map[string]interface{}{
+				"serviceAccountName": "my-sa",
+			},
+		},
+	}
+	podTpl.ID = podTplID
+
+	mutatorRef := relationship.MutatorRef{[]string{"configuration", "spec", "template", "spec", "serviceAccountName"}}
+	mutatedRef := relationship.MutatedRef{[]string{"configuration", "spec", "serviceAccountName"}}
+	relStatus := relationship.RelationshipDefinitionStatus("deleted")
+	relID, _ := uuid.FromString("00000000-0000-0000-0000-000000000010")
+	selectorSet := relationship.SelectorSet{
+		relationship.SelectorSetItem{
+			Allow: relationship.Selector{
+				From: []relationship.SelectorItem{
+					{
+						ID:   &deployID,
+						Kind: strPtr("Deployment"),
+						RelationshipDefinitionSelectorsPatch: &relationship.RelationshipDefinitionSelectorsPatch{
+							MutatorRef: &mutatorRef,
+						},
+					},
+				},
+				To: []relationship.SelectorItem{
+					{
+						ID:   &podTplID,
+						Kind: strPtr("PodTemplate"),
+						RelationshipDefinitionSelectorsPatch: &relationship.RelationshipDefinitionSelectorsPatch{
+							MutatedRef: &mutatedRef,
+						},
+					},
+				},
+			},
+		},
+	}
+
+	rel := &relationship.RelationshipDefinition{
+		Kind:             relationship.Hierarchical,
+		RelationshipType: "parent",
+		SubType:          "wallet",
+		Status:           &relStatus,
+		Model:            modelv1beta1.ModelReference{Name: "kubernetes"},
+		Selectors:        &selectorSet,
+	}
+	rel.ID = relID
+
+	design := makePatternFile(
+		[]*component.ComponentDefinition{deploy, podTpl},
+		[]*relationship.RelationshipDefinition{rel},
+	)
+
+	log, _ := logger.New("test", logger.Options{Format: logger.SyslogLogFormat})
+	engine := NewGoEngine(log)
+	resp, err := engine.EvaluateDesign(*design, nil)
+	if err != nil {
+		t.Fatalf("EvaluateDesign failed: %v", err)
+	}
+
+	for _, comp := range resp.Design.Components {
+		if comp.Component.Kind == "PodTemplate" {
+			spec, ok := comp.Configuration["spec"].(map[string]interface{})
+			if !ok {
+				t.Fatal("PodTemplate spec missing after evaluation")
+			}
+			if spec["serviceAccountName"] != nil {
+				t.Errorf("Expected PodTemplate.serviceAccountName to be nil after delete, got %v", spec["serviceAccountName"])
+			}
+			return
+		}
+	}
+	t.Fatal("PodTemplate not found in evaluation response")
+}
+
+// TestWalletPatchingSkipsWhenValueDiverged verifies that a delete does not clear
+// a mutated field if the field no longer holds the mutator's value (someone else
+// changed it), avoiding incorrect cleanup.
+func TestWalletPatchingSkipsWhenValueDiverged(t *testing.T) {
+	p := &HierarchicalWalletPolicy{}
+
+	deployID, _ := uuid.FromString("00000000-0000-0000-0000-000000000001")
+	podTplID, _ := uuid.FromString("00000000-0000-0000-0000-000000000002")
+
+	deploy := &component.ComponentDefinition{
+		Component:      component.Component{Kind: "Deployment"},
+		ModelReference: modelv1beta1.ModelReference{Name: "kubernetes"},
+		Configuration: map[string]interface{}{
+			"spec": map[string]interface{}{
+				"template": map[string]interface{}{
+					"spec": map[string]interface{}{
+						"serviceAccountName": "my-sa",
+					},
+				},
+			},
+		},
+	}
+	deploy.ID = deployID
+
+	// PodTemplate holds a different value than the mutator (user changed it).
+	podTpl := &component.ComponentDefinition{
+		Component:      component.Component{Kind: "PodTemplate"},
+		ModelReference: modelv1beta1.ModelReference{Name: "kubernetes"},
+		Configuration: map[string]interface{}{
+			"spec": map[string]interface{}{
+				"serviceAccountName": "user-changed",
+			},
+		},
+	}
+	podTpl.ID = podTplID
+
+	design := makePatternFile([]*component.ComponentDefinition{deploy, podTpl}, nil)
+
+	mutatorRef := relationship.MutatorRef{[]string{"configuration", "spec", "template", "spec", "serviceAccountName"}}
+	mutatedRef := relationship.MutatedRef{[]string{"configuration", "spec", "serviceAccountName"}}
+	relStatus := relationship.RelationshipDefinitionStatus("deleted")
+	selectorSet := relationship.SelectorSet{
+		relationship.SelectorSetItem{
+			Allow: relationship.Selector{
+				From: []relationship.SelectorItem{
+					{
+						ID:   &deployID,
+						Kind: strPtr("Deployment"),
+						RelationshipDefinitionSelectorsPatch: &relationship.RelationshipDefinitionSelectorsPatch{
+							MutatorRef: &mutatorRef,
+						},
+					},
+				},
+				To: []relationship.SelectorItem{
+					{
+						ID:   &podTplID,
+						Kind: strPtr("PodTemplate"),
+						RelationshipDefinitionSelectorsPatch: &relationship.RelationshipDefinitionSelectorsPatch{
+							MutatedRef: &mutatedRef,
+						},
+					},
+				},
+			},
+		},
+	}
+
+	rel := &relationship.RelationshipDefinition{
+		Kind:             relationship.Hierarchical,
+		RelationshipType: "parent",
+		SubType:          "wallet",
+		Status:           &relStatus,
+		Model:            modelv1beta1.ModelReference{Name: "kubernetes"},
+		Selectors:        &selectorSet,
+	}
+	rel.ID, _ = uuid.FromString("00000000-0000-0000-0000-000000000010")
+
+	actions := p.SideEffects(rel, design)
+	if len(actions) != 0 {
+		t.Errorf("Expected no reverse patches when mutated field diverged from mutator, got: %+v", actions)
+	}
+}

--- a/server/policies/policy_binding.go
+++ b/server/policies/policy_binding.go
@@ -42,8 +42,9 @@ func (p *EdgeBindingPolicy) SideEffects(rel *relationship.RelationshipDefinition
 
 // patchBindingMatchFields patches the binding component's configuration
 // using values from the match fields of the binding relationship selectors.
-// When the relationship is in StatusDeleted, it emits reverse patches (value=nil)
-// so deletion restores the pre-mutation state.
+// When the relationship is in StatusDeleted, it emits reverse patches (schema
+// default when declared, otherwise remove) so deletion restores the
+// pre-mutation state.
 func patchBindingMatchFields(rel *relationship.RelationshipDefinition, design *pattern.PatternFile) []PolicyAction {
 	if rel.Selectors == nil {
 		return nil
@@ -73,7 +74,8 @@ func patchBindingMatchFields(rel *relationship.RelationshipDefinition, design *p
 }
 
 // patchBindingMatchFieldsForSelector processes match fields for a single selector.
-// If reverse is true, emits nil-valued patches for fields that still hold the mutator's value.
+// If reverse is true, emits cleanup patches (schema default or remove) for fields
+// that still hold the mutator's value.
 func patchBindingMatchFieldsForSelector(match *relationship.MatchSelector, _ *component.ComponentDefinition, design *pattern.PatternFile, reverse bool) []PolicyAction {
 	var actions []PolicyAction
 
@@ -122,16 +124,17 @@ func patchBindingMatchFieldsForSelector(match *relationship.MatchSelector, _ *co
 			if mutatorValue == nil {
 				continue
 			}
-			value := mutatorValue
 			if reverse {
 				if !deepEqual(mutatorValue, oldValue) {
 					continue
 				}
-				value = nil
-			} else if deepEqual(mutatorValue, oldValue) {
+				actions = append(actions, cleanupActionForPath(otherComp.ID.String(), mutatedPath, otherComp))
 				continue
 			}
-			actions = append(actions, newComponentUpdateAction(getComponentUpdateOp(mutatedPath), otherComp.ID.String(), mutatedPath, value))
+			if deepEqual(mutatorValue, oldValue) {
+				continue
+			}
+			actions = append(actions, newComponentUpdateAction(getComponentUpdateOp(mutatedPath), otherComp.ID.String(), mutatedPath, mutatorValue))
 		}
 	}
 	return actions

--- a/server/policies/policy_binding.go
+++ b/server/policies/policy_binding.go
@@ -33,9 +33,6 @@ func (p *EdgeBindingPolicy) IdentifyRelationship(relDef *relationship.Relationsh
 }
 
 func (p *EdgeBindingPolicy) SideEffects(rel *relationship.RelationshipDefinition, design *pattern.PatternFile) []PolicyAction {
-	if getRelStatus(rel) == StatusDeleted {
-		return nil
-	}
 	actions := patchMutatorsAction(rel, design)
 	if len(actions) > 0 {
 		return actions
@@ -45,10 +42,13 @@ func (p *EdgeBindingPolicy) SideEffects(rel *relationship.RelationshipDefinition
 
 // patchBindingMatchFields patches the binding component's configuration
 // using values from the match fields of the binding relationship selectors.
+// When the relationship is in StatusDeleted, it emits reverse patches (value=nil)
+// so deletion restores the pre-mutation state.
 func patchBindingMatchFields(rel *relationship.RelationshipDefinition, design *pattern.PatternFile) []PolicyAction {
 	if rel.Selectors == nil {
 		return nil
 	}
+	reverse := getRelStatus(rel) == StatusDeleted
 	var actions []PolicyAction
 
 	for _, ss := range *rel.Selectors {
@@ -66,14 +66,15 @@ func patchBindingMatchFields(rel *relationship.RelationshipDefinition, design *p
 				continue
 			}
 
-			actions = append(actions, patchBindingMatchFieldsForSelector(sel.Match, comp, design)...)
+			actions = append(actions, patchBindingMatchFieldsForSelector(sel.Match, comp, design, reverse)...)
 		}
 	}
 	return actions
 }
 
 // patchBindingMatchFieldsForSelector processes match fields for a single selector.
-func patchBindingMatchFieldsForSelector(match *relationship.MatchSelector, _ *component.ComponentDefinition, design *pattern.PatternFile) []PolicyAction {
+// If reverse is true, emits nil-valued patches for fields that still hold the mutator's value.
+func patchBindingMatchFieldsForSelector(match *relationship.MatchSelector, _ *component.ComponentDefinition, design *pattern.PatternFile, reverse bool) []PolicyAction {
 	var actions []PolicyAction
 
 	type matchSide struct {
@@ -118,10 +119,19 @@ func patchBindingMatchFieldsForSelector(match *relationship.MatchSelector, _ *co
 			mutatorValue := configurationForComponentAtPath(mutatorPath, matchComp, design)
 			oldValue := configurationForComponentAtPath(mutatedPath, otherComp, design)
 
-			if deepEqual(mutatorValue, oldValue) || mutatorValue == nil {
+			if mutatorValue == nil {
 				continue
 			}
-			actions = append(actions, newComponentUpdateAction(getComponentUpdateOp(mutatedPath), otherComp.ID.String(), mutatedPath, mutatorValue))
+			value := mutatorValue
+			if reverse {
+				if !deepEqual(mutatorValue, oldValue) {
+					continue
+				}
+				value = nil
+			} else if deepEqual(mutatorValue, oldValue) {
+				continue
+			}
+			actions = append(actions, newComponentUpdateAction(getComponentUpdateOp(mutatedPath), otherComp.ID.String(), mutatedPath, value))
 		}
 	}
 	return actions

--- a/server/policies/policy_edge_network.go
+++ b/server/policies/policy_edge_network.go
@@ -32,8 +32,5 @@ func (p *EdgeNonBindingPolicy) IdentifyRelationship(relDef *relationship.Relatio
 }
 
 func (p *EdgeNonBindingPolicy) SideEffects(rel *relationship.RelationshipDefinition, design *pattern.PatternFile) []PolicyAction {
-	if getRelStatus(rel) == StatusDeleted {
-		return nil
-	}
 	return patchMutatorsAction(rel, design)
 }

--- a/server/policies/policy_hierarchical.go
+++ b/server/policies/policy_hierarchical.go
@@ -65,8 +65,5 @@ func (p *HierarchicalParentChildPolicy) IdentifyRelationship(relDef *relationshi
 }
 
 func (p *HierarchicalParentChildPolicy) SideEffects(rel *relationship.RelationshipDefinition, design *pattern.PatternFile) []PolicyAction {
-	if getRelStatus(rel) == StatusDeleted {
-		return nil
-	}
 	return patchMutatorsAction(rel, design)
 }

--- a/server/policies/policy_wallet.go
+++ b/server/policies/policy_wallet.go
@@ -33,8 +33,5 @@ func (p *HierarchicalWalletPolicy) IdentifyRelationship(relDef *relationship.Rel
 }
 
 func (p *HierarchicalWalletPolicy) SideEffects(rel *relationship.RelationshipDefinition, design *pattern.PatternFile) []PolicyAction {
-	if getRelStatus(rel) == StatusDeleted {
-		return nil
-	}
 	return patchMutatorsAction(rel, design)
 }


### PR DESCRIPTION
**Notes for Reviewers**

- Fixes #18881 (Cleanup on Delete).
- Relates to #17330 (Go policy engine port).

## Why

When a relationship is deleted, field mutations applied by `SideEffects()` are not reversed. A field patched from an unset/default value to `"foo"` stays `"foo"` after the relationship is removed, because `SideEffects()` returns early on `StatusDeleted` and no reverse patch is emitted. Matches the OPA engine's behavior, so #17330 does not regress it, but it is a real gap.

## How

On delete, emit a reverse patch using a two-tier cleanup:

1. If the mutated component's JSON schema declares a `default` at the mutated path, restore the field to that default.
2. Otherwise, remove the field from the configuration (via \`sjson.Delete\`).

Only emitted when the mutated field still equals the mutator's value; if the field has diverged (user edited it), nothing is changed.

Affected policies: `edge_binding`, `edge_non_binding`, `hierarchical_parent_child`, `hierarchical_wallet`.

## Tests

- `TestWalletPatchingCleanupOnDelete`: delete emits a remove action when no schema default exists.
- `TestWalletPatchingCleanupUsesSchemaDefault`: delete restores the schema default when one is declared.
- `TestWalletCleanupOnDeleteFullPipeline`: end-to-end, the mutated key is absent from the result after delete.
- `TestWalletPatchingSkipsWhenValueDiverged`: no cleanup when the field was user-edited.

**[Signed commits](https://github.com/meshery/meshery/blob/master/CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [x] Yes, I signed my commits.