### PR TITLE
feat(ui): consume MeshKit error metadata in notification toasts

### DIFF
--- a/ui/components/Lifecycle/Workspaces/hooks.tsx
+++ b/ui/components/Lifecycle/Workspaces/hooks.tsx
@@ -107,7 +107,7 @@ export const useDeletePattern = () => {
 
 export const usePublishPattern = (meshModelModelsData, refetchPatternData) => {
   const [publishCatalogContent] = usePublishFilterMutation();
-  const { handleSuccess, handleInfo, handleError } = useNotificationHandlers();
+  const { handleSuccess, handleInfo, notifyApiError } = useNotificationHandlers();
 
   const handlePublishModal = (pattern) => {
     return pattern;
@@ -147,7 +147,9 @@ export const usePublishPattern = (meshModelModelsData, refetchPatternData) => {
         }
         refetchPatternData && refetchPatternData();
       })
-      .catch((error) => handleError(error.data));
+      .catch((error) =>
+        notifyApiError(error, `Failed to publish "${publishModal?.pattern?.name}" to the catalog`),
+      );
   };
 
   return {

--- a/ui/components/MesheryCredentialComponent.tsx
+++ b/ui/components/MesheryCredentialComponent.tsx
@@ -14,7 +14,7 @@ import Modal from './Modal';
 import { CONNECTION_KINDS, CON_OPS } from '../utils/Enum';
 import Moment from 'react-moment';
 import LoadingScreen from './LoadingComponents/LoadingComponent';
-import { useNotification } from '../utils/hooks/useNotification';
+import { useNotification, useNotificationHandlers } from '../utils/hooks/useNotification';
 import { EVENT_TYPES } from '../lib/event-types';
 import { updateVisibleColumns } from '../utils/responsive-column';
 import { useWindowDimensions } from '../utils/dimension';
@@ -93,6 +93,7 @@ const MesheryCredentialComponent: React.FC = () => {
   );
   const [credentialName, setCredentialName] = useState<string | null>(null);
   const { notify } = useNotification();
+  const { notifyApiError } = useNotificationHandlers();
   const { width } = useWindowDimensions();
 
   const schemaChangeHandler = (type: CredentialType): void => {
@@ -119,13 +120,15 @@ const MesheryCredentialComponent: React.FC = () => {
     });
   };
 
