### PR TITLE
chore(deps): bump meshkit v1.0.6 -> v1.0.7 + flip Event consumer reads

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -49,9 +49,9 @@ require (
 	github.com/lib/pq v1.12.1
 	github.com/manifoldco/promptui v0.9.0
 	github.com/meshery/meshery-operator v0.8.11
-	github.com/meshery/meshkit v1.0.6
+	github.com/meshery/meshkit v1.0.7
 	github.com/meshery/meshsync v1.0.0
-	github.com/meshery/schemas v1.2.0
+	github.com/meshery/schemas v1.2.2
 	github.com/nsf/termbox-go v1.1.1
 	github.com/oapi-codegen/runtime v1.3.1
 	github.com/olekukonko/tablewriter v1.1.0

--- a/go.sum
+++ b/go.sum
@@ -1490,12 +1490,12 @@ github.com/maxatome/go-testdeep v1.14.0 h1:rRlLv1+kI8eOI3OaBXZwb3O7xY3exRzdW5QyX
 github.com/maxatome/go-testdeep v1.14.0/go.mod h1:lPZc/HAcJMP92l7yI6TRz1aZN5URwUBUAfUNvrclaNM=
 github.com/meshery/meshery-operator v0.8.11 h1:eDo2Sw0jjVrXsvvhF8LenADM58pK+7Z68ROPVIejTPc=
 github.com/meshery/meshery-operator v0.8.11/go.mod h1:hQEtFKKa5Fr/Mskk6bV5ip3bQ0+3F0u1voYS3XisBp4=
-github.com/meshery/meshkit v1.0.6 h1:lL6zUg9On18vBVG6tXIpBhUFjr7bNHT86s65Sl/z2UU=
-github.com/meshery/meshkit v1.0.6/go.mod h1:7RAgCZsK4AhmirU8QWjJToTG82D7ev2iALeRerODK04=
+github.com/meshery/meshkit v1.0.7 h1:yuF+4VdCH+koaGJOIZknoYuD2qYgyUf5B+OHkq/OwN0=
+github.com/meshery/meshkit v1.0.7/go.mod h1:cTDLb/QPwSzPgMSweoakXztmmj0Kpz5+E3dyFym8REM=
 github.com/meshery/meshsync v1.0.0 h1:BIHEVG4BDjqOnSd3vBt9B4IfWJNTfMRAgdwLroBcCfY=
 github.com/meshery/meshsync v1.0.0/go.mod h1:mFsPXkZRiCSuk5DhxBTrkWdlo6peItRBUoIEEQCovIg=
-github.com/meshery/schemas v1.2.0 h1:SlSP9WR21uaLoNOglcMh2lpDqZl/XzXLqSrmz/Y+CwU=
-github.com/meshery/schemas v1.2.0/go.mod h1:UrkQFIKza3S3CuLR9yKt5a7xZW3ksSVd6N0yUdhvhRE=
+github.com/meshery/schemas v1.2.2 h1:L07RaoqjzRRQxheAxTE5HCIqqcjfihKO5i5IBxCHic0=
+github.com/meshery/schemas v1.2.2/go.mod h1:UrkQFIKza3S3CuLR9yKt5a7xZW3ksSVd6N0yUdhvhRE=
 github.com/miekg/dns v1.1.57 h1:Jzi7ApEIzwEPLHWRcafCN9LZSBbqQpxjt/wpgvg7wcM=
 github.com/miekg/dns v1.1.57/go.mod h1:uqRjCRUuEAA6qsOiJvDd+CFo/vW+y5WR6SNmHE55hZk=
 github.com/miekg/pkcs11 v1.0.2/go.mod h1:XsNlhZGX73bx86s2hdc/FuaLm2CPZJemRLMA+WTFxgs=

--- a/server/handlers/events_streamer.go
+++ b/server/handlers/events_streamer.go
@@ -235,7 +235,13 @@ func getEventFilter(req *http.Request) (*events.EventsFilter, error) {
 	category := urlValues.Get("category")
 	action := urlValues.Get("action")
 	severity := urlValues.Get("severity")
-	acted_upon := urlValues.Get("acted_upon")
+	// Canonical camelCase URL param matches meshkit EventsFilter JSON tag
+	// (`actedUpon`); fall back to legacy snake_case for back-compat with any
+	// older clients that have not been bumped yet.
+	actedUpon := urlValues.Get("actedUpon")
+	if actedUpon == "" {
+		actedUpon = urlValues.Get("acted_upon")
+	}
 
 	eventFilter := &events.EventsFilter{}
 	if category != "" {
@@ -259,8 +265,8 @@ func getEventFilter(req *http.Request) (*events.EventsFilter, error) {
 		}
 	}
 
-	if acted_upon != "" {
-		err := json.Unmarshal([]byte(acted_upon), &eventFilter.ActedUpon)
+	if actedUpon != "" {
+		err := json.Unmarshal([]byte(actedUpon), &eventFilter.ActedUpon)
 		if err != nil {
 			return eventFilter, models.ErrUnmarshal(err, "event acted upon filter")
 		}

--- a/ui/components/NotificationCenter/README.md
+++ b/ui/components/NotificationCenter/README.md
@@ -40,7 +40,7 @@ To ensure a seamless user experience with bulk operations in the Notification Ce
 
 # Metadata Formatter Documentation
 
-When an event is received from the server, it adheres to a fixed schema containing information that is valuable for presentation to the user. This information typically includes details such as the description, date, user_id, system_id, action, and acted-upon resources. Additionally, sometimes there may be a detailed traceback, a summary, or a comprehensive error log, all of which are dynamically generated data encapsulated within the metadata of the event. Presenting this structured data in a user-friendly manner is a crucial task because it contains valuable insights into ongoing operations.
+When an event is received from the server, it adheres to a fixed schema containing information that is valuable for presentation to the user. This information typically includes details such as the description, date, userID, systemID, action, and actedUpon resources. Additionally, sometimes there may be a detailed traceback, a summary, or a comprehensive error log, all of which are dynamically generated data encapsulated within the metadata of the event. Presenting this structured data in a user-friendly manner is a crucial task because it contains valuable insights into ongoing operations.
 
 Here's a refactored and enhanced version of your documentation with improved clarity, structure, and readability:
 

--- a/ui/components/NotificationCenter/index.tsx
+++ b/ui/components/NotificationCenter/index.tsx
@@ -98,8 +98,8 @@ export const NotificationCenterProvider = ({ children }) => {
   );
 };
 
-const getSeverityCount = (count_by_severity_level, severity) => {
-  return count_by_severity_level.find((item) => item.severity === severity)?.count || 0;
+const getSeverityCount = (countBySeverityLevel, severity) => {
+  return countBySeverityLevel.find((item) => item.severity === severity)?.count || 0;
 };
 
 const EmptyState = () => {
@@ -135,16 +135,16 @@ const NavbarNotificationIcon = () => {
     );
   }
 
-  const count_by_severity_level = data?.count_by_severity_level || [];
+  const countBySeverityLevel = data?.countBySeverityLevel || [];
 
   const currentTopSeverity =
-    getSeverityCount(count_by_severity_level, SEVERITY.ERROR) > 0
+    getSeverityCount(countBySeverityLevel, SEVERITY.ERROR) > 0
       ? SEVERITY.ERROR
-      : getSeverityCount(count_by_severity_level, SEVERITY.WARNING) > 0
+      : getSeverityCount(countBySeverityLevel, SEVERITY.WARNING) > 0
         ? SEVERITY.WARNING
         : null;
   const currentSeverityStyle = currentTopSeverity ? SEVERITY_STYLE[currentTopSeverity] : null;
-  const topSeverityCount = getSeverityCount(count_by_severity_level, currentTopSeverity);
+  const topSeverityCount = getSeverityCount(countBySeverityLevel, currentTopSeverity);
   if (currentTopSeverity) {
     return (
       <StyledBadge
@@ -197,10 +197,10 @@ const Header = ({ handleFilter, handleClose }) => {
   const { data } = useGetEventsSummaryQuery({
     status: STATUS.UNREAD,
   });
-  const { count_by_severity_level, read_count } = data || {
-    count_by_severity_level: [],
-    total_count: 0,
-    read_count: 0,
+  const { countBySeverityLevel, readCount } = data || {
+    countBySeverityLevel: [],
+    totalCount: 0,
+    readCount: 0,
   };
 
   const onClickSeverity = (severity) => {
@@ -233,7 +233,7 @@ const Header = ({ handleFilter, handleClose }) => {
             handleClick={() => onClickSeverity(severity)}
             notificationStyle={SEVERITY_STYLE[severity]}
             type={`Unread ${severity}(s)`}
-            count={getSeverityCount(count_by_severity_level, severity)}
+            count={getSeverityCount(countBySeverityLevel, severity)}
           />
         ))}
         <NotificationCountChip
@@ -241,7 +241,7 @@ const Header = ({ handleFilter, handleClose }) => {
           handleClick={() => onClickStatus(STATUS.READ)}
           type={STATUS.READ}
           severity={STATUS.READ}
-          count={read_count}
+          count={readCount}
         />
       </SeverityChips>
     </NotificationContainer>

--- a/ui/components/NotificationCenter/notification.tsx
+++ b/ui/components/NotificationCenter/notification.tsx
@@ -297,7 +297,7 @@ export const Notification = ({ event_id }) => {
 
   const uiConfig = useSelector((state) => state.events.ui);
 
-  const { data: user } = useGetUserByIdQuery(event.user_id);
+  const { data: user } = useGetUserByIdQuery(event.userID);
 
   const userName = `${user?.firstName || ''} ${user?.lastName || ''}`;
   const userAvatarUrl = user?.avatarUrl || '';
@@ -313,15 +313,15 @@ export const Notification = ({ event_id }) => {
   };
 
   const eventActors = [
-    ...(event.user_id && user
-      ? [{ name: userName, avatar_url: userAvatarUrl, tooltip: userName }]
+    ...(event.userID && user
+      ? [{ name: userName, avatarUrl: userAvatarUrl, tooltip: userName }]
       : []),
-    ...(event.system_id
+    ...(event.systemID
       ? [
           {
             name: 'Meshery',
-            avatar_url: '/static/img/meshery-logo.png',
-            tooltip: `System ID: ${event.system_id}`,
+            avatarUrl: '/static/img/meshery-logo.png',
+            tooltip: `System ID: ${event.systemID}`,
           },
         ]
       : []),
@@ -416,7 +416,7 @@ export const Notification = ({ event_id }) => {
           </GridItem>
           <GridItem item xs="auto" style={{ gap: '0.5rem', marginLeft: 'auto', flexShrink: 0 }}>
             <Box sx={{ display: { xs: 'none', sm: 'block' } }}>
-              <FormattedTime date={event.created_at} />
+              <FormattedTime date={event.createdAt} />
             </Box>
             <BasicMenu event={event} />
           </GridItem>

--- a/ui/machines/operationsCenter.ts
+++ b/ui/machines/operationsCenter.ts
@@ -33,16 +33,10 @@ const subscriptionActor = fromCallback(({ sendBack }) => {
           return;
         }
 
-        const event = {
-          ...result.event,
-          user_id: result.event.userID,
-          system_id: result.event.systemID,
-          updated_at: result.event.updatedAt,
-          created_at: result.event.createdAt,
-          deleted_at: result.event.deletedAt,
-          operation_id: result.event.operationID,
-        };
-        sendBack(events.eventReceivedFromServer(event));
+        // GraphQL Event payload (canonical camelCase) is consumed as-is by
+        // downstream UI; meshkit Event JSON tags also flipped to camelCase in
+        // v1.0.7 so the REST /api/system/events list endpoint matches.
+        sendBack(events.eventReceivedFromServer(result.event));
       } catch (error) {
         console.error('[operationsCenter] An error occurred in processing event', error);
       }

--- a/ui/rtk-query/notificationCenter.ts
+++ b/ui/rtk-query/notificationCenter.ts
@@ -92,6 +92,9 @@ export const notificationCenterApi = api
             params: {
               ...parsedFilters,
               page: page,
+              // `sort` here is the SQL column name, not a JSON field — the
+              // server passes it through to GORM via SanitizeOrderInput which
+              // whitelists DB column names (created_at, updated_at, name).
               sort: 'created_at',
               order: 'desc',
               pagesize: 15,
@@ -114,9 +117,9 @@ export const notificationCenterApi = api
         },
         transformResponse: (response) => {
           return {
-            count_by_severity_level: response.count_by_severity_level,
-            total_count: response.total_count,
-            read_count: response.read_count || 0,
+            countBySeverityLevel: response.countBySeverityLevel,
+            totalCount: response.totalCount,
+            readCount: response.readCount || 0,
           };
         },
         providesTags: [PROVIDER_TAGS.EVENT],

--- a/ui/store/middleware/rtkErrorMiddleware.ts
+++ b/ui/store/middleware/rtkErrorMiddleware.ts
@@ -30,7 +30,7 @@ export const rtkErrorMiddleware: Middleware = (storeApi) => (next) => (action) =
         description: `${endpointName}: ${errorMessage}`,
         action: 'api_error',
         category: 'api',
-        created_at: new Date().toISOString(),
+        createdAt: new Date().toISOString(),
       }),
     );
   }

--- a/ui/store/slices/__tests__/events.test.ts
+++ b/ui/store/slices/__tests__/events.test.ts
@@ -11,7 +11,7 @@ const makeEvent = (overrides = {}) => ({
   severity: 'info',
   status: 'unread',
   description: 'Test event',
-  created_at: '2025-01-01T00:00:00Z',
+  createdAt: '2025-01-01T00:00:00Z',
   ...overrides,
 });
 

--- a/ui/store/slices/events.ts
+++ b/ui/store/slices/events.ts
@@ -34,10 +34,10 @@ const defaultEventProperties = {
 
 const eventsEntityAdapter = createEntityAdapter({
   selectId: (event) => event.id,
-  //sort based on update_at timestamp(utc)
+  //sort based on createdAt timestamp(utc)
   sortComparer: (a, b) => {
-    if (b?.created_at?.localeCompare && a?.created_at?.localeCompare) {
-      return b.created_at?.localeCompare(a.created_at);
+    if (b?.createdAt?.localeCompare && a?.createdAt?.localeCompare) {
+      return b.createdAt?.localeCompare(a.createdAt);
     }
     return 0;
   },


### PR DESCRIPTION
## Summary

- Bumps `github.com/meshery/meshkit` v1.0.6 to v1.0.7, which flips the `Event` and `EventsFilter` struct `json:` tags from snake_case to canonical camelCase (`acted_upon` -> `actedUpon`, `user_id` -> `userID`, `system_id` -> `systemID`, `created_at` -> `createdAt`, `updated_at` -> `updatedAt`, `deleted_at` -> `deletedAt`, `operation_id` -> `operationID`, `sort_on` -> `sortOn`). meshkit v1.0.7 also pulls in `github.com/meshery/schemas` v1.2.0 -> v1.2.2.
- Updates meshery's server-side and UI Event consumer code in lockstep so the wire format stays decode-compatible end to end.
- Clears the residual Event-shaped snake_case reads that Phase 5 (#18974) explicitly deferred to this slice.

## Why

Per the multi-repo cascade plan, meshkit owns the canonical Event/EventsFilter contract. Phase 5 (#18974) flipped meshery's local-mirror types and most UI consumers but explicitly deferred the meshkit-shaped Event reads (`event.user_id`, `event.system_id`, `event.created_at`) and the `EventsResponse` summary keys (`count_by_severity_level`, `total_count`, `read_count`) to a follow-up because meshkit was still on v1.0.6. With v1.0.7 published, this PR closes that loop.

## Files changed

**Server (Go)**
- `go.mod` / `go.sum` - meshkit v1.0.6 -> v1.0.7, schemas v1.2.0 -> v1.2.2
- `server/handlers/events_streamer.go` - `getEventFilter` accepts the canonical `actedUpon` URL query param, falling back to legacy `acted_upon` for older clients still in the wild

**UI (TypeScript)**
- `ui/machines/operationsCenter.ts` - drop the snake_case re-alias hack in the GraphQL subscription callback; the upstream Event payload is canonical camelCase (GraphQL `Event` type) and the REST list response now matches via meshkit v1.0.7
- `ui/store/slices/events.ts` - `sortComparer` reads `createdAt` instead of `created_at`
- `ui/store/middleware/rtkErrorMiddleware.ts` - synthetic RTK error event emits `createdAt`
- `ui/store/slices/__tests__/events.test.ts` - fixture uses `createdAt`
- `ui/rtk-query/notificationCenter.ts` - `getEventsSummary` `transformResponse` reads canonical summary keys (`countBySeverityLevel`, `totalCount`, `readCount`); leaves the `sort` URL param as `created_at` because it is the GORM column name, not a JSON field, and is whitelisted by `SanitizeOrderInput` (annotated with a comment to that effect)
- `ui/components/NotificationCenter/index.tsx` - `NavbarNotificationIcon` + `Header` destructure `countBySeverityLevel` / `readCount`; helper parameter renamed for parity
- `ui/components/NotificationCenter/notification.tsx` - `Notification` reads `event.userID`, `event.systemID`, `event.createdAt`; `eventActors` push `avatarUrl` so the existing `AvatarStack` (already on `avatarUrl` post Phase 5) renders
- `ui/components/NotificationCenter/README.md` - doc snippet refers to canonical schema field names

## Test plan

- [x] `go get github.com/meshery/meshkit@v1.0.7 && go mod tidy` succeeds and resolves to schemas v1.2.2
- [x] `go build ./...` clean
- [x] `make error` clean
- [x] `go test -count=1 ./server/...` passes (all packages green)
- [x] `npm install` clean
- [x] `npm test` (vitest) - 5 files, 34 tests passing, including the updated `events.test.ts` fixture
- [x] `npx eslint` clean across the touched UI files
- [x] Verified no remaining `event.user_id` / `event.system_id` / `event.created_at` / `event.acted_upon` / `event.operation_id` / `event.updated_at` / `event.deleted_at` reads anywhere in `ui/`
- [x] Verified no remaining `count_by_severity_level` / `total_count` / `read_count` / `sort_on` references in event-related UI code
- [ ] Smoke test the live UI Notification Center against a Provider that emits Events to confirm decode parity end to end (recommend reviewer also runs this)

## Out of scope

- K8sContext metadata literal flip - separate slice (Phase 5b in another worktree)
- URL `:ID` route param cleanup - separate slice
- mesheryctl CLI surface - tracked separately in Phase 6

Signed-off-by: Lee Calcote <leecalcote@gmail.com>