### PR TITLE
fix(security,docs): address review feedback on #18886

### DIFF
--- a/server/handlers/credentials_handlers.go
+++ b/server/handlers/credentials_handlers.go
@@ -23,7 +23,6 @@ func (h *Handler) SaveUserCredential(w http.ResponseWriter, req *http.Request, _
 
 	userUUID := user.ID
 	credential := models.Credential{
-		UserId: userUUID,
 		Secret: map[string]interface{}{},
 	}
 
@@ -33,6 +32,11 @@ func (h *Handler) SaveUserCredential(w http.ResponseWriter, req *http.Request, _
 		http.Error(w, "unable to parse credential data", http.StatusInternalServerError)
 		return
 	}
+
+	// Bind credential ownership to the authenticated user AFTER unmarshal so a
+	// client-supplied `userId` in the request body cannot redirect a credential
+	// onto another user's account.
+	credential.UserId = userUUID
 
 	createdCredential, err := provider.SaveUserCredential(token, &credential)
 	if err != nil {
@@ -109,7 +113,6 @@ func (h *Handler) UpdateUserCredential(w http.ResponseWriter, req *http.Request,
 
 	userUUID := user.ID
 	credential := &models.Credential{
-		UserId: userUUID,
 		Secret: map[string]interface{}{},
 	}
 	err = json.Unmarshal(bd, credential)
@@ -118,6 +121,12 @@ func (h *Handler) UpdateUserCredential(w http.ResponseWriter, req *http.Request,
 		http.Error(w, "unable to parse credential data", http.StatusInternalServerError)
 		return
 	}
+
+	// Bind credential ownership to the authenticated user AFTER unmarshal so a
+	// client-supplied `userId` in the request body cannot hijack another user's
+	// credential (the provider layer's authorization check should rely on this
+	// field to confirm the caller owns the credential being updated).
+	credential.UserId = userUUID
 
 	_, err = provider.UpdateUserCredential(req, credential)
 	if err != nil {

--- a/server/handlers/credentials_handlers_test.go
+++ b/server/handlers/credentials_handlers_test.go
@@ -1,0 +1,109 @@
+package handlers
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"sync/atomic"
+	"testing"
+
+	"github.com/gofrs/uuid"
+	"github.com/meshery/meshery/server/models"
+)
+
+// credentialSpyProvider captures the Credential passed to SaveUserCredential
+// and UpdateUserCredential so tests can assert that the authenticated
+// user's ID replaces any client-supplied `userId` in the request body.
+type credentialSpyProvider struct {
+	*models.DefaultLocalProvider
+	observedSave   atomic.Pointer[models.Credential]
+	observedUpdate atomic.Pointer[models.Credential]
+}
+
+func newCredentialSpyProvider() *credentialSpyProvider {
+	base := &models.DefaultLocalProvider{}
+	base.Initialize()
+	return &credentialSpyProvider{DefaultLocalProvider: base}
+}
+
+func (m *credentialSpyProvider) SaveUserCredential(_ string, c *models.Credential) (*models.Credential, error) {
+	cp := *c
+	m.observedSave.Store(&cp)
+	return c, nil
+}
+
+func (m *credentialSpyProvider) UpdateUserCredential(_ *http.Request, c *models.Credential) (*models.Credential, error) {
+	cp := *c
+	m.observedUpdate.Store(&cp)
+	return c, nil
+}
+
+// TestSaveUserCredential_ClientSuppliedUserIdCannotOverride verifies the
+// authorization-hardening fix: a client posting a body with a `userId`
+// pointing at some other user must NOT be able to create a credential
+// under that other user's account. The handler binds `credential.UserId`
+// to the authenticated user's ID after unmarshal precisely so this
+// overwrite attempt fails safely.
+func TestSaveUserCredential_ClientSuppliedUserIdCannotOverride(t *testing.T) {
+	authUser := &models.User{ID: uuid.Must(uuid.FromString("11111111-1111-1111-1111-111111111111"))}
+	attacker := uuid.Must(uuid.FromString("22222222-2222-2222-2222-222222222222"))
+	body := fmt.Sprintf(`{"userId":%q,"name":"poisoned","type":"token","secret":{"k":"v"}}`, attacker)
+
+	h := newTestHandler(t, map[string]models.Provider{}, "")
+	p := newCredentialSpyProvider()
+
+	req := httptest.NewRequest(http.MethodPost, "/api/integrations/credentials", bytes.NewBufferString(body))
+	req = req.WithContext(context.WithValue(req.Context(), models.TokenCtxKey, "test-token"))
+	rec := httptest.NewRecorder()
+
+	h.SaveUserCredential(rec, req, nil, authUser, p)
+
+	if rec.Code != http.StatusCreated {
+		t.Fatalf("expected 201, got %d (body=%q)", rec.Code, rec.Body.String())
+	}
+	saved := p.observedSave.Load()
+	if saved == nil {
+		t.Fatalf("provider SaveUserCredential was not invoked")
+	}
+	if saved.UserId != authUser.ID {
+		t.Fatalf("credential.UserId was %v, want authenticated user %v — client-supplied userId leaked through", saved.UserId, authUser.ID)
+	}
+	if saved.UserId == attacker {
+		t.Fatalf("credential.UserId matches attacker-supplied value %v — authorization bypass", attacker)
+	}
+}
+
+// TestUpdateUserCredential_ClientSuppliedUserIdCannotOverride verifies
+// the same hardening on the update path: a client cannot redirect an
+// update onto another user's credential by supplying a foreign
+// `userId` in the body.
+func TestUpdateUserCredential_ClientSuppliedUserIdCannotOverride(t *testing.T) {
+	authUser := &models.User{ID: uuid.Must(uuid.FromString("33333333-3333-3333-3333-333333333333"))}
+	attacker := uuid.Must(uuid.FromString("44444444-4444-4444-4444-444444444444"))
+	body := fmt.Sprintf(`{"userId":%q,"id":"abcdefab-abcd-abcd-abcd-abcdefabcdef","name":"renamed","type":"token","secret":{}}`, attacker)
+
+	h := newTestHandler(t, map[string]models.Provider{}, "")
+	p := newCredentialSpyProvider()
+
+	req := httptest.NewRequest(http.MethodPut, "/api/integrations/credentials", bytes.NewBufferString(body))
+	req = req.WithContext(context.WithValue(req.Context(), models.TokenCtxKey, "test-token"))
+	rec := httptest.NewRecorder()
+
+	h.UpdateUserCredential(rec, req, nil, authUser, p)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d (body=%q)", rec.Code, rec.Body.String())
+	}
+	updated := p.observedUpdate.Load()
+	if updated == nil {
+		t.Fatalf("provider UpdateUserCredential was not invoked")
+	}
+	if updated.UserId != authUser.ID {
+		t.Fatalf("credential.UserId was %v, want authenticated user %v — client-supplied userId leaked through", updated.UserId, authUser.ID)
+	}
+	if updated.UserId == attacker {
+		t.Fatalf("credential.UserId matches attacker-supplied value %v — authorization bypass", attacker)
+	}
+}

--- a/server/models/organization.go
+++ b/server/models/organization.go
@@ -57,12 +57,17 @@ func (p *OrganizationsPage) UnmarshalJSON(data []byte) error {
 	}
 	p.Organizations = raw.Organizations
 	p.Page = raw.Page
+	// Match stdlib json.Unmarshal semantics: fields absent from the input
+	// reset to their zero value on the destination (important when callers
+	// reuse the same OrganizationsPage across decodes).
+	p.TotalCount = 0
 	switch {
 	case raw.TotalCount != nil:
 		p.TotalCount = *raw.TotalCount
 	case raw.TotalCountLegacy != nil:
 		p.TotalCount = *raw.TotalCountLegacy
 	}
+	p.PageSize = 0
 	switch {
 	case raw.PageSize != nil:
 		p.PageSize = *raw.PageSize

--- a/server/models/organization.go
+++ b/server/models/organization.go
@@ -1,13 +1,73 @@
 package models
 
 import (
+	"encoding/json"
+
 	"github.com/meshery/schemas/models/v1beta2/organization"
 )
 
+// OrganizationsPage is the Meshery-local response envelope for
+// `GET /api/identity/orgs`. Canonical wire form is camelCase per the
+// identifier-naming migration; legacy snake_case keys (`total_count`,
+// `page_size`) are emitted alongside for the deprecation window so
+// external consumers still reading the old spellings keep working.
+// Unmarshal likewise accepts either spelling so any inbound serialization
+// (round-trip via clients) tolerates both.
+//
+// Once every known consumer has migrated off the snake_case keys, drop
+// MarshalJSON/UnmarshalJSON and keep only the camelCase struct tags.
+//
 // TODO: Move to schemas
 type OrganizationsPage struct {
 	Organizations []*organization.Organization `json:"organizations"`
 	TotalCount    int                          `json:"totalCount"`
 	Page          uint64                       `json:"page"`
 	PageSize      uint64                       `json:"pageSize"`
+}
+
+// MarshalJSON emits both camelCase (canonical) and snake_case (legacy)
+// keys for TotalCount and PageSize so external consumers reading either
+// spelling continue to work during the deprecation window.
+func (p OrganizationsPage) MarshalJSON() ([]byte, error) {
+	type alias OrganizationsPage
+	return json.Marshal(struct {
+		alias
+		TotalCountLegacy int    `json:"total_count"`
+		PageSizeLegacy   uint64 `json:"page_size"`
+	}{
+		alias:            alias(p),
+		TotalCountLegacy: p.TotalCount,
+		PageSizeLegacy:   p.PageSize,
+	})
+}
+
+// UnmarshalJSON accepts either the canonical camelCase keys or the
+// legacy snake_case keys. Canonical keys win when both are present.
+func (p *OrganizationsPage) UnmarshalJSON(data []byte) error {
+	var raw struct {
+		Organizations    []*organization.Organization `json:"organizations"`
+		TotalCount       *int                         `json:"totalCount"`
+		TotalCountLegacy *int                         `json:"total_count"`
+		Page             uint64                       `json:"page"`
+		PageSize         *uint64                      `json:"pageSize"`
+		PageSizeLegacy   *uint64                      `json:"page_size"`
+	}
+	if err := json.Unmarshal(data, &raw); err != nil {
+		return err
+	}
+	p.Organizations = raw.Organizations
+	p.Page = raw.Page
+	switch {
+	case raw.TotalCount != nil:
+		p.TotalCount = *raw.TotalCount
+	case raw.TotalCountLegacy != nil:
+		p.TotalCount = *raw.TotalCountLegacy
+	}
+	switch {
+	case raw.PageSize != nil:
+		p.PageSize = *raw.PageSize
+	case raw.PageSizeLegacy != nil:
+		p.PageSize = *raw.PageSizeLegacy
+	}
+	return nil
 }

--- a/server/models/organization_test.go
+++ b/server/models/organization_test.go
@@ -42,6 +42,7 @@ func TestOrganizationsPage_UnmarshalAcceptsEitherKeyFlavor(t *testing.T) {
 		{"canonical only", `{"totalCount":5,"page":1,"pageSize":10}`, 5, 10},
 		{"legacy only", `{"total_count":5,"page":1,"page_size":10}`, 5, 10},
 		{"canonical wins when both present", `{"totalCount":9,"total_count":1,"page":1,"pageSize":50,"page_size":5}`, 9, 50},
+		{"both flavors absent zeroes the fields", `{"page":1}`, 0, 0},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
@@ -56,5 +57,32 @@ func TestOrganizationsPage_UnmarshalAcceptsEitherKeyFlavor(t *testing.T) {
 				t.Errorf("PageSize = %d, want %d", got.PageSize, tc.wantPageSz)
 			}
 		})
+	}
+}
+
+// TestOrganizationsPage_UnmarshalResetsFieldsOnReuse locks in std-library
+// json.Unmarshal semantics: when the destination struct is reused across
+// decodes and the second input omits TotalCount / PageSize entirely, the
+// destination's fields must reset to zero rather than carry stale values
+// forward from the prior decode.
+func TestOrganizationsPage_UnmarshalResetsFieldsOnReuse(t *testing.T) {
+	var p OrganizationsPage
+	if err := json.Unmarshal([]byte(`{"totalCount":99,"pageSize":77,"page":1}`), &p); err != nil {
+		t.Fatalf("first unmarshal: %v", err)
+	}
+	if p.TotalCount != 99 || p.PageSize != 77 {
+		t.Fatalf("prime decode wrong: got TotalCount=%d PageSize=%d", p.TotalCount, p.PageSize)
+	}
+	if err := json.Unmarshal([]byte(`{"page":2}`), &p); err != nil {
+		t.Fatalf("second unmarshal: %v", err)
+	}
+	if p.TotalCount != 0 {
+		t.Errorf("TotalCount leaked stale value %d across reuse", p.TotalCount)
+	}
+	if p.PageSize != 0 {
+		t.Errorf("PageSize leaked stale value %d across reuse", p.PageSize)
+	}
+	if p.Page != 2 {
+		t.Errorf("Page = %d, want 2", p.Page)
 	}
 }

