### PR TITLE
fix(remote-provider,handlers): canonical camelCase wrapper keys + dual-accept on request bodies

### DIFF
--- a/server/handlers/meshery_pattern_handler.go
+++ b/server/handlers/meshery_pattern_handler.go
@@ -46,23 +46,103 @@ import (
 )
 
 // MesheryPatternRequestBody refers to the type of request body that
-// SaveMesheryPattern would receive
-// Deprecated
+// SaveMesheryPattern would receive. Canonical wire form for the
+// wrapper is `patternData` (camelCase) per the identifier-naming
+// migration; the legacy snake_case `pattern_data` spelling is still
+// dual-accepted via UnmarshalJSON for the deprecation window so
+// unmigrated clients keep working. Canonical wins when both are
+// present.
+//
+// Deprecated: retained for API compatibility; no live call site reads
+// this type today (POST /api/pattern decodes directly into
+// DesignPostPayload). Kept so external tooling that reflects on the
+// server package still finds the shape.
 type MesheryPatternPOSTRequestBody struct {
 	Name        string             `json:"name,omitempty"`
 	URL         string             `json:"url,omitempty"`
 	Path        string             `json:"path,omitempty"`
 	Save        bool               `json:"save,omitempty"`
-	PatternData *DesignPostPayload `json:"pattern_data,omitempty"`
+	PatternData *DesignPostPayload `json:"patternData,omitempty"`
 }
 
+// UnmarshalJSON dual-accepts the canonical camelCase `patternData`
+// and the legacy snake_case `pattern_data` wrapper keys for
+// PatternData. Canonical wins when both are present. Other fields
+// unmarshal via stdlib default rules through the embedded-alias
+// pattern; PatternData is explicitly re-zeroed before the precedence
+// switch so a reused receiver does not carry a stale pointer when
+// the next payload omits both spellings.
+func (p *MesheryPatternPOSTRequestBody) UnmarshalJSON(data []byte) error {
+	type alias MesheryPatternPOSTRequestBody
+	aux := &struct {
+		*alias
+		PatternDataCanonical *DesignPostPayload `json:"patternData,omitempty"`
+		PatternDataLegacy    *DesignPostPayload `json:"pattern_data,omitempty"`
+	}{alias: (*alias)(p)}
+	if err := json.Unmarshal(data, aux); err != nil {
+		return err
+	}
+	p.PatternData = nil
+	switch {
+	case aux.PatternDataCanonical != nil:
+		p.PatternData = aux.PatternDataCanonical
+	case aux.PatternDataLegacy != nil:
+		p.PatternData = aux.PatternDataLegacy
+	}
+	return nil
+}
+
+// MesheryPatternUPDATERequestBody is the request body for the pattern
+// UPDATE / save path handled by handlePatternUpdate. Canonical wire
+// form for both PatternData (`patternData`) and CytoscapeJSON
+// (`cytoscapeJSON`) is camelCase per the identifier-naming migration;
+// legacy snake_case spellings (`pattern_data`, `cytoscape_json`) are
+// dual-accepted via UnmarshalJSON for the deprecation window.
+// Canonical wins when both are present.
 type MesheryPatternUPDATERequestBody struct {
 	Name          string                 `json:"name,omitempty"`
 	URL           string                 `json:"url,omitempty"`
 	Path          string                 `json:"path,omitempty"`
 	Save          bool                   `json:"save,omitempty"`
-	PatternData   *models.MesheryPattern `json:"pattern_data,omitempty"`
-	CytoscapeJSON string                 `json:"cytoscape_json,omitempty"`
+	PatternData   *models.MesheryPattern `json:"patternData,omitempty"`
+	CytoscapeJSON string                 `json:"cytoscapeJSON,omitempty"`
+}
+
+// UnmarshalJSON dual-accepts the canonical camelCase keys
+// (`patternData`, `cytoscapeJSON`) and the legacy snake_case keys
+// (`pattern_data`, `cytoscape_json`) on the UPDATE request body.
+// Canonical wins when both are present for a given field. Other
+// fields unmarshal via stdlib default rules through the embedded-alias
+// pattern; PatternData and CytoscapeJSON are explicitly reset before
+// the precedence switches so a reused receiver does not carry stale
+// values when the next payload omits both spellings.
+func (p *MesheryPatternUPDATERequestBody) UnmarshalJSON(data []byte) error {
+	type alias MesheryPatternUPDATERequestBody
+	aux := &struct {
+		*alias
+		PatternDataCanonical   *models.MesheryPattern `json:"patternData,omitempty"`
+		PatternDataLegacy      *models.MesheryPattern `json:"pattern_data,omitempty"`
+		CytoscapeJSONCanonical *string                `json:"cytoscapeJSON,omitempty"`
+		CytoscapeJSONLegacy    *string                `json:"cytoscape_json,omitempty"`
+	}{alias: (*alias)(p)}
+	if err := json.Unmarshal(data, aux); err != nil {
+		return err
+	}
+	p.PatternData = nil
+	switch {
+	case aux.PatternDataCanonical != nil:
+		p.PatternData = aux.PatternDataCanonical
+	case aux.PatternDataLegacy != nil:
+		p.PatternData = aux.PatternDataLegacy
+	}
+	p.CytoscapeJSON = ""
+	switch {
+	case aux.CytoscapeJSONCanonical != nil:
+		p.CytoscapeJSON = *aux.CytoscapeJSONCanonical
+	case aux.CytoscapeJSONLegacy != nil:
+		p.CytoscapeJSON = *aux.CytoscapeJSONLegacy
+	}
+	return nil
 }
 
 // DesignPostPayload is the request body for POST /api/pattern. Canonical

