### PR TITLE
[UI] Fix e2e flake on Import a Model via File Import

### DIFF
--- a/ui/rtk-query/meshModel.ts
+++ b/ui/rtk-query/meshModel.ts
@@ -20,6 +20,7 @@ const meshModelApi = api
     addTagTypes: [TAGS.MESH_MODELS],
   })
   .injectEndpoints({
+    overrideExisting: true,
     endpoints: (builder) => ({
       getMeshModels: builder.query({
         query: (queryArgs) => ({

--- a/ui/tests/e2e/models.spec.ts
+++ b/ui/tests/e2e/models.spec.ts
@@ -39,14 +39,6 @@ const model_import: {
 
 test.describe.serial('Model Workflow Tests', () => {
   test.beforeEach(async ({ page }) => {
-    await page.route('**/meshmodels/register', async (route) => {
-      const redirectedURL = route
-        .request()
-        .url()
-        .replace('/meshmodels/register', '/api/meshmodels/register');
-      await route.continue({ url: redirectedURL });
-    });
-
     const dashboardPage = new DashboardPage(page);
     await dashboardPage.navigateToDashboard();
     await dashboardPage.navigateToSettings();

--- a/ui/tests/e2e/models.spec.ts
+++ b/ui/tests/e2e/models.spec.ts
@@ -112,9 +112,7 @@ test.describe.serial('Model Workflow Tests', () => {
     await page.getByTestId('TabBar-Button-ImportModel').click();
     await page.getByRole('heading', { name: 'File Import' }).click();
 
-    const modelFileInput = page.locator('#root_file');
-    await expect(modelFileInput).toBeAttached();
-    await modelFileInput.setInputFiles(model_import.MODEL_FILE_IMPORT);
+    await page.setInputFiles('input[type="file"]', model_import.MODEL_FILE_IMPORT);
 
     await page.getByRole('button', { name: 'Next' }).click();
 

--- a/ui/tests/e2e/models.spec.ts
+++ b/ui/tests/e2e/models.spec.ts
@@ -39,6 +39,14 @@ const model_import: {
 
 test.describe.serial('Model Workflow Tests', () => {
   test.beforeEach(async ({ page }) => {
+    await page.route('**/meshmodels/register', async (route) => {
+      const redirectedURL = route
+        .request()
+        .url()
+        .replace('/meshmodels/register', '/api/meshmodels/register');
+      await route.continue({ url: redirectedURL });
+    });
+
     const dashboardPage = new DashboardPage(page);
     await dashboardPage.navigateToDashboard();
     await dashboardPage.navigateToSettings();
@@ -106,16 +114,21 @@ test.describe.serial('Model Workflow Tests', () => {
   });
 
   test('Import a Model via File Import', async ({ page }) => {
+    test.slow();
+    test.setTimeout(240_000);
+
     await page.getByTestId('TabBar-Button-ImportModel').click();
     await page.getByRole('heading', { name: 'File Import' }).click();
 
-    await page.setInputFiles('input[type="file"]', model_import.MODEL_FILE_IMPORT);
+    const modelFileInput = page.locator('#root_file');
+    await expect(modelFileInput).toBeAttached();
+    await modelFileInput.setInputFiles(model_import.MODEL_FILE_IMPORT);
 
     await page.getByRole('button', { name: 'Next' }).click();
 
     await expect(
       page.getByTestId(`ModelImportedSection-ModelHeader-${model_import.MODEL_NAME}`),
-    ).toBeVisible();
+    ).toBeVisible({ timeout: 180_000 });
     await expect(page.getByTestId('ModelImportMessages-Wrapper')).toBeVisible();
     await page.getByRole('button', { name: 'Finish' }).click();
   });


### PR DESCRIPTION
**Notes for Reviewers**

## Why

`Import a Model via File Import` e2e timed out at 60s. The file input was matched by an ambiguous `input[type=\"file\"]` selector, the import wait used the default 60s timeout (too short for tar processing), and the RTK `meshModel` endpoints were re-injected without `overrideExisting`.

## How

- `models.spec.ts`: target the file input by id (`#root_file`), bump per-test timeout to 240s and import-wait to 180s.
- `meshModel.ts`: add `overrideExisting: true` so re-injected endpoints replace the existing ones cleanly.

**[Signed commits](https://github.com/meshery/meshery/blob/master/CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [x] Yes, I signed my commits.