--- a/server/models/organization_test.go
+++ b/server/models/organization_test.go
@@ -1,0 +1,60 @@
+package models
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+)
+
+// TestOrganizationsPage_MarshalEmitsBothKeyFlavors locks in the
+// deprecation-window contract: MarshalJSON emits both the canonical
+// camelCase (`totalCount`, `pageSize`) AND the legacy snake_case
+// (`total_count`, `page_size`) spellings so external consumers on
+// either vocabulary keep working while they migrate.
+func TestOrganizationsPage_MarshalEmitsBothKeyFlavors(t *testing.T) {
+	p := OrganizationsPage{
+		TotalCount: 7,
+		Page:       2,
+		PageSize:   25,
+	}
+	b, err := json.Marshal(p)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	out := string(b)
+	for _, want := range []string{`"totalCount":7`, `"total_count":7`, `"pageSize":25`, `"page_size":25`, `"page":2`} {
+		if !strings.Contains(out, want) {
+			t.Errorf("marshal output missing %q; got %s", want, out)
+		}
+	}
+}
+
+// TestOrganizationsPage_UnmarshalAcceptsEitherKeyFlavor verifies that
+// either wire form round-trips back into the struct. Canonical wins if
+// both are present.
+func TestOrganizationsPage_UnmarshalAcceptsEitherKeyFlavor(t *testing.T) {
+	cases := []struct {
+		name        string
+		body        string
+		wantTotal   int
+		wantPageSz  uint64
+	}{
+		{"canonical only", `{"totalCount":5,"page":1,"pageSize":10}`, 5, 10},
+		{"legacy only", `{"total_count":5,"page":1,"page_size":10}`, 5, 10},
+		{"canonical wins when both present", `{"totalCount":9,"total_count":1,"page":1,"pageSize":50,"page_size":5}`, 9, 50},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			var got OrganizationsPage
+			if err := json.Unmarshal([]byte(tc.body), &got); err != nil {
+				t.Fatalf("unmarshal: %v", err)
+			}
+			if got.TotalCount != tc.wantTotal {
+				t.Errorf("TotalCount = %d, want %d", got.TotalCount, tc.wantTotal)
+			}
+			if got.PageSize != tc.wantPageSz {
+				t.Errorf("PageSize = %d, want %d", got.PageSize, tc.wantPageSz)
+			}
+		})
+	}
+}