--- a/server/handlers/meshery_pattern_handler_test.go
+++ b/server/handlers/meshery_pattern_handler_test.go
@@ -3,6 +3,8 @@ package handlers
 import (
 	"encoding/json"
 	"testing"
+
+	"github.com/meshery/meshery/server/models"
 )
 
 // buildDesignPostBody returns a JSON body that wraps a minimal PatternFile
@@ -225,3 +227,321 @@ func topLevelKeys(m map[string]json.RawMessage) []string {
 	}
 	return keys
 }
+
+// -----------------------------------------------------------------------------
+// MesheryPatternPOSTRequestBody wrapper-key dual-accept tests
+// -----------------------------------------------------------------------------
+
+// buildPatternPostBody returns a JSON body that wraps a minimal
+// DesignPostPayload (carrying a name) under the provided wrapper key.
+// Tests use the inner design name to assert which spelling "won" when
+// multiple spellings are present.
+func buildPatternPostBody(key, designName string) string {
+	inner := map[string]any{
+		"id":   "00000000-0000-0000-0000-000000000000",
+		"name": designName,
+	}
+	body := map[string]any{
+		"name": "envelope",
+		key:    inner,
+	}
+	out, err := json.Marshal(body)
+	if err != nil {
+		panic(err)
+	}
+	return string(out)
+}
+
+// buildPatternPostBodyMulti returns a JSON body with multiple wrapper
+// spellings present, each carrying a distinct inner name so precedence
+// tests can assert which spelling won.
+func buildPatternPostBodyMulti(entries map[string]string) string {
+	body := map[string]any{"name": "e"}
+	for key, innerName := range entries {
+		body[key] = map[string]any{
+			"id":   "00000000-0000-0000-0000-000000000000",
+			"name": innerName,
+		}
+	}
+	out, err := json.Marshal(body)
+	if err != nil {
+		panic(err)
+	}
+	return string(out)
+}
+
+// TestMesheryPatternPOSTRequestBody_UnmarshalAcceptsBothSpellings locks
+// in the deprecation-window contract for POST /api/pattern: the
+// handler accepts both the canonical `patternData` (camelCase) and the
+// legacy `pattern_data` (snake_case) wrapper keys.
+func TestMesheryPatternPOSTRequestBody_UnmarshalAcceptsBothSpellings(t *testing.T) {
+	cases := []struct {
+		name     string
+		body     string
+		wantName string
+	}{
+		{
+			name:     "canonical patternData only",
+			body:     buildPatternPostBody("patternData", "from-patternData"),
+			wantName: "from-patternData",
+		},
+		{
+			name:     "legacy pattern_data only",
+			body:     buildPatternPostBody("pattern_data", "from-pattern_data"),
+			wantName: "from-pattern_data",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			var got MesheryPatternPOSTRequestBody
+			if err := json.Unmarshal([]byte(tc.body), &got); err != nil {
+				t.Fatalf("unmarshal: %v", err)
+			}
+			if got.PatternData == nil {
+				t.Fatalf("PatternData is nil, want populated")
+			}
+			if got.PatternData.Name != tc.wantName {
+				t.Errorf("PatternData.Name = %q, want %q", got.PatternData.Name, tc.wantName)
+			}
+		})
+	}
+}
+
+// TestMesheryPatternPOSTRequestBody_UnmarshalPrecedenceCanonicalWins
+// locks the canonical-wins rule: when both `patternData` and
+// `pattern_data` are present in one payload, the canonical camelCase
+// spelling wins. Migrating clients temporarily emit both.
+func TestMesheryPatternPOSTRequestBody_UnmarshalPrecedenceCanonicalWins(t *testing.T) {
+	body := buildPatternPostBodyMulti(map[string]string{
+		"patternData":  "canonical",
+		"pattern_data": "legacy",
+	})
+	var got MesheryPatternPOSTRequestBody
+	if err := json.Unmarshal([]byte(body), &got); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if got.PatternData == nil {
+		t.Fatalf("PatternData is nil, want canonical")
+	}
+	if got.PatternData.Name != "canonical" {
+		t.Errorf("PatternData.Name = %q, want %q (precedence violated)", got.PatternData.Name, "canonical")
+	}
+}
+
+// TestMesheryPatternPOSTRequestBody_UnmarshalAbsentZeroes verifies that
+// a payload omitting both wrapper spellings leaves PatternData nil
+// without returning an error, matching stdlib json.Unmarshal behavior.
+func TestMesheryPatternPOSTRequestBody_UnmarshalAbsentZeroes(t *testing.T) {
+	var got MesheryPatternPOSTRequestBody
+	if err := json.Unmarshal([]byte(`{"name":"envelope-only"}`), &got); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if got.Name != "envelope-only" {
+		t.Errorf("Name = %q, want %q", got.Name, "envelope-only")
+	}
+	if got.PatternData != nil {
+		t.Errorf("PatternData = %+v, want nil", got.PatternData)
+	}
+}
+
+// TestMesheryPatternPOSTRequestBody_UnmarshalResetsOnReuse locks in
+// stdlib json.Unmarshal semantics across decodes: when a single
+// MesheryPatternPOSTRequestBody is reused, PatternData must reset to
+// nil if the next payload omits both spellings — otherwise stale
+// design data leaks across requests.
+func TestMesheryPatternPOSTRequestBody_UnmarshalResetsOnReuse(t *testing.T) {
+	var p MesheryPatternPOSTRequestBody
+	first := buildPatternPostBody("patternData", "first-design")
+	if err := json.Unmarshal([]byte(first), &p); err != nil {
+		t.Fatalf("first unmarshal: %v", err)
+	}
+	if p.PatternData == nil || p.PatternData.Name != "first-design" {
+		t.Fatalf("prime decode wrong: %+v", p.PatternData)
+	}
+	if err := json.Unmarshal([]byte(`{"name":"second-envelope"}`), &p); err != nil {
+		t.Fatalf("second unmarshal: %v", err)
+	}
+	if p.PatternData != nil {
+		t.Errorf("PatternData leaked stale value %+v across reuse", p.PatternData)
+	}
+	if p.Name != "second-envelope" {
+		t.Errorf("Name = %q, want %q", p.Name, "second-envelope")
+	}
+}
+
+// -----------------------------------------------------------------------------
+// MesheryPatternUPDATERequestBody wrapper-key dual-accept tests
+// -----------------------------------------------------------------------------
+
+// buildPatternUpdateBody returns a JSON body for PUT /api/pattern.
+// The MesheryPattern wrapped under patternKey carries a name; the
+// cytoscape payload is wrapped under cytoscapeKey as a plain string.
+// Empty key strings skip emitting that wrapper.
+func buildPatternUpdateBody(patternKey, patternName, cytoscapeKey, cytoscapeVal string) string {
+	body := map[string]any{
+		"name": "envelope",
+		"url":  "",
+	}
+	if patternKey != "" {
+		body[patternKey] = map[string]any{
+			"id":   "00000000-0000-0000-0000-000000000000",
+			"name": patternName,
+		}
+	}
+	if cytoscapeKey != "" {
+		body[cytoscapeKey] = cytoscapeVal
+	}
+	out, err := json.Marshal(body)
+	if err != nil {
+		panic(err)
+	}
+	return string(out)
+}
+
+// TestMesheryPatternUPDATERequestBody_UnmarshalPatternDataAcceptsBothSpellings
+// locks in the dual-accept contract on PatternData for PUT /api/pattern.
+func TestMesheryPatternUPDATERequestBody_UnmarshalPatternDataAcceptsBothSpellings(t *testing.T) {
+	cases := []struct {
+		name     string
+		body     string
+		wantName string
+	}{
+		{
+			name:     "canonical patternData only",
+			body:     buildPatternUpdateBody("patternData", "from-patternData", "", ""),
+			wantName: "from-patternData",
+		},
+		{
+			name:     "legacy pattern_data only",
+			body:     buildPatternUpdateBody("pattern_data", "from-pattern_data", "", ""),
+			wantName: "from-pattern_data",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			var got MesheryPatternUPDATERequestBody
+			if err := json.Unmarshal([]byte(tc.body), &got); err != nil {
+				t.Fatalf("unmarshal: %v", err)
+			}
+			if got.PatternData == nil {
+				t.Fatalf("PatternData is nil, want populated")
+			}
+			if got.PatternData.Name != tc.wantName {
+				t.Errorf("PatternData.Name = %q, want %q", got.PatternData.Name, tc.wantName)
+			}
+		})
+	}
+}
+
+// TestMesheryPatternUPDATERequestBody_UnmarshalCytoscapeAcceptsBothSpellings
+// locks in the dual-accept contract on CytoscapeJSON for PUT /api/pattern.
+func TestMesheryPatternUPDATERequestBody_UnmarshalCytoscapeAcceptsBothSpellings(t *testing.T) {
+	cases := []struct {
+		name string
+		body string
+		want string
+	}{
+		{
+			name: "canonical cytoscapeJSON only",
+			body: buildPatternUpdateBody("", "", "cytoscapeJSON", "graph-canonical"),
+			want: "graph-canonical",
+		},
+		{
+			name: "legacy cytoscape_json only",
+			body: buildPatternUpdateBody("", "", "cytoscape_json", "graph-legacy"),
+			want: "graph-legacy",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			var got MesheryPatternUPDATERequestBody
+			if err := json.Unmarshal([]byte(tc.body), &got); err != nil {
+				t.Fatalf("unmarshal: %v", err)
+			}
+			if got.CytoscapeJSON != tc.want {
+				t.Errorf("CytoscapeJSON = %q, want %q", got.CytoscapeJSON, tc.want)
+			}
+		})
+	}
+}
+
+// TestMesheryPatternUPDATERequestBody_UnmarshalPrecedenceCanonicalWins
+// locks the canonical-wins rule: when both spellings are present on
+// either field, the camelCase spelling wins.
+func TestMesheryPatternUPDATERequestBody_UnmarshalPrecedenceCanonicalWins(t *testing.T) {
+	raw, err := json.Marshal(map[string]any{
+		"name":           "envelope",
+		"patternData":    map[string]any{"id": "00000000-0000-0000-0000-000000000000", "name": "canonical"},
+		"pattern_data":   map[string]any{"id": "00000000-0000-0000-0000-000000000000", "name": "legacy"},
+		"cytoscapeJSON":  "canonical-graph",
+		"cytoscape_json": "legacy-graph",
+	})
+	if err != nil {
+		t.Fatalf("marshal input: %v", err)
+	}
+	var got MesheryPatternUPDATERequestBody
+	if err := json.Unmarshal(raw, &got); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if got.PatternData == nil || got.PatternData.Name != "canonical" {
+		t.Errorf("PatternData = %+v, want name=%q", got.PatternData, "canonical")
+	}
+	if got.CytoscapeJSON != "canonical-graph" {
+		t.Errorf("CytoscapeJSON = %q, want %q", got.CytoscapeJSON, "canonical-graph")
+	}
+}
+
+// TestMesheryPatternUPDATERequestBody_UnmarshalAbsentZeroes verifies that
+// a payload containing neither PatternData spelling nor either
+// CytoscapeJSON spelling leaves both fields at zero values without
+// returning an error.
+func TestMesheryPatternUPDATERequestBody_UnmarshalAbsentZeroes(t *testing.T) {
+	var got MesheryPatternUPDATERequestBody
+	if err := json.Unmarshal([]byte(`{"name":"envelope-only"}`), &got); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if got.Name != "envelope-only" {
+		t.Errorf("Name = %q, want %q", got.Name, "envelope-only")
+	}
+	if got.PatternData != nil {
+		t.Errorf("PatternData = %+v, want nil", got.PatternData)
+	}
+	if got.CytoscapeJSON != "" {
+		t.Errorf("CytoscapeJSON = %q, want empty", got.CytoscapeJSON)
+	}
+}
+
+// TestMesheryPatternUPDATERequestBody_UnmarshalResetsOnReuse locks in
+// reuse semantics: a reused MesheryPatternUPDATERequestBody must reset
+// PatternData to nil and CytoscapeJSON to "" when the next payload
+// omits both spellings.
+func TestMesheryPatternUPDATERequestBody_UnmarshalResetsOnReuse(t *testing.T) {
+	var p MesheryPatternUPDATERequestBody
+	first := buildPatternUpdateBody("patternData", "first-design", "cytoscapeJSON", "first-graph")
+	if err := json.Unmarshal([]byte(first), &p); err != nil {
+		t.Fatalf("first unmarshal: %v", err)
+	}
+	if p.PatternData == nil || p.PatternData.Name != "first-design" {
+		t.Fatalf("prime decode PatternData wrong: %+v", p.PatternData)
+	}
+	if p.CytoscapeJSON != "first-graph" {
+		t.Fatalf("prime decode CytoscapeJSON = %q, want %q", p.CytoscapeJSON, "first-graph")
+	}
+	if err := json.Unmarshal([]byte(`{"name":"second-envelope"}`), &p); err != nil {
+		t.Fatalf("second unmarshal: %v", err)
+	}
+	if p.PatternData != nil {
+		t.Errorf("PatternData leaked stale value %+v across reuse", p.PatternData)
+	}
+	if p.CytoscapeJSON != "" {
+		t.Errorf("CytoscapeJSON leaked stale value %q across reuse", p.CytoscapeJSON)
+	}
+	if p.Name != "second-envelope" {
+		t.Errorf("Name = %q, want %q", p.Name, "second-envelope")
+	}
+}
+
+// Compile-time type reference: pulls models into the test graph so the
+// MesheryPattern field type resolves without introducing import churn
+// if the test file grows additional model-backed cases later.
+var _ = models.MesheryPattern{}

