### PR TITLE
fix(remote-provider): only set X-API-Key for the anonymous global token

### DIFF
--- a/server/models/remote_auth.go
+++ b/server/models/remote_auth.go
@@ -170,9 +170,9 @@ func (l *RemoteProvider) doRequestHelper(req *http.Request, token string) (*http
 		Transport: tracing.NewTransport(http.DefaultTransport), // Create tracing transport to pass tracing context
 	}
 	req.Header.Set("Authorization", fmt.Sprintf("bearer %s", token))
-	// if token == models.GlobalTokenForAnonymousResults { // disabling because of import cycle
-	req.Header.Set("X-API-Key", token) // adds the token as special passphrase incase the token is a special passphrase
-	// }
+	if token == GlobalTokenForAnonymousResults {
+		req.Header.Set("X-API-Key", token)
+	}
 	req.Header.Set("SystemID", viper.GetString("INSTANCE_ID")) // Adds the system id to the header for event tracking
 	resp, err := c.Do(req)
 	if err != nil {

--- a/server/models/remote_auth.go
+++ b/server/models/remote_auth.go
@@ -172,6 +172,12 @@ func (l *RemoteProvider) doRequestHelper(req *http.Request, token string) (*http
 	req.Header.Set("Authorization", fmt.Sprintf("bearer %s", token))
 	if token == GlobalTokenForAnonymousResults {
 		req.Header.Set("X-API-Key", token)
+	} else {
+		// Defensive: drop any inbound X-API-Key copied through proxy paths
+		// (e.g. ExtensionProxy). The cloud's static-token fallback rejects
+		// anything other than GlobalTokenForAnonymousResults, so leaking a
+		// caller-supplied value here would only confuse the auth path.
+		req.Header.Del("X-API-Key")
 	}
 	req.Header.Set("SystemID", viper.GetString("INSTANCE_ID")) // Adds the system id to the header for event tracking
 	resp, err := c.Do(req)

--- a/server/models/remote_auth_test.go
+++ b/server/models/remote_auth_test.go
@@ -10,6 +10,7 @@ import (
 	"net/http/httptest"
 	"net/url"
 	"strings"
+	"sync"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -373,16 +374,35 @@ func TestRemoteProviderDoRequest_RetriesWithFreshBodyAfterRefresh(t *testing.T) 
 // passphrase contract: X-API-Key MUST only be set when the outbound request
 // is being made with the global anonymous token, never with a real user JWT.
 // Setting X-API-Key with a user JWT pollutes the cloud's static-token
-// fallback path and broke anonymous flows in kanvas.new.
+// fallback path and broke anonymous flows in kanvas.new. The test also
+// covers the defensive Del path: a caller-supplied X-API-Key on a
+// non-anonymous outbound request must be stripped before reaching cloud.
 func TestRemoteProviderDoRequest_XAPIKeyAnonymousOnly(t *testing.T) {
-	var anonHeader, userHeader string
+	var (
+		mu      sync.Mutex
+		headers = map[string]string{}
+	)
+	record := func(label, value string) {
+		mu.Lock()
+		defer mu.Unlock()
+		headers[label] = value
+	}
+	read := func(label string) string {
+		mu.Lock()
+		defer mu.Unlock()
+		return headers[label]
+	}
+
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		switch r.URL.Path {
 		case "/anon":
-			anonHeader = r.Header.Get("X-API-Key")
+			record("anon", r.Header.Get("X-API-Key"))
 			w.WriteHeader(http.StatusOK)
 		case "/user":
-			userHeader = r.Header.Get("X-API-Key")
+			record("user", r.Header.Get("X-API-Key"))
+			w.WriteHeader(http.StatusOK)
+		case "/user-with-stale-api-key":
+			record("stale", r.Header.Get("X-API-Key"))
 			w.WriteHeader(http.StatusOK)
 		default:
 			http.NotFound(w, r)
@@ -392,6 +412,19 @@ func TestRemoteProviderDoRequest_XAPIKeyAnonymousOnly(t *testing.T) {
 
 	provider := newTestRemoteProvider(t, server.URL)
 
+	assertOK := func(resp *http.Response, label string) {
+		t.Helper()
+		defer func() {
+			if cerr := resp.Body.Close(); cerr != nil {
+				t.Logf("%s: error closing response body: %v", label, cerr)
+			}
+		}()
+		if resp.StatusCode != http.StatusOK {
+			body, _ := io.ReadAll(resp.Body)
+			t.Fatalf("%s: status %d, body: %s", label, resp.StatusCode, strings.TrimSpace(string(body)))
+		}
+	}
+
 	anonReq, err := http.NewRequest(http.MethodGet, server.URL+"/anon", nil)
 	if err != nil {
 		t.Fatalf("failed to build anonymous request: %v", err)
@@ -400,7 +433,7 @@ func TestRemoteProviderDoRequest_XAPIKeyAnonymousOnly(t *testing.T) {
 	if err != nil {
 		t.Fatalf("anon request failed: %v", err)
 	}
-	_ = resp.Body.Close()
+	assertOK(resp, "anon request")
 
 	userToken := encodeTestToken(t, oauth2.Token{AccessToken: "real-user-jwt", TokenType: "Bearer"})
 	userReq, err := http.NewRequest(http.MethodGet, server.URL+"/user", nil)
@@ -411,12 +444,27 @@ func TestRemoteProviderDoRequest_XAPIKeyAnonymousOnly(t *testing.T) {
 	if err != nil {
 		t.Fatalf("user request failed: %v", err)
 	}
-	_ = resp.Body.Close()
+	assertOK(resp, "user request")
 
-	if anonHeader != GlobalTokenForAnonymousResults {
-		t.Fatalf("anonymous request must carry X-API-Key=%q, got %q", GlobalTokenForAnonymousResults, anonHeader)
+	// Inbound proxy header that should be stripped, not forwarded.
+	staleReq, err := http.NewRequest(http.MethodGet, server.URL+"/user-with-stale-api-key", nil)
+	if err != nil {
+		t.Fatalf("failed to build stale request: %v", err)
 	}
-	if userHeader != "" {
-		t.Fatalf("authenticated request must NOT set X-API-Key, got %q", userHeader)
+	staleReq.Header.Set("X-API-Key", "leaked-from-inbound-request")
+	resp, err = provider.DoRequest(staleReq, userToken)
+	if err != nil {
+		t.Fatalf("stale request failed: %v", err)
+	}
+	assertOK(resp, "stale request")
+
+	if got := read("anon"); got != GlobalTokenForAnonymousResults {
+		t.Fatalf("anonymous request must carry X-API-Key=%q, got %q", GlobalTokenForAnonymousResults, got)
+	}
+	if got := read("user"); got != "" {
+		t.Fatalf("authenticated request must NOT set X-API-Key, got %q", got)
+	}
+	if got := read("stale"); got != "" {
+		t.Fatalf("authenticated request with inbound X-API-Key must strip it, got %q", got)
 	}
 }

--- a/server/models/remote_auth_test.go
+++ b/server/models/remote_auth_test.go
@@ -368,3 +368,55 @@ func TestRemoteProviderDoRequest_RetriesWithFreshBodyAfterRefresh(t *testing.T) 
 		t.Fatalf("expected exactly one refresh request, got %d", got)
 	}
 }
+
+// TestRemoteProviderDoRequest_XAPIKeyAnonymousOnly guards the anonymous
+// passphrase contract: X-API-Key MUST only be set when the outbound request
+// is being made with the global anonymous token, never with a real user JWT.
+// Setting X-API-Key with a user JWT pollutes the cloud's static-token
+// fallback path and broke anonymous flows in kanvas.new.
+func TestRemoteProviderDoRequest_XAPIKeyAnonymousOnly(t *testing.T) {
+	var anonHeader, userHeader string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/anon":
+			anonHeader = r.Header.Get("X-API-Key")
+			w.WriteHeader(http.StatusOK)
+		case "/user":
+			userHeader = r.Header.Get("X-API-Key")
+			w.WriteHeader(http.StatusOK)
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer server.Close()
+
+	provider := newTestRemoteProvider(t, server.URL)
+
+	anonReq, err := http.NewRequest(http.MethodGet, server.URL+"/anon", nil)
+	if err != nil {
+		t.Fatalf("failed to build anonymous request: %v", err)
+	}
+	resp, err := provider.DoRequest(anonReq, GlobalTokenForAnonymousResults)
+	if err != nil {
+		t.Fatalf("anon request failed: %v", err)
+	}
+	_ = resp.Body.Close()
+
+	userToken := encodeTestToken(t, oauth2.Token{AccessToken: "real-user-jwt", TokenType: "Bearer"})
+	userReq, err := http.NewRequest(http.MethodGet, server.URL+"/user", nil)
+	if err != nil {
+		t.Fatalf("failed to build user request: %v", err)
+	}
+	resp, err = provider.DoRequest(userReq, userToken)
+	if err != nil {
+		t.Fatalf("user request failed: %v", err)
+	}
+	_ = resp.Body.Close()
+
+	if anonHeader != GlobalTokenForAnonymousResults {
+		t.Fatalf("anonymous request must carry X-API-Key=%q, got %q", GlobalTokenForAnonymousResults, anonHeader)
+	}
+	if userHeader != "" {
+		t.Fatalf("authenticated request must NOT set X-API-Key, got %q", userHeader)
+	}
+}


### PR DESCRIPTION
## Summary

`RemoteProvider.doRequestHelper` was unconditionally setting `X-API-Key` to the bearer token on every outbound request to Meshery Cloud:

```go
req.Header.Set("Authorization", fmt.Sprintf("bearer %s", token))
// if token == models.GlobalTokenForAnonymousResults { // disabling because of import cycle
req.Header.Set("X-API-Key", token) // adds the token as special passphrase incase the token is a special passphrase
// }
```

The "import cycle" justification is wrong. `GlobalTokenForAnonymousResults` is defined in this very package (`server/models/user.go`); the original author seems to have tried `models.GlobalTokenForAnonymousResults` (a Go syntax error — you can't qualify identifiers with the current package name) and assumed it was an import cycle.

Restoring the guard. `X-API-Key` now only goes out when the outbound token is the special anonymous passphrase. Authenticated user requests carry only `Authorization: bearer <jwt>`.

## Why this broke anonymous browsing

Anonymous user support is a coordinated flow across three repos:

1. Browser hits kanvas.new without a token → Meshery Server's `InitiateLogin` sees `PersistAnonymousUser` capability and calls `InterceptLoginAndInitiateAnonymousUserSession` (correctly using a fresh `http.Client` with `X-API-Key: GlobalTokenForAnonymousResults`).
2. Cloud's `/api/identity/users/anonymous` (wrapped in `AuthMiddlewareORSpecialToken`) creates an anonymous user, returns a JWT.
3. Server sets the JWT cookie, kanvas loads, subsequent kanvas requests proxy through Server's `ExtensionProxy` → cloud — and *those* requests went through `doRequestHelper`, which polluted them with `X-API-Key: <user-jwt>`.

Cloud's `getStaticUserHelper` rejects any `X-API-Key` that isn't `GlobalTokenForAnonymousResults`, which silently broke any cloud handler that falls through from `getUserHelper` to `getStaticUserHelper` (e.g., `meshery_results.go`). Combined with the recent NULL-`users.status` backfill on the cloud side (`layer5io/meshery-cloud@ce0ca94d`) and an XState init-stall in Kanvas (`layer5labs/meshery-extensions#…`), the anonymous flow on kanvas.new was unusable.

## Changes

- `server/models/remote_auth.go` — restore the anonymous-only conditional around `X-API-Key`. Removes the misleading "import cycle" comment.
- `server/models/remote_auth_test.go` — new `TestRemoteProviderDoRequest_XAPIKeyAnonymousOnly` regression test covering both the anonymous-token path (X-API-Key MUST be set) and the user-JWT path (X-API-Key MUST NOT be set), so this contract can't silently regress again.

## Test plan

- [x] `go test ./server/models/ -run TestRemoteProviderDoRequest_XAPIKeyAnonymousOnly` — passes.
- [x] `go test ./server/models/ -run TestRemoteProviderDoRequest_DoesNotRefreshAnonymousToken` — still passes (existing anonymous-token regression).
- [x] `go build ./server/models/...` — clean.
- [ ] End-to-end: hit kanvas.new in a private window, confirm an anonymous JWT is minted by Cloud and subsequent `/api/extensions/...` requests succeed (no spurious 401 from `getStaticUserHelper`).
- [ ] Authenticated regression: log in as a normal user, confirm cloud-bound requests carry `Authorization: bearer <jwt>` and *not* `X-API-Key`.
