### PR TITLE
chore(schemas): repoint connection consumers to v1beta3 (Phase 3)

### DIFF
--- a/mesheryctl/internal/cli/root/connections/connection.go
+++ b/mesheryctl/internal/cli/root/connections/connection.go
@@ -6,7 +6,7 @@ import (
 	"github.com/meshery/meshery/mesheryctl/internal/cli/pkg/api"
 	"github.com/meshery/meshery/mesheryctl/internal/cli/root/config"
 	"github.com/meshery/meshery/mesheryctl/pkg/utils"
-	"github.com/meshery/schemas/models/v1beta1/connection"
+	"github.com/meshery/schemas/models/v1beta3/connection"
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"

--- a/mesheryctl/internal/cli/root/connections/fixtures/list.connection.api.empty.response.golden
+++ b/mesheryctl/internal/cli/root/connections/fixtures/list.connection.api.empty.response.golden
@@ -1,6 +1,6 @@
 {
   "page": 0,
-  "page_size": 10,
-  "total_count": 0,
+  "pageSize": 10,
+  "totalCount": 0,
   "connections": []
 }

--- a/mesheryctl/internal/cli/root/connections/fixtures/list.connection.api.response.golden
+++ b/mesheryctl/internal/cli/root/connections/fixtures/list.connection.api.response.golden
@@ -1,91 +1,91 @@
 {
   "page": 0,
-  "page_size": 10,
-  "total_count": 6,
+  "pageSize": 10,
+  "totalCount": 6,
   "connections": [
     {
       "id": "f3c8b9b1-3d1a-4d8b-9e92-123456789333",
       "name": "meshery-ex1",
       "kind": "meshery",
       "type": "platform",
-      "sub_type": "cluster",
+      "subType": "cluster",
       "status": "connected",
       "metadata": {
         "server_version": "v1.29.0",
         "context": "local-3"
       },
-      "created_at": "2025-01-01T10:00:00Z",
-      "updated_at": "2025-01-01T10:00:00Z"
+      "createdAt": "2025-01-01T10:00:00Z",
+      "updatedAt": "2025-01-01T10:00:00Z"
     },
     {
       "id": "f3c8b9b1-3d1a-4d8b-9e92-123456789444",
       "name": "meshery-ex2",
       "kind": "meshery",
       "type": "platform",
-      "sub_type": "cluster",
+      "subType": "cluster",
       "status": "connected",
       "metadata": {
         "server_version": "v1.29.0",
         "context": "local-4"
       },
-      "created_at": "2025-01-01T10:00:00Z",
-      "updated_at": "2025-01-01T10:00:00Z"
+      "createdAt": "2025-01-01T10:00:00Z",
+      "updatedAt": "2025-01-01T10:00:00Z"
     },
     {
       "id": "f3c8b9b1-3d1a-4d8b-9e92-123456789777",
       "name": "meshery-ex5",
       "kind": "meshery",
       "type": "platform",
-      "sub_type": "cluster",
+      "subType": "cluster",
       "status": "connected",
       "metadata": {
         "server_version": "v1.29.0",
         "context": "local-7"
       },
-      "created_at": "2025-01-01T10:00:00Z",
-      "updated_at": "2025-01-01T10:00:00Z"
+      "createdAt": "2025-01-01T10:00:00Z",
+      "updatedAt": "2025-01-01T10:00:00Z"
     },
     {
       "id": "f3c8b9b1-3d1a-4d8b-9e92-123456789888",
       "name": "meshery-ex6",
       "kind": "meshery",
       "type": "platform",
-      "sub_type": "cluster",
+      "subType": "cluster",
       "status": "deleted",
       "metadata": {
         "server_version": "v1.29.0",
         "context": "local-8"
       },
-      "created_at": "2025-01-01T10:00:00Z",
-      "updated_at": "2025-01-01T10:00:00Z"
+      "createdAt": "2025-01-01T10:00:00Z",
+      "updatedAt": "2025-01-01T10:00:00Z"
     },
     {
       "id": "f3c8b9b1-3d1a-4d8b-9e92-123456789123",
       "name": "meshery-ex8",
       "kind": "meshery",
       "type": "platform",
-      "sub_type": "cluster",
+      "subType": "cluster",
       "status": "connected",
       "metadata": {
         "server_version": "v1.29.0",
         "context": "local-10"
       },
-      "created_at": "2025-01-01T10:00:00Z",
-      "updated_at": "2025-01-01T10:00:00Z"
+      "createdAt": "2025-01-01T10:00:00Z",
+      "updatedAt": "2025-01-01T10:00:00Z"
     },
     {
       "id": "f3c8b9b1-3d1a-4d8b-9e92-123456789456",
       "name": "meshery-ex9",
       "kind": "meshery",
       "type": "platform",
-      "sub_type": "cluster",
+      "subType": "cluster",
       "status": "connected",
       "metadata": {
         "server_version": "v1.29.0",
         "context": "local-11"
       },
-      "created_at": "2025-01-01T10:00:00Z",
-      "updated_at": "2025-01-01T10:00:00Z"
+      "createdAt": "2025-01-01T10:00:00Z",
+      "updatedAt": "2025-01-01T10:00:00Z"
     }
   ]
 }

--- a/mesheryctl/internal/cli/root/connections/fixtures/list.connection.kind.api.response.golden
+++ b/mesheryctl/internal/cli/root/connections/fixtures/list.connection.kind.api.response.golden
@@ -1,7 +1,7 @@
 {
   "page": 0,
-  "page_size": 10,
-  "total_count": 5,
+  "pageSize": 10,
+  "totalCount": 5,
   "connections": [
     {
       "id": "f3c8b9b1-3d1a-4d8b-9e92-123456789111",
@@ -14,8 +14,8 @@
         "server_version": "v1.29.0",
         "context": "local-1"
       },
-      "created_at": "2025-01-01T10:00:00Z",
-      "updated_at": "2025-01-01T10:00:00Z"
+      "createdAt": "2025-01-01T10:00:00Z",
+      "updatedAt": "2025-01-01T10:00:00Z"
     },
     {
       "id": "f3c8b9b1-3d1a-4d8b-9e92-123456789222",
@@ -28,8 +28,8 @@
         "server_version": "v1.29.0",
         "context": "local-2"
       },
-      "created_at": "2025-01-01T10:00:00Z",
-      "updated_at": "2025-01-01T10:00:00Z"
+      "createdAt": "2025-01-01T10:00:00Z",
+      "updatedAt": "2025-01-01T10:00:00Z"
     },
     {
       "id": "f3c8b9b1-3d1a-4d8b-9e92-123456789555",
@@ -42,8 +42,8 @@
         "server_version": "v1.29.0",
         "context": "local-5"
       },
-      "created_at": "2025-01-01T10:00:00Z",
-      "updated_at": "2025-01-01T10:00:00Z"
+      "createdAt": "2025-01-01T10:00:00Z",
+      "updatedAt": "2025-01-01T10:00:00Z"
     },
     {
       "id": "f3c8b9b1-3d1a-4d8b-9e92-123456789666",
@@ -56,8 +56,8 @@
         "server_version": "v1.29.0",
         "context": "local-6"
       },
-      "created_at": "2025-01-01T10:00:00Z",
-      "updated_at": "2025-01-01T10:00:00Z"
+      "createdAt": "2025-01-01T10:00:00Z",
+      "updatedAt": "2025-01-01T10:00:00Z"
     },
     {
       "id": "f3c8b9b1-3d1a-4d8b-9e92-123456789999",
@@ -70,8 +70,8 @@
         "server_version": "v1.29.0",
         "context": "local-9"
       },
-      "created_at": "2025-01-01T10:00:00Z",
-      "updated_at": "2025-01-01T10:00:00Z"
+      "createdAt": "2025-01-01T10:00:00Z",
+      "updatedAt": "2025-01-01T10:00:00Z"
     }
   ]
 }

--- a/mesheryctl/internal/cli/root/connections/fixtures/list.connection.kind.count.api.response.golden
+++ b/mesheryctl/internal/cli/root/connections/fixtures/list.connection.kind.count.api.response.golden
@@ -1,7 +1,7 @@
 {
   "page": 0,
-  "page_size": 10,
-  "total_count": 6,
+  "pageSize": 10,
+  "totalCount": 6,
   "connections": [
     {
       "id": "f3c8b9b1-3d1a-4d8b-9e92-123456789333",
@@ -14,8 +14,8 @@
         "server_version": "v1.29.0",
         "context": "local-3"
       },
-      "created_at": "2025-01-01T10:00:00Z",
-      "updated_at": "2025-01-01T10:00:00Z"
+      "createdAt": "2025-01-01T10:00:00Z",
+      "updatedAt": "2025-01-01T10:00:00Z"
     },
     {
       "id": "f3c8b9b1-3d1a-4d8b-9e92-123456789444",
@@ -28,8 +28,8 @@
         "server_version": "v1.29.0",
         "context": "local-4"
       },
-      "created_at": "2025-01-01T10:00:00Z",
-      "updated_at": "2025-01-01T10:00:00Z"
+      "createdAt": "2025-01-01T10:00:00Z",
+      "updatedAt": "2025-01-01T10:00:00Z"
     },
     {
       "id": "f3c8b9b1-3d1a-4d8b-9e92-123456789777",
@@ -42,8 +42,8 @@
         "server_version": "v1.29.0",
         "context": "local-7"
       },
