### PR TITLE
[Server] Stop ProviderUIHandler from emitting an empty meshery-provider cookie

### DIFF
--- a/server/handlers/middlewares.go
+++ b/server/handlers/middlewares.go
@@ -65,7 +65,7 @@ func (h *Handler) ProviderMiddleware(next http.Handler) http.Handler {
 		if providerName != "" {
 			provider = h.config.Providers[providerName]
 			if provider == nil && h.Provider != "" && providerName == h.Provider {
-				h.log.Errorf("enforced provider %q is not registered in h.config.Providers; /user/login will redirect-loop until this deployment config is corrected", h.Provider)
+				h.log.Errorf("enforced provider %q is not registered in h.config.Providers; ProviderUIHandler will degrade to serving the provider-selection UI instead of auto-login. Register %q in PROVIDERS or unset PROVIDER on this deployment.", h.Provider, h.Provider)
 			}
 		}
 		ctx := context.WithValue(req.Context(), models.ProviderCtxKey, provider) // nolint

--- a/server/handlers/provider_handler.go
+++ b/server/handlers/provider_handler.go
@@ -59,8 +59,8 @@ func (h *Handler) ProvidersHandler(w http.ResponseWriter, _ *http.Request) {
 // handler) will fail the type assertion and 302 the request right back to
 // /provider — producing an infinite /user/login ⇄ /provider redirect loop.
 //
-// We hit exactly that loop on kanvas.new: stable-latest images are built
-// with PLAYGROUND=true baked in, and the kanvas.new deployment was missing
+// We hit exactly that loop with meshery extension images that are built
+// with PLAYGROUND=true baked in, and their deployment was missing
 // the PROVIDER env var. ProviderUIHandler entered the auto-select branch
 // (because PlaygroundBuild was true), wrote `meshery-provider=` (empty
 // because h.Provider was unset), and looped. PR #19006 already closed the

--- a/server/handlers/provider_handler.go
+++ b/server/handlers/provider_handler.go
@@ -47,22 +47,56 @@ func (h *Handler) ProvidersHandler(w http.ResponseWriter, _ *http.Request) {
 	_, _ = w.Write(bd)
 }
 
-// ProviderUIHandler - serves providers UI
+// ProviderUIHandler serves the provider-selection UI, or — when the deployment
+// has a single provider it can auto-select — sets the meshery-provider cookie
+// and bounces the request to /user/login so the user never sees the chooser.
+//
+// Auto-select is gated on h.Provider being non-empty AND registered in
+// h.config.Providers. We must never set an empty meshery-provider cookie or
+// one that names an unregistered provider: ProviderMiddleware ignores empty
+// cookie values, and an unregistered name resolves to a nil Provider in the
+// request context. Either way, AuthMiddleware (and the inline /user/login
+// handler) will fail the type assertion and 302 the request right back to
+// /provider — producing an infinite /user/login ⇄ /provider redirect loop.
+//
+// We hit exactly that loop on kanvas.new: stable-latest images are built
+// with PLAYGROUND=true baked in, and the kanvas.new deployment was missing
+// the PROVIDER env var. ProviderUIHandler entered the auto-select branch
+// (because PlaygroundBuild was true), wrote `meshery-provider=` (empty
+// because h.Provider was unset), and looped. PR #19006 already closed the
+// matching path inside ProviderMiddleware (cookie-roundtrip fragility on
+// SameSite/CDN), but it relied on h.Provider being set — so it didn't help
+// the deployment-misconfig case at all. This handler is the actual source
+// of the empty cookie, and the fix belongs here.
+//
+// In any "can't safely auto-select" branch we fall through to ServeUI so
+// the operator at least gets the provider-chooser page (degraded UX, but
+// reachable) and a clear log line pointing at the deployment misconfig.
 func (h *Handler) ProviderUIHandler(w http.ResponseWriter, r *http.Request) {
-	if h.config.PlaygroundBuild || h.Provider != "" { //Always use Remote provider for Playground build or when Provider is enforced
-		http.SetCookie(w, &http.Cookie{
-			Name:     h.config.ProviderCookieName,
-			Value:    h.Provider,
-			Path:     "/",
-			HttpOnly: true,
-		})
-		// Propagate existing request parameters, if present.
-		redirectURL := "/user/login"
-		if r.URL.RawQuery != "" {
-			redirectURL += "?" + r.URL.RawQuery
+	if h.Provider != "" {
+		if _, ok := h.config.Providers[h.Provider]; ok {
+			http.SetCookie(w, &http.Cookie{
+				Name:     h.config.ProviderCookieName,
+				Value:    h.Provider,
+				Path:     "/",
+				HttpOnly: true,
+			})
+			// Propagate existing request parameters, if present.
+			redirectURL := "/user/login"
+			if r.URL.RawQuery != "" {
+				redirectURL += "?" + r.URL.RawQuery
+			}
+			http.Redirect(w, r, redirectURL, http.StatusFound)
+			return
 		}
-		http.Redirect(w, r, redirectURL, http.StatusFound)
-		return
+		h.log.Errorf(
+			"enforced provider %q is not registered in h.config.Providers; serving the provider-selection UI instead of looping. Register %q in PROVIDERS or unset PROVIDER on this deployment.",
+			h.Provider, h.Provider,
+		)
+	} else if h.config.PlaygroundBuild {
+		h.log.Errorf(
+			"PLAYGROUND=true but PROVIDER env var is unset on this deployment; serving the provider-selection UI instead of looping between /user/login and /provider. Set PROVIDER (e.g. PROVIDER=Meshery) to restore one-click playground access.",
+		)
 	}
 	h.ServeUI(w, r, "/provider", "../../provider-ui/out/")
 }

--- a/server/handlers/provider_handler.go
+++ b/server/handlers/provider_handler.go
@@ -74,7 +74,7 @@ func (h *Handler) ProvidersHandler(w http.ResponseWriter, _ *http.Request) {
 // reachable) and a clear log line pointing at the deployment misconfig.
 func (h *Handler) ProviderUIHandler(w http.ResponseWriter, r *http.Request) {
 	if h.Provider != "" {
-		if _, ok := h.config.Providers[h.Provider]; ok {
+		if h.config.Providers[h.Provider] != nil {
 			http.SetCookie(w, &http.Cookie{
 				Name:     h.config.ProviderCookieName,
 				Value:    h.Provider,

--- a/server/handlers/provider_handler_test.go
+++ b/server/handlers/provider_handler_test.go
@@ -171,7 +171,7 @@ func TestProviderUIHandler_LoopGuards(t *testing.T) {
 		wantCookieValue  string // empty means assert no cookie set
 	}{
 		{
-			name:             "kanvas.new regression: PLAYGROUND=true, PROVIDER unset → must NOT loop",
+			name:             "production playground regression: PLAYGROUND=true, PROVIDER unset → must NOT loop",
 			playgroundBuild:  true,
 			providerOverride: "",
 			providers:        registered,

--- a/server/handlers/provider_handler_test.go
+++ b/server/handlers/provider_handler_test.go
@@ -104,7 +104,7 @@ func TestProviderUIHandler_NoneEnvVarRedirectsThroughLogin(t *testing.T) {
 	}
 
 	// Regression: previous version of this test did not assert on the cookie
-	// value, which let the empty-cookie loop trigger ship to kanvas.new. The
+	// value, which let the empty-cookie loop trigger ship. The
 	// auto-select branch must always set a non-empty cookie naming a
 	// registered provider.
 	assertProviderCookieIsRegistered(t, resp, "meshery-provider", providers)
@@ -127,7 +127,7 @@ func assertProviderCookieIsRegistered(t *testing.T, resp *http.Response, cookieN
 			continue
 		}
 		if c.Value == "" {
-			t.Fatalf("ProviderUIHandler emitted empty %s cookie — this is the kanvas.new redirect-loop trigger", cookieName)
+			t.Fatalf("ProviderUIHandler emitted empty %s cookie — this is a redirect-loop trigger", cookieName)
 		}
 		if _, ok := providers[c.Value]; !ok {
 			t.Fatalf("ProviderUIHandler emitted %s=%q which is not a registered provider — this would loop via ProviderMiddleware nil-provider path", cookieName, c.Value)
@@ -151,7 +151,7 @@ func assertNoProviderCookieSet(t *testing.T, resp *http.Response, cookieName str
 // providerRegistered) combinations that decide whether ProviderUIHandler may
 // auto-select and redirect, or must degrade to the provider-selection UI.
 //
-// The kanvas.new outage was exactly the (PlaygroundBuild=true, h.Provider="",
+// Meshery extension image outages are exactly the (PlaygroundBuild=true, h.Provider="",
 // any registry) row: the handler wrote an empty meshery-provider cookie,
 // which ProviderMiddleware rightly ignored, which made AuthMiddleware bounce
 // the request back to /provider — infinite loop. Guarding that row, plus the

--- a/server/handlers/provider_handler_test.go
+++ b/server/handlers/provider_handler_test.go
@@ -102,6 +102,199 @@ func TestProviderUIHandler_NoneEnvVarRedirectsThroughLogin(t *testing.T) {
 	if loc != "/user/login" {
 		t.Errorf("expected redirect to /user/login, got %s", loc)
 	}
+
+	// Regression: previous version of this test did not assert on the cookie
+	// value, which let the empty-cookie loop trigger ship to kanvas.new. The
+	// auto-select branch must always set a non-empty cookie naming a
+	// registered provider.
+	assertProviderCookieIsRegistered(t, resp, "meshery-provider", providers)
+}
+
+// assertProviderCookieIsRegistered fails the test if any meshery-provider
+// cookie in the response has an empty value or names a provider that is
+// not in the registered providers map. Empty / unregistered cookies are
+// the trigger for the /user/login ⇄ /provider redirect loop documented in
+// ProviderUIHandler.
+func assertProviderCookieIsRegistered(t *testing.T, resp *http.Response, cookieName string, providers map[string]models.Provider) {
+	t.Helper()
+	for _, c := range resp.Cookies() {
+		if c.Name != cookieName {
+			continue
+		}
+		// LogoutHandler-style cookie deletions (MaxAge<0) are intentional
+		// empties — those are not the bug we are guarding against.
+		if c.MaxAge < 0 {
+			continue
+		}
+		if c.Value == "" {
+			t.Fatalf("ProviderUIHandler emitted empty %s cookie — this is the kanvas.new redirect-loop trigger", cookieName)
+		}
+		if _, ok := providers[c.Value]; !ok {
+			t.Fatalf("ProviderUIHandler emitted %s=%q which is not a registered provider — this would loop via ProviderMiddleware nil-provider path", cookieName, c.Value)
+		}
+	}
+}
+
+// assertNoProviderCookieSet fails the test if any non-deletion meshery-provider
+// cookie was written. Used for the degraded-fallthrough paths where we MUST
+// reach ServeUI without setting the cookie.
+func assertNoProviderCookieSet(t *testing.T, resp *http.Response, cookieName string) {
+	t.Helper()
+	for _, c := range resp.Cookies() {
+		if c.Name == cookieName && c.MaxAge >= 0 {
+			t.Fatalf("ProviderUIHandler set %s=%q on a fallthrough path — must serve provider chooser instead of writing a cookie that would close the redirect loop", cookieName, c.Value)
+		}
+	}
+}
+
+// TestProviderUIHandler_LoopGuards covers the (PlaygroundBuild, h.Provider,
+// providerRegistered) combinations that decide whether ProviderUIHandler may
+// auto-select and redirect, or must degrade to the provider-selection UI.
+//
+// The kanvas.new outage was exactly the (PlaygroundBuild=true, h.Provider="",
+// any registry) row: the handler wrote an empty meshery-provider cookie,
+// which ProviderMiddleware rightly ignored, which made AuthMiddleware bounce
+// the request back to /provider — infinite loop. Guarding that row, plus the
+// adjacent "h.Provider names something not in the registry" row, is the
+// whole point of this matrix.
+func TestProviderUIHandler_LoopGuards(t *testing.T) {
+	local := &models.DefaultLocalProvider{}
+	local.Initialize()
+	registered := map[string]models.Provider{local.Name(): local} // local.Name() == "None"
+
+	tests := []struct {
+		name             string
+		playgroundBuild  bool
+		providerOverride string
+		providers        map[string]models.Provider
+		wantRedirect     bool   // true means 302 to /user/login + cookie set
+		wantCookieValue  string // empty means assert no cookie set
+	}{
+		{
+			name:             "kanvas.new regression: PLAYGROUND=true, PROVIDER unset → must NOT loop",
+			playgroundBuild:  true,
+			providerOverride: "",
+			providers:        registered,
+			wantRedirect:     false,
+			wantCookieValue:  "",
+		},
+		{
+			name:             "PLAYGROUND=false, PROVIDER unset → standard multi-provider chooser, no cookie",
+			playgroundBuild:  false,
+			providerOverride: "",
+			providers:        registered,
+			wantRedirect:     false,
+			wantCookieValue:  "",
+		},
+		{
+			name:             "PLAYGROUND=true, PROVIDER set + registered → auto-select happy path",
+			playgroundBuild:  true,
+			providerOverride: local.Name(),
+			providers:        registered,
+			wantRedirect:     true,
+			wantCookieValue:  local.Name(),
+		},
+		{
+			name:             "PLAYGROUND=false, PROVIDER set + registered → enforced-provider auto-select",
+			playgroundBuild:  false,
+			providerOverride: local.Name(),
+			providers:        registered,
+			wantRedirect:     true,
+			wantCookieValue:  local.Name(),
+		},
+		{
+			name:             "PROVIDER names an unregistered provider → must NOT set bogus cookie that would loop",
+			playgroundBuild:  false,
+			providerOverride: "Meshery",
+			providers:        registered, // does not contain "Meshery"
+			wantRedirect:     false,
+			wantCookieValue:  "",
+		},
+		{
+			name:             "PLAYGROUND=true + PROVIDER unregistered → must degrade, not loop",
+			playgroundBuild:  true,
+			providerOverride: "Meshery",
+			providers:        registered, // does not contain "Meshery"
+			wantRedirect:     false,
+			wantCookieValue:  "",
+		},
+	}
+
+	for _, tc := range tests {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			h := newTestHandler(t, tc.providers, tc.providerOverride)
+			h.config.PlaygroundBuild = tc.playgroundBuild
+
+			req := httptest.NewRequest(http.MethodGet, "/provider", nil)
+			rec := httptest.NewRecorder()
+
+			h.ProviderUIHandler(rec, req)
+
+			resp := rec.Result()
+			t.Cleanup(func() {
+				if err := resp.Body.Close(); err != nil {
+					t.Errorf("failed to close response body: %v", err)
+				}
+			})
+
+			if tc.wantRedirect {
+				if resp.StatusCode != http.StatusFound {
+					t.Fatalf("want 302 Found, got %d", resp.StatusCode)
+				}
+				if loc := resp.Header.Get("Location"); loc != "/user/login" {
+					t.Errorf("want redirect to /user/login, got %q", loc)
+				}
+				assertProviderCookieIsRegistered(t, resp, "meshery-provider", tc.providers)
+
+				var got string
+				for _, c := range resp.Cookies() {
+					if c.Name == "meshery-provider" {
+						got = c.Value
+					}
+				}
+				if got != tc.wantCookieValue {
+					t.Errorf("want cookie value %q, got %q", tc.wantCookieValue, got)
+				}
+				return
+			}
+
+			// Fallthrough paths: must NOT 302, must NOT set the cookie. The
+			// status code itself depends on whether ServeUI finds the static
+			// file under ../../provider-ui/out/ — in unit tests we don't
+			// require a built provider-ui, so we accept any non-302 response.
+			if resp.StatusCode == http.StatusFound {
+				t.Fatalf("ProviderUIHandler must not redirect on fallthrough (got 302 to %q) — this is the loop trigger", resp.Header.Get("Location"))
+			}
+			assertNoProviderCookieSet(t, resp, "meshery-provider")
+		})
+	}
+}
+
+// TestProviderUIHandler_PreservesQueryStringOnAutoSelect makes sure deep-link
+// query params (e.g. ?ref=<base64>) survive the auto-select redirect, which
+// is the only path that takes the user to /user/login through this handler.
+func TestProviderUIHandler_PreservesQueryStringOnAutoSelect(t *testing.T) {
+	local := &models.DefaultLocalProvider{}
+	local.Initialize()
+	providers := map[string]models.Provider{local.Name(): local}
+	h := newTestHandler(t, providers, local.Name())
+
+	req := httptest.NewRequest(http.MethodGet, "/provider?ref=L2V4dGVuc2lvbi9tZXNobWFw", nil)
+	rec := httptest.NewRecorder()
+	h.ProviderUIHandler(rec, req)
+
+	resp := rec.Result()
+	t.Cleanup(func() { _ = resp.Body.Close() })
+
+	if resp.StatusCode != http.StatusFound {
+		t.Fatalf("want 302 Found, got %d", resp.StatusCode)
+	}
+	wantLoc := "/user/login?ref=L2V4dGVuc2lvbi9tZXNobWFw"
+	if loc := resp.Header.Get("Location"); loc != wantLoc {
+		t.Errorf("want %q, got %q", wantLoc, loc)
+	}
 }
 
 func TestLoginHandler_NoneProviderRedirectsHome(t *testing.T) {


### PR DESCRIPTION
## Summary

A production playground host is **still** stuck in an infinite `/user/login` ⇄ `/provider` redirect loop. PR #19006 fixed one variant of this loop (cookie not propagating across SameSite/CDN boundaries when an enforced provider IS configured), but its fallback uses `h.Provider` — so it does nothing when `h.Provider` is unset on the deployment, which is exactly this case. This PR closes the second variant at the actual source of the empty cookie.

## Reproduction (live trace from the affected host)

```
$ curl -sS -L --max-redirs 20 -D - -o /dev/null https://<production-host>/

GET /         → 302 Location: /provider?
GET /provider → 302 Location: /user/login    Set-Cookie: meshery-provider=; Path=/; HttpOnly  ← EMPTY VALUE
GET /user/login → 302 Location: /provider
GET /provider → 302 Location: /user/login    Set-Cookie: meshery-provider=; Path=/; HttpOnly  ← EMPTY VALUE
... (loops until curl --max-redirs cap)
```

The cookie shape (no `Expires`, no `MaxAge`) is unique to one writer in the codebase: `ProviderUIHandler`'s auto-select branch.

## Root cause

`server/handlers/provider_handler.go` (pre-fix):

```go
if h.config.PlaygroundBuild || h.Provider != "" {
    http.SetCookie(w, &http.Cookie{
        Name:     h.config.ProviderCookieName,
        Value:    h.Provider,        // "" when PROVIDER env var is unset
        Path:     "/",
        HttpOnly: true,
    })
    http.Redirect(w, r, "/user/login", http.StatusFound)
    return
}
```

When `PLAYGROUND=true` AND `h.Provider` is `""`, the OR short-circuits via `PlaygroundBuild` and writes an **empty** `meshery-provider` cookie. Downstream:

1. `ProviderMiddleware.resolveProviderName` correctly ignores the empty cookie value and falls through to `h.Provider` — also empty.
2. The inline `/user/login` handler (`server/router/server.go:377-385`) fails the type assertion on the resulting `nil` Provider context value.
3. It 302s back to `/provider`. **Loop.**

### Why this affects every stable build

`.github/workflows/build-and-release-stable.yml:35` builds the stable-latest image with `--build-arg PLAYGROUND=true`. Any deployment of those images that omits `PROVIDER` hits this. `install/playground/kubernetes/meshery-playground-deployment.yaml` sets both `PROVIDER` and `PLAYGROUND=true`, but the affected production host evidently ships PLAYGROUND only.

## Fix

Tighten the auto-select gate so it fires **only** when:
- `h.Provider != ""`, AND
- `h.config.Providers[h.Provider]` is registered

Anything else falls through to `ServeUI` (the provider-chooser page), with an `Errorf` naming the specific deployment misconfig so operators see it in logs immediately.

Worst-case behavior is now "user sees the chooser, picks a provider, logs in" — reachable and recoverable, instead of an infinite loop.

The happy path (PLAYGROUND=true + a registered enforced PROVIDER) is **unchanged**: cookie set, single 302 to `/user/login`. Verified by the existing `TestProviderUIHandler_NoneEnvVarRedirectsThroughLogin` plus a new cookie-value assertion (the previous test only checked `Location`, which is precisely how this bug shipped past review).

Also updates `ProviderMiddleware`'s diagnostic Errorf — it claimed "/user/login will redirect-loop until corrected" which is no longer true post-fix; the loop is the symptom we're removing.

## Operator follow-up (out of scope but required for full UX restore)

This code fix prevents the **loop**. To restore one-click playground UX on the affected production host, the deployment also needs a registered `PROVIDER` set on the `meshery` container env (mirror the [playground k8s YAML](https://github.com/meshery/meshery/blob/master/install/playground/kubernetes/meshery-playground-deployment.yaml#L21-L26)).

## Relationship to #19006

| | #19006 | This PR |
|---|---|---|
| Loop trigger | Cookie set by `/provider` doesn't propagate (SameSite/CDN) | `/provider` writes an empty cookie (PROVIDER unset) |
| Fix layer | `ProviderMiddleware.resolveProviderName` falls back to `h.Provider` | `ProviderUIHandler` refuses to write empty/unregistered cookies |
| Helps when `h.Provider == ""`? | No — fallback returns "" too | Yes — degrades to chooser instead of looping |

Both fixes are needed.

## Test plan

- [x] `go test ./server/handlers/` — full handlers package, all tests green
- [x] `go vet ./server/handlers/...` — clean
- [x] `go build ./server/...` — clean
- [x] New `TestProviderUIHandler_LoopGuards` parametric matrix covers all 6 (PlaygroundBuild × h.Provider × registered?) combinations:
  - production-playground regression row (PLAYGROUND=true, PROVIDER unset → must NOT loop)
  - PROVIDER set but unregistered (would also have looped)
  - Both happy paths (auto-select with registered provider)
  - Both no-op paths (multi-provider chooser)
- [x] New `TestProviderUIHandler_PreservesQueryStringOnAutoSelect` guards `?ref=<base64>` deep-link survival
- [x] Extended `TestProviderUIHandler_NoneEnvVarRedirectsThroughLogin` to assert cookie value (regression guard for the missing assertion that let this ship)
- [x] New `assertProviderCookieIsRegistered` / `assertNoProviderCookieSet` helpers — future tests fail loudly if the bad cookie shape returns
- [ ] Post-deploy: re-curl the production host once this lands in a stable build → expect single 302 chain ending at provider chooser page (not a loop)
- [ ] After production deployment is updated with a registered `PROVIDER` → expect single 302 to `/user/login` then OAuth handshake with the configured remote provider