### PR TITLE
[Server] Replace JSON schema-version bridges with typed copies

### DIFF
--- a/server/handlers/meshsync_handler.go
+++ b/server/handlers/meshsync_handler.go
@@ -371,7 +371,7 @@ func (h *Handler) GetMeshSyncResources(rw http.ResponseWriter, r *http.Request, 
 
 	// meshkit's patterns.DehydratePattern operates on v1beta3/design.PatternFile;
 	// this handler still produces a v1beta1/pattern.PatternFile (the
-	// evaluation engine carve-out). Bridge via JSON round-trip just for
+	// evaluation engine carve-out). Bridge via a typed shallow copy just for
 	// the dehydrate call, then fold the dehydrated fields back onto the
 	// v1beta1 value so the response envelope keeps its existing wire shape.
 	// Log bridge/round-trip errors instead of silently swallowing them —

--- a/server/handlers/policy_relationship_handler.go
+++ b/server/handlers/policy_relationship_handler.go
@@ -288,7 +288,7 @@ func (h *Handler) EvaluateDesign(
 	// meshkit's patternHelpers.HydratePattern is typed against
 	// v1beta3/design.PatternFile but this evaluation-engine carve-out
 	// still holds the design as v1beta1/pattern.PatternFile, so bridge
-	// via JSON round-trip and fold the hydrated fields back onto the
+	// via a typed shallow copy and fold the hydrated fields back onto the
 	// v1beta1 design before the policy passes run.
 	if bridged, bridgeErr := utils.PatternV1beta1ToV1beta3(&relationshipPolicyEvalPayload.Design); bridgeErr == nil && bridged != nil {
 		if hydrateErrs := patternHelpers.HydratePattern(bridged, h.registryManager); len(hydrateErrs) > 0 {

--- a/server/models/pattern/utils/component_version_bridge.go
+++ b/server/models/pattern/utils/component_version_bridge.go
@@ -1,7 +1,7 @@
 // Package utils contains helpers that bridge the v1beta2/component and
 // v1beta3/component representations of a component definition.
 //
-// Why this bridge exists
+// # Why this bridge exists
 //
 // meshery/schemas pins v1beta3/design.PatternFile.Components to
 // *v1beta2/component.ComponentDefinition (see schemas' v1beta3/const.go
@@ -23,9 +23,102 @@
 package utils
 
 import (
+	componentv1beta1 "github.com/meshery/schemas/models/v1beta1/component"
 	componentv1beta2 "github.com/meshery/schemas/models/v1beta2/component"
 	componentv1beta3 "github.com/meshery/schemas/models/v1beta3/component"
 )
+
+// ComponentV1beta1ToV1beta2 returns a v1beta2/component.ComponentDefinition
+// whose inner reference-typed fields (Model pointer, Capabilities slice,
+// Configuration map, Styles pointer, Metadata.AdditionalProperties map,
+// ModelId pointer) alias the source. Mutations through those aliased maps /
+// pointer targets on the returned value remain visible on the source; scalar
+// field updates on the returned value do NOT.
+func ComponentV1beta1ToV1beta2(src *componentv1beta1.ComponentDefinition) *componentv1beta2.ComponentDefinition {
+	if src == nil {
+		return nil
+	}
+	dst := &componentv1beta2.ComponentDefinition{
+		ID:             src.ID,
+		SchemaVersion:  src.SchemaVersion,
+		Version:        src.Version,
+		DisplayName:    src.DisplayName,
+		Description:    src.Description,
+		Format:         componentv1beta2.ComponentDefinitionFormat(src.Format),
+		Model:          src.Model,
+		ModelReference: src.ModelReference,
+		Styles:         src.Styles,
+		Capabilities:   src.Capabilities,
+		Metadata: componentv1beta2.ComponentDefinition_Metadata{
+			Genealogy:             src.Metadata.Genealogy,
+			IsAnnotation:          src.Metadata.IsAnnotation,
+			IsNamespaced:          src.Metadata.IsNamespaced,
+			Published:             src.Metadata.Published,
+			InstanceDetails:       src.Metadata.InstanceDetails,
+			ConfigurationUISchema: src.Metadata.ConfigurationUISchema,
+			AdditionalProperties:  src.Metadata.AdditionalProperties,
+		},
+		Configuration: src.Configuration,
+		Component: componentv1beta2.Component{
+			Kind:    src.Component.Kind,
+			Version: src.Component.Version,
+			Schema:  src.Component.Schema,
+		},
+		CreatedAt: src.CreatedAt,
+		UpdatedAt: src.UpdatedAt,
+		ModelId:   src.ModelId,
+	}
+	if src.Status != nil {
+		st := componentv1beta2.ComponentDefinitionStatus(*src.Status)
+		dst.Status = &st
+	}
+	return dst
+}
+
+// ComponentV1beta2ToV1beta1 is the inverse bridge: a shallow field copy that
+// keeps pointer/reference-typed inner fields (Model, Styles, Capabilities,
+// Configuration, Metadata.AdditionalProperties, ModelId) aliased across both
+// versions so mutations remain visible across the bridge.
+func ComponentV1beta2ToV1beta1(src *componentv1beta2.ComponentDefinition) *componentv1beta1.ComponentDefinition {
+	if src == nil {
+		return nil
+	}
+	dst := &componentv1beta1.ComponentDefinition{
+		ID:             src.ID,
+		SchemaVersion:  src.SchemaVersion,
+		Version:        src.Version,
+		DisplayName:    src.DisplayName,
+		Description:    src.Description,
+		Format:         componentv1beta1.ComponentDefinitionFormat(src.Format),
+		Model:          src.Model,
+		ModelReference: src.ModelReference,
+		Styles:         src.Styles,
+		Capabilities:   src.Capabilities,
+		Metadata: componentv1beta1.ComponentDefinition_Metadata{
+			Genealogy:             src.Metadata.Genealogy,
+			IsAnnotation:          src.Metadata.IsAnnotation,
+			IsNamespaced:          src.Metadata.IsNamespaced,
+			Published:             src.Metadata.Published,
+			InstanceDetails:       src.Metadata.InstanceDetails,
+			ConfigurationUISchema: src.Metadata.ConfigurationUISchema,
+			AdditionalProperties:  src.Metadata.AdditionalProperties,
+		},
+		Configuration: src.Configuration,
+		Component: componentv1beta1.Component{
+			Kind:    src.Component.Kind,
+			Version: src.Component.Version,
+			Schema:  src.Component.Schema,
+		},
+		CreatedAt: src.CreatedAt,
+		UpdatedAt: src.UpdatedAt,
+		ModelId:   src.ModelId,
+	}
+	if src.Status != nil {
+		st := componentv1beta1.ComponentDefinitionStatus(*src.Status)
+		dst.Status = &st
+	}
+	return dst
+}
 
 // ComponentV1beta2ToV1beta3 returns a v1beta3/component.ComponentDefinition
 // whose inner reference-typed fields (Model pointer, Capabilities slice,

--- a/server/models/pattern/utils/patternfile_version_bridge.go
+++ b/server/models/pattern/utils/patternfile_version_bridge.go
@@ -1,39 +1,47 @@
 // This file bridges the v1beta1/pattern.PatternFile and
-// v1beta3/design.PatternFile representations by round-tripping through
-// JSON. It exists because the evaluation-engine (rego policies,
+// v1beta3/design.PatternFile representations with typed shallow field
+// copies. It exists because the evaluation-engine (rego policies,
 // EvaluationRequest / EvaluationResponse) is a documented carve-out that
 // still consumes v1beta1/pattern, while meshkit's HydratePattern /
 // DehydratePattern helpers operate exclusively on v1beta3/design.
 //
 // The nested component representation differs between the two versions
-// (v1beta1/component vs v1beta2/component) but their JSON wire forms
-// overlap on the fields the policy engine and dehydrate helper read, so
-// a Marshal + Unmarshal is both straightforward and forward-compatible
-// with future field additions.
+// (v1beta1/component vs v1beta2/component), while relationships stay on
+// the same v1beta2 type in both versions. The conversion therefore
+// reuses the component shallow-copy bridges and preserves aliasing for
+// shared maps, slices, and pointer targets instead of silently dropping
+// non-JSON fields such as AdditionalProperties.
 package utils
 
 import (
-	"encoding/json"
-
+	componentv1beta1 "github.com/meshery/schemas/models/v1beta1/component"
 	patternv1beta1 "github.com/meshery/schemas/models/v1beta1/pattern"
+	componentv1beta2 "github.com/meshery/schemas/models/v1beta2/component"
 	designv1beta3 "github.com/meshery/schemas/models/v1beta3/design"
 )
 
 // PatternV1beta3ToV1beta1 converts a v1beta3/design.PatternFile into the
 // v1beta1/pattern.PatternFile shape that the evaluation engine still
-// consumes. Errors surface only if JSON encoding / decoding fails, which
-// would indicate a malformed PatternFile to begin with.
+// consumes. The conversion is a shallow typed copy, so the error return
+// is preserved only for caller stability.
 func PatternV1beta3ToV1beta1(src *designv1beta3.PatternFile) (*patternv1beta1.PatternFile, error) {
 	if src == nil {
 		return nil, nil
 	}
-	raw, err := json.Marshal(src)
-	if err != nil {
-		return nil, err
+	dst := &patternv1beta1.PatternFile{
+		ID:            src.ID,
+		Name:          src.Name,
+		SchemaVersion: src.SchemaVersion,
+		Version:       src.Version,
+		Metadata:      patternMetadataV1beta3ToV1beta1(src.Metadata),
+		Preferences:   designPreferencesV1beta3ToV1beta1(src.Preferences),
+		Relationships: src.Relationships,
 	}
-	dst := &patternv1beta1.PatternFile{}
-	if err := json.Unmarshal(raw, dst); err != nil {
-		return nil, err
+	if src.Components != nil {
+		dst.Components = make([]*componentv1beta1.ComponentDefinition, len(src.Components))
+		for i, component := range src.Components {
+			dst.Components[i] = ComponentV1beta2ToV1beta1(component)
+		}
 	}
 	return dst, nil
 }
@@ -45,13 +53,58 @@ func PatternV1beta1ToV1beta3(src *patternv1beta1.PatternFile) (*designv1beta3.Pa
 	if src == nil {
 		return nil, nil
 	}
-	raw, err := json.Marshal(src)
-	if err != nil {
-		return nil, err
+	dst := &designv1beta3.PatternFile{
+		ID:            src.ID,
+		Name:          src.Name,
+		SchemaVersion: src.SchemaVersion,
+		Version:       src.Version,
+		Metadata:      patternMetadataV1beta1ToV1beta3(src.Metadata),
+		Preferences:   designPreferencesV1beta1ToV1beta3(src.Preferences),
+		Relationships: src.Relationships,
 	}
-	dst := &designv1beta3.PatternFile{}
-	if err := json.Unmarshal(raw, dst); err != nil {
-		return nil, err
+	if src.Components != nil {
+		dst.Components = make([]*componentv1beta2.ComponentDefinition, len(src.Components))
+		for i, component := range src.Components {
+			dst.Components[i] = ComponentV1beta1ToV1beta2(component)
+		}
 	}
 	return dst, nil
+}
+
+func patternMetadataV1beta1ToV1beta3(src *patternv1beta1.PatternFile_Metadata) *designv1beta3.PatternFile_Metadata {
+	if src == nil {
+		return nil
+	}
+	return &designv1beta3.PatternFile_Metadata{
+		ResolvedAliases:      src.ResolvedAliases,
+		AdditionalProperties: src.AdditionalProperties,
+	}
+}
+
+func patternMetadataV1beta3ToV1beta1(src *designv1beta3.PatternFile_Metadata) *patternv1beta1.PatternFile_Metadata {
+	if src == nil {
+		return nil
+	}
+	return &patternv1beta1.PatternFile_Metadata{
+		ResolvedAliases:      src.ResolvedAliases,
+		AdditionalProperties: src.AdditionalProperties,
+	}
+}
+
+func designPreferencesV1beta1ToV1beta3(src *patternv1beta1.DesignPreferences) *designv1beta3.DesignPreferences {
+	if src == nil {
+		return nil
+	}
+	return &designv1beta3.DesignPreferences{
+		Layers: src.Layers,
+	}
+}
+
+func designPreferencesV1beta3ToV1beta1(src *designv1beta3.DesignPreferences) *patternv1beta1.DesignPreferences {
+	if src == nil {
+		return nil
+	}
+	return &patternv1beta1.DesignPreferences{
+		Layers: src.Layers,
+	}
 }

--- a/server/models/pattern/utils/patternfile_version_bridge_test.go
+++ b/server/models/pattern/utils/patternfile_version_bridge_test.go
@@ -1,0 +1,155 @@
+package utils
+
+import (
+	"encoding/json"
+	"testing"
+
+	componentv1beta1 "github.com/meshery/schemas/models/v1beta1/component"
+	modelv1beta1 "github.com/meshery/schemas/models/v1beta1/model"
+	patternv1beta1 "github.com/meshery/schemas/models/v1beta1/pattern"
+	relationshipv1beta2 "github.com/meshery/schemas/models/v1beta2/relationship"
+	designv1beta3 "github.com/meshery/schemas/models/v1beta3/design"
+)
+
+func TestPatternV1beta1ToV1beta3_PreservesAliasedFields(t *testing.T) {
+	src := newPatternV1beta1Fixture()
+
+	dst, err := PatternV1beta1ToV1beta3(src)
+	if err != nil {
+		t.Fatalf("PatternV1beta1ToV1beta3() unexpected error: %v", err)
+	}
+	if dst == nil {
+		t.Fatal("PatternV1beta1ToV1beta3() returned nil")
+	}
+	if got, want := dst.Name, src.Name; got != want {
+		t.Fatalf("Name = %q, want %q", got, want)
+	}
+	if len(dst.Components) != 1 {
+		t.Fatalf("expected 1 component, got %d", len(dst.Components))
+	}
+	if dst.Relationships[0] != src.Relationships[0] {
+		t.Fatal("relationship pointers should stay aliased across the pattern bridge")
+	}
+	if got := dst.Metadata.AdditionalProperties["team"]; got != "meshery" {
+		t.Fatalf("metadata additionalProperties not preserved, got %#v", got)
+	}
+	if got := dst.Components[0].Metadata.AdditionalProperties["componentKey"]; got != "componentValue" {
+		t.Fatalf("component metadata additionalProperties not preserved, got %#v", got)
+	}
+
+	dst.Preferences.Layers["annotations"] = true
+	if got := src.Preferences.Layers["annotations"]; got != true {
+		t.Fatalf("preference layers mutation did not reflect on source, got %#v", got)
+	}
+
+	dst.Metadata.AdditionalProperties["owner"] = "catalog"
+	if got := src.Metadata.AdditionalProperties["owner"]; got != "catalog" {
+		t.Fatalf("metadata alias lost, got %#v", got)
+	}
+
+	dst.Components[0].Configuration["replicas"] = 3
+	if got := src.Components[0].Configuration["replicas"]; got != 3 {
+		t.Fatalf("component configuration alias lost, got %#v", got)
+	}
+
+	dst.Components[0].Metadata.AdditionalProperties["ui"] = "dark"
+	if got := src.Components[0].Metadata.AdditionalProperties["ui"]; got != "dark" {
+		t.Fatalf("component metadata alias lost, got %#v", got)
+	}
+
+	roundtripped, err := PatternV1beta3ToV1beta1(dst)
+	if err != nil {
+		t.Fatalf("PatternV1beta3ToV1beta1() unexpected error: %v", err)
+	}
+	if roundtripped == nil {
+		t.Fatal("PatternV1beta3ToV1beta1() returned nil")
+	}
+	if got := roundtripped.Components[0].Configuration["replicas"]; got != 3 {
+		t.Fatalf("round-tripped component configuration missing mutation, got %#v", got)
+	}
+	if got := roundtripped.Metadata.AdditionalProperties["owner"]; got != "catalog" {
+		t.Fatalf("round-tripped metadata missing mutation, got %#v", got)
+	}
+}
+
+func TestPatternV1beta1ToV1beta3_PreservesAliasContractLostByJSON(t *testing.T) {
+	src := newPatternV1beta1Fixture()
+
+	typed, err := PatternV1beta1ToV1beta3(src)
+	if err != nil {
+		t.Fatalf("PatternV1beta1ToV1beta3() unexpected error: %v", err)
+	}
+
+	raw, err := json.Marshal(src)
+	if err != nil {
+		t.Fatalf("json.Marshal() unexpected error: %v", err)
+	}
+	var legacy designv1beta3.PatternFile
+	if err := json.Unmarshal(raw, &legacy); err != nil {
+		t.Fatalf("json.Unmarshal() unexpected error: %v", err)
+	}
+
+	typed.Preferences.Layers["typed-layer"] = "present"
+	if got := src.Preferences.Layers["typed-layer"]; got != "present" {
+		t.Fatalf("typed bridge lost preference aliasing, got %#v", got)
+	}
+	legacy.Preferences.Layers["json-layer"] = "detached"
+	if _, ok := src.Preferences.Layers["json-layer"]; ok {
+		t.Fatal("legacy JSON path unexpectedly preserved preference aliasing")
+	}
+
+	typed.Components[0].Configuration["typed-config"] = "present"
+	if got := src.Components[0].Configuration["typed-config"]; got != "present" {
+		t.Fatalf("typed bridge lost component configuration aliasing, got %#v", got)
+	}
+	legacy.Components[0].Configuration["json-config"] = "detached"
+	if _, ok := src.Components[0].Configuration["json-config"]; ok {
+		t.Fatal("legacy JSON path unexpectedly preserved component configuration aliasing")
+	}
+}
+
+func newPatternV1beta1Fixture() *patternv1beta1.PatternFile {
+	return &patternv1beta1.PatternFile{
+		Name:          "typed-bridge",
+		SchemaVersion: "designs.meshery.io/v1beta1",
+		Version:       "0.0.1",
+		Metadata: &patternv1beta1.PatternFile_Metadata{
+			AdditionalProperties: map[string]interface{}{
+				"team": "meshery",
+			},
+		},
+		Components: []*componentv1beta1.ComponentDefinition{
+			{
+				DisplayName: "nginx",
+				ModelReference: modelv1beta1.ModelReference{
+					Name: "kubernetes",
+				},
+				Metadata: componentv1beta1.ComponentDefinition_Metadata{
+					AdditionalProperties: map[string]interface{}{
+						"componentKey": "componentValue",
+					},
+				},
+				Configuration: map[string]interface{}{
+					"replicas": 1,
+				},
+				Component: componentv1beta1.Component{
+					Kind:    "Deployment",
+					Version: "apps/v1",
+				},
+			},
+		},
+		Preferences: &patternv1beta1.DesignPreferences{
+			Layers: map[string]interface{}{
+				"relationships": false,
+			},
+		},
+		Relationships: []*relationshipv1beta2.RelationshipDefinition{
+			{
+				Kind:             relationshipv1beta2.RelationshipDefinitionKind("hierarchical"),
+				RelationshipType: "parent",
+				SubType:          "inventory",
+				Version:          "0.0.1",
+			},
+		},
+	}
+}

--- a/server/models/pattern/utils/relationship_version_bridge.go
+++ b/server/models/pattern/utils/relationship_version_bridge.go
@@ -117,6 +117,10 @@ func relationshipMetadataV1alpha3ToV1beta2(src *relationshipv1alpha3.Relationshi
 	if src == nil {
 		return nil
 	}
+	// Keep the explicit field copy here instead of a direct struct conversion:
+	// the metadata envelope is structurally close across versions, but its
+	// Styles pointer targets version-specific structs whose enum-typed pointer
+	// fields differ by package and therefore cannot be converted wholesale.
 	return &relationshipv1beta2.RelationshipMetadata{
 		Description:          src.Description,
 		IsAnnotation:         src.IsAnnotation,
@@ -129,6 +133,9 @@ func relationshipMetadataV1beta2ToV1alpha3(src *relationshipv1beta2.Relationship
 	if src == nil {
 		return nil
 	}
+	// Same rationale as relationshipMetadataV1alpha3ToV1beta2: the nested Styles
+	// payload carries version-specific enum pointer types, so the bridge must
+	// copy explicitly rather than rely on a direct struct conversion.
 	return &relationshipv1alpha3.RelationshipMetadata{
 		Description:          src.Description,
 		IsAnnotation:         src.IsAnnotation,
@@ -217,6 +224,9 @@ func selectorSetV1alpha3ToV1beta2(src *relationshipv1alpha3.SelectorSet) *relati
 	if src == nil {
 		return nil
 	}
+	// Rebuild the outer selector slice because the item types differ across
+	// versions; inner pointer- and slice-typed fields stay aliased via the
+	// nested helpers so in-place mutations remain visible to both sides.
 	dst := make(relationshipv1beta2.SelectorSet, len(*src))
 	for i, item := range *src {
 		dst[i] = selectorSetItemV1alpha3ToV1beta2(item)
@@ -228,6 +238,9 @@ func selectorSetV1beta2ToV1alpha3(src *relationshipv1beta2.SelectorSet) *relatio
 	if src == nil {
 		return nil
 	}
+	// Rebuild the outer selector slice because the item types differ across
+	// versions; inner pointer- and slice-typed fields stay aliased via the
+	// nested helpers so in-place mutations remain visible to both sides.
 	dst := make(relationshipv1alpha3.SelectorSet, len(*src))
 	for i, item := range *src {
 		dst[i] = selectorSetItemV1beta2ToV1alpha3(item)

--- a/server/models/pattern/utils/relationship_version_bridge.go
+++ b/server/models/pattern/utils/relationship_version_bridge.go
@@ -1,0 +1,400 @@
+package utils
+
+import (
+	capabilityv1alpha1 "github.com/meshery/schemas/models/v1alpha1/capability"
+	relationshipv1alpha3 "github.com/meshery/schemas/models/v1alpha3/relationship"
+	capabilityv1beta1 "github.com/meshery/schemas/models/v1beta1/capability"
+	relationshipv1beta2 "github.com/meshery/schemas/models/v1beta2/relationship"
+)
+
+// RelationshipV1alpha3ToV1beta2 converts the registry's v1alpha3
+// RelationshipDefinition into the v1beta2 shape used by the Go policy engine.
+// The conversion is a shallow typed copy: shared maps, selector/model pointers,
+// and same-typed scalar pointers remain aliased, while fields whose pointed-to
+// named types differ across versions are copied explicitly.
+func RelationshipV1alpha3ToV1beta2(src *relationshipv1alpha3.RelationshipDefinition) *relationshipv1beta2.RelationshipDefinition {
+	if src == nil {
+		return nil
+	}
+	dst := &relationshipv1beta2.RelationshipDefinition{
+		ID:                   src.ID,
+		Capabilities:         relationshipCapabilitiesV1alpha3ToV1beta2(src.Capabilities),
+		EvaluationQuery:      src.EvaluationQuery,
+		Kind:                 relationshipv1beta2.RelationshipDefinitionKind(src.Kind),
+		RelationshipMetadata: relationshipMetadataV1alpha3ToV1beta2(src.Metadata),
+		Model:                src.Model,
+		ModelId:              src.ModelId,
+		SchemaVersion:        src.SchemaVersion,
+		Selectors:            selectorSetV1alpha3ToV1beta2(src.Selectors),
+		SubType:              src.SubType,
+		Status:               convertEnumPtr[relationshipv1alpha3.RelationshipDefinitionStatus, relationshipv1beta2.RelationshipDefinitionStatus](src.Status),
+		RelationshipType:     src.RelationshipType,
+		Version:              src.Version,
+	}
+	return dst
+}
+
+// RelationshipV1beta2ToV1alpha3 is the inverse bridge used by tests and future
+// callers that need to round-trip a relationship definition back into the
+// registry-facing schema version.
+func RelationshipV1beta2ToV1alpha3(src *relationshipv1beta2.RelationshipDefinition) *relationshipv1alpha3.RelationshipDefinition {
+	if src == nil {
+		return nil
+	}
+	dst := &relationshipv1alpha3.RelationshipDefinition{
+		ID:               src.ID,
+		Capabilities:     relationshipCapabilitiesV1beta2ToV1alpha3(src.Capabilities),
+		EvaluationQuery:  src.EvaluationQuery,
+		Kind:             relationshipv1alpha3.RelationshipDefinitionKind(src.Kind),
+		Metadata:         relationshipMetadataV1beta2ToV1alpha3(src.RelationshipMetadata),
+		Model:            src.Model,
+		ModelId:          src.ModelId,
+		SchemaVersion:    src.SchemaVersion,
+		Selectors:        selectorSetV1beta2ToV1alpha3(src.Selectors),
+		SubType:          src.SubType,
+		Status:           convertEnumPtr[relationshipv1beta2.RelationshipDefinitionStatus, relationshipv1alpha3.RelationshipDefinitionStatus](src.Status),
+		RelationshipType: src.RelationshipType,
+		Version:          src.Version,
+	}
+	return dst
+}
+
+func relationshipCapabilitiesV1alpha3ToV1beta2(src *[]capabilityv1alpha1.Capability) *[]capabilityv1beta1.Capability {
+	if src == nil {
+		return nil
+	}
+	dst := make([]capabilityv1beta1.Capability, len(*src))
+	for i, capability := range *src {
+		dst[i] = capabilityV1alpha1ToV1beta1(capability)
+	}
+	return &dst
+}
+
+func relationshipCapabilitiesV1beta2ToV1alpha3(src *[]capabilityv1beta1.Capability) *[]capabilityv1alpha1.Capability {
+	if src == nil {
+		return nil
+	}
+	dst := make([]capabilityv1alpha1.Capability, len(*src))
+	for i, capability := range *src {
+		dst[i] = capabilityV1beta1ToV1alpha1(capability)
+	}
+	return &dst
+}
+
+func capabilityV1alpha1ToV1beta1(src capabilityv1alpha1.Capability) capabilityv1beta1.Capability {
+	return capabilityv1beta1.Capability{
+		Description:   src.Description,
+		DisplayName:   src.DisplayName,
+		EntityState:   src.EntityState,
+		Key:           src.Key,
+		Kind:          src.Kind,
+		Metadata:      src.Metadata,
+		SchemaVersion: src.SchemaVersion,
+		Status:        capabilityv1beta1.CapabilityStatus(src.Status),
+		SubType:       src.SubType,
+		Type:          src.Type,
+		Version:       src.Version,
+	}
+}
+
+func capabilityV1beta1ToV1alpha1(src capabilityv1beta1.Capability) capabilityv1alpha1.Capability {
+	return capabilityv1alpha1.Capability{
+		Description:   src.Description,
+		DisplayName:   src.DisplayName,
+		EntityState:   src.EntityState,
+		Key:           src.Key,
+		Kind:          src.Kind,
+		Metadata:      src.Metadata,
+		SchemaVersion: src.SchemaVersion,
+		Status:        capabilityv1alpha1.CapabilityStatus(src.Status),
+		SubType:       src.SubType,
+		Type:          src.Type,
+		Version:       src.Version,
+	}
+}
+
+func relationshipMetadataV1alpha3ToV1beta2(src *relationshipv1alpha3.RelationshipMetadata) *relationshipv1beta2.RelationshipMetadata {
+	if src == nil {
+		return nil
+	}
+	return &relationshipv1beta2.RelationshipMetadata{
+		Description:          src.Description,
+		IsAnnotation:         src.IsAnnotation,
+		Styles:               relationshipStylesV1alpha3ToV1beta2(src.Styles),
+		AdditionalProperties: src.AdditionalProperties,
+	}
+}
+
+func relationshipMetadataV1beta2ToV1alpha3(src *relationshipv1beta2.RelationshipMetadata) *relationshipv1alpha3.RelationshipMetadata {
+	if src == nil {
+		return nil
+	}
+	return &relationshipv1alpha3.RelationshipMetadata{
+		Description:          src.Description,
+		IsAnnotation:         src.IsAnnotation,
+		Styles:               relationshipStylesV1beta2ToV1alpha3(src.Styles),
+		AdditionalProperties: src.AdditionalProperties,
+	}
+}
+
+func relationshipStylesV1alpha3ToV1beta2(src *relationshipv1alpha3.RelationshipDefinitionMetadataStyles) *relationshipv1beta2.RelationshipDefinitionMetadataStyles {
+	if src == nil {
+		return nil
+	}
+	return &relationshipv1beta2.RelationshipDefinitionMetadataStyles{
+		ArrowScale:          src.ArrowScale,
+		Color:               src.Color,
+		CurveStyle:          convertEnumPtr[relationshipv1alpha3.RelationshipDefinitionMetadataStylesCurveStyle, relationshipv1beta2.RelationshipDefinitionMetadataStylesCurveStyle](src.CurveStyle),
+		EdgeAnimation:       src.EdgeAnimation,
+		FontFamily:          src.FontFamily,
+		FontSize:            src.FontSize,
+		FontStyle:           src.FontStyle,
+		FontWeight:          src.FontWeight,
+		Label:               src.Label,
+		LineCap:             convertEnumPtr[relationshipv1alpha3.RelationshipDefinitionMetadataStylesLineCap, relationshipv1beta2.RelationshipDefinitionMetadataStylesLineCap](src.LineCap),
+		LineColor:           src.LineColor,
+		LineOpacity:         src.LineOpacity,
+		LineStyle:           convertEnumPtr[relationshipv1alpha3.RelationshipDefinitionMetadataStylesLineStyle, relationshipv1beta2.RelationshipDefinitionMetadataStylesLineStyle](src.LineStyle),
+		MidTargetArrowColor: src.MidTargetArrowColor,
+		MidTargetArrowFill:  convertEnumPtr[relationshipv1alpha3.RelationshipDefinitionMetadataStylesMidTargetArrowFill, relationshipv1beta2.RelationshipDefinitionMetadataStylesMidTargetArrowFill](src.MidTargetArrowFill),
+		MidTargetArrowShape: convertEnumPtr[relationshipv1alpha3.RelationshipDefinitionMetadataStylesMidTargetArrowShape, relationshipv1beta2.RelationshipDefinitionMetadataStylesMidTargetArrowShape](src.MidTargetArrowShape),
+		Opacity:             src.Opacity,
+		PrimaryColor:        src.PrimaryColor,
+		SecondaryColor:      src.SecondaryColor,
+		SourceLabel:         src.SourceLabel,
+		SvgColor:            src.SvgColor,
+		SvgComplete:         src.SvgComplete,
+		SvgWhite:            src.SvgWhite,
+		TargetArrowColor:    src.TargetArrowColor,
+		TargetArrowFill:     convertEnumPtr[relationshipv1alpha3.RelationshipDefinitionMetadataStylesTargetArrowFill, relationshipv1beta2.RelationshipDefinitionMetadataStylesTargetArrowFill](src.TargetArrowFill),
+		TargetArrowShape:    convertEnumPtr[relationshipv1alpha3.RelationshipDefinitionMetadataStylesTargetArrowShape, relationshipv1beta2.RelationshipDefinitionMetadataStylesTargetArrowShape](src.TargetArrowShape),
+		TargetLabel:         src.TargetLabel,
+		TextOpacity:         src.TextOpacity,
+		TextTransform:       convertEnumPtr[relationshipv1alpha3.RelationshipDefinitionMetadataStylesTextTransform, relationshipv1beta2.RelationshipDefinitionMetadataStylesTextTransform](src.TextTransform),
+		ZIndex:              src.ZIndex,
+	}
+}
+
+func relationshipStylesV1beta2ToV1alpha3(src *relationshipv1beta2.RelationshipDefinitionMetadataStyles) *relationshipv1alpha3.RelationshipDefinitionMetadataStyles {
+	if src == nil {
+		return nil
+	}
+	return &relationshipv1alpha3.RelationshipDefinitionMetadataStyles{
+		ArrowScale:          src.ArrowScale,
+		Color:               src.Color,
+		CurveStyle:          convertEnumPtr[relationshipv1beta2.RelationshipDefinitionMetadataStylesCurveStyle, relationshipv1alpha3.RelationshipDefinitionMetadataStylesCurveStyle](src.CurveStyle),
+		EdgeAnimation:       src.EdgeAnimation,
+		FontFamily:          src.FontFamily,
+		FontSize:            src.FontSize,
+		FontStyle:           src.FontStyle,
+		FontWeight:          src.FontWeight,
+		Label:               src.Label,
+		LineCap:             convertEnumPtr[relationshipv1beta2.RelationshipDefinitionMetadataStylesLineCap, relationshipv1alpha3.RelationshipDefinitionMetadataStylesLineCap](src.LineCap),
+		LineColor:           src.LineColor,
+		LineOpacity:         src.LineOpacity,
+		LineStyle:           convertEnumPtr[relationshipv1beta2.RelationshipDefinitionMetadataStylesLineStyle, relationshipv1alpha3.RelationshipDefinitionMetadataStylesLineStyle](src.LineStyle),
+		MidTargetArrowColor: src.MidTargetArrowColor,
+		MidTargetArrowFill:  convertEnumPtr[relationshipv1beta2.RelationshipDefinitionMetadataStylesMidTargetArrowFill, relationshipv1alpha3.RelationshipDefinitionMetadataStylesMidTargetArrowFill](src.MidTargetArrowFill),
+		MidTargetArrowShape: convertEnumPtr[relationshipv1beta2.RelationshipDefinitionMetadataStylesMidTargetArrowShape, relationshipv1alpha3.RelationshipDefinitionMetadataStylesMidTargetArrowShape](src.MidTargetArrowShape),
+		Opacity:             src.Opacity,
+		PrimaryColor:        src.PrimaryColor,
+		SecondaryColor:      src.SecondaryColor,
+		SourceLabel:         src.SourceLabel,
+		SvgColor:            src.SvgColor,
+		SvgComplete:         src.SvgComplete,
+		SvgWhite:            src.SvgWhite,
+		TargetArrowColor:    src.TargetArrowColor,
+		TargetArrowFill:     convertEnumPtr[relationshipv1beta2.RelationshipDefinitionMetadataStylesTargetArrowFill, relationshipv1alpha3.RelationshipDefinitionMetadataStylesTargetArrowFill](src.TargetArrowFill),
+		TargetArrowShape:    convertEnumPtr[relationshipv1beta2.RelationshipDefinitionMetadataStylesTargetArrowShape, relationshipv1alpha3.RelationshipDefinitionMetadataStylesTargetArrowShape](src.TargetArrowShape),
+		TargetLabel:         src.TargetLabel,
+		TextOpacity:         src.TextOpacity,
+		TextTransform:       convertEnumPtr[relationshipv1beta2.RelationshipDefinitionMetadataStylesTextTransform, relationshipv1alpha3.RelationshipDefinitionMetadataStylesTextTransform](src.TextTransform),
+		ZIndex:              src.ZIndex,
+	}
+}
+
+func selectorSetV1alpha3ToV1beta2(src *relationshipv1alpha3.SelectorSet) *relationshipv1beta2.SelectorSet {
+	if src == nil {
+		return nil
+	}
+	dst := make(relationshipv1beta2.SelectorSet, len(*src))
+	for i, item := range *src {
+		dst[i] = selectorSetItemV1alpha3ToV1beta2(item)
+	}
+	return &dst
+}
+
+func selectorSetV1beta2ToV1alpha3(src *relationshipv1beta2.SelectorSet) *relationshipv1alpha3.SelectorSet {
+	if src == nil {
+		return nil
+	}
+	dst := make(relationshipv1alpha3.SelectorSet, len(*src))
+	for i, item := range *src {
+		dst[i] = selectorSetItemV1beta2ToV1alpha3(item)
+	}
+	return &dst
+}
+
+func selectorSetItemV1alpha3ToV1beta2(src relationshipv1alpha3.SelectorSetItem) relationshipv1beta2.SelectorSetItem {
+	return relationshipv1beta2.SelectorSetItem{
+		Allow: selectorV1alpha3ToV1beta2(src.Allow),
+		Deny:  selectorV1alpha3ToV1beta2Ptr(src.Deny),
+	}
+}
+
+func selectorSetItemV1beta2ToV1alpha3(src relationshipv1beta2.SelectorSetItem) relationshipv1alpha3.SelectorSetItem {
+	return relationshipv1alpha3.SelectorSetItem{
+		Allow: selectorV1beta2ToV1alpha3(src.Allow),
+		Deny:  selectorV1beta2ToV1alpha3Ptr(src.Deny),
+	}
+}
+
+func selectorV1alpha3ToV1beta2(src relationshipv1alpha3.Selector) relationshipv1beta2.Selector {
+	return relationshipv1beta2.Selector{
+		From: selectorItemsV1alpha3ToV1beta2(src.From),
+		To:   selectorItemsV1alpha3ToV1beta2(src.To),
+	}
+}
+
+func selectorV1beta2ToV1alpha3(src relationshipv1beta2.Selector) relationshipv1alpha3.Selector {
+	return relationshipv1alpha3.Selector{
+		From: selectorItemsV1beta2ToV1alpha3(src.From),
+		To:   selectorItemsV1beta2ToV1alpha3(src.To),
+	}
+}
+
+func selectorV1alpha3ToV1beta2Ptr(src *relationshipv1alpha3.Selector) *relationshipv1beta2.Selector {
+	if src == nil {
+		return nil
+	}
+	dst := selectorV1alpha3ToV1beta2(*src)
+	return &dst
+}
+
+func selectorV1beta2ToV1alpha3Ptr(src *relationshipv1beta2.Selector) *relationshipv1alpha3.Selector {
+	if src == nil {
+		return nil
+	}
+	dst := selectorV1beta2ToV1alpha3(*src)
+	return &dst
+}
+
+func selectorItemsV1alpha3ToV1beta2(src []relationshipv1alpha3.SelectorItem) []relationshipv1beta2.SelectorItem {
+	if src == nil {
+		return nil
+	}
+	dst := make([]relationshipv1beta2.SelectorItem, len(src))
+	for i, item := range src {
+		dst[i] = relationshipv1beta2.SelectorItem{
+			ID:                                   item.ID,
+			Kind:                                 item.Kind,
+			Match:                                matchSelectorV1alpha3ToV1beta2(item.Match),
+			MatchStrategyMatrix:                  item.MatchStrategyMatrix,
+			Model:                                item.Model,
+			RelationshipDefinitionSelectorsPatch: relationshipSelectorsPatchV1alpha3ToV1beta2(item.Patch),
+		}
+	}
+	return dst
+}
+
+func selectorItemsV1beta2ToV1alpha3(src []relationshipv1beta2.SelectorItem) []relationshipv1alpha3.SelectorItem {
+	if src == nil {
+		return nil
+	}
+	dst := make([]relationshipv1alpha3.SelectorItem, len(src))
+	for i, item := range src {
+		dst[i] = relationshipv1alpha3.SelectorItem{
+			ID:                  item.ID,
+			Kind:                item.Kind,
+			Match:               matchSelectorV1beta2ToV1alpha3(item.Match),
+			MatchStrategyMatrix: item.MatchStrategyMatrix,
+			Model:               item.Model,
+			Patch:               relationshipSelectorsPatchV1beta2ToV1alpha3(item.RelationshipDefinitionSelectorsPatch),
+		}
+	}
+	return dst
+}
+
+func matchSelectorV1alpha3ToV1beta2(src *relationshipv1alpha3.MatchSelector) *relationshipv1beta2.MatchSelector {
+	if src == nil {
+		return nil
+	}
+	return &relationshipv1beta2.MatchSelector{
+		From: matchSelectorItemsV1alpha3ToV1beta2(src.From),
+		Refs: src.Refs,
+		To:   matchSelectorItemsV1alpha3ToV1beta2(src.To),
+	}
+}
+
+func matchSelectorV1beta2ToV1alpha3(src *relationshipv1beta2.MatchSelector) *relationshipv1alpha3.MatchSelector {
+	if src == nil {
+		return nil
+	}
+	return &relationshipv1alpha3.MatchSelector{
+		From: matchSelectorItemsV1beta2ToV1alpha3(src.From),
+		Refs: src.Refs,
+		To:   matchSelectorItemsV1beta2ToV1alpha3(src.To),
+	}
+}
+
+func matchSelectorItemsV1alpha3ToV1beta2(src *[]relationshipv1alpha3.MatchSelectorItem) *[]relationshipv1beta2.MatchSelectorItem {
+	if src == nil {
+		return nil
+	}
+	dst := make([]relationshipv1beta2.MatchSelectorItem, len(*src))
+	for i, item := range *src {
+		dst[i] = relationshipv1beta2.MatchSelectorItem{
+			ID:         item.ID,
+			Kind:       item.Kind,
+			MutatedRef: item.MutatedRef,
+			MutatorRef: item.MutatorRef,
+		}
+	}
+	return &dst
+}
+
+func matchSelectorItemsV1beta2ToV1alpha3(src *[]relationshipv1beta2.MatchSelectorItem) *[]relationshipv1alpha3.MatchSelectorItem {
+	if src == nil {
+		return nil
+	}
+	dst := make([]relationshipv1alpha3.MatchSelectorItem, len(*src))
+	for i, item := range *src {
+		dst[i] = relationshipv1alpha3.MatchSelectorItem{
+			ID:         item.ID,
+			Kind:       item.Kind,
+			MutatedRef: item.MutatedRef,
+			MutatorRef: item.MutatorRef,
+		}
+	}
+	return &dst
+}
+
+func relationshipSelectorsPatchV1alpha3ToV1beta2(src *relationshipv1alpha3.RelationshipDefinitionSelectorsPatch) *relationshipv1beta2.RelationshipDefinitionSelectorsPatch {
+	if src == nil {
+		return nil
+	}
+	return &relationshipv1beta2.RelationshipDefinitionSelectorsPatch{
+		MutatedRef:    src.MutatedRef,
+		MutatorRef:    src.MutatorRef,
+		PatchStrategy: convertEnumPtr[relationshipv1alpha3.RelationshipDefinitionSelectorsPatchStrategy, relationshipv1beta2.RelationshipDefinitionSelectorsPatchStrategy](src.PatchStrategy),
+	}
+}
+
+func relationshipSelectorsPatchV1beta2ToV1alpha3(src *relationshipv1beta2.RelationshipDefinitionSelectorsPatch) *relationshipv1alpha3.RelationshipDefinitionSelectorsPatch {
+	if src == nil {
+		return nil
+	}
+	return &relationshipv1alpha3.RelationshipDefinitionSelectorsPatch{
+		MutatedRef:    src.MutatedRef,
+		MutatorRef:    src.MutatorRef,
+		PatchStrategy: convertEnumPtr[relationshipv1beta2.RelationshipDefinitionSelectorsPatchStrategy, relationshipv1alpha3.RelationshipDefinitionSelectorsPatchStrategy](src.PatchStrategy),
+	}
+}
+
+func convertEnumPtr[Src ~string, Dst ~string](src *Src) *Dst {
+	if src == nil {
+		return nil
+	}
+	dst := Dst(*src)
+	return &dst
+}

--- a/server/models/pattern/utils/relationship_version_bridge_test.go
+++ b/server/models/pattern/utils/relationship_version_bridge_test.go
@@ -1,0 +1,189 @@
+package utils
+
+import (
+	"encoding/json"
+	"testing"
+
+	capabilityv1alpha1 "github.com/meshery/schemas/models/v1alpha1/capability"
+	relationshipv1alpha3 "github.com/meshery/schemas/models/v1alpha3/relationship"
+	modelv1beta1 "github.com/meshery/schemas/models/v1beta1/model"
+	relationshipv1beta2 "github.com/meshery/schemas/models/v1beta2/relationship"
+)
+
+func TestRelationshipV1alpha3ToV1beta2_PreservesAliasedFields(t *testing.T) {
+	src := newRelationshipV1alpha3Fixture()
+
+	dst := RelationshipV1alpha3ToV1beta2(src)
+	if dst == nil {
+		t.Fatal("RelationshipV1alpha3ToV1beta2() returned nil")
+	}
+	if got, want := dst.RelationshipType, src.RelationshipType; got != want {
+		t.Fatalf("RelationshipType = %q, want %q", got, want)
+	}
+	if dst.RelationshipMetadata == nil || dst.RelationshipMetadata.Styles == nil {
+		t.Fatal("typed bridge lost relationship metadata/styles")
+	}
+	if got := dst.RelationshipMetadata.AdditionalProperties["owner"]; got != "meshery" {
+		t.Fatalf("metadata additionalProperties not preserved, got %#v", got)
+	}
+	if got := *dst.RelationshipMetadata.Styles.SourceLabel; got != "mounted-by" {
+		t.Fatalf("SourceLabel = %q, want %q", got, "mounted-by")
+	}
+	if got := string(*dst.RelationshipMetadata.Styles.CurveStyle); got != "bezier" {
+		t.Fatalf("CurveStyle = %q, want %q", got, "bezier")
+	}
+	if got := (*dst.Selectors)[0].Allow.From[0].RelationshipDefinitionSelectorsPatch; got == nil {
+		t.Fatal("typed bridge lost selector patch")
+	}
+
+	dst.RelationshipMetadata.AdditionalProperties["audited"] = true
+	if got := src.Metadata.AdditionalProperties["audited"]; got != true {
+		t.Fatalf("metadata alias lost, got %#v", got)
+	}
+
+	*dst.RelationshipMetadata.Styles.SourceLabel = "depends-on"
+	if got := *src.Metadata.Styles.SourceLabel; got != "depends-on" {
+		t.Fatalf("style pointer alias lost, got %q", got)
+	}
+
+	if (*dst.Capabilities)[0].Metadata == nil {
+		t.Fatal("typed bridge lost capability metadata")
+	}
+	(*(*dst.Capabilities)[0].Metadata)["scope"] = "namespace"
+	if got := (*(*src.Capabilities)[0].Metadata)["scope"]; got != "namespace" {
+		t.Fatalf("capability metadata alias lost, got %#v", got)
+	}
+
+	(*dst.Selectors)[0].Allow.From[0].Model.Name = "meshery"
+	if got := (*src.Selectors)[0].Allow.From[0].Model.Name; got != "meshery" {
+		t.Fatalf("selector model pointer alias lost, got %q", got)
+	}
+
+	roundtripped := RelationshipV1beta2ToV1alpha3(dst)
+	if roundtripped == nil {
+		t.Fatal("RelationshipV1beta2ToV1alpha3() returned nil")
+	}
+	if got := roundtripped.Metadata.AdditionalProperties["audited"]; got != true {
+		t.Fatalf("round-tripped metadata missing aliased mutation, got %#v", got)
+	}
+	if got := *roundtripped.Metadata.Styles.SourceLabel; got != "depends-on" {
+		t.Fatalf("round-tripped SourceLabel = %q, want %q", got, "depends-on")
+	}
+}
+
+func TestRelationshipV1alpha3ToV1beta2_PreservesFieldsDroppedByJSON(t *testing.T) {
+	src := newRelationshipV1alpha3Fixture()
+
+	typed := RelationshipV1alpha3ToV1beta2(src)
+
+	raw, err := json.Marshal(src)
+	if err != nil {
+		t.Fatalf("json.Marshal() unexpected error: %v", err)
+	}
+	var legacy relationshipv1beta2.RelationshipDefinition
+	if err := json.Unmarshal(raw, &legacy); err != nil {
+		t.Fatalf("json.Unmarshal() unexpected error: %v", err)
+	}
+
+	if legacy.RelationshipMetadata != nil && legacy.RelationshipMetadata.Styles != nil && legacy.RelationshipMetadata.Styles.SourceLabel != nil {
+		t.Fatalf("legacy JSON path unexpectedly preserved SourceLabel: %q", *legacy.RelationshipMetadata.Styles.SourceLabel)
+	}
+	if legacy.Selectors != nil && (*legacy.Selectors)[0].Allow.From[0].MatchStrategyMatrix != nil {
+		t.Fatalf("legacy JSON path unexpectedly preserved MatchStrategyMatrix: %#v", *(*legacy.Selectors)[0].Allow.From[0].MatchStrategyMatrix)
+	}
+
+	if typed.RelationshipMetadata == nil || typed.RelationshipMetadata.Styles == nil || typed.RelationshipMetadata.Styles.SourceLabel == nil {
+		t.Fatal("typed bridge lost SourceLabel")
+	}
+	if got := *typed.RelationshipMetadata.Styles.SourceLabel; got != "mounted-by" {
+		t.Fatalf("typed bridge SourceLabel = %q, want %q", got, "mounted-by")
+	}
+	if typed.Selectors == nil || (*typed.Selectors)[0].Allow.From[0].MatchStrategyMatrix == nil {
+		t.Fatal("typed bridge lost MatchStrategyMatrix")
+	}
+}
+
+func newRelationshipV1alpha3Fixture() *relationshipv1alpha3.RelationshipDefinition {
+	description := "relationship bridge"
+	isAnnotation := true
+	sourceLabel := "mounted-by"
+	fontFamily := "Inter"
+	targetArrowColor := "#00B39F"
+	curveStyle := relationshipv1alpha3.RelationshipDefinitionMetadataStylesCurveStyle("bezier")
+	status := relationshipv1alpha3.RelationshipDefinitionStatus("approved")
+	patchStrategy := relationshipv1alpha3.RelationshipDefinitionSelectorsPatchStrategy("copy")
+	kind := "Deployment"
+	matchStrategyMatrix := [][]string{{"from.kind", "to.kind"}}
+	capabilityMetadata := map[string]interface{}{"scope": "cluster"}
+	modelRef := &modelv1beta1.ModelReference{Name: "kubernetes"}
+	mutatedRef := relationshipv1alpha3.MutatedRef{{"spec", "template"}}
+	mutatorRef := relationshipv1alpha3.MutatorRef{{"metadata", "labels", "app"}}
+
+	return &relationshipv1alpha3.RelationshipDefinition{
+		Capabilities: &[]capabilityv1alpha1.Capability{
+			{
+				DisplayName: "Patch",
+				Key:         "patch",
+				Kind:        "action",
+				Type:        "mutation",
+				SubType:     "copy",
+				EntityState: []string{"enabled"},
+				Metadata:    &capabilityMetadata,
+				Status:      capabilityv1alpha1.Enabled,
+				Version:     "0.0.1",
+			},
+		},
+		EvaluationQuery: stringPtr("rego.rule"),
+		Kind:            relationshipv1alpha3.RelationshipDefinitionKind("edge"),
+		Metadata: &relationshipv1alpha3.RelationshipMetadata{
+			Description:  &description,
+			IsAnnotation: &isAnnotation,
+			Styles: &relationshipv1alpha3.RelationshipDefinitionMetadataStyles{
+				CurveStyle:       &curveStyle,
+				FontFamily:       &fontFamily,
+				PrimaryColor:     "#00B39F",
+				SourceLabel:      &sourceLabel,
+				SvgColor:         "#111111",
+				SvgWhite:         "#FFFFFF",
+				TargetArrowColor: &targetArrowColor,
+			},
+			AdditionalProperties: map[string]interface{}{
+				"owner": "meshery",
+			},
+		},
+		Model:         modelv1beta1.ModelReference{Name: "kubernetes"},
+		SchemaVersion: "relationships.meshery.io/v1alpha3",
+		Selectors: &relationshipv1alpha3.SelectorSet{
+			{
+				Allow: relationshipv1alpha3.Selector{
+					From: []relationshipv1alpha3.SelectorItem{
+						{
+							Kind:                &kind,
+							MatchStrategyMatrix: &matchStrategyMatrix,
+							Model:               modelRef,
+							Patch: &relationshipv1alpha3.RelationshipDefinitionSelectorsPatch{
+								MutatedRef:    &mutatedRef,
+								MutatorRef:    &mutatorRef,
+								PatchStrategy: &patchStrategy,
+							},
+						},
+					},
+					To: []relationshipv1alpha3.SelectorItem{
+						{
+							Kind:  &kind,
+							Model: modelRef,
+						},
+					},
+				},
+			},
+		},
+		SubType:          "mount",
+		Status:           &status,
+		RelationshipType: "non-binding",
+		Version:          "0.0.1",
+	}
+}
+
+func stringPtr(v string) *string {
+	return &v
+}

--- a/server/models/pattern/utils/relationship_version_bridge_test.go
+++ b/server/models/pattern/utils/relationship_version_bridge_test.go
@@ -59,6 +59,16 @@ func TestRelationshipV1alpha3ToV1beta2_PreservesAliasedFields(t *testing.T) {
 		t.Fatalf("selector model pointer alias lost, got %q", got)
 	}
 
+	(*(*dst.Selectors)[0].Allow.From[0].MatchStrategyMatrix)[0][0] = "from.metadata.name"
+	if got := (*(*src.Selectors)[0].Allow.From[0].MatchStrategyMatrix)[0][0]; got != "from.metadata.name" {
+		t.Fatalf("selector matchStrategyMatrix alias lost, got %q", got)
+	}
+
+	(*(*dst.Selectors)[0].Allow.From[0].RelationshipDefinitionSelectorsPatch.MutatedRef)[0][0] = "status"
+	if got := (*(*src.Selectors)[0].Allow.From[0].Patch.MutatedRef)[0][0]; got != "status" {
+		t.Fatalf("selector mutatedRef alias lost, got %q", got)
+	}
+
 	roundtripped := RelationshipV1beta2ToV1alpha3(dst)
 	if roundtripped == nil {
 		t.Fatal("RelationshipV1beta2ToV1alpha3() returned nil")
@@ -68,6 +78,9 @@ func TestRelationshipV1alpha3ToV1beta2_PreservesAliasedFields(t *testing.T) {
 	}
 	if got := *roundtripped.Metadata.Styles.SourceLabel; got != "depends-on" {
 		t.Fatalf("round-tripped SourceLabel = %q, want %q", got, "depends-on")
+	}
+	if got := (*(*roundtripped.Selectors)[0].Allow.From[0].Patch.MutatedRef)[0][0]; got != "status" {
+		t.Fatalf("round-tripped MutatedRef = %q, want %q", got, "status")
 	}
 }
 

--- a/server/policies/engine.go
+++ b/server/policies/engine.go
@@ -1,11 +1,11 @@
 package policies
 
 import (
-	"encoding/json"
-
+	patternutils "github.com/meshery/meshery/server/models/pattern/utils"
 	"github.com/meshery/meshkit/logger"
-	"github.com/meshery/schemas/models/v1beta2/relationship"
+	relationshipv1alpha3 "github.com/meshery/schemas/models/v1alpha3/relationship"
 	"github.com/meshery/schemas/models/v1beta1/pattern"
+	"github.com/meshery/schemas/models/v1beta2/relationship"
 )
 
 // GoEngine is the native Go policy evaluation engine.
@@ -38,16 +38,16 @@ func ConvertRelationships(registeredRelationships []interface{}) []*relationship
 			rels = append(rels, v)
 		case relationship.RelationshipDefinition:
 			rels = append(rels, &v)
+		case *relationshipv1alpha3.RelationshipDefinition:
+			if bridged := patternutils.RelationshipV1alpha3ToV1beta2(v); bridged != nil {
+				rels = append(rels, bridged)
+			}
+		case relationshipv1alpha3.RelationshipDefinition:
+			if bridged := patternutils.RelationshipV1alpha3ToV1beta2(&v); bridged != nil {
+				rels = append(rels, bridged)
+			}
 		default:
-			data, err := json.Marshal(r)
-			if err != nil {
-				continue
-			}
-			var rel relationship.RelationshipDefinition
-			if err := json.Unmarshal(data, &rel); err != nil {
-				continue
-			}
-			rels = append(rels, &rel)
+			continue
 		}
 	}
 	return rels
@@ -194,4 +194,3 @@ func buildTrace(actions []PolicyAction, originalDesign, finalDesign *pattern.Pat
 	}
 	return trace
 }
-

--- a/server/policies/engine_test.go
+++ b/server/policies/engine_test.go
@@ -6,10 +6,11 @@ import (
 
 	"github.com/gofrs/uuid"
 	"github.com/meshery/meshkit/logger"
-	"github.com/meshery/schemas/models/v1beta2/relationship"
+	relationshipv1alpha3 "github.com/meshery/schemas/models/v1alpha3/relationship"
 	"github.com/meshery/schemas/models/v1beta1/component"
 	modelv1beta1 "github.com/meshery/schemas/models/v1beta1/model"
 	"github.com/meshery/schemas/models/v1beta1/pattern"
+	"github.com/meshery/schemas/models/v1beta2/relationship"
 )
 
 // strPtr returns a pointer to the given string.
@@ -235,6 +236,75 @@ func TestFromAndToComponentsExist(t *testing.T) {
 	if fromAndToComponentsExist(relMissing, design) {
 		t.Error("Expected missing component to be detected")
 	}
+}
+
+func TestConvertRelationships(t *testing.T) {
+	t.Run("keeps v1beta2 pointers untouched", func(t *testing.T) {
+		src := &relationship.RelationshipDefinition{RelationshipType: "non-binding"}
+
+		got := ConvertRelationships([]interface{}{src})
+
+		if len(got) != 1 {
+			t.Fatalf("expected 1 relationship, got %d", len(got))
+		}
+		if got[0] != src {
+			t.Fatal("v1beta2 relationship pointer should be returned unchanged")
+		}
+	})
+
+	t.Run("bridges v1alpha3 without json tag loss", func(t *testing.T) {
+		sourceLabel := "mounted-by"
+		matchStrategyMatrix := [][]string{{"from.kind", "to.kind"}}
+		kind := "Deployment"
+
+		src := relationshipv1alpha3.RelationshipDefinition{
+			Kind:             relationshipv1alpha3.RelationshipDefinitionKind("edge"),
+			RelationshipType: "non-binding",
+			Metadata: &relationshipv1alpha3.RelationshipMetadata{
+				Styles: &relationshipv1alpha3.RelationshipDefinitionMetadataStyles{
+					SourceLabel:  &sourceLabel,
+					PrimaryColor: "#00B39F",
+					SvgColor:     "#111111",
+					SvgWhite:     "#FFFFFF",
+				},
+			},
+			Selectors: &relationshipv1alpha3.SelectorSet{
+				{
+					Allow: relationshipv1alpha3.Selector{
+						From: []relationshipv1alpha3.SelectorItem{
+							{
+								Kind:                &kind,
+								MatchStrategyMatrix: &matchStrategyMatrix,
+								Model:               &modelv1beta1.ModelReference{Name: "kubernetes"},
+							},
+						},
+					},
+				},
+			},
+		}
+
+		got := ConvertRelationships([]interface{}{src})
+
+		if len(got) != 1 {
+			t.Fatalf("expected 1 relationship, got %d", len(got))
+		}
+		if got[0].RelationshipMetadata == nil || got[0].RelationshipMetadata.Styles == nil || got[0].RelationshipMetadata.Styles.SourceLabel == nil {
+			t.Fatal("converted relationship lost SourceLabel")
+		}
+		if *got[0].RelationshipMetadata.Styles.SourceLabel != sourceLabel {
+			t.Fatalf("SourceLabel = %q, want %q", *got[0].RelationshipMetadata.Styles.SourceLabel, sourceLabel)
+		}
+		if got[0].Selectors == nil || (*got[0].Selectors)[0].Allow.From[0].MatchStrategyMatrix == nil {
+			t.Fatal("converted relationship lost MatchStrategyMatrix")
+		}
+	})
+
+	t.Run("skips unsupported relationship shapes", func(t *testing.T) {
+		got := ConvertRelationships([]interface{}{"not-a-relationship"})
+		if len(got) != 0 {
+			t.Fatalf("expected unsupported value to be skipped, got %d relationships", len(got))
+		}
+	})
 }
 
 func TestValidateRelationshipsInDesign(t *testing.T) {


### PR DESCRIPTION
## Related Issues
Closes #19097

## Summary
- replace the remaining pattern-file JSON round-trip bridge with typed shallow copies
- add a typed v1alpha3-to-v1beta2 relationship bridge for the Go policy engine
- add regression tests for alias preservation and JSON tag drift cases