### PR TITLE
chore(schemas): repoint low-risk resources to canonical-casing versions (Phase 3)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -51,7 +51,7 @@ require (
 	github.com/meshery/meshery-operator v0.8.11
 	github.com/meshery/meshkit v1.0.2
 	github.com/meshery/meshsync v1.0.0
-	github.com/meshery/schemas v1.0.9
+	github.com/meshery/schemas v1.1.0
 	github.com/nsf/termbox-go v1.1.1
 	github.com/oapi-codegen/runtime v1.3.1
 	github.com/olekukonko/tablewriter v1.1.0
@@ -261,7 +261,7 @@ require (
 	github.com/inhies/go-bytesize v0.0.0-20220417184213-4913239db9cf // indirect
 	github.com/jackc/pgpassfile v1.0.0 // indirect
 	github.com/jackc/pgservicefile v0.0.0-20240606120523-5a60cdf6a761 // indirect
-	github.com/jackc/pgx/v5 v5.9.0 // indirect
+	github.com/jackc/pgx/v5 v5.9.2 // indirect
 	github.com/jackc/puddle/v2 v2.2.2 // indirect
 	github.com/jbenet/go-context v0.0.0-20150711004518-d14ea06fba99 // indirect
 	github.com/jhump/protoreflect v1.17.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1348,8 +1348,8 @@ github.com/jackc/pgpassfile v1.0.0 h1:/6Hmqy13Ss2zCq62VdNG8tM1wchn8zjSGOBJ6icpsI
 github.com/jackc/pgpassfile v1.0.0/go.mod h1:CEx0iS5ambNFdcRtxPj5JhEz+xB6uRky5eyVu/W2HEg=
 github.com/jackc/pgservicefile v0.0.0-20240606120523-5a60cdf6a761 h1:iCEnooe7UlwOQYpKFhBabPMi4aNAfoODPEFNiAnClxo=
 github.com/jackc/pgservicefile v0.0.0-20240606120523-5a60cdf6a761/go.mod h1:5TJZWKEWniPve33vlWYSoGYefn3gLQRzjfDlhSJ9ZKM=
-github.com/jackc/pgx/v5 v5.9.0 h1:T/dI+2TvmI2H8s/KH1/lXIbz1CUFk3gn5oTjr0/mBsE=
-github.com/jackc/pgx/v5 v5.9.0/go.mod h1:mal1tBGAFfLHvZzaYh77YS/eC6IX9OWbRV1QIIM0Jn4=
+github.com/jackc/pgx/v5 v5.9.2 h1:3ZhOzMWnR4yJ+RW1XImIPsD1aNSz4T4fyP7zlQb56hw=
+github.com/jackc/pgx/v5 v5.9.2/go.mod h1:mal1tBGAFfLHvZzaYh77YS/eC6IX9OWbRV1QIIM0Jn4=
 github.com/jackc/puddle/v2 v2.2.2 h1:PR8nw+E/1w0GLuRFSmiioY6UooMp6KJv0/61nB7icHo=
 github.com/jackc/puddle/v2 v2.2.2/go.mod h1:vriiEXHvEE654aYKXXjOvZM39qJ0q+azkZFrfEOc3H4=
 github.com/jarcoal/httpmock v1.4.1 h1:0Ju+VCFuARfFlhVXFc2HxlcQkfB+Xq12/EotHko+x2A=
@@ -1494,8 +1494,8 @@ github.com/meshery/meshkit v1.0.2 h1:B4l624AapuSeM7aFYyxA+jYxx4YZRZNPPgDhzjnpZH0
 github.com/meshery/meshkit v1.0.2/go.mod h1:otsT6pbFm6npq2Tfjk6A0Nhv4c9UgzPyhPLVDS9Hhug=
 github.com/meshery/meshsync v1.0.0 h1:BIHEVG4BDjqOnSd3vBt9B4IfWJNTfMRAgdwLroBcCfY=
 github.com/meshery/meshsync v1.0.0/go.mod h1:mFsPXkZRiCSuk5DhxBTrkWdlo6peItRBUoIEEQCovIg=
-github.com/meshery/schemas v1.0.9 h1:6iQ3MIiApyHdr4wC1yvB2s+3FfcSfUChnGNF0x54keg=
-github.com/meshery/schemas v1.0.9/go.mod h1:QNARm+MBykXTSwefgaC1bopx6XtA5h4QvEGKa+Nwk/g=
+github.com/meshery/schemas v1.1.0 h1:DsZkEP15TZcD5E5NTnsEZPvELZAyjr3WKTGLi62j7Pw=
+github.com/meshery/schemas v1.1.0/go.mod h1:UrkQFIKza3S3CuLR9yKt5a7xZW3ksSVd6N0yUdhvhRE=
 github.com/miekg/dns v1.1.57 h1:Jzi7ApEIzwEPLHWRcafCN9LZSBbqQpxjt/wpgvg7wcM=
 github.com/miekg/dns v1.1.57/go.mod h1:uqRjCRUuEAA6qsOiJvDd+CFo/vW+y5WR6SNmHE55hZk=
 github.com/miekg/pkcs11 v1.0.2/go.mod h1:XsNlhZGX73bx86s2hdc/FuaLm2CPZJemRLMA+WTFxgs=

--- a/mesheryctl/internal/cli/root/organizations/fixtures/list.organization.response.golden
+++ b/mesheryctl/internal/cli/root/organizations/fixtures/list.organization.response.golden
@@ -1,7 +1,7 @@
 {
     "page": 0,
-    "page_size": 10,
-    "total_count": 1,
+    "pageSize": 10,
+    "totalCount": 1,
     "organizations": [
         {
             "id": "d475eb6c-e26c-4eb6-b110-22653de9b2fd",
@@ -13,10 +13,10 @@
                 "preferences": {
                     "theme": {
                         "logo": {
-                            "desktop_view": {},
-                            "mobile_view": {},
-                            "dark_desktop_view": {},
-                            "dark_mobile_view":{}
+                            "desktopView": {},
+                            "mobileView": {},
+                            "darkDesktopView": {},
+                            "darkMobileView":{}
                         }
                     },
                     "dashboard": {
@@ -24,9 +24,9 @@
                     }
                 }
             },
-            "created_at": "2024-03-16T01:39:35.179176Z",
-            "updated_at": "2024-05-01T14:25:36.491489Z",
-            "deleted_at": {
+            "createdAt": "2024-03-16T01:39:35.179176Z",
+            "updatedAt": "2024-05-01T14:25:36.491489Z",
+            "deletedAt": {
                 "Time": "0001-01-01T00:00:00Z",
                 "Valid": false
             }

--- a/server/cmd/main.go
+++ b/server/cmd/main.go
@@ -41,7 +41,7 @@ import (
 	meshsyncmodel "github.com/meshery/meshsync/pkg/model"
 	schemasConnection "github.com/meshery/schemas/models/v1beta1/connection"
 	"github.com/meshery/schemas/models/v1beta1/environment"
-	schemasOrganization "github.com/meshery/schemas/models/v1beta1/organization"
+	schemasOrganization "github.com/meshery/schemas/models/v1beta2/organization"
 	"github.com/meshery/schemas/models/v1beta1/workspace"
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/viper"

--- a/server/handlers/credentials_handlers.go
+++ b/server/handlers/credentials_handlers.go
@@ -23,7 +23,7 @@ func (h *Handler) SaveUserCredential(w http.ResponseWriter, req *http.Request, _
 
 	userUUID := user.ID
 	credential := models.Credential{
-		UserId: &userUUID,
+		UserId: userUUID,
 		Secret: map[string]interface{}{},
 	}
 
@@ -109,7 +109,7 @@ func (h *Handler) UpdateUserCredential(w http.ResponseWriter, req *http.Request,
 
 	userUUID := user.ID
 	credential := &models.Credential{
-		UserId: &userUUID,
+		UserId: userUUID,
 		Secret: map[string]interface{}{},
 	}
 	err = json.Unmarshal(bd, credential)

--- a/server/handlers/grafana_handlers.go
+++ b/server/handlers/grafana_handlers.go
@@ -69,7 +69,7 @@ func (h *Handler) GrafanaConfigHandler(w http.ResponseWriter, req *http.Request,
 
 		userUUID := user.ID
 		credential, err := p.SaveUserCredential(token, &models.Credential{
-			UserId: &userUUID,
+			UserId: userUUID,
 			Type:   "grafana",
 			Secret: grafanaCred,
 			Name:   credName,
@@ -91,7 +91,7 @@ func (h *Handler) GrafanaConfigHandler(w http.ResponseWriter, req *http.Request,
 			MetaData:         grafanaConn,
 			CredentialSecret: grafanaCred,
 			Name:             connName,
-			CredentialID:     credential.ID,
+			CredentialID:     &credential.ID,
 		}, token, false)
 
 		if err != nil {

--- a/server/handlers/prometheus_handlers.go
+++ b/server/handlers/prometheus_handlers.go
@@ -189,7 +189,7 @@ func (h *Handler) PrometheusConfigHandler(w http.ResponseWriter, req *http.Reque
 
 		userUUID := user.ID
 		credential, err := provider.SaveUserCredential(token, &models.Credential{
-			UserId: &userUUID,
+			UserId: userUUID,
 			Type:   "prometheus",
 			Secret: promCred,
 			Name:   credName,
@@ -211,7 +211,7 @@ func (h *Handler) PrometheusConfigHandler(w http.ResponseWriter, req *http.Reque
 			MetaData:         promConn,
 			CredentialSecret: promCred,
 			Name:             connName,
-			CredentialID:     credential.ID,
+			CredentialID:     &credential.ID,
 		}, token, false)
 
 		if err != nil {

--- a/server/machines/actions.go
+++ b/server/machines/actions.go
@@ -55,7 +55,7 @@ func (da *DefaultConnectAction) Execute(ctx context.Context, machineCtx interfac
 		credName, _ := payload.CredentialSecret["name"].(string)
 		credential, err = provider.SaveUserCredential(token, &models.Credential{
 			Name:   credName,
-			UserId: &userUUID,
+			UserId: userUUID,
 			Type:   payload.Kind,
 			Secret: payload.CredentialSecret,
 		})
@@ -88,7 +88,7 @@ func (da *DefaultConnectAction) Execute(ctx context.Context, machineCtx interfac
 		}
 		credentialID = &parsed
 	} else {
-		credentialID = credential.ID
+		credentialID = &credential.ID
 	}
 
 	connection, err := provider.SaveConnection(&connections.ConnectionPayload{

--- a/server/models/credentials.go
+++ b/server/models/credentials.go
@@ -1,6 +1,6 @@
 package models
 
-import "github.com/meshery/schemas/models/v1beta1/credential"
+import "github.com/meshery/schemas/models/v1beta2/credential"
 
 type Credential = credential.Credential
 

--- a/server/models/default_local_provider.go
+++ b/server/models/default_local_provider.go
@@ -31,7 +31,7 @@ import (
 	"github.com/meshery/meshkit/utils/walker"
 	schemasConnection "github.com/meshery/schemas/models/v1beta1/connection"
 	"github.com/meshery/schemas/models/v1beta1/environment"
-	"github.com/meshery/schemas/models/v1beta1/organization"
+	"github.com/meshery/schemas/models/v1beta2/organization"
 	"github.com/meshery/schemas/models/v1beta1/pattern"
 	"github.com/meshery/schemas/models/v1beta1/workspace"
 	"github.com/oapi-codegen/runtime/types"

--- a/server/models/key.go
+++ b/server/models/key.go
@@ -1,6 +1,6 @@
 package models
 
-import "github.com/meshery/schemas/models/v1beta1/key"
+import "github.com/meshery/schemas/models/v1beta2/key"
 
 type Key = key.Key
 

--- a/server/models/organization.go
+++ b/server/models/organization.go
@@ -1,13 +1,13 @@
 package models
 
 import (
-	"github.com/meshery/schemas/models/v1beta1/organization"
+	"github.com/meshery/schemas/models/v1beta2/organization"
 )
 
 // TODO: Move to schemas
 type OrganizationsPage struct {
 	Organizations []*organization.Organization `json:"organizations"`
-	TotalCount    int                          `json:"total_count"`
+	TotalCount    int                          `json:"totalCount"`
 	Page          uint64                       `json:"page"`
-	PageSize      uint64                       `json:"page_size"`
+	PageSize      uint64                       `json:"pageSize"`
 }

--- a/server/models/organization_persistor.go
+++ b/server/models/organization_persistor.go
@@ -8,7 +8,7 @@ import (
 
 	"github.com/gofrs/uuid"
 	"github.com/meshery/meshkit/database"
-	"github.com/meshery/schemas/models/v1beta1/organization"
+	"github.com/meshery/schemas/models/v1beta2/organization"
 )
 
 // MesheryApplicationPersister is the persister for persisting

--- a/server/models/schedule.go
+++ b/server/models/schedule.go
@@ -1,6 +1,6 @@
 package models
 
-import "github.com/meshery/schemas/models/v1beta1/schedule"
+import "github.com/meshery/schemas/models/v1beta2/schedule"
 
 type Schedule = schedule.Schedule
 

--- a/server/models/user.go
+++ b/server/models/user.go
@@ -3,7 +3,7 @@ package models
 import (
 	"encoding/gob"
 
-	userV1beta "github.com/meshery/schemas/models/v1beta1/user"
+	userV1beta "github.com/meshery/schemas/models/v1beta2/user"
 )
 
 func init() {

--- a/server/models/workspace_persister.go
+++ b/server/models/workspace_persister.go
@@ -14,7 +14,7 @@ import (
 	"github.com/meshery/meshkit/database"
 	"github.com/meshery/schemas/models/v1beta1/environment"
 	patternv1beta1 "github.com/meshery/schemas/models/v1beta1/pattern"
-	viewv1beta1 "github.com/meshery/schemas/models/v1beta1/view"
+	viewv1beta2 "github.com/meshery/schemas/models/v1beta2/view"
 	"github.com/meshery/schemas/models/v1beta1/workspace"
 	"gorm.io/gorm"
 )
@@ -646,7 +646,7 @@ func (wp *WorkspacePersister) GetWorkspaceViews(workspaceID core.Uuid, search, o
 		pageSize = "10"
 	}
 
-	viewsFetched := []workspace.MesheryView{}
+	viewsFetched := []viewv1beta2.MesheryViewWithLocation{}
 	pageUint, err := strconv.ParseUint(page, 10, 32)
 	if err != nil {
 		return nil, err
@@ -662,7 +662,7 @@ func (wp *WorkspacePersister) GetWorkspaceViews(workspaceID core.Uuid, search, o
 		Paginate(uint(pageUint), uint(pageSizeUint))(query).Find(&viewsFetched)
 	}
 
-	viewsPage := &viewv1beta1.MesheryViewPage{
+	viewsPage := &viewv1beta2.MesheryViewPage{
 		Page:       int(pageUint),
 		PageSize:   len(viewsFetched),
 		TotalCount: int(count),


### PR DESCRIPTION
## Summary

Per the Phase 3 per-resource consumer-repoint plan in
[`meshery/schemas:docs/identifier-naming-migration.md`](https://github.com/meshery/schemas/blob/master/docs/identifier-naming-migration.md),
this PR repoints six low-risk constructs in `server` and `mesheryctl` from
their legacy `v1beta1` Go packages to the canonical-casing `v1beta2`
packages shipped in `@meshery/schemas@1.1.0`.

Each resource touched here has ≤ 4 Go consumer sites in this repo, so
the batch is intentionally narrow. Higher-cardinality constructs
(design, connection, environment, workspace, …) will follow in
separately-scoped PRs.

## Dependency

This branch cherry-picks the pending `github.com/meshery/schemas@v1.1.0`
Go-module bump from the auto-generated #18013 so reviewers can land the
whole unit atomically. If #18013 merges first, the first commit here
becomes a no-op on rebase.

## Per-resource changes

| Resource | Sites | Before | After | Schemas PR |
|---|---|---|---|---|
| `schedule` | 1 | `v1beta1/schedule` | `v1beta2/schedule` | [schemas#817](https://github.com/meshery/schemas/pull/817) |
| `view` | 1 | `v1beta1/view` | `v1beta2/view` | [schemas#810](https://github.com/meshery/schemas/pull/810) |
| `key` | 1 | `v1beta1/key` | `v1beta2/key` | [schemas#811](https://github.com/meshery/schemas/pull/811) |
| `credential` | 1 | `v1beta1/credential` | `v1beta2/credential` | (Phase 3 credential version bump) |
| `user` | 1 | `v1beta1/user` | `v1beta2/user` | [schemas#804](https://github.com/meshery/schemas/pull/804) |
| `organization` | 4 | `v1beta1/organization` | `v1beta2/organization` | [schemas#805](https://github.com/meshery/schemas/pull/805) |

### schedule
- `server/models/schedule.go` — import flip.

### view
- `server/models/workspace_persister.go` — import-alias rename + retype
  of `viewsFetched` from `workspace.MesheryView` (which aliases
  `viewv1beta1.MesheryViewWithLocation`) to
  `viewv1beta2.MesheryViewWithLocation`. The v1beta2 struct's
  `DeletedAt` shifted from value to pointer semantics, so the two
  generated types are not assignable and the retype is unavoidable.

### key
- `server/models/key.go` — import flip only.

### credential
- `server/models/credentials.go` — import flip.
- `server/handlers/credentials_handlers.go`,
  `server/handlers/grafana_handlers.go`,
  `server/handlers/prometheus_handlers.go`,
  `server/machines/actions.go` — resolve two field-type shifts that the
  regenerator produced:
  - `Credential.UserId`: `*core.Uuid` → `core.Uuid`. Every caller
    constructing a `Credential` was passing `&userUUID`; now they pass
    `userUUID` by value.
  - `Credential.ID`: `*core.Uuid` → `core.Uuid`. The callers that thread
    the returned credential's ID into
    `connections.ConnectionPayload.CredentialID` (still `*core.Uuid`)
    now take the address of the value (`&credential.ID`) rather than
    copying the pointer.

### user
- `server/models/user.go` — import-alias flip. No Meshery call site
  references the renamed initialism fields (`GrafanaAPIKey`,
  `GrafanaURL`, `PrometheusURL`), so no field-access fixes were
  required. The `prefObj.Prometheus.PrometheusURL` usage in
  `server/handlers/load_test_handler.go:556` is a distinct local
  `models.Prometheus` type in `server/models/preference.go`, unaffected.

### organization
- `server/models/organization.go` — import flip + canonicalized JSON tags
  on the Meshery-local `OrganizationsPage` envelope (`totalCount`,
  `pageSize`). `Page` stays `page`.
- `server/models/organization_persistor.go`,
  `server/models/default_local_provider.go`,
  `server/cmd/main.go` — import flips. Existing `org.ID == uuid.Nil`
  and `uuid.NewV4()` sites still typecheck because `core.Uuid` is a
  type alias to `github.com/gofrs/uuid.UUID`.
- `mesheryctl/internal/cli/root/organizations/fixtures/list.organization.response.golden`
  — the mocked HTTP response for `TestListOrganizations`. Updated to
  emit canonical camelCase (`totalCount`, `pageSize`, `createdAt`,
  `updatedAt`, `deletedAt`, and the theme logo's
  `desktopView` / `mobileView` / `darkDesktopView` / `darkMobileView` —
  the last four were already camelCase in v1beta1 but the fixture had
  been authored in snake_case). `TestListOrganizations` passes on the
  updated fixture.

## Known follow-ups (out of scope for this batch)

Per the Phase 3 charter the UI is addressed in a separate repoint PR.
Callers that still read snake_case wire keys off these endpoints — most
visibly `ui/components/SpacesSwitcher/MyViewsContent.tsx` (reads
`viewsData?.total_count` / `viewsData?.page_size` off the views-in-workspace
response) — will need to flip to `totalCount` / `pageSize` when the UI
repoint lands. No Go callers in this repo still depend on the legacy
wire keys for the six resources touched here.

`CredentialPage` intentionally still carries the legacy snake_case
pagination envelope (`page_size`, `total_count`); per AGENTS
§identifier-naming the pagination-envelope migration is a deprecation
path scheduled at each resource's next canonical-casing version bump,
not in-place.

## Test plan

- [x] `cd server && go build ./...` — clean.
- [x] `cd mesheryctl && go build ./...` — clean.
- [x] `cd server && go test -count=1 -short ./...` — all packages pass,
  including `models/`, `handlers/`, `machines/kubernetes`, `cmd/`,
  `policies/`, `router/`.
- [x] `cd mesheryctl && go test -count=1 -short ./...` — all packages
  pass, including `internal/cli/root/organizations/` (fixture updated in
  this PR).
- [x] Verified no lingering `v1beta1/(schedule|view|key|credential|user|organization)`
  imports remain under `server/` or `mesheryctl/`.