### PR TITLE
[mesheryctl] Fix perf result panic on empty load generators

### DIFF
--- a/mesheryctl/internal/cli/root/perf/apply.go
+++ b/mesheryctl/internal/cli/root/perf/apply.go
@@ -143,7 +143,7 @@ mesheryctl perf apply meshery-profile-new --url "https://google.com" --load-gene
 			}
 
 			if testURL == "" {
-				testURL = testClient.EndpointUrls[0]
+				testURL = firstString(testClient.EndpointUrls)
 			}
 
 			if testMesh == "" {

--- a/mesheryctl/internal/cli/root/perf/apply.go
+++ b/mesheryctl/internal/cli/root/perf/apply.go
@@ -235,7 +235,7 @@ mesheryctl perf apply meshery-profile-new --url "https://google.com" --load-gene
 			// what if user passed profile-name but didn't passed the url
 			// we use url from performance profile
 			if testURL == "" {
-				testURL = profiles[index].Endpoints[0]
+				testURL = firstString(profiles[index].Endpoints)
 			}
 
 			// reset profile name without %20
@@ -244,7 +244,7 @@ mesheryctl perf apply meshery-profile-new --url "https://google.com" --load-gene
 				profileName = profiles[index].Name
 
 				if loadGenerator == "" {
-					loadGenerator = profiles[index].LoadGenerators[0]
+					loadGenerator = firstString(profiles[index].LoadGenerators)
 				}
 
 				if concurrentRequests == "" {

--- a/mesheryctl/internal/cli/root/perf/fixtures/result.profile.emptyLoadGenerators.response.golden
+++ b/mesheryctl/internal/cli/root/perf/fixtures/result.profile.emptyLoadGenerators.response.golden
@@ -5,11 +5,11 @@
   "profiles": [
     {
       "id": "a2a555cf-ae16-479c-b5d2-a35656ba741e",
-      "name": "Abhishek",
+      "name": "John Doe",
       "userId": "a99bf5ae-10c3-44fa-bee1-af4238e2c847",
       "loadGenerators": [],
       "endpoints": [
-        "https://twitter.com/layer5"
+        "https://x.com/mesheryio"
       ],
       "serviceMesh": "consul",
       "concurrentRequest": 10,

--- a/mesheryctl/internal/cli/root/perf/fixtures/result.profile.emptyLoadGenerators.response.golden
+++ b/mesheryctl/internal/cli/root/perf/fixtures/result.profile.emptyLoadGenerators.response.golden
@@ -1,0 +1,24 @@
+{
+  "page": 0,
+  "pageSize": 10,
+  "totalCount": 1,
+  "profiles": [
+    {
+      "id": "a2a555cf-ae16-479c-b5d2-a35656ba741e",
+      "name": "Abhishek",
+      "userId": "a99bf5ae-10c3-44fa-bee1-af4238e2c847",
+      "loadGenerators": [],
+      "endpoints": [
+        "https://twitter.com/layer5"
+      ],
+      "serviceMesh": "consul",
+      "concurrentRequest": 10,
+      "qps": 2,
+      "duration": "30s",
+      "last_run": "2021-08-29T16:43:38.599411Z",
+      "totalResults": 1,
+      "createdAt": "2021-08-29T11:13:27.445119Z",
+      "updatedAt": "2021-08-29T11:13:27.445129Z"
+    }
+  ]
+}

--- a/mesheryctl/internal/cli/root/perf/profile.go
+++ b/mesheryctl/internal/cli/root/perf/profile.go
@@ -121,8 +121,8 @@ mesheryctl perf profile test --view
 			fmt.Printf("Name: %v\n", a.Name)
 			fmt.Printf("ID: %s\n", a.ID.String())
 			fmt.Printf("Total Results: %d\n", a.TotalResults)
-			fmt.Printf("Endpoint: %v\n", a.Endpoints[0])
-			fmt.Printf("Load Generators: %v\n", a.LoadGenerators[0])
+			fmt.Printf("Endpoint: %v\n", firstString(a.Endpoints))
+			fmt.Printf("Load Generators: %v\n", firstString(a.LoadGenerators))
 			fmt.Printf("Test run duration: %v\n", a.Duration)
 			fmt.Printf("QPS: %d\n", a.QPS)
 			fmt.Printf("Infrastructure: %v\n", a.ServiceMesh)
@@ -188,15 +188,24 @@ func profilesToStringArrays(profiles []models.PerformanceProfile) [][]string {
 	var data [][]string
 
 	for _, profile := range profiles {
+		loadGenerator := firstString(profile.LoadGenerators)
 		// adding profile to data for list output
 		if profile.LastRun != nil {
-			data = append(data, []string{profile.Name, profile.ID.String(), fmt.Sprintf("%d", profile.TotalResults), profile.LoadGenerators[0], profile.LastRun.Time.Format("2006-01-02 15:04:05")})
+			data = append(data, []string{profile.Name, profile.ID.String(), fmt.Sprintf("%d", profile.TotalResults), loadGenerator, profile.LastRun.Time.Format("2006-01-02 15:04:05")})
 		} else {
-			data = append(data, []string{profile.Name, profile.ID.String(), fmt.Sprintf("%d", profile.TotalResults), profile.LoadGenerators[0], ""})
+			data = append(data, []string{profile.Name, profile.ID.String(), fmt.Sprintf("%d", profile.TotalResults), loadGenerator, ""})
 		}
 	}
 
 	return data
+}
+
+func firstString(values []string) string {
+	if len(values) == 0 {
+		return ""
+	}
+
+	return values[0]
 }
 
 func userPrompt(key string, label string, data [][]string) (int, error) {

--- a/mesheryctl/internal/cli/root/perf/profile.go
+++ b/mesheryctl/internal/cli/root/perf/profile.go
@@ -200,7 +200,7 @@ func profilesToStringArrays(profiles []models.PerformanceProfile) [][]string {
 	return data
 }
 
-func firstString(values []string) string {
+func firstString[S ~[]string](values S) string {
 	if len(values) == 0 {
 		return ""
 	}

--- a/mesheryctl/internal/cli/root/perf/result_test.go
+++ b/mesheryctl/internal/cli/root/perf/result_test.go
@@ -7,8 +7,10 @@ import (
 	"runtime"
 	"testing"
 
+	"github.com/gofrs/uuid"
 	"github.com/meshery/meshery/mesheryctl/internal/cli/pkg/display"
 	"github.com/meshery/meshery/mesheryctl/pkg/utils"
+	"github.com/meshery/meshery/server/models"
 )
 
 var tempProfileID = "a2a555cf-ae16-479c-b5d2-a35656ba741e"
@@ -65,6 +67,16 @@ func TestResultCmd(t *testing.T) {
 				{Method: "GET", URL: resultURL, Response: "result.list.response.golden", ResponseCode: 200},
 			},
 			ExpectedResponse: "result.yaml.output.golden",
+			ExpectError:      false,
+		},
+		{
+			Name: "result output tolerates empty load generators",
+			Args: []string{"result", "abhishek"},
+			URLs: []utils.MockURL{
+				{Method: "GET", URL: profileURL, Response: "result.profile.emptyLoadGenerators.response.golden", ResponseCode: 200},
+				{Method: "GET", URL: resultURL, Response: "result.list.response.golden", ResponseCode: 200},
+			},
+			ExpectedResponse: "result.list.output.golden",
 			ExpectError:      false,
 		},
 	}
@@ -150,4 +162,30 @@ func TestResultCmd(t *testing.T) {
 
 	// Run tests in logger format
 	utils.RunMesheryctlMultiURLTests(t, update, PerfCmd, loggerTests, currDir, "perf", resetVariables)
+}
+
+func TestProfilesToStringArraysHandlesMissingLoadGenerators(t *testing.T) {
+	t.Parallel()
+
+	id := uuid.Nil
+	data := profilesToStringArrays([]models.PerformanceProfile{
+		{
+			ID:             &id,
+			Name:           "test-profile",
+			TotalResults:   3,
+			LoadGenerators: nil,
+		},
+	})
+
+	if len(data) != 1 {
+		t.Fatalf("expected 1 row, got %d", len(data))
+	}
+
+	if len(data[0]) != 5 {
+		t.Fatalf("expected 5 columns, got %d", len(data[0]))
+	}
+
+	if data[0][3] != "" {
+		t.Fatalf("expected empty load generator cell, got %q", data[0][3])
+	}
 }

--- a/mesheryctl/internal/cli/root/perf/result_test.go
+++ b/mesheryctl/internal/cli/root/perf/result_test.go
@@ -72,7 +72,7 @@ func TestResultCmd(t *testing.T) {
 		},
 		{
 			Name: "result output tolerates empty load generators",
-			Args: []string{"result", "abhishek"},
+			Args: []string{"result", "John Doe"},
 			URLs: []utils.MockURL{
 				{Method: "GET", URL: profileURL, Response: "result.profile.emptyLoadGenerators.response.golden", ResponseCode: 200},
 				{Method: "GET", URL: resultURL, Response: "result.list.response.golden", ResponseCode: 200},

--- a/mesheryctl/internal/cli/root/perf/result_test.go
+++ b/mesheryctl/internal/cli/root/perf/result_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/meshery/meshery/mesheryctl/internal/cli/pkg/display"
 	"github.com/meshery/meshery/mesheryctl/pkg/utils"
 	"github.com/meshery/meshery/server/models"
+	core "github.com/meshery/schemas/models/core"
 )
 
 var tempProfileID = "a2a555cf-ae16-479c-b5d2-a35656ba741e"
@@ -167,7 +168,7 @@ func TestResultCmd(t *testing.T) {
 func TestProfilesToStringArraysHandlesMissingLoadGenerators(t *testing.T) {
 	t.Parallel()
 
-	id := uuid.Nil
+	id := core.Uuid(uuid.Nil)
 	data := profilesToStringArrays([]models.PerformanceProfile{
 		{
 			ID:             &id,


### PR DESCRIPTION
## Summary
- guard perf profile formatting against empty `loadGenerators` slices
- reuse the same safe lookup in adjacent perf CLI paths that read profile endpoints or load generators
- add regression coverage for `mesheryctl perf result` when a profile has no load generators

## Tests
- `cd mesheryctl && go test ./internal/cli/root/perf`
- `cd mesheryctl && go test ./...`