### PR TITLE
[Server] Fix non-determinism in relationship eval engine

### DIFF
--- a/server/policies/engine_test.go
+++ b/server/policies/engine_test.go
@@ -633,3 +633,58 @@ func TestAliasIsInvalidStatusMatrix(t *testing.T) {
 		})
 	}
 }
+
+// MatchLabelsPolicy must produce identical relationship UUIDs across runs for
+// the same input. Pre-fix, sibling identification leaked Go map iteration order
+// (groupMap range) and pointer addresses (fmt.Sprintf("%v", selectorSetItem))
+// into the generated IDs.
+func TestMatchLabelsPolicyIdentificationIsDeterministic(t *testing.T) {
+	pod := func(idHex string) *component.ComponentDefinition {
+		c := &component.ComponentDefinition{
+			Component: component.Component{Kind: "Pod"},
+			Configuration: map[string]interface{}{
+				"metadata": map[string]interface{}{
+					"labels": map[string]interface{}{"app": "meshery", "tier": "api"},
+				},
+			},
+		}
+		c.ID, _ = uuid.FromString("00000000-0000-0000-0000-" + idHex)
+		return c
+	}
+	podA, podB, podC := pod("00000000aaa1"), pod("00000000bbb2"), pod("00000000ccc3")
+
+	makeRel := func() *relationship.RelationshipDefinition {
+		kind := "Pod"
+		refs := [][]string{{"configuration", "metadata", "labels"}}
+		ss := relationship.SelectorSetItem{
+			Allow: relationship.Selector{
+				From: []relationship.SelectorItem{{Kind: &kind, Match: &relationship.MatchSelector{Refs: &refs}}},
+				To:   []relationship.SelectorItem{{Kind: &kind, Match: &relationship.MatchSelector{Refs: &refs}}},
+			},
+		}
+		return &relationship.RelationshipDefinition{
+			Kind:             relationship.RelationshipDefinitionKind("edge"),
+			RelationshipType: "sibling",
+			Selectors:        &relationship.SelectorSet{ss},
+		}
+	}
+
+	design := makePatternFile([]*component.ComponentDefinition{podA, podB, podC}, nil)
+	p := &MatchLabelsPolicy{}
+
+	first := p.IdentifyRelationship(makeRel(), design)
+	if len(first) == 0 {
+		t.Fatal("expected at least one matchlabels relationship")
+	}
+	for i := 0; i < 5; i++ {
+		again := p.IdentifyRelationship(makeRel(), design)
+		if len(again) != len(first) {
+			t.Fatalf("identification count drift: run %d got %d, first run %d", i, len(again), len(first))
+		}
+		for j := range first {
+			if first[j].ID != again[j].ID {
+				t.Fatalf("UUID drift run=%d index=%d: %v vs %v", i, j, first[j].ID, again[j].ID)
+			}
+		}
+	}
+}

