### PR TITLE
chore(ui): bump @sistent/sistent to v0.19.0 (Phase 2.K)

### DIFF
--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -36,7 +36,7 @@
         "@rjsf/utils": "^6.4.1",
         "@rjsf/validator-ajv8": "^6.4.1",
         "@sistent/mui-datatables": "^6.1.1",
-        "@sistent/sistent": "^0.18.8",
+        "@sistent/sistent": "^0.19.0",
         "@tippyjs/react": "^4.2.6",
         "@uiw/codemirror-theme-material": "^4.25.8",
         "@uiw/react-codemirror": "^4.25.8",
@@ -3731,9 +3731,9 @@
       }
     },
     "node_modules/@sistent/sistent": {
-      "version": "0.18.8",
-      "resolved": "https://registry.npmjs.org/@sistent/sistent/-/sistent-0.18.8.tgz",
-      "integrity": "sha512-rGBIbI8S0Q/olW23/QlrDRmvJWLxbdg9NiDBrimAUqziF1n4N/z9WdVDp5ttplMnG+xOPeq3s5r7/yGiItbPGQ==",
+      "version": "0.19.0",
+      "resolved": "https://registry.npmjs.org/@sistent/sistent/-/sistent-0.19.0.tgz",
+      "integrity": "sha512-m5YR+NsCPXPD0PUaQXQO1ei9DP1Tq+AVFhT7syttKiLxuX/M1FRCTDuakAkLRVhlE52T6nSQtafjkhgWgsEL7Q==",
       "dependencies": {
         "@emotion/react": "^11.14.0",
         "@emotion/styled": "^11.14.1",

--- a/ui/package.json
+++ b/ui/package.json
@@ -61,7 +61,7 @@
     "@rjsf/utils": "^6.4.1",
     "@rjsf/validator-ajv8": "^6.4.1",
     "@sistent/mui-datatables": "^6.1.1",
-    "@sistent/sistent": "^0.18.8",
+    "@sistent/sistent": "^0.19.0",
     "@tippyjs/react": "^4.2.6",
     "@uiw/codemirror-theme-material": "^4.25.8",
     "@uiw/react-codemirror": "^4.25.8",


### PR DESCRIPTION
## Summary

Phase 2.K consumer pin of the Option B identifier-naming migration: pin
`@sistent/sistent` from `^0.18.8` to `^0.19.0` in `ui/package.json`.

Sistent 0.19.0 publishes canonical camelCase types aligned with the
identifier-naming contract in `meshery/schemas`. This PR pins the UI to
that version so downstream surfaces consume the canonical shape going
forward.

### Related

- layer5io/sistent#1431 — Sistent v0.19.0 release
- meshery/schemas#832 — tracks the 10 residual snake keys deferred to a
  later Sistent minor (`team_name`, `joined_at`, `last_run`, `next_run`,
  `design_type`, `view_count`, `download_count`, `clone_count`,
  `deployment_count`, `share_count`)
- layer5io/meshery-cloud#5094 — parallel consumer pin on meshery-cloud
  (merged)

### Snake to camel flips in this PR

None required at the consumer surface. Sistent 0.19.0's public type
surface at the Meshery UI's consumption points does not re-type the
entity fields enumerated in the migration plan
(`organization_id`/`organizationId`, `created_at`/`createdAt`,
`user_id`/`userId`, `first_name`/`firstName`, `last_name`/`lastName`,
`avatar_url`/`avatarUrl`, `role_names`/`roleNames`, `team_id`/`teamId`,
`last_login_time`/`lastLoginTime`, `pattern_info`/`patternInfo`,
`pattern_caveats`/`patternCaveats`), and `next build --turbopack` reports
zero TypeScript errors against 0.19.0 for the current meshery UI
checkout. Field-level camelCase propagation will land with the
per-resource Phase 3 PRs that repoint individual RTK Query clients.

### Test plan

- [x] `npm install --legacy-peer-deps` in `ui/` updates the lockfile
  cleanly to `@sistent/sistent@0.19.0`
- [x] `npm run build` in `ui/` reports `Finished TypeScript in <1s` with
  zero errors (the downstream runtime page-data collection step is
  unrelated to the type surface and tracks a separate Next 16 /
  Turbopack externalization matter)
- [ ] CI: `Error codes utility`, `UI build`, `Docker build`,
  `Validate GraphQL schema`, `runner / eslint`, `KanvasScreenshot`,
  `DCO`, `triage` checks green
- [ ] CI: `consumer-audit` surfaces no new divergence on
  `meshery/schemas` for this branch