### PR TITLE
fix(ui,handlers): canonical camelCase wire keys in rtk-query (Option B Phase 2 tail)

### DIFF
--- a/server/handlers/environments_handlers.go
+++ b/server/handlers/environments_handlers.go
@@ -8,10 +8,51 @@ import (
 	"net/http"
 
 	"github.com/gorilla/mux"
+	openapi_types "github.com/oapi-codegen/runtime/types"
 
 	"github.com/meshery/meshery/server/models"
 	"github.com/meshery/schemas/models/v1beta1/environment"
 )
+
+// environmentPayloadWire is a handler-local dual-accept wrapper around
+// environment.EnvironmentPayload. The schemas-generated struct tags
+// OrgId as json:"organization_id" (required by the current published
+// v1beta1 contract), but the canonical wire contract and every in-repo
+// consumer now emit the camelCase `organizationId`. Because Go's
+// encoding/json case-insensitive tag fallback will not match across an
+// underscore boundary, a struct tagged `organization_id` would silently
+// drop a JSON key of `organizationId`. This wrapper intercepts both
+// spellings during the Phase 2 deprecation window. Canonical wins when
+// both are present. Retire once schemas v1beta2 flips the tag and this
+// handler consumes the new version.
+type environmentPayloadWire struct {
+	environment.EnvironmentPayload
+}
+
+func (p *environmentPayloadWire) UnmarshalJSON(data []byte) error {
+	type alias environment.EnvironmentPayload
+	aux := struct {
+		*alias
+		OrgIdCamel  *openapi_types.UUID `json:"organizationId,omitempty"`
+		OrgIdSnake  *openapi_types.UUID `json:"organization_id,omitempty"`
+	}{alias: (*alias)(&p.EnvironmentPayload)}
+
+	// Zero OrgId so a reused receiver does not carry stale data when the
+	// next payload omits both spellings.
+	p.EnvironmentPayload.OrgId = openapi_types.UUID{}
+
+	if err := json.Unmarshal(data, &aux); err != nil {
+		return err
+	}
+	// Canonical wins when both are supplied.
+	switch {
+	case aux.OrgIdCamel != nil:
+		p.EnvironmentPayload.OrgId = *aux.OrgIdCamel
+	case aux.OrgIdSnake != nil:
+		p.EnvironmentPayload.OrgId = *aux.OrgIdSnake
+	}
+	return nil
+}
 
 func (h *Handler) GetEnvironments(w http.ResponseWriter, req *http.Request, _ *models.Preference, _ *models.User, provider models.Provider) {
 	token, ok := req.Context().Value(models.TokenCtxKey).(string)
@@ -71,8 +112,8 @@ func (h *Handler) SaveEnvironment(w http.ResponseWriter, req *http.Request, _ *m
 		return
 	}
 
-	environment := environment.EnvironmentPayload{}
-	err = json.Unmarshal(bd, &environment)
+	wire := environmentPayloadWire{}
+	err = json.Unmarshal(bd, &wire)
 	obj := "environment"
 
 	if err != nil {
@@ -81,6 +122,7 @@ func (h *Handler) SaveEnvironment(w http.ResponseWriter, req *http.Request, _ *m
 		return
 	}
 
+	environment := wire.EnvironmentPayload
 	resp, err := provider.SaveEnvironment(req, &environment, "", false)
 	if err != nil {
 		h.log.Error(ErrGetResult(err))
@@ -122,8 +164,8 @@ func (h *Handler) UpdateEnvironmentHandler(w http.ResponseWriter, req *http.Requ
 		return
 	}
 
-	environment := environment.EnvironmentPayload{}
-	err = json.Unmarshal(bd, &environment)
+	wire := environmentPayloadWire{}
+	err = json.Unmarshal(bd, &wire)
 	obj := "environment"
 
 	if err != nil {
@@ -132,6 +174,7 @@ func (h *Handler) UpdateEnvironmentHandler(w http.ResponseWriter, req *http.Requ
 		return
 	}
 
+	environment := wire.EnvironmentPayload
 	resp, err := provider.UpdateEnvironment(req, &environment, environmentID)
 	if err != nil {
 		h.log.Error(ErrGetResult(err))

--- a/server/handlers/environments_handlers.go
+++ b/server/handlers/environments_handlers.go
@@ -39,7 +39,7 @@ func (p *environmentPayloadWire) UnmarshalJSON(data []byte) error {
 
 	// Zero OrgId so a reused receiver does not carry stale data when the
 	// next payload omits both spellings.
-	p.EnvironmentPayload.OrgId = openapi_types.UUID{}
+	p.OrgId = openapi_types.UUID{}
 
 	if err := json.Unmarshal(data, &aux); err != nil {
 		return err
@@ -47,9 +47,9 @@ func (p *environmentPayloadWire) UnmarshalJSON(data []byte) error {
 	// Canonical wins when both are supplied.
 	switch {
 	case aux.OrgIdCamel != nil:
-		p.EnvironmentPayload.OrgId = *aux.OrgIdCamel
+		p.OrgId = *aux.OrgIdCamel
 	case aux.OrgIdSnake != nil:
-		p.EnvironmentPayload.OrgId = *aux.OrgIdSnake
+		p.OrgId = *aux.OrgIdSnake
 	}
 	return nil
 }

--- a/server/handlers/k8sconfig_handler.go
+++ b/server/handlers/k8sconfig_handler.go
@@ -322,7 +322,7 @@ func (h *Handler) KubernetesPingHandler(w http.ResponseWriter, req *http.Request
 		}
 		return
 	}
-	http.Error(w, "Empty contextID. Pass the context ID(in query parameter \"context\") of the kuberenetes to be pinged", http.StatusBadRequest)
+	http.Error(w, "Empty connection ID. Pass the connection ID of the kubernetes context to be pinged in the canonical query parameter \"connectionId\" (the legacy \"connection_id\" spelling is also accepted during the Phase 2 deprecation window).", http.StatusBadRequest)
 }
 
 func (h *Handler) K8sRegistrationHandler(w http.ResponseWriter, req *http.Request, _ *models.Preference, user *models.User, provider models.Provider) {

--- a/server/handlers/k8sconfig_handler.go
+++ b/server/handlers/k8sconfig_handler.go
@@ -278,7 +278,15 @@ func (h *Handler) KubernetesPingHandler(w http.ResponseWriter, req *http.Request
 		return
 	}
 
-	connectionID := req.URL.Query().Get("connection_id")
+	// Canonical query param is `connectionId`; `connection_id` is
+	// dual-accepted during the Phase 2 deprecation window so any legacy
+	// client (mesheryctl, older UI bundles) keeps working. Retire the
+	// fallback once Phase 3 consumer migration completes.
+	q := req.URL.Query()
+	connectionID := q.Get("connectionId")
+	if connectionID == "" {
+		connectionID = q.Get("connection_id")
+	}
 	if connectionID != "" {
 		// Get the context associated with this ID
 		k8sContext, err := provider.GetK8sContext(token, connectionID)

--- a/server/handlers/server_events_configuration_handler.go
+++ b/server/handlers/server_events_configuration_handler.go
@@ -29,7 +29,31 @@ type LogLevelRequest struct {
 	// required: true
 	// enum: panic,fatal,error,warn,info,debug,trace
 	// example: debug
-	LogLevel string `json:"event_log_level"`
+	LogLevel string `json:"eventLogLevel"`
+}
+
+// UnmarshalJSON dual-accepts the canonical `eventLogLevel` wire key and the
+// legacy `event_log_level` spelling during the Phase 2 deprecation window.
+// Go's encoding/json case-insensitive tag fallback does NOT cross an
+// underscore boundary, so a struct tagged `eventLogLevel` would silently
+// drop a payload keyed `event_log_level`. Canonical wins when both are
+// present. Retire the fallback once Phase 3 consumer migration completes.
+func (r *LogLevelRequest) UnmarshalJSON(data []byte) error {
+	aux := struct {
+		Canonical *string `json:"eventLogLevel,omitempty"`
+		Legacy    *string `json:"event_log_level,omitempty"`
+	}{}
+	r.LogLevel = ""
+	if err := json.Unmarshal(data, &aux); err != nil {
+		return err
+	}
+	switch {
+	case aux.Canonical != nil:
+		r.LogLevel = *aux.Canonical
+	case aux.Legacy != nil:
+		r.LogLevel = *aux.Legacy
+	}
+	return nil
 }
 
 // getAvailableLogLevels returns all valid logging levels supported by the system

--- a/server/handlers/workspace_handlers.go
+++ b/server/handlers/workspace_handlers.go
@@ -7,10 +7,78 @@ import (
 	"net/http"
 
 	"github.com/gorilla/mux"
+	openapi_types "github.com/oapi-codegen/runtime/types"
 
 	"github.com/meshery/meshery/server/models"
 	"github.com/meshery/schemas/models/v1beta1/workspace"
 )
+
+// workspacePayloadWire is a handler-local dual-accept wrapper around
+// workspace.WorkspacePayload. The schemas-generated struct tags
+// OrganizationID as json:"organization_id" (required by the current
+// published v1beta1 contract), but the canonical wire contract and every
+// in-repo consumer now emit the camelCase `organizationId`. Go's
+// encoding/json case-insensitive tag fallback does NOT match across an
+// underscore boundary, so a struct tagged `organization_id` silently drops
+// a JSON key of `organizationId`. This wrapper intercepts both spellings
+// during the Phase 2 deprecation window. Canonical wins when both are
+// present. Retire once schemas v1beta2 flips the tag to `organizationId`
+// and this handler consumes the new version.
+type workspacePayloadWire struct {
+	workspace.WorkspacePayload
+}
+
+func (p *workspacePayloadWire) UnmarshalJSON(data []byte) error {
+	type alias workspace.WorkspacePayload
+	aux := struct {
+		*alias
+		OrganizationIDCamel *openapi_types.UUID `json:"organizationId,omitempty"`
+		OrganizationIDSnake *openapi_types.UUID `json:"organization_id,omitempty"`
+	}{alias: (*alias)(&p.WorkspacePayload)}
+
+	// Zero OrganizationID so a reused receiver does not carry stale data
+	// when the next payload omits both spellings.
+	p.WorkspacePayload.OrganizationID = openapi_types.UUID{}
+
+	if err := json.Unmarshal(data, &aux); err != nil {
+		return err
+	}
+	// Canonical wins when both are supplied.
+	switch {
+	case aux.OrganizationIDCamel != nil:
+		p.WorkspacePayload.OrganizationID = *aux.OrganizationIDCamel
+	case aux.OrganizationIDSnake != nil:
+		p.WorkspacePayload.OrganizationID = *aux.OrganizationIDSnake
+	}
+	return nil
+}
+
+// workspaceUpdatePayloadWire mirrors workspacePayloadWire for the PUT path.
+type workspaceUpdatePayloadWire struct {
+	workspace.WorkspaceUpdatePayload
+}
+
+func (p *workspaceUpdatePayloadWire) UnmarshalJSON(data []byte) error {
+	type alias workspace.WorkspaceUpdatePayload
+	aux := struct {
+		*alias
+		OrganizationIDCamel *openapi_types.UUID `json:"organizationId,omitempty"`
+		OrganizationIDSnake *openapi_types.UUID `json:"organization_id,omitempty"`
+	}{alias: (*alias)(&p.WorkspaceUpdatePayload)}
+
+	p.WorkspaceUpdatePayload.OrganizationID = openapi_types.UUID{}
+
+	if err := json.Unmarshal(data, &aux); err != nil {
+		return err
+	}
+	switch {
+	case aux.OrganizationIDCamel != nil:
+		p.WorkspaceUpdatePayload.OrganizationID = *aux.OrganizationIDCamel
+	case aux.OrganizationIDSnake != nil:
+		p.WorkspaceUpdatePayload.OrganizationID = *aux.OrganizationIDSnake
+	}
+	return nil
+}
 
 func (h *Handler) GetWorkspacesHandler(w http.ResponseWriter, req *http.Request, _ *models.Preference, _ *models.User, provider models.Provider) {
 	token, ok := req.Context().Value(models.TokenCtxKey).(string)
@@ -83,8 +151,8 @@ func (h *Handler) SaveWorkspaceHandler(w http.ResponseWriter, req *http.Request,
 		return
 	}
 
-	workspace := workspace.WorkspacePayload{}
-	err = json.Unmarshal(bd, &workspace)
+	wire := workspacePayloadWire{}
+	err = json.Unmarshal(bd, &wire)
 	obj := "workspace"
 
 	if err != nil {
@@ -93,6 +161,7 @@ func (h *Handler) SaveWorkspaceHandler(w http.ResponseWriter, req *http.Request,
 		return
 	}
 
+	workspace := wire.WorkspacePayload
 	bf, err := provider.SaveWorkspace(req, &workspace, "", false)
 	if err != nil {
 		h.log.Error(ErrGetResult(err))
@@ -134,8 +203,8 @@ func (h *Handler) UpdateWorkspaceHandler(w http.ResponseWriter, req *http.Reques
 		return
 	}
 
-	workspacePayload := workspace.WorkspaceUpdatePayload{}
-	err = json.Unmarshal(bd, &workspacePayload)
+	wire := workspaceUpdatePayloadWire{}
+	err = json.Unmarshal(bd, &wire)
 	obj := "workspace"
 
 	if err != nil {
@@ -144,6 +213,7 @@ func (h *Handler) UpdateWorkspaceHandler(w http.ResponseWriter, req *http.Reques
 		return
 	}
 
+	workspacePayload := wire.WorkspaceUpdatePayload
 	resp, err := provider.UpdateWorkspace(req, &workspacePayload, workspaceID)
 	if err != nil {
 		h.log.Error(ErrGetResult(err))

--- a/server/handlers/workspace_handlers.go
+++ b/server/handlers/workspace_handlers.go
@@ -38,7 +38,7 @@ func (p *workspacePayloadWire) UnmarshalJSON(data []byte) error {
 
 	// Zero OrganizationID so a reused receiver does not carry stale data
 	// when the next payload omits both spellings.
-	p.WorkspacePayload.OrganizationID = openapi_types.UUID{}
+	p.OrganizationID = openapi_types.UUID{}
 
 	if err := json.Unmarshal(data, &aux); err != nil {
 		return err
@@ -46,9 +46,9 @@ func (p *workspacePayloadWire) UnmarshalJSON(data []byte) error {
 	// Canonical wins when both are supplied.
 	switch {
 	case aux.OrganizationIDCamel != nil:
-		p.WorkspacePayload.OrganizationID = *aux.OrganizationIDCamel
+		p.OrganizationID = *aux.OrganizationIDCamel
 	case aux.OrganizationIDSnake != nil:
-		p.WorkspacePayload.OrganizationID = *aux.OrganizationIDSnake
+		p.OrganizationID = *aux.OrganizationIDSnake
 	}
 	return nil
 }
@@ -66,16 +66,16 @@ func (p *workspaceUpdatePayloadWire) UnmarshalJSON(data []byte) error {
 		OrganizationIDSnake *openapi_types.UUID `json:"organization_id,omitempty"`
 	}{alias: (*alias)(&p.WorkspaceUpdatePayload)}
 
-	p.WorkspaceUpdatePayload.OrganizationID = openapi_types.UUID{}
+	p.OrganizationID = openapi_types.UUID{}
 
 	if err := json.Unmarshal(data, &aux); err != nil {
 		return err
 	}
 	switch {
 	case aux.OrganizationIDCamel != nil:
-		p.WorkspaceUpdatePayload.OrganizationID = *aux.OrganizationIDCamel
+		p.OrganizationID = *aux.OrganizationIDCamel
 	case aux.OrganizationIDSnake != nil:
-		p.WorkspaceUpdatePayload.OrganizationID = *aux.OrganizationIDSnake
+		p.OrganizationID = *aux.OrganizationIDSnake
 	}
 	return nil
 }

--- a/server/handlers/workspace_handlers_test.go
+++ b/server/handlers/workspace_handlers_test.go
@@ -2,6 +2,7 @@ package handlers
 
 import (
 	"context"
+	"encoding/json"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -168,6 +169,104 @@ func TestGetWorkspaceByIdHandler_AcceptsOrgIdAndLegacyOrgID(t *testing.T) {
 
 			if tc.wantProvider && provider.observedOrgID != tc.wantOrgID {
 				t.Fatalf("provider received orgID=%q, want %q", provider.observedOrgID, tc.wantOrgID)
+			}
+		})
+	}
+}
+
+// TestWorkspacePayloadWire_UnmarshalJSON exercises the dual-accept body
+// contract for POST /api/workspaces. The schemas-generated struct tags
+// OrganizationID as json:"organization_id", but canonical in-repo consumers
+// now emit `organizationId`. Go's case-insensitive tag fallback does NOT
+// match across an underscore boundary, so the wrapper's UnmarshalJSON must
+// intercept both spellings during the Phase 2 deprecation window. Canonical
+// must win when both are supplied. Table is kept narrow on purpose: the
+// wrapper only routes OrganizationID, so we only assert that field here.
+func TestWorkspacePayloadWire_UnmarshalJSON(t *testing.T) {
+	const (
+		canonicalUUID = "11111111-1111-1111-1111-111111111111"
+		legacyUUID    = "22222222-2222-2222-2222-222222222222"
+	)
+
+	cases := []struct {
+		name    string
+		body    string
+		wantOrg string
+	}{
+		{
+			name:    "canonical organizationId only",
+			body:    `{"name":"ws","organizationId":"` + canonicalUUID + `"}`,
+			wantOrg: canonicalUUID,
+		},
+		{
+			name:    "legacy organization_id only",
+			body:    `{"name":"ws","organization_id":"` + legacyUUID + `"}`,
+			wantOrg: legacyUUID,
+		},
+		{
+			name:    "both supplied, canonical wins",
+			body:    `{"name":"ws","organizationId":"` + canonicalUUID + `","organization_id":"` + legacyUUID + `"}`,
+			wantOrg: canonicalUUID,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			var wire workspacePayloadWire
+			if err := json.Unmarshal([]byte(tc.body), &wire); err != nil {
+				t.Fatalf("unexpected unmarshal error: %v", err)
+			}
+			if got := wire.OrganizationID.String(); got != tc.wantOrg {
+				t.Fatalf("OrganizationID = %q, want %q", got, tc.wantOrg)
+			}
+			if wire.Name != "ws" {
+				t.Fatalf("Name = %q, want %q", wire.Name, "ws")
+			}
+		})
+	}
+}
+
+// TestWorkspaceUpdatePayloadWire_UnmarshalJSON mirrors the payload coverage
+// for the PUT /api/workspaces/{id} path: the update wrapper must route both
+// `organizationId` (canonical) and `organization_id` (legacy) onto the
+// underlying schemas-generated OrganizationID field, with canonical taking
+// precedence when both are present.
+func TestWorkspaceUpdatePayloadWire_UnmarshalJSON(t *testing.T) {
+	const (
+		canonicalUUID = "33333333-3333-3333-3333-333333333333"
+		legacyUUID    = "44444444-4444-4444-4444-444444444444"
+	)
+
+	cases := []struct {
+		name    string
+		body    string
+		wantOrg string
+	}{
+		{
+			name:    "canonical organizationId only",
+			body:    `{"name":"ws","organizationId":"` + canonicalUUID + `"}`,
+			wantOrg: canonicalUUID,
+		},
+		{
+			name:    "legacy organization_id only",
+			body:    `{"name":"ws","organization_id":"` + legacyUUID + `"}`,
+			wantOrg: legacyUUID,
+		},
+		{
+			name:    "both supplied, canonical wins",
+			body:    `{"name":"ws","organizationId":"` + canonicalUUID + `","organization_id":"` + legacyUUID + `"}`,
+			wantOrg: canonicalUUID,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			var wire workspaceUpdatePayloadWire
+			if err := json.Unmarshal([]byte(tc.body), &wire); err != nil {
+				t.Fatalf("unexpected unmarshal error: %v", err)
+			}
+			if got := wire.OrganizationID.String(); got != tc.wantOrg {
+				t.Fatalf("OrganizationID = %q, want %q", got, tc.wantOrg)
 			}
 		})
 	}

--- a/ui/rtk-query/connection.ts
+++ b/ui/rtk-query/connection.ts
@@ -85,7 +85,7 @@ const connectionsApi = api.injectEndpoints({
     pingKubernetes: builder.query({
       query: (connectionId) => ({
         url: mesheryApiPath(`system/kubernetes/ping`),
-        params: { connection_id: connectionId },
+        params: { connectionId: connectionId },
         credentials: 'include',
       }),
     }),

--- a/ui/rtk-query/environments.ts
+++ b/ui/rtk-query/environments.ts
@@ -41,7 +41,8 @@ export const useCreateEnvironmentMutation = () => {
       body: {
         name: queryArg.environmentPayload?.name,
         description: queryArg.environmentPayload?.description,
-        organization_id:
+        organizationId:
+          queryArg.environmentPayload?.organizationId ||
           queryArg.environmentPayload?.organization_id ||
           queryArg.environmentPayload?.OrganizationID,
       },
@@ -70,7 +71,8 @@ export const useUpdateEnvironmentMutation = () => {
       body: {
         name: queryArg.environmentPayload?.name,
         description: queryArg.environmentPayload?.description,
-        organization_id:
+        organizationId:
+          queryArg.environmentPayload?.organizationId ||
           queryArg.environmentPayload?.organization_id ||
           queryArg.environmentPayload?.OrganizationID,
       },

--- a/ui/rtk-query/notificationCenter.ts
+++ b/ui/rtk-query/notificationCenter.ts
@@ -216,7 +216,7 @@ export const notificationCenterApi = api
           url: `/api/system/events/config`,
           method: 'PUT',
           body: {
-            event_log_level: logLevel,
+            eventLogLevel: logLevel,
           },
         }),
         onQueryStarted: async (logLevel, { dispatch, queryFulfilled }) => {

--- a/ui/rtk-query/workspace.ts
+++ b/ui/rtk-query/workspace.ts
@@ -321,7 +321,7 @@ const workspacesApi = api
           body: {
             name: queryArg.name,
             description: queryArg.description,
-            organization_id: queryArg.organization_id,
+            organizationId: queryArg.organizationId || queryArg.organization_id,
           },
         }),
         invalidatesTags: () => [{ type: TAGS.WORKSPACES }],
@@ -334,7 +334,7 @@ const workspacesApi = api
           body: {
             name: queryArg.name,
             description: queryArg.description,
-            organization_id: queryArg.organization_id,
+            organizationId: queryArg.organizationId || queryArg.organization_id,
           },
         }),
         invalidatesTags: () => [{ type: TAGS.WORKSPACES }],
@@ -375,7 +375,9 @@ export const useCreateWorkspaceMutation = () => {
     trigger({
       name: queryArg.workspacePayload?.name,
       description: queryArg.workspacePayload?.description,
-      organization_id: queryArg.workspacePayload?.organization_id,
+      organizationId:
+        queryArg.workspacePayload?.organizationId ||
+        queryArg.workspacePayload?.organization_id,
     });
 
   return [wrappedTrigger, result] as const;
@@ -389,7 +391,9 @@ export const useUpdateWorkspaceMutation = () => {
       id: queryArg.workspaceId,
       name: queryArg.workspacePayload?.name,
       description: queryArg.workspacePayload?.description,
-      organization_id: queryArg.workspacePayload?.organization_id,
+      organizationId:
+        queryArg.workspacePayload?.organizationId ||
+        queryArg.workspacePayload?.organization_id,
     });
 
   return [wrappedTrigger, result] as const;

--- a/ui/rtk-query/workspace.ts
+++ b/ui/rtk-query/workspace.ts
@@ -376,8 +376,7 @@ export const useCreateWorkspaceMutation = () => {
       name: queryArg.workspacePayload?.name,
       description: queryArg.workspacePayload?.description,
       organizationId:
-        queryArg.workspacePayload?.organizationId ||
-        queryArg.workspacePayload?.organization_id,
+        queryArg.workspacePayload?.organizationId || queryArg.workspacePayload?.organization_id,
     });
 
   return [wrappedTrigger, result] as const;
@@ -392,8 +391,7 @@ export const useUpdateWorkspaceMutation = () => {
       name: queryArg.workspacePayload?.name,
       description: queryArg.workspacePayload?.description,
       organizationId:
-        queryArg.workspacePayload?.organizationId ||
-        queryArg.workspacePayload?.organization_id,
+        queryArg.workspacePayload?.organizationId || queryArg.workspacePayload?.organization_id,
     });
 
   return [wrappedTrigger, result] as const;


### PR DESCRIPTION
## Summary

Finalizes the Layer5/Meshery identifier-naming migration ("Option B" tail) by flipping the last 6 `snake_case` wire keys in `ui/rtk-query/` to the canonical `camelCase` contract published in [meshery/schemas](https://github.com/meshery/schemas/blob/master/docs/identifier-naming-migration.md). Every body-wrapper flip is paired with server-side dual-accept `UnmarshalJSON` so legacy clients (`mesheryctl`, older UI bundles, previous-release `meshery-cloud`) keep working during the Phase 2 deprecation window.

Verified against `make consumer-audit MESHERY_REPO=...` in `meshery/schemas`: **zero remaining TypeScript findings** on `ui/rtk-query/` (no `case-flip`, no `snake-case-wrapper`, no `snake-case-param` entries).

## The 6 UI sites flipped

| File:line | Endpoint | Key | Kind |
|---|---|---|---|
| `ui/rtk-query/connection.ts:88` | `GET /api/system/kubernetes/ping` | `connection_id` → `connectionId` | query param |
| `ui/rtk-query/environments.ts:44` | `POST /api/environments` | `organization_id` → `organizationId` | body wrapper |
| `ui/rtk-query/environments.ts:73` | `PUT /api/environments/{id}` | `organization_id` → `organizationId` | body wrapper |
| `ui/rtk-query/notificationCenter.ts:219` | `PUT /api/system/events/config` | `event_log_level` → `eventLogLevel` | body wrapper |
| `ui/rtk-query/workspace.ts:324` | `POST /api/workspaces` | `organization_id` → `organizationId` | body wrapper |
| `ui/rtk-query/workspace.ts:337` | `PUT /api/workspaces/{id}` | `organization_id` → `organizationId` | body wrapper |

Also flips the two internal-plumbing wrappers at `ui/rtk-query/workspace.ts:378,392` (`useCreateWorkspaceMutation` / `useUpdateWorkspaceMutation`) that feed `queryArg` into the RTK mutations above, so the in-UI call graph emits the canonical key end-to-end. The mutations retain a `|| queryArg.organization_id` fallback so the existing caller shape (passing `organization_id` on the mutation arg) keeps working during the deprecation window.

## Server-side dual-accept rationale

Go's `encoding/json` matches JSON keys against struct tags exactly, then case-insensitively against the tag — **not** against the field name, and the case-insensitive fallback does **not** cross an underscore boundary. So a struct tagged `organization_id` would silently drop a JSON key of `organizationId`. Flipping the UI without handler dual-accept would produce silent write failures.

The `meshery/schemas` Go types (`WorkspacePayload.OrganizationID`, `EnvironmentPayload.OrgId`) are generated from the published `v1beta1` OpenAPI contract and still tag these fields as `json:"organization_id"`. The canonical-casing bump lives in `v1beta2` per the migration plan — it's not this PR's scope. So dual-accept is added at the handler boundary using the pattern established by:

- `628738e9b32` — `fix(handlers): dual-accept orgId + legacy orgID during Phase 2 window`
- `a5455a323f7` — `fix(remote-provider,handlers): canonical camelCase wrapper keys + dual-accept on request bodies`

Changes:

- **`server/handlers/workspace_handlers.go`** — adds local `workspacePayloadWire` and `workspaceUpdatePayloadWire` with `UnmarshalJSON` that decodes both `organizationId` (canonical) and `organization_id` (legacy), zeros the field before the precedence switch (so a reused receiver does not retain stale data), and lets canonical win when both spellings are present.
- **`server/handlers/environments_handlers.go`** — same pattern for `environmentPayloadWire` around `EnvironmentPayload.OrgId`.
- **`server/handlers/server_events_configuration_handler.go`** — flips `LogLevelRequest.LogLevel` tag from `event_log_level` to `eventLogLevel` and adds `UnmarshalJSON` dual-accept. The response shape (`event_log_level`, `available_levels`) is intentionally **not** flipped: the UI reads those keys via `transformResponse` and the consumer-audit only flagged the request body; the response-shape migration belongs in its own per-resource camelCase bump.
- **`server/handlers/k8sconfig_handler.go`** — `KubernetesPingHandler` now reads the canonical `connectionId` query param with a `connection_id` fallback during the deprecation window.

## Test plan

- [x] `go build ./...` green
- [x] `go vet ./server/handlers/...` green
- [x] `go test -count=1 -short ./server/handlers/ -run "Workspace|Environment"` passes
- [x] `make consumer-audit` in `meshery/schemas` reports zero TypeScript findings on this tree (no `case-flip`, `snake-case-wrapper`, or `snake-case-param` entries)
- [ ] Reviewer: spot-check the three UI flows end-to-end against a running server (create/update workspace, create/update environment, update event log level, ping kubernetes) to confirm dual-accept handlers decode both legacy and canonical payloads
- [ ] Reviewer: confirm the next schemas version bump retires the wrappers (tracked as a follow-up when `v1beta2` flips the tags)

## References

- Migration plan: https://github.com/meshery/schemas/blob/master/docs/identifier-naming-migration.md
- Prior Phase 2 precedent commits: `628738e9b32`, `a5455a323f7`

## Pre-existing CI failure (out-of-scope)

The `MeshKit Error Codes Utility Runner` check reports a duplicate error code `'1231'` shared between `ErrGenerateDataForInvalidResponseCode` and `ErrPublishCode` in `mesheryctl/internal/cli/root/registry/error.go`. This PR does **not** touch that file. The same failure is pre-existing on `master`:

- `44396ef50abe27d54a8b23e96af4433efaead92a` (merge of #18900) — failed
- `fefc89f98408e015f81015dd394573a049d3fe3a` (merge of #18392) — failed

Out of scope for this PR. A separate fix should reassign one of the two codes.
