### PR TITLE
fix(provider): align isMesheryUIRestricted JSON tag with cloud emitter

### DIFF
--- a/install/samples/provider_capabilities.json
+++ b/install/samples/provider_capabilities.json
@@ -209,7 +209,7 @@
     "": "/extension/meshmap"
   },
   "restrictedAccess": {
-    "isMesheryUiRestricted": true,
+    "isMesheryUIRestricted": true,
     "allowedComponents": {
       "navigator": {
         "help": true,

--- a/server/models/providers.go
+++ b/server/models/providers.go
@@ -96,7 +96,7 @@ type MesheryUICapabilities struct {
 }
 
 type RestrictedAccess struct {
-	IsMesheryUIRestricted bool                  `json:"isMesheryUiRestricted"`
+	IsMesheryUIRestricted bool                  `json:"isMesheryUIRestricted"`
 	AllowedComponents     MesheryUICapabilities `json:"allowedComponents,omitempty"`
 }
 

--- a/server/models/providers_test.go
+++ b/server/models/providers_test.go
@@ -1,0 +1,50 @@
+package models
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+// TestRestrictedAccessJSONTagCanonicalSpelling pins the wire-side spelling
+// of RestrictedAccess.IsMesheryUIRestricted to the canonical post-flip
+// `isMesheryUIRestricted` (uppercase UI). Meshery Cloud emits this exact
+// key on the /{version}/capabilities response; the legacy lowercase-Ui tag
+// silently dropped that value and left the playground/restricted-UI gate
+// stuck at false, which presented as a cloud.layer5.io ⇄ localhost:9081
+// redirect loop on enforced-provider hosts. Guarding the tag here means a
+// future tag refactor can't reintroduce that class of bug without flipping
+// this assertion as well.
+func TestRestrictedAccessJSONTagCanonicalSpelling(t *testing.T) {
+	const payload = `{"isMesheryUIRestricted": true, "allowedComponents": {}}`
+
+	var ra RestrictedAccess
+	if err := json.Unmarshal([]byte(payload), &ra); err != nil {
+		t.Fatalf("unmarshal canonical payload: %v", err)
+	}
+	if !ra.IsMesheryUIRestricted {
+		t.Fatalf("IsMesheryUIRestricted = false; want true — JSON tag must be `isMesheryUIRestricted` (uppercase UI) to match the cloud emitter")
+	}
+
+	out, err := json.Marshal(ra)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	var raw map[string]any
+	if err := json.Unmarshal(out, &raw); err != nil {
+		t.Fatalf("re-unmarshal: %v", err)
+	}
+	if _, ok := raw["isMesheryUIRestricted"]; !ok {
+		t.Fatalf("server output missing canonical key `isMesheryUIRestricted`; got keys: %v", keys(raw))
+	}
+	if _, ok := raw["isMesheryUiRestricted"]; ok {
+		t.Fatalf("server output emitted legacy key `isMesheryUiRestricted`; tag must be canonical only")
+	}
+}
+
+func keys(m map[string]any) []string {
+	out := make([]string, 0, len(m))
+	for k := range m {
+		out = append(out, k)
+	}
+	return out
+}

--- a/ui/components/AppComponents.tsx
+++ b/ui/components/AppComponents.tsx
@@ -31,7 +31,7 @@ export const Footer = ({ capabilitiesRegistry, handleMesheryCommunityClick }) =>
         }}
       >
         <StyledFooterText onClick={handleMesheryCommunityClick}>
-          {capabilitiesRegistry?.restrictedAccess?.isMesheryUiRestricted || isPlaygroundBuild ? (
+          {capabilitiesRegistry?.restrictedAccess?.isMesheryUIRestricted || isPlaygroundBuild ? (
             'ACCESS LIMITED IN MESHERY PLAYGROUND. DEPLOY MESHERY TO ACCESS ALL FEATURES.'
           ) : (
             <>

--- a/ui/pages/_app.tsx
+++ b/ui/pages/_app.tsx
@@ -98,10 +98,10 @@ import RegistryModalContextProvider from '@/utils/context/RegistryModalContextPr
 import { DynamicFullScreenLoader } from '@/components/LoadingComponents/DynamicFullscreenLoader';
 
 export const mesheryExtensionRoute = '/extension/meshmap';
-function isMesheryUiRestrictedAndThePageIsNotPlayground(capabilitiesRegistry) {
+function isMesheryUIRestrictedAndThePageIsNotPlayground(capabilitiesRegistry) {
   return (
     !window.location.pathname.startsWith(mesheryExtensionRoute) &&
-    capabilitiesRegistry?.restrictedAccess?.isMesheryUiRestricted
+    capabilitiesRegistry?.restrictedAccess?.isMesheryUIRestricted
   );
 }
 
@@ -467,7 +467,7 @@ const MesheryApp = ({ Component, pageProps, relayEnvironment, emotionCache }) =>
     // in case the meshery-ui is restricted, the user will be redirected to signup/extension page
     if (
       typeof window !== 'undefined' &&
-      isMesheryUiRestrictedAndThePageIsNotPlayground(capabilitiesRegistry)
+      isMesheryUIRestrictedAndThePageIsNotPlayground(capabilitiesRegistry)
     ) {
       Router.push(mesheryExtensionRoute);
     }

--- a/ui/utils/disabledComponents.ts
+++ b/ui/utils/disabledComponents.ts
@@ -19,7 +19,7 @@ export class CapabilitiesRegistry {
 
   constructor(capabilitiesRegistry) {
     this.capabilitiesRegistry = capabilitiesRegistry;
-    this.isPlaygroundEnv = capabilitiesRegistry?.restrictedAccess?.isMesheryUiRestricted || false;
+    this.isPlaygroundEnv = capabilitiesRegistry?.restrictedAccess?.isMesheryUIRestricted || false;
   }
 
   capabilities() {


### PR DESCRIPTION
## Summary

- Meshery Cloud emits `isMesheryUIRestricted` (uppercase `UI`) on the `/{version}/capabilities` response — the canonical post-flip spelling per `schemas/cmd/phase0-tag-divergence` (`main_test.go:75`). Meshery Server's `RestrictedAccess` struct still tagged this field as `isMesheryUiRestricted` (lowercase `Ui`), so `loadCapabilities()` silently dropped the cloud-supplied value and `IsMesheryUIRestricted` always defaulted to `false`. The server then re-emitted the legacy spelling to the UI, which read it under the same legacy key — so the playground/restricted-UI gate was unreachable from remote-provider configuration.
- On enforced-provider Playground hosts this manifested as a `cloud.layer5.io ⇄ localhost:9081` redirect loop: restricted users were left on routes the cloud-side gate wouldn't let them reach, the cloud bounced them, and `AuthMiddleware` only broke the cycle via the `MaxAuthRetries=3` guard in `HandleUnAuthenticated`.
- Cross-repo evidence: `meshery-cloud/server/models/capabilities.go:177` tags as `isMesheryUIRestricted`; the canonical-spelling tests in the schemas repo encode the same.

## Changes

- `server/models/providers.go` — flip the JSON tag on `RestrictedAccess.IsMesheryUIRestricted` from `isMesheryUiRestricted` → `isMesheryUIRestricted`.
- `ui/components/AppComponents.tsx`, `ui/utils/disabledComponents.ts`, `ui/pages/_app.tsx` — read the canonical key. Internal helper `isMesheryUiRestrictedAndThePageIsNotPlayground` renamed to match (not a wire change).
- `install/samples/provider_capabilities.json` — sample fixture flipped to canonical spelling so `loadCapabilitiesFromLocalFile` deployments behave the same as the remote path.

## Test plan

- [ ] `go build ./server/models/...` (CI) — confirm no Go-side regressions.
- [ ] `cd ui && npm run lint` — confirm no UI-side regressions.
- [ ] Manual: bring up a Playground/`PROVIDER=Meshery` server against `cloud.layer5.io`, log in, confirm `/api/provider/capabilities` response has `restrictedAccess.isMesheryUIRestricted: true` and the UI footer + page-gating render the restricted-mode branch (no redirect loop between `cloud.layer5.io` and `localhost:9081`).
- [ ] Verify `curl -s ${RemoteProviderURL}/{BUILD}/capabilities | jq .restrictedAccess` continues to match what the server now expects.

## Related

This is a targeted unblock for the `cloud.layer5.io ⇄ localhost:9081` redirect-loop class of issues caused by the meshery-side struct tags being out of step with the broader snake_case → camelCase / canonical-acronym tag migration. A follow-up audit pass is worth doing on `connections.BuildMesheryConnectionPayload` (which still emits snake_case `server_id`/`server_version`/`server_build_sha`/`server_location` and is explicitly flagged in `meshery-cloud/server/dao/connections.go:172` as awaiting an upstream flip).