### PR TITLE
Correctly name api end point resources based on normalised tags 

### DIFF
--- a/docs/layouts/rest-apis/single.html
+++ b/docs/layouts/rest-apis/single.html
@@ -100,6 +100,8 @@
   {{ $resolvedLabel := $baseLabel }}
   {{ if gt (index $baseTagLabelCounts $baseLabel | default 0) 1 }}
     {{ $parts := split $tagName "_" }}
+    {{ $suffixParts := after 1 $parts }}
+    {{ $suffixLabel := delimit $suffixParts " " }}
     {{ if ne $suffixLabel "" }}
       {{ $suffixLabel = $suffixLabel | title }}
     {{ end }}

--- a/docs/layouts/rest-apis/single.html
+++ b/docs/layouts/rest-apis/single.html
@@ -83,12 +83,36 @@
   {{ end }}
 {{ end }}
 
-{{ $sortedTagEntries := slice }}
+{{ $baseTagLabels := dict }}
+{{ $baseTagLabelCounts := dict }}
 {{ range $tagName := $orderedTags }}
   {{ $tagMeta := partial "rest-apis/tag-meta.html" (dict "name" $tagName "tags" $tagIndex) }}
+  {{ $baseLabel := index $tagMeta "label" | default "Ungrouped" }}
+  {{ $baseTagLabels = merge $baseTagLabels (dict $tagName $baseLabel) }}
+  {{ $baseCount := index $baseTagLabelCounts $baseLabel | default 0 }}
+  {{ $baseTagLabelCounts = merge $baseTagLabelCounts (dict $baseLabel (add $baseCount 1)) }}
+{{ end }}
+
+{{ $tagLabels := dict }}
+{{ $sortedTagEntries := slice }}
+{{ range $tagName := $orderedTags }}
+  {{ $baseLabel := index $baseTagLabels $tagName | default "Ungrouped" }}
+  {{ $resolvedLabel := $baseLabel }}
+  {{ if gt (index $baseTagLabelCounts $baseLabel | default 0) 1 }}
+    {{ $parts := split $tagName "_" }}
+    {{ $suffix := index $parts (sub (len $parts) 1) | default $tagName }}
+    {{ $suffixLabel := replace $suffix "_" " " }}
+    {{ if ne $suffixLabel "" }}
+      {{ $suffixLabel = $suffixLabel | title }}
+    {{ end }}
+    {{ if and (ne $suffixLabel "") (ne (lower $suffixLabel) (lower $baseLabel)) }}
+      {{ $resolvedLabel = printf "%s %s" $baseLabel $suffixLabel }}
+    {{ end }}
+  {{ end }}
+  {{ $tagLabels = merge $tagLabels (dict $tagName $resolvedLabel) }}
   {{ $sortedTagEntries = $sortedTagEntries | append (dict
     "name" $tagName
-    "label" (index $tagMeta "label")
+    "label" $resolvedLabel
   ) }}
 {{ end }}
 {{ $sortedTagEntries = sort $sortedTagEntries "label" }}
@@ -96,6 +120,12 @@
 {{ range $sortedTagEntries }}
   {{ $orderedTags = $orderedTags | append .name }}
 {{ end }}
+
+{{ $normalizedOperations := slice }}
+{{ range $operations }}
+  {{ $normalizedOperations = $normalizedOperations | append (merge . (dict "tagLabel" ((index $tagLabels .tag) | default .tagLabel))) }}
+{{ end }}
+{{ $operations = $normalizedOperations }}
 
 {{ if gt (len $operations) 0 }}
   <div class="rest-api-page" data-rest-api-root>
@@ -138,15 +168,15 @@
             <span class="rest-api-category-button__count">{{ len $operations }}</span>
           </button>
           {{ range $tagName := $orderedTags }}
-            {{ $tagMeta := partial "rest-apis/tag-meta.html" (dict "name" $tagName "tags" $tagIndex) }}
+            {{ $tagLabel := index $tagLabels $tagName | default $tagName }}
             <button
               type="button"
               class="rest-api-category-button"
               data-tag-filter="{{ $tagName }}"
-              data-tag-label="{{ index $tagMeta "label" }}"
+              data-tag-label="{{ $tagLabel }}"
               aria-pressed="false"
             >
-              <span>{{ index $tagMeta "label" }}</span>
+              <span>{{ $tagLabel }}</span>
               <span class="rest-api-category-button__count">{{ index $tagCounts $tagName }}</span>
             </button>
           {{ end }}
@@ -189,10 +219,9 @@
               {{ end }}
               {{ $groupTagEntries := slice }}
               {{ range $tagName := $groupTags }}
-                {{ $subsectionMeta := partial "rest-apis/tag-subsection-meta.html" (dict "name" $tagName "tags" $tagIndex) }}
                 {{ $groupTagEntries = $groupTagEntries | append (dict
                   "name" $tagName
-                  "label" (index $subsectionMeta "label")
+                  "label" ((index $tagLabels $tagName) | default $tagName)
                 ) }}
               {{ end }}
               {{ $groupTagEntries = sort $groupTagEntries "label" }}
@@ -209,9 +238,8 @@
                 {{ $showHeading := gt (len $groupTags) 1 }}
                 {{ if and (not $showHeading) (gt (len $groupTags) 0) }}
                   {{ $onlyTag := index $groupTags 0 }}
