### PR TITLE
fix(connections): emit camelCase server metadata keys in payload

### DIFF
--- a/server/models/connections/connections.go
+++ b/server/models/connections/connections.go
@@ -116,10 +116,10 @@ type ConnectionPayload struct {
 
 func BuildMesheryConnectionPayload(serverURL string, credential map[string]interface{}) *ConnectionPayload {
 	metadata := map[string]interface{}{
-		"server_id":        viper.GetString("INSTANCE_ID"),
-		"server_version":   viper.GetString("BUILD"),
-		"server_build_sha": viper.GetString("COMMITSHA"),
-		"server_location":  serverURL,
+		"serverId":       viper.GetString("INSTANCE_ID"),
+		"serverVersion":  viper.GetString("BUILD"),
+		"serverBuildSha": viper.GetString("COMMITSHA"),
+		"serverLocation": serverURL,
 	}
 	return &ConnectionPayload{
 		Kind:             "meshery",

--- a/server/models/connections/connections_payload_test.go
+++ b/server/models/connections/connections_payload_test.go
@@ -1,0 +1,43 @@
+package connections
+
+import (
+	"testing"
+
+	"github.com/spf13/viper"
+	"github.com/stretchr/testify/assert"
+)
+
+// TestBuildMesheryConnectionPayloadEmitsCanonicalCamelCaseKeys locks in
+// the canonical camelCase wire-format contract for the four
+// server-* JSONB metadata keys flipped in Phase 5c. The downstream
+// Remote Provider DAO (meshery-cloud) accepts both spellings during
+// the rollout window, but the upstream emitter must emit only the
+// canonical form. Regressing this back to snake_case would be a wire
+// contract violation per the identifier-naming overhaul.
+func TestBuildMesheryConnectionPayloadEmitsCanonicalCamelCaseKeys(t *testing.T) {
+	viper.Set("INSTANCE_ID", "instance-123")
+	viper.Set("BUILD", "v0.0.0-test")
+	viper.Set("COMMITSHA", "deadbeef")
+	t.Cleanup(func() {
+		viper.Set("INSTANCE_ID", "")
+		viper.Set("BUILD", "")
+		viper.Set("COMMITSHA", "")
+	})
+
+	payload := BuildMesheryConnectionPayload("https://example.test", nil)
+
+	assert.Equal(t, "instance-123", payload.MetaData["serverId"])
+	assert.Equal(t, "v0.0.0-test", payload.MetaData["serverVersion"])
+	assert.Equal(t, "deadbeef", payload.MetaData["serverBuildSha"])
+	assert.Equal(t, "https://example.test", payload.MetaData["serverLocation"])
+
+	for _, legacy := range []string{"server_id", "server_version", "server_build_sha", "server_location"} {
+		_, present := payload.MetaData[legacy]
+		assert.Falsef(t, present, "legacy snake_case key %q must not be emitted", legacy)
+	}
+
+	assert.Equal(t, "meshery", payload.Kind)
+	assert.Equal(t, "platform", payload.Type)
+	assert.Equal(t, "management", payload.SubType)
+	assert.Equal(t, CONNECTED, payload.Status)
+}


### PR DESCRIPTION
## Summary

- Phase 5c of the identifier-naming overhaul. `BuildMesheryConnectionPayload` previously emitted four snake_case literal keys (`server_id`, `server_version`, `server_build_sha`, `server_location`) into the connection's JSONB `metadata` blob, violating the canonical camelCase-wire identifier-naming contract.
- Flips the keys to canonical `serverId`, `serverVersion`, `serverBuildSha`, `serverLocation`. `ConnectionPayload.MetaData` is `map[string]interface{}` so no struct-tag changes are involved.
- The downstream Remote Provider DAO ([meshery-cloud#5193](https://github.com/layer5io/meshery-cloud/pull/0)) is being updated in lockstep to read the canonical keys with COALESCE fallback to legacy snake_case keys, so running mixed Meshery Server + Meshery Cloud versions during the rollout window is safe.

Companion to #18986 (Phase 5b — K8sContext metadata flip). Related: #19071.

## Test plan

- [x] `go build ./server/models/connections/...` — green
- [x] Verified no other call sites in the meshery repo read these specific snake_case literals
- [ ] CI: meshery server unit tests, lint
- [ ] After merge: confirm Meshery Server posts a connection with `metadata.serverId` (not `server_id`) against a meshery-cloud instance running the companion PR