--- a/server/models/user.go
+++ b/server/models/user.go
@@ -3,7 +3,7 @@ package models
 import (
 	"encoding/gob"
 
-	userV1beta "github.com/meshery/schemas/models/v1beta2/user"
+	userV1beta2 "github.com/meshery/schemas/models/v1beta2/user"
 )
 
 func init() {
@@ -16,7 +16,7 @@ var (
 )
 
 // User - represents a user in Meshery
-type User = userV1beta.User
+type User = userV1beta2.User
 
 type AllUsers struct {
 	Page       int     `json:"page"`


### PR DESCRIPTION
## Summary

Follow-up for review comments that landed on [#18886](https://github.com/meshery/meshery/pull/18886) after it merged. Four items: two security hardening fixes on the credential handlers, one import-alias rename, and one wire-contract preservation on the `OrganizationsPage` envelope.

## Why

Post-merge triage of #18886 surfaced a set of comments the original PR did not account for. Most load-bearing: the credential save/update handlers allowed a client-supplied `userId` in the request body to overwrite the authenticated user's ID — an authorization-bypass path. This PR closes that door, adds regression tests, and sweeps up the three smaller items raised in the same review pass.

## Changes

### Security hardening (gemini high/medium)

- `server/handlers/credentials_handlers.go::SaveUserCredential` — move the `credential.UserId = userUUID` assignment to **after** `json.Unmarshal`. Previously the assignment ran first and could be overwritten by a body containing `"userId": "<other-user-uuid>"`, letting a caller create a credential under someone else's account. Same fix on `UpdateUserCredential`.
- `server/handlers/credentials_handlers_test.go` (new) — two regression tests that POST/PUT bodies with foreign `userId` values and assert the provider spy receives the authenticated user's ID, not the attacker-supplied one.

### Import alias rename (copilot low[1])

- `server/models/user.go` — rename `userV1beta` → `userV1beta2` so the alias matches the imported package version (`v1beta2/user`). Makes future version bumps easier to audit.

### Wire-contract preservation on `OrganizationsPage` (copilot low[2])

- `server/models/organization.go` — add custom `MarshalJSON` that emits **both** `totalCount` + `total_count` and `pageSize` + `page_size`, and custom `UnmarshalJSON` that accepts either (canonical wins when both are present). This preserves backward compatibility for any external consumer still reading the snake_case keys while the canonical camelCase form becomes the primary contract. Retire the legacy emit once every known consumer has migrated (tracked against Phase 4.A).
- `server/models/organization_test.go` (new) — four round-trip cases (marshal emits both, unmarshal accepts canonical only / legacy only / both-present with canonical winning).

## Tests

- `go build ./...` (server + mesheryctl) — green.
- `go test -count=1 ./handlers/... ./models/...` — green, including the new regression tests.

## Docs

No user-facing docs affected; the behavior on the wire is now *more* permissive (dual-emit), not less.

## Migration impact

- **Security:** closes a genuine authorization-bypass vector on `POST`/`PUT /api/integrations/credentials`. Deployments should adopt this before the #18886 changes are exercised at scale.
- **OrganizationsPage envelope:** the canonical camelCase keys introduced in #18886 are preserved; the legacy snake_case keys are now emitted alongside so no external consumer regresses. Strictly additive compared to #18886's `master`.

## Rollback

Revert this commit; the authorization-bypass returns but #18886's core repoints stay in place.

## Test plan

- [x] `git commit -s` (DCO signed)
- [x] Credential userId-override regression tests pass
- [x] OrganizationsPage dual-emit / dual-accept tests pass
- [x] Full `go build ./...` + `go test ./handlers/... ./models/...` green