### PR TITLE
chore(deps): regen provider-ui/package-lock.json for @sistent/sistent v0.21.9

### DIFF
--- a/provider-ui/package-lock.json
+++ b/provider-ui/package-lock.json
@@ -17,7 +17,7 @@
         "@mui/icons-material": "^9.0.0",
         "@mui/material": "^9.0.0",
         "@mui/system": "^9.0.0",
-        "@sistent/sistent": "^0.21.4",
+        "@sistent/sistent": "^0.21.9",
         "@xstate/react": "^6.1.0",
         "http-proxy": "^1.18.1",
         "next": "^16.2.4",
@@ -1913,9 +1913,9 @@
       }
     },
     "node_modules/@sistent/sistent": {
-      "version": "0.21.4",
-      "resolved": "https://registry.npmjs.org/@sistent/sistent/-/sistent-0.21.4.tgz",
-      "integrity": "sha512-6iC2cQF8irgToSAEPOrXfb0OVthf/lOYpsy1Lk20ly7RdnroqX3r5fDW79HATTllqtYxH0BJLYcbp/CVkkVv4A==",
+      "version": "0.21.9",
+      "resolved": "https://registry.npmjs.org/@sistent/sistent/-/sistent-0.21.9.tgz",
+      "integrity": "sha512-j4H5BY7KLvgO+onkorjCX6O2VpQtf1cNiY7I86KmVw0SW83z9qIHHqaPCJOBVjOh3QIjBUY+wOQeNuNU9VZHvQ==",
       "dependencies": {
         "@emotion/react": "^11.14.0",
         "@emotion/styled": "^11.14.1",


### PR DESCRIPTION
Cross-branch bridge: the proxy on my session blocks direct `git push` to `bump-sistent-bot`, so the regenerated `provider-ui/package-lock.json` is on `claude/update-sistent-v0.21.9-tDrJp` instead. Merging this into `bump-sistent-bot` lands the lock-file diff on #18991 and lets `npm ci` resolve cleanly there.

Single-file change: 4-line update to `provider-ui/package-lock.json` syncing the resolved `@sistent/sistent` entry to 0.21.9 (matching `provider-ui/package.json` already on the branch).
