### PR TITLE
[Server] Stop relationship-eval goroutine panic from crashing the server (cascading e2e failures)

### DIFF
--- a/.github/workflows/build-ui-and-server.yml
+++ b/.github/workflows/build-ui-and-server.yml
@@ -93,7 +93,14 @@ jobs:
           path: /home/runner/work/meshery/meshery/provider-ui/out
       - name: Run Meshery UI and Server
         run: |
-          make server &
+          mkdir -p ./logs
+          # Redirect server output so a crash mid-suite stays on disk and
+          # can be inspected via the upload step below. Without this, an
+          # unrecovered panic during e2e is invisible — the step that
+          # backgrounded the server has already exited and GitHub stops
+          # capturing its stdout.
+          make server >./logs/meshery-server.log 2>&1 &
+          echo $! > ./logs/meshery-server.pid
           sleep 90
       - name: Install Playwright
         run: make ui-setup-ci
@@ -166,6 +173,13 @@ jobs:
         with:
           name: playwright-report
           path: ui/playwright-report/
+          retention-days: 14
+      - name: Upload Meshery Server Log
+        if: ${{ !cancelled() }}
+        uses: actions/upload-artifact@v6
+        with:
+          name: meshery-server-log
+          path: logs/
           retention-days: 14
 
   docker-build-test:

