### PR TITLE
fix: correct misleading error message in ErrGettingRequestContext

### DIFF
--- a/mesheryctl/internal/cli/root/error.go
+++ b/mesheryctl/internal/cli/root/error.go
@@ -49,7 +49,7 @@ func ErrConnectingToServer(err error) error {
 }
 
 func ErrGettingRequestContext(err error) error {
-	return errors.New(ErrGettingRequestContextCode, errors.Fatal, []string{"Unable to add token to config"}, []string{"Unable to add token to config", err.Error()}, []string{}, []string{})
+	return errors.New(ErrGettingRequestContextCode, errors.Fatal, []string{"Unable to get request context"}, []string{"Unable to get request context", err.Error()}, []string{}, []string{})
 }
 
 func ErrUnmarshallingAPIData(err error) error {


### PR DESCRIPTION
## Description

Fixes the `ErrGettingRequestContext` function in `mesheryctl/internal/cli/root/error.go` which was returning the wrong error message.

The function was displaying `"Unable to add token to config"` — which belongs to the separate `ErrAddingTokenToConfig` error — instead of a message that accurately describes a failure to get the HTTP request context.

This was a copy-paste mistake that caused user confusion during troubleshooting: users would see a token config error when the real failure had nothing to do with their token.

## Changes

- `mesheryctl/internal/cli/root/error.go`: Updated `ErrGettingRequestContext` message from `"Unable to add token to config"` → `"Unable to get request context"`

## Testing

The change corrects the string returned by `ErrGettingRequestContext`. Any caller of this function (e.g., `mesheryctl version`) will now display the correct error message when HTTP request context creation fails.

## Related Issue

Closes #19069

---

**Signed-off-by:** Parth Agrawal <94750839+parth-agrawall@users.noreply.github.com>