### PR TITLE
[Docs] Use Qanelas Soft for REST API reference typography

### DIFF
--- a/docs/assets/scss/_rest-api-reference.scss
+++ b/docs/assets/scss/_rest-api-reference.scss
@@ -14,6 +14,14 @@ $method-head: #7d8790;
 }
 
 .rest-api-reference-page {
+  .rest-api-page,
+  .rest-api-page pre,
+  .rest-api-page code,
+  .rest-api-page kbd,
+  .rest-api-page samp {
+    font-family: "Qanelas Soft", "Open Sans", sans-serif;
+  }
+
   .main-container {
     overflow-x: visible;
   }
@@ -428,7 +436,7 @@ $method-head: #7d8790;
   .rest-api-nav-link__path,
   .rest-api-operation__path,
   .rest-api-try-item__url {
-    font-family: SFMono-Regular, Menlo, Monaco, Consolas, liberation mono, courier new, monospace;
+    font-family: "Qanelas Soft", "Open Sans", sans-serif;
     overflow-wrap: anywhere;
     word-break: break-word;
   }

--- a/docs/assets/scss/_sidebar.scss
+++ b/docs/assets/scss/_sidebar.scss
@@ -143,7 +143,7 @@
   }
 
   & .td-search__input::placeholder {
-    font-family: "Open Sans";
+    font-family: inherit;
     color: rgba(238, 241, 244, 0.72);
   }
 


### PR DESCRIPTION
**Notes for Reviewers**

- This PR fixes #18835
- Keeps the Qanelas Soft change scoped to the REST API reference instead of changing code typography site-wide


**[Signed commits](https://github.com/meshery/meshery/blob/master/CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [x] Yes, I signed my commits.