### PR TITLE
[Docs] Enable intra-page navigation on REST API overview page

### DIFF
--- a/docs/content/en/reference/rest-apis/_index.md
+++ b/docs/content/en/reference/rest-apis/_index.md
@@ -2,6 +2,7 @@
 title: REST API
 description: Meshery REST API documentation
 data: openapi
+display_toc: true
 aliases: 
 - /reference/rest-apis/swagger
 ---

--- a/docs/content/en/reference/rest-apis/_index.md
+++ b/docs/content/en/reference/rest-apis/_index.md
@@ -2,7 +2,6 @@
 title: REST API
 description: Meshery REST API documentation
 data: openapi
-display_toc: false
 aliases: 
 - /reference/rest-apis/swagger
 ---

--- a/docs/content/en/reference/rest-apis/_index.md
+++ b/docs/content/en/reference/rest-apis/_index.md
@@ -16,12 +16,11 @@ Meshery's REST API specifications are now maintained and published from the [mes
 
 Each of Meshery's APIs is subject to Meshery's authentication and authorization system. Meshery requires a valid token in order to allow clients to invoke its APIs.
 
-<details>
-  <summary>Authentication</summary>
-  Requests to any of the API endpoints must be authenticated and include a valid JWT access token in the HTTP headers. The type of authentication is determined by the selected <a href='/extensibility/providers'>Providers</a>. Use of the Local Provider, "None", puts Meshery into single-user mode and uses minimal, intentionally insecure authentication.
+### Authentication
 
-  {{% alert color="dark" title="What are authentication tokens?" %}}Meshery authentication tokens allow users or systems to authenticate with Meshery Server via either its two clients, <a href='/reference/mesheryctl'>Meshery CLI</a> and <a href='/extensibility/api#how-to-get-your-token'>Meshery UI</a>, or its two APIs: <a href='/reference/rest-apis'>REST</a> or <a href='/reference/graphql-apis'>GraphQL</a>. <p>Meshery's authentication token system provides secure access to Meshery's management features.</p>{{% /alert %}}
-</details>
+Requests to any of the API endpoints must be authenticated and include a valid JWT access token in the HTTP headers. The type of authentication is determined by the selected <a href='/extensibility/providers'>Providers</a>. Use of the Local Provider, "None", puts Meshery into single-user mode and uses minimal, intentionally insecure authentication.
+
+{{% alert color="dark" title="What are authentication tokens?" %}}Meshery authentication tokens allow users or systems to authenticate with Meshery Server via either its two clients, <a href='/reference/mesheryctl'>Meshery CLI</a> and <a href='/extensibility/api#how-to-get-your-token'>Meshery UI</a>, or its two APIs: <a href='/reference/rest-apis'>REST</a> or <a href='/reference/graphql-apis'>GraphQL</a>. <p>Meshery's authentication token system provides secure access to Meshery's management features.</p>{{% /alert %}}
 
 ### How to get your token
 

--- a/docs/content/en/reference/rest-apis/_index.md
+++ b/docs/content/en/reference/rest-apis/_index.md
@@ -2,7 +2,6 @@
 title: REST API
 description: Meshery REST API documentation
 data: openapi
-display_toc: true
 aliases: 
 - /reference/rest-apis/swagger
 ---
@@ -17,11 +16,12 @@ Meshery's REST API specifications are now maintained and published from the [mes
 
 Each of Meshery's APIs is subject to Meshery's authentication and authorization system. Meshery requires a valid token in order to allow clients to invoke its APIs.
 
-### Authentication
+<details>
+  <summary>Authentication</summary>
+  Requests to any of the API endpoints must be authenticated and include a valid JWT access token in the HTTP headers. The type of authentication is determined by the selected <a href='/extensibility/providers'>Providers</a>. Use of the Local Provider, "None", puts Meshery into single-user mode and uses minimal, intentionally insecure authentication.
 
-Requests to any of the API endpoints must be authenticated and include a valid JWT access token in the HTTP headers. The type of authentication is determined by the selected <a href='/extensibility/providers'>Providers</a>. Use of the Local Provider, "None", puts Meshery into single-user mode and uses minimal, intentionally insecure authentication.
-
-{{% alert color="dark" title="What are authentication tokens?" %}}Meshery authentication tokens allow users or systems to authenticate with Meshery Server via either its two clients, <a href='/reference/mesheryctl'>Meshery CLI</a> and <a href='/extensibility/api#how-to-get-your-token'>Meshery UI</a>, or its two APIs: <a href='/reference/rest-apis'>REST</a> or <a href='/reference/graphql-apis'>GraphQL</a>. <p>Meshery's authentication token system provides secure access to Meshery's management features.</p>{{% /alert %}}
+  {{% alert color="dark" title="What are authentication tokens?" %}}Meshery authentication tokens allow users or systems to authenticate with Meshery Server via either its two clients, <a href='/reference/mesheryctl'>Meshery CLI</a> and <a href='/extensibility/api#how-to-get-your-token'>Meshery UI</a>, or its two APIs: <a href='/reference/rest-apis'>REST</a> or <a href='/reference/graphql-apis'>GraphQL</a>. <p>Meshery's authentication token system provides secure access to Meshery's management features.</p>{{% /alert %}}
+</details>
 
 ### How to get your token
 

--- a/docs/content/en/reference/rest-apis/endpoints.md
+++ b/docs/content/en/reference/rest-apis/endpoints.md
@@ -3,5 +3,4 @@ title: REST API Reference
 description: Meshery REST API Reference
 layout: rest-apis
 data: openapi
-display_toc: true
 ---

--- a/docs/content/en/reference/rest-apis/endpoints.md
+++ b/docs/content/en/reference/rest-apis/endpoints.md
@@ -3,5 +3,5 @@ title: REST API Reference
 description: Meshery REST API Reference
 layout: rest-apis
 data: openapi
-display_toc: false
+display_toc: true
 ---


### PR DESCRIPTION
## Description

Enables the right-side Table of Contents (intra-page navigation) on the REST API overview page (`/reference/rest-apis/`).

### Problem

The REST API overview page had `display_toc: false` in its frontmatter, which suppressed the standard Docsy TOC sidebar. This meant users couldn't quickly navigate to sections like Authentication, How to get your token, How to access Meshery's REST API, and Endpoints.

### Changes

**`docs/content/en/reference/rest-apis/_index.md`**
- Removed `display_toc: false` from frontmatter to enable the standard Hugo/Docsy TOC

The endpoints reference page (`endpoints.md`) retains `display_toc: false` since it uses its own custom interactive sidebar navigation with search and resource filtering.

**[Signed commits](https://github.com/meshery/meshery/blob/master/CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [x] Yes, I signed my commits.