-      "created_at": "2025-01-01T10:00:00Z",
-      "updated_at": "2025-01-01T10:00:00Z"
+      "createdAt": "2025-01-01T10:00:00Z",
+      "updatedAt": "2025-01-01T10:00:00Z"
     },
     {
       "id": "f3c8b9b1-3d1a-4d8b-9e92-123456789888",
@@ -56,8 +56,8 @@
         "server_version": "v1.29.0",
         "context": "local-8"
       },
-      "created_at": "2025-01-01T10:00:00Z",
-      "updated_at": "2025-01-01T10:00:00Z"
+      "createdAt": "2025-01-01T10:00:00Z",
+      "updatedAt": "2025-01-01T10:00:00Z"
     },
     {
       "id": "f3c8b9b1-3d1a-4d8b-9e92-123456789123",
@@ -70,8 +70,8 @@
         "server_version": "v1.29.0",
         "context": "local-10"
       },
-      "created_at": "2025-01-01T10:00:00Z",
-      "updated_at": "2025-01-01T10:00:00Z"
+      "createdAt": "2025-01-01T10:00:00Z",
+      "updatedAt": "2025-01-01T10:00:00Z"
     },
     {
       "id": "f3c8b9b1-3d1a-4d8b-9e92-123456789456",
@@ -84,8 +84,8 @@
         "server_version": "v1.29.0",
         "context": "local-11"
       },
-      "created_at": "2025-01-01T10:00:00Z",
-      "updated_at": "2025-01-01T10:00:00Z"
+      "createdAt": "2025-01-01T10:00:00Z",
+      "updatedAt": "2025-01-01T10:00:00Z"
     }
   ]
 }

--- a/mesheryctl/internal/cli/root/connections/fixtures/list.connection.page.api.response.golden
+++ b/mesheryctl/internal/cli/root/connections/fixtures/list.connection.page.api.response.golden
@@ -1,7 +1,7 @@
 {
   "page": 0,
-  "page_size": 10,
-  "total_count": 10,
+  "pageSize": 10,
+  "totalCount": 10,
   "connections": [
     {
       "id": "f3c8b9b1-3d1a-4d8b-9e92-123456789111",
@@ -14,8 +14,8 @@
         "server_version": "v1.29.0",
         "context": "local-1"
       },
-      "created_at": "2025-01-01T10:00:00Z",
-      "updated_at": "2025-01-01T10:00:00Z"
+      "createdAt": "2025-01-01T10:00:00Z",
+      "updatedAt": "2025-01-01T10:00:00Z"
     },
     {
       "id": "f3c8b9b1-3d1a-4d8b-9e92-123456789222",
@@ -28,8 +28,8 @@
         "server_version": "v1.29.0",
         "context": "local-2"
       },
-      "created_at": "2025-01-01T10:00:00Z",
-      "updated_at": "2025-01-01T10:00:00Z"
+      "createdAt": "2025-01-01T10:00:00Z",
+      "updatedAt": "2025-01-01T10:00:00Z"
     },
     {
       "id": "f3c8b9b1-3d1a-4d8b-9e92-123456789333",
@@ -42,8 +42,8 @@
         "server_version": "v1.29.0",
         "context": "local-3"
       },
-      "created_at": "2025-01-01T10:00:00Z",
-      "updated_at": "2025-01-01T10:00:00Z"
+      "createdAt": "2025-01-01T10:00:00Z",
+      "updatedAt": "2025-01-01T10:00:00Z"
     },
     {
       "id": "f3c8b9b1-3d1a-4d8b-9e92-123456789444",
@@ -56,8 +56,8 @@
         "server_version": "v1.29.0",
         "context": "local-4"
       },
-      "created_at": "2025-01-01T10:00:00Z",
-      "updated_at": "2025-01-01T10:00:00Z"
+      "createdAt": "2025-01-01T10:00:00Z",
+      "updatedAt": "2025-01-01T10:00:00Z"
     },
     {
       "id": "f3c8b9b1-3d1a-4d8b-9e92-123456789555",
@@ -70,8 +70,8 @@
         "server_version": "v1.29.0",
         "context": "local-5"
       },
-      "created_at": "2025-01-01T10:00:00Z",
-      "updated_at": "2025-01-01T10:00:00Z"
+      "createdAt": "2025-01-01T10:00:00Z",
+      "updatedAt": "2025-01-01T10:00:00Z"
     },
     {
       "id": "f3c8b9b1-3d1a-4d8b-9e92-123456789666",
@@ -84,8 +84,8 @@
         "server_version": "v1.29.0",
         "context": "local-6"
       },
-      "created_at": "2025-01-01T10:00:00Z",
-      "updated_at": "2025-01-01T10:00:00Z"
+      "createdAt": "2025-01-01T10:00:00Z",
+      "updatedAt": "2025-01-01T10:00:00Z"
     },
     {
       "id": "f3c8b9b1-3d1a-4d8b-9e92-123456789777",
@@ -98,8 +98,8 @@
         "server_version": "v1.29.0",
         "context": "local-7"
       },
-      "created_at": "2025-01-01T10:00:00Z",
-      "updated_at": "2025-01-01T10:00:00Z"
+      "createdAt": "2025-01-01T10:00:00Z",
+      "updatedAt": "2025-01-01T10:00:00Z"
     },
     {
       "id": "f3c8b9b1-3d1a-4d8b-9e92-123456789888",
@@ -112,8 +112,8 @@
         "server_version": "v1.29.0",
         "context": "local-8"
       },
-      "created_at": "2025-01-01T10:00:00Z",
-      "updated_at": "2025-01-01T10:00:00Z"
+      "createdAt": "2025-01-01T10:00:00Z",
+      "updatedAt": "2025-01-01T10:00:00Z"
     },
     {
       "id": "f3c8b9b1-3d1a-4d8b-9e92-123456789999",
@@ -126,8 +126,8 @@
         "server_version": "v1.29.0",
         "context": "local-9"
       },
-      "created_at": "2025-01-01T10:00:00Z",
-      "updated_at": "2025-01-01T10:00:00Z"
+      "createdAt": "2025-01-01T10:00:00Z",
+      "updatedAt": "2025-01-01T10:00:00Z"
     },
     {
       "id": "f3c8b9b1-3d1a-4d8b-9e92-123456789123",
@@ -140,8 +140,8 @@
         "server_version": "v1.29.0",
         "context": "local-10"
       },
-      "created_at": "2025-01-01T10:00:00Z",
-      "updated_at": "2025-01-01T10:00:00Z"
+      "createdAt": "2025-01-01T10:00:00Z",
+      "updatedAt": "2025-01-01T10:00:00Z"
     }
   ]
 }

--- a/mesheryctl/internal/cli/root/connections/fixtures/list.connection.pagesize.api.response.golden
+++ b/mesheryctl/internal/cli/root/connections/fixtures/list.connection.pagesize.api.response.golden
@@ -1,7 +1,7 @@
 {
   "page": 0,
-  "page_size": 10,
-  "total_count": 3,
+  "pageSize": 10,
+  "totalCount": 3,
   "connections": [
     {
       "id": "f3c8b9b1-3d1a-4d8b-9e92-123456789111",
@@ -14,8 +14,8 @@
         "server_version": "v1.29.0",
         "context": "local-1"
       },
-      "created_at": "2025-01-01T10:00:00Z",
-      "updated_at": "2025-01-01T10:00:00Z"
+      "createdAt": "2025-01-01T10:00:00Z",
+      "updatedAt": "2025-01-01T10:00:00Z"
     },
     {
       "id": "f3c8b9b1-3d1a-4d8b-9e92-123456789222",
@@ -28,8 +28,8 @@
         "server_version": "v1.29.0",
         "context": "local-2"
       },
-      "created_at": "2025-01-01T10:00:00Z",
-      "updated_at": "2025-01-01T10:00:00Z"
+      "createdAt": "2025-01-01T10:00:00Z",
+      "updatedAt": "2025-01-01T10:00:00Z"
     },
     {
       "id": "f3c8b9b1-3d1a-4d8b-9e92-123456789333",
@@ -42,8 +42,8 @@
         "server_version": "v1.29.0",
         "context": "local-3"
       },
-      "created_at": "2025-01-01T10:00:00Z",
-      "updated_at": "2025-01-01T10:00:00Z"
+      "createdAt": "2025-01-01T10:00:00Z",
+      "updatedAt": "2025-01-01T10:00:00Z"
     }
   ]
 }

--- a/mesheryctl/internal/cli/root/connections/fixtures/list.connection.status.api.response.golden
+++ b/mesheryctl/internal/cli/root/connections/fixtures/list.connection.status.api.response.golden
@@ -1,7 +1,7 @@
 {
   "page": 0,
-  "page_size": 10,
-  "total_count": 9,
+  "pageSize": 10,
+  "totalCount": 9,
   "connections": [
     {
       "id": "f3c8b9b1-3d1a-4d8b-9e92-123456789111",
@@ -14,8 +14,8 @@
         "server_version": "v1.29.0",
         "context": "local-1"
       },
-      "created_at": "2025-01-01T10:00:00Z",
-      "updated_at": "2025-01-01T10:00:00Z"
+      "createdAt": "2025-01-01T10:00:00Z",
+      "updatedAt": "2025-01-01T10:00:00Z"
     },
     {
       "id": "f3c8b9b1-3d1a-4d8b-9e92-123456789333",
@@ -28,8 +28,8 @@
         "server_version": "v1.29.0",
         "context": "local-3"
       },
-      "created_at": "2025-01-01T10:00:00Z",
-      "updated_at": "2025-01-01T10:00:00Z"
+      "createdAt": "2025-01-01T10:00:00Z",
+      "updatedAt": "2025-01-01T10:00:00Z"
     },
     {
       "id": "f3c8b9b1-3d1a-4d8b-9e92-123456789444",
@@ -42,8 +42,8 @@
         "server_version": "v1.29.0",
         "context": "local-4"
       },