-                  {{ $onlyMeta := partial "rest-apis/tag-subsection-meta.html" (dict "name" $onlyTag "tags" $tagIndex) }}
                   {{ $normalizedGroup := replaceRE "[^a-z0-9]+" "" (lower $groupLabel) }}
-                  {{ $normalizedOnly := replaceRE "[^a-z0-9]+" "" (lower (index $onlyMeta "label")) }}
+                  {{ $normalizedOnly := replaceRE "[^a-z0-9]+" "" (lower ((index $tagLabels $onlyTag) | default $onlyTag)) }}
                   {{ $showHeading = ne $normalizedGroup $normalizedOnly }}
                 {{ end }}
                 <section class="rest-api-nav-group" data-rest-api-group>
@@ -220,7 +248,7 @@
                   {{ end }}
                   <div class="rest-api-nav-group__items">
                     {{ range $tagName := $groupTags }}
-                      {{ $subsectionMeta := partial "rest-apis/tag-subsection-meta.html" (dict "name" $tagName "tags" $tagIndex) }}
+                      {{ $resolvedTagLabel := index $tagLabels $tagName | default $tagName }}
                       {{ $groupOperations := where $operations "tag" $tagName }}
                       {{ if gt (len $groupOperations) 0 }}
                         <section class="rest-api-nav-subgroup" data-rest-api-subgroup data-tag-name="{{ $tagName }}">
@@ -230,7 +258,7 @@
                             data-subgroup-toggle
                             aria-expanded="false"
                           >
-                            <span class="rest-api-nav-subgroup__title">{{ index $subsectionMeta "label" }}</span>
+                            <span class="rest-api-nav-subgroup__title">{{ $resolvedTagLabel }}</span>
                             <span class="rest-api-nav-subgroup__toggle-meta">
                               <span class="rest-api-nav-subgroup__count" data-subgroup-count data-total-count="{{ len $groupOperations }}">{{ len $groupOperations }}</span>
                               <span class="rest-api-nav-subgroup__chevron" aria-hidden="true"></span>
@@ -248,7 +276,7 @@
                                     data-path-id="{{ .pathId }}"
                                     data-tag-name="{{ .tag }}"
                                     data-tag-label="{{ .tagLabel }}"
-                                    data-search="{{ lower (printf "%s %s %s %s %s" .method .path .summary $groupLabel (index $subsectionMeta "label")) }}"
+                                    data-search="{{ lower (printf "%s %s %s %s %s" .method .path .summary $groupLabel .tagLabel) }}"
                                   >
                                     <span class="rest-api-nav-link__top">
                                       <span class="rest-api-method-badge rest-api-method-badge--{{ .method }}">{{ upper .method }}</span>
@@ -283,7 +311,7 @@
                 {{ end }}
                 <div class="rest-api-nav-group__items">
                   {{ range $tagName := $remainingTags }}
-                    {{ $tagMeta := partial "rest-apis/tag-subsection-meta.html" (dict "name" $tagName "tags" $tagIndex) }}
+                    {{ $resolvedTagLabel := index $tagLabels $tagName | default $tagName }}
                     {{ $groupOperations := where $operations "tag" $tagName }}
                     <section class="rest-api-nav-subgroup" data-rest-api-subgroup data-tag-name="{{ $tagName }}">
                       <button
@@ -292,7 +320,7 @@
                         data-subgroup-toggle
                         aria-expanded="false"
                       >
-                        <span class="rest-api-nav-subgroup__title">{{ index $tagMeta "label" }}</span>
+                        <span class="rest-api-nav-subgroup__title">{{ $resolvedTagLabel }}</span>
                         <span class="rest-api-nav-subgroup__toggle-meta">
                           <span class="rest-api-nav-subgroup__count" data-subgroup-count data-total-count="{{ len $groupOperations }}">{{ len $groupOperations }}</span>
                           <span class="rest-api-nav-subgroup__chevron" aria-hidden="true"></span>

--- a/docs/layouts/rest-apis/single.html
+++ b/docs/layouts/rest-apis/single.html
@@ -100,8 +100,6 @@
   {{ $resolvedLabel := $baseLabel }}
   {{ if gt (index $baseTagLabelCounts $baseLabel | default 0) 1 }}
     {{ $parts := split $tagName "_" }}
-    {{ $suffix := index $parts (sub (len $parts) 1) | default $tagName }}
-    {{ $suffixLabel := replace $suffix "_" " " }}
     {{ if ne $suffixLabel "" }}
       {{ $suffixLabel = $suffixLabel | title }}
     {{ end }}


### PR DESCRIPTION
**Notes for Reviewers**

Before (duplicating Users):
<img width="1030" height="241" alt="image" src="https://github.com/user-attachments/assets/f1e3cc6e-40d8-4fbe-9361-5975b8d7082f" />

After:
<img width="1030" height="254" alt="image" src="https://github.com/user-attachments/assets/38cb706a-8b1e-485f-95d4-9b8a034f6b0b" />


**[Signed commits](https://github.com/meshery/meshery/blob/master/CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [x] Yes, I signed my commits.

<!--
Thank you for contributing to Meshery! 

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. Sign your commits.
4. Include before and after screenshots/terminal output.

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.
-->
