### PR TITLE
fix(server): authenticate shutdown deregister & logout after dereg

### DIFF
--- a/server/cmd/main.go
+++ b/server/cmd/main.go
@@ -453,8 +453,14 @@ func main() {
 		// so it doesn't throw error each server is stopped. Reason: support for none provider is not yet implemented
 		if p.Name() != "None" {
 			log.Info("De-registering Meshery server.")
-			err = p.DeleteMesheryConnection()
-			if err != nil {
+			if err = p.DeleteMesheryConnection(); err != nil {
+				log.Error(err)
+				continue
+			}
+			// Logout follows deregistration so the session that authorized
+			// the delete is revoked only after the connection is removed.
+			log.Info("Logging out Meshery server session.")
+			if err = p.LogoutMesheryServer(); err != nil {
 				log.Error(err)
 			}
 		}

--- a/server/models/default_local_provider.go
+++ b/server/models/default_local_provider.go
@@ -1193,6 +1193,12 @@ func (l *DefaultLocalProvider) DeleteMesheryConnection() error {
 	return err
 }
 
+// LogoutMesheryServer is a no-op for the local provider: there is no
+// remote session to revoke.
+func (l *DefaultLocalProvider) LogoutMesheryServer() error {
+	return nil
+}
+
 // GetGenericPersister - to return persister
 func (l *DefaultLocalProvider) GetGenericPersister() *database.Handler {
 	return l.GenericPersister

--- a/server/models/providers.go
+++ b/server/models/providers.go
@@ -478,6 +478,10 @@ type Provider interface {
 	UpdateConnectionStatusByID(token string, connectionID core.Uuid, connectionStatus connections.ConnectionStatus) (*connections.Connection, int, error)
 	DeleteConnection(req *http.Request, connID core.Uuid) (*connections.Connection, error)
 	DeleteMesheryConnection() error
+	// LogoutMesheryServer revokes the server-cached user session against the
+	// provider. Called at shutdown after DeleteMesheryConnection so that
+	// logout occurs post-deregistration.
+	LogoutMesheryServer() error
 
 	SaveUserCredential(token string, credential *Credential) (*Credential, error)
 	GetUserCredentials(req *http.Request, userID string, page, pageSize int, search, order string) (*CredentialsPage, error)

--- a/server/models/remote_provider.go
+++ b/server/models/remote_provider.go
@@ -62,6 +62,14 @@ type RemoteProvider struct {
 	TokenStoreMut sync.Mutex
 	Keys          []map[string]string
 
+	// mostRecentToken caches the last valid user token observed during the
+	// session so it can be reused at server shutdown to authenticate the
+	// deregistration call (DeleteMesheryConnection) and the subsequent token
+	// revocation. The anonymous global token is rejected by the remote
+	// provider for these privileged operations.
+	mostRecentToken    string
+	mostRecentTokenMut sync.RWMutex
+
 	LoginCookieDuration time.Duration
 
 	// provider and token cookie expiry bound
@@ -3993,6 +4001,11 @@ func (l *RemoteProvider) TokenHandler(w http.ResponseWriter, r *http.Request, _ 
 	// Clear the auth retry counter on successful token receipt
 	ClearAuthRetryCookie(w)
 
+	// Cache this token so DeleteMesheryConnection / shutdown logout can
+	// authenticate against the remote provider. Without this, shutdown
+	// uses the anonymous global token and the remote provider returns 401.
+	l.setMostRecentToken(tokenString)
+
 	// Get new capabilities
 	// Doing this here is important so that the latest capabilities are always fetched when a user logs in
 	providerProperties, err := l.loadCapabilities(tokenString)
@@ -4701,10 +4714,16 @@ func (l *RemoteProvider) DeleteMesheryConnection() error {
 	ep, _ := l.Capabilities.GetEndpointForFeature(PersistConnection)
 	remoteProviderURL, _ := url.Parse(fmt.Sprintf("%s%s/meshery/%s", l.RemoteProviderURL, ep, mesheryServerID))
 	cReq, _ := http.NewRequest(http.MethodDelete, remoteProviderURL.String(), nil)
-	cReq.Header.Set("X-API-Key", GlobalTokenForAnonymousResults)
-	cReq.Header.Set("SystemID", viper.GetString("INSTANCE_ID")) // Adds the system id to the header for event tracking
-	c := &http.Client{}
-	resp, err := c.Do(cReq)
+
+	// Prefer the cached user token captured at login over the anonymous
+	// global token; the remote provider rejects the latter (401) for
+	// privileged delete operations. DoRequest sets Authorization, X-API-Key,
+	// and SystemID headers, and transparently refreshes the token on 401.
+	token := l.getMostRecentToken()
+	if token == "" {
+		token = GlobalTokenForAnonymousResults
+	}
+	resp, err := l.DoRequest(cReq, token)
 	if err != nil {
 		if resp == nil {
 			return ErrUnreachableRemoteProvider(err)
@@ -4720,6 +4739,49 @@ func (l *RemoteProvider) DeleteMesheryConnection() error {
 	}
 
 	return ErrDelete(fmt.Errorf("could not delete meshery connection"), " Meshery Connection", resp.StatusCode)
+}
+
+// setMostRecentToken records the most recent valid user token. Used so that
+// shutdown-time operations (deregistration, logout) can authenticate against
+// the remote provider without an active HTTP request in scope.
+func (l *RemoteProvider) setMostRecentToken(token string) {
+	if strings.TrimSpace(token) == "" {
+		return
+	}
+	l.mostRecentTokenMut.Lock()
+	defer l.mostRecentTokenMut.Unlock()
+	l.mostRecentToken = token
+}
+
+func (l *RemoteProvider) getMostRecentToken() string {
+	l.mostRecentTokenMut.RLock()
+	defer l.mostRecentTokenMut.RUnlock()
+	return l.mostRecentToken
+}
+
+func (l *RemoteProvider) clearMostRecentToken() {
+	l.mostRecentTokenMut.Lock()
+	defer l.mostRecentTokenMut.Unlock()
+	l.mostRecentToken = ""
+}
+
+// LogoutMesheryServer performs a server-side logout against the remote
+// provider using the cached user token. Intended to be invoked at server
+// shutdown, *after* DeleteMesheryConnection, so that the session that
+// authorized the deregistration is then revoked. Unlike Logout, this does
+// not require an http.Request/ResponseWriter pair.
+func (l *RemoteProvider) LogoutMesheryServer() error {
+	token := l.getMostRecentToken()
+	if token == "" {
+		// nothing to revoke — user never logged in during this run
+		return nil
+	}
+	defer l.clearMostRecentToken()
+
+	if err := l.revokeToken(token); err != nil {
+		return ErrLogout(err)
+	}
+	return nil
 }
 
 // TarXZF takes in a source url downloads the tar.gz file


### PR DESCRIPTION
## Summary

At server shutdown the deregistration call reliably failed with a 401 and there was no logout step after deregistration:

```
ERRO ... Status Code: 401 .could not delete meshery connection
     Short Description: Unable to de-register Meshery Server from Remote Provider.
     Probable Cause: ... Session might have expired; token could be invalid.
```

Root cause: `RemoteProvider.DeleteMesheryConnection` authenticated with `GlobalTokenForAnonymousResults` (`"dev_token"`), which the remote provider rejects for privileged delete operations.

## Changes

- `server/models/remote_provider.go`
  - Cache the most recent valid user token on `RemoteProvider` (RWMutex-protected); set it in `TokenHandler` after the JWT cookie is issued.
  - `DeleteMesheryConnection` now uses `DoRequest` with the cached user token (falling back to the anonymous token only if no user has logged in this run). `DoRequest` also handles transparent token refresh on 401.
  - New `LogoutMesheryServer()` revokes the cached token via the existing `revokeToken` flow and clears the cache.
- `server/models/providers.go` — `Provider` interface gains `LogoutMesheryServer() error`.
- `server/models/default_local_provider.go` — `DefaultLocalProvider.LogoutMesheryServer` is a no-op (no remote session).
- `server/cmd/main.go` — shutdown loop calls `LogoutMesheryServer` only after a successful `DeleteMesheryConnection`, so logout follows deregistration.

## Test plan

- [ ] `go build ./...` for the server
- [ ] Login via remote provider, then `Ctrl+C` the server — confirm:
  - [ ] No `meshery-server-1272` 401 deregistration error in logs
  - [ ] `De-registering Meshery server.` is followed by `Logging out Meshery server session.`
  - [ ] Connection no longer present on the remote provider after shutdown
- [ ] Local (None) provider shutdown still works without errors
- [ ] Shutdown without ever logging in still works (cached token empty → falls back to anonymous as before, logout is a no-op)