-      "created_at": "2025-01-01T10:00:00Z",
-      "updated_at": "2025-01-01T10:00:00Z"
+      "createdAt": "2025-01-01T10:00:00Z",
+      "updatedAt": "2025-01-01T10:00:00Z"
     },
     {
       "id": "f3c8b9b1-3d1a-4d8b-9e92-123456789555",
@@ -56,8 +56,8 @@
         "server_version": "v1.29.0",
         "context": "local-5"
       },
-      "created_at": "2025-01-01T10:00:00Z",
-      "updated_at": "2025-01-01T10:00:00Z"
+      "createdAt": "2025-01-01T10:00:00Z",
+      "updatedAt": "2025-01-01T10:00:00Z"
     },
     {
       "id": "f3c8b9b1-3d1a-4d8b-9e92-123456789666",
@@ -70,8 +70,8 @@
         "server_version": "v1.29.0",
         "context": "local-6"
       },
-      "created_at": "2025-01-01T10:00:00Z",
-      "updated_at": "2025-01-01T10:00:00Z"
+      "createdAt": "2025-01-01T10:00:00Z",
+      "updatedAt": "2025-01-01T10:00:00Z"
     },
     {
       "id": "f3c8b9b1-3d1a-4d8b-9e92-123456789777",
@@ -84,8 +84,8 @@
         "server_version": "v1.29.0",
         "context": "local-7"
       },
-      "created_at": "2025-01-01T10:00:00Z",
-      "updated_at": "2025-01-01T10:00:00Z"
+      "createdAt": "2025-01-01T10:00:00Z",
+      "updatedAt": "2025-01-01T10:00:00Z"
     },
     {
       "id": "f3c8b9b1-3d1a-4d8b-9e92-123456789999",
@@ -98,8 +98,8 @@
         "server_version": "v1.29.0",
         "context": "local-9"
       },
-      "created_at": "2025-01-01T10:00:00Z",
-      "updated_at": "2025-01-01T10:00:00Z"
+      "createdAt": "2025-01-01T10:00:00Z",
+      "updatedAt": "2025-01-01T10:00:00Z"
     },
     {
       "id": "f3c8b9b1-3d1a-4d8b-9e92-123456789123",
@@ -112,8 +112,8 @@
         "server_version": "v1.29.0",
         "context": "local-10"
       },
-      "created_at": "2025-01-01T10:00:00Z",
-      "updated_at": "2025-01-01T10:00:00Z"
+      "createdAt": "2025-01-01T10:00:00Z",
+      "updatedAt": "2025-01-01T10:00:00Z"
     },
     {
       "id": "f3c8b9b1-3d1a-4d8b-9e92-123456789456",
@@ -126,8 +126,8 @@
         "server_version": "v1.29.0",
         "context": "local-11"
       },
-      "created_at": "2025-01-01T10:00:00Z",
-      "updated_at": "2025-01-01T10:00:00Z"
+      "createdAt": "2025-01-01T10:00:00Z",
+      "updatedAt": "2025-01-01T10:00:00Z"
     }
   ]
 }

--- a/mesheryctl/internal/cli/root/connections/fixtures/list.connection.status.kind.api.response.golden
+++ b/mesheryctl/internal/cli/root/connections/fixtures/list.connection.status.kind.api.response.golden
@@ -1,7 +1,7 @@
 {
   "page": 0,
-  "page_size": 10,
-  "total_count": 4,
+  "pageSize": 10,
+  "totalCount": 4,
   "connections": [
     {
       "id": "f3c8b9b1-3d1a-4d8b-9e92-123456789111",
@@ -14,8 +14,8 @@
         "server_version": "v1.29.0",
         "context": "local-1"
       },
-      "created_at": "2025-01-01T10:00:00Z",
-      "updated_at": "2025-01-01T10:00:00Z"
+      "createdAt": "2025-01-01T10:00:00Z",
+      "updatedAt": "2025-01-01T10:00:00Z"
     },
     {
       "id": "f3c8b9b1-3d1a-4d8b-9e92-123456789555",
@@ -28,8 +28,8 @@
         "server_version": "v1.29.0",
         "context": "local-5"
       },
-      "created_at": "2025-01-01T10:00:00Z",
-      "updated_at": "2025-01-01T10:00:00Z"
+      "createdAt": "2025-01-01T10:00:00Z",
+      "updatedAt": "2025-01-01T10:00:00Z"
     },
     {
       "id": "f3c8b9b1-3d1a-4d8b-9e92-123456789666",
@@ -42,8 +42,8 @@
         "server_version": "v1.29.0",
         "context": "local-6"
       },
-      "created_at": "2025-01-01T10:00:00Z",
-      "updated_at": "2025-01-01T10:00:00Z"
+      "createdAt": "2025-01-01T10:00:00Z",
+      "updatedAt": "2025-01-01T10:00:00Z"
     },
     {
       "id": "f3c8b9b1-3d1a-4d8b-9e92-123456789999",
@@ -56,8 +56,8 @@
         "server_version": "v1.29.0",
         "context": "local-9"
       },
-      "created_at": "2025-01-01T10:00:00Z",
-      "updated_at": "2025-01-01T10:00:00Z"
+      "createdAt": "2025-01-01T10:00:00Z",
+      "updatedAt": "2025-01-01T10:00:00Z"
     }
   ]
 }

--- a/mesheryctl/internal/cli/root/connections/fixtures/view.connection.api.empty.response.golden
+++ b/mesheryctl/internal/cli/root/connections/fixtures/view.connection.api.empty.response.golden
@@ -1,4 +1,4 @@
 {
-  "total_count": 0,
+  "totalCount": 0,
   "connections": []
 }

--- a/mesheryctl/internal/cli/root/connections/fixtures/view.connection.api.response.golden
+++ b/mesheryctl/internal/cli/root/connections/fixtures/view.connection.api.response.golden
@@ -10,8 +10,8 @@
     "version": "v1.34.0"
   },
   "status": "connected",
-  "created_at": "2026-02-01T10:01:03.577292Z",
-  "updated_at": "2026-02-01T10:04:43.869192Z",
-  "deleted_at": null,
+  "createdAt": "2026-02-01T10:01:03.577292Z",
+  "updatedAt": "2026-02-01T10:04:43.869192Z",
+  "deletedAt": null,
   "schemaVersion": ""
 }

--- a/mesheryctl/internal/cli/root/connections/fixtures/view.connection.api.yaml.response.golden
+++ b/mesheryctl/internal/cli/root/connections/fixtures/view.connection.api.yaml.response.golden
@@ -8,6 +8,6 @@ metadata:
     deployment_type: ""
     version: v1.34.0
 status: connected
-created_at: 2026-02-01T10:01:03.577292Z
-updated_at: 2026-02-01T10:04:43.869192Z
+createdAt: 2026-02-01T10:01:03.577292Z
+updatedAt: 2026-02-01T10:04:43.869192Z
 schemaVersion: ""

--- a/mesheryctl/internal/cli/root/connections/list.go
+++ b/mesheryctl/internal/cli/root/connections/list.go
@@ -7,7 +7,7 @@ import (
 
 	"github.com/meshery/meshery/mesheryctl/internal/cli/pkg/display"
 	"github.com/meshery/meshery/mesheryctl/pkg/utils"
-	"github.com/meshery/schemas/models/v1beta1/connection"
+	"github.com/meshery/schemas/models/v1beta3/connection"
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 )

--- a/mesheryctl/internal/cli/root/connections/testdata/view.connection.output.golden
+++ b/mesheryctl/internal/cli/root/connections/testdata/view.connection.output.golden
@@ -10,8 +10,8 @@
     "version": "v1.34.0"
   },
   "status": "connected",
-  "created_at": "2026-02-01T10:01:03.577292Z",
-  "updated_at": "2026-02-01T10:04:43.869192Z",
-  "deleted_at": null,
+  "createdAt": "2026-02-01T10:01:03.577292Z",
+  "updatedAt": "2026-02-01T10:04:43.869192Z",
+  "deletedAt": null,
   "schemaVersion": ""
 }

--- a/mesheryctl/internal/cli/root/connections/testdata/view.connection.yaml.output.golden
+++ b/mesheryctl/internal/cli/root/connections/testdata/view.connection.yaml.output.golden
@@ -8,9 +8,6 @@ metadata:
     deployment_type: ""
     version: v1.34.0
 status: connected
-user_id: null
-created_at: 2026-02-01T10:01:03.577292Z
-updated_at: 2026-02-01T10:04:43.869192Z
-deleted_at: null
-environments: []
+createdAt: 2026-02-01T10:01:03.577292Z
+updatedAt: 2026-02-01T10:04:43.869192Z
 schemaVersion: ""