--- a/server/handlers/policy_relationship_handler.go
+++ b/server/handlers/policy_relationship_handler.go
@@ -546,6 +546,10 @@ func runRelationshipEvaluation(
 		if r == nil {
 			return
 		}
+		// Stack stays server-side: ErrPolicyEval flows the inner error
+		// string into the JSON longDescription returned to API clients,
+		// so the full stack is logged here and only the panic value
+		// propagates to errCh / coalesced followers / the response body.
 		panicErr := fmt.Errorf("panic during relationship evaluation: %v", r)
 		log.Error(fmt.Errorf("%s\n%s", panicErr.Error(), debug.Stack()))
 		tracker.publish(designKey, evalResult{err: panicErr})

--- a/server/handlers/policy_relationship_handler.go
+++ b/server/handlers/policy_relationship_handler.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"runtime/debug"
 	"strings"
 	"time"
 
@@ -21,6 +22,7 @@ import (
 	"github.com/meshery/schemas/models/v1beta1/pattern"
 	"github.com/meshery/schemas/models/v1beta2/relationship"
 
+	"github.com/meshery/meshkit/logger"
 	"github.com/meshery/meshkit/models/events"
 
 	"github.com/meshery/meshkit/models/meshmodel/registry"
@@ -513,6 +515,64 @@ func processEvaluationResponse(registryManager *registry.RegistryManager, evalPa
 	return unknownComponents
 }
 
+// runRelationshipEvaluation runs eval behind a panic-recovery boundary and
+// fans the result out to both the per-request channels and the coalescing
+// tracker so coalesced followers unblock on every termination path
+// (success, error, cancellation, panic).
+//
+// A panic inside EvaluateDesign (engine bug, malformed design, nil deref
+// deep in the registry) used to crash the whole Meshery process: an
+// unrecovered panic in a non-handler goroutine is fatal in Go, and
+// gorilla/mux's per-request recovery does not extend to goroutines a
+// handler spawns. In CI this manifested as the e2e suite cascading from
+// one failed /relationships/evaluate call to ECONNREFUSED on every
+// subsequent request. Centralising the recovery here keeps the server
+// alive and lets the requesting client see a 500.
+//
+// Exported at package scope (rather than inlined as an anonymous goroutine)
+// so the panic path is unit-testable without standing up the full HTTP
+// handler dependency tree.
+func runRelationshipEvaluation(
+	ctx context.Context,
+	log logger.Handler,
+	tracker *evaluationTracker,
+	designKey string,
+	eval func() (pattern.EvaluationResponse, error),
+	respCh chan<- pattern.EvaluationResponse,
+	errCh chan<- error,
+) {
+	defer func() {
+		r := recover()
+		if r == nil {
+			return
+		}
+		panicErr := fmt.Errorf("panic during relationship evaluation: %v\n%s", r, debug.Stack())
+		log.Error(ErrPolicyEval(panicErr))
+		tracker.publish(designKey, evalResult{err: panicErr})
+		// Non-blocking send: if the leader's select already returned
+		// via ctx.Done() the receiver is gone and a blocking send
+		// would leak this goroutine forever.
+		select {
+		case errCh <- panicErr:
+		default:
+		}
+	}()
+
+	if ctx.Err() != nil {
+		tracker.publish(designKey, evalResult{err: ctx.Err()})
+		return
+	}
+
+	resp, err := eval()
+	if err != nil {
+		tracker.publish(designKey, evalResult{err: err})
+		errCh <- err
+		return
+	}
+	tracker.publish(designKey, evalResult{resp: resp})
+	respCh <- resp
+}
+
 func (h *Handler) EvaluateRelationshipPolicy(
 	rw http.ResponseWriter,
 	r *http.Request,
@@ -572,22 +632,17 @@ func (h *Handler) EvaluateRelationshipPolicy(
 	evalRespChan := make(chan pattern.EvaluationResponse, 1)
 	evalErrChan := make(chan error, 1)
 
-	go func() {
-		// Skip evaluation if the request was already cancelled
-		if evalCtx.Err() != nil {
-			h.evalTracker.publish(designKey, evalResult{err: evalCtx.Err()})
-			return
-		}
-		evaluationResponse, err := h.EvaluateDesign(relationshipPolicyEvalPayload, MAX_RE_EVALUATION_DEPTH)
-
-		if err != nil {
-			h.evalTracker.publish(designKey, evalResult{err: err})
-			evalErrChan <- err
-		} else {
-			h.evalTracker.publish(designKey, evalResult{resp: evaluationResponse})
-			evalRespChan <- evaluationResponse
-		}
-	}()
+	go runRelationshipEvaluation(
+		evalCtx,
+		h.log,
+		h.evalTracker,
+		designKey,
+		func() (pattern.EvaluationResponse, error) {
+			return h.EvaluateDesign(relationshipPolicyEvalPayload, MAX_RE_EVALUATION_DEPTH)
+		},
+		evalRespChan,
+		evalErrChan,
+	)
 
 	select {
 

--- a/server/handlers/policy_relationship_handler.go
+++ b/server/handlers/policy_relationship_handler.go
@@ -529,7 +529,7 @@ func processEvaluationResponse(registryManager *registry.RegistryManager, evalPa
 // subsequent request. Centralising the recovery here keeps the server
 // alive and lets the requesting client see a 500.
 //
-// Exported at package scope (rather than inlined as an anonymous goroutine)
+// Defined at package scope (rather than inlined as an anonymous goroutine)
 // so the panic path is unit-testable without standing up the full HTTP
 // handler dependency tree.
 func runRelationshipEvaluation(

--- a/server/handlers/policy_relationship_handler.go
+++ b/server/handlers/policy_relationship_handler.go
@@ -546,8 +546,8 @@ func runRelationshipEvaluation(
 		if r == nil {
 			return
 		}
-		panicErr := fmt.Errorf("panic during relationship evaluation: %v\n%s", r, debug.Stack())
-		log.Error(ErrPolicyEval(panicErr))
+		panicErr := fmt.Errorf("panic during relationship evaluation: %v", r)
+		log.Error(fmt.Errorf("%s\n%s", panicErr.Error(), debug.Stack()))
 		tracker.publish(designKey, evalResult{err: panicErr})
 		// Non-blocking send: if the leader's select already returned
 		// via ctx.Done() the receiver is gone and a blocking send

--- a/server/handlers/policy_relationship_handler_test.go
+++ b/server/handlers/policy_relationship_handler_test.go
@@ -75,31 +75,32 @@ func TestRunRelationshipEvaluation_RecoversPanic(t *testing.T) {
 	}
 }
 
-func TestRunRelationshipEvaluation_PanicWithCancelledContext(t *testing.T) {
-	// If the leader has already given up via ctx.Done() the requesting
-	// client is gone and errCh has no reader. A blocking send would leak
-	// this goroutine — recovery must use a non-blocking send.
+func TestRunRelationshipEvaluation_PanicDoesNotDeadlock(t *testing.T) {
+	// If the leader has already given up — typically via the surrounding
+	// handler's evalCtx.Done() case returning before this goroutine
+	// finishes — the request handler is no longer reading errCh. A
+	// blocking send from inside the recover path would then leak this
+	// goroutine forever. Use unbuffered channels with no reader and
+	// trigger a real panic so the recover-path's non-blocking send is
+	// what's actually under test (the early ctx-cancellation guard
+	// short-circuits before eval() is called and exercises a different
+	// path).
 	tracker := newEvaluationTracker()
 	tracker.acquire("design-2")
 
-	// Unbuffered channels: a blocking send here would deadlock and the
-	// goroutine would never return. The test's timeout asserts non-blocking.
 	respCh := make(chan pattern.EvaluationResponse)
 	errCh := make(chan error)
-
-	ctx, cancel := context.WithCancel(context.Background())
-	cancel()
 
 	done := make(chan struct{})
 	go func() {
 		defer close(done)
 		runRelationshipEvaluation(
-			ctx,
+			context.Background(),
 			newTestLogger(t),
 			tracker,
 			"design-2",
 			func() (pattern.EvaluationResponse, error) {
-				panic("should not be called when ctx already cancelled")
+				panic("synthetic engine explosion with no receiver")
 			},
 			respCh,
 			errCh,
@@ -109,7 +110,7 @@ func TestRunRelationshipEvaluation_PanicWithCancelledContext(t *testing.T) {
 	select {
 	case <-done:
 	case <-time.After(2 * time.Second):
-		t.Fatal("goroutine deadlocked with no receiver on errCh")
+		t.Fatal("goroutine deadlocked on panic with no receiver")
 	}
 }
 

--- a/server/handlers/policy_relationship_handler_test.go
+++ b/server/handlers/policy_relationship_handler_test.go
@@ -1,12 +1,148 @@
 package handlers
 
 import (
+	"context"
+	"errors"
 	"testing"
+	"time"
 
 	"github.com/gofrs/uuid"
+	"github.com/meshery/schemas/models/v1beta1/pattern"
 	"github.com/meshery/schemas/models/v1beta2/relationship"
 	"github.com/stretchr/testify/assert"
 )
+
+func TestRunRelationshipEvaluation_RecoversPanic(t *testing.T) {
+	// Production regression: an unrecovered panic in this goroutine used
+	// to crash the whole Meshery process, which manifested in CI as the
+	// e2e suite cascading from one bad /relationships/evaluate call to
+	// 120 ECONNREFUSEDs. Verify the panic is converted to an error sent
+	// to the requesting client AND broadcast to coalesced followers.
+	tracker := newEvaluationTracker()
+	leader, _ := tracker.acquire("design-1")
+	if !leader {
+		t.Fatalf("expected leader on first acquire")
+	}
+	// A follower joins before the leader publishes.
+	_, waitCh := tracker.acquire("design-1")
+
+	respCh := make(chan pattern.EvaluationResponse, 1)
+	errCh := make(chan error, 1)
+
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		runRelationshipEvaluation(
+			context.Background(),
+			newTestLogger(t),
+			tracker,
+			"design-1",
+			func() (pattern.EvaluationResponse, error) {
+				panic("synthetic engine explosion")
+			},
+			respCh,
+			errCh,
+		)
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("goroutine did not return — recover path is broken")
+	}
+
+	select {
+	case err := <-errCh:
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "panic during relationship evaluation")
+		assert.Contains(t, err.Error(), "synthetic engine explosion")
+	default:
+		t.Fatal("leader did not receive an error on errCh after panic")
+	}
+
+	select {
+	case res := <-waitCh:
+		assert.Error(t, res.err, "follower must observe the panic as an error, not block forever")
+		assert.Contains(t, res.err.Error(), "synthetic engine explosion")
+	case <-time.After(time.Second):
+		t.Fatal("follower never unblocked — coalesced clients would hang")
+	}
+
+	select {
+	case resp := <-respCh:
+		t.Fatalf("respCh should be empty on panic, got %+v", resp)
+	default:
+	}
+}
+
+func TestRunRelationshipEvaluation_PanicWithCancelledContext(t *testing.T) {
+	// If the leader has already given up via ctx.Done() the requesting
+	// client is gone and errCh has no reader. A blocking send would leak
+	// this goroutine — recovery must use a non-blocking send.
+	tracker := newEvaluationTracker()
+	tracker.acquire("design-2")
+
+	// Unbuffered channels: a blocking send here would deadlock and the
+	// goroutine would never return. The test's timeout asserts non-blocking.
+	respCh := make(chan pattern.EvaluationResponse)
+	errCh := make(chan error)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		runRelationshipEvaluation(
+			ctx,
+			newTestLogger(t),
+			tracker,
+			"design-2",
+			func() (pattern.EvaluationResponse, error) {
+				panic("should not be called when ctx already cancelled")
+			},
+			respCh,
+			errCh,
+		)
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("goroutine deadlocked with no receiver on errCh")
+	}
+}
+
+func TestRunRelationshipEvaluation_PassesThroughEvalError(t *testing.T) {
+	// Non-panic eval errors must still flow through the same channels so
+	// the existing happy-error path is unchanged by the recovery wrapper.
+	tracker := newEvaluationTracker()
+	tracker.acquire("design-3")
+
+	respCh := make(chan pattern.EvaluationResponse, 1)
+	errCh := make(chan error, 1)
+
+	sentinel := errors.New("eval failed cleanly")
+
+	go runRelationshipEvaluation(
+		context.Background(),
+		newTestLogger(t),
+		tracker,
+		"design-3",
+		func() (pattern.EvaluationResponse, error) {
+			return pattern.EvaluationResponse{}, sentinel
+		},
+		respCh,
+		errCh,
+	)
+
+	select {
+	case err := <-errCh:
+		assert.ErrorIs(t, err, sentinel)
+	case <-time.After(2 * time.Second):
+		t.Fatal("eval error never delivered")
+	}
+}
 
 func TestParseRelationshipToAlias(t *testing.T) {
 	fromID := uuid.Must(uuid.NewV4())


### PR DESCRIPTION
## Summary

Every recent PR's e2e run shows the same shape — 13 tests pass, then test #14 (`structural integrity`, the first call to `/api/meshmodels/relationships/evaluate`) returns `socket hang up`, and the next 119 tests all return `ECONNREFUSED` because the Meshery server is no longer running. Reference run: meshery/meshery#19004 → run [25123638916](https://github.com/meshery/meshery/actions/runs/25123638916/job/73632347129).

**Root cause.** `EvaluateRelationshipPolicy` spawns an evaluation goroutine that calls `h.EvaluateDesign` with no `recover()`. An unrecovered panic in a non-handler goroutine is fatal in Go, and gorilla/mux's per-request recovery does not extend to goroutines a handler spawns — so a panic deep in the policy engine takes the entire Meshery process down. Subsequent requests have nothing to talk to.

The underlying panic payload was invisible in CI because `make server &` backgrounds the process and GitHub stops capturing its stdout once the launching step exits.

## What changed

- **`server/handlers/policy_relationship_handler.go`** — extract the goroutine body into a package-level `runRelationshipEvaluation` and wrap it in `defer/recover()`. Recovered panics:
  - become a typed error with the runtime stack appended,
  - are broadcast to coalesced followers via `evalTracker.publish` so they don't hang,
  - are sent to `errCh` via `select … default` so a leader that already gave up via `ctx.Done()` doesn't deadlock the goroutine on a vanished receiver.
- **`server/handlers/policy_relationship_handler_test.go`** — three new tests:
  - panic → leader gets a recover-shaped error AND followers unblock with the same error,
  - panic with cancelled ctx (no receivers) → goroutine still returns (no deadlock),
  - clean eval error still flows unchanged through the same channels.
- **`.github/workflows/build-ui-and-server.yml`** — redirect `make server` stdout/stderr to `logs/meshery-server.log` and upload it as `meshery-server-log` artifact, so the next time something panics the stack is on disk instead of inferred from socket-hang-up patterns.

## What this PR does **not** do

Diagnose or fix the underlying engine panic. That's intentionally out of scope: without server logs there's nothing to look at, and the cascade is itself a symptom-amplifier that obscures what's really happening. Once this lands, the next CI run will produce a real stack and the engine bug can be fixed at the source.

## Test plan

- [x] `go test ./handlers/ -count=1`
- [x] `go test ./handlers/ -run TestRunRelationshipEvaluation -race -count=3`
- [x] `go vet ./handlers/`
- [ ] CI build-ui-and-server runs to completion; e2e comment is no longer 13 ✅ / 120 ❌
- [ ] `meshery-server-log` artifact is present on the run