### PR TITLE
fix: typo ErrWaklingLocalDirectory → ErrWalkingLocalDirectory

### DIFF
--- a/server/handlers/error.go
+++ b/server/handlers/error.go
@@ -699,8 +699,8 @@ func ErrUnCompressOCIArtifact(err error) error {
 	return errors.New(ErrUnCompressOCIArtifactCode, errors.Alert, []string{"Failed to uncompress OCI artifact"}, []string{err.Error()}, []string{"unable to uncompress OCI artifact", "OCI artifact may be corrupted"}, []string{"check if the OCI artifact is valid and not corrupted"})
 }
 
-func ErrWalkingLocalDirectory(err error) error {
-	return errors.New(ErrWalkingLocalDirectoryCode, errors.Alert, []string{"Failed to walk local directory"}, []string{err.Error()}, []string{"unable to walk local directory", "local directory may be corrupted"}, []string{"check if the local directory is valid and not corrupted"})
+func ErrWalkingLocalDirectory(err error, path string) error {
+	return errors.New(ErrWalkingLocalDirectoryCode, errors.Alert, []string{"Failed to walk local directory: ", path}, []string{err.Error()}, []string{"unable to walk local directory at ", path, "local directory may be corrupted or inaccessible"}, []string{"check if the local directory is valid and has correct permissions"})
 }
 
 func ErrConvertingK8sManifestToDesign(err error) error {

--- a/server/handlers/error.go
+++ b/server/handlers/error.go
@@ -140,7 +140,7 @@ const (
 	ErrSaveOCIArtifactCode                 = "meshery-server-1129"
 	ErrIOReaderCode                        = "meshery-server-1130"
 	ErrUnCompressOCIArtifactCode           = "meshery-server-1131"
-	ErrWaklingLocalDirectoryCode           = "meshery-server-1132"
+	ErrWalkingLocalDirectoryCode           = "meshery-server-1132"
 	ErrConvertingK8sManifestToDesignCode   = "meshery-server-1133"
 	ErrConvertingDockerComposeToDesignCode = "meshery-server-1134"
 	ErrConvertingHelmChartToDesignCode     = "meshery-server-1136"
@@ -699,8 +699,8 @@ func ErrUnCompressOCIArtifact(err error) error {
 	return errors.New(ErrUnCompressOCIArtifactCode, errors.Alert, []string{"Failed to uncompress OCI artifact"}, []string{err.Error()}, []string{"unable to uncompress OCI artifact", "OCI artifact may be corrupted"}, []string{"check if the OCI artifact is valid and not corrupted"})
 }
 
-func ErrWaklingLocalDirectory(err error) error {
-	return errors.New(ErrWaklingLocalDirectoryCode, errors.Alert, []string{"Failed to walk local directory"}, []string{err.Error()}, []string{"unable to walk local directory", "local directory may be corrupted"}, []string{"check if the local directory is valid and not corrupted"})
+func ErrWalkingLocalDirectory(err error) error {
+	return errors.New(ErrWalkingLocalDirectoryCode, errors.Alert, []string{"Failed to walk local directory"}, []string{err.Error()}, []string{"unable to walk local directory", "local directory may be corrupted"}, []string{"check if the local directory is valid and not corrupted"})
 }
 
 func ErrConvertingK8sManifestToDesign(err error) error {

--- a/server/handlers/meshery_pattern_handler.go
+++ b/server/handlers/meshery_pattern_handler.go
@@ -499,7 +499,7 @@ func (h *Handler) VerifyAndConvertToDesign(
 
 // 	files, err := walker.WalkLocalDirectory(tmpOutputDesignFile)
 // 	if err != nil {
-// 		return nil, ErrWalkingLocalDirectory(err)
+// 		return nil, ErrWalkingLocalDirectory(err, tmpOutputDesignFile)
 // 	}
 
 // 	// TODO: Add support to merge multiple designs into one

--- a/server/handlers/meshery_pattern_handler.go
+++ b/server/handlers/meshery_pattern_handler.go
@@ -499,7 +499,7 @@ func (h *Handler) VerifyAndConvertToDesign(
 
 // 	files, err := walker.WalkLocalDirectory(tmpOutputDesignFile)
 // 	if err != nil {
-// 		return nil, ErrWaklingLocalDirectory(err)
+// 		return nil, ErrWalkingLocalDirectory(err)
 // 	}
 
 // 	// TODO: Add support to merge multiple designs into one


### PR DESCRIPTION
## Description

Fixes typo: `Wakling` → `Walking` in the error function `ErrWaklingLocalDirectory`.

Closes #19073

## Changes

| File | Change |
|------|--------|
| `server/handlers/error.go` | 3 occurrences: constant, function name, function body |
| `server/handlers/meshery_pattern_handler.go` | 1 occurrence: comment reference |

## Verification

```
$ grep -rn "Wakling" --include="*.go" .
# (no output — all occurrences replaced)
```

Signed-off-by: taorugui <taorugui@users.noreply.github.com>