### PR TITLE
fix(notification-center): guard against undefined params.InputProps in TypingFilter

### DIFF
--- a/ui/components/TypingFilter/__tests__/buildCustomInputProps.test.tsx
+++ b/ui/components/TypingFilter/__tests__/buildCustomInputProps.test.tsx
@@ -1,0 +1,44 @@
+import React, { isValidElement } from 'react';
+import { describe, it, expect } from 'vitest';
+import { buildCustomInputProps } from '../buildCustomInputProps';
+
+const leading = <span data-testid="leading">filter</span>;
+
+describe('buildCustomInputProps', () => {
+  // Regression: NotificationCenter threw "undefined is not an object
+  // (evaluating 'e.InputProps.startAdornment')" because params.InputProps
+  // could be undefined when MUI's Autocomplete renderInput callback fired
+  // before InputProps was wired through.
+  it('does not throw when params.InputProps is undefined', () => {
+    expect(() => buildCustomInputProps(undefined, leading)).not.toThrow();
+    const result = buildCustomInputProps(undefined, leading);
+    expect(result).toBeDefined();
+    expect(isValidElement(result.startAdornment)).toBe(true);
+  });
+
+  it('preserves existing startAdornment after the leading adornment', () => {
+    const existing = <span data-testid="existing">existing</span>;
+    const result = buildCustomInputProps({ startAdornment: existing }, leading);
+    const fragment = result.startAdornment as React.ReactElement;
+    expect(isValidElement(fragment)).toBe(true);
+    const children = (fragment.props as { children: React.ReactNode[] }).children;
+    expect(children[0]).toBe(leading);
+    expect(children[1]).toBe(existing);
+  });
+
+  it('forwards arbitrary InputProps fields untouched', () => {
+    const ref = React.createRef<HTMLDivElement>();
+    const result = buildCustomInputProps(
+      { ref, className: 'foo', startAdornment: undefined },
+      leading,
+    );
+    expect(result.ref).toBe(ref);
+    expect(result.className).toBe('foo');
+  });
+
+  it('handles an empty InputProps object', () => {
+    expect(() => buildCustomInputProps({}, leading)).not.toThrow();
+    const result = buildCustomInputProps({}, leading);
+    expect(isValidElement(result.startAdornment)).toBe(true);
+  });
+});

--- a/ui/components/TypingFilter/buildCustomInputProps.tsx
+++ b/ui/components/TypingFilter/buildCustomInputProps.tsx
@@ -1,0 +1,22 @@
+import React, { type ReactNode } from 'react';
+
+export type AutocompleteInputProps = {
+  startAdornment?: ReactNode;
+  [key: string]: unknown;
+};
+
+export const buildCustomInputProps = (
+  paramsInputProps: AutocompleteInputProps | undefined,
+  leadingAdornment: ReactNode,
+): AutocompleteInputProps => {
+  const inputProps = paramsInputProps ?? {};
+  return {
+    ...inputProps,
+    startAdornment: (
+      <>
+        {leadingAdornment}
+        {inputProps.startAdornment}
+      </>
+    ),
+  };
+};

--- a/ui/components/TypingFilter/index.tsx
+++ b/ui/components/TypingFilter/index.tsx
@@ -10,6 +10,7 @@ import {
 import { InputField, Root, DropDown } from './style';
 import React, { useState, useEffect } from 'react';
 import { iconSmall } from 'css/icons.styles';
+import { buildCustomInputProps } from './buildCustomInputProps';
 
 function transformData(data) {
   const result = {};
@@ -283,20 +284,12 @@ const TypingFilter = ({ filterSchema, placeholder, handleFilter, defaultFilters 
           />
         }
         renderInput={(params) => {
-          const customInputProps = {
-            ...params.InputProps,
-            startAdornment: (
-              <>
-                <InputAdornment
-                  position="start"
-                  style={{ marginInline: '0.25rem', height: 'auto' }}
-                >
-                  <ContentFilterIcon fill={theme.palette.icon.default} />
-                </InputAdornment>
-                {params.InputProps.startAdornment}
-              </>
-            ),
-          };
+          const customInputProps = buildCustomInputProps(
+            params.InputProps,
+            <InputAdornment position="start" style={{ marginInline: '0.25rem', height: 'auto' }}>
+              <ContentFilterIcon fill={theme.palette.icon.default} />
+            </InputAdornment>,
+          );
 
           return (
             <InputField


### PR DESCRIPTION
## Summary

- Fixes the Notification Center crash: `Error: undefined is not an object (evaluating 'e.InputProps.startAdornment')`.
- The `TypingFilter` `renderInput` callback dereferenced `params.InputProps.startAdornment` directly. When MUI's `Autocomplete` invoked the callback before `InputProps` was populated, this threw and brought down the Notification Center.
- Extracted the prop-building logic into `buildCustomInputProps`, which defaults a missing `InputProps` to `{}` and safely composes the leading adornment with any existing `startAdornment`.

## Test plan

- [x] `npx vitest run components/TypingFilter/__tests__/buildCustomInputProps.test.tsx` — 4/4 passing, covering the `undefined`, empty-object, existing-adornment, and pass-through cases.
- [x] `npx vitest run` — full suite: 38/38 passing.
- [x] `npx eslint components/TypingFilter/` — clean.
- [ ] Smoke-test the Notification Center filter input in the running UI to confirm the crash no longer occurs.
