### PR TITLE
[mesheryctl] Fix invisible provider options in system login

### DIFF
--- a/mesheryctl/pkg/utils/auth.go
+++ b/mesheryctl/pkg/utils/auth.go
@@ -22,8 +22,33 @@ import (
 )
 
 type Provider struct {
-	ProviderURL  string `json:"provider_url,omitempty"`
-	ProviderName string `json:"provider_name,omitempty"`
+	ProviderURL  string `json:"providerUrl,omitempty"`
+	ProviderName string `json:"providerName,omitempty"`
+}
+
+func (p *Provider) UnmarshalJSON(data []byte) error {
+	type providerAlias Provider
+	aux := struct {
+		providerAlias
+		ProviderURLLegacy  string `json:"provider_url,omitempty"`
+		ProviderNameLegacy string `json:"provider_name,omitempty"`
+	}{}
+
+	if err := json.Unmarshal(data, &aux); err != nil {
+		return err
+	}
+
+	p.ProviderURL = aux.ProviderURL
+	if p.ProviderURL == "" {
+		p.ProviderURL = aux.ProviderURLLegacy
+	}
+
+	p.ProviderName = aux.ProviderName
+	if p.ProviderName == "" {
+		p.ProviderName = aux.ProviderNameLegacy
+	}
+
+	return nil
 }
 
 // NewRequest creates *http.Request and handles adding authentication for Meshery itself

--- a/mesheryctl/pkg/utils/auth.go
+++ b/mesheryctl/pkg/utils/auth.go
@@ -35,7 +35,7 @@ func (p *Provider) UnmarshalJSON(data []byte) error {
 	}{}
 
 	if err := json.Unmarshal(data, &aux); err != nil {
-		return err
+		return ErrUnmarshal(err)
 	}
 
 	p.ProviderURL = aux.ProviderURL

--- a/mesheryctl/pkg/utils/auth_test.go
+++ b/mesheryctl/pkg/utils/auth_test.go
@@ -15,6 +15,7 @@
 package utils
 
 import (
+	"encoding/json"
 	"fmt"
 	"net/http"
 	"net/http/httptest"
@@ -62,4 +63,38 @@ func TestAuth(t *testing.T) {
 		}
 	})
 	//@Aisuko Need a token file to do other testings
+}
+
+func TestProviderUnmarshalJSON(t *testing.T) {
+	t.Run("accepts canonical camelCase provider fields", func(t *testing.T) {
+		payload := []byte(`{"providerUrl":"https://cloud.layer5.io","providerName":"Layer5"}`)
+		provider := Provider{}
+
+		if err := json.Unmarshal(payload, &provider); err != nil {
+			t.Fatalf("failed to unmarshal provider payload: %v", err)
+		}
+
+		if provider.ProviderName != "Layer5" {
+			t.Fatalf("expected provider name Layer5, got %q", provider.ProviderName)
+		}
+		if provider.ProviderURL != "https://cloud.layer5.io" {
+			t.Fatalf("expected provider URL https://cloud.layer5.io, got %q", provider.ProviderURL)
+		}
+	})
+
+	t.Run("accepts legacy snake_case provider fields", func(t *testing.T) {
+		payload := []byte(`{"provider_url":"https://cloud.layer5.io","provider_name":"Layer5"}`)
+		provider := Provider{}
+
+		if err := json.Unmarshal(payload, &provider); err != nil {
+			t.Fatalf("failed to unmarshal provider payload: %v", err)
+		}
+
+		if provider.ProviderName != "Layer5" {
+			t.Fatalf("expected provider name Layer5, got %q", provider.ProviderName)
+		}
+		if provider.ProviderURL != "https://cloud.layer5.io" {
+			t.Fatalf("expected provider URL https://cloud.layer5.io, got %q", provider.ProviderURL)
+		}
+	})
 }

--- a/mesheryctl/pkg/utils/auth_test.go
+++ b/mesheryctl/pkg/utils/auth_test.go
@@ -66,7 +66,7 @@ func TestAuth(t *testing.T) {
 }
 
 func TestProviderUnmarshalJSON(t *testing.T) {
-	t.Run("accepts canonical camelCase provider fields", func(t *testing.T) {
+	t.Run("Given canonical camelCase provider fields, When unmarshaled, Then it populates Provider correctly", func(t *testing.T) {
 		payload := []byte(`{"providerUrl":"https://cloud.layer5.io","providerName":"Layer5"}`)
 		provider := Provider{}
 
@@ -82,7 +82,7 @@ func TestProviderUnmarshalJSON(t *testing.T) {
 		}
 	})
 
-	t.Run("accepts legacy snake_case provider fields", func(t *testing.T) {
+	t.Run("Given legacy snake_case provider fields, When unmarshaled, Then it populates Provider correctly", func(t *testing.T) {
 		payload := []byte(`{"provider_url":"https://cloud.layer5.io","provider_name":"Layer5"}`)
 		provider := Provider{}
 


### PR DESCRIPTION
**Notes for Reviewers**
- Resolves an issue where `mesheryctl system login` displayed blank provider options in the terminal prompt.
- Updates the JSON unmarshaling in `mesheryctl/pkg/utils/auth.go` to correctly read the canonical `camelCase` fields (`providerName`, `providerUrl`) that the Meshery Server has emitted since the Phase 5 identifier-naming overhaul (commit `58e59d7d5f8`).
- Implements a custom `UnmarshalJSON` function to dual-accept both the new `camelCase` and legacy `snake_case` tags, maintaining backward compatibility with older server versions during the deprecation window.
- Adds unit tests to ensure both canonical and legacy wire formats are correctly parsed.


**[Signed commits](https://github.com/meshery/meshery/blob/master/CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [x] Yes, I signed my commits.

<!--
Thank you for contributing to Meshery! 

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. Sign your commits.
4. Include before and after screenshots/terminal output.

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.
-->
