### PR TITLE
fix(wire-format): canonicalize OPEN_*_EXTENSIONS event-bus payloads + ViewInfoModal props

### DIFF
--- a/ui/components/SpacesSwitcher/MainViewsContent.tsx
+++ b/ui/components/SpacesSwitcher/MainViewsContent.tsx
@@ -297,8 +297,8 @@ const MainViewsContent = ({
         <ViewInfoModal
           open={infoModal}
           closeModal={handleCloseInfoModal}
-          view_id={selectedView?.id}
-          view_name={selectedView?.name}
+          viewId={selectedView?.id}
+          viewName={selectedView?.name}
           metadata={selectedView?.metadata}
         />
       )}

--- a/ui/components/ViewInfoModal.tsx
+++ b/ui/components/ViewInfoModal.tsx
@@ -81,12 +81,12 @@ export const ActionBox = styled(Box)(() => ({
   gap: '1rem',
 }));
 
-export const ViewInfoModal_ = ({ open, closeModal, view_id, view_name, metadata, refetch }) => {
+export const ViewInfoModal_ = ({ open, closeModal, viewId, viewName, metadata, refetch }) => {
   const [formState, setFormState] = useState(metadata);
   const viewRes = useGetViewQuery(
-    { viewId: view_id },
+    { viewId },
     {
-      skip: !view_id,
+      skip: !viewId,
     },
   );
   const userRes = useGetLoggedInUserQuery();
@@ -124,7 +124,7 @@ export const ViewInfoModal_ = ({ open, closeModal, view_id, view_name, metadata,
     <Modal
       open={open}
       closeModal={closeModal}
-      title={view_name}
+      title={viewName}
       headerIcon={<ViewIcon {...iconLarge} fill={theme.palette.common.white} />}
       maxWidth="sm"
     >

--- a/ui/utils/utils.tsx
+++ b/ui/utils/utils.tsx
@@ -505,8 +505,8 @@ export const openViewScopedToDesignInOperator = (designName, designId, router) =
     mesheryEventBus.publish({
       type: 'OPEN_VIEW_SCOPED_TO_DESIGN',
       data: {
-        design_id: designId,
-        design_name: designName,
+        designId,
+        designName,
       },
     });
     return;
@@ -531,8 +531,8 @@ export const openDesignInKanvas = (designId, designName, router) => {
     mesheryEventBus.publish({
       type: 'OPEN_DESIGN_IN_KANVAS',
       data: {
-        design_id: designId,
-        design_name: designName,
+        designId,
+        designName,
       },
     });
     return;
@@ -547,8 +547,8 @@ export const openViewInKanvas = (viewId, viewName, router) => {
     mesheryEventBus.publish({
       type: 'OPEN_VIEW_IN_KANVAS',
       data: {
-        view_id: viewId,
-        view_name: viewName,
+        viewId,
+        viewName,
       },
     });
     return;


### PR DESCRIPTION
## Summary

Pairs with [meshery-extensions#4221](https://github.com/layer5labs/meshery-extensions/pull/4221) (commit \`fc0f39a65\`) to close the last residual cross-repo snake_case identifiers in the meshery ↔ meshery-extensions event-bus contract.

## Changes

1. **\`ui/utils/utils.tsx\`** — three \`mesheryEventBus.publish\` sites (\`openViewScopedToDesignInOperator\`, \`openDesignInExtension\`, \`openViewInExtension\`) emitted payloads with snake_case keys (\`design_id\`, \`design_name\`, \`view_id\`, \`view_name\`). Function parameters were already camelCase, so the fix is shorthand property assignment to emit canonical wire keys directly.

2. **\`ui/components/ViewInfoModal.tsx\`** — \`<ViewInfoModal_>\` destructured \`{ open, closeModal, view_id, view_name, metadata, refetch }\` but inside immediately rebuilt \`useGetViewQuery({ viewId: view_id })\`. Flipped destructure to \`{ ..., viewId, viewName, ... }\` so it matches the canonical TS-camelCase rule and aligns with the field name used downstream.

3. **\`ui/components/SpacesSwitcher/MainViewsContent.tsx\`** — \`<ViewInfoModal>\` call-site flipped \`view_id={...}\`/\`view_name={...}\` → \`viewId={...}\`/\`viewName={...}\` to match the new prop contract.

## Why this is a real bug today (not just a stylistic flip)

The consumer in \`meshery-extensions/meshmap/src/modules/editor/modes/appModeActor.ts\` had already half-flipped:

\`\`\`ts
sendBack({
  type: \"LOAD_VIEW_RESOURCE\",
  data: {
    id: event.data.viewId,        // canonical — undefined today
    name: event.data.view_name    // legacy — works today
  }
});
\`\`\`

Result: \`id\` was undefined at runtime when the publisher emitted \`view_id\`. After both PRs merge, the publisher emits \`viewId\` and the consumer reads \`viewId\` — symmetry restored.

## Coordination

- Extensions PR (consumer flip + type def): https://github.com/layer5labs/meshery-extensions/pull/4221
- Both should land in the same release window. There's a brief development window where one repo is ahead of the other, but the failure mode (events not picked up) is the same as today's half-broken state, not worse.

## Out of scope

URL query-param shape (\`?design_id=...\`) in the non-extension branch of these functions, plus matching \`params.get(\"design_id\")\` reads in extensions \`routing.ts\` and other URL builders / e2e tests. That migration needs transitional dual-read handling for bookmarked / shared URLs and is tracked as a separate workstream.

## Test plan

- [x] \`tsc\` clean on touched files (no new errors).
- [x] All publisher / consumer / call-site references are consistent (no half-flipped state).
- [ ] Smoke-test on a deploy: open a design from \`/configuration/designs\` → verify it opens in Extension with the design name displayed in the title bar (consumer must see canonical \`designName\`).
- [ ] Smoke-test: open a view from the Workspaces \`Views\` tab → verify the InfoModal renders with the view name as the modal title.