### PR TITLE
[Docs] Update adapter contributor proto path and generation command

### DIFF
--- a/docs/content/en/project/contributing/contributing-adapters.md
+++ b/docs/content/en/project/contributing/contributing-adapters.md
@@ -27,13 +27,14 @@ Another way to test your local changes is to run the adapter as a process. To do
 Meshery uses adapters to manage and interact with different cloud native infrastructure. Meshery adapters are written in Go. Whether you are creating a new adapter or modifying an existing adapter, be sure to read the [Meshery Adapters](https://docs.google.com/document/d/1b8JAMzr3Rntu7CudRaYv6r6ccACJONAB5t7ISCaPNuA/edit#) design specification. For new adapters, start with the Repository Template(https://github.com/meshery/meshery). 
 
 1. Get the proto buf spec file from Meshery repo:
-   `wget https://raw.githubusercontent.com/meshery/meshery/master/meshes/meshops.proto`
+   `wget https://raw.githubusercontent.com/meshery/meshery/master/server/meshes/meshops.proto`
 1. Generate code
    1. Using Go as an example, do the following:
       - adding GOPATH to PATH: `export PATH=$PATH:$GOPATH/bin`
       - install grpc: `go get -u google.golang.org/grpc`
-      - install protoc plugin for go: `go get -u github.com/golang/protobuf/protoc-gen-go`
-      - Generate Go code: `protoc -I meshes/ meshes/meshops.proto --go_out=plugins=grpc:./meshes/`
+      - install protoc plugin for go: `go install google.golang.org/protobuf/cmd/protoc-gen-go@latest`
+      - install protoc plugin for Go gRPC: `go install google.golang.org/grpc/cmd/protoc-gen-go-grpc@latest`
+      - Generate Go code: `protoc --proto_path=meshes --go_out=meshes --go_opt=paths=source_relative --go-grpc_out=meshes --go-grpc_opt=paths=source_relative meshops.proto`
    1. For other languages, please refer to gRPC.io for language-specific guides.
 1. Implement the service methods and expose the gRPC server on a port of your choice (e.g. 10000).
 

--- a/docs/content/en/project/contributing/contributing-adapters.md
+++ b/docs/content/en/project/contributing/contributing-adapters.md
@@ -27,7 +27,7 @@ Another way to test your local changes is to run the adapter as a process. To do
 Meshery uses adapters to manage and interact with different cloud native infrastructure. Meshery adapters are written in Go. Whether you are creating a new adapter or modifying an existing adapter, be sure to read the [Meshery Adapters](https://docs.google.com/document/d/1b8JAMzr3Rntu7CudRaYv6r6ccACJONAB5t7ISCaPNuA/edit#) design specification. For new adapters, start with the Repository Template(https://github.com/meshery/meshery). 
 
 1. Get the proto buf spec file from Meshery repo:
-   `wget https://raw.githubusercontent.com/meshery/meshery/master/server/meshes/meshops.proto`
+wget -P meshes https://raw.githubusercontent.com/meshery/meshery/master/server/meshes/meshops.proto
 1. Generate code
    1. Using Go as an example, do the following:
       - adding GOPATH to PATH: `export PATH=$PATH:$GOPATH/bin`


### PR DESCRIPTION
**Notes for Reviewers**

- Updates the adapter contributor guide to reference the current `server/meshes/meshops.proto` path.
- Replaces the deprecated Go protobuf generation command with the current `protoc-gen-go` and `protoc-gen-go-grpc` flow.

- This PR fixes #19185 

**[Signed commits](https://github.com/meshery/meshery/blob/master/CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [x] Yes, I signed my commits.

<!--
Thank you for contributing to Meshery! 

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. Sign your commits.
4. Include before and after screenshots/terminal output.

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.
-->
