### PR TITLE
[Docs] Fix missing intra-page navigation on REST API reference page

### DIFF
--- a/docs/_includes/toc.html
+++ b/docs/_includes/toc.html
@@ -33,6 +33,20 @@ $(document).ready(function() {
              })
              $("#link_" + div_id).append(children);
         });
+
+        // Fallback for layouts (e.g. swagger) where h2/h3 headings are nested
+        // inside wrapper divs and are not direct siblings of h1 elements.
+        if (toc.children().length === 0) {
+            $('.td-content').find('h2[id], h3[id]').each(function() {
+                var heading = $(this);
+                if (!heading.hasClass('noTOC')) {
+                    var heading_id = heading.attr('id');
+                    var heading_text = heading.text().split('¶')[0];
+                    var content = '<li class="md-nav__item"><a class="md-nav__link" href="#' + heading_id + '" title="' + heading_text + '">' + heading_text + '</a></li>';
+                    toc.append(content);
+                }
+            });
+        }
         //added 'selected' tag to the first element of toc
         $('.md-nav__link').first().addClass('selected');
 

--- a/docs/_layouts/swagger.html
+++ b/docs/_layouts/swagger.html
@@ -25,7 +25,8 @@ title: Rest API Docs
 
 {% for route in sorted_paths %}
 <div class="swagger-path">
-    <h2 class="swagger-path">{{ route[0] }}</h2>
+    {% assign route_id = route[0] | slugify %}
+    <h2 class="swagger-path" id="{{ route_id }}">{{ route[0] }}</h2>
 {% if route[0] contains '/api/oam' %}
     <span class="deprecated-label">Deprecated</span>
 {% endif %}


### PR DESCRIPTION
## Description

This PR fixes the missing intra-page navigation (TOC) issue on the REST API reference pages in Meshery Docs.

### Changes Made
- Added unique `id` attributes to dynamically generated `h2` headings in `swagger.html` using Liquid `slugify`.
- Added fallback TOC generation in `toc.html` for layouts where headings are nested inside wrapper `div`s.
- Ensured the fallback only activates when the existing TOC logic finds no entries, avoiding impact on other pages.

### Why
The existing TOC logic expected headings to be direct siblings of `h1`, but the REST API pages generate headings inside nested containers, causing the navigation to remain empty.

### Notes for Reviewers
- Fixes #19077

### Checklist
- [x] Tested locally
- [ ] Signed commits included

