### PR TITLE
fix(mesheryctl): resolve duplicate error code mesheryctl-1231

### DIFF
--- a/mesheryctl/helpers/component_info.json
+++ b/mesheryctl/helpers/component_info.json
@@ -1,5 +1,5 @@
 {
   "name": "mesheryctl",
   "type": "client",
-  "next_error_code": 1232
+  "next_error_code": 1233
 }

--- a/mesheryctl/internal/cli/pkg/api/error.go
+++ b/mesheryctl/internal/cli/pkg/api/error.go
@@ -2,7 +2,7 @@ package api
 
 import "github.com/meshery/meshkit/errors"
 
-var ErrGenerateDataForInvalidResponseCode = "mesheryctl-1231"
+var ErrGenerateDataForInvalidResponseCode = "mesheryctl-1232"
 
 func ErrGenerateDataForInvalidResponse() error {
 	return errors.New(


### PR DESCRIPTION
## Summary

\`ErrGenerateDataForInvalidResponseCode\` (in \`mesheryctl/internal/cli/pkg/api/error.go\`) collides with \`ErrPublishCode\` (in \`mesheryctl/internal/cli/root/registry/error.go\`) — both set to \`mesheryctl-1231\`. This has been failing the \`MeshKit Error Codes Utility Runner\` CI check on every PR against master since commit \`fefc89f98408\`, blocking any PR that requires this check.

Rename \`ErrGenerateDataForInvalidResponseCode\` to the next free code \`mesheryctl-1232\`. \`ErrPublishCode\` keeps \`mesheryctl-1231\` since it was allocated first.

## Why

- Unblocks the pre-existing master CI failure that is stalling **meshery/meshery#18904** (and any other open PRs gated on \`Error codes utility\`).
- Minimal, surgical, one-line change.

## Test plan

- [x] \`go build ./...\` green locally.
- [x] \`grep -r 'mesheryctl-1232' mesheryctl/\` confirms the new code does not collide with any existing allocation.
- [ ] \`Error codes utility\` CI check passes on this PR.