### PR TITLE
fix(eval): hydrate styles on evaluator-added components

### DIFF
--- a/server/handlers/policy_relationship_handler.go
+++ b/server/handlers/policy_relationship_handler.go
@@ -21,6 +21,7 @@ import (
 	"github.com/meshery/schemas/models/v1beta1/component"
 	"github.com/meshery/schemas/models/v1beta1/pattern"
 	"github.com/meshery/schemas/models/v1beta2/relationship"
+	componentv1beta3 "github.com/meshery/schemas/models/v1beta3/component"
 
 	"github.com/meshery/meshkit/logger"
 	"github.com/meshery/meshkit/models/events"
@@ -595,22 +596,73 @@ func componentDefinitionToMap(comp *component.ComponentDefinition) (map[string]i
 	return item, true
 }
 
+// registryComponentDefinitionToV1beta1 bridges the v1beta3 ComponentDefinition
+// the meshkit registry returns into the v1beta1 ComponentDefinition that
+// pattern.PatternFile.Components is typed against. This handler — and every
+// caller of processEvaluationResponse — operates on v1beta1; v1beta3 is only
+// the registry's storage representation.
+//
+// Mechanism: a shallow field copy that keeps pointer- and reference-typed
+// inner fields (Model, Styles, Capabilities, Configuration,
+// Metadata.AdditionalProperties, ModelID) aliased across both versions, so
+// later in-place mutations meshkit helpers (e.g.
+// orchestration.EnrichComponentWithMesheryMetadata) might make through one
+// of those pointers remain visible from the v1beta1 view. This parallels
+// the existing models/pattern/utils.ComponentV1beta3ToV1beta2 bridge — same
+// pattern, different target version.
+//
+// Why not json.Marshal/json.Unmarshal: a JSON round-trip silently drops
+// fields whose tags differ across versions (already true today —
+// v1beta1 uses `json:"created_at,omitempty"` while v1beta3 uses
+// `json:"createdAt"`) and deep-clones the inner pointer targets, which
+// breaks the alias contract the existing bridge documents. Future tag
+// drift would compound the data loss with no compile-time signal.
 func registryComponentDefinitionToV1beta1(entity interface{}) (*component.ComponentDefinition, bool) {
 	if entity == nil {
 		return nil, false
 	}
-	raw, err := json.Marshal(entity)
-	if err != nil {
+	src, ok := entity.(*componentv1beta3.ComponentDefinition)
+	if !ok || src == nil {
 		return nil, false
 	}
-	var converted component.ComponentDefinition
-	if err := json.Unmarshal(raw, &converted); err != nil {
+	if src.Component.Kind == "" {
 		return nil, false
 	}
-	if converted.Component.Kind == "" {
-		return nil, false
+	dst := &component.ComponentDefinition{
+		ID:             src.ID,
+		SchemaVersion:  src.SchemaVersion,
+		Version:        src.Version,
+		DisplayName:    src.DisplayName,
+		Description:    src.Description,
+		Format:         component.ComponentDefinitionFormat(src.Format),
+		Model:          src.Model,
+		ModelReference: src.ModelReference,
+		Styles:         src.Styles,
+		Capabilities:   src.Capabilities,
+		Metadata: component.ComponentDefinition_Metadata{
+			Genealogy:             src.Metadata.Genealogy,
+			IsAnnotation:          src.Metadata.IsAnnotation,
+			IsNamespaced:          src.Metadata.IsNamespaced,
+			Published:             src.Metadata.Published,
+			InstanceDetails:       src.Metadata.InstanceDetails,
+			ConfigurationUISchema: src.Metadata.ConfigurationUISchema,
+			AdditionalProperties:  src.Metadata.AdditionalProperties,
+		},
+		Configuration: src.Configuration,
+		Component: component.Component{
+			Kind:    src.Component.Kind,
+			Version: src.Component.Version,
+			Schema:  src.Component.Schema,
+		},
+		CreatedAt: src.CreatedAt,
+		UpdatedAt: src.UpdatedAt,
+		ModelId:   src.ModelID,
 	}
-	return &converted, true
+	if src.Status != nil {
+		st := component.ComponentDefinitionStatus(*src.Status)
+		dst.Status = &st
+	}
+	return dst, true
 }
 
 // runRelationshipEvaluation runs eval behind a panic-recovery boundary and

--- a/server/handlers/policy_relationship_handler.go
+++ b/server/handlers/policy_relationship_handler.go
@@ -438,18 +438,22 @@ func processEvaluationResponse(reg *registry.RegistryManager, evalPayload patter
 		} else {
 			compFilter.ModelName = _c.ModelReference.Name
 		}
+		if compFilter.ModelName == "*" {
+			compFilter.ModelName = ""
+		}
 
 		entities, _, _, _ := reg.GetEntitiesMemoized(compFilter, registryCache)
 		if len(entities) == 0 {
 			unknownComponents = append(unknownComponents, &_c)
 			continue
 		}
-		_component, ok := entities[0].(*component.ComponentDefinition)
-		if !ok || _component == nil {
+		_component, ok := registryComponentDefinitionToV1beta1(entities[0])
+		if !ok {
 			unknownComponents = append(unknownComponents, &_c)
 			continue
 		}
 
+		originalStyles := _c.Styles
 		_component.ID = _c.ID
 		if _c.DisplayName != "" {
 			_component.DisplayName = _c.DisplayName
@@ -461,6 +465,12 @@ func processEvaluationResponse(reg *registry.RegistryManager, evalPayload patter
 		_component.Metadata.IsAnnotation = _c.Metadata.IsAnnotation
 		_component.Configuration = _c.Configuration
 		_component.Capabilities = &defaultCapabilities
+		if originalStyles != nil && originalStyles.Position != nil {
+			if _component.Styles == nil {
+				_component.Styles = &core.ComponentStyles{}
+			}
+			_component.Styles.Position = originalStyles.Position
+		}
 		compsAdded = append(compsAdded, *_component)
 	}
 
@@ -474,6 +484,7 @@ func processEvaluationResponse(reg *registry.RegistryManager, evalPayload patter
 	evalResponse.Trace.ComponentsUpdated = compsUpdated
 
 	cmps := append(compsAdded, compsUpdated...)
+	hydrateAddComponentActions(evalResponse.Actions, compsAdded)
 
 	if evalPayload.Options != nil && evalPayload.Options.ReturnDiffOnly != nil && *evalPayload.Options.ReturnDiffOnly {
 		evalResponse.Design.Relationships = []*relationship.RelationshipDefinition{}
@@ -517,6 +528,89 @@ func processEvaluationResponse(reg *registry.RegistryManager, evalPayload patter
 	}
 
 	return unknownComponents
+}
+
+func hydrateAddComponentActions(actions []pattern.Action, compsAdded []component.ComponentDefinition) {
+	if len(actions) == 0 || len(compsAdded) == 0 {
+		return
+	}
+
+	componentsByID := map[string]component.ComponentDefinition{}
+	for _, comp := range compsAdded {
+		componentsByID[comp.ID.String()] = comp
+	}
+	actionItemsByID := map[string]map[string]interface{}{}
+
+	for idx := range actions {
+		if actions[idx].Op != "add_component" {
+			continue
+		}
+		id := actionItemID(actions[idx])
+		if id == "" {
+			continue
+		}
+		comp, ok := componentsByID[id]
+		if !ok {
+			continue
+		}
+		item, ok := actionItemsByID[id]
+		if !ok {
+			item, ok = componentDefinitionToMap(&comp)
+			if !ok {
+				continue
+			}
+			actionItemsByID[id] = item
+		}
+		if actions[idx].Value == nil {
+			actions[idx].Value = map[string]interface{}{}
+		}
+		actions[idx].Value["item"] = item
+	}
+}
+
+func actionItemID(action pattern.Action) string {
+	if action.Value == nil {
+		return ""
+	}
+	item, ok := action.Value["item"].(map[string]interface{})
+	if !ok {
+		return ""
+	}
+	id, ok := item["id"].(string)
+	if !ok {
+		return ""
+	}
+	return id
+}
+
+func componentDefinitionToMap(comp *component.ComponentDefinition) (map[string]interface{}, bool) {
+	raw, err := json.Marshal(comp)
+	if err != nil {
+		return nil, false
+	}
+	var item map[string]interface{}
+	if err := json.Unmarshal(raw, &item); err != nil {
+		return nil, false
+	}
+	return item, true
+}
+
+func registryComponentDefinitionToV1beta1(entity interface{}) (*component.ComponentDefinition, bool) {
+	if entity == nil {
+		return nil, false
+	}
+	raw, err := json.Marshal(entity)
+	if err != nil {
+		return nil, false
+	}
+	var converted component.ComponentDefinition
+	if err := json.Unmarshal(raw, &converted); err != nil {
+		return nil, false
+	}
+	if converted.Component.Kind == "" {
+		return nil, false
+	}
+	return &converted, true
 }
 
 // runRelationshipEvaluation runs eval behind a panic-recovery boundary and

--- a/server/handlers/policy_relationship_handler.go
+++ b/server/handlers/policy_relationship_handler.go
@@ -439,9 +439,6 @@ func processEvaluationResponse(reg *registry.RegistryManager, evalPayload patter
 		} else {
 			compFilter.ModelName = _c.ModelReference.Name
 		}
-		if compFilter.ModelName == "*" {
-			compFilter.ModelName = ""
-		}
 
 		entities, _, _, _ := reg.GetEntitiesMemoized(compFilter, registryCache)
 		if len(entities) == 0 {

--- a/server/handlers/policy_relationship_handler_test.go
+++ b/server/handlers/policy_relationship_handler_test.go
@@ -415,6 +415,259 @@ func TestProcessEvaluationResponse_HydratesWildcardModelEntries(t *testing.T) {
 	assert.Equal(t, "#123456", *resp.Trace.ComponentsAdded[0].Styles.BackgroundColor)
 }
 
+// seedNamespaceComponent registers a second styled component (Namespace)
+// alongside the Job from seedTestComponent so multi-component hydration
+// scenarios have two distinct kinds with two distinct styles to
+// disambiguate. Reuses the same connection/model identity as
+// seedTestComponent (kubernetes v1.25.0) to keep the model_dbs row
+// shared — RegisterEntity rejects two components claiming the same
+// generated model ID via separate registrations otherwise.
+func seedNamespaceComponent(t *testing.T, rm *registry.RegistryManager) {
+	t.Helper()
+	conn := connection.Connection{
+		Name:    "test-registrant",
+		Kind:    "kubernetes",
+		Type:    "platform",
+		SubType: "orchestration",
+		Status:  connection.ConnectionStatusConnected,
+	}
+	enabled := v1beta3comp.Enabled
+	bgColor := "#326CE5"
+	primary := "#326CE5"
+	shape := core.Shape("rectangle")
+	comp := v1beta3comp.ComponentDefinition{
+		DisplayName:   "Namespace",
+		SchemaVersion: "core.meshery.io/v1beta1",
+		Status:        &enabled,
+		Component: v1beta3comp.Component{
+			Kind:    "Namespace",
+			Version: "v1",
+			Schema:  `{"properties":{}}`,
+		},
+		Model: &model.ModelDefinition{
+			Name:          "kubernetes",
+			DisplayName:   "Kubernetes",
+			SchemaVersion: "models.meshery.io/v1beta1",
+			Version:       "v1.25.0",
+			Model:         model.Model{Version: "v1.25.0"},
+			Category:      category.CategoryDefinition{Name: "Orchestration"},
+			Status:        model.Enabled,
+		},
+		Styles: &core.ComponentStyles{
+			BackgroundColor: &bgColor,
+			PrimaryColor:    primary,
+			Shape:           &shape,
+		},
+	}
+	id, err := comp.GenerateID()
+	require.NoError(t, err)
+	comp.ID = id
+	_, _, err = rm.RegisterEntity(conn, &comp)
+	require.NoError(t, err, "seedNamespaceComponent: RegisterEntity failed")
+}
+
+// Per-instance preservation invariant: when the evaluator adds a new
+// component (e.g. Namespace auto-added for a Pod), the user's custom
+// styling on EXISTING design components (e.g. a Pod whose color the user
+// changed from green to red) must not be overwritten. Hydration is for
+// new components only — existing components flow through unmodified.
+//
+// This is the contract that lets users customize node appearance without
+// losing those customizations every time the evaluator runs (and the
+// evaluator runs after almost every UI mutation: ADD_COMPONENT,
+// UPDATE_CONFIGURATION, MERGE_DESIGN, …).
+//
+// Regression guard: a future "improvement" that loops over
+// Design.Components and applies registry styles to all of them — rather
+// than only to Trace.ComponentsAdded — would silently destroy every
+// per-instance customization in the design. This test fails fast if that
+// happens.
+func TestProcessEvaluationResponse_PreservesUserCustomizationsOnExistingComponents(t *testing.T) {
+	t.Parallel()
+
+	rm, _ := newTestRegistryManager(t)
+	seedTestComponent(t, rm)        // Job, registry BackgroundColor "#123456"
+	seedNamespaceComponent(t, rm)   // Namespace, registry BackgroundColor "#326CE5"
+
+	existingPodID, err := uuid.NewV4()
+	require.NoError(t, err)
+	addedNamespaceID, err := uuid.NewV4()
+	require.NoError(t, err)
+
+	// User customization on the existing component: red background. The
+	// registry's default for "Job" is "#123456"; if hydration accidentally
+	// touched existing components it would overwrite this with "#123456".
+	userBg := "#FF0000"
+	existingPod := &component.ComponentDefinition{
+		ID:          existingPodID,
+		Component:   component.Component{Kind: "Job", Version: "batch/v1"},
+		DisplayName: "user-customized-job",
+		Styles:      &core.ComponentStyles{BackgroundColor: &userBg},
+	}
+
+	// New component the evaluator just added — bare, no styles.
+	addedNamespace := &component.ComponentDefinition{
+		ID:          addedNamespaceID,
+		Component:   component.Component{Kind: "Namespace", Version: "v1"},
+		DisplayName: "default",
+		ModelReference: model.ModelReference{Name: "kubernetes"},
+	}
+
+	resp := &pattern.EvaluationResponse{
+		Design: pattern.PatternFile{
+			Version:    "0.0.1",
+			Components: []*component.ComponentDefinition{existingPod, addedNamespace},
+		},
+		Trace: pattern.Trace{
+			ComponentsAdded: []component.ComponentDefinition{*addedNamespace},
+		},
+	}
+
+	got := processEvaluationResponse(rm, pattern.EvaluationRequest{}, resp)
+	require.Empty(t, got, "Namespace must hydrate from registry, not strand into unknownComponents")
+
+	require.Len(t, resp.Design.Components, 2)
+	var hydratedPod, hydratedNs *component.ComponentDefinition
+	for _, c := range resp.Design.Components {
+		switch c.ID {
+		case existingPodID:
+			hydratedPod = c
+		case addedNamespaceID:
+			hydratedNs = c
+		}
+	}
+	require.NotNil(t, hydratedPod, "existing user-customized component must remain in design")
+	require.NotNil(t, hydratedNs, "evaluator-added component must be present in design")
+
+	// Invariant 1: existing user customization survives unmodified.
+	require.NotNil(t, hydratedPod.Styles)
+	require.NotNil(t, hydratedPod.Styles.BackgroundColor)
+	assert.Equal(t, "#FF0000", *hydratedPod.Styles.BackgroundColor,
+		"user-customized BackgroundColor must not be overwritten by hydration")
+	assert.Equal(t, "user-customized-job", string(hydratedPod.DisplayName),
+		"user-set DisplayName must not be overwritten by hydration")
+
+	// Invariant 2: newly-added component is hydrated from the registry.
+	require.NotNil(t, hydratedNs.Styles, "new component must have registry styles after hydration")
+	require.NotNil(t, hydratedNs.Styles.BackgroundColor)
+	assert.Equal(t, "#326CE5", *hydratedNs.Styles.BackgroundColor,
+		"new component must carry the registry's BackgroundColor")
+}
+
+// Multi-component hydration: the evaluator may add several components
+// in a single pass (e.g. a Pod referencing both a missing Namespace and
+// a missing ServiceAccount). Each must hydrate to its own registry-defined
+// styles, and the registry-cache reuse across the loop must not bleed
+// styles from one kind into another.
+//
+// Regression guard for any future change that breaks the per-iteration
+// filter construction, the registry-cache scoping, or the ID-match
+// loop in the design-component swap.
+func TestProcessEvaluationResponse_HydratesMultipleAddedComponents(t *testing.T) {
+	t.Parallel()
+
+	rm, _ := newTestRegistryManager(t)
+	seedTestComponent(t, rm)       // Job → BackgroundColor "#123456"
+	seedNamespaceComponent(t, rm)  // Namespace → BackgroundColor "#326CE5"
+
+	jobID, err := uuid.NewV4()
+	require.NoError(t, err)
+	nsID, err := uuid.NewV4()
+	require.NoError(t, err)
+
+	bareJob := &component.ComponentDefinition{
+		ID:             jobID,
+		Component:      component.Component{Kind: "Job", Version: "batch/v1"},
+		DisplayName:    "auto-job",
+		ModelReference: model.ModelReference{Name: "kubernetes"},
+	}
+	bareNs := &component.ComponentDefinition{
+		ID:             nsID,
+		Component:      component.Component{Kind: "Namespace", Version: "v1"},
+		DisplayName:    "auto-ns",
+		ModelReference: model.ModelReference{Name: "kubernetes"},
+	}
+
+	resp := &pattern.EvaluationResponse{
+		Design: pattern.PatternFile{
+			Version:    "0.0.1",
+			Components: []*component.ComponentDefinition{bareJob, bareNs},
+		},
+		Trace: pattern.Trace{
+			ComponentsAdded: []component.ComponentDefinition{*bareJob, *bareNs},
+		},
+	}
+
+	got := processEvaluationResponse(rm, pattern.EvaluationRequest{}, resp)
+	require.Empty(t, got, "all known kinds must hydrate; nothing should fall to unknownComponents")
+	require.Len(t, resp.Design.Components, 2)
+
+	byID := map[core.Uuid]*component.ComponentDefinition{}
+	for _, c := range resp.Design.Components {
+		byID[c.ID] = c
+	}
+
+	// Each kind hydrates to ITS OWN registry colour — no cross-bleed
+	// from registry-cache reuse.
+	require.NotNil(t, byID[jobID].Styles)
+	require.NotNil(t, byID[jobID].Styles.BackgroundColor)
+	assert.Equal(t, "#123456", *byID[jobID].Styles.BackgroundColor, "Job must hydrate to its own colour")
+
+	require.NotNil(t, byID[nsID].Styles)
+	require.NotNil(t, byID[nsID].Styles.BackgroundColor)
+	assert.Equal(t, "#326CE5", *byID[nsID].Styles.BackgroundColor, "Namespace must hydrate to its own colour")
+}
+
+// Position preservation under the wildcard-model code path. The bridge
+// subtest in TestProcessEvaluationResponse_NilPointerGuard already covers
+// position preservation under the canonical-model path; this test pins
+// the same guarantee for the second-root-cause path (ModelName == "*"
+// fallback) so a future regression on either path fails an explicit
+// assertion rather than silently dropping evaluator-emitted positions.
+func TestProcessEvaluationResponse_PreservesPositionAcrossWildcardHydration(t *testing.T) {
+	t.Parallel()
+
+	rm, _ := newTestRegistryManager(t)
+	seedTestComponent(t, rm) // Job in kubernetes model
+
+	id, err := uuid.NewV4()
+	require.NoError(t, err)
+	position := &struct {
+		X float64 `json:"x" yaml:"x"`
+		Y float64 `json:"y" yaml:"y"`
+	}{X: 42, Y: 84}
+
+	resp := &pattern.EvaluationResponse{
+		Design: pattern.PatternFile{Version: "0.0.1"},
+		Trace: pattern.Trace{
+			ComponentsAdded: []component.ComponentDefinition{
+				{
+					ID:        id,
+					Component: component.Component{Kind: "Job", Version: "batch/v1"},
+					// Wildcard model name as identify_additions.rego emits.
+					Model: &model.ModelDefinition{
+						Name:    "*",
+						Version: "v1.25.0",
+						Model:   model.Model{Version: "v1.25.0"},
+					},
+					// Evaluator-emitted position — must survive registry hydration.
+					Styles: &core.ComponentStyles{Position: position},
+				},
+			},
+		},
+	}
+
+	got := processEvaluationResponse(rm, pattern.EvaluationRequest{}, resp)
+	require.Empty(t, got)
+	require.Len(t, resp.Trace.ComponentsAdded, 1)
+	hydrated := resp.Trace.ComponentsAdded[0]
+	require.NotNil(t, hydrated.Styles, "registry styles must apply under wildcard fallback")
+	require.NotNil(t, hydrated.Styles.BackgroundColor, "registry BackgroundColor present after wildcard hydration")
+	require.NotNil(t, hydrated.Styles.Position, "evaluator-emitted Position must survive wildcard hydration")
+	assert.Equal(t, float64(42), hydrated.Styles.Position.X)
+	assert.Equal(t, float64(84), hydrated.Styles.Position.Y)
+}
+
 func TestParseRelationshipToAlias(t *testing.T) {
 	fromID := uuid.Must(uuid.NewV4())
 	toID := uuid.Must(uuid.NewV4())

--- a/server/handlers/policy_relationship_handler_test.go
+++ b/server/handlers/policy_relationship_handler_test.go
@@ -385,36 +385,6 @@ func TestProcessEvaluationResponse_NilPointerGuard(t *testing.T) {
 	})
 }
 
-func TestProcessEvaluationResponse_HydratesWildcardModelEntries(t *testing.T) {
-	t.Parallel()
-
-	rm, _ := newTestRegistryManager(t)
-	seedTestComponent(t, rm)
-
-	resp := &pattern.EvaluationResponse{
-		Design: pattern.PatternFile{Version: "0.0.1"},
-		Trace: pattern.Trace{
-			ComponentsAdded: []component.ComponentDefinition{
-				{
-					Component: component.Component{Kind: "Job", Version: "batch/v1"},
-					Model: &model.ModelDefinition{
-						Name:    "*",
-						Version: "v1.25.0",
-						Model:   model.Model{Version: "v1.25.0"},
-					},
-				},
-			},
-		},
-	}
-
-	got := processEvaluationResponse(rm, pattern.EvaluationRequest{}, resp)
-	require.Empty(t, got, "wildcard model should resolve to a registry entity, not unknownComponents")
-	require.Len(t, resp.Trace.ComponentsAdded, 1)
-	require.NotNil(t, resp.Trace.ComponentsAdded[0].Styles)
-	require.NotNil(t, resp.Trace.ComponentsAdded[0].Styles.BackgroundColor)
-	assert.Equal(t, "#123456", *resp.Trace.ComponentsAdded[0].Styles.BackgroundColor)
-}
-
 // seedNamespaceComponent registers a second styled component (Namespace)
 // alongside the Job from seedTestComponent so multi-component hydration
 // scenarios have two distinct kinds with two distinct styles to
@@ -616,56 +586,6 @@ func TestProcessEvaluationResponse_HydratesMultipleAddedComponents(t *testing.T)
 	require.NotNil(t, byID[nsID].Styles)
 	require.NotNil(t, byID[nsID].Styles.BackgroundColor)
 	assert.Equal(t, "#326CE5", *byID[nsID].Styles.BackgroundColor, "Namespace must hydrate to its own colour")
-}
-
-// Position preservation under the wildcard-model code path. The bridge
-// subtest in TestProcessEvaluationResponse_NilPointerGuard already covers
-// position preservation under the canonical-model path; this test pins
-// the same guarantee for the second-root-cause path (ModelName == "*"
-// fallback) so a future regression on either path fails an explicit
-// assertion rather than silently dropping evaluator-emitted positions.
-func TestProcessEvaluationResponse_PreservesPositionAcrossWildcardHydration(t *testing.T) {
-	t.Parallel()
-
-	rm, _ := newTestRegistryManager(t)
-	seedTestComponent(t, rm) // Job in kubernetes model
-
-	id, err := uuid.NewV4()
-	require.NoError(t, err)
-	position := &struct {
-		X float64 `json:"x" yaml:"x"`
-		Y float64 `json:"y" yaml:"y"`
-	}{X: 42, Y: 84}
-
-	resp := &pattern.EvaluationResponse{
-		Design: pattern.PatternFile{Version: "0.0.1"},
-		Trace: pattern.Trace{
-			ComponentsAdded: []component.ComponentDefinition{
-				{
-					ID:        id,
-					Component: component.Component{Kind: "Job", Version: "batch/v1"},
-					// Wildcard model name as identify_additions.rego emits.
-					Model: &model.ModelDefinition{
-						Name:    "*",
-						Version: "v1.25.0",
-						Model:   model.Model{Version: "v1.25.0"},
-					},
-					// Evaluator-emitted position — must survive registry hydration.
-					Styles: &core.ComponentStyles{Position: position},
-				},
-			},
-		},
-	}
-
-	got := processEvaluationResponse(rm, pattern.EvaluationRequest{}, resp)
-	require.Empty(t, got)
-	require.Len(t, resp.Trace.ComponentsAdded, 1)
-	hydrated := resp.Trace.ComponentsAdded[0]
-	require.NotNil(t, hydrated.Styles, "registry styles must apply under wildcard fallback")
-	require.NotNil(t, hydrated.Styles.BackgroundColor, "registry BackgroundColor present after wildcard hydration")
-	require.NotNil(t, hydrated.Styles.Position, "evaluator-emitted Position must survive wildcard hydration")
-	assert.Equal(t, float64(42), hydrated.Styles.Position.X)
-	assert.Equal(t, float64(84), hydrated.Styles.Position.Y)
 }
 
 func TestParseRelationshipToAlias(t *testing.T) {

--- a/server/handlers/policy_relationship_handler_test.go
+++ b/server/handlers/policy_relationship_handler_test.go
@@ -9,9 +9,10 @@ import (
 	"github.com/gofrs/uuid"
 	"github.com/meshery/meshkit/database"
 	"github.com/meshery/meshkit/models/meshmodel/registry"
-	"github.com/meshery/schemas/models/v1beta1/connection"
+	"github.com/meshery/schemas/models/core"
 	"github.com/meshery/schemas/models/v1beta1/category"
 	"github.com/meshery/schemas/models/v1beta1/component"
+	"github.com/meshery/schemas/models/v1beta1/connection"
 	"github.com/meshery/schemas/models/v1beta1/model"
 	"github.com/meshery/schemas/models/v1beta1/pattern"
 	"github.com/meshery/schemas/models/v1beta2/relationship"
@@ -168,8 +169,7 @@ func TestRunRelationshipEvaluation_PassesThroughEvalError(t *testing.T) {
 // seedTestComponent registers a v1beta3.ComponentDefinition into the given
 // RegistryManager using the registry's own RegisterEntity API — no raw SQL.
 // The returned component has Kind/Version matching the evalResp fixture so
-// that ComponentFilter.Get finds it and returns *v1beta3.ComponentDefinition,
-// which triggers the *v1beta1.ComponentDefinition type-assertion failure.
+// that ComponentFilter.Get finds it and returns the canonical registry type.
 func seedTestComponent(t *testing.T, rm *registry.RegistryManager) {
 	t.Helper()
 	conn := connection.Connection{
@@ -180,6 +180,8 @@ func seedTestComponent(t *testing.T, rm *registry.RegistryManager) {
 		Status:  connection.ConnectionStatusConnected,
 	}
 	enabled := v1beta3comp.Enabled
+	bgColor := "#123456"
+	shape := core.Shape("round-rectangle")
 	comp := v1beta3comp.ComponentDefinition{
 		DisplayName:   "Job",
 		SchemaVersion: "core.meshery.io/v1beta1",
@@ -198,6 +200,11 @@ func seedTestComponent(t *testing.T, rm *registry.RegistryManager) {
 			Category:      category.CategoryDefinition{Name: "Orchestration"},
 			Status:        model.Enabled,
 		},
+		Styles: &core.ComponentStyles{
+			BackgroundColor: &bgColor,
+			PrimaryColor:    "#123456",
+			Shape:           &shape,
+		},
 	}
 	id, err := comp.GenerateID()
 	require.NoError(t, err)
@@ -208,10 +215,10 @@ func seedTestComponent(t *testing.T, rm *registry.RegistryManager) {
 
 // Regression test for #18915: nil pointer dereference in processEvaluationResponse.
 //
-// Root cause: ComponentFilter.Get (meshkit v1beta1 filter package) returns
-// *v1beta3.ComponentDefinition, but the handler asserts *v1beta1.ComponentDefinition.
-// Without the guard the assertion silently returns nil=(*v1beta1.ComponentDefinition)(nil)
-// and the next dereference causes a SIGSEGV.
+// Original root cause: ComponentFilter.Get (meshkit v1beta1 filter package)
+// returns *v1beta3.ComponentDefinition, while this handler works with
+// v1beta1 evaluation payloads. The conversion must be explicit so the handler
+// neither panics nor treats valid registry-backed components as unknown.
 //
 // Real production panic (guard absent):
 //
@@ -251,19 +258,60 @@ func TestProcessEvaluationResponse_NilPointerGuard(t *testing.T) {
 		assert.Equal(t, "Job", got[0].Component.Kind)
 	})
 
-	t.Run("type assertion failure routes to unknownComponents", func(t *testing.T) {
+	t.Run("v1beta3 registry component hydrates v1beta1 evaluation response", func(t *testing.T) {
 		t.Parallel()
-		// !ok guard: registry returns *v1beta3.ComponentDefinition (the real production
-		// type), which fails the *v1beta1.ComponentDefinition assertion in the handler.
-		// Without the guard this is the exact path that caused the production SIGSEGV.
 		rm, _ := newTestRegistryManager(t)
-		seedTestComponent(t, rm) // seeds via RegisterEntity — no raw SQL
+		seedTestComponent(t, rm)
+		id, err := uuid.NewV4()
+		require.NoError(t, err)
+		position := &struct {
+			X float64 `json:"x" yaml:"x"`
+			Y float64 `json:"y" yaml:"y"`
+		}{X: 10, Y: 20}
+		partial := &component.ComponentDefinition{
+			ID:             id,
+			Component:      component.Component{Kind: "Job", Version: "batch/v1"},
+			DisplayName:    "test-job",
+			ModelReference: model.ModelReference{Name: "kubernetes"},
+			Styles:         &core.ComponentStyles{Position: position},
+		}
+		resp := &pattern.EvaluationResponse{
+			Design: pattern.PatternFile{
+				Version:    "0.0.1",
+				Components: []*component.ComponentDefinition{partial},
+			},
+			Trace: pattern.Trace{
+				ComponentsAdded: []component.ComponentDefinition{*partial},
+			},
+			Actions: []pattern.Action{
+				{
+					Op: "add_component",
+					Value: map[string]interface{}{
+						"item": map[string]interface{}{
+							"id": id.String(),
+						},
+					},
+				},
+			},
+		}
 		var got []*component.ComponentDefinition
 		require.NotPanics(t, func() {
-			got = processEvaluationResponse(rm, pattern.EvaluationRequest{}, makeResp("test-job"))
-		}, "must not panic when type assertion on registry entity fails")
-		require.Len(t, got, 1)
-		assert.Equal(t, "Job", got[0].Component.Kind)
+			got = processEvaluationResponse(rm, pattern.EvaluationRequest{}, resp)
+		}, "must not panic when registry returns canonical v1beta3 components")
+		require.Empty(t, got)
+		require.Len(t, resp.Design.Components, 1)
+		require.NotNil(t, resp.Design.Components[0].Styles)
+		require.NotNil(t, resp.Design.Components[0].Styles.BackgroundColor)
+		assert.Equal(t, "#123456", *resp.Design.Components[0].Styles.BackgroundColor)
+		require.NotNil(t, resp.Design.Components[0].Styles.Position)
+		assert.Equal(t, float64(10), resp.Design.Components[0].Styles.Position.X)
+		assert.Equal(t, float64(20), resp.Design.Components[0].Styles.Position.Y)
+		require.Len(t, resp.Actions, 1)
+		item, ok := resp.Actions[0].Value["item"].(map[string]interface{})
+		require.True(t, ok)
+		styles, ok := item["styles"].(map[string]interface{})
+		require.True(t, ok)
+		assert.Equal(t, "#123456", styles["background-color"])
 	})
 
 	t.Run("explicit DisplayName is preserved on unknown component", func(t *testing.T) {
@@ -335,6 +383,36 @@ func TestProcessEvaluationResponse_NilPointerGuard(t *testing.T) {
 		require.Len(t, got, 1)
 		assert.True(t, got[0].Metadata.IsAnnotation)
 	})
+}
+
+func TestProcessEvaluationResponse_HydratesWildcardModelEntries(t *testing.T) {
+	t.Parallel()
+
+	rm, _ := newTestRegistryManager(t)
+	seedTestComponent(t, rm)
+
+	resp := &pattern.EvaluationResponse{
+		Design: pattern.PatternFile{Version: "0.0.1"},
+		Trace: pattern.Trace{
+			ComponentsAdded: []component.ComponentDefinition{
+				{
+					Component: component.Component{Kind: "Job", Version: "batch/v1"},
+					Model: &model.ModelDefinition{
+						Name:    "*",
+						Version: "v1.25.0",
+						Model:   model.Model{Version: "v1.25.0"},
+					},
+				},
+			},
+		},
+	}
+
+	got := processEvaluationResponse(rm, pattern.EvaluationRequest{}, resp)
+	require.Empty(t, got, "wildcard model should resolve to a registry entity, not unknownComponents")
+	require.Len(t, resp.Trace.ComponentsAdded, 1)
+	require.NotNil(t, resp.Trace.ComponentsAdded[0].Styles)
+	require.NotNil(t, resp.Trace.ComponentsAdded[0].Styles.BackgroundColor)
+	assert.Equal(t, "#123456", *resp.Trace.ComponentsAdded[0].Styles.BackgroundColor)
 }
 
 func TestParseRelationshipToAlias(t *testing.T) {

--- a/server/policies/engine.go
+++ b/server/policies/engine.go
@@ -108,6 +108,16 @@ func (e *GoEngine) evaluate(design *pattern.PatternFile, relsInScope []*relation
 	combinedActions := append(allActions, identifyActions...)
 	designWithIdentified := applyActionsToDesign(design, combinedActions)
 
+	// Phase 2.5: Identify inventory parents the design is missing. Mirrors
+	// identify_additions.rego — without this the Go engine silently skips
+	// auto-creating Namespaces for namespaced resources, diverging from the
+	// Rego engine's behavior.
+	inventoryActions := identifyInventoryAdditions(designWithIdentified, relsInScope)
+	if len(inventoryActions) > 0 {
+		combinedActions = append(combinedActions, inventoryActions...)
+		designWithIdentified = applyActionsToDesign(design, combinedActions)
+	}
+
 	// Phase 3: Generate and apply actions.
 	var phaseActions []PolicyAction
 	for _, policy := range e.policies {
@@ -116,6 +126,7 @@ func (e *GoEngine) evaluate(design *pattern.PatternFile, relsInScope []*relation
 	}
 
 	allActions = append(allActions, identifyActions...)
+	allActions = append(allActions, inventoryActions...)
 	allActions = append(allActions, phaseActions...)
 
 	finalDesign := applyActionsToDesign(designWithIdentified, phaseActions)

--- a/server/policies/policy_inventory.go
+++ b/server/policies/policy_inventory.go
@@ -1,0 +1,324 @@
+package policies
+
+import (
+	"encoding/json"
+	"strings"
+
+	"github.com/gofrs/uuid"
+	"github.com/meshery/schemas/models/v1beta1/component"
+	modelv1beta1 "github.com/meshery/schemas/models/v1beta1/model"
+	"github.com/meshery/schemas/models/v1beta1/pattern"
+	"github.com/meshery/schemas/models/v1beta2/relationship"
+)
+
+// identifyInventoryAdditions emits add_component actions for inventory
+// parents the relationship implies but the design lacks. Direct port of
+// identify_additions.rego (the rule that auto-creates a Namespace when the
+// design contains a Pod referencing one by metadata.namespace but no such
+// Namespace component exists).
+//
+// Why this exists: the OPA/Rego policy engine ships this behavior, the Go
+// policy engine did not. Same input design produced different results
+// depending on USE_GO_POLICY_ENGINE — a real parity break that surfaced as
+// "Kanvas designs are missing components when the Go engine is used."
+//
+// Fires only on hierarchical/parent/inventory relationships; everything
+// else returns no actions, matching the rego rule's guard clauses.
+func identifyInventoryAdditions(
+	design *pattern.PatternFile,
+	relsInScope []*relationship.RelationshipDefinition,
+) []PolicyAction {
+	if design == nil {
+		return nil
+	}
+	var actions []PolicyAction
+	for _, rel := range relsInScope {
+		if !isHierarchicalParentInventory(rel) {
+			continue
+		}
+		actions = append(actions, identifyInventoryAdditionsForRel(rel, design)...)
+	}
+	return actions
+}
+
+func isHierarchicalParentInventory(rel *relationship.RelationshipDefinition) bool {
+	if rel == nil {
+		return false
+	}
+	return strings.EqualFold(string(rel.Kind), "hierarchical") &&
+		strings.EqualFold(rel.RelationshipType, "parent") &&
+		strings.EqualFold(rel.SubType, "inventory")
+}
+
+// identifyInventoryAdditionsForRel runs the per-relationship branch of
+// identify_additions.rego: split the from/to selectors into mutated/mutator
+// pools, find existing components matching the mutated selectors, and for
+// each (mutated_component, mutator_selector) pair emit a new component
+// unless one already exists with matching mutatorRef values.
+func identifyInventoryAdditionsForRel(
+	rel *relationship.RelationshipDefinition,
+	design *pattern.PatternFile,
+) []PolicyAction {
+	if rel.Selectors == nil {
+		return nil
+	}
+	var out []PolicyAction
+	emittedIDs := map[string]bool{}
+
+	for _, ss := range *rel.Selectors {
+		mutatedSels, mutatorSels := partitionByPatchRole(ss)
+
+		for _, mutatedSel := range mutatedSels {
+			mutatedRefs := *mutatedSel.RelationshipDefinitionSelectorsPatch.MutatedRef
+			for _, mutatedComp := range design.Components {
+				if mutatedComp == nil {
+					continue
+				}
+				if !selectorAndComponentKindMatches(mutatedSel, mutatedComp) {
+					continue
+				}
+				values, ok := extractValuesAtPaths(mutatedComp, mutatedRefs, design)
+				if !ok {
+					continue
+				}
+
+				for _, mutatorSel := range mutatorSels {
+					mutatorRefs := *mutatorSel.RelationshipDefinitionSelectorsPatch.MutatorRef
+					if existsMatchingMutatorComponent(design, mutatorSel, mutatorRefs, values) {
+						continue
+					}
+					candidate := buildInventoryParentCandidate(mutatorSel, mutatorRefs, values)
+					if candidate == nil {
+						continue
+					}
+					// The rego runs feasibility against the relationship-as-a-whole;
+					// re-use the existing helper so cross-model relationships
+					// (azure EventSubscription→azure-storage StorageAccount) are
+					// treated identically here.
+					if feasibleRelationshipSelectorBetween(mutatedComp, candidate, rel) == nil {
+						continue
+					}
+					if emittedIDs[candidate.ID.String()] {
+						continue
+					}
+					emittedIDs[candidate.ID.String()] = true
+					out = append(out, newAddComponentAction(candidate))
+				}
+			}
+		}
+	}
+	return out
+}
+
+// partitionByPatchRole walks both allow.from and allow.to and returns
+// selectors with mutatedRef separately from those with mutatorRef. Mirrors
+// the rego helpers `mutated_selectors` / `mutator_selectors` over the union
+// of from+to.
+func partitionByPatchRole(ss relationship.SelectorSetItem) (mutated, mutator []relationship.SelectorItem) {
+	classify := func(s relationship.SelectorItem) {
+		if s.RelationshipDefinitionSelectorsPatch == nil {
+			return
+		}
+		if s.RelationshipDefinitionSelectorsPatch.MutatedRef != nil &&
+			len(*s.RelationshipDefinitionSelectorsPatch.MutatedRef) > 0 {
+			mutated = append(mutated, s)
+		}
+		if s.RelationshipDefinitionSelectorsPatch.MutatorRef != nil &&
+			len(*s.RelationshipDefinitionSelectorsPatch.MutatorRef) > 0 {
+			mutator = append(mutator, s)
+		}
+	}
+	for _, s := range ss.Allow.From {
+		classify(s)
+	}
+	for _, s := range ss.Allow.To {
+		classify(s)
+	}
+	return mutated, mutator
+}
+
+// extractValuesAtPaths returns one value per path; a path that resolves to
+// nil disqualifies the whole list (matching the rego's
+// `count(values) == count(refs)` guard via `value != null` filter).
+func extractValuesAtPaths(
+	comp *component.ComponentDefinition,
+	paths [][]string,
+	design *pattern.PatternFile,
+) ([]interface{}, bool) {
+	if len(paths) == 0 {
+		return nil, false
+	}
+	values := make([]interface{}, 0, len(paths))
+	for _, p := range paths {
+		v := configurationForComponentAtPath(p, comp, design)
+		if v == nil {
+			return nil, false
+		}
+		values = append(values, v)
+	}
+	return values, true
+}
+
+// existsMatchingMutatorComponent answers "is there already a parent in the
+// design with values at mutatorRef matching the mutated child's values?" If
+// yes, the rego skips emitting the add_component action — duplicates aren't
+// wanted.
+func existsMatchingMutatorComponent(
+	design *pattern.PatternFile,
+	mutatorSel relationship.SelectorItem,
+	mutatorRefs [][]string,
+	mutatedValues []interface{},
+) bool {
+	for _, comp := range design.Components {
+		if comp == nil {
+			continue
+		}
+		if !selectorAndComponentKindMatches(mutatorSel, comp) {
+			continue
+		}
+		existing, ok := extractValuesAtPaths(comp, mutatorRefs, design)
+		if !ok {
+			continue
+		}
+		if equalValueLists(mutatedValues, existing) {
+			return true
+		}
+	}
+	return false
+}
+
+// equalValueLists compares two value lists element-wise via JSON
+// equality. The rego match_object uses set-equality but in practice
+// mutated/mutator pairs are 1:1 in current relationship JSONs; element-wise
+// is sufficient and avoids a quadratic permutation match.
+func equalValueLists(a, b []interface{}) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if !jsonValuesEqual(a[i], b[i]) {
+			return false
+		}
+	}
+	return true
+}
+
+// jsonValuesEqual compares two configuration values using their JSON
+// serialization, matching how the rego compares values across types
+// (strings, numbers, nested maps).
+func jsonValuesEqual(a, b interface{}) bool {
+	if a == nil && b == nil {
+		return true
+	}
+	if a == nil || b == nil {
+		return false
+	}
+	aBytes, err := json.Marshal(a)
+	if err != nil {
+		return false
+	}
+	bBytes, err := json.Marshal(b)
+	if err != nil {
+		return false
+	}
+	return string(aBytes) == string(bBytes)
+}
+
+// buildInventoryParentCandidate constructs the new component that would be
+// added to the design — the equivalent of the rego's `declaration_with_id`
+// at the end of process_comps_to_add.
+//
+// The candidate's model comes from the mutator selector (the to-side of an
+// inventory relationship), which is always concrete in shipped relationship
+// JSONs. The candidate's displayName / configuration is populated by
+// applying mutator-path patches: typically mutatorRef=[["displayName"]]
+// pairs with mutatedValues=["default"] to produce DisplayName="default".
+func buildInventoryParentCandidate(
+	mutatorSel relationship.SelectorItem,
+	mutatorRefs [][]string,
+	mutatedValues []interface{},
+) *component.ComponentDefinition {
+	kind := selectorItemKind(mutatorSel)
+	if kind == "" {
+		return nil
+	}
+	id, err := uuid.NewV4()
+	if err != nil {
+		return nil
+	}
+
+	candidate := &component.ComponentDefinition{
+		ID:        id,
+		Component: component.Component{Kind: kind},
+	}
+
+	// Populate both Model and ModelReference. The rego sets only the
+	// `model` JSON field (which unmarshals into Go's .Model). Callers
+	// downstream of this (registry hydration in
+	// policy_relationship_handler.processEvaluationResponse) read .Model
+	// first and fall back to .ModelReference; populating both keeps the
+	// candidate consistent with what rego emits AND with engine.go's
+	// pre-evaluation normalization invariant.
+	if mutatorSel.Model != nil {
+		candidate.ModelReference = *mutatorSel.Model
+		candidate.Model = &modelv1beta1.ModelDefinition{
+			Name:        mutatorSel.Model.Name,
+			Version:     mutatorSel.Model.Version,
+			DisplayName: mutatorSel.Model.DisplayName,
+			Model:       mutatorSel.Model.Model,
+		}
+	}
+
+	// Apply mutator-path patches (e.g. mutatorRef[i]=["displayName"] with
+	// mutatedValues[i]="default" → DisplayName="default"). Inventory
+	// relationship JSONs in tree today use only top-level paths and
+	// configuration.* paths; cover both shapes.
+	count := len(mutatorRefs)
+	if len(mutatedValues) < count {
+		count = len(mutatedValues)
+	}
+	for i := 0; i < count; i++ {
+		applyPathToCandidate(candidate, mutatorRefs[i], mutatedValues[i])
+	}
+
+	return candidate
+}
+
+// applyPathToCandidate writes value at path on the candidate. Supports the
+// two path shapes inventory relationship JSONs actually emit today:
+// top-level [displayName] and configuration.<...>. Anything else is
+// dropped silently — same fail-mode as the rego when json.patch is given a
+// path that doesn't match the target object.
+func applyPathToCandidate(comp *component.ComponentDefinition, path []string, value interface{}) {
+	if len(path) == 0 {
+		return
+	}
+	if len(path) == 1 && path[0] == "displayName" {
+		if s, ok := value.(string); ok {
+			comp.DisplayName = s
+		}
+		return
+	}
+	if path[0] == "configuration" {
+		if comp.Configuration == nil {
+			comp.Configuration = map[string]interface{}{}
+		}
+		setNestedConfigValue(comp.Configuration, path[1:], value)
+	}
+}
+
+func setNestedConfigValue(m map[string]interface{}, path []string, value interface{}) {
+	if len(path) == 0 {
+		return
+	}
+	if len(path) == 1 {
+		m[path[0]] = value
+		return
+	}
+	next, ok := m[path[0]].(map[string]interface{})
+	if !ok {
+		next = map[string]interface{}{}
+		m[path[0]] = next
+	}
+	setNestedConfigValue(next, path[1:], value)
+}

--- a/server/policies/policy_inventory_test.go
+++ b/server/policies/policy_inventory_test.go
@@ -1,0 +1,357 @@
+package policies
+
+import (
+	"context"
+	"encoding/json"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/gofrs/uuid"
+	"github.com/meshery/schemas/models/v1beta1/component"
+	modelv1beta1 "github.com/meshery/schemas/models/v1beta1/model"
+	"github.com/meshery/schemas/models/v1beta1/pattern"
+	"github.com/meshery/schemas/models/v1beta2/relationship"
+	"github.com/open-policy-agent/opa/v1/rego"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// kubernetesInventoryRelationship returns the canonical k8s
+// hierarchical-parent-inventory relationship: any namespaced kind in any
+// model points to a Namespace via metadata.namespace; the new Namespace's
+// displayName is set from that value.
+func kubernetesInventoryRelationship() *relationship.RelationshipDefinition {
+	mutatedRef := relationship.MutatedRef{{"configuration", "metadata", "namespace"}}
+	mutatorRef := relationship.MutatorRef{{"displayName"}}
+	wildcard := "*"
+	namespace := "Namespace"
+	return &relationship.RelationshipDefinition{
+		Kind:             relationship.RelationshipDefinitionKind("hierarchical"),
+		RelationshipType: "parent",
+		SubType:          "inventory",
+		Selectors: &relationship.SelectorSet{
+			relationship.SelectorSetItem{
+				Allow: relationship.Selector{
+					From: []relationship.SelectorItem{{
+						Kind: &wildcard,
+						Model: &modelv1beta1.ModelReference{
+							Name: "*",
+						},
+						RelationshipDefinitionSelectorsPatch: &relationship.RelationshipDefinitionSelectorsPatch{
+							MutatedRef: &mutatedRef,
+						},
+					}},
+					To: []relationship.SelectorItem{{
+						Kind: &namespace,
+						Model: &modelv1beta1.ModelReference{
+							Name: "kubernetes",
+						},
+						RelationshipDefinitionSelectorsPatch: &relationship.RelationshipDefinitionSelectorsPatch{
+							MutatorRef: &mutatorRef,
+						},
+					}},
+				},
+			},
+		},
+	}
+}
+
+// crossModelInventoryRelationship returns a relationship modeled on the
+// real azure-event-grid EventSubscription → azure-storage StorageAccount
+// dependency: the parent (StorageAccount) is in a different model than
+// the child (EventSubscription). Used to verify the auto-added parent
+// follows the to-side model, not the child's model.
+func crossModelInventoryRelationship() *relationship.RelationshipDefinition {
+	mutatedRef := relationship.MutatedRef{{"configuration", "spec", "destination", "storageAccount"}}
+	mutatorRef := relationship.MutatorRef{{"displayName"}}
+	fromKind := "EventSubscription"
+	toKind := "StorageAccount"
+	return &relationship.RelationshipDefinition{
+		Kind:             relationship.RelationshipDefinitionKind("hierarchical"),
+		RelationshipType: "parent",
+		SubType:          "inventory",
+		Selectors: &relationship.SelectorSet{
+			relationship.SelectorSetItem{
+				Allow: relationship.Selector{
+					From: []relationship.SelectorItem{{
+						Kind:  &fromKind,
+						Model: &modelv1beta1.ModelReference{Name: "azure-event-grid"},
+						RelationshipDefinitionSelectorsPatch: &relationship.RelationshipDefinitionSelectorsPatch{
+							MutatedRef: &mutatedRef,
+						},
+					}},
+					To: []relationship.SelectorItem{{
+						Kind:  &toKind,
+						Model: &modelv1beta1.ModelReference{Name: "azure-storage"},
+						RelationshipDefinitionSelectorsPatch: &relationship.RelationshipDefinitionSelectorsPatch{
+							MutatorRef: &mutatorRef,
+						},
+					}},
+				},
+			},
+		},
+	}
+}
+
+// makePodWithNamespace builds a single-Pod design with metadata.namespace
+// set to the given value — the canonical bug-fixture: a Kubernetes resource
+// referencing a Namespace that does not yet exist.
+func makePodWithNamespace(t *testing.T, ns string) (*pattern.PatternFile, *component.ComponentDefinition) {
+	t.Helper()
+	id, err := uuid.NewV4()
+	require.NoError(t, err)
+	pod := &component.ComponentDefinition{
+		ID:        id,
+		Component: component.Component{Kind: "Pod", Version: "v1"},
+		Model: &modelv1beta1.ModelDefinition{
+			Name:    "kubernetes",
+			Version: "v1.25.0",
+			Model:   modelv1beta1.Model{Version: "v1.25.0"},
+		},
+		ModelReference: modelv1beta1.ModelReference{Name: "kubernetes"},
+		Configuration: map[string]interface{}{
+			"metadata": map[string]interface{}{
+				"namespace": ns,
+			},
+		},
+	}
+	return makePatternFile([]*component.ComponentDefinition{pod}, nil), pod
+}
+
+// Bug regression — Pod with metadata.namespace and no Namespace component:
+// the Go engine must auto-emit an add_component action for a Namespace
+// in the kubernetes model, displayName matching the referenced value.
+// Without identifyInventoryAdditions wired into engine.evaluate, this
+// returns nothing — the parity bug behind issue #19090.
+func TestIdentifyInventoryAdditions_PodImpliesNamespace(t *testing.T) {
+	t.Parallel()
+	design, _ := makePodWithNamespace(t, "default")
+	rel := kubernetesInventoryRelationship()
+
+	actions := identifyInventoryAdditions(design, []*relationship.RelationshipDefinition{rel})
+
+	require.Len(t, actions, 1, "exactly one Namespace must be auto-added for one Pod with one missing parent")
+	a := actions[0]
+	assert.Equal(t, AddComponentOp, a.Op)
+	require.NotNil(t, a.Component)
+	assert.Equal(t, "Namespace", a.Component.Component.Kind, "auto-added kind must be Namespace, not the from-side wildcard")
+	require.NotNil(t, a.Component.Model, "Model must be populated so processEvaluationResponse can hydrate styles")
+	assert.Equal(t, "kubernetes", a.Component.Model.Name, "Model.Name must follow the to-side selector, not the wildcard")
+	assert.Equal(t, "kubernetes", a.Component.ModelReference.Name)
+	assert.Equal(t, "default", string(a.Component.DisplayName), "DisplayName must come from the mutator-path patch (mutatorRef=displayName ↔ mutatedValue='default')")
+}
+
+// If a Namespace named "default" already exists, no add_component action
+// must be emitted — the rego rule's `every` guard avoids creating a
+// duplicate parent.
+func TestIdentifyInventoryAdditions_SkipsWhenParentAlreadyPresent(t *testing.T) {
+	t.Parallel()
+	design, pod := makePodWithNamespace(t, "default")
+	nsID, err := uuid.NewV4()
+	require.NoError(t, err)
+	ns := &component.ComponentDefinition{
+		ID:             nsID,
+		Component:      component.Component{Kind: "Namespace", Version: "v1"},
+		DisplayName:    "default",
+		Model:          &modelv1beta1.ModelDefinition{Name: "kubernetes"},
+		ModelReference: modelv1beta1.ModelReference{Name: "kubernetes"},
+	}
+	design.Components = append(design.Components, ns)
+	_ = pod
+
+	actions := identifyInventoryAdditions(design, []*relationship.RelationshipDefinition{kubernetesInventoryRelationship()})
+	assert.Empty(t, actions, "must not emit add_component when a matching parent already exists in the design")
+}
+
+// Cross-model regression: if the relationship has a different model on the
+// to-side than the from-side (e.g. azure-event-grid EventSubscription →
+// azure-storage StorageAccount), the auto-added parent must inherit the
+// to-side model. This is the exact case where my originally-suggested
+// "use mutated_component.model" Rego edit would have broken behavior; this
+// test pins the correct contract.
+func TestIdentifyInventoryAdditions_PreservesToSideModelForCrossModelRelationships(t *testing.T) {
+	t.Parallel()
+	id, err := uuid.NewV4()
+	require.NoError(t, err)
+	sub := &component.ComponentDefinition{
+		ID:        id,
+		Component: component.Component{Kind: "EventSubscription", Version: "v1"},
+		Model: &modelv1beta1.ModelDefinition{
+			Name: "azure-event-grid",
+		},
+		ModelReference: modelv1beta1.ModelReference{Name: "azure-event-grid"},
+		Configuration: map[string]interface{}{
+			"spec": map[string]interface{}{
+				"destination": map[string]interface{}{
+					"storageAccount": "saproduction",
+				},
+			},
+		},
+	}
+	design := makePatternFile([]*component.ComponentDefinition{sub}, nil)
+
+	actions := identifyInventoryAdditions(design, []*relationship.RelationshipDefinition{crossModelInventoryRelationship()})
+	require.Len(t, actions, 1)
+	added := actions[0].Component
+	require.NotNil(t, added)
+	assert.Equal(t, "StorageAccount", added.Component.Kind)
+	require.NotNil(t, added.Model)
+	assert.Equal(t, "azure-storage", added.Model.Name,
+		"cross-model parent must follow the to-side model (azure-storage), not the from-side (azure-event-grid)")
+	assert.Equal(t, "saproduction", string(added.DisplayName))
+}
+
+// Non-inventory relationships (alias, edge, etc.) must be ignored. Without
+// this guard, a stray inventoryActions side-effect could fire for any
+// hierarchical relationship.
+func TestIdentifyInventoryAdditions_IgnoresNonInventoryRelationships(t *testing.T) {
+	t.Parallel()
+	design, _ := makePodWithNamespace(t, "default")
+	notInventory := kubernetesInventoryRelationship()
+	notInventory.SubType = "alias"
+
+	actions := identifyInventoryAdditions(design, []*relationship.RelationshipDefinition{notInventory})
+	assert.Empty(t, actions, "alias relationships must not produce inventory add_component actions")
+}
+
+// Cross-engine parity — runs the same Pod-references-default-Namespace
+// fixture through BOTH the Rego engine (data.relationship_evaluation_policy.identify_additions)
+// AND the Go engine (identifyInventoryAdditions), then asserts the emitted
+// new component carries the same Kind, Model.Name, and DisplayName.
+//
+// Pins the behavioral contract that USE_GO_POLICY_ENGINE produces the same
+// auto-added component as the OPA path. Without this test, future
+// divergence (intentional or accidental) would only surface as user-visible
+// bugs once again.
+func TestParity_RegoAndGoEngineEmitEquivalentInventoryAdditions(t *testing.T) {
+	t.Parallel()
+
+	// --- Go engine ---
+	design, _ := makePodWithNamespace(t, "default")
+	rel := kubernetesInventoryRelationship()
+
+	goActions := identifyInventoryAdditions(design, []*relationship.RelationshipDefinition{rel})
+	require.Len(t, goActions, 1, "Go engine must emit one add_component for one missing parent")
+	require.NotNil(t, goActions[0].Component)
+	goNew := goActions[0].Component
+
+	// --- Rego engine ---
+	policiesDir := "../meshmodel/meshery-core/0.7.2/v1.0.0/policies"
+	files, err := collectRegoFiles(policiesDir)
+	require.NoError(t, err)
+	var modules []func(*rego.Rego)
+	for _, file := range files {
+		if strings.Contains(file, "/tests/") || strings.HasSuffix(file, ".template") {
+			continue
+		}
+		content, readErr := os.ReadFile(file)
+		require.NoError(t, readErr)
+		modules = append(modules, rego.Module(file, string(content)))
+	}
+
+	// Mirror the rego's expected input shape — selector JSON keys match
+	// the kubernetes hierarchical-parent-inventory relationship JSON.
+	regoInput := map[string]interface{}{
+		"design_file": map[string]interface{}{
+			"components": []interface{}{
+				map[string]interface{}{
+					"id":        "pod-1",
+					"component": map[string]interface{}{"kind": "Pod"},
+					"model": map[string]interface{}{
+						"name":    "kubernetes",
+						"version": "v1.25.0",
+						"model":   map[string]interface{}{"version": "v1.25.0"},
+					},
+					"configuration": map[string]interface{}{
+						"metadata": map[string]interface{}{"namespace": "default"},
+					},
+				},
+			},
+			"relationships": []interface{}{},
+		},
+		"relationship": map[string]interface{}{
+			"kind":    "hierarchical",
+			"type":    "parent",
+			"subType": "inventory",
+			"selectors": []interface{}{
+				map[string]interface{}{
+					"allow": map[string]interface{}{
+						"from": []interface{}{
+							map[string]interface{}{
+								"kind":  "*",
+								"model": map[string]interface{}{"name": "*", "version": "", "model": map[string]interface{}{"version": ""}},
+								"patch": map[string]interface{}{
+									"mutatedRef": []interface{}{[]interface{}{"configuration", "metadata", "namespace"}},
+								},
+							},
+						},
+						"to": []interface{}{
+							map[string]interface{}{
+								"kind":  "Namespace",
+								"model": map[string]interface{}{"name": "kubernetes", "version": "", "model": map[string]interface{}{"version": ""}},
+								"patch": map[string]interface{}{
+									"mutatorRef": []interface{}{[]interface{}{"displayName"}},
+								},
+							},
+						},
+					},
+					"deny": map[string]interface{}{"from": []interface{}{}, "to": []interface{}{}},
+				},
+			},
+		},
+	}
+
+	opts := append(modules,
+		rego.Query("data.relationship_evaluation_policy.identify_additions(input.design_file, input.relationship)"),
+		rego.Input(regoInput),
+	)
+
+	rs, err := rego.New(opts...).Eval(context.Background())
+	require.NoError(t, err)
+	require.NotEmpty(t, rs)
+	require.NotEmpty(t, rs[0].Expressions)
+
+	results, ok := rs[0].Expressions[0].Value.([]interface{})
+	require.True(t, ok)
+	require.Len(t, results, 1, "rego engine must emit one add_component for one missing parent")
+
+	regoNew, ok := results[0].(map[string]interface{})
+	require.True(t, ok)
+
+	// --- Compare ---
+	regoKind := regoNew["component"].(map[string]interface{})["kind"]
+	regoModel := regoNew["model"].(map[string]interface{})["name"]
+	regoDisplay := regoNew["displayName"]
+
+	assert.Equal(t, "Namespace", goNew.Component.Kind)
+	assert.Equal(t, regoKind, goNew.Component.Kind, "Go and Rego must agree on the auto-added Kind")
+
+	require.NotNil(t, goNew.Model)
+	assert.Equal(t, "kubernetes", goNew.Model.Name)
+	assert.Equal(t, regoModel, goNew.Model.Name, "Go and Rego must agree on the auto-added Model.Name")
+
+	assert.Equal(t, "default", string(goNew.DisplayName))
+	assert.Equal(t, regoDisplay, string(goNew.DisplayName), "Go and Rego must agree on the auto-added DisplayName")
+
+	// Sanity: full JSON serialization of the relevant fields. Catches
+	// future field divergences that escape the explicit assertions above.
+	type comparisonShape struct {
+		Kind        string `json:"kind"`
+		ModelName   string `json:"modelName"`
+		DisplayName string `json:"displayName"`
+	}
+	goShape := comparisonShape{
+		Kind:        goNew.Component.Kind,
+		ModelName:   goNew.Model.Name,
+		DisplayName: string(goNew.DisplayName),
+	}
+	regoShape := comparisonShape{
+		Kind:        regoKind.(string),
+		ModelName:   regoModel.(string),
+		DisplayName: regoDisplay.(string),
+	}
+	gj, _ := json.Marshal(goShape)
+	rj, _ := json.Marshal(regoShape)
+	assert.Equal(t, string(rj), string(gj), "Go and Rego engine outputs diverge — auto-added component shape mismatch")
+}


### PR DESCRIPTION
Components added by the relationship evaluator rendered without styles in Kanvas because the v1beta1 type assertion on the registry entity silently failed (registry returns v1beta3). Convert via JSON round-trip and patch the matching add_component action payload.