### PR TITLE
chore(server): remove dead getLatestKubeVersionFromRegistry block

### DIFF
--- a/server/handlers/utils.go
+++ b/server/handlers/utils.go
@@ -63,27 +63,3 @@ func extractBoolQueryParams(r *http.Request, params ...string) (map[string]bool,
 	}
 	return result, nil
 }
-
-// TODO: Remone completely after confirm is no more needed
-// func getLatestKubeVersionFromRegistry(reg *registry.RegistryManager) string {
-// 	entities, _, _, _ := reg.GetEntities(&v1beta1.ModelFilter{
-// 		Name: "kubernetes",
-// 	})
-
-// 	versions := []string{}
-
-// 	for _, entity := range entities {
-// 		modelDef, err := utils.Cast[*model.ModelDefinition](entity)
-// 		if err != nil {
-// 			continue
-// 		}
-// 		versions = append(versions, modelDef.Model.Version)
-// 	}
-// 	if len(versions) == 0 {
-// 		return ""
-// 	}
-
-// 	versions = utils.SortDottedStringsByDigits(versions)
-
-// 	return versions[0]
-// }


### PR DESCRIPTION
## Summary

Removes a commented-out function (`getLatestKubeVersionFromRegistry`) from `server/handlers/utils.go` that's been carrying a "TODO: Remone completely after confirm is no more needed" marker for years. No live code references it.

Independent of any other PR — branches off master and targets master.

## Test plan

- [x] No live references found via `grep -r getLatestKubeVersionFromRegistry server/ ui/ mesheryctl/`.
- [x] `go build ./...` clean.
- [x] `go vet ./handlers/...` clean.
- [x] `go test ./handlers/...` passes.

## Plan reference

Follow-up #3 from the final code review on [#18919](https://github.com/meshery/meshery/pull/18919).