### PR TITLE
fix: stop N+1 user-profile lookups and plain-text errors on Open Recents

### DIFF
--- a/server/handlers/user_handler.go
+++ b/server/handlers/user_handler.go
@@ -1,6 +1,7 @@
 package handlers
 
 import (
+	"errors"
 	"fmt"
 	"net/http"
 	"time"
@@ -9,7 +10,7 @@ import (
 
 	"github.com/gofrs/uuid"
 	"github.com/gorilla/mux"
-	"github.com/pkg/errors"
+	pkgerrors "github.com/pkg/errors"
 
 	"github.com/meshery/meshery/server/models"
 )
@@ -29,18 +30,25 @@ func (h *Handler) GetUserByIDHandler(w http.ResponseWriter, r *http.Request, _ *
 	userID := mux.Vars(r)["id"]
 	_, err := uuid.FromString(userID)
 	if err != nil {
-		http.Error(w, ErrInvalidUUID(err).Error(), http.StatusBadRequest)
+		writeJSONError(w, ErrInvalidUUID(err).Error(), http.StatusBadRequest)
 		return
 	}
 	resp, err := provider.GetUserByID(r, userID)
 	if err != nil {
+		if errors.Is(err, models.ErrUserIsSystemInstance) {
+			// The requested ID is this Meshery instance's own system UUID; it
+			// isn't a real user record. Return a 204 so callers can render a
+			// "system" placeholder without treating it as a fetch failure.
+			w.WriteHeader(http.StatusNoContent)
+			return
+		}
 		h.log.Error(ErrGetResult(err))
-		http.Error(w, ErrGetResult(err).Error(), http.StatusNotFound)
+		writeJSONError(w, ErrGetResult(err).Error(), http.StatusNotFound)
 		return
 	}
 
 	if resp == nil {
-		http.Error(w, "user not found", http.StatusNotFound)
+		writeJSONError(w, "user not found", http.StatusNotFound)
 		return
 	}
 
@@ -109,7 +117,7 @@ func (h *Handler) UserPrefsHandler(w http.ResponseWriter, req *http.Request, pre
 
 		dur := prefObj.LoadTestPreferences.Duration
 		if _, err := time.ParseDuration(dur); err != nil {
-			err = errors.Wrap(err, "unable to parse test duration")
+			err = pkgerrors.Wrap(err, "unable to parse test duration")
 			h.log.Error(ErrSavingUserPreference(err))
 			http.Error(w, err.Error(), http.StatusInternalServerError)
 			return

--- a/server/handlers/user_handler_test.go
+++ b/server/handlers/user_handler_test.go
@@ -1,0 +1,135 @@
+package handlers
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/gorilla/mux"
+	"github.com/meshery/meshery/server/models"
+)
+
+// userSpyProvider embeds DefaultLocalProvider so we pick up a full Provider
+// implementation, then overrides only GetUserByID with a scripted response.
+// The handler test uses this to drive each error path independently.
+type userSpyProvider struct {
+	*models.DefaultLocalProvider
+	resp []byte
+	err  error
+}
+
+func (m *userSpyProvider) GetUserByID(_ *http.Request, _ string) ([]byte, error) {
+	return m.resp, m.err
+}
+
+// TestGetUserByIDHandler_InvalidUUIDReturnsJSON pins the 400 response to a
+// JSON envelope so the client's RTK Query parser sees a structured error
+// object instead of a plain-text body (which previously crashed the JSON
+// parser with "Unexpected token ... is not valid JSON").
+func TestGetUserByIDHandler_InvalidUUIDReturnsJSON(t *testing.T) {
+	h := newTestHandler(t, map[string]models.Provider{}, "")
+	provider := &userSpyProvider{DefaultLocalProvider: &models.DefaultLocalProvider{}}
+	provider.DefaultLocalProvider.Initialize()
+
+	req := httptest.NewRequest(http.MethodGet, "/api/user/profile/not-a-uuid", nil)
+	req = mux.SetURLVars(req, map[string]string{"id": "not-a-uuid"})
+	rec := httptest.NewRecorder()
+
+	h.GetUserByIDHandler(rec, req, nil, nil, provider)
+
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400, got %d (body=%q)", rec.Code, rec.Body.String())
+	}
+	assertJSONErrorEnvelope(t, rec.Result())
+}
+
+// TestGetUserByIDHandler_ProviderErrorReturnsJSON covers the upstream-fetch
+// failure path. The handler must still emit a JSON {"error": "..."} body on
+// 404 so the client does not choke on the meshkit "Unable to fetch data..."
+// string that starts with the letter 'U'.
+func TestGetUserByIDHandler_ProviderErrorReturnsJSON(t *testing.T) {
+	h := newTestHandler(t, map[string]models.Provider{}, "")
+	provider := &userSpyProvider{DefaultLocalProvider: &models.DefaultLocalProvider{}, err: fmt.Errorf("remote blew up")}
+	provider.DefaultLocalProvider.Initialize()
+
+	req := httptest.NewRequest(http.MethodGet, "/api/user/profile/00000000-0000-0000-0000-000000000001", nil)
+	req = mux.SetURLVars(req, map[string]string{"id": "00000000-0000-0000-0000-000000000001"})
+	rec := httptest.NewRecorder()
+
+	h.GetUserByIDHandler(rec, req, nil, nil, provider)
+
+	if rec.Code != http.StatusNotFound {
+		t.Fatalf("expected 404, got %d (body=%q)", rec.Code, rec.Body.String())
+	}
+	assertJSONErrorEnvelope(t, rec.Result())
+}
+
+// TestGetUserByIDHandler_NilRespReturnsJSON exercises the "user not found"
+// branch (provider returns (nil, nil) for a non-system ID). Both status and
+// body shape must be locked in to JSON so the client behaviour is predictable.
+func TestGetUserByIDHandler_NilRespReturnsJSON(t *testing.T) {
+	h := newTestHandler(t, map[string]models.Provider{}, "")
+	provider := &userSpyProvider{DefaultLocalProvider: &models.DefaultLocalProvider{}}
+	provider.DefaultLocalProvider.Initialize()
+
+	req := httptest.NewRequest(http.MethodGet, "/api/user/profile/00000000-0000-0000-0000-000000000002", nil)
+	req = mux.SetURLVars(req, map[string]string{"id": "00000000-0000-0000-0000-000000000002"})
+	rec := httptest.NewRecorder()
+
+	h.GetUserByIDHandler(rec, req, nil, nil, provider)
+
+	if rec.Code != http.StatusNotFound {
+		t.Fatalf("expected 404, got %d (body=%q)", rec.Code, rec.Body.String())
+	}
+	assertJSONErrorEnvelope(t, rec.Result())
+}
+
+// TestGetUserByIDHandler_SystemInstanceReturns204 verifies that when the
+// provider signals ErrUserIsSystemInstance (the requested ID is this
+// Meshery instance's own UUID, not a real user), the handler responds with
+// 204 No Content. This lets the UI render a "system" placeholder without
+// the row re-triggering a failed fetch forever — the original bug surface.
+func TestGetUserByIDHandler_SystemInstanceReturns204(t *testing.T) {
+	h := newTestHandler(t, map[string]models.Provider{}, "")
+	provider := &userSpyProvider{
+		DefaultLocalProvider: &models.DefaultLocalProvider{},
+		err:                  models.ErrUserIsSystemInstance,
+	}
+	provider.DefaultLocalProvider.Initialize()
+
+	req := httptest.NewRequest(http.MethodGet, "/api/user/profile/00000000-0000-0000-0000-000000000003", nil)
+	req = mux.SetURLVars(req, map[string]string{"id": "00000000-0000-0000-0000-000000000003"})
+	rec := httptest.NewRecorder()
+
+	h.GetUserByIDHandler(rec, req, nil, nil, provider)
+
+	if rec.Code != http.StatusNoContent {
+		t.Fatalf("expected 204 for system instance ID, got %d (body=%q)", rec.Code, rec.Body.String())
+	}
+	if body := rec.Body.Bytes(); len(body) != 0 {
+		t.Errorf("expected empty body for 204, got %q", string(body))
+	}
+}
+
+// assertJSONErrorEnvelope confirms that the writeJSONError contract held:
+// Content-Type is application/json (so RTK Query routes to its JSON handler)
+// and the body parses to {"error": "<non-empty>"} (so the client's default
+// transformErrorResponse produces a typed error instead of a SyntaxError).
+func assertJSONErrorEnvelope(t *testing.T, resp *http.Response) {
+	t.Helper()
+	defer func() { _ = resp.Body.Close() }()
+
+	if ct := resp.Header.Get("Content-Type"); ct != "application/json; charset=utf-8" {
+		t.Errorf("expected Content-Type application/json; charset=utf-8, got %q", ct)
+	}
+
+	var decoded map[string]string
+	if err := json.NewDecoder(resp.Body).Decode(&decoded); err != nil {
+		t.Fatalf("expected body to parse as JSON, got %v", err)
+	}
+	if decoded["error"] == "" {
+		t.Errorf("expected non-empty error field, got %+v", decoded)
+	}
+}

--- a/server/handlers/user_handler_test.go
+++ b/server/handlers/user_handler_test.go
@@ -31,7 +31,7 @@ func (m *userSpyProvider) GetUserByID(_ *http.Request, _ string) ([]byte, error)
 func TestGetUserByIDHandler_InvalidUUIDReturnsJSON(t *testing.T) {
 	h := newTestHandler(t, map[string]models.Provider{}, "")
 	provider := &userSpyProvider{DefaultLocalProvider: &models.DefaultLocalProvider{}}
-	provider.DefaultLocalProvider.Initialize()
+	provider.Initialize()
 
 	req := httptest.NewRequest(http.MethodGet, "/api/user/profile/not-a-uuid", nil)
 	req = mux.SetURLVars(req, map[string]string{"id": "not-a-uuid"})
@@ -52,7 +52,7 @@ func TestGetUserByIDHandler_InvalidUUIDReturnsJSON(t *testing.T) {
 func TestGetUserByIDHandler_ProviderErrorReturnsJSON(t *testing.T) {
 	h := newTestHandler(t, map[string]models.Provider{}, "")
 	provider := &userSpyProvider{DefaultLocalProvider: &models.DefaultLocalProvider{}, err: fmt.Errorf("remote blew up")}
-	provider.DefaultLocalProvider.Initialize()
+	provider.Initialize()
 
 	req := httptest.NewRequest(http.MethodGet, "/api/user/profile/00000000-0000-0000-0000-000000000001", nil)
 	req = mux.SetURLVars(req, map[string]string{"id": "00000000-0000-0000-0000-000000000001"})
@@ -72,7 +72,7 @@ func TestGetUserByIDHandler_ProviderErrorReturnsJSON(t *testing.T) {
 func TestGetUserByIDHandler_NilRespReturnsJSON(t *testing.T) {
 	h := newTestHandler(t, map[string]models.Provider{}, "")
 	provider := &userSpyProvider{DefaultLocalProvider: &models.DefaultLocalProvider{}}
-	provider.DefaultLocalProvider.Initialize()
+	provider.Initialize()
 
 	req := httptest.NewRequest(http.MethodGet, "/api/user/profile/00000000-0000-0000-0000-000000000002", nil)
 	req = mux.SetURLVars(req, map[string]string{"id": "00000000-0000-0000-0000-000000000002"})
@@ -97,7 +97,7 @@ func TestGetUserByIDHandler_SystemInstanceReturns204(t *testing.T) {
 		DefaultLocalProvider: &models.DefaultLocalProvider{},
 		err:                  models.ErrUserIsSystemInstance,
 	}
-	provider.DefaultLocalProvider.Initialize()
+	provider.Initialize()
 
 	req := httptest.NewRequest(http.MethodGet, "/api/user/profile/00000000-0000-0000-0000-000000000003", nil)
 	req = mux.SetURLVars(req, map[string]string{"id": "00000000-0000-0000-0000-000000000003"})

--- a/server/models/error.go
+++ b/server/models/error.go
@@ -2,11 +2,19 @@
 package models
 
 import (
+	stderrors "errors"
 	"fmt"
 	"time"
 
 	"github.com/meshery/meshkit/errors"
 )
+
+// ErrUserIsSystemInstance is returned by Provider.GetUserByID when the
+// requested userID matches this Meshery instance's own INSTANCE_ID. Callers
+// can use errors.Is to detect the sentinel and return a policy-appropriate
+// response (e.g. a 204 so the UI renders a "system" placeholder) instead of
+// conflating it with a missing user.
+var ErrUserIsSystemInstance = stderrors.New("requested ID is the Meshery instance's system UUID, not a user")
 
 // Please reference the following before contributing an error code:
 // https://docs.meshery.io/project/contributing/contributing-error

--- a/server/models/remote_provider.go
+++ b/server/models/remote_provider.go
@@ -593,7 +593,11 @@ func (l *RemoteProvider) GetUserDetails(req *http.Request) (*User, error) {
 func (l *RemoteProvider) GetUserByID(req *http.Request, userID string) ([]byte, error) {
 	systemID := viper.GetString("INSTANCE_ID")
 	if userID == systemID {
-		return nil, nil
+		// Designs/events created by Meshery itself (not a logged-in user)
+		// carry the instance's UUID as user_id. The remote provider has no
+		// record for it; surface a typed sentinel so the handler can decide
+		// the response shape instead of every caller racing to 404.
+		return nil, ErrUserIsSystemInstance
 	}
 	if !l.Capabilities.IsSupported(UsersProfile) {
 		err := ErrInvalidCapability("UsersProfile", l.ProviderName)

--- a/server/models/remote_provider_test.go
+++ b/server/models/remote_provider_test.go
@@ -1,11 +1,14 @@
 package models
 
 import (
+	stderrors "errors"
 	"net/http"
 	"net/http/httptest"
 	"strings"
 	"sync/atomic"
 	"testing"
+
+	"github.com/spf13/viper"
 )
 
 // TestRemoteProvider_OutboundOrgIdIsCanonical asserts that RemoteProvider
@@ -152,5 +155,32 @@ func TestRemoteProvider_OutboundOrgIdIsCanonical(t *testing.T) {
 				t.Errorf("expected path %q, got %q", tc.wantPath, got.path)
 			}
 		})
+	}
+}
+
+// TestRemoteProvider_GetUserByID_SystemInstanceReturnsSentinel pins the
+// contract with GetUserByIDHandler: when the caller asks for this Meshery
+// instance's own UUID (because a design's user_id is the instance UUID and
+// not a real user), the remote provider must signal with
+// ErrUserIsSystemInstance so the handler can respond 204 No Content instead
+// of conflating it with "user missing" (404) or emitting a plain-text body
+// that later crashes the client's JSON parser. This is the signal the Open
+// Recents 404/SyntaxError loop traced back to.
+func TestRemoteProvider_GetUserByID_SystemInstanceReturnsSentinel(t *testing.T) {
+	const instanceID = "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee"
+	viper.Set("INSTANCE_ID", instanceID)
+	t.Cleanup(func() { viper.Set("INSTANCE_ID", "") })
+
+	rp := &RemoteProvider{}
+	body, err := rp.GetUserByID(nil, instanceID)
+
+	if body != nil {
+		t.Errorf("expected nil body for system instance ID, got %q", string(body))
+	}
+	if err == nil {
+		t.Fatal("expected ErrUserIsSystemInstance, got nil — silent (nil, nil) is the old bug")
+	}
+	if !stderrors.Is(err, ErrUserIsSystemInstance) {
+		t.Errorf("expected err to match ErrUserIsSystemInstance via errors.Is, got %v", err)
 	}
 }

--- a/ui/components/MesheryFilters/FiltersCard.tsx
+++ b/ui/components/MesheryFilters/FiltersCard.tsx
@@ -93,7 +93,7 @@ function FiltersCard_({
   const [fullScreen, setFullScreen] = useState(false);
   const [showCode, setShowCode] = useState(false);
 
-  const { data: owner } = useGetUserByIdQuery(ownerId || '');
+  const { data: owner } = useGetUserByIdQuery(ownerId);
 
   const toggleFullScreen = () => {
     setFullScreen(!fullScreen);

--- a/ui/components/MesheryPatterns/MesheryPatternCard.tsx
+++ b/ui/components/MesheryPatterns/MesheryPatternCard.tsx
@@ -82,7 +82,7 @@ function MesheryPatternCard_({
     setFullScreen(!fullScreen);
   };
 
-  const { data: owner } = useGetUserByIdQuery(pattern.user_id || '');
+  const { data: owner } = useGetUserByIdQuery(pattern.user_id);
   const catalogContentKeys = Object.keys(description);
   const catalogContentValues = Object.values(description);
   const theme = useTheme();

--- a/ui/components/NotificationCenter/notification.tsx
+++ b/ui/components/NotificationCenter/notification.tsx
@@ -297,7 +297,7 @@ export const Notification = ({ event_id }) => {
 
   const uiConfig = useSelector((state) => state.events.ui);
 
-  const { data: user } = useGetUserByIdQuery(event.user_id || '');
+  const { data: user } = useGetUserByIdQuery(event.user_id);
 
   const userName = `${user?.first_name || ''} ${user?.last_name || ''}`;
   const userAvatarUrl = user?.avatar_url || '';

--- a/ui/components/SpacesSwitcher/DesignViewListItem.tsx
+++ b/ui/components/SpacesSwitcher/DesignViewListItem.tsx
@@ -46,9 +46,30 @@ const DesignViewListItem = ({
   showWorkspaceName = true,
   showOrganizationName = true,
 }) => {
-  const { data: userData, isLoading: isUserLoading } = useGetUserProfileSummaryByIdQuery({
-    id: selectedItem.user_id,
-  });
+  // Parent queries (expandUser: true) already merge the owner's profile onto
+  // the design/view, so prefer the embedded fields and only fall back to the
+  // per-row lookup when they are missing. This also avoids N extra requests
+  // when rendering a page of results.
+  const hasEmbeddedUser = Boolean(
+    selectedItem?.first_name ||
+    selectedItem?.last_name ||
+    selectedItem?.avatar_url ||
+    selectedItem?.email,
+  );
+  const { data: fetchedUserData, isLoading: isUserLoading } = useGetUserProfileSummaryByIdQuery(
+    { id: selectedItem?.user_id },
+    { skip: hasEmbeddedUser || !selectedItem?.user_id },
+  );
+  const userData = hasEmbeddedUser
+    ? {
+        id: selectedItem.user_id,
+        user_id: selectedItem.user_id,
+        first_name: selectedItem.first_name,
+        last_name: selectedItem.last_name,
+        avatar_url: selectedItem.avatar_url,
+        email: selectedItem.email,
+      }
+    : fetchedUserData;
   const { multiSelectedContent, setMultiSelectedContent } = useContext(WorkspaceModalContext);
   return (
     <>

--- a/ui/components/SpacesSwitcher/DesignViewListItem.tsx
+++ b/ui/components/SpacesSwitcher/DesignViewListItem.tsx
@@ -50,11 +50,16 @@ const DesignViewListItem = ({
   // the design/view, so prefer the embedded fields and only fall back to the
   // per-row lookup when they are missing. This also avoids N extra requests
   // when rendering a page of results.
+  //
+  // user_id is required too — without it the downstream profile-link href
+  // would resolve to /user/undefined. If it's missing we let the query run
+  // (or be skipped by the guard below) rather than render a broken link.
   const hasEmbeddedUser = Boolean(
-    selectedItem?.first_name ||
-    selectedItem?.last_name ||
-    selectedItem?.avatar_url ||
-    selectedItem?.email,
+    selectedItem?.user_id &&
+    (selectedItem?.first_name ||
+      selectedItem?.last_name ||
+      selectedItem?.avatar_url ||
+      selectedItem?.email),
   );
   const { data: fetchedUserData, isLoading: isUserLoading } = useGetUserProfileSummaryByIdQuery(
     { id: selectedItem?.user_id },

--- a/ui/components/SpacesSwitcher/ShareModal.tsx
+++ b/ui/components/SpacesSwitcher/ShareModal.tsx
@@ -22,9 +22,10 @@ export const ShareModal_ = ({ selectedResource, dataName, handleShareModalClose 
     : selectedResource;
   const resourceType = dataName === 'design' ? 'pattern' : dataName;
 
-  const { data: ownerData, isSuccess: isOwnerDataFetched } = useGetUserProfileSummaryByIdQuery({
-    id: firstSelectedResource?.user_id,
-  });
+  const { data: ownerData, isSuccess: isOwnerDataFetched } = useGetUserProfileSummaryByIdQuery(
+    { id: firstSelectedResource?.user_id },
+    { skip: !firstSelectedResource?.user_id },
+  );
 
   const { data: accessActorsInfoOfResource, isSuccess: accessActorsFetched } =
     useGetAccessActorsInfoOfResourceQuery({

--- a/ui/rtk-query/user.ts
+++ b/ui/rtk-query/user.ts
@@ -112,14 +112,15 @@ export const userApi = api
       getUserProfileSummaryById: builder.query({
         query: (queryArg) => ({
           url: `/api/user/profile/${queryArg.id}`,
-          // Some upstream error paths return plain text (e.g. "user not found").
-          // Parse JSON on success but fall back to raw text for errors so RTK
-          // Query surfaces a typed error object instead of a SyntaxError at
-          // runtime.
+          // Attempt JSON parsing on every response — success bodies are JSON,
+          // and most error paths also return structured JSON via
+          // writeJSONError. Fall back to the raw text for any non-JSON error
+          // body (legacy upstreams, reverse proxies, etc.) so RTK Query
+          // surfaces a readable error.data instead of throwing SyntaxError.
           responseHandler: async (response) => {
             const text = await response.text();
-            if (!response.ok) {
-              return text;
+            if (!text) {
+              return undefined;
             }
             try {
               return JSON.parse(text);
@@ -278,9 +279,12 @@ export const useGetUserByIdQuery = (id, options = {}) =>
     {
       id,
     },
-    // Falsy id would hit the server with an empty/invalid UUID and surface a 400;
-    // skipping preserves the handler's input contract.
-    { skip: !id, ...options },
+    // Falsy id must always skip — a caller's explicit skip can tighten but
+    // not loosen that invariant. Merging options first and forcing skip last
+    // prevents `{skip: false}` in options from re-enabling the query with an
+    // empty/invalid UUID and reintroducing the 400/404 loop this wrapper
+    // exists to prevent.
+    { ...options, skip: !id || options?.skip },
   );
 
 export const useGetUsersForOrgQuery = (queryArg, options) =>

--- a/ui/rtk-query/user.ts
+++ b/ui/rtk-query/user.ts
@@ -112,16 +112,33 @@ export const userApi = api
       getUserProfileSummaryById: builder.query({
         query: (queryArg) => ({
           url: `/api/user/profile/${queryArg.id}`,
+          // Some upstream error paths return plain text (e.g. "user not found").
+          // Parse JSON on success but fall back to raw text for errors so RTK
+          // Query surfaces a typed error object instead of a SyntaxError at
+          // runtime.
+          responseHandler: async (response) => {
+            const text = await response.text();
+            if (!response.ok) {
+              return text;
+            }
+            try {
+              return JSON.parse(text);
+            } catch {
+              return text;
+            }
+          },
         }),
         transformResponse: (response) => {
-          // Modify the response data to keep only necessary fields
+          if (!response || typeof response !== 'object') {
+            return undefined;
+          }
           return {
             id: response.id,
-            email: response?.email,
-            user_id: response?.user_id,
-            avatar_url: response?.avatar_url,
-            first_name: response?.first_name,
-            last_name: response?.last_name,
+            email: response.email,
+            user_id: response.user_id,
+            avatar_url: response.avatar_url,
+            first_name: response.first_name,
+            last_name: response.last_name,
           };
         },
       }),
@@ -256,12 +273,14 @@ export const {
   useGetUserProfileSummaryByIdQuery,
 } = userApi;
 
-export const useGetUserByIdQuery = (id, options) =>
+export const useGetUserByIdQuery = (id, options = {}) =>
   useGetUserProfileSummaryByIdQuery(
     {
       id,
     },
-    options,
+    // Falsy id would hit the server with an empty/invalid UUID and surface a 400;
+    // skipping preserves the handler's input contract.
+    { skip: !id, ...options },
   );
 
 export const useGetUsersForOrgQuery = (queryArg, options) =>


### PR DESCRIPTION
## Summary

- **Fixes the Open Recents console error loop**: clicking Open Recents in Kanvas triggered N per-row `GET /api/user/profile/{id}` calls and — for each user the remote provider couldn't resolve — RTK Query threw `SyntaxError: Unexpected token 'S', "Status Cod"... is not valid JSON` because the server returned a plain-text body.
- **Stops the N+1**: `DesignViewListItem` now uses the owner fields already merged on each design by `expandUser: true` instead of re-querying per row. `useGetUserByIdQuery` wrapper auto-skips when id is falsy.
- **Structured JSON errors** on `GetUserByIDHandler`, using the existing `writeJSONError` helper.
- **Typed sentinel** (`models.ErrUserIsSystemInstance`) replaces the silent `(nil, nil)` return in `RemoteProvider.GetUserByID` for the INSTANCE_ID case; the handler converts that into **204 No Content** so the UI renders a "system" placeholder without retrying.

## Root cause

The user bug report attached hundreds of stacked `uk`/`uw` frames — React reconciliation re-running in a loop. The `RecentContent` tab fetches designs with `expandUser: true`, which already populates `first_name`, `last_name`, `avatar_url`, `email` on each design. `DesignViewListItem` ignored that and fired `useGetUserProfileSummaryByIdQuery` per row. When any design's `user_id` pointed to a user the current session couldn't resolve (cross-org, deleted, or Meshery's own INSTANCE_ID), the upstream 404 propagated back as plain text from `http.Error`, which the RTK Query JSON parser crashed on. On each rerender the cache miss re-fetched and re-crashed.

Coordinating PRs:
- [layer5io/meshery-cloud#](https://github.com/layer5io/meshery-cloud/pulls) — 404 + JSON error body on `/api/identity/users/profile/:id` (plus a latent nil-deref fix on non-ErrNoRows DAO errors).
- [layer5io/sistent#](https://github.com/layer5io/sistent/pulls) — same `skip` guard on `CatalogDetail/RightPanel` so the catalog view doesn't fire with an empty id.

## Test plan

- [x] New handler tests (`server/handlers/user_handler_test.go`) cover invalid-UUID / provider-error / nil-resp / system-instance paths and pin the JSON envelope.
- [x] New provider test (`server/models/remote_provider_test.go::TestRemoteProvider_GetUserByID_SystemInstanceReturnsSentinel`) pins the typed sentinel contract.
- [x] `go test ./server/handlers/ ./server/models/` — all green.
- [x] `tsc --noEmit` clean on changed UI files.
- [x] `eslint` + `prettier` clean on changed UI files.
- [ ] Manual: open Kanvas → Open Recents → confirm no `SyntaxError`, no repeating 404s, avatars render from the embedded user info without per-row network calls in DevTools.