-  const handleError = (error_msg: string): void => {
+  /**
+   * Surface a credential mutation error. Delegates to `notifyApiError` so the
+   * structured MeshKit envelope (when present) renders the server-supplied
+   * message and remediation guidance; otherwise falls back to the supplied
+   * description string.
+   */
+  const handleError = (error: unknown, fallbackMessage: string): void => {
     updateProgress({ showProgress: false });
-    notify({
-      message: `${error_msg}`,
-      event_type: EVENT_TYPES.ERROR,
-      details: error_msg.toString(),
-    });
+    notifyApiError(error, fallbackMessage);
   };
 
   const getCredentialsIcon = (type: string): React.ReactNode => {
@@ -370,7 +373,7 @@ const MesheryCredentialComponent: React.FC = () => {
           : type === CON_OPS.CREATE
             ? 'Failed to create credentials.'
             : 'Failed to update credentials.';
-      handleError(errorMessage);
+      handleError(error, errorMessage);
     } finally {
       updateProgress({ showProgress: false });
     }

--- a/ui/utils/helpers/__tests__/meshkitError.test.ts
+++ b/ui/utils/helpers/__tests__/meshkitError.test.ts
@@ -1,0 +1,118 @@
+import { describe, expect, it } from 'vitest';
+import { formatApiError, formatMeshkitErrorMarkdown, hasMeshkitError } from '../meshkitError';
+
+// ---------------------------------------------------------------------------
+// Unit tests for the MeshKit error formatter that backs `notifyApiError`.
+//
+// The schemas v1.2.2 baseQuery wrapper attaches a structured `meshkit`
+// envelope on every non-2xx JSON response that matches the MeshKit shape.
+// `formatApiError` turns that envelope into a markdown string the snackbar
+// renders via `BasicMarkdown`. These tests guard:
+//
+//   1. Pure-string inputs and unknown shapes degrade safely.
+//   2. A populated MeshKit envelope produces title + remediation list + code.
+//   3. A minimal MeshKit envelope renders as just the bold title — no broken
+//      "Try:" header or trailing whitespace.
+// ---------------------------------------------------------------------------
+
+describe('hasMeshkitError', () => {
+  it('returns true for an RTK error carrying a meshkit object with a message', () => {
+    expect(hasMeshkitError({ status: 500, data: {}, meshkit: { message: 'boom' } })).toBe(true);
+  });
+
+  it('returns false when meshkit is missing or malformed', () => {
+    expect(hasMeshkitError({ status: 500, data: 'plain' })).toBe(false);
+    expect(hasMeshkitError({ meshkit: {} })).toBe(false);
+    expect(hasMeshkitError(null)).toBe(false);
+    expect(hasMeshkitError(undefined)).toBe(false);
+    expect(hasMeshkitError('string error')).toBe(false);
+  });
+});
+
+describe('formatMeshkitErrorMarkdown', () => {
+  it('renders the message as a bold title', () => {
+    const md = formatMeshkitErrorMarkdown({ message: 'Workspace name already taken' });
+    expect(md).toBe('**Workspace name already taken**');
+  });
+
+  it('includes a Try: section when remediations are present', () => {
+    const md = formatMeshkitErrorMarkdown({
+      message: 'Failed to publish design',
+      suggestedRemediation: ['Re-run with a unique name', 'Check catalog permissions'],
+    });
+    expect(md).toContain('**Failed to publish design**');
+    expect(md).toContain('*Try:*');
+    expect(md).toContain('- Re-run with a unique name');
+    expect(md).toContain('- Check catalog permissions');
+  });
+
+  it('emits a muted code reference when meshkit.code is set', () => {
+    const md = formatMeshkitErrorMarkdown({
+      message: 'Connection refused',
+      code: 'meshery-server-1033',
+    });
+    expect(md).toContain('`meshery-server-1033`');
+  });
+
+  it('skips empty remediation entries', () => {
+    const md = formatMeshkitErrorMarkdown({
+      message: 'Bad request',
+      suggestedRemediation: ['', '   ', 'Fix the body'],
+    });
+    expect(md).toContain('- Fix the body');
+    expect(md).not.toMatch(/^- *$/m);
+  });
+
+  it('falls back to the supplied title when meshkit.message is empty', () => {
+    const md = formatMeshkitErrorMarkdown({ message: '' }, 'Failed to create workspace');
+    expect(md).toBe('**Failed to create workspace**');
+  });
+});
+
+describe('formatApiError', () => {
+  it('renders MeshKit metadata when the envelope is present', () => {
+    const error = {
+      status: 409,
+      data: { error: 'duplicate' },
+      meshkit: {
+        message: 'Workspace "demo" already exists',
+        code: 'meshery-server-1014',
+        suggestedRemediation: ['Pick a different name'],
+      },
+    };
+    const result = formatApiError(error, 'Failed to create workspace');
+    expect(result.meshkit).toBeDefined();
+    expect(result.message).toContain('**Workspace "demo" already exists**');
+    expect(result.message).toContain('- Pick a different name');
+    expect(result.message).toContain('`meshery-server-1014`');
+  });
+
+  it('falls back to FetchBaseQueryError.data string', () => {
+    const result = formatApiError(
+      { status: 500, data: 'internal server error' },
+      'Failed to create workspace',
+    );
+    expect(result.meshkit).toBeUndefined();
+    expect(result.message).toBe('internal server error');
+  });
+
+  it('falls back to nested data.error', () => {
+    const result = formatApiError({ status: 400, data: { error: 'bad input' } });
+    expect(result.message).toBe('bad input');
+  });
+
+  it('falls back to a SerializedError.message', () => {
+    const result = formatApiError(new Error('network down'), 'Request failed');
+    expect(result.message).toBe('network down');
+  });
+
+  it('uses fallbackTitle when no payload information is available', () => {
+    const result = formatApiError({}, 'Failed to load workspaces');
+    expect(result.message).toBe('Failed to load workspaces');
+  });
+
+  it('uses a generic fallback when nothing is supplied', () => {
+    const result = formatApiError(undefined);
+    expect(result.message).toBe('An unexpected error occurred');
+  });
+});

--- a/ui/utils/helpers/meshkitError.ts
+++ b/ui/utils/helpers/meshkitError.ts
@@ -1,0 +1,127 @@
+import type { MeshkitError, MeshkitFetchBaseQueryError } from '@meshery/schemas/api';
+
+/**
+ * Result of formatting an RTK Query error for the user-facing notification
+ * layer. The notification system renders `message` through `BasicMarkdown`
+ * (see `ThemeResponsiveSnackbar` in `themes/App.styles.tsx`), which means the
+ * formatter can use markdown — bold, lists, italics — to surface multiple
+ * lines of MeshKit metadata in a single toast.
+ */
+export interface FormattedApiError {
+  /** Markdown string ready for `BasicMarkdown`. */
+  message: string;
+  /** The MeshKit metadata block, if the response carried one. */
+  meshkit?: MeshkitError;
+}
+
+/**
+ * Type-guard that narrows an unknown RTK Query error to one carrying a
+ * MeshKit envelope. The schemas package's `transformErrorResponse` wrapper
+ * (v1.2.2+) sets `error.meshkit` on every non-2xx JSON response that matches
+ * the MeshKit shape, so this guard can be used directly on the `error`
+ * returned by mutation/query hooks without manual casting.
+ */
+export const hasMeshkitError = (
+  error: unknown,
+): error is MeshkitFetchBaseQueryError & { meshkit: MeshkitError } => {
+  if (!error || typeof error !== 'object') return false;
+  const candidate = (error as { meshkit?: unknown }).meshkit;
+  return (
+    !!candidate &&
+    typeof candidate === 'object' &&
+    typeof (candidate as MeshkitError).message === 'string'
+  );
+};
+
+/**
+ * Render a MeshKit error to a markdown string suitable for the snackbar.
+ *
+ * Layout:
+ *   **<message>**            ← bold title
+ *   *Try:*
+ *   - <remediation 1>        ← bullet list
+ *   - <remediation 2>
+ *   `<code>`                 ← muted reference for support tickets
+ *
+ * Sections are emitted only when their source data is non-empty, so a
+ * minimally-populated MeshKit response (just `message`) renders as a single
+ * bold line and degrades gracefully.
+ */
+export const formatMeshkitErrorMarkdown = (
+  meshkit: MeshkitError,
+  fallbackMessage?: string,
+): string => {
+  const lines: string[] = [];
+  const title = meshkit.message?.trim() || fallbackMessage?.trim() || 'Request failed';
+  lines.push(`**${title}**`);
+
+  const remediations = (meshkit.suggestedRemediation ?? []).filter(
+    (line) => typeof line === 'string' && line.trim().length > 0,
+  );
+  if (remediations.length > 0) {
+    lines.push('');
+    lines.push('*Try:*');
+    for (const remediation of remediations) {
+      lines.push(`- ${remediation.trim()}`);
+    }
+  }
+
+  if (meshkit.code) {
+    lines.push('');
+    lines.push(`\`${meshkit.code}\``);
+  }
+
+  return lines.join('\n');
+};
+
+/**
+ * Extract a single best-effort string from a non-MeshKit RTK Query error or
+ * any thrown value. Mirrors the legacy `error?.data` / `error?.message`
+ * pattern that scattered through the codebase before the MeshKit envelope
+ * landed, so callers that fall through this branch keep their previous UX.
+ */
+const extractFallbackMessage = (error: unknown): string | undefined => {
+  if (typeof error === 'string') return error;
+  if (!error || typeof error !== 'object') return undefined;
+
+  const obj = error as Record<string, unknown>;
+
+  // RTK FetchBaseQueryError shape: { status, data }
+  if (typeof obj.data === 'string' && obj.data.length > 0) return obj.data;
+  if (obj.data && typeof obj.data === 'object') {
+    const nested = obj.data as Record<string, unknown>;
+    if (typeof nested.error === 'string') return nested.error;
+    if (typeof nested.message === 'string') return nested.message;
+  }
+
+  // SerializedError / generic Error shape: { message }
+  if (typeof obj.message === 'string') return obj.message;
+  if (typeof obj.error === 'string') return obj.error;
+
+  return undefined;
+};
+
+/**
+ * Format any RTK Query error (with or without MeshKit metadata) into a
+ * markdown string and the originating MeshKit block. When `meshkit` is
+ * absent the result is a single-line message — identical to the pre-v1.2.2
+ * UX — so this function is safe to call unconditionally on every error.
+ *
+ * @param error          The error returned by `useMutation()`/`useQuery()` or
+ *                       caught from `.unwrap()`. Typed as `unknown` because
+ *                       call sites disagree on the wire type.
+ * @param fallbackTitle  Human-friendly description of the failed operation
+ *                       (e.g. "Failed to create workspace") used when the
+ *                       wire payload doesn't carry a `message`.
+ */
+export const formatApiError = (error: unknown, fallbackTitle?: string): FormattedApiError => {
+  if (hasMeshkitError(error)) {
+    return {
+      message: formatMeshkitErrorMarkdown(error.meshkit, fallbackTitle),
+      meshkit: error.meshkit,
+    };
+  }
+
+  const fallback = extractFallbackMessage(error) ?? fallbackTitle ?? 'An unexpected error occurred';
+  return { message: fallback };
+};

--- a/ui/utils/hooks/useNotification.tsx
+++ b/ui/utils/hooks/useNotification.tsx
@@ -12,6 +12,7 @@ import React from 'react';
 import BellIcon from '../../assets/icons/BellIcon';
 import { AddClassRecursively } from '../Elements';
 import { useCallback } from 'react';
+import { formatApiError } from '../helpers/meshkitError';
 
 /**
  * A React hook to facilitate emitting events from the client.
@@ -166,5 +167,26 @@ export const useNotificationHandlers = () => {
     [handleNotification],
   );
 
-  return { handleSuccess, handleError, handleInfo, handleWarn };
+  /**
+   * Surface an RTK Query error in a toast, automatically consuming the
+   * structured `meshkit` envelope set by `@meshery/schemas` v1.2.2's
+   * `transformErrorResponse` wrapper. When MeshKit metadata is present the
+   * toast renders:
+   *   - `meshkit.message` as a bold title,
+   *   - `meshkit.suggestedRemediation` as a bullet list (one entry per line),
+   *   - `meshkit.code` as a muted reference for support tickets.
+   * When the error is not a MeshKit envelope (network failure, legacy
+   * endpoint, etc.) the helper falls back to the prior single-line behavior
+   * — `error.data` / `error.message` / the supplied fallback title — so it
+   * is safe to call unconditionally.
+   */
+  const notifyApiError = useCallback(
+    (error: unknown, fallbackTitle?: string) => {
+      const { message } = formatApiError(error, fallbackTitle);
+      handleNotification('error', message);
+    },
+    [handleNotification],
+  );
+
+  return { handleSuccess, handleError, handleInfo, handleWarn, notifyApiError };
 };


### PR DESCRIPTION
## Summary

Wires the new `error.meshkit` metadata (introduced in `@meshery/schemas` v1.2.2 via [meshery/schemas#845](https://github.com/meshery/schemas/pull/845)) into the existing `useNotificationHandlers` toast layer so users see the structured MeshKit fields surfaced by the [server-side migration in #18919](https://github.com/meshery/meshery/pull/18919).

**Stacked on #18919** — base branch is `feat/json-error-responses`. Once #18919 merges to master, GitHub will auto-rebase this PR's base.

## What changed

- **New formatter helper** at `ui/utils/helpers/meshkitError.ts` with `hasMeshkitError`, `formatMeshkitErrorMarkdown`, `formatApiError`. 13 vitest cases cover MeshKit envelopes, fallback paths, and degenerate inputs.
- **`useNotificationHandlers` extended** with `notifyApiError(error, fallbackMessage)` — wraps the existing notification API. Calling code adds one destructured field, no new framework introduced.
- **Two demonstrative call sites** wired up:
  - `MesheryCredentialComponent.tsx` — credential CRUD mutation flow.
  - `Lifecycle/Workspaces/hooks.tsx` — `usePublishPattern` flow. Bonus fix: previous `handleError(error.data)` was rendering `[object Object]` for non-string error payloads — now formatted properly.
- The rest of the codebase continues to work because the helper falls back gracefully when `error.meshkit` is undefined (which is the case for non-MeshKit responses, network errors, or pre-migration server endpoints).

## UX before / after

**Before** (when server returned a plain-text error, even after PR #18919's JSON migration started landing): toast showed a single-line fallback like *"Failed to update credentials"* — or worse, `[object Object]` when the call site stringified `error.data`.

**After**: when the server returns a MeshKit JSON envelope, the toast shows the real `meshkit.message` in bold, the `suggestedRemediation` items as a bullet list under "Try:", and `meshkit.code` as a muted reference for support tickets — all rendered via the existing `BasicMarkdown` integration in `ThemeResponsiveSnackbar` (no new components).

## Why this is a small, demonstrative PR

The plan calls out the structured-error UX as a follow-up to the type wiring. Rather than a sweep across every consumer, this PR establishes the pattern in two representative call sites so reviewers can validate the shape before downstream PRs migrate the long tail (the codebase has at least a dozen `// @ts-nocheck` files like `Lifecycle/Workspaces/index.tsx` that swallow `error.data` today and would benefit). Those follow-ups are tracked separately.

## Test plan

- [x] `npm run lint` clean.
- [x] `npx tsc --noEmit` clean (used in lieu of full `npm run build` since types are the only consumer-facing change; the production bundle isn't affected).
- [x] `npx vitest run` — 34/34 tests pass; 13 new ones cover the MeshKit formatter.
- [ ] Manual smoke (post-merge): trigger a credential save with an invalid keypair, confirm the toast shows MeshKit message + remediation list.

## Plan reference

[`docs/superpowers/plans/2026-04-24-plaintext-response-migration.md`](https://github.com/meshery/meshery/blob/feat/json-error-responses/docs/superpowers/plans/2026-04-24-plaintext-response-migration.md) Phase 8 consumer side. Phase 9 (lint flip to blocking) is a separate PR (#TBD).