### PR TITLE
fix(handlers): clarify design fetch/get/delete error messages

### DIFF
--- a/server/handlers/error.go
+++ b/server/handlers/error.go
@@ -553,7 +553,7 @@ func ErrGetPattern(err error) error {
 		ErrGetPatternCode,
 		errors.Alert,
 		[]string{"Unable to open this design"},
-		[]string{fmt.Sprintf("The server could not return the requested design. Underlying error: %s", err.Error())},
+		[]string{fmt.Sprintf("The server could not return the requested design. Underlying error: %v", err)},
 		[]string{
 			"The design ID in the URL is malformed or does not exist.",
 			"The design has been deleted by its owner.",
@@ -561,7 +561,7 @@ func ErrGetPattern(err error) error {
 			"Your session has expired or the remote provider is currently unreachable.",
 		},
 		[]string{
-			"Verify the design link — design IDs are UUIDs and are case-sensitive.",
+			"Verify the design link — confirm the full design ID is intact, with no missing or extra characters.",
 			"Open My Designs and confirm the design still exists; if it was shared with you, ask the owner to re-share or grant access.",
 			"Sign out and sign back in to refresh your session, then retry.",
 		},
@@ -573,10 +573,10 @@ func ErrDeletePattern(err error) error {
 		ErrDeletePatternCode,
 		errors.Alert,
 		[]string{"Unable to delete this design"},
-		[]string{fmt.Sprintf("The server could not delete the requested design. Underlying error: %s", err.Error())},
+		[]string{fmt.Sprintf("The server could not delete the requested design. Underlying error: %v", err)},
 		[]string{
 			"The design ID is malformed or no longer exists — it may already have been deleted.",
-			"Your account does not have permission to delete this design (only the owner or an organization admin can delete it).",
+			"Your account does not have permission to delete this design — only authorized users (such as the owner) can delete it.",
 			"Your session has expired or the remote provider is currently unreachable.",
 		},
 		[]string{
@@ -592,7 +592,7 @@ func ErrFetchPattern(err error) error {
 		ErrFetchPatternCode,
 		errors.Alert,
 		[]string{"Unable to load your designs"},
-		[]string{fmt.Sprintf("The server could not retrieve the list of designs. Underlying error: %s", err.Error())},
+		[]string{fmt.Sprintf("The server could not retrieve the list of designs. Underlying error: %v", err)},
 		[]string{
 			"The remote provider is currently unreachable or returned an error.",
 			"Your session has expired or your authentication token is no longer valid.",

--- a/server/handlers/error.go
+++ b/server/handlers/error.go
@@ -549,15 +549,61 @@ func ErrDeleteApplication(err error) error {
 }
 
 func ErrGetPattern(err error) error {
-	return errors.New(ErrGetPatternCode, errors.Alert, []string{"Error failed to get design"}, []string{err.Error()}, []string{"Cannot get the design with the given design ID"}, []string{"Check if the given design ID is correct"})
+	return errors.New(
+		ErrGetPatternCode,
+		errors.Alert,
+		[]string{"Unable to open this design"},
+		[]string{fmt.Sprintf("The server could not return the requested design. Underlying error: %s", err.Error())},
+		[]string{
+			"The design ID in the URL is malformed or does not exist.",
+			"The design has been deleted by its owner.",
+			"Your account does not have permission to view this design — it may belong to another organization or be set to private.",
+			"Your session has expired or the remote provider is currently unreachable.",
+		},
+		[]string{
+			"Verify the design link — design IDs are UUIDs and are case-sensitive.",
+			"Open My Designs and confirm the design still exists; if it was shared with you, ask the owner to re-share or grant access.",
+			"Sign out and sign back in to refresh your session, then retry.",
+		},
+	)
 }
 
 func ErrDeletePattern(err error) error {
-	return errors.New(ErrDeletePatternCode, errors.Alert, []string{"Error failed to delete design"}, []string{err.Error()}, []string{"Failed to delete design with the given ID"}, []string{"Check if the design ID is correct"})
+	return errors.New(
+		ErrDeletePatternCode,
+		errors.Alert,
+		[]string{"Unable to delete this design"},
+		[]string{fmt.Sprintf("The server could not delete the requested design. Underlying error: %s", err.Error())},
+		[]string{
+			"The design ID is malformed or no longer exists — it may already have been deleted.",
+			"Your account does not have permission to delete this design (only the owner or an organization admin can delete it).",
+			"Your session has expired or the remote provider is currently unreachable.",
+		},
+		[]string{
+			"Refresh the designs list to confirm the design still exists before retrying.",
+			"If the design was shared with you, ask its owner to delete it.",
+			"Sign out and sign back in to refresh your session, then retry.",
+		},
+	)
 }
 
 func ErrFetchPattern(err error) error {
-	return errors.New(ErrFetchPatternCode, errors.Alert, []string{"Error failed to fetch design"}, []string{err.Error()}, []string{"Failed to retrieve the list of all the designs"}, []string{})
+	return errors.New(
+		ErrFetchPatternCode,
+		errors.Alert,
+		[]string{"Unable to load your designs"},
+		[]string{fmt.Sprintf("The server could not retrieve the list of designs. Underlying error: %s", err.Error())},
+		[]string{
+			"The remote provider is currently unreachable or returned an error.",
+			"Your session has expired or your authentication token is no longer valid.",
+			"Network connectivity between Meshery Server and the remote provider has been interrupted.",
+		},
+		[]string{
+			"Check your network connection and reload the page.",
+			"Sign out and sign back in to refresh your session, then retry.",
+			"Confirm that the configured remote provider is online.",
+		},
+	)
 }
 
 func ErrFetchProfile(err error) error {


### PR DESCRIPTION
## Summary

- Rewrites `ErrGetPattern`, `ErrDeletePattern`, and `ErrFetchPattern` in `server/handlers/error.go` to emit human-readable short descriptions, multiple probable causes, and actionable remediations instead of single-cause/single-remediation strings.
- Preserves the underlying error in the long description so operators retain full diagnostic context.
- No API or schema changes — only the human-readable strings rendered by the existing meshkit error-notification panel.

## Motivation

When a design failed to load (e.g. the Layer5 Cloud authz middleware returns `invalid resource id`), the notification rendered in Kanvas/Meshery UI surfaced only the raw backend message and a single vague remediation ("Check if the given design ID is correct"). End users had no actionable guidance for the realistic causes — deleted design, missing permission, expired session, unreachable provider.

After this change, the same failure renders a clearer title ("Unable to open this design"), four distinct probable causes, and three concrete next steps the user can take.

## Test plan

- [ ] `go build ./server/handlers/...` succeeds.
- [ ] Trigger `ErrGetPattern` by requesting a design ID the user does not have access to; verify the rendered notification shows the new short description, all four probable causes, and all three remediations.
- [ ] Trigger `ErrFetchPattern` by simulating a remote-provider outage; verify the new strings appear.
- [ ] Trigger `ErrDeletePattern` by attempting to delete a design owned by another user; verify the new strings appear.
- [ ] Verify the underlying error is still embedded in the long description so logs/troubleshooting are unaffected.