### PR TITLE
[Docs] Remove repetitive REST API reference summary text

### DIFF
--- a/docs/layouts/rest-apis/single.html
+++ b/docs/layouts/rest-apis/single.html
@@ -132,7 +132,6 @@
     <section class="rest-api-overview" aria-label="REST API overview">
       <p class="rest-api-overview__eyebrow">Meshery REST API reference</p>
       <p class="rest-api-overview__summary">
-        {{ len $operations }} API endpoints across {{ len $orderedTags }} resources.
         This reference is generated from <a href="{{ $schemaURL }}">OpenAPI schema</a> used by the Meshery docs.
       </p>
       <ul class="rest-api-overview__stats">


### PR DESCRIPTION
**Notes for Reviewers**

Removes the duplicate "N API endpoints across M resources." sentence from the REST API reference page overview section (`/reference/rest-apis/endpoints`). The counts are already shown in the summary stat cards below, making the sentence redundant.

- This PR fixes #18957

**[Signed commits](https://github.com/meshery/meshery/blob/master/CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [x] Yes, I signed my commits.
