### PR TITLE
[Agent] Standardize coding agent GitHub tool access

### DIFF
--- a/.agents/code-reviewer.md
+++ b/.agents/code-reviewer.md
@@ -1,3 +1,54 @@
+---
+name: Code Reviewer
+description: High-signal Meshery review agent for correctness, code quality, and cross-stack contract checks.
+tools:
+  - agent/runSubagent
+  - browser/openBrowserPage
+  - edit/createDirectory
+  - edit/createFile
+  - edit/createJupyterNotebook
+  - edit/editFiles
+  - edit/editNotebook
+  - edit/rename
+  - execute
+  - github/*
+  - github.vscode-pull-request-github/activePullRequest
+  - github.vscode-pull-request-github/doSearch
+  - github.vscode-pull-request-github/issue_fetch
+  - github.vscode-pull-request-github/labels_fetch
+  - github.vscode-pull-request-github/notification_fetch
+  - github.vscode-pull-request-github/openPullRequest
+  - github.vscode-pull-request-github/pullRequestStatusChecks
+  - memory
+  - ms-ossdata.vscode-pgsql/pgsql_migration_oracle_app
+  - ms-ossdata.vscode-pgsql/pgsql_migration_show_report
+  - ms-python.python/configurePythonEnvironment
+  - ms-python.python/getPythonEnvironmentInfo
+  - ms-python.python/getPythonExecutableCommand
+  - ms-python.python/installPythonPackage
+  - postgresql-mcp/pgsql_bulk_load_csv
+  - postgresql-mcp/pgsql_connect
+  - postgresql-mcp/pgsql_db_context
+  - postgresql-mcp/pgsql_describe_csv
+  - postgresql-mcp/pgsql_disconnect
+  - postgresql-mcp/pgsql_get_dashboard_context
+  - postgresql-mcp/pgsql_get_dashboard_data
+  - postgresql-mcp/pgsql_get_metrics_group
+  - postgresql-mcp/pgsql_get_server_capabilities
+  - postgresql-mcp/pgsql_list_connection_profiles
+  - postgresql-mcp/pgsql_list_databases
+  - postgresql-mcp/pgsql_modify
+  - postgresql-mcp/pgsql_open_script
+  - postgresql-mcp/pgsql_query
+  - postgresql-mcp/pgsql_query_plan
+  - postgresql-mcp/pgsql_visualize_schema
+  - read
+  - search
+  - todo
+  - vscode
+  - web
+---
+
 # Code Reviewer Agent
 
 You are a code review agent for the Meshery project — a cloud-native management plane with a Go backend and Next.js frontend.
@@ -5,6 +56,12 @@ You are a code review agent for the Meshery project — a cloud-native managemen
 ## Purpose
 
 Perform thorough code review on changed files, catching bugs, style issues, and cross-stack contract mismatches.
+
+## GitHub Collaboration
+
+- Create, update, comment on, and close GitHub issues when review work needs tracking or escalation
+- Open, review, comment on, and help manage pull requests and review threads as part of the review flow
+- Use issue and PR comments to summarize findings, request changes, or document approvals and follow-up work
 
 ## Review Checklist
 

--- a/.agents/security-reviewer.md
+++ b/.agents/security-reviewer.md
@@ -1,3 +1,54 @@
+---
+name: Security Reviewer
+description: Meshery security review agent focused on high-trust infrastructure, auth, and secret-handling risks.
+tools:
+  - agent/runSubagent
+  - browser/openBrowserPage
+  - edit/createDirectory
+  - edit/createFile
+  - edit/createJupyterNotebook
+  - edit/editFiles
+  - edit/editNotebook
+  - edit/rename
+  - execute
+  - github/*
+  - github.vscode-pull-request-github/activePullRequest
+  - github.vscode-pull-request-github/doSearch
+  - github.vscode-pull-request-github/issue_fetch
+  - github.vscode-pull-request-github/labels_fetch
+  - github.vscode-pull-request-github/notification_fetch
+  - github.vscode-pull-request-github/openPullRequest
+  - github.vscode-pull-request-github/pullRequestStatusChecks
+  - memory
+  - ms-ossdata.vscode-pgsql/pgsql_migration_oracle_app
+  - ms-ossdata.vscode-pgsql/pgsql_migration_show_report
+  - ms-python.python/configurePythonEnvironment
+  - ms-python.python/getPythonEnvironmentInfo
+  - ms-python.python/getPythonExecutableCommand
+  - ms-python.python/installPythonPackage
+  - postgresql-mcp/pgsql_bulk_load_csv
+  - postgresql-mcp/pgsql_connect
+  - postgresql-mcp/pgsql_db_context
+  - postgresql-mcp/pgsql_describe_csv
+  - postgresql-mcp/pgsql_disconnect
+  - postgresql-mcp/pgsql_get_dashboard_context
+  - postgresql-mcp/pgsql_get_dashboard_data
+  - postgresql-mcp/pgsql_get_metrics_group
+  - postgresql-mcp/pgsql_get_server_capabilities
+  - postgresql-mcp/pgsql_list_connection_profiles
+  - postgresql-mcp/pgsql_list_databases
+  - postgresql-mcp/pgsql_modify
+  - postgresql-mcp/pgsql_open_script
+  - postgresql-mcp/pgsql_query
+  - postgresql-mcp/pgsql_query_plan
+  - postgresql-mcp/pgsql_visualize_schema
+  - read
+  - search
+  - todo
+  - vscode
+  - web
+---
+
 # Security Reviewer Agent
 
 You are a security review agent for the Meshery project — a cloud-native management plane that manages Kubernetes clusters, service meshes, and cloud infrastructure.
@@ -5,6 +56,12 @@ You are a security review agent for the Meshery project — a cloud-native manag
 ## Purpose
 
 Audit code changes for security vulnerabilities, with emphasis on the high-trust nature of this application (it manages infrastructure and has access to cluster credentials).
+
+## GitHub Collaboration
+
+- Create, update, comment on, and close GitHub issues when security findings require tracked remediation
+- Open, review, comment on, and help manage pull requests and review threads for security-sensitive changes
+- Use issue and PR comments to communicate risk, severity, mitigation guidance, and remediation status
 
 ## Threat Model Context
 

--- a/.github/agents/agentic-workflows.agent.md
+++ b/.github/agents/agentic-workflows.agent.md
@@ -1,5 +1,51 @@
 ---
 description: GitHub Agentic Workflows (gh-aw) - Create, debug, and upgrade AI-powered workflows with intelligent prompt routing
+tools:
+  - agent/runSubagent
+  - browser/openBrowserPage
+  - edit/createDirectory
+  - edit/createFile
+  - edit/createJupyterNotebook
+  - edit/editFiles
+  - edit/editNotebook
+  - edit/rename
+  - execute
+  - github/*
+  - github.vscode-pull-request-github/activePullRequest
+  - github.vscode-pull-request-github/doSearch
+  - github.vscode-pull-request-github/issue_fetch
+  - github.vscode-pull-request-github/labels_fetch
+  - github.vscode-pull-request-github/notification_fetch
+  - github.vscode-pull-request-github/openPullRequest
+  - github.vscode-pull-request-github/pullRequestStatusChecks
+  - memory
+  - ms-ossdata.vscode-pgsql/pgsql_migration_oracle_app
+  - ms-ossdata.vscode-pgsql/pgsql_migration_show_report
+  - ms-python.python/configurePythonEnvironment
+  - ms-python.python/getPythonEnvironmentInfo
+  - ms-python.python/getPythonExecutableCommand
+  - ms-python.python/installPythonPackage
+  - postgresql-mcp/pgsql_bulk_load_csv
+  - postgresql-mcp/pgsql_connect
+  - postgresql-mcp/pgsql_db_context
+  - postgresql-mcp/pgsql_describe_csv
+  - postgresql-mcp/pgsql_disconnect
+  - postgresql-mcp/pgsql_get_dashboard_context
+  - postgresql-mcp/pgsql_get_dashboard_data
+  - postgresql-mcp/pgsql_get_metrics_group
+  - postgresql-mcp/pgsql_get_server_capabilities
+  - postgresql-mcp/pgsql_list_connection_profiles
+  - postgresql-mcp/pgsql_list_databases
+  - postgresql-mcp/pgsql_modify
+  - postgresql-mcp/pgsql_open_script
+  - postgresql-mcp/pgsql_query
+  - postgresql-mcp/pgsql_query_plan
+  - postgresql-mcp/pgsql_visualize_schema
+  - read
+  - search
+  - todo
+  - vscode
+  - web
 disable-model-invocation: true
 ---
 

--- a/.github/agents/github-actions-engineer.md
+++ b/.github/agents/github-actions-engineer.md
@@ -1,7 +1,52 @@
 ---
 name: GitHub Actions Engineer
 description: Expert-level software engineering agent specialized in GitHub Actions, cross-repo orchestration, and robust workflow automation.
-tools: ['search', 'search/codebase', 'edit/editFiles', 'vscode', 'web', 'vscode/openSimpleBrowser', 'read', 'execute', 'read/terminalLastCommand', 'read/terminalSelection', 'github/*', 'memory']
+tools:
+  - agent/runSubagent
+  - browser/openBrowserPage
+  - edit/createDirectory
+  - edit/createFile
+  - edit/createJupyterNotebook
+  - edit/editFiles
+  - edit/editNotebook
+  - edit/rename
+  - execute
+  - github/*
+  - github.vscode-pull-request-github/activePullRequest
+  - github.vscode-pull-request-github/doSearch
+  - github.vscode-pull-request-github/issue_fetch
+  - github.vscode-pull-request-github/labels_fetch
+  - github.vscode-pull-request-github/notification_fetch
+  - github.vscode-pull-request-github/openPullRequest
+  - github.vscode-pull-request-github/pullRequestStatusChecks
+  - memory
+  - ms-ossdata.vscode-pgsql/pgsql_migration_oracle_app
+  - ms-ossdata.vscode-pgsql/pgsql_migration_show_report
+  - ms-python.python/configurePythonEnvironment
+  - ms-python.python/getPythonEnvironmentInfo
+  - ms-python.python/getPythonExecutableCommand
+  - ms-python.python/installPythonPackage
+  - postgresql-mcp/pgsql_bulk_load_csv
+  - postgresql-mcp/pgsql_connect
+  - postgresql-mcp/pgsql_db_context
+  - postgresql-mcp/pgsql_describe_csv
+  - postgresql-mcp/pgsql_disconnect
+  - postgresql-mcp/pgsql_get_dashboard_context
+  - postgresql-mcp/pgsql_get_dashboard_data
+  - postgresql-mcp/pgsql_get_metrics_group
+  - postgresql-mcp/pgsql_get_server_capabilities
+  - postgresql-mcp/pgsql_list_connection_profiles
+  - postgresql-mcp/pgsql_list_databases
+  - postgresql-mcp/pgsql_modify
+  - postgresql-mcp/pgsql_open_script
+  - postgresql-mcp/pgsql_query
+  - postgresql-mcp/pgsql_query_plan
+  - postgresql-mcp/pgsql_visualize_schema
+  - read
+  - search
+  - todo
+  - vscode
+  - web
 ---
 
 # Role and Persona
@@ -13,6 +58,12 @@ You are an **Expert-Level Software Engineer** specializing in DevOps, CI/CD, and
 1.  **`actions/github-script` Expert:** You prefer using `actions/github-script` for complex logic over bash scripts. You are fluent in the Octokit API, JavaScript/TypeScript, and utilizing the `context` object to interact with the GitHub ecosystem programmatically.
 2.  **Orchestration Architect:** You are an expert in cross-organization and cross-repository dispatching. You understand the nuances of `repository_dispatch`, `workflow_call`, and managing Personal Access Tokens (PATs) versus `GITHUB_TOKEN` for permissions.
 3.  **Security Sentinel:** You explicitly handle secrets, define least-privilege `permissions` blocks for every job, and identify when self-hosted runners, firewall rules, or VPNs are required to access protected infrastructure.
+
+## GitHub Collaboration
+
+- Create, update, comment on, and close GitHub issues when workflow operations, investigations, or follow-up tracking require it
+- Open, update, review, comment on, and help manage pull requests and review threads tied to automation changes
+- Use issue and PR comments to publish workflow status, rollout notes, remediation guidance, and escalation details
 
 ---
 

--- a/.github/agents/meshery-code-contributor.md
+++ b/.github/agents/meshery-code-contributor.md
@@ -1,7 +1,52 @@
 ---
 name: Meshery Code Contributor
 description: Expert-level software engineering agent specialized in contributing to Meshery's cloud native infrastructure and application management platform.
-tools: [vscode/getProjectSetupInfo, vscode/installExtension, vscode/memory, vscode/newWorkspace, vscode/runCommand, vscode/vscodeAPI, vscode/extensions, vscode/askQuestions, execute/runNotebookCell, execute/testFailure, execute/getTerminalOutput, execute/awaitTerminal, execute/killTerminal, execute/createAndRunTask, execute/runInTerminal, execute/runTests, read/getNotebookSummary, read/problems, read/readFile, read/viewImage, read/readNotebookCellOutput, read/terminalSelection, read/terminalLastCommand, agent/runSubagent, edit/createDirectory, edit/createFile, edit/createJupyterNotebook, edit/editFiles, edit/editNotebook, edit/rename, search/changes, search/codebase, search/fileSearch, search/listDirectory, search/textSearch, search/usages, web/fetch, web/githubRepo, postgresql-mcp/pgsql_bulk_load_csv, postgresql-mcp/pgsql_connect, postgresql-mcp/pgsql_db_context, postgresql-mcp/pgsql_describe_csv, postgresql-mcp/pgsql_disconnect, postgresql-mcp/pgsql_get_dashboard_context, postgresql-mcp/pgsql_get_dashboard_data, postgresql-mcp/pgsql_get_metrics_group, postgresql-mcp/pgsql_get_server_capabilities, postgresql-mcp/pgsql_list_connection_profiles, postgresql-mcp/pgsql_list_databases, postgresql-mcp/pgsql_modify, postgresql-mcp/pgsql_open_script, postgresql-mcp/pgsql_query, postgresql-mcp/pgsql_query_plan, postgresql-mcp/pgsql_visualize_schema, github/*, browser/openBrowserPage, github.vscode-pull-request-github/issue_fetch, github.vscode-pull-request-github/labels_fetch, github.vscode-pull-request-github/notification_fetch, github.vscode-pull-request-github/doSearch, github.vscode-pull-request-github/activePullRequest, github.vscode-pull-request-github/pullRequestStatusChecks, github.vscode-pull-request-github/openPullRequest, ms-ossdata.vscode-pgsql/pgsql_migration_oracle_app, ms-ossdata.vscode-pgsql/pgsql_migration_show_report, ms-python.python/getPythonEnvironmentInfo, ms-python.python/getPythonExecutableCommand, ms-python.python/installPythonPackage, ms-python.python/configurePythonEnvironment, todo]
+tools:
+  - agent/runSubagent
+  - browser/openBrowserPage
+  - edit/createDirectory
+  - edit/createFile
+  - edit/createJupyterNotebook
+  - edit/editFiles
+  - edit/editNotebook
+  - edit/rename
+  - execute
+  - github/*
+  - github.vscode-pull-request-github/activePullRequest
+  - github.vscode-pull-request-github/doSearch
+  - github.vscode-pull-request-github/issue_fetch
+  - github.vscode-pull-request-github/labels_fetch
+  - github.vscode-pull-request-github/notification_fetch
+  - github.vscode-pull-request-github/openPullRequest
+  - github.vscode-pull-request-github/pullRequestStatusChecks
+  - memory
+  - ms-ossdata.vscode-pgsql/pgsql_migration_oracle_app
+  - ms-ossdata.vscode-pgsql/pgsql_migration_show_report
+  - ms-python.python/configurePythonEnvironment
+  - ms-python.python/getPythonEnvironmentInfo
+  - ms-python.python/getPythonExecutableCommand
+  - ms-python.python/installPythonPackage
+  - postgresql-mcp/pgsql_bulk_load_csv
+  - postgresql-mcp/pgsql_connect
+  - postgresql-mcp/pgsql_db_context
+  - postgresql-mcp/pgsql_describe_csv
+  - postgresql-mcp/pgsql_disconnect
+  - postgresql-mcp/pgsql_get_dashboard_context
+  - postgresql-mcp/pgsql_get_dashboard_data
+  - postgresql-mcp/pgsql_get_metrics_group
+  - postgresql-mcp/pgsql_get_server_capabilities
+  - postgresql-mcp/pgsql_list_connection_profiles
+  - postgresql-mcp/pgsql_list_databases
+  - postgresql-mcp/pgsql_modify
+  - postgresql-mcp/pgsql_open_script
+  - postgresql-mcp/pgsql_query
+  - postgresql-mcp/pgsql_query_plan
+  - postgresql-mcp/pgsql_visualize_schema
+  - read
+  - search
+  - todo
+  - vscode
+  - web
 ---
 
 # Meshery Code Contributor
@@ -44,8 +89,9 @@ You are an expert-level software engineering agent specialized in contributing t
 
 ### GitHub Collaboration
 - Review pull requests end-to-end using GitHub tooling
-- Post PR comments, submit review comments, and reply in review threads when the task calls for it
-- Use PR comments to communicate progress, request changes, or summarize findings with clear next actions
+- Create, update, comment on, and close GitHub issues when the task calls for it
+- Open, update, review, comment on, and help manage pull requests and review threads
+- Use issue and PR comments to communicate progress, request changes, or summarize findings with clear next actions
 
 ## Meshery Design Principles
 

--- a/.github/agents/meshery-docs-contributor.md
+++ b/.github/agents/meshery-docs-contributor.md
@@ -1,7 +1,52 @@
 ---
 name: Meshery Docs Contributor
 description: Expert-level documentation agent specialized in contributing to Meshery's Hugo-based documentation site with deep knowledge of technical writing, information architecture, Markdown, Hugo templates, shortcodes, partials, and the Meshery ecosystem.
-tools: ['search/changes', 'search/codebase', 'edit/editFiles', 'vscode/extensions', 'web/fetch', 'web/githubRepo', 'vscode/getProjectSetupInfo', 'vscode/installExtension', 'vscode/newWorkspace', 'vscode/runCommand', 'vscode/openSimpleBrowser', 'read/problems', 'execute/getTerminalOutput', 'execute/runInTerminal', 'read/terminalLastCommand', 'read/terminalSelection', 'execute/createAndRunTask', 'execute', 'execute/runTask', 'execute/runTests', 'search', 'search/searchResults', 'execute/testFailure', 'search/usages', 'vscode/vscodeAPI', 'github/*', 'memory']
+tools:
+  - agent/runSubagent
+  - browser/openBrowserPage
+  - edit/createDirectory
+  - edit/createFile
+  - edit/createJupyterNotebook
+  - edit/editFiles
+  - edit/editNotebook
+  - edit/rename
+  - execute
+  - github/*
+  - github.vscode-pull-request-github/activePullRequest
+  - github.vscode-pull-request-github/doSearch
+  - github.vscode-pull-request-github/issue_fetch
+  - github.vscode-pull-request-github/labels_fetch
+  - github.vscode-pull-request-github/notification_fetch
+  - github.vscode-pull-request-github/openPullRequest
+  - github.vscode-pull-request-github/pullRequestStatusChecks
+  - memory
+  - ms-ossdata.vscode-pgsql/pgsql_migration_oracle_app
+  - ms-ossdata.vscode-pgsql/pgsql_migration_show_report
+  - ms-python.python/configurePythonEnvironment
+  - ms-python.python/getPythonEnvironmentInfo
+  - ms-python.python/getPythonExecutableCommand
+  - ms-python.python/installPythonPackage
+  - postgresql-mcp/pgsql_bulk_load_csv
+  - postgresql-mcp/pgsql_connect
+  - postgresql-mcp/pgsql_db_context
+  - postgresql-mcp/pgsql_describe_csv
+  - postgresql-mcp/pgsql_disconnect
+  - postgresql-mcp/pgsql_get_dashboard_context
+  - postgresql-mcp/pgsql_get_dashboard_data
+  - postgresql-mcp/pgsql_get_metrics_group
+  - postgresql-mcp/pgsql_get_server_capabilities
+  - postgresql-mcp/pgsql_list_connection_profiles
+  - postgresql-mcp/pgsql_list_databases
+  - postgresql-mcp/pgsql_modify
+  - postgresql-mcp/pgsql_open_script
+  - postgresql-mcp/pgsql_query
+  - postgresql-mcp/pgsql_query_plan
+  - postgresql-mcp/pgsql_visualize_schema
+  - read
+  - search
+  - todo
+  - vscode
+  - web
 ---
 
 # Meshery Docs Contributor
@@ -49,6 +94,11 @@ You are an expert-level documentation agent specialized in contributing to **Mes
 ├── integrations/           # Integration content and data
 └── public/                 # Generated output
 ```
+
+### GitHub Collaboration
+- Create, update, comment on, and close documentation-related GitHub issues when the task calls for it
+- Open, update, review, and comment on pull requests that change docs, site structure, or generated references
+- Use issue and PR comments to communicate progress, editorial feedback, migration notes, and follow-up actions
 
 ### Current documentation conventions
 - The active documentation root is `/docs`.

--- a/.github/agents/relationship-fixture-agent.md
+++ b/.github/agents/relationship-fixture-agent.md
@@ -1,7 +1,52 @@
 ---
 name: Model Relationships Test Agent
 description: How to create new relationship test fixture designs for Meshery
-tools: ['search/changes', 'search/codebase', 'edit/editFiles', 'vscode/extensions', 'web/fetch', 'web/githubRepo', 'vscode/getProjectSetupInfo', 'vscode/installExtension', 'vscode/newWorkspace', 'vscode/runCommand', 'vscode/openSimpleBrowser', 'read/problems', 'execute/getTerminalOutput', 'execute/runInTerminal', 'read/terminalLastCommand', 'read/terminalSelection', 'execute/createAndRunTask', 'execute', 'execute/runTask', 'execute/runTests', 'search', 'search/searchResults', 'execute/testFailure', 'search/usages', 'vscode/vscodeAPI', 'github/*', 'memory']
+tools:
+  - agent/runSubagent
+  - browser/openBrowserPage
+  - edit/createDirectory
+  - edit/createFile
+  - edit/createJupyterNotebook
+  - edit/editFiles
+  - edit/editNotebook
+  - edit/rename
+  - execute
+  - github/*
+  - github.vscode-pull-request-github/activePullRequest
+  - github.vscode-pull-request-github/doSearch
+  - github.vscode-pull-request-github/issue_fetch
+  - github.vscode-pull-request-github/labels_fetch
+  - github.vscode-pull-request-github/notification_fetch
+  - github.vscode-pull-request-github/openPullRequest
+  - github.vscode-pull-request-github/pullRequestStatusChecks
+  - memory
+  - ms-ossdata.vscode-pgsql/pgsql_migration_oracle_app
+  - ms-ossdata.vscode-pgsql/pgsql_migration_show_report
+  - ms-python.python/configurePythonEnvironment
+  - ms-python.python/getPythonEnvironmentInfo
+  - ms-python.python/getPythonExecutableCommand
+  - ms-python.python/installPythonPackage
+  - postgresql-mcp/pgsql_bulk_load_csv
+  - postgresql-mcp/pgsql_connect
+  - postgresql-mcp/pgsql_db_context
+  - postgresql-mcp/pgsql_describe_csv
+  - postgresql-mcp/pgsql_disconnect
+  - postgresql-mcp/pgsql_get_dashboard_context
+  - postgresql-mcp/pgsql_get_dashboard_data
+  - postgresql-mcp/pgsql_get_metrics_group
+  - postgresql-mcp/pgsql_get_server_capabilities
+  - postgresql-mcp/pgsql_list_connection_profiles
+  - postgresql-mcp/pgsql_list_databases
+  - postgresql-mcp/pgsql_modify
+  - postgresql-mcp/pgsql_open_script
+  - postgresql-mcp/pgsql_query
+  - postgresql-mcp/pgsql_query_plan
+  - postgresql-mcp/pgsql_visualize_schema
+  - read
+  - search
+  - todo
+  - vscode
+  - web
 ---
 
 # Relationship Test Fixture Design Guide
@@ -15,6 +60,12 @@ Relationship test fixtures are JSON files that define a **Meshery Design** conta
 2. **Relationships** - The expected relationships that should be identified between components
 
 These fixtures are used by `ui/tests/e2e/relationship_evaluation.spec.js` to verify that the relationship evaluation API correctly identifies relationships between components.
+
+## GitHub Collaboration
+
+- Create, update, comment on, and close GitHub issues when fixture work needs follow-up tracking or bug documentation
+- Open, update, review, comment on, and help manage pull requests that add or refine relationship fixtures
+- Use issue and PR comments to document fixture intent, uncovered edge cases, and expected validation outcomes
 
 ---
 


### PR DESCRIPTION
## Summary
- standardize the repository's coding agents on a full tool profile
- ensure agents have full GitHub issue and pull request capabilities via `github/*`
- add explicit collaboration guidance covering issue creation, issue comments, PR comments, reviews, and closure flows

## Scope
- `.github/agents/meshery-code-contributor.md`
- `.github/agents/meshery-docs-contributor.md`
- `.github/agents/github-actions-engineer.md`
- `.github/agents/relationship-fixture-agent.md`
- `.github/agents/agentic-workflows.agent.md`
- `.agents/code-reviewer.md`
- `.agents/security-reviewer.md`
