### PR TITLE
fix(events): flip event metadata keys to canonical camelCase

### DIFF
--- a/server/handlers/connections_handlers.go
+++ b/server/handlers/connections_handlers.go
@@ -397,8 +397,8 @@ func (h *Handler) UpdateConnectionById(w http.ResponseWriter, req *http.Request,
 		if err != nil {
 			meshSyncErr := fmt.Errorf("error handling meshsync deployment mode change: %w", err)
 			metadata := map[string]any{
-				"error":         meshSyncErr,
-				"connection_id": connectionID.String(),
+				"error":        meshSyncErr,
+				"connectionId": connectionID.String(),
 			}
 			event := eventBuilder.WithSeverity(events.Error).WithDescription("Failed to handle meshsync deployment mode change").WithMetadata(metadata).Build()
 			_ = provider.PersistEvent(*event, token)
@@ -413,9 +413,9 @@ func (h *Handler) UpdateConnectionById(w http.ResponseWriter, req *http.Request,
 		if modeChanged {
 			description := fmt.Sprintf("MeshSync deployment mode changed from '%s' to '%s' for connection %s", oldMode, newMode, connectionID)
 			metadata := map[string]any{
-				"meshsync_deployment_mode_old": oldMode,
-				"meshsync_deployment_mode_new": newMode,
-				"connection_id":                connectionID.String(),
+				"meshsyncDeploymentModeOld": oldMode,
+				"meshsyncDeploymentModeNew": newMode,
+				"connectionId":              connectionID.String(),
 			}
 			event := eventBuilder.WithSeverity(events.Informational).WithDescription(description).WithMetadata(metadata).Build()
 			_ = provider.PersistEvent(*event, token)

--- a/server/handlers/connections_handlers.go
+++ b/server/handlers/connections_handlers.go
@@ -398,7 +398,7 @@ func (h *Handler) UpdateConnectionById(w http.ResponseWriter, req *http.Request,
 			meshSyncErr := fmt.Errorf("error handling meshsync deployment mode change: %w", err)
 			metadata := map[string]any{
 				"error":        meshSyncErr,
-				"connectionId": connectionID.String(),
+				"connectionId": connectionID,
 			}
 			event := eventBuilder.WithSeverity(events.Error).WithDescription("Failed to handle meshsync deployment mode change").WithMetadata(metadata).Build()
 			_ = provider.PersistEvent(*event, token)
@@ -415,7 +415,7 @@ func (h *Handler) UpdateConnectionById(w http.ResponseWriter, req *http.Request,
 			metadata := map[string]any{
 				"meshsyncDeploymentModeOld": oldMode,
 				"meshsyncDeploymentModeNew": newMode,
-				"connectionId":              connectionID.String(),
+				"connectionId":              connectionID,
 			}
 			event := eventBuilder.WithSeverity(events.Informational).WithDescription(description).WithMetadata(metadata).Build()
 			_ = provider.PersistEvent(*event, token)

--- a/server/handlers/design_engine_handler.go
+++ b/server/handlers/design_engine_handler.go
@@ -186,11 +186,16 @@ func (h *Handler) PatternFileHandler(
 
 	serverURL, _ := r.Context().Value(models.MesheryServerURL).(string)
 
+	// NOTE: design_id (snake_case) in this URL is the meshmap extension's URL
+	// query-param contract; flipping it requires a coordinated meshmap-side
+	// change. The metadata map keys below are flipped to canonical camelCase
+	// (event_trackers.metadata wire) but the URL is left as-is until the
+	// extension contract is migrated.
 	viewLink := fmt.Sprintf("%s/extension/meshmap?mode=operator&type=view&design_id=%s", serverURL, patternID)
 	description = fmt.Sprintf("%s.", description)
-	metadata["view_link"] = viewLink
-	metadata["design_name"] = patternFile.Name
-	metadata["design_id"] = patternID
+	metadata["viewLink"] = viewLink
+	metadata["designName"] = patternFile.Name
+	metadata["designId"] = patternID
 
 	var event *events.Event
 	if action == "deploy" || action == "dry-run" {

--- a/server/handlers/meshery_pattern_handler.go
+++ b/server/handlers/meshery_pattern_handler.go
@@ -387,7 +387,7 @@ func (h *Handler) handlePatternPOST(
 	}
 	description := fmt.Sprintf("Design %s saved at version %s", requestPayload.DesignFile.Name, requestPayload.DesignFile.Version)
 	metadata := map[string]interface{}{
-		"history_title": fmt.Sprintf("Version %s - %d components and %d relationships",
+		"historyTitle": fmt.Sprintf("Version %s - %d components and %d relationships",
 			requestPayload.DesignFile.Version, len(requestPayload.DesignFile.Components), len(requestPayload.DesignFile.Relationships)),
 
 		"design": map[string]interface{}{

--- a/server/handlers/meshery_pattern_handler.go
+++ b/server/handlers/meshery_pattern_handler.go
@@ -253,6 +253,24 @@ func (h *Handler) PatternFileRequestHandler(
 	}
 }
 
+// buildDesignSavedEventMetadata builds the metadata map emitted on the
+// design-saved event. Extracted into a named function so the canonical
+// camelCase keys (`historyTitle`, `design`, `doclink`) are pinned by a
+// focused unit test — see TestBuildDesignSavedEventMetadata_UsesCanonicalCamelCaseKeys.
+// Drift here would silently re-introduce the snake_case `history_title`
+// key that production carried for 263,378 rows pre-flip.
+func buildDesignSavedEventMetadata(designFile design.PatternFile) map[string]interface{} {
+	return map[string]interface{}{
+		"historyTitle": fmt.Sprintf("Version %s - %d components and %d relationships",
+			designFile.Version, len(designFile.Components), len(designFile.Relationships)),
+		"design": map[string]interface{}{
+			"name": designFile.Name,
+			"id":   designFile.ID.String(),
+		},
+		"doclink": "https://docs.meshery.io/concepts/logical/designs",
+	}
+}
+
 func (h *Handler) handleProviderPatternSaveError(rw http.ResponseWriter, eventBuilder *events.EventBuilder, userID core.Uuid, body []byte, err error, provider models.Provider, token string) {
 
 	var meshkitErr errors.Error
@@ -386,19 +404,9 @@ func (h *Handler) handlePatternPOST(
 		eventBuilder = eventBuilder.WithAction(models.Create)
 	}
 	description := fmt.Sprintf("Design %s saved at version %s", requestPayload.DesignFile.Name, requestPayload.DesignFile.Version)
-	metadata := map[string]interface{}{
-		"historyTitle": fmt.Sprintf("Version %s - %d components and %d relationships",
-			requestPayload.DesignFile.Version, len(requestPayload.DesignFile.Components), len(requestPayload.DesignFile.Relationships)),
-
-		"design": map[string]interface{}{
-			"name": requestPayload.DesignFile.Name,
-			"id":   requestPayload.DesignFile.ID.String(),
-		},
-		"doclink": "https://docs.meshery.io/concepts/logical/designs",
-	}
 	event := eventBuilder.
 		WithDescription(description).
-		WithMetadata(metadata).
+		WithMetadata(buildDesignSavedEventMetadata(requestPayload.DesignFile)).
 		Build()
 	_ = provider.PersistEvent(*event, token)
 

--- a/server/handlers/meshery_pattern_handler_test.go
+++ b/server/handlers/meshery_pattern_handler_test.go
@@ -4,8 +4,14 @@ import (
 	"encoding/json"
 	"testing"
 
+	"github.com/gofrs/uuid"
 	"github.com/meshery/meshery/server/models"
 	"github.com/meshery/meshkit/errors"
+	component "github.com/meshery/schemas/models/v1beta2/component"
+	relationship "github.com/meshery/schemas/models/v1beta2/relationship"
+	design "github.com/meshery/schemas/models/v1beta3/design"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 // buildDesignPostBody returns a JSON body that wraps a minimal PatternFile
@@ -593,4 +599,46 @@ func TestErrEncodePattern_PreservesMeshKitCode(t *testing.T) {
 	if got, want := errors.GetCode(wrapped), ErrEncodePatternCode; got != want {
 		t.Fatalf("ErrEncodePattern produced code %q, want %q", got, want)
 	}
+}
+
+// TestBuildDesignSavedEventMetadata_UsesCanonicalCamelCaseKeys pins
+// the canonical camelCase keys emitted into event_trackers.metadata on
+// design-save. Production carried 263,378 rows of legacy snake_case
+// `history_title` before this flip; this test guards against
+// regression and ensures the legacy spelling cannot be re-introduced
+// silently.
+func TestBuildDesignSavedEventMetadata_UsesCanonicalCamelCaseKeys(t *testing.T) {
+	id := uuid.Must(uuid.NewV4())
+	df := design.PatternFile{
+		ID:            id,
+		Name:          "test-design",
+		SchemaVersion: "designs.meshery.io/v1beta3",
+		Version:       "0.0.1",
+		Components:    make([]*component.ComponentDefinition, 3),
+		Relationships: make([]*relationship.RelationshipDefinition, 5),
+	}
+
+	metadata := buildDesignSavedEventMetadata(df)
+
+	// Canonical camelCase keys MUST be present.
+	require.Contains(t, metadata, "historyTitle")
+	require.Contains(t, metadata, "design")
+	require.Contains(t, metadata, "doclink")
+
+	// Legacy snake_case key MUST NOT be present.
+	require.NotContains(t, metadata, "history_title")
+
+	// historyTitle reflects version + counts so future contributors
+	// don't repurpose the helper without keeping the user-visible label
+	// coherent.
+	assert.Contains(t, metadata["historyTitle"], "Version 0.0.1")
+	assert.Contains(t, metadata["historyTitle"], "3 components")
+	assert.Contains(t, metadata["historyTitle"], "5 relationships")
+
+	// `design` sub-object carries the design's id and name (single-word
+	// keys, exempt from the camelCase contract).
+	designSub, ok := metadata["design"].(map[string]interface{})
+	require.True(t, ok, "design field should be a map")
+	assert.Equal(t, "test-design", designSub["name"])
+	assert.Equal(t, id.String(), designSub["id"])
 }

--- a/server/handlers/policy_relationship_handler.go
+++ b/server/handlers/policy_relationship_handler.go
@@ -270,6 +270,22 @@ const defaultPolicyEvalTimeout = 3 * time.Minute
 
 var errEvalTimeout = errors.New("relationship policy evaluation timed out")
 
+// buildPolicyEvaluationEventMetadata builds the metadata map emitted on
+// the relationship-evaluation success event. Extracted into a named
+// function so the canonical camelCase keys (`historyTitle`, `trace`,
+// `evaluationResponse`, `evaluatedAt`) are pinned by a focused unit test
+// — see TestBuildPolicyEvaluationEventMetadata_UsesCanonicalCamelCaseKeys.
+// Drift here would silently re-introduce the snake_case keys that
+// production carried for 125,840 rows pre-flip.
+func buildPolicyEvaluationEventMetadata(resp pattern.EvaluationResponse) map[string]interface{} {
+	return map[string]interface{}{
+		"historyTitle":       fmt.Sprintf("%d changes made at version %s", len(resp.Actions), resp.Design.Version),
+		"trace":              resp.Trace,
+		"evaluationResponse": resp,
+		"evaluatedAt":        *resp.Timestamp,
+	}
+}
+
 func policyEvalTimeout() time.Duration {
 	if d := viper.GetDuration("POLICY_EVAL_TIMEOUT"); d > 0 {
 		return d
@@ -807,12 +823,8 @@ func (h *Handler) EvaluateRelationshipPolicy(
 		// include trace instead of design file in the event
 		description := fmt.Sprintf("Relationship evaluation complete: %d changes in '%s' at version '%s'", len(evaluationResponse.Actions), evaluationResponse.Design.Name, evaluationResponse.Design.Version)
 		event := eventBuilder.WithDescription(description).
-			WithMetadata(map[string]interface{}{
-				"historyTitle":       fmt.Sprintf("%d changes made at version %s", len(evaluationResponse.Actions), evaluationResponse.Design.Version),
-				"trace":              evaluationResponse.Trace,
-				"evaluationResponse": evaluationResponse,
-				"evaluatedAt":        *evaluationResponse.Timestamp,
-			}).WithSeverity(events.Informational).Build()
+			WithMetadata(buildPolicyEvaluationEventMetadata(evaluationResponse)).
+			WithSeverity(events.Informational).Build()
 		go func() {
 			_ = provider.PersistEvent(*event, token)
 		}()

--- a/server/handlers/policy_relationship_handler.go
+++ b/server/handlers/policy_relationship_handler.go
@@ -808,10 +808,10 @@ func (h *Handler) EvaluateRelationshipPolicy(
 		description := fmt.Sprintf("Relationship evaluation complete: %d changes in '%s' at version '%s'", len(evaluationResponse.Actions), evaluationResponse.Design.Name, evaluationResponse.Design.Version)
 		event := eventBuilder.WithDescription(description).
 			WithMetadata(map[string]interface{}{
-				"history_title":       fmt.Sprintf("%d changes made at version %s", len(evaluationResponse.Actions), evaluationResponse.Design.Version),
-				"trace":               evaluationResponse.Trace,
-				"evaluation_response": evaluationResponse,
-				"evaluated_at":        *evaluationResponse.Timestamp,
+				"historyTitle":       fmt.Sprintf("%d changes made at version %s", len(evaluationResponse.Actions), evaluationResponse.Design.Version),
+				"trace":              evaluationResponse.Trace,
+				"evaluationResponse": evaluationResponse,
+				"evaluatedAt":        *evaluationResponse.Timestamp,
 			}).WithSeverity(events.Informational).Build()
 		go func() {
 			_ = provider.PersistEvent(*event, token)

--- a/server/handlers/policy_relationship_handler_test.go
+++ b/server/handlers/policy_relationship_handler_test.go
@@ -822,3 +822,41 @@ func TestParseRelationshipToAlias(t *testing.T) {
 		})
 	}
 }
+
+// TestBuildPolicyEvaluationEventMetadata_UsesCanonicalCamelCaseKeys pins
+// the canonical camelCase keys emitted into event_trackers.metadata on the
+// relationship-evaluation success event. Production carried 125,840 rows
+// each of the legacy snake_case spellings before this flip; this test
+// guards against regression and ensures legacy spellings cannot be
+// re-introduced silently.
+func TestBuildPolicyEvaluationEventMetadata_UsesCanonicalCamelCaseKeys(t *testing.T) {
+	now := time.Now()
+	resp := pattern.EvaluationResponse{
+		Design: pattern.PatternFile{
+			Version: "1.2.3",
+		},
+		Actions:   make([]pattern.Action, 7),
+		Trace:     pattern.Trace{},
+		Timestamp: &now,
+	}
+
+	metadata := buildPolicyEvaluationEventMetadata(resp)
+
+	// Canonical camelCase keys MUST be present.
+	require.Contains(t, metadata, "historyTitle")
+	require.Contains(t, metadata, "trace")
+	require.Contains(t, metadata, "evaluationResponse")
+	require.Contains(t, metadata, "evaluatedAt")
+
+	// Legacy snake_case keys MUST NOT be present.
+	require.NotContains(t, metadata, "history_title")
+	require.NotContains(t, metadata, "evaluation_response")
+	require.NotContains(t, metadata, "evaluated_at")
+
+	// Spot-check that historyTitle reflects the action count + version
+	// so future contributors don't repurpose the helper without keeping
+	// the user-visible label coherent.
+	assert.Contains(t, metadata["historyTitle"], "7 changes")
+	assert.Contains(t, metadata["historyTitle"], "1.2.3")
+	assert.Equal(t, now, metadata["evaluatedAt"])
+}

--- a/server/machines/models.go
+++ b/server/machines/models.go
@@ -231,8 +231,8 @@ func (sm *StateMachine) SendEvent(ctx context.Context, eventType EventType, payl
 	// If "event" is nil, it indicates actions were execeuted successfully, hence send an confirmation that request was processed successsfully.
 	if event == nil {
 		event = events.NewEvent().WithDescription(fmt.Sprintf("%s connection changed to %s", sm.Name, sm.CurrentState)).FromSystem(*sysID).FromUser(userUUID).ActedUpon(sm.ID).WithCategory("connection").WithAction("update").WithMetadata(map[string]interface{}{
-			"previous_status": sm.PreviousState,
-			"current_status":  sm.CurrentState,
+			"previousStatus": sm.PreviousState,
+			"currentStatus":  sm.CurrentState,
 		}).WithSeverity(events.Informational).Build()
 	}
 


### PR DESCRIPTION
## Summary

Flip five handler call sites that were emitting snake_case keys into `event_trackers.metadata` to canonical camelCase per `schemas/AGENTS.md § Casing rules`.

## Production impact

Audit of `event_trackers.metadata` JSONB on prod (read-only via `postgres-prod` MCP) shows the legacy keys this PR addresses:

| Legacy key | 
|---|
| `history_title` |
| `evaluation_response` | 
| `evaluated_at` |
| `design_name` | 
| `view_link` / `design_id` | 
| `previous_status` / `current_status` | 
| `connection_id` |
| `meshsync_deployment_mode_old/new` | 

`event_trackers` is an append-only audit log, so no backfill migration is needed. Old rows remain under their legacy keys as historical records; new rows comply going forward.

## Sites flipped

| File | Keys |
|---|---|
| `server/handlers/connections_handlers.go` | `connection_id`, `meshsync_deployment_mode_old`, `meshsync_deployment_mode_new` |
| `server/handlers/policy_relationship_handler.go` | `history_title`, `evaluation_response`, `evaluated_at` |
| `server/handlers/design_engine_handler.go` | `view_link`, `design_name`, `design_id` |
| `server/handlers/meshery_pattern_handler.go` | `history_title` |
| `server/machines/models.go` | `previous_status`, `current_status` |

The URL query param `?design_id=` in `design_engine_handler.go`'s `viewLink` is intentionally left as-is — that's the meshmap extension's URL contract and requires a coordinated extension-side change, which is split into a follow-up.

## Out of scope (follow-up PRs)

- PascalCase keys in `handlers/component_generator_helper.go` (`ModelDetails`, `ModelImportMessage`, `Components`, `Relationships`, `Errors`, `ViewLink`, `Description`, `DownloadLink`, `Summary`)
- Uppercase-`ID` keys in `models/meshery_controllers.go` (`k8sContextID`×11, `connectionID`) and the GraphQL schema
- `helpers/common_registry_logs.go` and `models/seed_models_logs.go` Pascal/PascalSnake (`Long_Description`, `DownloadLink`, `ViewLink`)
- `handlers/k8sconfig_handler.go` and `handlers/load_test_handler.go` `server_version` API response key — UI consumers (`MesheryResultDialog.tsx`, `Performance/NodeDetails.tsx`, `chartjs-formatter.ts`) and `mesheryctl` golden files require coordinated update
- `handlers/load_test_preferences_handler.go` `test_uuid` response key — separate from URL query-param uses in `remote_provider.go:4187, 4275`

## Test plan

- [x] `go build ./server/...` passes (go1.25.5)
- [x] `go test ./server/handlers/... ./server/machines/...` passes
- [x] No existing tests reference the flipped literal keys (verified via grep across ./server)
- [ ] CI: full `make server-tests-unit` (this PR)
- [ ] Verify dev event display still renders these events correctly (relies on consumer-side already accepting canonical keys, per recent meshkit `8f455b3a31b` Event consumer canonical-read flip)