### PR TITLE
docs(server): explain log/wire error divergence in SessionInjectorMiddleware

### DIFF
--- a/server/handlers/middlewares.go
+++ b/server/handlers/middlewares.go
@@ -197,12 +197,12 @@ func (h *Handler) SessionInjectorMiddleware(next func(http.ResponseWriter, *http
 			h.log.Error(ErrGetUserDetails(err))
 			// INTENTIONAL log/wire divergence. We log ErrGetUserDetails so the
 			// operational trail captures *what* failed (the get-user call), but
-			// we surface ErrTransientProvider on the wire so the client knows
-			// *why* the failure is transient (Cloud unreachable vs. genuine
-			// auth failure). Conflating the two would either flood logs with
-			// misleading transient classifications or hide the auth-vs-network
-			// distinction from clients. Don't "fix" this to match without
-			// reading PR #18919.
+			// we surface ErrTransientProvider on the wire so the client can
+			// distinguish between a transient failure (e.g., Cloud unreachable)
+			// and a genuine auth failure. Conflating the two would either flood
+			// logs with misleading transient classifications or hide the
+			// auth-vs-network distinction from clients. Don't "fix" this to
+			// match without reading PR #18919.
 			//
 			// Behavioral consequence: on a transient provider error we must NOT
 			// destroy the user's session by logging them out — that would cause

--- a/server/handlers/middlewares.go
+++ b/server/handlers/middlewares.go
@@ -195,10 +195,19 @@ func (h *Handler) SessionInjectorMiddleware(next func(http.ResponseWriter, *http
 		user, err := provider.GetUserDetails(req)
 		if err != nil {
 			h.log.Error(ErrGetUserDetails(err))
-			// Distinguish auth failures from transient provider errors.
-			// If the token cookie is missing/invalid, the user genuinely needs to re-authenticate.
-			// But if Cloud is temporarily unreachable, we must NOT destroy the user's session
-			// by logging them out — that would cause a redirect loop when Cloud recovers.
+			// INTENTIONAL log/wire divergence. We log ErrGetUserDetails so the
+			// operational trail captures *what* failed (the get-user call), but
+			// we surface ErrTransientProvider on the wire so the client knows
+			// *why* the failure is transient (Cloud unreachable vs. genuine
+			// auth failure). Conflating the two would either flood logs with
+			// misleading transient classifications or hide the auth-vs-network
+			// distinction from clients. Don't "fix" this to match without
+			// reading PR #18919.
+			//
+			// Behavioral consequence: on a transient provider error we must NOT
+			// destroy the user's session by logging them out — that would cause
+			// a redirect loop when Cloud recovers. A missing/invalid token
+			// cookie still falls through to the genuine auth-failure path below.
 			if isTransientProviderError(err) {
 				writeMeshkitError(w, ErrTransientProvider(err), http.StatusServiceUnavailable)
 				return


### PR DESCRIPTION
## Summary

Adds a code comment in `server/handlers/middlewares.go` explaining the intentional log/wire error divergence on the transient-provider path of `SessionInjectorMiddleware`:

- **Logs** `ErrGetUserDetails(err)` — captures *what* call failed.
- **Writes** `ErrTransientProvider(err)` on a 503 — tells the client *why* it's transient (Cloud outage vs. auth failure).

Conflating them would either flood logs with misleading transient classifications or hide the auth-vs-network distinction from clients.

**Stacked on #18919** — base branch is `feat/json-error-responses`.

## Test plan

Comment-only change. `go build` and `go vet` clean.

## Plan reference

Follow-up #4 from the final code review on [#18919](https://github.com/meshery/meshery/pull/18919).