### PR TITLE
chore(deps): bump meshkit to v1.0.5 + unblock master Docker build

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -49,7 +49,7 @@ require (
 	github.com/lib/pq v1.12.1
 	github.com/manifoldco/promptui v0.9.0
 	github.com/meshery/meshery-operator v0.8.11
-	github.com/meshery/meshkit v1.0.5-0.20260423195249-f01c33f65a0a
+	github.com/meshery/meshkit v1.0.5
 	github.com/meshery/meshsync v1.0.0
 	github.com/meshery/schemas v1.1.1-0.20260423191936-9b21d62d73e4
 	github.com/nsf/termbox-go v1.1.1

--- a/go.sum
+++ b/go.sum
@@ -1490,8 +1490,8 @@ github.com/maxatome/go-testdeep v1.14.0 h1:rRlLv1+kI8eOI3OaBXZwb3O7xY3exRzdW5QyX
 github.com/maxatome/go-testdeep v1.14.0/go.mod h1:lPZc/HAcJMP92l7yI6TRz1aZN5URwUBUAfUNvrclaNM=
 github.com/meshery/meshery-operator v0.8.11 h1:eDo2Sw0jjVrXsvvhF8LenADM58pK+7Z68ROPVIejTPc=
 github.com/meshery/meshery-operator v0.8.11/go.mod h1:hQEtFKKa5Fr/Mskk6bV5ip3bQ0+3F0u1voYS3XisBp4=
-github.com/meshery/meshkit v1.0.5-0.20260423195249-f01c33f65a0a h1:m0QUt4110XYAY7yqdv8TaK50InAmkCRBkY0zrj4oDno=
-github.com/meshery/meshkit v1.0.5-0.20260423195249-f01c33f65a0a/go.mod h1:KZTGytuDxOQTLULqFhb0sI8pi+lee2PDyWoUuR9rf6E=
+github.com/meshery/meshkit v1.0.5 h1:PgjIGZsn4KOp0pa2ROUId+vz58RmOOmlAWh+rrJ509M=
+github.com/meshery/meshkit v1.0.5/go.mod h1:WBQvfPZLp52vfX14aXs7u1TO/FZ1SYQnRo0B52Zae34=
 github.com/meshery/meshsync v1.0.0 h1:BIHEVG4BDjqOnSd3vBt9B4IfWJNTfMRAgdwLroBcCfY=
 github.com/meshery/meshsync v1.0.0/go.mod h1:mFsPXkZRiCSuk5DhxBTrkWdlo6peItRBUoIEEQCovIg=
 github.com/meshery/schemas v1.1.1-0.20260423191936-9b21d62d73e4 h1:SHaWs9uEBE/QzXg5TN3wcUvwMnEAY9KNbrGCpVqks2w=

--- a/server/models/connection_persister.go
+++ b/server/models/connection_persister.go
@@ -63,10 +63,15 @@ func (cp *ConnectionPersister) GetConnections(search, order string, page, pageSi
 
 	connectionsFetched := []*connections.Connection{}
 	query.Table("connections").Count(&count)
-	environmentsFetched := []*environments.EnvironmentData{}
 	Paginate(uint(page), uint(pageSize))(query).Find(&connectionsFetched)
 
 	for _, connectionFetched := range connectionsFetched {
+		// Declare a fresh slice per iteration so GORM's Find(&slice)
+		// populates a distinct underlying array for each connection. If
+		// the slice were hoisted out of the loop, all connections would
+		// end up sharing the same header and subsequent iterations would
+		// clobber earlier results.
+		environmentsFetched := []*environments.EnvironmentData{}
 		cp.DB.Table("environment_connection_mappings").Joins("LEFT JOIN environments ON environments.id = environment_connection_mappings.environment_id").Select("environments.*").
 			Where("connection_id = ?", connectionFetched.ID).
 			Find(&environmentsFetched)

--- a/server/models/environments/environment.go
+++ b/server/models/environments/environment.go
@@ -1,7 +1,7 @@
 package environments
 
 import (
-	schemasEnvironment "github.com/meshery/schemas/models/v1beta1/environment"
+	schemasEnvironment "github.com/meshery/schemas/models/v1beta3/environment"
 )
 
 type EnvironmentData = schemasEnvironment.Environment


### PR DESCRIPTION
## Summary

Two small, related fixes:

1. Bump \`github.com/meshery/meshkit\` from the commit-SHA pseudo-version \`v1.0.5-0.20260423195249-f01c33f65a0a\` to the tagged release \`v1.0.5\`.
2. Repair two master-level mismatches that left the Docker build red on every open PR:
   - \`server/models/environments/environment.go\` — \`EnvironmentData\` alias repointed from \`v1beta1/environment\` to \`v1beta3/environment\` (v1beta3/connection's \`Environments\` field is typed against v1beta3/environment after schemas PR #824).
   - \`server/models/connection_persister.go\` — move the \`environmentsFetched\` slice declaration inside the per-connection loop. GORM's \`Find(&slice)\` reuses the backing array, so hoisting the declaration caused every returned connection to share (and trample) the same environments slice.

## Why

- meshkit v1.0.5 is now the canonical tag corresponding to the bundled consumer-repoint work landed in PR #18894. Replacing the pseudo-version keeps \`go.mod\` readable and pins a reproducible semver.
- Until the two master-level fixes land, every PR's Docker build fails at the same line (\`connection_persister.go:74:36\`) regardless of PR content, masking any real breakages.

## Changes

- \`go.mod\`, \`go.sum\` — meshkit pin: pseudo-version → \`v1.0.5\`.
- \`server/models/environments/environment.go\` — alias flip to \`v1beta3/environment\`.
- \`server/models/connection_persister.go\` — per-iteration slice declaration + comment.

## Tests

\`go build ./...\` clean across \`server\` and \`mesheryctl\`.

## Docs / migration impact

Pure dependency bump + bug fix; no wire-format changes.

## Rollback

Revert this commit.

## Test plan

- [x] \`git commit -s\`
- [x] \`go build ./...\` green
- [ ] CI Docker build on this PR goes green (was red on every open PR; this closes the root cause)