### PR TITLE
[Docs] Fix 404 assets on deep routes

### DIFF
--- a/docs/hugo.toml
+++ b/docs/hugo.toml
@@ -1,6 +1,6 @@
 baseURL = "https://docs.meshery.io"
 title = "Documentation"
-relativeURLs = true
+relativeURLs = false
 canonifyURLs = false
 
 # Language settings

--- a/docs/layouts/_default/baseof.html
+++ b/docs/layouts/_default/baseof.html
@@ -6,7 +6,7 @@
     <script src="https://cdn.jsdelivr.net/npm/clipboard@1/dist/clipboard.min.js"></script>
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.0/css/all.min.css">
 
-    <script src="{{ "js/error-code-handler.js" | relURL }}"></script>
+    <script src="{{ "js/error-code-handler.js" | absURL }}"></script>
     
   </head>
 

--- a/docs/layouts/_default/baseof.html
+++ b/docs/layouts/_default/baseof.html
@@ -6,7 +6,7 @@
     <script src="https://cdn.jsdelivr.net/npm/clipboard@1/dist/clipboard.min.js"></script>
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.0/css/all.min.css">
 
-    <script src="{{ "js/error-code-handler.js" | absURL }}"></script>
+    <script src="/js/error-code-handler.js"></script>
     
   </head>
 

--- a/docs/layouts/partials/head.html
+++ b/docs/layouts/partials/head.html
@@ -108,9 +108,10 @@
   {{- $sass := resources.Get "scss/_styles_project.scss" -}} {{- $opts := dict "transpiler"
   "dartsass" "targetPath" "css/styles.css" -}} {{- with $sass | toCSS $opts |
   minify | fingerprint -}}
+  {{- $cssPath := printf "/%s" (strings.TrimPrefix "/" .RelPermalink) -}}
   <link
     rel="stylesheet"
-    href="{{ .Permalink }}"
+    href="{{ $cssPath }}"
     integrity="{{ .Data.Integrity }}"
     crossorigin="anonymous"
   />

--- a/docs/layouts/partials/head.html
+++ b/docs/layouts/partials/head.html
@@ -110,7 +110,7 @@
   minify | fingerprint -}}
   <link
     rel="stylesheet"
-    href="{{ .RelPermalink }}"
+    href="{{ .Permalink }}"
     integrity="{{ .Data.Integrity }}"
     crossorigin="anonymous"
   />


### PR DESCRIPTION
**Notes for Reviewers**

- This PR fixes #19142 
- Ensures docs assets load on deep invalid routes by using absolute URLs for the compiled CSS and js/error-code-handler.js.
- Behavior: invalid routes now render the 404 page without broken layout.

https://github.com/user-attachments/assets/5c3ad234-9e79-4768-ad60-229ddd579c2c

**[Signed commits](https://github.com/meshery/meshery/blob/master/CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [x] Yes, I signed my commits.

<!--
Thank you for contributing to Meshery! 

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. Sign your commits.
4. Include before and after screenshots/terminal output.

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.
-->
