### PR TITLE
docs: cross-reference the identifier-naming contributor guide

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -28,6 +28,8 @@ performance management, and multi-tenancy capabilities across any cloud or on-pr
 
 ## Identifier Naming Conventions — MANDATORY
 
+Full canonical directory: <https://github.com/meshery/schemas/blob/master/docs/identifier-naming-contributor-guide.md> — the reader-friendly 26-row naming table with before/after and do/don't examples. The inline per-layer forms below remain the repo-scoped authority; the guide is the ecosystem-wide reference.
+
 This repository adheres to the canonical camelCase-wire identifier-naming contract
 defined authoritatively in `meshery/schemas/AGENTS.md § Casing rules at a
 glance`. The contract is **not optional**; deviations should be treated as

--- a/README.md
+++ b/README.md
@@ -321,6 +321,8 @@ Learn more about the <a href="https://meshery.io/community#meshmates">MeshMates<
 
 Please do! We're a warm and welcoming community of open source contributors. Please join. All types of contributions are welcome. Be sure to read the [Contributor Guides](https://docs.meshery.io/project/contributing) for a tour of resources available to you and how to get started.
 
+**Naming conventions.** This repository adheres to the canonical camelCase-wire identifier-naming contract shared across the Meshery / Layer5 ecosystem. See the [identifier-naming contributor guide](https://github.com/meshery/schemas/blob/master/docs/identifier-naming-contributor-guide.md) in `meshery/schemas` for the full reader-friendly directory (26-row naming table with before/after and do/don't examples). Repo-specific mandates live in [`AGENTS.md § Identifier Naming Conventions`](./AGENTS.md).
+
 <!-- <a href="https://youtu.be/MXQV-i-Hkf8"><img alt="Deploying Linkerd with Meshery" src="https://docs.meshery.io/assets/img/readme/deploying-linkerd-with-meshery.png" width="100%" align="center" /></a> -->
 
 <div>&nbsp;</div>


### PR DESCRIPTION
## Summary

Add a single, consistent pointer to the new canonical reference at `meshery/schemas:docs/identifier-naming-contributor-guide.md` from both discovery entry points in this repo.

- `README.md`: "Contributing" section now lists the ecosystem-wide naming contributor guide with a lead-in indicating repo-scoped authority lives in `AGENTS.md`.
- `AGENTS.md`: adds a "Full canonical directory" pointer line at the top of the pre-existing "Identifier Naming Conventions — MANDATORY" section landed in Phase 4.C of the naming migration.

Inline rules are unchanged. The contributor guide is the ecosystem-wide reader-friendly reference (26-row naming table with before/after and do/don't examples); the inline table here remains the repo-scoped authority for server handlers, `mesheryctl` commands, and UI RTK slices.

Paired cross-reference PRs are being opened in `meshery/schemas`, `layer5io/meshery-cloud`, `layer5labs/meshery-extensions`, `layer5io/sistent`, and `meshery/meshkit`.

## Test plan

- [x] `git diff --stat` shows 2 doc-only files, +4 lines / -0 lines, no code modified.
- [x] Pointer wording matches the pattern used across every repo's PR so reviewers can grep for drift.
- [x] Branch opened off `origin/master`, signed off per DCO.