### PR TITLE
[Docs] Replace body_class with layout for REST API reference

### DIFF
--- a/docs/assets/scss/_rest-api-reference.scss
+++ b/docs/assets/scss/_rest-api-reference.scss
@@ -13,21 +13,19 @@ $method-head: #7d8790;
   color: var(--color-white);
 }
 
-.rest-api-reference-page {
+.rest-api-reference-main {
+  overflow-x: visible;
+}
+
+.rest-api-reference-content {
+  max-width: none;
+
   .rest-api-page,
   .rest-api-page pre,
   .rest-api-page code,
   .rest-api-page kbd,
   .rest-api-page samp {
     font-family: "Qanelas Soft", "Open Sans", sans-serif;
-  }
-
-  .main-container {
-    overflow-x: visible;
-  }
-
-  .td-content {
-    max-width: none;
   }
 
   .rest-api-page {

--- a/docs/content/en/reference/rest-apis/_index.md
+++ b/docs/content/en/reference/rest-apis/_index.md
@@ -1,10 +1,8 @@
 ---
 title: REST API
 description: Meshery REST API documentation
-type: rest-apis
 data: openapi
 display_toc: false
-body_class: rest-api-reference-page
 aliases: 
 - /reference/rest-apis/swagger
 ---

--- a/docs/content/en/reference/rest-apis/endpoints.md
+++ b/docs/content/en/reference/rest-apis/endpoints.md
@@ -1,8 +1,7 @@
 ---
 title: REST API Reference
 description: Meshery REST API Reference
-type: rest-apis
+layout: rest-apis
 data: openapi
 display_toc: false
-body_class: rest-api-reference-page
 ---

--- a/docs/layouts/_default/baseof.html
+++ b/docs/layouts/_default/baseof.html
@@ -10,7 +10,7 @@
     
   </head>
 
-  <body class="td-{{ .Kind }} {{ with .Params.body_class }}{{ . }}{{ end }}">
+  <body class="td-{{ .Kind }}{{ with .Params.body_class }} {{ . }}{{ end }}{{ block "body_class" . }}{{ end }}">
     <script>
       (function() {
         const savedMode = localStorage.getItem("mode");
@@ -68,7 +68,7 @@
         </div>
       </div>
 
-      <main class="main-container" role="main">
+      <main class="main-container{{ block "main_class" . }}{{ end }}" role="main">
         <nav aria-label="breadcrumb">
           <ol class="breadcrumb spb-1">
             <li class="breadcrumb-item active" aria-current="page">
@@ -76,7 +76,7 @@
             </li>
           </ol>
         </nav>
-        <div class="td-content">
+        <div class="td-content{{ block "td_content_class" . }}{{ end }}">
           {{ if ne (.Params.display_title | default true) false }}
             <h1>{{ .Title }}</h1>
           {{ end }}

--- a/docs/layouts/_default/rest-apis.html
+++ b/docs/layouts/_default/rest-apis.html
@@ -12,7 +12,7 @@
 {{ $components := index $spec "components" | default dict }}
 {{ $securitySchemes := index $components "securitySchemes" | default dict }}
 {{ $tagGroups := index $spec "x-tagGroups" | default (slice) }}
-{{ $schemaURL := "https://raw.githubusercontent.com/meshery/meshery/refs/heads/master/docs/data/openapi.yml" }}
+{{ $schemaURL := "https://raw.githubusercontent.com/meshery/meshery/master/docs/data/openapi.yml" }}
 {{ $defaultOssServer := dict
   "url" "http://localhost:9081"
   "description" "Meshery Server default URL"
@@ -1204,8 +1204,12 @@ document.addEventListener("DOMContentLoaded", function () {
   });
 
   if (searchInput) {
+    var searchTimeout;
     searchInput.addEventListener("input", function () {
-      applyFilter({ updateHash: false });
+      window.clearTimeout(searchTimeout);
+      searchTimeout = window.setTimeout(function () {
+        applyFilter({ updateHash: false });
+      }, 250);
     });
   }
 

--- a/docs/layouts/_default/rest-apis.html
+++ b/docs/layouts/_default/rest-apis.html
@@ -1,0 +1,1231 @@
+{{ define "main_class" }} rest-api-reference-main{{ end }}
+{{ define "td_content_class" }} rest-api-reference-content{{ end }}
+
+{{ define "main" }}
+{{ .Content }}
+{{ $data := .Params.data }}
+{{ $spec := index site.Data $data }}
+{{ if not $spec }}
+  {{ $spec = .Params }}
+{{ end }}
+
+{{ $components := index $spec "components" | default dict }}
+{{ $securitySchemes := index $components "securitySchemes" | default dict }}
+{{ $tagGroups := index $spec "x-tagGroups" | default (slice) }}
+{{ $schemaURL := "https://raw.githubusercontent.com/meshery/meshery/refs/heads/master/docs/data/openapi.yml" }}
+{{ $defaultOssServer := dict
+  "url" "http://localhost:9081"
+  "description" "Meshery Server default URL"
+}}
+{{ $tagIndex := dict }}
+{{ range $spec.tags }}
+  {{ $tagIndex = merge $tagIndex (dict .name .) }}
+{{ end }}
+
+{{ $methodOrder := slice "get" "post" "put" "patch" "delete" "options" "head" }}
+{{ $operations := slice }}
+{{ $tagCounts := dict }}
+
+{{ range $path, $route := $spec.paths }}
+  {{ range $methodOrder }}
+    {{ $method := . }}
+    {{ with index $route $method }}
+      {{ $operation := . }}
+      {{ if partial "rest-apis/is-operation-included.html" $operation }}
+        {{ $servers := index $operation "servers" | default (index $route "servers") | default ($spec.servers | default (slice)) }}
+        {{ $tagName := "Ungrouped" }}
+        {{ with $operation.tags }}
+          {{ $tagName = index . 0 }}
+        {{ end }}
+        {{ $tagMeta := partial "rest-apis/tag-meta.html" (dict "name" $tagName "tags" $tagIndex) }}
+        {{ $pathSlug := replaceRE "[{}]" "" $path }}
+        {{ $pathSlug = replaceRE "[^a-zA-Z0-9]+" "-" $pathSlug }}
+        {{ $pathSlug = lower $pathSlug }}
+        {{ $pathSlug = replaceRE "^-+|-+$" "" $pathSlug }}
+        {{ if eq $pathSlug "" }}
+          {{ $pathSlug = "root" }}
+        {{ end }}
+        {{ $operationID := printf "%s-%s" $method $pathSlug }}
+        {{ $operations = $operations | append (dict
+          "id" $operationID
+          "pathId" $pathSlug
+          "path" $path
+          "method" $method
+          "summary" ($operation.summary | default $path)
+          "description" $operation.description
+          "tag" $tagName
+          "tagLabel" (index $tagMeta "label")
+          "tagDescription" (index $tagMeta "description")
+          "servers" $servers
+          "data" $operation
+        ) }}
+        {{ $count := index $tagCounts $tagName | default 0 }}
+        {{ $tagCounts = merge $tagCounts (dict $tagName (add $count 1)) }}
+      {{ end }}
+    {{ end }}
+  {{ end }}
+{{ end }}
+
+{{ $orderedTags := slice }}
+{{ range $tagGroup := $tagGroups }}
+  {{ range $tagName := ($tagGroup.tags | default (slice)) }}
+    {{ if and (gt ((index $tagCounts $tagName) | default 0) 0) (not (in $orderedTags $tagName)) }}
+      {{ $orderedTags = $orderedTags | append $tagName }}
+    {{ end }}
+  {{ end }}
+{{ end }}
+{{ range $spec.tags }}
+  {{ $tagName := .name }}
+  {{ if and (gt ((index $tagCounts $tagName) | default 0) 0) (not (in $orderedTags $tagName)) }}
+    {{ $orderedTags = $orderedTags | append $tagName }}
+  {{ end }}
+{{ end }}
+{{ range $operations }}
+  {{ if not (in $orderedTags .tag) }}
+    {{ $orderedTags = $orderedTags | append .tag }}
+  {{ end }}
+{{ end }}
+
+{{ $baseTagLabels := dict }}
+{{ $baseTagLabelCounts := dict }}
+{{ range $tagName := $orderedTags }}
+  {{ $tagMeta := partial "rest-apis/tag-meta.html" (dict "name" $tagName "tags" $tagIndex) }}
+  {{ $baseLabel := index $tagMeta "label" | default "Ungrouped" }}
+  {{ $baseTagLabels = merge $baseTagLabels (dict $tagName $baseLabel) }}
+  {{ $baseCount := index $baseTagLabelCounts $baseLabel | default 0 }}
+  {{ $baseTagLabelCounts = merge $baseTagLabelCounts (dict $baseLabel (add $baseCount 1)) }}
+{{ end }}
+
+{{ $tagLabels := dict }}
+{{ $sortedTagEntries := slice }}
+{{ range $tagName := $orderedTags }}
+  {{ $baseLabel := index $baseTagLabels $tagName | default "Ungrouped" }}
+  {{ $resolvedLabel := $baseLabel }}
+  {{ if gt (index $baseTagLabelCounts $baseLabel | default 0) 1 }}
+    {{ $parts := split $tagName "_" }}
+    {{ $suffixParts := after 1 $parts }}
+    {{ $suffixLabel := delimit $suffixParts " " }}
+    {{ if ne $suffixLabel "" }}
+      {{ $suffixLabel = $suffixLabel | title }}
+    {{ end }}
+    {{ if and (ne $suffixLabel "") (ne (lower $suffixLabel) (lower $baseLabel)) }}
+      {{ $resolvedLabel = printf "%s %s" $baseLabel $suffixLabel }}
+    {{ end }}
+  {{ end }}
+  {{ $tagLabels = merge $tagLabels (dict $tagName $resolvedLabel) }}
+  {{ $sortedTagEntries = $sortedTagEntries | append (dict
+    "name" $tagName
+    "label" $resolvedLabel
+  ) }}
+{{ end }}
+{{ $sortedTagEntries = sort $sortedTagEntries "label" }}
+{{ $orderedTags = slice }}
+{{ range $sortedTagEntries }}
+  {{ $orderedTags = $orderedTags | append .name }}
+{{ end }}
+
+{{ $normalizedOperations := slice }}
+{{ range $operations }}
+  {{ $normalizedOperations = $normalizedOperations | append (merge . (dict "tagLabel" ((index $tagLabels .tag) | default .tagLabel))) }}
+{{ end }}
+{{ $operations = $normalizedOperations }}
+
+{{ if gt (len $operations) 0 }}
+  <div class="rest-api-page" data-rest-api-root>
+    <section class="rest-api-overview" aria-label="REST API overview">
+      <p class="rest-api-overview__eyebrow">Meshery REST API reference</p>
+      <p class="rest-api-overview__summary">
+        {{ len $operations }} API endpoints across {{ len $orderedTags }} resources.
+        This reference is generated from <a href="{{ $schemaURL }}">OpenAPI schema</a> used by the Meshery docs.
+      </p>
+      <ul class="rest-api-overview__stats">
+        <li><strong>{{ len $orderedTags }}</strong><span>resources</span></li>
+        <li><strong>{{ len $operations }}</strong><span>endpoints</span></li>
+      </ul>
+    </section>
+
+    <section class="rest-api-controls" aria-label="REST API controls">
+      <div class="rest-api-controls__search">
+        <label class="rest-api-search-label" for="rest-api-search">Search endpoints</label>
+        <input
+          id="rest-api-search"
+          class="rest-api-search"
+          type="search"
+          autocomplete="off"
+          placeholder="Search paths, summaries, methods, and resources"
+          data-rest-api-search
+        />
+      </div>
+
+      <div class="rest-api-controls__categories">
+        <p class="rest-api-controls__label">Resources</p>
+        <div class="rest-api-category-bar" data-rest-api-tag-filters>
+          <button
+            type="button"
+            class="rest-api-category-button is-active"
+            data-tag-filter="all"
+            data-tag-label="All resources"
+            aria-pressed="true"
+          >
+            <span>All resources</span>
+            <span class="rest-api-category-button__count">{{ len $operations }}</span>
+          </button>
+          {{ range $tagName := $orderedTags }}
+            {{ $tagLabel := index $tagLabels $tagName | default $tagName }}
+            <button
+              type="button"
+              class="rest-api-category-button"
+              data-tag-filter="{{ $tagName }}"
+              data-tag-label="{{ $tagLabel }}"
+              aria-pressed="false"
+            >
+              <span>{{ $tagLabel }}</span>
+              <span class="rest-api-category-button__count">{{ index $tagCounts $tagName }}</span>
+            </button>
+          {{ end }}
+        </div>
+      </div>
+
+      <div class="rest-api-results">
+        <p class="rest-api-results__text" data-rest-api-results-text>Showing all {{ len $operations }} endpoints.</p>
+      </div>
+    </section>
+
+    <div class="rest-api-layout">
+      <aside class="rest-api-sidebar" aria-label="REST endpoint navigation">
+        <div class="rest-api-sidebar__inner">
+          <div class="rest-api-nav-toolbar">
+            <button
+              type="button"
+              class="rest-api-nav-control"
+              data-toggle-all-groups
+              data-toggle-mode="expand"
+              aria-label="Expand all resources"
+            >
+              <span class="rest-api-nav-control__icon" aria-hidden="true">
+                <span></span>
+                <span></span>
+              </span>
+              <span class="rest-api-nav-control__text">Expand all</span>
+            </button>
+          </div>
+
+          <div class="rest-api-nav" data-rest-api-nav>
+            {{ $renderedTags := slice }}
+            {{ range $tagGroup := $tagGroups }}
+              {{ $groupTags := slice }}
+              {{ range $tagName := ($tagGroup.tags | default (slice)) }}
+                {{ $tagCount := index $tagCounts $tagName | default 0 }}
+                {{ if gt $tagCount 0 }}
+                  {{ $groupTags = $groupTags | append $tagName }}
+                {{ end }}
+              {{ end }}
+              {{ $groupTagEntries := slice }}
+              {{ range $tagName := $groupTags }}
+                {{ $groupTagEntries = $groupTagEntries | append (dict
+                  "name" $tagName
+                  "label" ((index $tagLabels $tagName) | default $tagName)
+                ) }}
+              {{ end }}
+              {{ $groupTagEntries = sort $groupTagEntries "label" }}
+              {{ $groupTags = slice }}
+              {{ range $groupTagEntries }}
+                {{ $groupTags = $groupTags | append .name }}
+              {{ end }}
+
+              {{ if gt (len $groupTags) 0 }}
+                {{ $groupLabel := replace ($tagGroup.name | default "Ungrouped") "_" " " }}
+                {{ if eq $groupLabel (lower $groupLabel) }}
+                  {{ $groupLabel = $groupLabel | title }}
+                {{ end }}
+                {{ $showHeading := gt (len $groupTags) 1 }}
+                {{ if and (not $showHeading) (gt (len $groupTags) 0) }}
+                  {{ $onlyTag := index $groupTags 0 }}
+                  {{ $normalizedGroup := replaceRE "[^a-z0-9]+" "" (lower $groupLabel) }}
+                  {{ $normalizedOnly := replaceRE "[^a-z0-9]+" "" (lower ((index $tagLabels $onlyTag) | default $onlyTag)) }}
+                  {{ $showHeading = ne $normalizedGroup $normalizedOnly }}
+                {{ end }}
+                <section class="rest-api-nav-group" data-rest-api-group>
+                  {{ if $showHeading }}
+                    <p class="rest-api-nav-group__heading">{{ $groupLabel }}</p>
+                  {{ end }}
+                  <div class="rest-api-nav-group__items">
+                    {{ range $tagName := $groupTags }}
+                      {{ $resolvedTagLabel := index $tagLabels $tagName | default $tagName }}
+                      {{ $groupOperations := where $operations "tag" $tagName }}
+                      {{ if gt (len $groupOperations) 0 }}
+                        <section class="rest-api-nav-subgroup" data-rest-api-subgroup data-tag-name="{{ $tagName }}">
+                          <button
+                            type="button"
+                            class="rest-api-nav-subgroup__toggle"
+                            data-subgroup-toggle
+                            aria-expanded="false"
+                          >
+                            <span class="rest-api-nav-subgroup__title">{{ $resolvedTagLabel }}</span>
+                            <span class="rest-api-nav-subgroup__toggle-meta">
+                              <span class="rest-api-nav-subgroup__count" data-subgroup-count data-total-count="{{ len $groupOperations }}">{{ len $groupOperations }}</span>
+                              <span class="rest-api-nav-subgroup__chevron" aria-hidden="true"></span>
+                            </span>
+                          </button>
+                          <div class="rest-api-nav-subgroup__panel" data-subgroup-panel hidden>
+                            <ul class="rest-api-nav-list rest-api-nav-list--endpoints">
+                              {{ range $groupOperations }}
+                                <li class="rest-api-nav-item">
+                                  <a
+                                    href="#{{ .id }}"
+                                    class="rest-api-nav-link"
+                                    data-operation-link
+                                    data-operation-id="{{ .id }}"
+                                    data-path-id="{{ .pathId }}"
+                                    data-tag-name="{{ .tag }}"
+                                    data-tag-label="{{ .tagLabel }}"
+                                    data-search="{{ lower (printf "%s %s %s %s %s" .method .path .summary $groupLabel .tagLabel) }}"
+                                  >
+                                    <span class="rest-api-nav-link__top">
+                                      <span class="rest-api-method-badge rest-api-method-badge--{{ .method }}">{{ upper .method }}</span>
+                                      <span class="rest-api-nav-link__path">{{ .path }}</span>
+                                    </span>
+                                    <span class="rest-api-nav-link__summary">{{ .summary }}</span>
+                                  </a>
+                                </li>
+                              {{ end }}
+                            </ul>
+                          </div>
+                        </section>
+                      {{ end }}
+                      {{ $renderedTags = $renderedTags | append $tagName }}
+                    {{ end }}
+                  </div>
+                </section>
+              {{ end }}
+            {{ end }}
+
+            {{ $remainingTags := slice }}
+            {{ range $tagName := $orderedTags }}
+              {{ if not (in $renderedTags $tagName) }}
+                {{ $remainingTags = $remainingTags | append $tagName }}
+              {{ end }}
+            {{ end }}
+
+            {{ if gt (len $remainingTags) 0 }}
+              <section class="rest-api-nav-group" data-rest-api-group>
+                {{ if gt (len $tagGroups) 0 }}
+                  <p class="rest-api-nav-group__heading">Additional resources</p>
+                {{ end }}
+                <div class="rest-api-nav-group__items">
+                  {{ range $tagName := $remainingTags }}
+                    {{ $resolvedTagLabel := index $tagLabels $tagName | default $tagName }}
+                    {{ $groupOperations := where $operations "tag" $tagName }}
+                    <section class="rest-api-nav-subgroup" data-rest-api-subgroup data-tag-name="{{ $tagName }}">
+                      <button
+                        type="button"
+                        class="rest-api-nav-subgroup__toggle"
+                        data-subgroup-toggle
+                        aria-expanded="false"
+                      >
+                        <span class="rest-api-nav-subgroup__title">{{ $resolvedTagLabel }}</span>
+                        <span class="rest-api-nav-subgroup__toggle-meta">
+                          <span class="rest-api-nav-subgroup__count" data-subgroup-count data-total-count="{{ len $groupOperations }}">{{ len $groupOperations }}</span>
+                          <span class="rest-api-nav-subgroup__chevron" aria-hidden="true"></span>
+                        </span>
+                      </button>
+                      <div class="rest-api-nav-subgroup__panel" data-subgroup-panel hidden>
+                        <ul class="rest-api-nav-list rest-api-nav-list--endpoints">
+                          {{ range $groupOperations }}
+                            <li class="rest-api-nav-item">
+                              <a
+                                href="#{{ .id }}"
+                                class="rest-api-nav-link"
+                                data-operation-link
+                                data-operation-id="{{ .id }}"
+                                data-path-id="{{ .pathId }}"
+                                data-tag-name="{{ .tag }}"
+                                data-tag-label="{{ .tagLabel }}"
+                                data-search="{{ lower (printf "%s %s %s %s" .method .path .summary .tagLabel) }}"
+                              >
+                                <span class="rest-api-nav-link__top">
+                                  <span class="rest-api-method-badge rest-api-method-badge--{{ .method }}">{{ upper .method }}</span>
+                                  <span class="rest-api-nav-link__path">{{ .path }}</span>
+                                </span>
+                                <span class="rest-api-nav-link__summary">{{ .summary }}</span>
+                              </a>
+                            </li>
+                          {{ end }}
+                        </ul>
+                      </div>
+                    </section>
+                  {{ end }}
+                </div>
+              </section>
+            {{ end }}
+          </div>
+
+          <p class="rest-api-nav__empty" data-rest-api-empty hidden>No endpoints match the current search or resource filter.</p>
+        </div>
+      </aside>
+
+      <section class="rest-api-content" data-rest-api-content aria-live="polite">
+        {{ range $operations }}
+          {{ $operationId := .id }}
+          {{ $operation := .data }}
+          {{ $operationPath := .path }}
+          {{ $authSummary := partial "rest-apis/auth-summary.html" (dict "operation" $operation "schemes" $securitySchemes) | strings.TrimSpace }}
+          {{ $parameters := $operation.parameters | default (slice) }}
+          {{ $servers := .servers | default (slice) }}
+
+          <article class="rest-api-operation" data-operation-panel data-operation-id="{{ .id }}" data-path-id="{{ .pathId }}">
+            <div class="rest-api-operation__header">
+              <div class="rest-api-operation__labels">
+                <span class="rest-api-method-badge rest-api-method-badge--{{ .method }}">{{ upper .method }}</span>
+                <span class="rest-api-chip">{{ .tagLabel }}</span>
+              </div>
+              <h2 class="rest-api-operation__path" id="{{ .id }}">{{ .path }}</h2>
+              <p class="rest-api-operation__summary">{{ .summary }}</p>
+              {{ with .description }}
+                <div class="rest-api-prose">{{ . | markdownify }}</div>
+              {{ end }}
+            </div>
+
+            {{ if $authSummary }}
+              <div class="rest-api-auth" id="authentication-{{ $operationId }}">
+                <p class="rest-api-auth__label">Authentication</p>
+                <span class="rest-api-auth__value">{{ $authSummary }}</span>
+              </div>
+            {{ end }}
+
+            {{ $ossServers := slice }}
+            {{ range $servers }}
+              {{ $serverUrl := index . "url" | default "" }}
+              {{ if and $serverUrl (not (strings.Contains $serverUrl "cloud.")) (not (strings.Contains $serverUrl "staging-cloud.")) }}
+                {{ $ossServers = $ossServers | append . }}
+              {{ end }}
+            {{ end }}
+            {{ if eq (len $ossServers) 0 }}
+              {{ $ossServers = $ossServers | append $defaultOssServer }}
+            {{ end }}
+            <section class="rest-api-section rest-api-section--try">
+              <div class="rest-api-section-heading rest-api-section-heading--try">
+                <h3 id="server-urls-{{ $operationId }}">Try this endpoint</h3>
+                <p class="rest-api-section-heading__summary">
+                  Use your Meshery hostname or local server URL when calling this endpoint.
+                </p>
+              </div>
+              <div class="rest-api-try-list">
+                {{ range $server := $ossServers }}
+                  {{ $serverUrl := index $server "url" | default "" }}
+                  {{ $serverDescription := index $server "description" | default "Meshery Server URL" }}
+                  <div class="rest-api-try-item">
+                    <p class="rest-api-try-item__label">{{ $serverDescription }}</p>
+                    <code class="rest-api-try-item__url">{{ printf "%s%s" $serverUrl $operationPath }}</code>
+                  </div>
+                {{ end }}
+              </div>
+            </section>
+
+            {{ if gt (len $parameters) 0 }}
+              <section class="rest-api-section rest-api-section--parameters">
+                <h3 id="parameters-{{ $operationId }}">Parameters</h3>
+                {{ $locations := slice
+                  (dict "key" "path" "label" "Path parameters")
+                  (dict "key" "query" "label" "Query parameters")
+                  (dict "key" "header" "label" "Header parameters")
+                  (dict "key" "cookie" "label" "Cookie parameters")
+                }}
+                {{ range $locations }}
+                  {{ $rows := where $parameters "in" .key }}
+                  {{ if gt (len $rows) 0 }}
+                    <div class="rest-api-section-block">
+                      <p class="rest-api-section-block__title">{{ .label }}</p>
+                      <div class="rest-api-table-wrapper">
+                        <table>
+                          <thead>
+                            <tr>
+                              <th>Name</th>
+                              <th>Type</th>
+                              <th>Required</th>
+                              <th>Description</th>
+                            </tr>
+                          </thead>
+                          <tbody>
+                            {{ range $rows }}
+                              {{ $parameterSchema := index . "schema" | default dict }}
+                              {{ $parameterType := partial "rest-apis/schema-type.html" $parameterSchema }}
+                              <tr>
+                                <td><code>{{ .name }}</code></td>
+                                <td>{{ $parameterType | default "schema" }}</td>
+                                <td>{{ if .required }}Yes{{ else }}No{{ end }}</td>
+                                <td>
+                                  {{ with .description }}
+                                    {{ . | markdownify }}
+                                  {{ else }}
+                                    <span class="rest-api-muted">No description provided.</span>
+                                  {{ end }}
+                                </td>
+                              </tr>
+                            {{ end }}
+                          </tbody>
+                        </table>
+                      </div>
+                    </div>
+                  {{ end }}
+                {{ end }}
+              </section>
+            {{ end }}
+
+            {{ with $operation.requestBody }}
+              {{ $requestBody := . }}
+              {{ $requestContentCount := len $requestBody.content }}
+              {{ $singleRequestContentType := "" }}
+              {{ if eq $requestContentCount 1 }}
+                {{ range $contentType, $_ := $requestBody.content }}
+                  {{ $singleRequestContentType = $contentType }}
+                {{ end }}
+              {{ end }}
+              <section class="rest-api-section">
+                <div class="rest-api-section-heading rest-api-section-heading--request">
+                  <div class="rest-api-section-header">
+                    <h3 id="request-body-{{ $operationId }}">Request body</h3>
+                    {{ if eq $requestContentCount 1 }}
+                      <div class="rest-api-section-header__meta">
+                        <span class="rest-api-section-header__type">{{ $singleRequestContentType }}</span>
+                        <span class="rest-api-chip rest-api-chip--subtle">{{ if $requestBody.required }}Required{{ else }}Optional{{ end }}</span>
+                      </div>
+                    {{ end }}
+                  </div>
+                  {{ with $requestBody.description }}
+                    <div class="rest-api-section-heading__summary rest-api-prose">{{ . | markdownify }}</div>
+                  {{ end }}
+                </div>
+                {{ range $contentType, $content := $requestBody.content }}
+                  {{ $schema := index $content "schema" | default dict }}
+                  {{ $schemaType := partial "rest-apis/schema-type.html" $schema }}
+                  {{ $fields := partial "rest-apis/schema-properties.html" $schema }}
+                  {{ $example := partial "rest-apis/content-example.html" $content }}
+                  <article class="rest-api-media-block">
+                    {{ if ne $requestContentCount 1 }}
+                      <div class="rest-api-media-block__header rest-api-media-block__header--request">
+                        <p class="rest-api-media-block__title">{{ $contentType }}</p>
+                        <span class="rest-api-chip rest-api-chip--subtle">{{ if $requestBody.required }}Required{{ else }}Optional{{ end }}</span>
+                      </div>
+                    {{ end }}
+
+                    {{ with index $schema "description" }}
+                      <div class="rest-api-prose">{{ . | markdownify }}</div>
+                    {{ else }}
+                      <p class="rest-api-media-block__summary">Schema: <code>{{ $schemaType }}</code></p>
+                    {{ end }}
+
+                    {{ if gt (len (index $fields "rows")) 0 }}
+                      <div class="rest-api-table-wrapper">
+                        <table>
+                          <thead>
+                            <tr>
+                              <th>Field</th>
+                              <th>Type</th>
+                              <th>Required</th>
+                              <th>Description</th>
+                            </tr>
+                          </thead>
+                          <tbody>
+                            {{ range index $fields "rows" }}
+                              <tr>
+                                <td><code>{{ .name }}</code></td>
+                                <td>{{ partial "rest-apis/schema-type.html" (index . "schema") }}</td>
+                                <td>{{ if .required }}Yes{{ else }}No{{ end }}</td>
+                                <td>
+                                  {{ with index .schema "description" }}
+                                    {{ . | markdownify }}
+                                  {{ else }}
+                                    <span class="rest-api-muted">No description provided.</span>
+                                  {{ end }}
+                                </td>
+                              </tr>
+                            {{ end }}
+                          </tbody>
+                        </table>
+                      </div>
+                    {{ else if index $schema "oneOf" }}
+                      <div class="rest-api-variant-grid">
+                        {{ range index $schema "oneOf" }}
+                          {{ $variantFields := partial "rest-apis/schema-properties.html" . }}
+                          <article class="rest-api-variant">
+                            <p class="rest-api-variant__title">{{ index . "title" | default (partial "rest-apis/schema-type.html" .) }}</p>
+                            {{ with index . "description" }}
+                              <div class="rest-api-prose">{{ . | markdownify }}</div>
+                            {{ end }}
+                            {{ if gt (len (index $variantFields "rows")) 0 }}
+                              <div class="rest-api-table-wrapper">
+                                <table>
+                                  <thead>
+                                    <tr>
+                                      <th>Field</th>
+                                      <th>Type</th>
+                                      <th>Required</th>
+                                      <th>Description</th>
+                                    </tr>
+                                  </thead>
+                                  <tbody>
+                                    {{ range index $variantFields "rows" }}
+                                      <tr>
+                                        <td><code>{{ .name }}</code></td>
+                                        <td>{{ partial "rest-apis/schema-type.html" (index . "schema") }}</td>
+                                        <td>{{ if .required }}Yes{{ else }}No{{ end }}</td>
+                                        <td>
+                                          {{ with index .schema "description" }}
+                                            {{ . | markdownify }}
+                                          {{ else }}
+                                            <span class="rest-api-muted">No description provided.</span>
+                                          {{ end }}
+                                        </td>
+                                      </tr>
+                                    {{ end }}
+                                  </tbody>
+                                </table>
+                              </div>
+                            {{ else }}
+                              <p class="rest-api-muted">Schema: <code>{{ partial "rest-apis/schema-type.html" . }}</code></p>
+                            {{ end }}
+                          </article>
+                        {{ end }}
+                      </div>
+                    {{ else }}
+                      <p class="rest-api-muted">Schema: <code>{{ $schemaType }}</code></p>
+                    {{ end }}
+
+                    {{ if $example }}
+                      <div class="rest-api-example">
+                        <p class="rest-api-example__title">Example payload</p>
+                        <pre><code class="language-{{ if strings.Contains $contentType "json" }}json{{ else }}http{{ end }}">{{ if or (reflect.IsMap $example) (reflect.IsSlice $example) }}{{ $example | jsonify (dict "indent" "  ") }}{{ else }}{{ $example }}{{ end }}</code></pre>
+                      </div>
+                    {{ end }}
+                  </article>
+                {{ end }}
+              </section>
+            {{ end }}
+
+            {{ with $operation.responses }}
+              <section class="rest-api-section rest-api-section--responses">
+                <div class="rest-api-section-heading rest-api-section-heading--responses">
+                  <p class="rest-api-section-heading__eyebrow">Returned data</p>
+                  <h3 id="responses-{{ $operationId }}">Responses</h3>
+                  <p class="rest-api-section-heading__summary">
+                    Status codes, content types, and response schemas returned by this endpoint.
+                  </p>
+                </div>
+                {{ range $code, $response := . }}
+                  {{ $statusCode := printf "%v" $code }}
+                  {{ $responseTone := "neutral" }}
+                  {{ if strings.HasPrefix $statusCode "2" }}
+                    {{ $responseTone = "success" }}
+                  {{ else if strings.HasPrefix $statusCode "3" }}
+                    {{ $responseTone = "info" }}
+                  {{ else if strings.HasPrefix $statusCode "4" }}
+                    {{ $responseTone = "warning" }}
+                  {{ else if strings.HasPrefix $statusCode "5" }}
+                    {{ $responseTone = "danger" }}
+                  {{ end }}
+
+                  {{ $responseContentCount := 0 }}
+                  {{ with $response.content }}
+                    {{ $responseContentCount = len . }}
+                  {{ end }}
+
+                  <article class="rest-api-response rest-api-response--{{ $responseTone }}">
+                    <div class="rest-api-response__header">
+                      <span class="rest-api-status">{{ $statusCode }}</span>
+                      <div class="rest-api-response__summary">
+                        {{ with $response.description }}
+                          {{ . | markdownify }}
+                        {{ else }}
+                          <p>No description provided.</p>
+                        {{ end }}
+                      </div>
+                      {{ if eq $responseContentCount 1 }}
+                        {{ with $response.content }}
+                          {{ range $contentType, $_ := . }}
+                            <p class="rest-api-response__content-type">{{ $contentType }}</p>
+                          {{ end }}
+                        {{ end }}
+                      {{ end }}
+                    </div>
+
+                    {{ with $response.content }}
+                      {{ range $contentType, $content := . }}
+                        {{ $schema := index $content "schema" | default dict }}
+                        {{ $schemaType := partial "rest-apis/schema-type.html" $schema }}
+                        {{ $fields := partial "rest-apis/schema-properties.html" $schema }}
+                        {{ $example := partial "rest-apis/content-example.html" $content }}
+                        <article class="rest-api-media-block rest-api-media-block--response">
+                          {{ if gt $responseContentCount 1 }}
+                            <div class="rest-api-media-block__header">
+                              <p class="rest-api-media-block__title">{{ $contentType }}</p>
+                            </div>
+                          {{ end }}
+
+                          {{ with index $schema "description" }}
+                            <div class="rest-api-prose">{{ . | markdownify }}</div>
+                          {{ else }}
+                            <p class="rest-api-media-block__summary">Schema: <code>{{ $schemaType }}</code></p>
+                          {{ end }}
+
+                          {{ if gt (len (index $fields "rows")) 0 }}
+                            <div class="rest-api-table-wrapper">
+                              <table>
+                                <thead>
+                                  <tr>
+                                    <th>Field</th>
+                                    <th>Type</th>
+                                    <th>Required</th>
+                                    <th>Description</th>
+                                  </tr>
+                                </thead>
+                                <tbody>
+                                  {{ range index $fields "rows" }}
+                                    <tr>
+                                      <td><code>{{ .name }}</code></td>
+                                      <td>{{ partial "rest-apis/schema-type.html" (index . "schema") }}</td>
+                                      <td>{{ if .required }}Yes{{ else }}No{{ end }}</td>
+                                      <td>
+                                        {{ with index .schema "description" }}
+                                          {{ . | markdownify }}
+                                        {{ else }}
+                                          <span class="rest-api-muted">No description provided.</span>
+                                        {{ end }}
+                                      </td>
+                                    </tr>
+                                  {{ end }}
+                                </tbody>
+                              </table>
+                            </div>
+                          {{ else if index $schema "oneOf" }}
+                            <div class="rest-api-variant-grid">
+                              {{ range index $schema "oneOf" }}
+                                {{ $variantFields := partial "rest-apis/schema-properties.html" . }}
+                                <article class="rest-api-variant">
+                                  <p class="rest-api-variant__title">{{ index . "title" | default (partial "rest-apis/schema-type.html" .) }}</p>
+                                  {{ with index . "description" }}
+                                    <div class="rest-api-prose">{{ . | markdownify }}</div>
+                                  {{ end }}
+                                  {{ if gt (len (index $variantFields "rows")) 0 }}
+                                    <div class="rest-api-table-wrapper">
+                                      <table>
+                                        <thead>
+                                          <tr>
+                                            <th>Field</th>
+                                            <th>Type</th>
+                                            <th>Required</th>
+                                            <th>Description</th>
+                                          </tr>
+                                        </thead>
+                                        <tbody>
+                                          {{ range index $variantFields "rows" }}
+                                            <tr>
+                                              <td><code>{{ .name }}</code></td>
+                                              <td>{{ partial "rest-apis/schema-type.html" (index . "schema") }}</td>
+                                              <td>{{ if .required }}Yes{{ else }}No{{ end }}</td>
+                                              <td>
+                                                {{ with index .schema "description" }}
+                                                  {{ . | markdownify }}
+                                                {{ else }}
+                                                  <span class="rest-api-muted">No description provided.</span>
+                                                {{ end }}
+                                              </td>
+                                            </tr>
+                                          {{ end }}
+                                        </tbody>
+                                      </table>
+                                    </div>
+                                  {{ else }}
+                                    <p class="rest-api-muted">Schema: <code>{{ partial "rest-apis/schema-type.html" . }}</code></p>
+                                  {{ end }}
+                                </article>
+                              {{ end }}
+                            </div>
+                          {{ else }}
+                            <p class="rest-api-muted">Schema: <code>{{ $schemaType }}</code></p>
+                          {{ end }}
+
+                          {{ if $example }}
+                            <div class="rest-api-example">
+                              <p class="rest-api-example__title">Example response</p>
+                              <pre><code class="language-{{ if strings.Contains $contentType "json" }}json{{ else }}http{{ end }}">{{ if or (reflect.IsMap $example) (reflect.IsSlice $example) }}{{ $example | jsonify (dict "indent" "  ") }}{{ else }}{{ $example }}{{ end }}</code></pre>
+                            </div>
+                          {{ end }}
+                        </article>
+                      {{ end }}
+                    {{ end }}
+                  </article>
+                {{ end }}
+              </section>
+            {{ end }}
+          </article>
+        {{ end }}
+      </section>
+    </div>
+  </div>
+{{ else }}
+  <p>No Meshery OSS REST operations were found in <code>docs/data/openapi.yml</code>.</p>
+{{ end }}
+
+<script type="text/javascript">
+document.addEventListener("DOMContentLoaded", function () {
+  var root = document.querySelector("[data-rest-api-root]");
+  if (!root) {
+    return;
+  }
+
+  var links = Array.prototype.slice.call(root.querySelectorAll("[data-operation-link]"));
+  var panels = Array.prototype.slice.call(root.querySelectorAll("[data-operation-panel]"));
+  var groups = Array.prototype.slice.call(root.querySelectorAll("[data-rest-api-group]"));
+  var subgroups = Array.prototype.slice.call(root.querySelectorAll("[data-rest-api-subgroup]"));
+  var subgroupToggles = Array.prototype.slice.call(root.querySelectorAll("[data-subgroup-toggle]"));
+  var toggleAllGroups = root.querySelector("[data-toggle-all-groups]");
+  var tagButtons = Array.prototype.slice.call(root.querySelectorAll("[data-tag-filter]"));
+  var searchInput = root.querySelector("[data-rest-api-search]");
+  var emptyState = root.querySelector("[data-rest-api-empty]");
+  var contentArea = root.querySelector("[data-rest-api-content]");
+  var resultsText = root.querySelector("[data-rest-api-results-text]");
+  var activeTag = "all";
+
+  function findLink(targetId) {
+    return links.find(function (link) {
+      return link.dataset.operationId === targetId || link.dataset.pathId === targetId;
+    });
+  }
+
+  function findPanel(targetId) {
+    return panels.find(function (panel) {
+      return panel.dataset.operationId === targetId || panel.dataset.pathId === targetId;
+    });
+  }
+
+  function findNestedTarget(targetId) {
+    if (!targetId) {
+      return null;
+    }
+
+    var target = document.getElementById(targetId);
+    if (!target) {
+      return null;
+    }
+
+    var panel = target.closest("[data-operation-panel]");
+    if (!panel) {
+      return null;
+    }
+
+    return {
+      element: target,
+      panel: panel,
+      link: findLink(panel.dataset.operationId)
+    };
+  }
+
+  function isOperationTarget(targetId) {
+    if (!targetId) {
+      return false;
+    }
+
+    return Boolean(findLink(targetId) && findPanel(targetId));
+  }
+
+  function getTargetFromHash() {
+    return window.location.hash.replace(/^#/, "");
+  }
+
+  function setSubgroupOpen(subgroup, isOpen) {
+    if (!subgroup) {
+      return;
+    }
+
+    var toggle = subgroup.querySelector("[data-subgroup-toggle]");
+    var panel = subgroup.querySelector("[data-subgroup-panel]");
+
+    subgroup.classList.toggle("is-open", isOpen);
+
+    if (toggle) {
+      toggle.setAttribute("aria-expanded", isOpen ? "true" : "false");
+    }
+
+    if (panel) {
+      panel.hidden = !isOpen;
+    }
+
+    syncToggleAllControl();
+  }
+
+  function visibleItemsInSubgroup(subgroup) {
+    return subgroup.querySelectorAll(".rest-api-nav-item:not([hidden])").length;
+  }
+
+  function visibleSubgroups() {
+    return subgroups.filter(function (subgroup) {
+      return !subgroup.hidden;
+    });
+  }
+
+  function openSubgroups() {
+    return visibleSubgroups().filter(function (subgroup) {
+      return subgroup.classList.contains("is-open");
+    });
+  }
+
+  function syncToggleAllControl() {
+    if (!toggleAllGroups) {
+      return;
+    }
+
+    var visible = visibleSubgroups();
+    var anyOpen = visible.some(function (subgroup) {
+      return subgroup.classList.contains("is-open");
+    });
+    var mode = anyOpen ? "collapse" : "expand";
+
+    toggleAllGroups.dataset.toggleMode = mode;
+    toggleAllGroups.setAttribute(
+      "aria-label",
+      anyOpen ? "Collapse all resources" : "Expand all resources"
+    );
+    toggleAllGroups.disabled = visible.length === 0;
+
+    var text = toggleAllGroups.querySelector(".rest-api-nav-control__text");
+    if (text) {
+      text.textContent = anyOpen ? "Collapse all" : "Expand all";
+    }
+  }
+
+  function visibleLinks() {
+    return links.filter(function (link) {
+      var item = link.closest(".rest-api-nav-item");
+      return item && !item.hidden;
+    });
+  }
+
+  function setContentVisibility(isVisible) {
+    if (!contentArea) {
+      return;
+    }
+
+    contentArea.hidden = !isVisible;
+  }
+
+  function scrollToElement(element) {
+    if (!element) {
+      return;
+    }
+
+    var rootStyles = window.getComputedStyle(document.documentElement);
+    var scrollPaddingTop = parseFloat(rootStyles.scrollPaddingTop) || 0;
+    var navbar = document.querySelector(".navbar");
+    var navbarHeight = navbar ? navbar.offsetHeight : 0;
+    var topOffset = scrollPaddingTop || navbarHeight || 0;
+    var top = Math.max(window.pageYOffset + element.getBoundingClientRect().top - topOffset - 4, 0);
+    var prefersReducedMotion = window.matchMedia("(prefers-reduced-motion: reduce)").matches;
+
+    if (prefersReducedMotion) {
+      window.scrollTo({
+        top: top,
+        left: 0,
+        behavior: "auto"
+      });
+      return;
+    }
+
+    var startTop = window.pageYOffset;
+    var distance = top - startTop;
+    var duration = 320;
+    var startTime = null;
+
+    function easeInOutCubic(progress) {
+      return progress < 0.5
+        ? 4 * progress * progress * progress
+        : 1 - Math.pow(-2 * progress + 2, 3) / 2;
+    }
+
+    function step(timestamp) {
+      if (startTime === null) {
+        startTime = timestamp;
+      }
+
+      var elapsed = timestamp - startTime;
+      var progress = Math.min(elapsed / duration, 1);
+      var eased = easeInOutCubic(progress);
+
+      window.scrollTo(0, startTop + distance * eased);
+
+      if (progress < 1) {
+        window.requestAnimationFrame(step);
+      }
+    }
+
+    window.requestAnimationFrame(step);
+  }
+
+  function clearActive(options) {
+    options = options || {};
+
+    links.forEach(function (item) {
+      item.classList.remove("is-active");
+      item.setAttribute("aria-current", "false");
+    });
+
+    panels.forEach(function (item) {
+      item.classList.remove("is-active");
+      item.hidden = root.classList.contains("is-enhanced");
+    });
+
+    setContentVisibility(false);
+
+    if (options.clearHash && window.location.hash) {
+      window.history.replaceState(null, "", window.location.pathname + window.location.search);
+    }
+  }
+
+  function setActive(targetId, options) {
+    options = options || {};
+
+    if (!targetId) {
+      clearActive(options);
+      return;
+    }
+
+    var link = findLink(targetId);
+    var panel = findPanel(targetId);
+
+    if (!link || !panel) {
+      clearActive(options);
+      return;
+    }
+
+    var activeId = panel.dataset.operationId;
+    var activeSubgroup = link.closest(".rest-api-nav-subgroup");
+
+    setSubgroupOpen(activeSubgroup, true);
+
+    links.forEach(function (item) {
+      var isActive = item.dataset.operationId === activeId;
+      item.classList.toggle("is-active", isActive);
+      item.setAttribute("aria-current", isActive ? "true" : "false");
+    });
+
+    panels.forEach(function (item) {
+      var isActive = item.dataset.operationId === activeId;
+      item.classList.toggle("is-active", isActive);
+      item.hidden = root.classList.contains("is-enhanced") && !isActive;
+    });
+
+    setContentVisibility(true);
+
+    if (options.updateHash && window.location.hash !== "#" + activeId) {
+      window.history.replaceState(null, "", "#" + activeId);
+    }
+
+    if (options.scroll) {
+      scrollToElement(panel);
+    }
+  }
+
+  function setActiveTag(tagName, options) {
+    options = options || {};
+    activeTag = tagName || "all";
+
+    tagButtons.forEach(function (button) {
+      var isActive = button.dataset.tagFilter === activeTag;
+      button.classList.toggle("is-active", isActive);
+      button.setAttribute("aria-pressed", isActive ? "true" : "false");
+    });
+
+    applyFilter(options);
+  }
+
+  function updateResultsText(visibleCount, query) {
+    if (!resultsText) {
+      return;
+    }
+
+    var categoryButton = tagButtons.find(function (button) {
+      return button.dataset.tagFilter === activeTag;
+    });
+    var label = categoryButton ? categoryButton.dataset.tagLabel : "All resources";
+
+    if (!visibleCount) {
+      resultsText.textContent = "No endpoints match the current filters.";
+      return;
+    }
+
+    if (query) {
+      resultsText.textContent = "Showing " + visibleCount + " endpoint" + (visibleCount === 1 ? "" : "s") + " in " + label + " for \"" + query + "\".";
+      return;
+    }
+
+    if (activeTag === "all") {
+      resultsText.textContent = "Showing all " + visibleCount + " endpoints.";
+      return;
+    }
+
+    resultsText.textContent = "Showing " + visibleCount + " endpoint" + (visibleCount === 1 ? "" : "s") + " in " + label + ".";
+  }
+
+  function applyFilter(options) {
+    options = options || {};
+
+    var query = (searchInput && searchInput.value || "").trim().toLowerCase();
+    var visibleCount = 0;
+
+    links.forEach(function (link) {
+      var item = link.closest(".rest-api-nav-item");
+      var haystack = (link.dataset.search || "").toLowerCase();
+      var matchesTag = activeTag === "all" || link.dataset.tagName === activeTag;
+      var matchesQuery = !query || haystack.indexOf(query) !== -1;
+      var visible = matchesTag && matchesQuery;
+
+      item.hidden = !visible;
+      if (visible) {
+        visibleCount += 1;
+      }
+    });
+
+    subgroups.forEach(function (subgroup) {
+      var count = visibleItemsInSubgroup(subgroup);
+      subgroup.hidden = count === 0;
+
+      var countNode = subgroup.querySelector("[data-subgroup-count]");
+      if (countNode) {
+        countNode.textContent = query || activeTag !== "all"
+          ? String(count)
+          : String(countNode.dataset.totalCount || count);
+      }
+
+      if (!subgroup.hidden && query) {
+        setSubgroupOpen(subgroup, true);
+      } else if (subgroup.hidden) {
+        setSubgroupOpen(subgroup, false);
+      }
+    });
+
+    groups.forEach(function (group) {
+      group.hidden = group.querySelectorAll("[data-rest-api-subgroup]:not([hidden])").length === 0;
+    });
+
+    if (emptyState) {
+      emptyState.hidden = visibleCount > 0;
+    }
+
+    updateResultsText(visibleCount, query);
+
+    var activeLink = links.find(function (link) {
+      return link.classList.contains("is-active");
+    });
+    var activeItem = activeLink ? activeLink.closest(".rest-api-nav-item") : null;
+
+    if (!activeLink || !activeItem || activeItem.hidden) {
+      if (options.autoSelect === false) {
+        clearActive();
+        return;
+      }
+
+      var firstVisible = visibleLinks()[0];
+      if (firstVisible) {
+        setActive(firstVisible.dataset.operationId, {
+          updateHash: options.updateHash !== false,
+          scroll: false
+        });
+      } else {
+        clearActive();
+      }
+    }
+  }
+
+  function activateHashTarget(targetId, options) {
+    options = options || {};
+
+    if (isOperationTarget(targetId)) {
+      var link = findLink(targetId);
+      if (link) {
+        setActiveTag(link.dataset.tagName, { updateHash: false, autoSelect: false });
+      }
+      setActive(targetId, options);
+      return true;
+    }
+
+    var nestedTarget = findNestedTarget(targetId);
+    if (nestedTarget && nestedTarget.link) {
+      setActiveTag(nestedTarget.link.dataset.tagName, { updateHash: false, autoSelect: false });
+      setActive(nestedTarget.panel.dataset.operationId, { scroll: false, updateHash: false });
+
+      if (options.scroll) {
+        window.requestAnimationFrame(function () {
+          scrollToElement(nestedTarget.element);
+        });
+      }
+
+      return true;
+    }
+
+    return false;
+  }
+
+  links.forEach(function (link) {
+    link.addEventListener("click", function (event) {
+      event.preventDefault();
+      setActive(link.dataset.operationId, {
+        updateHash: true,
+        scroll: true
+      });
+    });
+  });
+
+  subgroupToggles.forEach(function (toggle) {
+    toggle.addEventListener("click", function () {
+      var subgroup = toggle.closest(".rest-api-nav-subgroup");
+      setSubgroupOpen(subgroup, !subgroup.classList.contains("is-open"));
+    });
+  });
+
+  if (toggleAllGroups) {
+    toggleAllGroups.addEventListener("click", function () {
+      var shouldOpen = toggleAllGroups.dataset.toggleMode === "expand";
+      visibleSubgroups().forEach(function (subgroup) {
+        setSubgroupOpen(subgroup, shouldOpen);
+      });
+      if (!shouldOpen) {
+        clearActive({ clearHash: true });
+      } else if (openSubgroups().length === 0) {
+        setContentVisibility(false);
+      }
+      syncToggleAllControl();
+    });
+  }
+
+  tagButtons.forEach(function (button) {
+    button.addEventListener("click", function () {
+      setActiveTag(button.dataset.tagFilter, { updateHash: false });
+    });
+  });
+
+  if (searchInput) {
+    searchInput.addEventListener("input", function () {
+      applyFilter({ updateHash: false });
+    });
+  }
+
+  window.addEventListener("hashchange", function () {
+    var hashTarget = getTargetFromHash();
+    if (!activateHashTarget(hashTarget, { scroll: true, updateHash: false })) {
+      applyFilter({ updateHash: false });
+    }
+  });
+
+  root.classList.add("is-enhanced");
+  subgroups.forEach(function (subgroup) {
+    setSubgroupOpen(subgroup, false);
+  });
+  setContentVisibility(false);
+
+  var initialTarget = getTargetFromHash();
+  if (!activateHashTarget(initialTarget, { scroll: false, updateHash: false })) {
+    setActiveTag("all", { updateHash: false, autoSelect: false });
+  }
+});
+</script>
+{{ end }}


### PR DESCRIPTION
**Notes for Reviewers**

- This PR fixes #18948
- Scope is limited to `docs/content/en/reference/rest-apis/endpoints.md`
- Replaces `type: rest-apis` with `layout: rest-apis`
- Removes `body_class` from the page front matter
- Moves the styling hook to the layout/template so the existing UI remains unchanged

**[Signed commits](https://github.com/meshery/meshery/blob/master/CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [x] Yes, I signed my commits.