### PR TITLE
chore(deps): pin schemas v1.1.1 (drop pseudo-version)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -51,7 +51,7 @@ require (
 	github.com/meshery/meshery-operator v0.8.11
 	github.com/meshery/meshkit v1.0.5
 	github.com/meshery/meshsync v1.0.0
-	github.com/meshery/schemas v1.1.1-0.20260423191936-9b21d62d73e4
+	github.com/meshery/schemas v1.1.1
 	github.com/nsf/termbox-go v1.1.1
 	github.com/oapi-codegen/runtime v1.3.1
 	github.com/olekukonko/tablewriter v1.1.0

--- a/go.sum
+++ b/go.sum
@@ -1494,8 +1494,8 @@ github.com/meshery/meshkit v1.0.5 h1:PgjIGZsn4KOp0pa2ROUId+vz58RmOOmlAWh+rrJ509M
 github.com/meshery/meshkit v1.0.5/go.mod h1:WBQvfPZLp52vfX14aXs7u1TO/FZ1SYQnRo0B52Zae34=
 github.com/meshery/meshsync v1.0.0 h1:BIHEVG4BDjqOnSd3vBt9B4IfWJNTfMRAgdwLroBcCfY=
 github.com/meshery/meshsync v1.0.0/go.mod h1:mFsPXkZRiCSuk5DhxBTrkWdlo6peItRBUoIEEQCovIg=
-github.com/meshery/schemas v1.1.1-0.20260423191936-9b21d62d73e4 h1:SHaWs9uEBE/QzXg5TN3wcUvwMnEAY9KNbrGCpVqks2w=
-github.com/meshery/schemas v1.1.1-0.20260423191936-9b21d62d73e4/go.mod h1:UrkQFIKza3S3CuLR9yKt5a7xZW3ksSVd6N0yUdhvhRE=
+github.com/meshery/schemas v1.1.1 h1:mtSSv32Ml+eIOZ/f2BgvFN8JhxMk0RWQLrSPFu2FvN4=
+github.com/meshery/schemas v1.1.1/go.mod h1:UrkQFIKza3S3CuLR9yKt5a7xZW3ksSVd6N0yUdhvhRE=
 github.com/miekg/dns v1.1.57 h1:Jzi7ApEIzwEPLHWRcafCN9LZSBbqQpxjt/wpgvg7wcM=
 github.com/miekg/dns v1.1.57/go.mod h1:uqRjCRUuEAA6qsOiJvDd+CFo/vW+y5WR6SNmHE55hZk=
 github.com/miekg/pkcs11 v1.0.2/go.mod h1:XsNlhZGX73bx86s2hdc/FuaLm2CPZJemRLMA+WTFxgs=


### PR DESCRIPTION
## Summary

- Replaces the transitional pseudo-version pin `v1.1.1-0.20260423191936-9b21d62d73e4` with the clean `v1.1.1` semver tag.
- No-op content bump — the pseudo-version already pointed at v1.1.1's source tree, so module contents are unchanged.
- Part of a three-repo coordinated pin bump (this PR + `meshery/meshery-cloud` + `layer5labs/meshery-extensions`) now that `meshery/schemas` v1.1.1 is tagged.

## Test plan

- [x] `go get github.com/meshery/schemas@v1.1.1`
- [x] `go mod tidy`
- [x] `go build ./...` (clean)
- [x] `go test -count=1 -short ./...` — all packages pass except `TestSaveMesheryPattern_SendsPatternDataWrapperKey` in `server/models`, which is a **pre-existing Phase 3 canonical-casing drift** that also fails on `upstream/master` without this bump (verified via `git stash && go test` on master). Out of scope for a go.mod-only PR; being handled under a separate `fix/canonical-camelcase-wrapper-keys` branch.