--- a/server/models/meshery_filter.go
+++ b/server/models/meshery_filter.go
@@ -1,6 +1,7 @@
 package models
 
 import (
+	"encoding/json"
 	"time"
 
 	"github.com/meshery/meshery/server/internal/sql"
@@ -57,13 +58,56 @@ type MesheryCloneFilterRequestBody struct {
 }
 
 // MesheryFilterRequestBody refers to the type of request body that
-// SaveMesheryFilter would receive
+// SaveMesheryFilter would receive. Canonical wire form for the
+// wrapper is `filterData` (camelCase) per the identifier-naming
+// migration; the legacy snake_case `filter_data` spelling is still
+// dual-accepted via UnmarshalJSON for the deprecation window because
+// the existing UI (MesheryFilters/Filters.tsx) and the outbound
+// remote-provider call still emit `filter_data`. Canonical wins when
+// both are present.
+//
+// Note: the outbound wrapper in remote_provider.SaveMesheryFilter
+// continues to emit `filter_data` because meshery-cloud's
+// MesheryFilterRequestBody (server/handlers/meshery_filters.go:29)
+// has not yet been migrated to accept `filterData`. Flipping the
+// outbound without cloud dual-accept would silently drop the payload
+// (encoding/json does not match `filterData` to a `filter_data`
+// tag even case-insensitively — the underscore is significant). That
+// cross-repo coordination is tracked as part of the per-resource
+// Phase 3 migration for filter.
 type MesheryFilterRequestBody struct {
 	URL        string                `json:"url,omitempty"`
 	Path       string                `json:"path,omitempty"`
 	Save       bool                  `json:"save,omitempty"`
 	Config     string                `json:"config,omitempty"`
-	FilterData *MesheryFilterPayload `json:"filter_data,omitempty"`
+	FilterData *MesheryFilterPayload `json:"filterData,omitempty"`
+}
+
+// UnmarshalJSON dual-accepts the canonical camelCase `filterData`
+// and the legacy snake_case `filter_data` wrapper keys for
+// FilterData. Canonical wins when both are present. Other fields
+// unmarshal via stdlib default rules through the embedded-alias
+// pattern; FilterData is explicitly re-zeroed before the precedence
+// switch so a reused receiver does not carry a stale pointer when
+// the next payload omits both spellings.
+func (p *MesheryFilterRequestBody) UnmarshalJSON(data []byte) error {
+	type alias MesheryFilterRequestBody
+	aux := &struct {
+		*alias
+		FilterDataCanonical *MesheryFilterPayload `json:"filterData,omitempty"`
+		FilterDataLegacy    *MesheryFilterPayload `json:"filter_data,omitempty"`
+	}{alias: (*alias)(p)}
+	if err := json.Unmarshal(data, aux); err != nil {
+		return err
+	}
+	p.FilterData = nil
+	switch {
+	case aux.FilterDataCanonical != nil:
+		p.FilterData = aux.FilterDataCanonical
+	case aux.FilterDataLegacy != nil:
+		p.FilterData = aux.FilterDataLegacy
+	}
+	return nil
 }
 
 // GetFilterName takes in a stringified filterfile and extracts the name from it

--- a/server/models/meshery_filter_test.go
+++ b/server/models/meshery_filter_test.go
@@ -1,0 +1,145 @@
+package models
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+// buildFilterRequestBody returns a JSON body wrapping a minimal
+// MesheryFilterPayload (carrying a name) under the provided wrapper
+// key. The inner name lets tests assert which spelling "won" when
+// multiple spellings are present.
+func buildFilterRequestBody(key, filterName string) string {
+	body := map[string]any{
+		"url":  "",
+		"save": false,
+	}
+	if key != "" {
+		body[key] = map[string]any{
+			"id":   "00000000-0000-0000-0000-000000000000",
+			"name": filterName,
+		}
+	}
+	out, err := json.Marshal(body)
+	if err != nil {
+		panic(err)
+	}
+	return string(out)
+}
+
+// buildFilterRequestBodyMulti returns a JSON body with multiple
+// wrapper spellings present, each carrying a distinct inner name so
+// precedence tests can assert which spelling won.
+func buildFilterRequestBodyMulti(entries map[string]string) string {
+	body := map[string]any{"url": ""}
+	for key, innerName := range entries {
+		body[key] = map[string]any{
+			"id":   "00000000-0000-0000-0000-000000000000",
+			"name": innerName,
+		}
+	}
+	out, err := json.Marshal(body)
+	if err != nil {
+		panic(err)
+	}
+	return string(out)
+}
+
+// TestMesheryFilterRequestBody_UnmarshalAcceptsBothSpellings locks in
+// the deprecation-window contract for POST /api/filter: the handler
+// accepts both the canonical `filterData` (camelCase) and the legacy
+// `filter_data` (snake_case) wrapper keys.
+func TestMesheryFilterRequestBody_UnmarshalAcceptsBothSpellings(t *testing.T) {
+	cases := []struct {
+		name     string
+		body     string
+		wantName string
+	}{
+		{
+			name:     "canonical filterData only",
+			body:     buildFilterRequestBody("filterData", "from-filterData"),
+			wantName: "from-filterData",
+		},
+		{
+			name:     "legacy filter_data only",
+			body:     buildFilterRequestBody("filter_data", "from-filter_data"),
+			wantName: "from-filter_data",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			var got MesheryFilterRequestBody
+			if err := json.Unmarshal([]byte(tc.body), &got); err != nil {
+				t.Fatalf("unmarshal: %v", err)
+			}
+			if got.FilterData == nil {
+				t.Fatalf("FilterData is nil, want populated")
+			}
+			if got.FilterData.Name != tc.wantName {
+				t.Errorf("FilterData.Name = %q, want %q", got.FilterData.Name, tc.wantName)
+			}
+		})
+	}
+}
+
+// TestMesheryFilterRequestBody_UnmarshalPrecedenceCanonicalWins locks
+// the canonical-wins rule: when both spellings are present on
+// FilterData, the camelCase spelling wins. Migrating clients may
+// temporarily emit both.
+func TestMesheryFilterRequestBody_UnmarshalPrecedenceCanonicalWins(t *testing.T) {
+	body := buildFilterRequestBodyMulti(map[string]string{
+		"filterData":  "canonical",
+		"filter_data": "legacy",
+	})
+	var got MesheryFilterRequestBody
+	if err := json.Unmarshal([]byte(body), &got); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if got.FilterData == nil {
+		t.Fatalf("FilterData is nil, want canonical")
+	}
+	if got.FilterData.Name != "canonical" {
+		t.Errorf("FilterData.Name = %q, want %q (precedence violated)", got.FilterData.Name, "canonical")
+	}
+}
+
+// TestMesheryFilterRequestBody_UnmarshalAbsentZeroes verifies that a
+// payload omitting both wrapper spellings leaves FilterData nil
+// without returning an error, matching stdlib json.Unmarshal.
+func TestMesheryFilterRequestBody_UnmarshalAbsentZeroes(t *testing.T) {
+	var got MesheryFilterRequestBody
+	if err := json.Unmarshal([]byte(`{"url":"https://example.com"}`), &got); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if got.URL != "https://example.com" {
+		t.Errorf("URL = %q, want %q", got.URL, "https://example.com")
+	}
+	if got.FilterData != nil {
+		t.Errorf("FilterData = %+v, want nil", got.FilterData)
+	}
+}
+
+// TestMesheryFilterRequestBody_UnmarshalResetsOnReuse locks in stdlib
+// json.Unmarshal semantics across decodes: a reused
+// MesheryFilterRequestBody must reset FilterData to nil if the next
+// payload omits both spellings — otherwise stale filter data leaks
+// across requests.
+func TestMesheryFilterRequestBody_UnmarshalResetsOnReuse(t *testing.T) {
+	var p MesheryFilterRequestBody
+	first := buildFilterRequestBody("filterData", "first-filter")
+	if err := json.Unmarshal([]byte(first), &p); err != nil {
+		t.Fatalf("first unmarshal: %v", err)
+	}
+	if p.FilterData == nil || p.FilterData.Name != "first-filter" {
+		t.Fatalf("prime decode wrong: %+v", p.FilterData)
+	}
+	if err := json.Unmarshal([]byte(`{"url":"https://second"}`), &p); err != nil {
+		t.Fatalf("second unmarshal: %v", err)
+	}
+	if p.FilterData != nil {
+		t.Errorf("FilterData leaked stale value %+v across reuse", p.FilterData)
+	}
+	if p.URL != "https://second" {
+		t.Errorf("URL = %q, want %q", p.URL, "https://second")
+	}
+}