--- a/mesheryctl/internal/cli/root/connections/view.go
+++ b/mesheryctl/internal/cli/root/connections/view.go
@@ -25,7 +25,7 @@ import (
 	"github.com/meshery/meshery/mesheryctl/internal/cli/pkg/api"
 	"github.com/meshery/meshery/mesheryctl/internal/cli/pkg/display"
 	"github.com/meshery/meshery/mesheryctl/pkg/utils"
-	"github.com/meshery/schemas/models/v1beta1/connection"
+	"github.com/meshery/schemas/models/v1beta3/connection"
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 )

--- a/server/cmd/main.go
+++ b/server/cmd/main.go
@@ -39,7 +39,6 @@ import (
 	"github.com/meshery/meshkit/utils/broadcast"
 	"github.com/meshery/meshkit/utils/events"
 	meshsyncmodel "github.com/meshery/meshsync/pkg/model"
-	schemasConnection "github.com/meshery/schemas/models/v1beta1/connection"
 	"github.com/meshery/schemas/models/v1beta1/environment"
 	schemasOrganization "github.com/meshery/schemas/models/v1beta2/organization"
 	"github.com/meshery/schemas/models/v1beta1/workspace"
@@ -126,7 +125,7 @@ func main() {
 	viper.SetDefault("SKIP_DOWNLOAD_EXTENSIONS", false)
 	viper.SetDefault("SKIP_COMP_GEN", false)
 	viper.SetDefault("PLAYGROUND", false)
-	viper.SetDefault("MESHSYNC_DEFAULT_DEPLOYMENT_MODE", schemasConnection.MeshsyncDeploymentModeDefault)
+	viper.SetDefault("MESHSYNC_DEFAULT_DEPLOYMENT_MODE", connections.MeshsyncDeploymentModeDefault)
 	store.Initialize()
 
 	// initialize tracing. Skip entirely when OTEL_CONFIG is unset so local dev
@@ -268,12 +267,12 @@ func main() {
 		os.Exit(1)
 	}
 
-	meshsyncDefaultDeploymentMode := schemasConnection.MeshsyncDeploymentModeFromString(
+	meshsyncDefaultDeploymentMode := connections.MeshsyncDeploymentModeFromString(
 		viper.GetString("MESHSYNC_DEFAULT_DEPLOYMENT_MODE"),
 	)
 
-	if meshsyncDefaultDeploymentMode == schemasConnection.MeshsyncDeploymentModeUndefined {
-		meshsyncDefaultDeploymentMode = schemasConnection.MeshsyncDeploymentModeDefault
+	if meshsyncDefaultDeploymentMode == connections.MeshsyncDeploymentModeUndefined {
+		meshsyncDefaultDeploymentMode = connections.MeshsyncDeploymentModeDefault
 	}
 
 	lProv := &models.DefaultLocalProvider{

--- a/server/handlers/connections_handlers.go
+++ b/server/handlers/connections_handlers.go
@@ -21,7 +21,6 @@ import (
 	"github.com/meshery/meshkit/errors"
 	"github.com/meshery/meshkit/models/events"
 	regv1beta1 "github.com/meshery/meshkit/models/meshmodel/registry/v1beta1"
-	schemasConnection "github.com/meshery/schemas/models/v1beta1/connection"
 )
 
 func (h *Handler) ProcessConnectionRegistration(w http.ResponseWriter, req *http.Request, prefObj *models.Preference, user *models.User, provider models.Provider) {
@@ -375,7 +374,7 @@ func (h *Handler) UpdateConnectionById(w http.ResponseWriter, req *http.Request,
 	// In fact this method is used (for now) only for perform meshsync deployment mode change.
 	// If mode change fails return error.
 	// TODO: also check that kind = "kubernetes" (when client starts to send full connection object)
-	if schemasConnection.MeshsyncDeploymentModeFromMetadata(connection.MetaData) != schemasConnection.MeshsyncDeploymentModeUndefined {
+	if connections.MeshsyncDeploymentModeFromMetadata(connection.MetaData) != connections.MeshsyncDeploymentModeUndefined {
 		// Handle meshsync deployment mode changes before connection update
 		token, _ := req.Context().Value(models.TokenCtxKey).(string)
 		oldMode, newMode, modeChanged, err := h.handleMeshSyncDeploymentModeChange(
@@ -586,13 +585,13 @@ func (h *Handler) handleMeshSyncDeploymentModeChange(
 	token string,
 	userID core.Uuid,
 	provider models.Provider,
-) (schemasConnection.MeshsyncDeploymentMode, schemasConnection.MeshsyncDeploymentMode, bool, error) {
+) (connections.MeshsyncDeploymentMode, connections.MeshsyncDeploymentMode, bool, error) {
 	if newConnection == nil {
-		return schemasConnection.MeshsyncDeploymentModeUndefined, schemasConnection.MeshsyncDeploymentModeUndefined, false, fmt.Errorf("new connection is nil, cannot compare meshsync deployment modes")
+		return connections.MeshsyncDeploymentModeUndefined, connections.MeshsyncDeploymentModeUndefined, false, fmt.Errorf("new connection is nil, cannot compare meshsync deployment modes")
 	}
 
 	if h.SystemID == nil {
-		return schemasConnection.MeshsyncDeploymentModeUndefined, schemasConnection.MeshsyncDeploymentModeUndefined, false, fmt.Errorf("system ID is not configured in handler")
+		return connections.MeshsyncDeploymentModeUndefined, connections.MeshsyncDeploymentModeUndefined, false, fmt.Errorf("system ID is not configured in handler")
 	}
 	// TODO is h.SystemID a correct instance id here?
 	mesheryInstanceID := *h.SystemID
@@ -600,22 +599,22 @@ func (h *Handler) handleMeshSyncDeploymentModeChange(
 	// Retrieve existing connection for mode comparison
 	existingConnection, statusCode, err := provider.GetConnectionByID(token, connectionID)
 	if err != nil {
-		return schemasConnection.MeshsyncDeploymentModeUndefined, schemasConnection.MeshsyncDeploymentModeUndefined, false, fmt.Errorf("failed to retrieve existing connection (status %d): %w", statusCode, err)
+		return connections.MeshsyncDeploymentModeUndefined, connections.MeshsyncDeploymentModeUndefined, false, fmt.Errorf("failed to retrieve existing connection (status %d): %w", statusCode, err)
 	}
 
 	if existingConnection == nil {
-		return schemasConnection.MeshsyncDeploymentModeUndefined, schemasConnection.MeshsyncDeploymentModeUndefined, false, fmt.Errorf("existing connection is nil, cannot compare meshsync deployment modes")
+		return connections.MeshsyncDeploymentModeUndefined, connections.MeshsyncDeploymentModeUndefined, false, fmt.Errorf("existing connection is nil, cannot compare meshsync deployment modes")
 	}
 
 	if existingConnection.Kind != "kubernetes" {
-		return schemasConnection.MeshsyncDeploymentModeUndefined, schemasConnection.MeshsyncDeploymentModeUndefined, false, fmt.Errorf("connection is not of kind kubernetes")
+		return connections.MeshsyncDeploymentModeUndefined, connections.MeshsyncDeploymentModeUndefined, false, fmt.Errorf("connection is not of kind kubernetes")
 	}
 
-	existingMeshSyncMode := schemasConnection.MeshsyncDeploymentModeFromMetadata(existingConnection.Metadata)
-	newMeshSyncMode := schemasConnection.MeshsyncDeploymentModeFromMetadata(newConnection.MetaData)
+	existingMeshSyncMode := connections.MeshsyncDeploymentModeFromMetadata(existingConnection.Metadata)
+	newMeshSyncMode := connections.MeshsyncDeploymentModeFromMetadata(newConnection.MetaData)
 
 	// draw back to default mode
-	if newMeshSyncMode == schemasConnection.MeshsyncDeploymentModeUndefined {
+	if newMeshSyncMode == connections.MeshsyncDeploymentModeUndefined {
 		newMeshSyncMode = h.MeshsyncDefaultDeploymentMode
 	}
 

--- a/server/handlers/handler_instance.go
+++ b/server/handlers/handler_instance.go
@@ -4,6 +4,7 @@ package handlers
 import (
 	"github.com/meshery/meshery/server/machines"
 	"github.com/meshery/meshery/server/models"
+	"github.com/meshery/meshery/server/models/connections"
 	gopolicies "github.com/meshery/meshery/server/policies"
 	"github.com/meshery/meshkit/broker"
 	"github.com/meshery/meshkit/database"
@@ -12,7 +13,6 @@ import (
 	meshmodel "github.com/meshery/meshkit/models/meshmodel/registry"
 	"github.com/meshery/meshkit/utils/events"
 	"github.com/meshery/schemas/models/core"
-	schemasConnection "github.com/meshery/schemas/models/v1beta1/connection"
 	"github.com/spf13/viper"
 	"github.com/vmihailenco/taskq/v3"
 )
@@ -35,7 +35,7 @@ type Handler struct {
 	Rego                                    *policies.Rego
 	GoEngine                                *gopolicies.GoEngine
 	ConnectionToStateMachineInstanceTracker *machines.ConnectionToStateMachineInstanceTracker
-	MeshsyncDefaultDeploymentMode           schemasConnection.MeshsyncDeploymentMode
+	MeshsyncDefaultDeploymentMode           connections.MeshsyncDeploymentMode
 	evalTracker                             *evaluationTracker
 }
 
@@ -53,7 +53,7 @@ func NewHandlerInstance(
 	provider string,
 	rego *policies.Rego,
 	connToInstanceTracker *machines.ConnectionToStateMachineInstanceTracker,
-	meshsyncDefaultDeploymentMode schemasConnection.MeshsyncDeploymentMode,
+	meshsyncDefaultDeploymentMode connections.MeshsyncDeploymentMode,
 ) models.HandlerInterface {
 
 	h := &Handler{

--- a/server/handlers/k8sconfig_handler.go
+++ b/server/handlers/k8sconfig_handler.go
@@ -24,7 +24,6 @@ import (
 	"github.com/meshery/meshkit/models/events"
 
 	"github.com/meshery/meshkit/utils"
-	schemasConnection "github.com/meshery/schemas/models/v1beta1/connection"
 	"github.com/pkg/errors"
 	"github.com/spf13/viper"
 )
@@ -140,9 +139,9 @@ func (h *Handler) addK8SConfig(user *models.User, _ *models.Preference, w http.R
 		// Create context-specific metadata with appropriate meshsync deployment mode
 		k8sContextsMetadata := make(map[string]any, 1)
 		meshsyncMode := getMeshsyncModeForContext(ctx)
-		schemasConnection.SetMeshsyncDeploymentModeToMetadata(
+		connections.SetMeshsyncDeploymentModeToMetadata(
 			k8sContextsMetadata,
-			schemasConnection.MeshsyncDeploymentModeFromString(meshsyncMode),
+			connections.MeshsyncDeploymentModeFromString(meshsyncMode),
 		)
 
 		connection, err := provider.SaveK8sContext(token, *ctx, k8sContextsMetadata)

--- a/server/machines/kubernetes/connect.go
+++ b/server/machines/kubernetes/connect.go
@@ -9,8 +9,8 @@ import (
 	"github.com/gofrs/uuid"
 	"github.com/meshery/meshery/server/machines"
 	"github.com/meshery/meshery/server/models"
+	"github.com/meshery/meshery/server/models/connections"
 	"github.com/meshery/meshkit/models/events"
-	schemasConnection "github.com/meshery/schemas/models/v1beta1/connection"
 	"github.com/spf13/viper"
 )
 
@@ -62,16 +62,16 @@ func (ca *ConnectAction) Execute(ctx context.Context, machineCtx interface{}, da
 		return machines.NoOp, eventBuilder.Build(), errConnection
 	}
 
-	meshsyncDeploymentMode := schemasConnection.MeshsyncDeploymentModeFromMetadata(connection.Metadata)
-	if meshsyncDeploymentMode == schemasConnection.MeshsyncDeploymentModeUndefined {
+	meshsyncDeploymentMode := connections.MeshsyncDeploymentModeFromMetadata(connection.Metadata)
+	if meshsyncDeploymentMode == connections.MeshsyncDeploymentModeUndefined {
 		// TODO:
 		// maybe not call to viper here and propagate default value from above,
 		// f.e. when machine is created
-		meshsyncDeploymentMode = schemasConnection.MeshsyncDeploymentModeFromString(
+		meshsyncDeploymentMode = connections.MeshsyncDeploymentModeFromString(
 			viper.GetString("MESHSYNC_DEFAULT_DEPLOYMENT_MODE"),
 		)
-		if meshsyncDeploymentMode == schemasConnection.MeshsyncDeploymentModeUndefined {
-			meshsyncDeploymentMode = schemasConnection.MeshsyncDeploymentModeDefault
+		if meshsyncDeploymentMode == connections.MeshsyncDeploymentModeUndefined {
+			meshsyncDeploymentMode = connections.MeshsyncDeploymentModeDefault
 		}
 	}
 

--- a/server/models/connection_persister.go
+++ b/server/models/connection_persister.go
@@ -11,7 +11,7 @@ import (
 	"github.com/meshery/meshery/server/models/connections"
 	"github.com/meshery/meshery/server/models/environments"
 	"github.com/meshery/meshkit/database"
-	schemasConnection "github.com/meshery/schemas/models/v1beta1/connection"
+	schemasConnection "github.com/meshery/schemas/models/v1beta3/connection"
 	"gorm.io/gorm"
 )
 
@@ -89,8 +89,13 @@ func (cp *ConnectionPersister) GetConnections(search, order string, page, pageSi
 	return connectionsPage, nil
 }
 
-// getConnectionsStatusSummary returns a map of connection status to count
-func (cp *ConnectionPersister) getConnectionsStatusSummary() (*map[schemasConnection.ConnectionStatus]int, error) {
+// getConnectionsStatusSummary returns a map of connection status to count.
+// The v1beta3 connection schema narrowed ConnectionPage.StatusSummary from
+// map[ConnectionStatus]int to map[ConnectionStatusValue]int (the two types
+// carry the same canonical values but ConnectionStatusValue is the one the
+// paginated list envelope now speaks), so build the summary against the
+// page-side type directly.
+func (cp *ConnectionPersister) getConnectionsStatusSummary() (*map[schemasConnection.ConnectionStatusValue]int, error) {
 	var statusCounts []struct {
 		Status string `gorm:"column:status"`
 		Count  int    `gorm:"column:count"`
@@ -105,9 +110,9 @@ func (cp *ConnectionPersister) getConnectionsStatusSummary() (*map[schemasConnec
 		return nil, fmt.Errorf("error fetching connection status summary: %v", err)
 	}
 
-	summary := make(map[schemasConnection.ConnectionStatus]int)
+	summary := make(map[schemasConnection.ConnectionStatusValue]int)
 	for _, sc := range statusCounts {
-		summary[schemasConnection.ConnectionStatus(sc.Status)] = sc.Count
+		summary[schemasConnection.ConnectionStatusValue(sc.Status)] = sc.Count
 	}
 
 	return &summary, nil

--- a/server/models/connections/connections.go
+++ b/server/models/connections/connections.go
@@ -8,7 +8,7 @@ import (
 
 	"github.com/meshery/meshkit/logger"
 	"github.com/meshery/schemas/models/core"
-	schemasConnection "github.com/meshery/schemas/models/v1beta1/connection"
+	schemasConnection "github.com/meshery/schemas/models/v1beta3/connection"
 )
 
 type ConnectionStatus = schemasConnection.ConnectionStatus
@@ -91,8 +91,13 @@ type ConnectionStatusInfo struct {
 	Count  int    `json:"count" db:"count"`
 }
 
+// ConnectionsStatusPage is a Meshery-local swagger stub for the status-per-kind
+// response wrapper surfaced on a few integrations endpoints. The canonical
+// v1beta3 schema publishes camelCase on the wire, so the JSON tag here matches
+// `connectionsStatus`. No runtime handler emits this struct today — it is a
+// doc-only placeholder referenced from server/handlers/doc.go.
 type ConnectionsStatusPage struct {
-	ConnectionsStatus []*ConnectionStatusInfo `json:"connections_status"`
+	ConnectionsStatus []*ConnectionStatusInfo `json:"connectionsStatus"`
 }
 
 type ConnectionPayload struct {

--- a/server/models/connections/meshsync_deployment_mode.go
+++ b/server/models/connections/meshsync_deployment_mode.go
@@ -10,9 +10,10 @@
 // here lets the Phase 3 consumer repoint drop every `v1beta1/connection`
 // import from meshery/meshery without waiting for a schemas-side port.
 //
-// TODO(identifier-naming-migration): Once schemas releases a v1beta3
-// connection_helper with these helpers (or an equivalent package), switch back
-// to the shared definition and delete this file.
+// Per the identifier-naming migration plan (docs/identifier-naming-migration.md
+// in meshery/schemas), Meshery-domain logic stays in meshery/meshery and the
+// schemas package remains a pure wire-contract. These helpers are intentionally
+// permanent here; schemas is not expected to re-export them.
 package connections
 
 import (
@@ -54,9 +55,12 @@ func MeshsyncDeploymentModeFromString(value string) MeshsyncDeploymentMode {
 
 // MeshsyncDeploymentModeFromMetadata extracts the deployment mode stored on
 // a connection's metadata map. Both strongly-typed (MeshsyncDeploymentMode)
-// and string-shaped values are accepted; any other type falls back to
-// MeshsyncDeploymentModeUndefined.
+// and string-shaped values are accepted; any other type (or a nil metadata
+// map) falls back to MeshsyncDeploymentModeUndefined.
 func MeshsyncDeploymentModeFromMetadata(metadata core.Map) MeshsyncDeploymentMode {
+	if metadata == nil {
+		return MeshsyncDeploymentModeUndefined
+	}
 	raw, exists := metadata[MeshsyncDeploymentModeMetadataKey]
 	if !exists {
 		return MeshsyncDeploymentModeUndefined
@@ -73,7 +77,12 @@ func MeshsyncDeploymentModeFromMetadata(metadata core.Map) MeshsyncDeploymentMod
 }
 
 // SetMeshsyncDeploymentModeToMetadata writes (or overwrites) the deployment
-// mode entry on a connection's metadata map.
+// mode entry on a connection's metadata map. A nil metadata map is a no-op
+// (writing to a nil map would panic); callers that need to set a mode on a
+// fresh connection must initialise the map first.
 func SetMeshsyncDeploymentModeToMetadata(metadata core.Map, value MeshsyncDeploymentMode) {
+	if metadata == nil {
+		return
+	}
 	metadata[MeshsyncDeploymentModeMetadataKey] = value
 }

--- a/server/models/connections/meshsync_deployment_mode.go
+++ b/server/models/connections/meshsync_deployment_mode.go
@@ -1,0 +1,79 @@
+// Package connections provides Meshery-local connection helpers that complement
+// the canonical `connection.Connection` wire contract defined in
+// github.com/meshery/schemas/models/v1beta3/connection.
+//
+// This file hosts the MeshsyncDeploymentMode helpers, previously declared in
+// `github.com/meshery/schemas/models/v1beta1/connection/connection_helper.go`.
+// The helpers are Meshery domain logic (how the server decides whether to run
+// meshsync in operator vs. embedded mode against a Kubernetes connection) and
+// do not belong to the wire contract that v1beta3 canonicalises. Moving them
+// here lets the Phase 3 consumer repoint drop every `v1beta1/connection`
+// import from meshery/meshery without waiting for a schemas-side port.
+//
+// TODO(identifier-naming-migration): Once schemas releases a v1beta3
+// connection_helper with these helpers (or an equivalent package), switch back
+// to the shared definition and delete this file.
+package connections
+
+import (
+	"github.com/meshery/schemas/models/core"
+)
+
+// MeshsyncDeploymentMode is the deployment mode of the meshsync controller for
+// a given Kubernetes connection. Values mirror the strings persisted in
+// `Connection.Metadata[MeshsyncDeploymentModeMetadataKey]`.
+type MeshsyncDeploymentMode string
+
+// MeshsyncDeploymentModeMetadataKey is the key under which the deployment mode
+// is stored on a connection's metadata map. Kept as snake_case because it is
+// persisted on the wire alongside other metadata entries and renaming it
+// would break every connection already carrying the key.
+const MeshsyncDeploymentModeMetadataKey = "meshsync_deployment_mode"
+
+const (
+	MeshsyncDeploymentModeOperator  MeshsyncDeploymentMode = "operator"
+	MeshsyncDeploymentModeEmbedded  MeshsyncDeploymentMode = "embedded"
+	MeshsyncDeploymentModeUndefined MeshsyncDeploymentMode = "undefined"
+	MeshsyncDeploymentModeDefault                          = MeshsyncDeploymentModeEmbedded
+)
+
+// MeshsyncDeploymentModeFromString coerces a free-form string (typically a
+// config value or a metadata entry) into one of the known deployment modes.
+// Anything that does not match a known value collapses to
+// MeshsyncDeploymentModeUndefined so callers can apply their own fallback.
+func MeshsyncDeploymentModeFromString(value string) MeshsyncDeploymentMode {
+	switch value {
+	case string(MeshsyncDeploymentModeOperator):
+		return MeshsyncDeploymentModeOperator
+	case string(MeshsyncDeploymentModeEmbedded):
+		return MeshsyncDeploymentModeEmbedded
+	default:
+		return MeshsyncDeploymentModeUndefined
+	}
+}
+
+// MeshsyncDeploymentModeFromMetadata extracts the deployment mode stored on
+// a connection's metadata map. Both strongly-typed (MeshsyncDeploymentMode)
+// and string-shaped values are accepted; any other type falls back to
+// MeshsyncDeploymentModeUndefined.
+func MeshsyncDeploymentModeFromMetadata(metadata core.Map) MeshsyncDeploymentMode {
+	raw, exists := metadata[MeshsyncDeploymentModeMetadataKey]
+	if !exists {
+		return MeshsyncDeploymentModeUndefined
+	}
+
+	switch v := raw.(type) {
+	case MeshsyncDeploymentMode:
+		return v
+	case string:
+		return MeshsyncDeploymentModeFromString(v)
+	default:
+		return MeshsyncDeploymentModeUndefined
+	}
+}
+
+// SetMeshsyncDeploymentModeToMetadata writes (or overwrites) the deployment
+// mode entry on a connection's metadata map.
+func SetMeshsyncDeploymentModeToMetadata(metadata core.Map, value MeshsyncDeploymentMode) {
+	metadata[MeshsyncDeploymentModeMetadataKey] = value
+}

--- a/server/models/connections/meshsync_deployment_mode_test.go
+++ b/server/models/connections/meshsync_deployment_mode_test.go
@@ -1,0 +1,100 @@
+package connections
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestMeshsyncDeploymentModeFromString(t *testing.T) {
+	tests := []struct {
+		input    string
+		expected MeshsyncDeploymentMode
+	}{
+		{"", MeshsyncDeploymentModeUndefined},
+		{string(MeshsyncDeploymentModeOperator), MeshsyncDeploymentModeOperator},
+		{string(MeshsyncDeploymentModeEmbedded), MeshsyncDeploymentModeEmbedded},
+		{"unknown", MeshsyncDeploymentModeUndefined},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.input, func(t *testing.T) {
+			assert := assert.New(t)
+			result := MeshsyncDeploymentModeFromString(tt.input)
+			assert.Equal(tt.expected, result)
+		})
+	}
+}
+
+func TestMeshsyncDeploymentModeFromMetadata(t *testing.T) {
+	tests := []struct {
+		name     string
+		metadata map[string]any
+		expected MeshsyncDeploymentMode
+	}{
+		{
+			name:     "no key",
+			metadata: map[string]any{},
+			expected: MeshsyncDeploymentModeUndefined,
+		},
+		{
+			name:     "wrong type",
+			metadata: map[string]any{MeshsyncDeploymentModeMetadataKey: 123},
+			expected: MeshsyncDeploymentModeUndefined,
+		},
+		{
+			name:     "empty string",
+			metadata: map[string]any{MeshsyncDeploymentModeMetadataKey: ""},
+			expected: MeshsyncDeploymentModeUndefined,
+		},
+		{
+			name:     "operator mode string",
+			metadata: map[string]any{MeshsyncDeploymentModeMetadataKey: string(MeshsyncDeploymentModeOperator)},
+			expected: MeshsyncDeploymentModeOperator,
+		},
+		{
+			name:     "embedded mode string",
+			metadata: map[string]any{MeshsyncDeploymentModeMetadataKey: string(MeshsyncDeploymentModeEmbedded)},
+			expected: MeshsyncDeploymentModeEmbedded,
+		},
+		{
+			name:     "unknown string",
+			metadata: map[string]any{MeshsyncDeploymentModeMetadataKey: "something-else"},
+			expected: MeshsyncDeploymentModeUndefined,
+		},
+		{
+			name:     "direct MeshsyncDeploymentMode type",
+			metadata: map[string]any{MeshsyncDeploymentModeMetadataKey: MeshsyncDeploymentModeOperator},
+			expected: MeshsyncDeploymentModeOperator,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert := assert.New(t)
+			result := MeshsyncDeploymentModeFromMetadata(tt.metadata)
+			assert.Equal(tt.expected, result)
+		})
+	}
+}
+
+func TestAddMeshsyncDeploymentModeToMetadata(t *testing.T) {
+	t.Run("adds mode to empty metadata map", func(t *testing.T) {
+		metadata := make(map[string]any)
+		SetMeshsyncDeploymentModeToMetadata(metadata, MeshsyncDeploymentModeEmbedded)
+
+		assert := assert.New(t)
+		assert.Contains(metadata, MeshsyncDeploymentModeMetadataKey)
+		assert.Equal(MeshsyncDeploymentModeEmbedded, metadata[MeshsyncDeploymentModeMetadataKey])
+	})
+
+	t.Run("overwrites existing mode in metadata", func(t *testing.T) {
+		metadata := map[string]any{
+			MeshsyncDeploymentModeMetadataKey: MeshsyncDeploymentModeOperator,
+		}
+		SetMeshsyncDeploymentModeToMetadata(metadata, MeshsyncDeploymentModeEmbedded)
+
+		assert := assert.New(t)
+		assert.Equal(MeshsyncDeploymentModeEmbedded, metadata[MeshsyncDeploymentModeMetadataKey])
+	})
+}

--- a/server/models/connections/meshsync_deployment_mode_test.go
+++ b/server/models/connections/meshsync_deployment_mode_test.go
@@ -8,20 +8,20 @@ import (
 
 func TestMeshsyncDeploymentModeFromString(t *testing.T) {
 	tests := []struct {
+		name     string
 		input    string
 		expected MeshsyncDeploymentMode
 	}{
-		{"", MeshsyncDeploymentModeUndefined},
-		{string(MeshsyncDeploymentModeOperator), MeshsyncDeploymentModeOperator},
-		{string(MeshsyncDeploymentModeEmbedded), MeshsyncDeploymentModeEmbedded},
-		{"unknown", MeshsyncDeploymentModeUndefined},
+		{name: "empty string", input: "", expected: MeshsyncDeploymentModeUndefined},
+		{name: "operator", input: string(MeshsyncDeploymentModeOperator), expected: MeshsyncDeploymentModeOperator},
+		{name: "embedded", input: string(MeshsyncDeploymentModeEmbedded), expected: MeshsyncDeploymentModeEmbedded},
+		{name: "unknown value", input: "unknown", expected: MeshsyncDeploymentModeUndefined},
 	}
 
 	for _, tt := range tests {
-		t.Run(tt.input, func(t *testing.T) {
-			assert := assert.New(t)
+		t.Run(tt.name, func(t *testing.T) {
 			result := MeshsyncDeploymentModeFromString(tt.input)
-			assert.Equal(tt.expected, result)
+			assert.Equal(t, tt.expected, result)
 		})
 	}
 }
@@ -32,6 +32,11 @@ func TestMeshsyncDeploymentModeFromMetadata(t *testing.T) {
 		metadata map[string]any
 		expected MeshsyncDeploymentMode
 	}{
+		{
+			name:     "nil metadata",
+			metadata: nil,
+			expected: MeshsyncDeploymentModeUndefined,
+		},
 		{
 			name:     "no key",
 			metadata: map[string]any{},
@@ -71,9 +76,8 @@ func TestMeshsyncDeploymentModeFromMetadata(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			assert := assert.New(t)
 			result := MeshsyncDeploymentModeFromMetadata(tt.metadata)
-			assert.Equal(tt.expected, result)
+			assert.Equal(t, tt.expected, result)
 		})
 	}
 }
@@ -83,9 +87,8 @@ func TestAddMeshsyncDeploymentModeToMetadata(t *testing.T) {
 		metadata := make(map[string]any)
 		SetMeshsyncDeploymentModeToMetadata(metadata, MeshsyncDeploymentModeEmbedded)
 
-		assert := assert.New(t)
-		assert.Contains(metadata, MeshsyncDeploymentModeMetadataKey)
-		assert.Equal(MeshsyncDeploymentModeEmbedded, metadata[MeshsyncDeploymentModeMetadataKey])
+		assert.Contains(t, metadata, MeshsyncDeploymentModeMetadataKey)
+		assert.Equal(t, MeshsyncDeploymentModeEmbedded, metadata[MeshsyncDeploymentModeMetadataKey])
 	})
 
 	t.Run("overwrites existing mode in metadata", func(t *testing.T) {
@@ -94,7 +97,13 @@ func TestAddMeshsyncDeploymentModeToMetadata(t *testing.T) {
 		}
 		SetMeshsyncDeploymentModeToMetadata(metadata, MeshsyncDeploymentModeEmbedded)
 
-		assert := assert.New(t)
-		assert.Equal(MeshsyncDeploymentModeEmbedded, metadata[MeshsyncDeploymentModeMetadataKey])
+		assert.Equal(t, MeshsyncDeploymentModeEmbedded, metadata[MeshsyncDeploymentModeMetadataKey])
+	})
+
+	t.Run("nil metadata is a no-op, not a panic", func(t *testing.T) {
+		var metadata map[string]any // nil map
+		assert.NotPanics(t, func() {
+			SetMeshsyncDeploymentModeToMetadata(metadata, MeshsyncDeploymentModeEmbedded)
+		})
 	})
 }

--- a/server/models/default_local_provider.go
+++ b/server/models/default_local_provider.go
@@ -29,7 +29,6 @@ import (
 	"github.com/meshery/meshkit/utils"
 	mesherykube "github.com/meshery/meshkit/utils/kubernetes"
 	"github.com/meshery/meshkit/utils/walker"
-	schemasConnection "github.com/meshery/schemas/models/v1beta1/connection"
 	"github.com/meshery/schemas/models/v1beta1/environment"
 	"github.com/meshery/schemas/models/v1beta2/organization"
 	"github.com/meshery/schemas/models/v1beta1/pattern"
@@ -67,7 +66,7 @@ type DefaultLocalProvider struct {
 	KubeClient       *mesherykube.Client
 	Log              logger.Handler
 
-	MeshsyncDefaultDeploymentMode schemasConnection.MeshsyncDeploymentMode
+	MeshsyncDefaultDeploymentMode connections.MeshsyncDeploymentMode
 }
 
 // Initialize will initialize the local provider
@@ -288,8 +287,8 @@ func (l *DefaultLocalProvider) SaveK8sContext(_ string, k8sContext K8sContext, a
 
 	maps.Copy(metadata, additionalMetadata)
 
-	if schemasConnection.MeshsyncDeploymentModeFromMetadata(metadata) == schemasConnection.MeshsyncDeploymentModeUndefined {
-		schemasConnection.SetMeshsyncDeploymentModeToMetadata(
+	if connections.MeshsyncDeploymentModeFromMetadata(metadata) == connections.MeshsyncDeploymentModeUndefined {
+		connections.SetMeshsyncDeploymentModeToMetadata(
 			metadata,
 			l.MeshsyncDefaultDeploymentMode,
 		)

--- a/server/models/meshery_controllers.go
+++ b/server/models/meshery_controllers.go
@@ -22,7 +22,7 @@ import (
 	"github.com/meshery/meshkit/utils"
 	mesherykube "github.com/meshery/meshkit/utils/kubernetes"
 	libmeshsync "github.com/meshery/meshsync/pkg/lib/meshsync"
-	schemasConnection "github.com/meshery/schemas/models/v1beta1/connection"
+	"github.com/meshery/meshery/server/models/connections"
 	"github.com/spf13/viper"
 )
 
@@ -61,7 +61,7 @@ type MesheryControllersHelper struct {
 	oprDepConfig controllers.OperatorDeploymentConfig
 	dbHandler    *database.Handler
 
-	meshsyncDeploymentMode schemasConnection.MeshsyncDeploymentMode
+	meshsyncDeploymentMode connections.MeshsyncDeploymentMode
 
 	// event broadcasting dependencies
 	eventBroadcaster *Broadcast
@@ -99,14 +99,14 @@ func NewMesheryControllersHelper(
 		// Resetting this value results in again subscribing to the Broker.
 		ctxMeshsyncDataHandler: nil,
 		dbHandler:              dbHandler,
-		meshsyncDeploymentMode: schemasConnection.MeshsyncDeploymentModeOperator,
+		meshsyncDeploymentMode: connections.MeshsyncDeploymentModeOperator,
 		eventBroadcaster:       eventBroadcaster,
 		provider:               provider,
 		systemID:               systemID,
 	}
 }
 
-func (mch *MesheryControllersHelper) SetMeshsyncDeploymentMode(value schemasConnection.MeshsyncDeploymentMode) *MesheryControllersHelper {
+func (mch *MesheryControllersHelper) SetMeshsyncDeploymentMode(value connections.MeshsyncDeploymentMode) *MesheryControllersHelper {
 	mch.meshsyncDeploymentMode = value
 	return mch
 }
@@ -125,9 +125,9 @@ func (mch *MesheryControllersHelper) AddMeshsynDataHandlers(ctx context.Context,
 		var stopFunc func()
 
 		switch mch.meshsyncDeploymentMode {
-		case schemasConnection.MeshsyncDeploymentModeOperator:
+		case connections.MeshsyncDeploymentModeOperator:
 			brokerHandler = mch.meshsynDataHandlersNatsBroker(k8scontext, userID)
-		case schemasConnection.MeshsyncDeploymentModeEmbedded:
+		case connections.MeshsyncDeploymentModeEmbedded:
 			brokerHandler = channelBroker.NewChannelBrokerHandler()
 			// use a standalone context here context.Background(), as
 			// meshsync run must be stopped only when meshsync data handler is deregistered
@@ -365,7 +365,7 @@ func (mch *MesheryControllersHelper) RemoveCtxControllerHandler(ctx context.Cont
 // should be called after AddCtxControllerHandlers
 func (mch *MesheryControllersHelper) UpdateOperatorsStatusMap(ot *OperatorTracker) *MesheryControllersHelper {
 	// go func(mch *MesheryControllersHelper) {
-	if mch.meshsyncDeploymentMode != schemasConnection.MeshsyncDeploymentModeOperator {
+	if mch.meshsyncDeploymentMode != connections.MeshsyncDeploymentModeOperator {
 		return mch
 	}
 
@@ -426,7 +426,7 @@ func (mch *MesheryControllersHelper) DeployUndeployedOperators(ot *OperatorTrack
 	if ot.DisableOperator { //Return true everytime so that operators stay in undeployed state across all contexts
 		return mch
 	}
-	if mch.meshsyncDeploymentMode != schemasConnection.MeshsyncDeploymentModeOperator {
+	if mch.meshsyncDeploymentMode != connections.MeshsyncDeploymentModeOperator {
 		return mch
 	}
 	// go func(mch *MesheryControllersHelper) {

--- a/server/models/remote_provider.go
+++ b/server/models/remote_provider.go
@@ -33,7 +33,6 @@ import (
 	"github.com/meshery/meshkit/logger"
 	"github.com/meshery/meshkit/models/events"
 	mesherykube "github.com/meshery/meshkit/utils/kubernetes"
-	schemasConnection "github.com/meshery/schemas/models/v1beta1/connection"
 	"github.com/meshery/schemas/models/v1beta1/environment"
 	"github.com/meshery/schemas/models/v1beta1/workspace"
 	"github.com/spf13/viper"
@@ -76,7 +75,7 @@ type RemoteProvider struct {
 	KubeClient         *mesherykube.Client
 	Log                logger.Handler
 
-	MeshsyncDefaultDeploymentMode schemasConnection.MeshsyncDeploymentMode
+	MeshsyncDefaultDeploymentMode connections.MeshsyncDeploymentMode
 }
 type AnonymousFlowResponse struct {
 	AccessToken string    `json:"access_token"`
@@ -944,8 +943,8 @@ func (l *RemoteProvider) SaveK8sContext(token string, k8sContext K8sContext, add
 	maps.Copy(metadata, additionalMetadata)
 
 	// if undefined -> set to default
-	if schemasConnection.MeshsyncDeploymentModeFromMetadata(metadata) == schemasConnection.MeshsyncDeploymentModeUndefined {
-		schemasConnection.SetMeshsyncDeploymentModeToMetadata(
+	if connections.MeshsyncDeploymentModeFromMetadata(metadata) == connections.MeshsyncDeploymentModeUndefined {
+		connections.SetMeshsyncDeploymentModeToMetadata(
 			metadata,
 			l.MeshsyncDefaultDeploymentMode,
 		)


### PR DESCRIPTION
## Summary

Phase 3 per-resource consumer repoint for the `connection` construct (schemas PR [meshery/schemas#806](https://github.com/meshery/schemas/pull/806)). Flip Meshery's Go consumers from `v1beta1/connection` to the canonical-casing `v1beta3/connection`, reconcile the field-shape and wire-format shifts, and update fixtures and expected-output goldens for `mesheryctl connection` commands.

## Sites touched

| File | Count | Notes |
| --- | --- | --- |
| `mesheryctl/internal/cli/root/connections/connection.go` | 1 | import flip only |
| `mesheryctl/internal/cli/root/connections/list.go` | 1 | import flip only |
| `mesheryctl/internal/cli/root/connections/view.go` | 1 | import flip only |
| `server/models/connections/connections.go` | 1 | import flip; central alias hub (`connections.Connection`, `.ConnectionPage`, `.ConnectionStatus`) now resolves to v1beta3 for every downstream consumer |
| `server/models/connection_persister.go` | 1 | import flip + `StatusSummary` retype from `*map[ConnectionStatus]int` → `*map[ConnectionStatusValue]int` |
| `server/cmd/main.go` | 1 | drop `v1beta1/connection` import; use local `connections.MeshsyncDeploymentMode*` helpers |
| `server/handlers/connections_handlers.go` | 1 | same |
| `server/handlers/handler_instance.go` | 1 | same |
| `server/handlers/k8sconfig_handler.go` | 1 | same |
| `server/machines/kubernetes/connect.go` | 1 | same |
| `server/models/default_local_provider.go` | 1 | same |
| `server/models/meshery_controllers.go` | 1 | same |
| `server/models/remote_provider.go` | 1 | same |
| `server/models/connections/meshsync_deployment_mode.go` | **new** | 79 lines — MeshsyncDeploymentMode helpers ported verbatim from `schemas/v1beta1/connection/connection_helper.go` into Meshery-local |
| `server/models/connections/meshsync_deployment_mode_test.go` | **new** | 100 lines — the helper's test suite, ported verbatim |
| `mesheryctl/internal/cli/root/connections/fixtures/*.golden` | 9 | `page_size`→`pageSize`, `total_count`→`totalCount`, `sub_type`→`subType`, `created_at`→`createdAt`, `updated_at`→`updatedAt`, `deleted_at`→`deletedAt`, `user_id`→`userId` on every HTTP-mock response fixture |
| `mesheryctl/internal/cli/root/connections/testdata/view.connection.{output,yaml.output}.golden` | 2 | regenerated with `go test -update`: camelCase on emitted fields, plus v1beta3's `yaml:",omitempty"` on nullable fields drops `userId: null`, `deletedAt: null`, and empty `environments: []` from the YAML output |

**Total code sites affected: 13 Go files repointed** (8 of them drop the `v1beta1/connection` import entirely in favour of the local helper, 5 flip to `v1beta3/connection`). Original scope was 20 files; 7 are intentionally retained on v1beta1 — see _Known limitations_ below.

## Field renames and type shifts handled

Wire-form (JSON tags) canonicalised by v1beta3 for the `Connection` entity:

- `user_id` → `userId`
- `created_at` → `createdAt`
- `updated_at` → `updatedAt`
- `deleted_at` → `deletedAt`
- `credentialId` retained (was already camelCase in v1beta1)

For `ConnectionPage`:

- `page_size` → `pageSize`
- `total_count` → `totalCount`
- `status_summary` → `statusSummary`

And a Go-type narrowing that required a cascading reconciliation:

- `ConnectionPage.StatusSummary` retyped from `*map[ConnectionStatus]int` → `*map[ConnectionStatusValue]int`. Both types carry the same canonical string values, but the page envelope now speaks `ConnectionStatusValue`. Reworked `ConnectionPersister.getConnectionsStatusSummary` to build the map against the new type.

v1beta3 also adds `yaml:"...,omitempty"` on nullable fields on `Connection` (`userId`, `deletedAt`, `environments`). `mesheryctl connection view`'s YAML output therefore no longer emits those keys when nil/empty — the expected-output goldens are regenerated to reflect this.

## Local envelope canonicalisation

`server/models/connections/ConnectionsStatusPage` — a Meshery-local swagger stub referenced only from `server/handlers/doc.go`; nothing emits it at runtime. Its JSON tag is canonicalised `connections_status` → `connectionsStatus` to match the v1beta3 wire form. **No dual-emit MarshalJSON pair is added** because the struct is not actually serialised anywhere today; adding the machinery would have been a no-op. If a handler starts returning this envelope in future, the dual-emit pattern (mirroring `server/models/organization.go`) should be added then.

The other local struct — `server/models/connections/ConnectionPayload`, which IS wire-facing (Meshery → Meshery Cloud `SaveConnection`) — still carries snake_case `sub_type`, `credential_id`, `credential_secret`, and `skip_credential_verification` JSON tags. Canonicalising this would require a coordinated change on the Meshery Cloud consumer; it is explicitly out of scope for this PR and tracked under the broader connection-resource migration in `meshery/schemas` `docs/identifier-naming-migration.md` §9.

## MeshsyncDeploymentMode helpers move to meshery-local

The `MeshsyncDeploymentMode*` helpers (`MeshsyncDeploymentMode` type, four constants, `MeshsyncDeploymentModeFromString`, `MeshsyncDeploymentModeFromMetadata`, `SetMeshsyncDeploymentModeToMetadata`, and the `MeshsyncDeploymentModeMetadataKey` constant) previously lived at `github.com/meshery/schemas/models/v1beta1/connection/connection_helper.go`. They are Meshery domain logic — how the server decides whether to run meshsync in operator vs. embedded mode against a Kubernetes connection — and do not belong to the wire contract that v1beta3 canonicalises. The canonical-casing v1beta3 schema ships without this helper so schemas remain a pure wire-contract package.

Port the helpers (and their test suite) into `server/models/connections/meshsync_deployment_mode.go` + `_test.go` verbatim. This is what lets all eight MeshsyncDeploymentMode callers drop their `v1beta1/connection` import cleanly, rather than retaining a dual-version import pair indefinitely.

The metadata key string (`"meshsync_deployment_mode"`) is preserved as snake_case — it is persisted inside each connection's `Metadata` map and renaming it would break every existing connection already carrying the key. Wire-format canonicalisation does not apply to map-embedded keys.

## Known limitations (out-of-scope follow-up)

Seven files retain the `v1beta1/connection` import because `meshkit@v1.0.0` — an external dependency — still types its `RegisterEntity` function parameter and its `ModelDefinition.Registrant` field as `v1beta1/connection.Connection`. The current list:

- `server/models/meshmodel/core/register.go`
- `server/models/pattern/patterns/patterns.go`
- `server/models/pattern/stages/provision.go`
- `server/handlers/component_handler.go`
- `server/handlers/component_generation.go`
- `server/handlers/meshery_pattern_handler.go`
- `server/helpers/common_registry_logs.go`

Each of these either calls `registryManager.RegisterEntity(connection.Connection{...}, ...)` or reads `comp.Model.Registrant.Status` — both of which force the v1beta1 type at the Go signature boundary. Flipping them to v1beta3 fails to compile against the current meshkit dependency. Full v1beta3 migration for these call sites is tracked as a coordinated cross-repo change: meshkit bumps first, then these seven files follow. Filed under the connection migration DAG in `meshery/schemas` `docs/identifier-naming-migration.md` §11.

## Test plan

- [x] `cd server && go build ./...` — clean
- [x] `cd server && go test -count=1 -short ./...` — all packages green, including the new `server/models/connections` MeshsyncDeploymentMode tests (`TestMeshsyncDeploymentModeFromString`, `TestMeshsyncDeploymentModeFromMetadata`, `TestAddMeshsyncDeploymentModeToMetadata`)
- [x] `cd mesheryctl && go build ./...` — clean
- [x] `cd mesheryctl && go test -count=1 -short ./...` — all packages green; `TestConnectionListCmd` and `TestConnectionViewCmd` subtests all PASS on the updated fixtures + regenerated goldens
- [x] `cd mesheryctl && go vet ./...` — clean
- [x] `cd server && go vet ./...` — clean
- [x] No residual `v1beta1/connection` imports _outside_ the seven meshkit-constrained files (see limitations above)

## References

- schemas PR: [meshery/schemas#806](https://github.com/meshery/schemas/pull/806) — `feat(connection): v1beta3 canonical-casing schema + orgIdQuery on list`
- Phase 3 migration plan: [`docs/identifier-naming-migration.md`](https://github.com/meshery/schemas/blob/master/docs/identifier-naming-migration.md) §9
- Prior low-risk batch: #18886