### PR TITLE
chore(remote-provider): flip outbound filter_data → filterData

### DIFF
--- a/server/models/remote_provider.go
+++ b/server/models/remote_provider.go
@@ -2790,8 +2790,8 @@ func (l *RemoteProvider) SaveMesheryFilter(tokenString string, filter *MesheryFi
 	ep, _ := l.Capabilities.GetEndpointForFeature(PersistMesheryFilters)
 
 	data, err := json.Marshal(map[string]interface{}{
-		"filter_data": filter,
-		"save":        true,
+		"filterData": filter,
+		"save":       true,
 	})
 
 	if err != nil {
@@ -3255,7 +3255,7 @@ func (l *RemoteProvider) RemoteFilterFile(req *http.Request, resourceURL, path s
 		"url":  resourceURL,
 		"save": save,
 		"path": path,
-		"filter_data": MesheryFilter{
+		"filterData": MesheryFilter{
 			FilterResource: resource,
 		},
 	})


### PR DESCRIPTION
Follow-up to meshery/meshery#18900. Flips the 2 outbound 'filter_data' wrapper keys in remote_provider.go to canonical 'filterData'. Safe now that meshery-cloud#5090 merged with dual-accept on the receiver.