--- a/server/models/remote_provider.go
+++ b/server/models/remote_provider.go
@@ -2161,8 +2161,17 @@ func (l *RemoteProvider) SaveMesheryPattern(tokenString string, pattern *Meshery
 
 	ep, _ := l.Capabilities.GetEndpointForFeature(PersistMesheryPatterns)
 
+	// Wrapper key is `patternData` (camelCase) to match the canonical
+	// schema contract published in meshery/schemas and consumed by
+	// meshery-cloud's MesheryPatternRequestBody, whose `PatternData`
+	// field carries the tag `json:"patternData,omitempty"` (see
+	// meshery-cloud commit 5d6f13e1b12, server/handlers/meshery_patterns.go:144).
+	// PR #18855 regressed this to `pattern_data`, which encoding/json
+	// does NOT match against a `patternData` tag (case-insensitive tag
+	// fallback does not bridge the underscore) — so remote-provider
+	// pattern creation silently dropped the payload until this revert.
 	data, err := json.Marshal(map[string]interface{}{
-		"pattern_data": pattern,
+		"patternData": pattern,
 		"save":        true,
 	})
 


### PR DESCRIPTION
## Summary

This PR reverts the `patternData` → `pattern_data` regression introduced in PR #18855 and expands the alignment to sibling handler request bodies, ensuring the Meshery server's wire contract for pattern / filter write paths uses the canonical camelCase identifier-naming migration form. Every flipped inbound struct grows a custom `UnmarshalJSON` that dual-accepts both spellings during the deprecation window (canonical wins when both present).

**Canonical reference:** meshery-cloud's `MesheryPatternRequestBody` (`layer5io/meshery-cloud/server/handlers/meshery_patterns.go:144`), whose `PatternData` field carries `json:"patternData,omitempty"` — documented in that repo's commit `5d6f13e1b12` as "intentionally `patternData` to match the canonical schema contract published in meshery/schemas."

## Why this was broken on master today

`encoding/json` matches JSON keys against struct tags **exactly**, then case-insensitively against **the tag** — not against the Go field name. A `patternData` tag will not match a `pattern_data` wire key (the underscore defeats the case-insensitive tag fallback). So after PR #18855 flipped `server/models/remote_provider.go:2165` from `patternData` to `pattern_data`, meshery-cloud silently dropped the entire pattern body on every `SaveMesheryPattern` call — the reviewer feedback that motivated #18855 was predicated on the incorrect assumption that Go's JSON decoder would fall back to the Go field name, which it does not.

## Per-key before / after

### Outbound wrapper key (`server/models/remote_provider.go`)

| Field | Before (master) | After |
|---|---|---|
| `SaveMesheryPattern` wrapper | `"pattern_data"` | `"patternData"` |

Scope decision: `"filter_data"` in `SaveMesheryFilter` and `SaveMesheryFilterResource` is deliberately **not** flipped here. meshery-cloud's `MesheryFilterRequestBody` still tags `FilterData` as `filter_data` (`server/handlers/meshery_filters.go:29`) and has no dual-accept. Flipping meshery's outbound to `filterData` without cloud migrating first would silently drop the payload for the same underscore-fallback reason documented above. That cross-repo coordination belongs in the per-resource Phase 3 migration for filter (meshery-cloud-side dual-accept lands first, then the meshery outbound flip). There is no `application_data` call site to flip — the meshery application handler is fully commented out and the cloud application routes are retired.

### Inbound request-body struct tags + dual-accept

| Struct.Field | Tag before | Tag after | Dual-accept on Unmarshal |
|---|---|---|---|
| `MesheryPatternPOSTRequestBody.PatternData` | `pattern_data` | `patternData` | + `pattern_data` |
| `MesheryPatternUPDATERequestBody.PatternData` | `pattern_data` | `patternData` | + `pattern_data` |
| `MesheryPatternUPDATERequestBody.CytoscapeJSON` | `cytoscape_json` | `cytoscapeJSON` | + `cytoscape_json` |
| `MesheryFilterRequestBody.FilterData` | `filter_data` | `filterData` | + `filter_data` |

Every dual-accept `UnmarshalJSON`:

- uses the embedded-alias pattern established on `DesignPostPayload` (same file, same idiom) so every non-custom field unmarshals via stdlib default rules — only the renamed key's precedence is custom-handled;
- explicitly re-zeros the custom-handled field before the precedence switch so a reused receiver does not carry stale data when the next payload omits both spellings;
- applies canonical-wins precedence when both spellings are present.

Note: `MesheryPatternPOSTRequestBody` is declared but not read by any live handler today (`POST /api/pattern` decodes directly into `DesignPostPayload`). The tag flip + `UnmarshalJSON` are retained per task directive and the type is now explicitly marked as deprecated / candidate for deletion in a follow-up. `MesheryPatternUPDATERequestBody` is actively used by `handlePatternUpdate` on `POST/PUT /api/pattern/{sourcetype}` and `MesheryFilterRequestBody` is actively used by the filter save handler — both flips matter on the live path.

## Files touched

- `server/models/remote_provider.go` — flip `"pattern_data"` → `"patternData"` on the `SaveMesheryPattern` outbound wrapper + comment documenting the cloud contract.
- `server/handlers/meshery_pattern_handler.go` — flip tags on `MesheryPatternPOSTRequestBody.PatternData` and `MesheryPatternUPDATERequestBody.{PatternData,CytoscapeJSON}`; add dual-accept `UnmarshalJSON` on both structs.
- `server/handlers/meshery_pattern_handler_test.go` — nine new sub-tests covering both dual-accept contracts (see below).
- `server/models/meshery_filter.go` — flip tag on `MesheryFilterRequestBody.FilterData`; add dual-accept `UnmarshalJSON`; document the Phase 3 cross-repo dependency for the outbound filter flip.
- `server/models/meshery_filter_test.go` (new) — four new dual-accept tests for the filter request body.

## Test plan

- [x] `go build ./...` clean across `server` and `mesheryctl`.
- [x] `go test -count=1 -short ./handlers/... ./models/...` — all tests pass including the new dual-accept suites.
- [x] `go vet ./server/...` clean.
- [x] New regression tests (all passing):
  - `TestMesheryPatternPOSTRequestBody_UnmarshalAcceptsBothSpellings` (canonical + legacy)
  - `TestMesheryPatternPOSTRequestBody_UnmarshalPrecedenceCanonicalWins`
  - `TestMesheryPatternPOSTRequestBody_UnmarshalAbsentZeroes`
  - `TestMesheryPatternPOSTRequestBody_UnmarshalResetsOnReuse`
  - `TestMesheryPatternUPDATERequestBody_UnmarshalPatternDataAcceptsBothSpellings` (canonical + legacy)
  - `TestMesheryPatternUPDATERequestBody_UnmarshalCytoscapeAcceptsBothSpellings` (canonical + legacy)
  - `TestMesheryPatternUPDATERequestBody_UnmarshalPrecedenceCanonicalWins`
  - `TestMesheryPatternUPDATERequestBody_UnmarshalAbsentZeroes`
  - `TestMesheryPatternUPDATERequestBody_UnmarshalResetsOnReuse`
  - `TestMesheryFilterRequestBody_UnmarshalAcceptsBothSpellings` (canonical + legacy)
  - `TestMesheryFilterRequestBody_UnmarshalPrecedenceCanonicalWins`
  - `TestMesheryFilterRequestBody_UnmarshalAbsentZeroes`
  - `TestMesheryFilterRequestBody_UnmarshalResetsOnReuse`
- [x] Existing `DesignPostPayload` test family still passes — no regression in the design-file dual-accept contract.

## Related

- Reverts regression introduced in #18855 (`server/models/remote_provider.go:2165`).
- Canonical reference: `meshery-cloud` commit `5d6f13e1b12` and the `MesheryPatternRequestBody` at `layer5io/meshery-cloud/server/handlers/meshery_patterns.go:144`.
- Tracks the identifier-naming migration (`meshery/schemas` Phase 3) for pattern; the filter outbound flip is queued for a coordinated cross-repo follow-up.