--- a/server/policies/policy_binding.go
+++ b/server/policies/policy_binding.go
@@ -1,6 +1,7 @@
 package policies
 
 import (
+	"sort"
 	"strings"
 
 	"github.com/meshery/schemas/models/v1beta2/relationship"
@@ -167,7 +168,14 @@ func identifyBindingRelationships(relDef *relationship.RelationshipDefinition, d
 		fromComps := filterComponentsByKindSetTyped(design.Components, fromSelByKind)
 		toComps := filterComponentsByToSelectorsTyped(design.Components, ss.Allow.To)
 
-		for bindingKind := range bindingKinds {
+		// Iterate kinds in sorted order so identification output (and thus
+		// generated relationship IDs) does not depend on map iteration randomness.
+		sortedBindingKinds := make([]string, 0, len(bindingKinds))
+		for k := range bindingKinds {
+			sortedBindingKinds = append(sortedBindingKinds, k)
+		}
+		sort.Strings(sortedBindingKinds)
+		for _, bindingKind := range sortedBindingKinds {
 			bindingDecls := filterComponentsByKindTyped(design.Components, bindingKind)
 			if len(bindingDecls) == 0 {
 				continue

--- a/server/policies/policy_matchlabels.go
+++ b/server/policies/policy_matchlabels.go
@@ -2,6 +2,7 @@ package policies
 
 import (
 	"fmt"
+	"sort"
 	"strings"
 
 	"github.com/meshery/schemas/models/v1beta2/relationship"
@@ -119,9 +120,16 @@ func identifyMatchlabels(design *pattern.PatternFile, relDef *relationship.Relat
 		}
 	}
 
+	// Iterate groupMap in sorted key order so the output (and the truncation
+	// when len > maxMatchLabels) is stable across runs.
+	sortedKeys := make([]string, 0, len(groupMap))
+	for k := range groupMap {
+		sortedKeys = append(sortedKeys, k)
+	}
+	sort.Strings(sortedKeys)
 	groups := make([]matchLabelGroup, 0, len(groupMap))
-	for _, g := range groupMap {
-		groups = append(groups, *g)
+	for _, k := range sortedKeys {
+		groups = append(groups, *groupMap[k])
 	}
 	if len(groups) > maxMatchLabels {
 		groups = groups[:maxMatchLabels]
@@ -161,7 +169,19 @@ func identifyMatchlabelRelationships(relDef *relationship.RelationshipDefinition
 			},
 		}
 
-		id := staticUUID(fmt.Sprintf("%v%s", ss, "sibling_match_labels_policy")).String()
+		compIDs := make([]string, 0, len(group.Components))
+		for _, c := range group.Components {
+			compIDs = append(compIDs, c.ID.String())
+		}
+		sort.Strings(compIDs)
+		seed := map[string]any{
+			"policy": "sibling_match_labels_policy",
+			"field":  group.Field,
+			"value":  group.Value,
+			"comps":  compIDs,
+		}
+		uuid := staticUUID(seed)
+		id := uuid.String()
 		if seen[id] {
 			continue
 		}
@@ -170,7 +190,7 @@ func identifyMatchlabelRelationships(relDef *relationship.RelationshipDefinition
 		decl := deepCopyRelDef(relDef)
 		selectors := relationship.SelectorSet{ss}
 		decl.Selectors = &selectors
-		decl.ID = staticUUID(fmt.Sprintf("%v%s", ss, "sibling_match_labels_policy"))
+		decl.ID = uuid
 		setRelStatus(decl, StatusIdentified)
 
 		identified = append(identified, decl)

--- a/server/policies/utils.go
+++ b/server/policies/utils.go
@@ -73,14 +73,18 @@ func isDirectReference(ref []string) bool {
 }
 
 // canonicalSeed converts a seed to a canonical string representation.
-// Uses json.Marshal for maps/slices to ensure deterministic key ordering.
+// Strings pass through verbatim; everything else goes through json.Marshal so
+// typed structs containing pointer fields don't leak %v memory addresses into
+// the seed (which would make staticUUID non-deterministic across processes).
 func canonicalSeed(seed interface{}) string {
-	switch seed.(type) {
-	case map[string]interface{}, []interface{}:
-		b, err := json.Marshal(seed)
-		if err == nil {
-			return string(b)
-		}
+	switch v := seed.(type) {
+	case nil:
+		return ""
+	case string:
+		return v
+	}
+	if b, err := json.Marshal(seed); err == nil {
+		return string(b)
 	}
 	return fmt.Sprintf("%v", seed)
 }

--- a/server/policies/utils_test.go
+++ b/server/policies/utils_test.go
@@ -3,6 +3,8 @@ package policies
 import (
 	"testing"
 	"time"
+
+	"github.com/meshery/schemas/models/v1beta2/relationship"
 )
 
 func TestObjectGetNested(t *testing.T) {
@@ -255,3 +257,24 @@ func TestNewUUIDNonDeterminism(t *testing.T) {
 		t.Error("newUUID should produce different UUIDs on successive calls (time-based)")
 	}
 }
+
+// Two SelectorSetItems built from independently-allocated pointer fields must
+// canonicalize to the same seed; otherwise %v leaks pointer addresses into
+// staticUUID.
+func TestCanonicalSeedTypedStructIsAddressIndependent(t *testing.T) {
+	build := func() relationship.SelectorSetItem {
+		kind := "Pod"
+		return relationship.SelectorSetItem{
+			Allow: relationship.Selector{
+				From: []relationship.SelectorItem{{Kind: &kind}},
+				To:   []relationship.SelectorItem{{Kind: &kind}},
+			},
+		}
+	}
+	a := canonicalSeed(build())
+	b := canonicalSeed(build())
+	if a != b {
+		t.Fatalf("canonicalSeed leaked pointer addresses for typed struct:\n  a=%s\n  b=%s", a, b)
+	}
+}
+


### PR DESCRIPTION
**Notes for Reviewers**

- Three sources of cross-process non-determinism in the Go relationship eval engine produced different relationship IDs / different selected matchlabel groups for the same input design across runs.
- Carved out from #18939 so it can land independently of the wasm work.

**[Signed commits](https://github.com/meshery/meshery/blob/master/CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [x] Yes, I signed my commits.