### PR TITLE
Fix typo in CLI contributing docs (#18940)

### DIFF
--- a/docs/content/en/project/contributing/contributing-cli-tests.md
+++ b/docs/content/en/project/contributing/contributing-cli-tests.md
@@ -217,7 +217,7 @@ To filter and view only CLI-related test cases using the Sheet Views feature:
 
 ![Meshery Test Plan Screenshot](/project/contributing/images/meshery-test-plan-v0.8.0-ui.png)
 
-## Developement
+## Development
 
 **End-to-End Tests:**
 


### PR DESCRIPTION
This PR fixes a typo in the contributing documentation for Meshery CLI end-to-end tests.

- Corrected "Developement" to "Development"

Closes #18940