### PR TITLE
chore(deps): bump github.com/meshery/schemas to v1.2.6

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -51,7 +51,7 @@ require (
 	github.com/meshery/meshery-operator v0.8.11
 	github.com/meshery/meshkit v1.0.7
 	github.com/meshery/meshsync v1.0.0
-	github.com/meshery/schemas v1.2.2
+	github.com/meshery/schemas v1.2.6
 	github.com/nsf/termbox-go v1.1.1
 	github.com/oapi-codegen/runtime v1.3.1
 	github.com/olekukonko/tablewriter v1.1.4

--- a/go.sum
+++ b/go.sum
@@ -1494,8 +1494,8 @@ github.com/meshery/meshkit v1.0.7 h1:yuF+4VdCH+koaGJOIZknoYuD2qYgyUf5B+OHkq/OwN0
 github.com/meshery/meshkit v1.0.7/go.mod h1:cTDLb/QPwSzPgMSweoakXztmmj0Kpz5+E3dyFym8REM=
 github.com/meshery/meshsync v1.0.0 h1:BIHEVG4BDjqOnSd3vBt9B4IfWJNTfMRAgdwLroBcCfY=
 github.com/meshery/meshsync v1.0.0/go.mod h1:mFsPXkZRiCSuk5DhxBTrkWdlo6peItRBUoIEEQCovIg=
-github.com/meshery/schemas v1.2.2 h1:L07RaoqjzRRQxheAxTE5HCIqqcjfihKO5i5IBxCHic0=
-github.com/meshery/schemas v1.2.2/go.mod h1:UrkQFIKza3S3CuLR9yKt5a7xZW3ksSVd6N0yUdhvhRE=
+github.com/meshery/schemas v1.2.6 h1:EKW4lQe/MUurmFxhW6Ulxe9u+b9828Ftmnc1bpEpzWQ=
+github.com/meshery/schemas v1.2.6/go.mod h1:QUDp59chV2L7KMHbywjumSJE1dkUK5P5vNNOU/2Z8as=
 github.com/miekg/dns v1.1.57 h1:Jzi7ApEIzwEPLHWRcafCN9LZSBbqQpxjt/wpgvg7wcM=
 github.com/miekg/dns v1.1.57/go.mod h1:uqRjCRUuEAA6qsOiJvDd+CFo/vW+y5WR6SNmHE55hZk=
 github.com/miekg/pkcs11 v1.0.2/go.mod h1:XsNlhZGX73bx86s2hdc/FuaLm2CPZJemRLMA+WTFxgs=


### PR DESCRIPTION
## Summary

- Bumps `github.com/meshery/schemas` from v1.2.2 to v1.2.6 (4 patch releases behind master).
- Surfaced by Phase 8a post-canonical-naming integration validation: meshery-cloud, meshery, and meshkit were all pinned at v1.2.2 even though the published Go module and the docs OpenAPI baseline already advanced to v1.2.6. Cloud's `TestPublishedDocsOpenAPIVersionNotAhead` was the canary failure.
- Companion PRs: meshkit#1000 and meshery-cloud#5145 (each lands the same v1.2.6 pin in its own go.mod).

## Test plan

- [x] `make error` — clean.
- [x] `go build ./...` — clean.
- [x] `go test -count=1 ./server/...` — all 22 packages pass (cmd, core, handlers, helpers, integration-tests/meshsync, internal/channels, internal/graphql/model, internal/sql, internal/store, machines/kubernetes, meshes, models, models/connections, models/httputil, models/pattern/core, models/pattern/planner, models/pattern/stages, policies (89s), router).
- [x] `cd ui && npx vitest run` — 5 suites / 34 tests pass (the validation report noted the original task command `npx jest --bail` was wrong; meshery UI uses vitest).

No code changes — pure dependency bump.