### PR TITLE
[Server] Break /user/login ⇄ /provider redirect loop in enforced-provider mode

### DIFF
--- a/server/handlers/middlewares.go
+++ b/server/handlers/middlewares.go
@@ -35,25 +35,38 @@ func isTransientProviderError(err error) bool {
 
 const providerQParamName = "provider"
 
+// resolveProviderName returns the provider name for a request based on, in
+// order: the provider cookie, the provider header, the ?provider= query
+// param, and finally the enforced default. Returns "" only in
+// multi-provider mode when the client supplied no hint.
+//
+// Falling through to enforcedProvider here is what removes the need for a
+// cookie round-trip via /provider, which is fragile across SameSite/popup/CDN
+// boundaries and was the trigger for an observed /user/login ⇄ /provider
+// redirect loop on enforced-provider hosts.
+func resolveProviderName(req *http.Request, cookieName, enforcedProvider string) string {
+	if ck, err := req.Cookie(cookieName); err == nil && ck.Value != "" {
+		return ck.Value
+	}
+	if hdr := req.Header.Get(cookieName); hdr != "" {
+		return hdr
+	}
+	if q := req.URL.Query().Get(providerQParamName); q != "" {
+		return q
+	}
+	return enforcedProvider
+}
+
 // ProviderMiddleware is a middleware to validate if a provider is set
 func (h *Handler) ProviderMiddleware(next http.Handler) http.Handler {
 	fn := func(w http.ResponseWriter, req *http.Request) {
-		var providerName string
 		var provider models.Provider
-		ck, err := req.Cookie(h.config.ProviderCookieName)
-		if err == nil {
-			providerName = ck.Value
-		} else {
-			providerName = req.Header.Get(h.config.ProviderCookieName)
-			// allow provider to be set using query parameter
-			// this is OK since provider information is not sensitive
-
-			if providerName == "" {
-				providerName = req.URL.Query().Get(providerQParamName)
-			}
-		}
+		providerName := resolveProviderName(req, h.config.ProviderCookieName, h.Provider)
 		if providerName != "" {
 			provider = h.config.Providers[providerName]
+			if provider == nil && h.Provider != "" && providerName == h.Provider {
+				h.log.Errorf("enforced provider %q is not registered in h.config.Providers; /user/login will redirect-loop until this deployment config is corrected", h.Provider)
+			}
 		}
 		ctx := context.WithValue(req.Context(), models.ProviderCtxKey, provider) // nolint
 

--- a/server/handlers/middlewares_test.go
+++ b/server/handlers/middlewares_test.go
@@ -9,6 +9,95 @@ import (
 	"testing"
 )
 
+// TestResolveProviderName covers the precedence rules for picking the
+// provider name from a request, plus the enforced-default fallback that
+// breaks the /user/login ⇄ /provider redirect loop on enforced-provider
+// deployments where the cookie isn't propagating back (SameSite/popup/CDN).
+func TestResolveProviderName(t *testing.T) {
+	const cookieName = "meshery-provider"
+
+	mkReq := func(setup func(*http.Request)) *http.Request {
+		req := httptest.NewRequest(http.MethodGet, "/user/login", nil)
+		if setup != nil {
+			setup(req)
+		}
+		return req
+	}
+
+	tests := []struct {
+		name             string
+		setup            func(*http.Request)
+		enforcedProvider string
+		want             string
+	}{
+		{
+			name:             "no signals, no enforced default → empty",
+			setup:            nil,
+			enforcedProvider: "",
+			want:             "",
+		},
+		{
+			name:             "no signals, enforced default returned",
+			setup:            nil,
+			enforcedProvider: "Layer5",
+			want:             "Layer5",
+		},
+		{
+			name: "cookie wins over enforced default",
+			setup: func(r *http.Request) {
+				r.AddCookie(&http.Cookie{Name: cookieName, Value: "Meshery"})
+			},
+			enforcedProvider: "Layer5",
+			want:             "Meshery",
+		},
+		{
+			name: "empty cookie falls through to header",
+			setup: func(r *http.Request) {
+				r.AddCookie(&http.Cookie{Name: cookieName, Value: ""})
+				r.Header.Set(cookieName, "Meshery")
+			},
+			enforcedProvider: "Layer5",
+			want:             "Meshery",
+		},
+		{
+			name: "header wins over query and enforced",
+			setup: func(r *http.Request) {
+				r.Header.Set(cookieName, "Meshery")
+				r.URL.RawQuery = "provider=None"
+			},
+			enforcedProvider: "Layer5",
+			want:             "Meshery",
+		},
+		{
+			name: "query wins over enforced when no cookie/header",
+			setup: func(r *http.Request) {
+				r.URL.RawQuery = "provider=None"
+			},
+			enforcedProvider: "Layer5",
+			want:             "None",
+		},
+		{
+			name: "cookie with whitespace value is honored verbatim",
+			setup: func(r *http.Request) {
+				r.AddCookie(&http.Cookie{Name: cookieName, Value: "Layer5"})
+			},
+			enforcedProvider: "",
+			want:             "Layer5",
+		},
+	}
+
+	for _, tc := range tests {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			got := resolveProviderName(mkReq(tc.setup), cookieName, tc.enforcedProvider)
+			if got != tc.want {
+				t.Fatalf("resolveProviderName: want %q, got %q", tc.want, got)
+			}
+		})
+	}
+}
+
 func TestAuthMiddleWare(t *testing.T) {
 	if testing.Short() {
 		t.Skip("Skipping test in short mode.")


### PR DESCRIPTION
**Notes for Reviewers**

- Fixes an infinite `/user/login` ⇄ `/provider` redirect loop observed in production on `kanvas.new`. Companion to [#18961](https://github.com/meshery/meshery/pull/18961) (`/login` 404 fix), but independent — that PR addresses a missing route, this one addresses a fragile auth-initiation handshake.

---

## What goes wrong today

In an enforced-provider deployment (`h.Provider != \"\"`), visiting `/user/login` without a `meshery-provider` cookie produces:

1. `GET /user/login` — no cookie, no header, no `?provider=` query.
2. [`ProviderMiddleware`](server/handlers/middlewares.go) leaves `provider` nil.
3. [`/user/login` handler](server/router/server.go#L377-L385): type-assert is `(nil, false)` → `302 /provider`.
4. [`ProviderUIHandler`](server/handlers/provider_handler.go#L51-L67): sees `h.Provider != \"\"` → sets cookie + `302 /user/login`.
5. Step 4's cookie is *supposed* to make step 2 succeed on the next hop, but in practice it doesn't always propagate. Browser DevTools chain on `kanvas.new`:

   ```
   /user/login ← /provider ← /user/login ← /provider ← … (16+ deep, never settles)
   ```

   Causes seen in the wild for cookie-not-propagating: SameSite=Lax default + cross-site initial nav, popup/iframe contexts, intermediate CDN/proxy stripping `Set-Cookie`, privacy-mode cookie blocking.

## Root cause

The design makes `/user/login` depend on a cookie round-trip via `/provider`, even when the server already knows the provider it must use. That round-trip is fragile.

## Fix

- `ProviderMiddleware` now falls back to `h.Provider` when no client-supplied hint (cookie / header / `?provider=`) is present. Provider context is populated on the **first** request, so `LoginHandler` → `InitiateLogin` redirects straight to OAuth without the `/provider` hop. Multi-provider mode (`h.Provider == \"\"`) is unchanged: no fallback, the `/provider` selection UI still runs.
- When `h.Provider` is set but missing from `h.config.Providers` (a config bug that would still loop even with the fallback), log a clear `errorf` so the next operator hitting it can diagnose in seconds.
- Resolution logic extracted into `resolveProviderName()` so it can be unit-tested directly. The existing comment in `middlewares_test.go` calls out that mocking the 100-method `models.Provider` interface is what blocks full middleware tests; the helper sidesteps that.

## Testing

```
go test ./server/handlers/ -run TestResolveProviderName -v   # 7/7 PASS
go test ./server/handlers/                                    # full suite passes
go build ./...                                                # clean
```

Test cases cover precedence (cookie > header > query > enforced default), the new fallback path, the empty-cookie fall-through, and the no-signals/multi-provider null case.

## Out of scope

- Cause-(a) deployment misconfig (`h.Provider` not registered in `h.config.Providers`) is logged but not auto-recovered — that's a deployment fix.
- A future PR could move toward server-side session-only provider state to retire the cookie-round-trip pattern entirely.

**[Signed commits](https://github.com/meshery/meshery/blob/master/CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [x] Yes, I signed my commits.