### PR TITLE
chore: remove Docker edge push and description steps from CI workflow

### DIFF
--- a/.github/workflows/build-ui-and-server.yml
+++ b/.github/workflows/build-ui-and-server.yml
@@ -198,25 +198,11 @@ jobs:
           sudo rm -rf /opt/ghc
           sudo rm -rf /opt/hostedtoolcache
       - name: Docker edge build & tag
-        if: startsWith(github.ref, 'refs/tags/') != true && success()
         env:
           RELEASE_CHANNEL: "edge"
         run: |
           DOCKER_BUILDKIT=1 docker build -f install/docker/Dockerfile --no-cache -t meshery:edge-latest --build-arg TOKEN=test --build-arg GIT_COMMITSHA=${GITHUB_SHA::8} --build-arg RELEASE_CHANNEL=${RELEASE_CHANNEL} .
           docker tag meshery:edge-latest meshery:edge-${GITHUB_SHA::8}
-      - name: Docker edge push
-        if: github.event_name != 'pull_request' && github.event_name != 'workflow_dispatch' && startsWith(github.ref, 'refs/tags/') && success()
-        run: |
-          docker push ${{ secrets.IMAGE_NAME }}:edge-latest
-          docker push ${{ secrets.IMAGE_NAME }}:edge-${GITHUB_REF/refs\/tags\//}
-          docker push ${{ secrets.IMAGE_NAME }}:edge-${GITHUB_SHA::8}
-      - name: Docker Hub Description
-        if: github.event_name != 'pull_request' && github.event_name != 'workflow_dispatch' && startsWith(github.ref, 'refs/tags/') && success()
-        uses: peter-evans/dockerhub-description@v5
-        with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_PASSWORD }}
-          repository: ${{ secrets.IMAGE_NAME }}
   # Run Rego policy tests
   rego-tests:
     name: Rego Policy Tests


### PR DESCRIPTION
Removes redudant/outdated docker push and removes secrets from workflow. 


It appears that this step has been superceded by Meshery Build and Releaser (edge) workflow. This was confirmed by looking at docker hub and checking the GITHUB_SHA to the edge release and following that back to the workflow that generated it. 