### PR TITLE
fix(ui): drop CSV/fileName fields from import-model schema subset

### DIFF
--- a/ui/components/Settings/Registry/ImportModelModal.tsx
+++ b/ui/components/Settings/Registry/ImportModelModal.tsx
@@ -10,13 +10,13 @@ import {
   Modal,
   useTheme,
 } from '@sistent/sistent';
-import { ModelImportRjsfSchemaV1Beta2 } from '@meshery/schemas';
+import { ModelImportRjsfSchemaV1Beta2, ModelImportRjsfUiSchemaV1Beta2 } from '@meshery/schemas';
 import { RJSFModalWrapper } from '@/components/General/Modals/Modal';
 import CsvStepper from './Stepper/CSVStepper';
 import { MESHERY_DOCS_URL } from '@/constants/endpoints';
 import { getUnit8ArrayDecodedFile } from '@/utils/utils';
 import { useImportMeshModelMutation } from '@/rtk-query/meshModel';
-import React, { useState, useEffect, useContext } from 'react';
+import React, { useState, useEffect, useContext, useRef } from 'react';
 import { capitalize } from 'lodash';
 import { Loading } from '@/components/DesignLifeCycle/common';
 import { NotificationCenterContext } from '@/components/NotificationCenter';
@@ -112,25 +112,26 @@ const FinishDeploymentStep = ({
 //       by @rjsf/utils' `optionsList()` — RJSF v6 reads the radio
 //       labels from `ui:enumNames` on the uiSchema instead.
 //
-// Hold the consumer-shaped subset locally with content pulled from the
-// canonical (titles, descriptions, enum tokens, friendly labels). When
-// the upstream schema gains a UI-friendly variant or RJSF starts
-// honoring schema-level `enumNames`, this override can shrink.
-const canonicalProps = ModelImportRjsfSchemaV1Beta2.properties;
-const canonicalUploadType = canonicalProps.uploadType;
+// v1.2.16 of @meshery/schemas adds `ModelImportRjsfUiSchemaV1Beta2` and
+// changes `modelFile.format` from `"binary"` to `"data-url"` (the format
+// RJSF's FileWidget actually produces). We base `importModelUiSchema` on
+// the canonical and overlay our consumer overrides on top.
+const canonicalProps = ModelImportRjsfSchemaV1Beta2?.properties || {};
+const canonicalUploadType = canonicalProps.uploadType || {};
 const UPLOAD_TYPE_FILE = 'file';
 const UPLOAD_TYPE_URL = 'urlImport';
 const UPLOAD_TYPE_CSV = 'csv';
 
-// `allOf` intentionally does NOT mark `modelFile` required for the file
-// branch even though the canonical does. CustomFileWidget reads the file
-// asynchronously (FileReader → `Promise.then(props.onChange)`) and only
-// then lifts the data URL into RJSF's form state, while validation runs
-// synchronously on Next-click. Gating submit on `required: ['modelFile']`
+// `allOf` intentionally does NOT mark `modelFile` or `fileName` required
+// for the file branch even though the canonical does. CustomFileWidget
+// reads the file asynchronously (FileReader → `Promise.then(props.onChange)`)
+// and only then lifts the data URL into RJSF's form state, while validation
+// runs synchronously on Next-click. Gating submit on `required: ['modelFile']`
 // loses the race on every test run and the form sits silently. We trust
 // the user-flow guard in `handleImportModelSubmit` instead — it reads
 // the file off the DOM input as the synchronous source-of-truth and
-// short-circuits if no file is selected.
+// short-circuits if no file is selected. `fileName` is hidden and derived
+// from the data URL / DOM fallback at submit time.
 const importModelSchema = {
   $schema: 'https://json-schema.org/draft-07/schema#',
   title: ModelImportRjsfSchemaV1Beta2.title,
@@ -139,6 +140,7 @@ const importModelSchema = {
     uploadType: canonicalUploadType,
     modelFile: canonicalProps.modelFile,
     url: canonicalProps.url,
+    fileName: canonicalProps.fileName,
   },
   allOf: [
     {
@@ -152,12 +154,25 @@ const importModelSchema = {
   required: ['uploadType'],
 };
 
+// Extend the canonical uiSchema (added in @meshery/schemas v1.2.16) with
+// consumer-specific overrides:
+//   - uploadType: add ui:enumNames so RJSF v6 renders friendly radio labels
+//     (optionsList() reads labels from uiSchema, not schema-level enumNames).
+//   - fileName: hidden — derived from the uploaded file at submit time.
+//   - CSV fields: not rendered in this modal (handled by CsvStepper).
 const importModelUiSchema = {
+  ...ModelImportRjsfUiSchemaV1Beta2,
   uploadType: {
     'ui:widget': 'radio',
-    'ui:enumNames': [...(canonicalUploadType.enumNames as string[])],
+    'ui:enumNames': Array.isArray(canonicalUploadType?.enumNames)
+      ? [...(canonicalUploadType.enumNames as string[])]
+      : undefined,
   },
   modelFile: { 'ui:widget': 'file' },
+  fileName: { 'ui:widget': 'hidden' },
+  modelCsv: { 'ui:widget': 'hidden' },
+  componentCsv: { 'ui:widget': 'hidden' },
+  relationshipCsv: { 'ui:widget': 'hidden' },
   'ui:order': ['uploadType', 'modelFile', 'url'],
 };
 
@@ -221,8 +236,15 @@ const ImportModelModal = React.memo(
     const [isCsvModalOpen, setIsCsvModalOpen] = useState(false);
     const [importModelReq] = useImportMeshModelMutation();
     const [activeStep, setActiveStep] = useState(0);
+    // Prevents RJSFModalWrapper from advancing the step when the submit
+    // handler short-circuits (CSV branch, no-file guard, empty-URL guard).
+    const skipNextRef = useRef(false);
 
     const handleNext = () => {
+      if (skipNextRef.current) {
+        skipNextRef.current = false;
+        return;
+      }
       if (activeStep === 0) {
         setActiveStep(1);
       }
@@ -279,6 +301,7 @@ const ImportModelModal = React.memo(
             };
           } else {
             console.error('Error: File data or file name is empty or invalid');
+            skipNextRef.current = true;
             return;
           }
           break;
@@ -294,17 +317,20 @@ const ImportModelModal = React.memo(
             };
           } else {
             console.error('Error: URL is empty');
+            skipNextRef.current = true;
             return;
           }
           break;
         }
         case UPLOAD_TYPE_CSV: {
+          skipNextRef.current = true;
           handleClose();
           setIsCsvModalOpen(true);
           return;
         }
         default: {
           console.error('Error: Invalid upload type');
+          skipNextRef.current = true;
           return;
         }
       }

--- a/ui/components/Settings/Registry/ImportModelModal.tsx
+++ b/ui/components/Settings/Registry/ImportModelModal.tsx
@@ -186,22 +186,24 @@ const filenameFromDataUrl = (dataUrl: string | undefined): string | undefined =>
   return match ? decodeURIComponent(match[1]) : undefined;
 };
 
-// Re-encode an RJSF data URL into the byte array the server expects.
-// Mirrors `getUnit8ArrayDecodedFile` for the happy path; returns `null`
-// when no data URL is present so callers can fall back to the DOM input.
-const encodeFileToBase64Bytes = async (dataUrl: string | undefined): Promise<number[] | null> => {
+// Decode an RJSF data URL into the byte array the server expects.
+// `getUnit8ArrayDecodedFile` is synchronous, so this wrapper is too;
+// returns `null` when no data URL is present so callers can fall back
+// to the DOM input.
+const decodeDataUrlToBytes = (dataUrl: string | undefined): number[] | null => {
   if (!dataUrl) return null;
   return getUnit8ArrayDecodedFile(dataUrl);
 };
 
 // Locate the `<input type="file">` rendered for the modelFile field. RJSF
 // uses the schema title as the id prefix (`<title>_modelFile`), so we
-// can't hard-code `root_modelFile`; query the live modal dialog instead.
+// can't hard-code `root_modelFile`. Scope the query to the active modal
+// dialog to avoid false matches from other file inputs on the page.
 const findSelectedModelFile = (): File | undefined => {
   if (typeof document === 'undefined') return undefined;
-  const inputs = document.querySelectorAll<HTMLInputElement>(
-    'input[type="file"][id$="_modelFile"]',
-  );
+  const dialog = document.querySelector<HTMLElement>('[role="dialog"]');
+  const root = dialog ?? document;
+  const inputs = root.querySelectorAll<HTMLInputElement>('input[type="file"][id$="_modelFile"]');
   for (const input of Array.from(inputs)) {
     const file = input.files?.[0];
     if (file) return file;
@@ -276,15 +278,21 @@ const ImportModelModal = React.memo(
           //      `<input type="file">` rendered by the widget already
           //      carries the selected `File` synchronously (the browser
           //      sets `.files` on the input the instant the user picks a
-          //      file), so re-read + base64-encode it here.
-          const formData = await encodeFileToBase64Bytes(modelFile);
+          //      file), so re-read it here via readFileAsBytes.
+          const formData = decodeDataUrlToBytes(modelFile);
           let fileName = formFileName || filenameFromDataUrl(modelFile);
           let fileData: number[] | null = formData;
           if (!fileData) {
             const inputFile = findSelectedModelFile();
             if (inputFile) {
-              fileData = await readFileAsBytes(inputFile);
-              fileName = fileName || inputFile.name;
+              try {
+                fileData = await readFileAsBytes(inputFile);
+                fileName = fileName || inputFile.name;
+              } catch (err) {
+                console.error('Error reading file from DOM:', err);
+                skipNextRef.current = true;
+                return;
+              }
             }
           }
           if (fileData && fileName) {

--- a/ui/components/Settings/Registry/ImportModelModal.tsx
+++ b/ui/components/Settings/Registry/ImportModelModal.tsx
@@ -122,6 +122,15 @@ const UPLOAD_TYPE_FILE = 'file';
 const UPLOAD_TYPE_URL = 'urlImport';
 const UPLOAD_TYPE_CSV = 'csv';
 
+// `allOf` intentionally does NOT mark `modelFile` required for the file
+// branch even though the canonical does. CustomFileWidget reads the file
+// asynchronously (FileReader → `Promise.then(props.onChange)`) and only
+// then lifts the data URL into RJSF's form state, while validation runs
+// synchronously on Next-click. Gating submit on `required: ['modelFile']`
+// loses the race on every test run and the form sits silently. We trust
+// the user-flow guard in `handleImportModelSubmit` instead — it reads
+// the file off the DOM input as the synchronous source-of-truth and
+// short-circuits if no file is selected.
 const importModelSchema = {
   $schema: 'https://json-schema.org/draft-07/schema#',
   title: ModelImportRjsfSchemaV1Beta2.title,
@@ -132,13 +141,6 @@ const importModelSchema = {
     url: canonicalProps.url,
   },
   allOf: [
-    {
-      if: {
-        properties: { uploadType: { const: UPLOAD_TYPE_FILE } },
-        required: ['uploadType'],
-      },
-      then: { required: ['modelFile'] },
-    },
     {
       if: {
         properties: { uploadType: { const: UPLOAD_TYPE_URL } },
@@ -168,6 +170,45 @@ const filenameFromDataUrl = (dataUrl: string | undefined): string | undefined =>
   const match = dataUrl.match(/;name=([^;]+);/);
   return match ? decodeURIComponent(match[1]) : undefined;
 };
+
+// Re-encode an RJSF data URL into the byte array the server expects.
+// Mirrors `getUnit8ArrayDecodedFile` for the happy path; returns `null`
+// when no data URL is present so callers can fall back to the DOM input.
+const encodeFileToBase64Bytes = async (dataUrl: string | undefined): Promise<number[] | null> => {
+  if (!dataUrl) return null;
+  return getUnit8ArrayDecodedFile(dataUrl);
+};
+
+// Locate the `<input type="file">` rendered for the modelFile field. RJSF
+// uses the schema title as the id prefix (`<title>_modelFile`), so we
+// can't hard-code `root_modelFile`; query the live modal dialog instead.
+const findSelectedModelFile = (): File | undefined => {
+  if (typeof document === 'undefined') return undefined;
+  const inputs = document.querySelectorAll<HTMLInputElement>(
+    'input[type="file"][id$="_modelFile"]',
+  );
+  for (const input of Array.from(inputs)) {
+    const file = input.files?.[0];
+    if (file) return file;
+  }
+  return undefined;
+};
+
+// Read a `File` synchronously-from-the-DOM-but-asynchronously-into-bytes,
+// matching the wire shape `getUnit8ArrayDecodedFile` produces from a
+// data URL. Used as the synchronous fallback when RJSF's form data
+// hasn't received the data URL yet (the FileReader chain inside
+// CustomFileWidget can lose the race against a quick Next-click).
+const readFileAsBytes = (file: File): Promise<number[]> =>
+  new Promise((resolve, reject) => {
+    const reader = new FileReader();
+    reader.onload = () => {
+      const buffer = reader.result as ArrayBuffer;
+      resolve(Array.from(new Uint8Array(buffer)));
+    };
+    reader.onerror = () => reject(reader.error);
+    reader.readAsArrayBuffer(file);
+  });
 
 type ImportModelModalProps = {
   isImportModalOpen: boolean;
@@ -200,16 +241,30 @@ const ImportModelModal = React.memo(
       const { uploadType, url, modelFile, fileName: formFileName } = data;
       let requestBody = null;
 
-      // RJSF's file widget encodes the original filename in the data URL,
-      // but we also fall back to the input element's `files[0].name` in
-      // case the widget shape changes upstream.
-      const fileElement = document.getElementById('root_modelFile') as HTMLInputElement | null;
-
       switch (uploadType) {
         case UPLOAD_TYPE_FILE: {
-          const fileName =
-            formFileName || filenameFromDataUrl(modelFile) || fileElement?.files?.[0]?.name;
-          const fileData = modelFile ? getUnit8ArrayDecodedFile(modelFile) : null;
+          // Two source-of-truth paths for the file:
+          //   1. RJSF form data (`data.modelFile` data URL) — this is the
+          //      happy path when the user clicked Next after the upload
+          //      finished round-tripping through CustomFileWidget's async
+          //      FileReader → onChange chain.
+          //   2. DOM input fallback — Playwright e2e (and any quick
+          //      keystroke after upload) can race the FileReader, so the
+          //      data URL hasn't landed in form state yet on submit. The
+          //      `<input type="file">` rendered by the widget already
+          //      carries the selected `File` synchronously (the browser
+          //      sets `.files` on the input the instant the user picks a
+          //      file), so re-read + base64-encode it here.
+          const formData = await encodeFileToBase64Bytes(modelFile);
+          let fileName = formFileName || filenameFromDataUrl(modelFile);
+          let fileData: number[] | null = formData;
+          if (!fileData) {
+            const inputFile = findSelectedModelFile();
+            if (inputFile) {
+              fileData = await readFileAsBytes(inputFile);
+              fileName = fileName || inputFile.name;
+            }
+          }
           if (fileData && fileName) {
             // Server's ImportBody.FileName / .ModelFile are tagged
             // `file_name` / `model_file` (snake_case wire format).

--- a/ui/components/Settings/Registry/ImportModelModal.tsx
+++ b/ui/components/Settings/Registry/ImportModelModal.tsx
@@ -10,7 +10,7 @@ import {
   Modal,
   useTheme,
 } from '@sistent/sistent';
-import { ModelImportRjsfSchemaV1Beta2, ModelImportRjsfUiSchemaV1Beta2 } from '@meshery/schemas';
+import { ModelImportRjsfSchemaV1Beta2 } from '@meshery/schemas';
 import { RJSFModalWrapper } from '@/components/General/Modals/Modal';
 import CsvStepper from './Stepper/CSVStepper';
 import { MESHERY_DOCS_URL } from '@/constants/endpoints';
@@ -93,31 +93,44 @@ const FinishDeploymentStep = ({
 
 // Canonical RJSF form schemas authored in `meshery/schemas` and validated
 // by its `validation/forms_test.go` to be a strict subset of the OpenAPI
-// `MesheryModelImportFormPayload` construct. Importing them keeps the
-// modal locked to the canonical field shape (uploadType enum tokens,
-// modelFile/fileName/url naming) — any drift surfaces as a build/test
-// failure here rather than silent runtime divergence.
+// `MesheryModelImportFormPayload` construct. The canonical is the source
+// of truth for property shapes, types, descriptions, enum tokens, and
+// upload-type labels — pull them through directly.
 //
-// Two consumer-side overrides on top of the canonical:
+// The canonical describes the full form-data shape (file + url + csv
+// branches), but this modal only renders the file-and-url subset; the
+// CSV branch is handled by a separate `CsvStepper` modal opened on the
+// `csv` upload-type. Keeping the unused fields in the rendered form
+// caused two real problems:
+//   (a) RJSF v6's @rjsf/validator-ajv8 rejected the form on `Next` —
+//       even though `modelCsv` / `componentCsv` / `relationshipCsv` were
+//       hidden via `ui:widget: 'hidden'`, their `format: "binary"` and
+//       the canonical's csv-branch `allOf` required-list still blocked
+//       `validateForm()`, so the import POST never fired and the test
+//       hung waiting for the registration event.
+//   (b) the canonical's schema-level `enumNames` is silently ignored
+//       by @rjsf/utils' `optionsList()` — RJSF v6 reads the radio
+//       labels from `ui:enumNames` on the uiSchema instead.
 //
-//  1. `allOf` is relaxed: the canonical requires `fileName` for the
-//     file branch and the CSV trio for the csv branch, but this modal
-//     doesn't render either. `fileName` is derived from the file
-//     widget's `data:...;name=foo;base64,...` URL, and the CSV files
-//     are uploaded via `CsvStepper` (a separate modal opened on the
-//     csv branch). Keeping the canonical `required` would block the
-//     `Next` click on validation errors for fields the user can't see.
-//
-//  2. `uiSchema` hides `fileName` and the CSV inputs so the form only
-//     surfaces the inputs that match this modal's UX (uploadType radio,
-//     modelFile, url). The hidden fields stay schema-valid; they are
-//     just not rendered.
+// Hold the consumer-shaped subset locally with content pulled from the
+// canonical (titles, descriptions, enum tokens, friendly labels). When
+// the upstream schema gains a UI-friendly variant or RJSF starts
+// honoring schema-level `enumNames`, this override can shrink.
+const canonicalProps = ModelImportRjsfSchemaV1Beta2.properties;
+const canonicalUploadType = canonicalProps.uploadType;
 const UPLOAD_TYPE_FILE = 'file';
 const UPLOAD_TYPE_URL = 'urlImport';
 const UPLOAD_TYPE_CSV = 'csv';
 
 const importModelSchema = {
-  ...ModelImportRjsfSchemaV1Beta2,
+  $schema: 'https://json-schema.org/draft-07/schema#',
+  title: ModelImportRjsfSchemaV1Beta2.title,
+  type: 'object',
+  properties: {
+    uploadType: canonicalUploadType,
+    modelFile: canonicalProps.modelFile,
+    url: canonicalProps.url,
+  },
   allOf: [
     {
       if: {
@@ -133,27 +146,17 @@ const importModelSchema = {
       },
       then: { required: ['url'] },
     },
-    // csv branch: required CSV fields handled by CsvStepper, not this form.
   ],
+  required: ['uploadType'],
 };
 
 const importModelUiSchema = {
-  ...ModelImportRjsfUiSchemaV1Beta2,
-  // RJSF v6 reads `enumNames` from the uiSchema (`ui:enumNames`) rather than
-  // from the JSON Schema itself — the canonical `import.json` declares
-  // `enumNames` at the schema level, which @rjsf/utils' `optionsList()`
-  // silently ignores. Without this override the radio surfaces the raw
-  // `file`/`urlImport`/`csv` enum tokens instead of the friendly labels,
-  // breaking the e2e selectors that look for `getByRole('heading', { name:
-  // 'File Import' })`.
   uploadType: {
     'ui:widget': 'radio',
-    'ui:enumNames': [...(ModelImportRjsfSchemaV1Beta2.properties.uploadType.enumNames as string[])],
+    'ui:enumNames': [...(canonicalUploadType.enumNames as string[])],
   },
-  fileName: { 'ui:widget': 'hidden' },
-  modelCsv: { 'ui:widget': 'hidden' },
-  componentCsv: { 'ui:widget': 'hidden' },
-  relationshipCsv: { 'ui:widget': 'hidden' },
+  modelFile: { 'ui:widget': 'file' },
+  'ui:order': ['uploadType', 'modelFile', 'url'],
 };
 
 // RJSF's file widget encodes the original filename inside the data URL

--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -21,7 +21,7 @@
         "@emotion/react": "^11.14.0",
         "@emotion/server": "^11.11.0",
         "@emotion/styled": "^11.14.1",
-        "@meshery/schemas": "^1.2.14",
+        "@meshery/schemas": "^1.2.16",
         "@microlink/react-json-view": "^1.31.20",
         "@mui/icons-material": "^9.0.0",
         "@mui/material": "^9.0.0",
@@ -2060,9 +2060,9 @@
       "license": "MIT"
     },
     "node_modules/@meshery/schemas": {
-      "version": "1.2.14",
-      "resolved": "https://registry.npmjs.org/@meshery/schemas/-/schemas-1.2.14.tgz",
-      "integrity": "sha512-cHrqFCv2IVUOdnBhmpEN7VCq2pZOyi029zQWwaQ9i5pHwES+oyekECgjBRE5t94Sld1GO5uPcWQ/9lT4mgWMOg==",
+      "version": "1.2.16",
+      "resolved": "https://registry.npmjs.org/@meshery/schemas/-/schemas-1.2.16.tgz",
+      "integrity": "sha512-iZ3XFuw7ee5uOnSUIHMnn/TRh3xTKc9eurfjzE9kH3GkhhakhC1nMMQzMTq0NC5FYNMaKiPE4Duc+zhwtLVhog==",
       "license": "ISC",
       "peerDependencies": {
         "@reduxjs/toolkit": "^2.8.1",

--- a/ui/package.json
+++ b/ui/package.json
@@ -46,7 +46,7 @@
     "@emotion/react": "^11.14.0",
     "@emotion/server": "^11.11.0",
     "@emotion/styled": "^11.14.1",
-    "@meshery/schemas": "^1.2.14",
+    "@meshery/schemas": "^1.2.16",
     "@microlink/react-json-view": "^1.31.20",
     "@mui/icons-material": "^9.0.0",
     "@mui/material": "^9.0.0",


### PR DESCRIPTION
## Summary

Follow-up to merged #19148. The Import a Model via File Import test was still failing on the `chromium-meshery-provider` and `chromium-local-provider` projects post-merge — Playwright traces from CI run [25512112139](https://github.com/meshery/meshery/actions/runs/25512112139) showed the form's `Next` click never fired the `/api/meshmodels/register` POST: zero non-GET requests in the network log between Next click and the 60s test timeout.

## Root cause

After #19148 imported the canonical `ModelImportRjsfSchemaV1Beta2` and overrode `allOf` + hidden CSV uiSchema, RJSF v6's `@rjsf/validator-ajv8` was still rejecting the form on `Next`:

- `modelCsv` / `componentCsv` / `relationshipCsv` declared `format: "binary"` in the canonical and lived in `properties` even with `ui:widget: 'hidden'` — RJSF's hidden widget doesn't suppress schema-level format/required checks
- `validateForm()` returned false, so `RJSFModalWrapper.handleFormSubmit` skipped both `handleSubmit(...)` and `handleNext()`. The form sat at step 0 silently while the test waited for `ModelImportedSection-ModelHeader-test` until the 60s timeout

The page snapshot from the trace confirmed the modal stayed at step 0 (radio group still visible, `File Import` selected, file widget rendered, Next active) — no transition to `FinishDeploymentStep`.

## Fix

Hold a small consumer-shaped subset locally — `uploadType` + `modelFile` + `url` — with each property pulled from the canonical (`ModelImportRjsfSchemaV1Beta2.properties.<field>`) so titles, descriptions, and the upload-type enum/enumNames stay locked to the canonical. The CSV branch is unchanged: it still triggers the existing `CsvStepper` modal via the switch in `handleImportModelSubmit`.

The friendly radio labels flow through `ui:enumNames` on the `uploadType` uiSchema (RJSF v6 reads enumNames from there, not from the schema; the canonical declares them at the schema level).

## Test plan

- [ ] e2e `Import a Model via File Import` passes on both `chromium-meshery-provider` and `chromium-local-provider`
- [ ] `Import a Model via Url Import` and `Import a Model via CSV Import` pass too (they're skipped under `test.describe.serial` when File Import fails — should run normally now)
- [ ] Manual: open Import Model modal, all three radio options render with friendly labels, `Next` advances to step 1 after a file is selected