### PR TITLE
fix(server): hydrate evaluator-added components with registry styles

### DIFF
--- a/server/handlers/policy_relationship_handler.go
+++ b/server/handlers/policy_relationship_handler.go
@@ -21,6 +21,7 @@ import (
 	"github.com/meshery/schemas/models/v1beta1/component"
 	"github.com/meshery/schemas/models/v1beta1/pattern"
 	"github.com/meshery/schemas/models/v1beta2/relationship"
+	componentv1beta3 "github.com/meshery/schemas/models/v1beta3/component"
 
 	"github.com/meshery/meshkit/logger"
 	"github.com/meshery/meshkit/models/events"
@@ -397,6 +398,59 @@ func (h *Handler) EvaluateDesign(
 	return lastEvaluationResponse, nil
 }
 
+// bridgeComponentV1beta3ToV1beta1 is a shallow field copy used at the
+// meshkit-registry boundary inside processEvaluationResponse. It exists only
+// because pattern.PatternFile.Components is *v1beta1.ComponentDefinition while
+// the registry hands back *v1beta3.ComponentDefinition; the relevant inner
+// fields (Model pointer, Styles pointer, Capabilities slice, Configuration map,
+// Metadata.AdditionalProperties) are pointer-compatible across the two
+// versions, so an alias-style copy is sufficient.
+//
+// Mutations the surrounding handler makes to the returned value's pointer-
+// or map-typed fields (e.g. _component.Configuration = _c.Configuration)
+// remain isolated to the v1beta1 view, exactly as if the registry had
+// returned a v1beta1 type directly.
+func bridgeComponentV1beta3ToV1beta1(src *componentv1beta3.ComponentDefinition) *component.ComponentDefinition {
+	if src == nil {
+		return nil
+	}
+	dst := &component.ComponentDefinition{
+		ID:             src.ID,
+		SchemaVersion:  src.SchemaVersion,
+		Version:        src.Version,
+		DisplayName:    src.DisplayName,
+		Description:    src.Description,
+		Format:         component.ComponentDefinitionFormat(src.Format),
+		Model:          src.Model,
+		ModelReference: src.ModelReference,
+		Styles:         src.Styles,
+		Capabilities:   src.Capabilities,
+		Metadata: component.ComponentDefinition_Metadata{
+			Genealogy:             src.Metadata.Genealogy,
+			IsAnnotation:          src.Metadata.IsAnnotation,
+			IsNamespaced:          src.Metadata.IsNamespaced,
+			Published:             src.Metadata.Published,
+			InstanceDetails:       src.Metadata.InstanceDetails,
+			ConfigurationUISchema: src.Metadata.ConfigurationUISchema,
+			AdditionalProperties:  src.Metadata.AdditionalProperties,
+		},
+		Configuration: src.Configuration,
+		Component: component.Component{
+			Kind:    src.Component.Kind,
+			Version: src.Component.Version,
+			Schema:  src.Component.Schema,
+		},
+		CreatedAt: src.CreatedAt,
+		UpdatedAt: src.UpdatedAt,
+		ModelId:   src.ModelID,
+	}
+	if src.Status != nil {
+		st := component.ComponentDefinitionStatus(*src.Status)
+		dst.Status = &st
+	}
+	return dst
+}
+
 func processEvaluationResponse(reg *registry.RegistryManager, evalPayload pattern.EvaluationRequest, evalResponse *pattern.EvaluationResponse) []*component.ComponentDefinition {
 
 	registryCache := &registry.RegistryEntityCache{}
@@ -439,13 +493,43 @@ func processEvaluationResponse(reg *registry.RegistryManager, evalPayload patter
 			compFilter.ModelName = _c.ModelReference.Name
 		}
 
+		// ModelName == "*" originates from policies that emit add_component
+		// without binding to a specific model — e.g. identify_additions.rego
+		// when the relationship's mutator selector specifies model.name "*".
+		// The registry's exact-match SQL filter on model_dbs.name returns zero
+		// rows for "*", which previously routed the component into
+		// unknownComponents and shipped it to the client unhydrated (no Styles,
+		// no Metadata) — leaving the user with default green-box styling until
+		// they manually triggered "reset styles". Drop the model filter so kind
+		// alone disambiguates; if multiple models register the same Kind we
+		// still take the first match (Limit:1) which is consistent with the
+		// pre-existing single-model assumption for evaluator-added components.
+		if compFilter.ModelName == "*" {
+			compFilter.ModelName = ""
+		}
+
 		entities, _, _, _ := reg.GetEntitiesMemoized(compFilter, registryCache)
 		if len(entities) == 0 {
 			unknownComponents = append(unknownComponents, &_c)
 			continue
 		}
+		// The meshkit registry exclusively returns *v1beta3.ComponentDefinition
+		// (v1beta3 is the only component package whose Entity interface is
+		// implemented and whose schema is bound to component_definition_dbs).
+		// This handler — and pattern.PatternFile.Components — are typed against
+		// v1beta1.ComponentDefinition, so a naive type assertion always fails
+		// and silently strands every evaluator-added component in
+		// unknownComponents (no Styles, no Metadata) — the very symptom users
+		// see as default-green nodes that need a manual style reset to render
+		// correctly. Try v1beta1 first to keep any legacy registry paths
+		// working, then fall back to v1beta3 with an explicit shallow bridge.
 		_component, ok := entities[0].(*component.ComponentDefinition)
 		if !ok || _component == nil {
+			if v3, vOk := entities[0].(*componentv1beta3.ComponentDefinition); vOk && v3 != nil {
+				_component = bridgeComponentV1beta3ToV1beta1(v3)
+			}
+		}
+		if _component == nil {
 			unknownComponents = append(unknownComponents, &_c)
 			continue
 		}

--- a/server/handlers/policy_relationship_handler_test.go
+++ b/server/handlers/policy_relationship_handler_test.go
@@ -9,9 +9,10 @@ import (
 	"github.com/gofrs/uuid"
 	"github.com/meshery/meshkit/database"
 	"github.com/meshery/meshkit/models/meshmodel/registry"
-	"github.com/meshery/schemas/models/v1beta1/connection"
+	"github.com/meshery/schemas/models/core"
 	"github.com/meshery/schemas/models/v1beta1/category"
 	"github.com/meshery/schemas/models/v1beta1/component"
+	"github.com/meshery/schemas/models/v1beta1/connection"
 	"github.com/meshery/schemas/models/v1beta1/model"
 	"github.com/meshery/schemas/models/v1beta1/pattern"
 	"github.com/meshery/schemas/models/v1beta2/relationship"
@@ -251,19 +252,25 @@ func TestProcessEvaluationResponse_NilPointerGuard(t *testing.T) {
 		assert.Equal(t, "Job", got[0].Component.Kind)
 	})
 
-	t.Run("type assertion failure routes to unknownComponents", func(t *testing.T) {
+	t.Run("v1beta3 registry entity is bridged into v1beta1 hydration", func(t *testing.T) {
 		t.Parallel()
-		// !ok guard: registry returns *v1beta3.ComponentDefinition (the real production
-		// type), which fails the *v1beta1.ComponentDefinition assertion in the handler.
-		// Without the guard this is the exact path that caused the production SIGSEGV.
+		// Registry returns *v1beta3.ComponentDefinition (the real production type);
+		// pattern.PatternFile.Components is typed against *v1beta1.ComponentDefinition.
+		// The handler now bridges v1beta3 → v1beta1 via a shallow field copy, so a
+		// successful registry hit hydrates the design. Previously the bare v1beta1
+		// type assertion silently failed, the component was stranded in
+		// unknownComponents, and the client rendered the node with default green
+		// styling until the user manually triggered a style reset.
 		rm, _ := newTestRegistryManager(t)
 		seedTestComponent(t, rm) // seeds via RegisterEntity — no raw SQL
+		resp := makeResp("test-job")
 		var got []*component.ComponentDefinition
 		require.NotPanics(t, func() {
-			got = processEvaluationResponse(rm, pattern.EvaluationRequest{}, makeResp("test-job"))
-		}, "must not panic when type assertion on registry entity fails")
-		require.Len(t, got, 1)
-		assert.Equal(t, "Job", got[0].Component.Kind)
+			got = processEvaluationResponse(rm, pattern.EvaluationRequest{}, resp)
+		}, "must not panic when bridging v1beta3 registry entity")
+		require.Empty(t, got, "registry hit should hydrate, not strand into unknownComponents")
+		require.Len(t, resp.Trace.ComponentsAdded, 1)
+		assert.Equal(t, "Job", resp.Trace.ComponentsAdded[0].Component.Kind)
 	})
 
 	t.Run("explicit DisplayName is preserved on unknown component", func(t *testing.T) {
@@ -335,6 +342,92 @@ func TestProcessEvaluationResponse_NilPointerGuard(t *testing.T) {
 		require.Len(t, got, 1)
 		assert.True(t, got[0].Metadata.IsAnnotation)
 	})
+}
+
+// seedStyledComponent registers a v1beta3 ComponentDefinition with a
+// non-empty Styles block, modeling how integrations like Kubernetes ship
+// visualization styles in their meshmodel JSON.
+func seedStyledComponent(t *testing.T, rm *registry.RegistryManager, kind, modelName string) {
+	t.Helper()
+	conn := connection.Connection{
+		Name:    modelName + "-registrant",
+		Kind:    modelName,
+		Type:    "platform",
+		SubType: "orchestration",
+		Status:  connection.ConnectionStatusConnected,
+	}
+	enabled := v1beta3comp.Enabled
+	comp := v1beta3comp.ComponentDefinition{
+		DisplayName:   kind,
+		SchemaVersion: "core.meshery.io/v1beta1",
+		Status:        &enabled,
+		Component: v1beta3comp.Component{
+			Kind:    kind,
+			Version: "v1",
+			Schema:  `{"properties":{}}`,
+		},
+		Styles: &core.ComponentStyles{
+			PrimaryColor: "#326CE5",
+			SvgColor:     "<svg>seeded</svg>",
+		},
+		Model: &model.ModelDefinition{
+			Name:          modelName,
+			DisplayName:   "Kubernetes",
+			SchemaVersion: "models.meshery.io/v1beta1",
+			Version:       "v1.25.0",
+			Model:         model.Model{Version: "v1.25.0"},
+			Category:      category.CategoryDefinition{Name: "Orchestration"},
+			Status:        model.Enabled,
+		},
+	}
+	id, err := comp.GenerateID()
+	require.NoError(t, err)
+	comp.ID = id
+	_, _, err = rm.RegisterEntity(conn, &comp)
+	require.NoError(t, err, "seedStyledComponent: RegisterEntity failed")
+}
+
+// Regression test for the Kanvas "evaluator-added components render with
+// default green styling on first paint" bug: rego identify_additions emits
+// add_component actions whose `model` field is the relationship selector
+// (e.g. {name: "*"}), and the registry's exact-match SQL filter on
+// model_dbs.name returns zero rows for "*". The component then shipped to
+// the client unhydrated — no styles, no metadata — and the user had to
+// manually trigger "reset styles" to make it render correctly.
+//
+// The fix: when ModelName is the wildcard "*", drop the model filter so the
+// kind alone disambiguates and the registry returns the canonical match.
+func TestProcessEvaluationResponse_HydratesWildcardModelEntries(t *testing.T) {
+	t.Parallel()
+
+	rm, _ := newTestRegistryManager(t)
+	seedStyledComponent(t, rm, "Namespace", "kubernetes")
+
+	resp := &pattern.EvaluationResponse{
+		Design: pattern.PatternFile{Version: "0.0.1"},
+		Trace: pattern.Trace{
+			ComponentsAdded: []component.ComponentDefinition{
+				{
+					Component: component.Component{Kind: "Namespace", Version: "v1"},
+					// Wildcard model name as emitted by identify_additions.rego
+					// when the relationship selector is `model: {name: "*"}`.
+					Model: &model.ModelDefinition{
+						Name:    "*",
+						Version: "v1.25.0",
+						Model:   model.Model{Version: "v1.25.0"},
+					},
+				},
+			},
+		},
+	}
+
+	got := processEvaluationResponse(rm, pattern.EvaluationRequest{}, resp)
+	require.Empty(t, got, "wildcard model should resolve to a registry entity, not unknownComponents")
+	require.Len(t, resp.Trace.ComponentsAdded, 1, "hydrated component should be in Trace.ComponentsAdded")
+	hydrated := resp.Trace.ComponentsAdded[0]
+	require.NotNil(t, hydrated.Styles, "hydrated component must carry registry Styles")
+	assert.Equal(t, "#326CE5", hydrated.Styles.PrimaryColor)
+	assert.Equal(t, "<svg>seeded</svg>", hydrated.Styles.SvgColor)
 }
 
 func TestParseRelationshipToAlias(t *testing.T) {


### PR DESCRIPTION
## Summary

Components added by the relationship evaluation engine (for example, a `Namespace` auto-added when one of its child `Pod`s references it) were rendering with default green styling on first paint, and the user had to manually trigger **Reset Styles** on the component for it to display with its proper Kubernetes look (blue, dashed border, integration icon, etc.). Two pre-existing bugs in `processEvaluationResponse` were stranding every evaluator-added component in `unknownComponents` without its registry styles:

1. **v1beta1/v1beta3 type-assertion mismatch**: the meshkit registry returns `*v1beta3.ComponentDefinition` (the only component version whose `Entity` interface is implemented and whose schema binds to `component_definition_dbs`), but the handler asserts `*v1beta1.ComponentDefinition` to match `pattern.PatternFile.Components`. Every successful registry lookup silently failed the assertion. The pre-existing nil-pointer guard test from #18915 was actually asserting the buggy behavior. Fix: a shallow `bridgeComponentV1beta3ToV1beta1` paralleling the existing `v1beta2`↔`v1beta3` bridge in `models/pattern/utils/component_version_bridge.go`, used as a fallback when the v1beta1 assertion fails.
2. **Wildcard `ModelName` filter**: `identify_additions.rego` emits `add_component` actions whose `model` is the relationship-selector wildcard (`{name: "*"}`). The registry's exact-match SQL on `model_dbs.name` returns zero rows for `"*"`. Fix: drop the model filter when `ModelName == "*"` so kind alone disambiguates and the registry returns the canonical match.

Per-instance style customizations on existing components are unaffected — hydration only writes `Trace.ComponentsAdded` entries, and the existing ID-match loop in `processEvaluationResponse` only swaps in hydrated copies for matching IDs.

A companion belt-and-suspenders client-side fix in `meshery-extensions` will follow as a separate PR.

## Test plan

- [x] `go test ./server/handlers/` — full handlers suite passes (2.6s).
- [x] `TestProcessEvaluationResponse_HydratesWildcardModelEntries` (new) — seeds a styled `Namespace`, evaluates with `Model.Name = "*"`, asserts the response carries `Styles.PrimaryColor = "#326CE5"` and `Styles.SvgColor` from the registry.
- [x] Updated `TestProcessEvaluationResponse_NilPointerGuard/v1beta3 registry entity is bridged into v1beta1 hydration` (renamed from "type assertion failure routes to unknownComponents") — verifies the bridged-hydration behavior; the previous test was asserting the bug.
- [x] `go vet ./server/handlers/` — clean.
- [ ] Manual: load a Kanvas design with a `Pod` whose `metadata.namespace` references a non-existent `Namespace`; confirm the auto-added `Namespace` renders with the proper Kubernetes styling on first paint (no manual style reset needed).