### PR TITLE
[UI] Improve connections components and add tests

### DIFF
--- a/ui/components/General/ErrorBoundary.tsx
+++ b/ui/components/General/ErrorBoundary.tsx
@@ -35,7 +35,7 @@ const CustomErrorFallback = (props) => {
   const [triggerWebhook] = useSupportWebHookMutation();
   const { data: userData } = useGetLoggedInUserQuery();
   const { data: providerData } = useGetProviderCapabilitiesQuery();
-  const showSupportBasedOnProvider = providerData?.provider_type === 'remote';
+  const showSupportBasedOnProvider = providerData?.providerType === 'remote';
 
   const handleOpenSupportModal = () => {
     setOpenSupportModal(true);

--- a/ui/components/General/Modals/Information/InfoModal.tsx
+++ b/ui/components/General/Modals/Information/InfoModal.tsx
@@ -131,7 +131,7 @@ const InfoModal_ = React.memo((props) => {
 
     const payload = {
       id: selectedResource?.id,
-      catalog_data: {
+      catalogData: {
         ...formData,
         compatibility: compatibilityStore,
         type: _.toLower(formData?.type),
@@ -185,8 +185,8 @@ const InfoModal_ = React.memo((props) => {
 
     body = JSON.stringify({
       name: selectedResource.name,
-      catalog_data: modifiedData,
-      design_file: yaml.load(selectedResource.patternFile),
+      catalogData: modifiedData,
+      designFile: yaml.load(selectedResource.patternFile),
       id: selectedResource.id,
       visibility: visibility,
     });
@@ -240,14 +240,14 @@ const InfoModal_ = React.memo((props) => {
   }
   const handleFormChange = (data) => {
     formStateRef.current = data;
-    setIsCatalogDataEqual(isEqualIgnoringCase(selectedResource?.catalog_data, data));
+    setIsCatalogDataEqual(isEqualIgnoringCase(selectedResource?.catalogData, data));
   };
 
   useEffect(() => {
-    if (selectedResource?.catalog_data && Object.keys(selectedResource?.catalog_data).length > 0) {
+    if (selectedResource?.catalogData && Object.keys(selectedResource?.catalogData).length > 0) {
       if (meshModels) {
         const compatibilitySet = new Set(
-          (selectedResource?.catalog_data?.compatibility || []).map((comp) => comp.toLowerCase()),
+          (selectedResource?.catalogData?.compatibility || []).map((comp) => comp.toLowerCase()),
         );
 
         const filteredCompatibilityArray = _.uniq(
@@ -260,16 +260,16 @@ const InfoModal_ = React.memo((props) => {
         );
 
         let modifiedData = {
-          ...selectedResource.catalog_data,
-          type: _.startCase(selectedResource?.catalog_data?.type),
+          ...selectedResource.catalogData,
+          type: _.startCase(selectedResource?.catalogData?.type),
           compatibility: filteredCompatibilityArray,
         };
         formStateRef.current = filterEmptyFields(modifiedData);
       }
     } else {
-      formStateRef.current = filterEmptyFields(selectedResource?.catalog_data);
+      formStateRef.current = filterEmptyFields(selectedResource?.catalogData);
     }
-  }, [selectedResource?.catalog_data, meshModels]);
+  }, [selectedResource?.catalogData, meshModels]);
 
   useEffect(() => {
     if (publishSchema) {
@@ -343,9 +343,9 @@ const InfoModal_ = React.memo((props) => {
                   alignItems: 'center',
                 }}
               >
-                {selectedResource?.catalog_data?.imageURL && !imageError ? (
+                {selectedResource?.catalogData?.imageURL && !imageError ? (
                   <img
-                    src={selectedResource.catalog_data.imageURL[0]}
+                    src={selectedResource.catalogData.imageURL[0]}
                     width="140"
                     alt={selectedResource?.name}
                     onError={handleError}

--- a/ui/components/MesheryFilters/FiltersGrid.tsx
+++ b/ui/components/MesheryFilters/FiltersGrid.tsx
@@ -26,7 +26,7 @@ type FiltersGridProps = {
     id: string;
     type: string;
     name: string;
-    catalog_data: unknown;
+    catalogData: unknown;
   }) => void;
   setSelectedFilter: (_value: { filter: any; show: boolean }) => void;
   selectedFilter: { show: boolean; filter: any };
@@ -52,7 +52,7 @@ type FilterCardGridItemProps = {
     id: string;
     type: string;
     name: string;
-    catalog_data: unknown;
+    catalogData: unknown;
   }) => void;
   setSelectedFilters: (_value: { filter: any; show: boolean }) => void;
   handleClone: () => void;
@@ -98,7 +98,7 @@ function FilterCardGridItem({
             id: filter.id,
             type: FILE_OPS.DELETE,
             name: filter.name,
-            catalog_data: filter.catalog_data,
+            catalogData: filter.catalogData,
           })
         }
         updateHandler={() =>
@@ -107,7 +107,7 @@ function FilterCardGridItem({
             id: filter.id,
             type: FILE_OPS.UPDATE,
             name: filter.name,
-            catalog_data: filter.catalog_data,
+            catalogData: filter.catalogData,
           })
         }
         setSelectedFilters={() => setSelectedFilters({ filter: filter, show: true })}

--- a/ui/components/Registry/RegistryModal.tsx
+++ b/ui/components/Registry/RegistryModal.tsx
@@ -235,9 +235,9 @@ export const Navigation = ({ setHeaderInfo }) => {
   });
   const counts = {
     models: modelsData ? removeDuplicateVersions(modelsData.models || []).length : 0,
-    components: componentsData?.total_count || 0,
-    relationships: relationshipsData?.total_count || 0,
-    registrants: registrantsData?.total_count || 0,
+    components: componentsData?.totalCount ?? componentsData?.total_count ?? 0,
+    relationships: relationshipsData?.totalCount ?? relationshipsData?.total_count ?? 0,
+    registrants: registrantsData?.totalCount ?? registrantsData?.total_count ?? 0,
   };
   const navConfig = getNavItems(theme, counts);
 

--- a/ui/components/SpacesSwitcher/WorkspaceModal.tsx
+++ b/ui/components/SpacesSwitcher/WorkspaceModal.tsx
@@ -240,7 +240,7 @@ const Navigation = ({ setHeaderInfo }) => {
   const closeList = useMediaQuery(theme.breakpoints.down('xl'));
   const [open, setOpen] = useState(!closeList);
   const { data: capabilitiesData } = useGetProviderCapabilitiesQuery();
-  const isLocalProvider = capabilitiesData?.provider_type === 'local';
+  const isLocalProvider = capabilitiesData?.providerType === 'local';
   const workspaceSwitcherContext = useContext(WorkspaceModalContext);
   const { selectedWorkspace } = workspaceSwitcherContext;
   const [selectedId, setSelectedId] = useState(selectedWorkspace?.id || 'Recents (Global)');

--- a/ui/components/UserPreferences/index.tsx
+++ b/ui/components/UserPreferences/index.tsx
@@ -82,10 +82,10 @@ interface ProviderExtension {
 }
 
 interface _ProviderInfo {
-  provider_name?: string;
-  provider_type?: string;
-  provider_url?: string;
-  provider_description?: string[];
+  providerName?: string;
+  providerType?: string;
+  providerUrl?: string;
+  providerDescription?: string[];
   capabilities?: ProviderCapability[];
   extensions?: Record<string, ProviderExtension[]>;
   [key: string]: unknown;
@@ -134,7 +134,7 @@ const UserPreference: React.FC<UserPreferenceProps> = (props) => {
   const [capabilitiesLoaded, setCapabilitiesLoaded] = useState(false);
   const { width } = useWindowDimensions();
   const [value, setValue] = useState(0);
-  const [providerInfo, setProviderInfo] = useState({});
+  const [providerInfo, setProviderInfo] = useState<_ProviderInfo>({});
   const theme = useTheme();
   const dispatch = useDispatch();
   const { capabilitiesRegistry } = useSelector((state) => state.ui);
@@ -386,8 +386,8 @@ const UserPreference: React.FC<UserPreferenceProps> = (props) => {
               <CardContent>
                 <Typography>
                   <ul>
-                    {providerInfo.provider_description &&
-                      providerInfo.provider_description.map((desc, index) => (
+                    {providerInfo.providerDescription &&
+                      providerInfo.providerDescription.map((desc, index) => (
                         <li key={index}>
                           <Typography>{desc}</Typography>
                         </li>

--- a/ui/components/connections/ConnectionChip.test.tsx
+++ b/ui/components/connections/ConnectionChip.test.tsx
@@ -1,0 +1,190 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+  ConnectionChip,
+  ConnectionStateChip,
+  TooltipWrappedConnectionChip,
+} from './ConnectionChip';
+
+const normalizeStaticImagePath = vi.fn((src?: string) => src);
+
+vi.mock('@sistent/sistent', () => {
+  const styled = (Component) => () => {
+    const StyledComponent = ({ children, ...props }) => (
+      <Component {...props}>{children}</Component>
+    );
+    StyledComponent.displayName = 'StyledSistentMock';
+    return StyledComponent;
+  };
+
+  return {
+    Avatar: ({ children, src, sx }) => (
+      <div data-testid="avatar" data-src={src} data-size={JSON.stringify(sx || {})}>
+        {children}
+      </div>
+    ),
+    AssignmentTurnedInIcon: () => <svg data-testid="assignment-icon" />,
+    CustomTooltip: ({ title, children }) => (
+      <div data-testid="tooltip" data-title={String(title)}>
+        {children}
+      </div>
+    ),
+    Typography: ({ children }) => <span>{children}</span>,
+    styled,
+    createTheme: () => ({ breakpoints: {} }),
+    useTheme: () => ({
+      palette: {
+        background: {
+          brand: { default: 'brand' },
+          warning: { default: 'warning' },
+        },
+        text: { disabled: 'disabled' },
+      },
+    }),
+  };
+});
+
+vi.mock('@/utils/fallback', () => ({
+  normalizeStaticImagePath: (...args) => normalizeStaticImagePath(...args),
+}));
+
+vi.mock('../../themes', () => ({
+  notificationColors: {
+    lightwarning: 'warning',
+    info: 'info',
+  },
+}));
+
+vi.mock('../CustomAvatar', () => ({
+  default: ({ children, color }) => (
+    <div data-testid="badge-avatar" data-color={color}>
+      {children}
+    </div>
+  ),
+}));
+
+vi.mock('./styles', () => {
+  const makeStateChip = (testId: string) => {
+    const StateChip = ({ avatar, label }) => (
+      <div data-testid={testId}>
+        {avatar}
+        <span>{label}</span>
+      </div>
+    );
+
+    StateChip.displayName = `${testId}Mock`;
+    return StateChip;
+  };
+
+  return {
+    ChipWrapper: ({ label, onClick, onDelete, disabled, avatar, style }) => (
+      <div data-testid="chip-wrapper" data-width={style?.width}>
+        {avatar}
+        <button onClick={onClick} disabled={disabled}>
+          {label}
+        </button>
+        {onDelete ? <button onClick={onDelete}>delete</button> : null}
+      </div>
+    ),
+    ConnectedChip: makeStateChip('connected-state-chip'),
+    DeletedChip: makeStateChip('deleted-state-chip'),
+    DisconnectedChip: makeStateChip('disconnected-state-chip'),
+    DiscoveredChip: makeStateChip('discovered-state-chip'),
+    IgnoredChip: makeStateChip('ignored-state-chip'),
+    MaintainanceChip: makeStateChip('maintenance-state-chip'),
+    NotFoundChip: makeStateChip('not-found-state-chip'),
+    RegisteredChip: makeStateChip('registered-state-chip'),
+  };
+});
+
+vi.mock('css/icons.styles', () => ({
+  iconMedium: {},
+  iconSmall: {},
+}));
+
+vi.mock('@/assets/icons/Connection', () => ({
+  default: () => <svg data-testid="connection-icon" />,
+}));
+
+vi.mock('../../assets/icons/disconnect', () => ({
+  default: () => <svg data-testid="disconnect-icon" />,
+}));
+
+describe('ConnectionChip', () => {
+  beforeEach(() => {
+    normalizeStaticImagePath.mockClear();
+  });
+
+  it('calls handlePing when clicked and renders a normalized avatar source', async () => {
+    const user = userEvent.setup();
+    const handlePing = vi.fn();
+
+    render(
+      <ConnectionChip
+        title="cluster-a"
+        handlePing={handlePing}
+        iconSrc="/static/img/kubernetes.svg"
+        status="connected"
+        width="12rem"
+      />,
+    );
+
+    await user.click(screen.getByRole('button', { name: 'cluster-a' }));
+
+    expect(handlePing).toHaveBeenCalledTimes(1);
+    expect(normalizeStaticImagePath).toHaveBeenCalledWith('/static/img/kubernetes.svg');
+    expect(screen.getByTestId('avatar')).toHaveAttribute('data-src', '/static/img/kubernetes.svg');
+    expect(screen.getByTestId('chip-wrapper')).toHaveAttribute('data-width', '12rem');
+    expect(screen.getByTestId('badge-avatar')).toHaveAttribute('data-color', 'brand');
+  });
+
+  it('respects disabled chips by blocking ping and delete actions', async () => {
+    const user = userEvent.setup();
+    const handlePing = vi.fn();
+    const onDelete = vi.fn();
+
+    render(
+      <ConnectionChip
+        title="operator"
+        handlePing={handlePing}
+        onDelete={onDelete}
+        disabled={true}
+        status="running"
+      />,
+    );
+
+    const button = screen.getByRole('button', { name: 'operator' });
+    expect(button).toBeDisabled();
+
+    await user.click(button);
+
+    expect(handlePing).not.toHaveBeenCalled();
+    expect(screen.queryByRole('button', { name: 'delete' })).not.toBeInTheDocument();
+  });
+});
+
+describe('TooltipWrappedConnectionChip', () => {
+  it('prefers explicit tooltip content over the title', () => {
+    render(<TooltipWrappedConnectionChip title="cluster-a" tooltip="Server: demo" />);
+
+    expect(screen.getByTestId('tooltip')).toHaveAttribute('data-title', 'Server: demo');
+  });
+});
+
+describe('ConnectionStateChip', () => {
+  it('maps actionable states to transition labels', () => {
+    render(<ConnectionStateChip status="connected" actionable={true} />);
+
+    expect(screen.getByTestId('connected-state-chip')).toHaveTextContent('Connect');
+  });
+
+  it('renders known states and falls back to the discovered chip for unknown statuses', () => {
+    const { rerender } = render(<ConnectionStateChip status="not found" />);
+    expect(screen.getByTestId('not-found-state-chip')).toHaveTextContent('not found');
+
+    rerender(<ConnectionStateChip status="mystery-state" />);
+    expect(screen.getByTestId('discovered-state-chip')).toHaveTextContent('mystery-state');
+  });
+});

--- a/ui/components/connections/ConnectionChip.tsx
+++ b/ui/components/connections/ConnectionChip.tsx
@@ -1,5 +1,5 @@
-import React from 'react';
-import { Avatar, AssignmentTurnedInIcon, useTheme } from '@sistent/sistent';
+import React, { memo } from 'react';
+import { Avatar, AssignmentTurnedInIcon, CustomTooltip, useTheme } from '@sistent/sistent';
 import CheckCircleIcon from '@mui/icons-material/CheckCircle';
 import ExploreIcon from '@mui/icons-material/Explore';
 import RemoveCircleIcon from '@mui/icons-material/RemoveCircle';
@@ -15,7 +15,6 @@ import {
   CONTROLLER_STATES,
 } from '../../utils/Enum';
 import { normalizeStaticImagePath } from '@/utils/fallback';
-import { CustomTooltip } from '@sistent/sistent';
 import {
   ChipWrapper,
   ConnectedChip,
@@ -30,207 +29,179 @@ import {
 import { iconMedium, iconSmall } from 'css/icons.styles';
 import ConnectionIcon from '@/assets/icons/Connection';
 
-export const ConnectionChip = ({ handlePing, onDelete, iconSrc, status, title, width }) => {
-  const chipStyle = { width };
+type ConnectionChipProps = {
+  handlePing?: () => void;
+  onDelete?: () => void;
+  iconSrc?: string;
+  status?: string;
+  title?: React.ReactNode;
+  tooltip?: React.ReactNode;
+  width?: string | number;
+  disabled?: boolean;
+};
+
+type ConnectionStateChipProps = {
+  status?: string;
+  actionable?: boolean;
+};
+
+const HEALTHY_STATUSES = new Set(
+  [CONNECTION_STATES.CONNECTED, CONTROLLER_STATES.DEPLOYED].map((status) => status.toLowerCase()),
+);
+const PARTIAL_STATUSES = new Set(
+  [
+    CONTROLLER_STATES.ENABLED,
+    CONTROLLER_STATES.RUNNING,
+    CONTROLLER_STATES.DEPLOYING,
+    CONNECTION_STATES.REGISTERED,
+  ].map((status) => status.toLowerCase()),
+);
+
+const STATE_CHIP_CONFIG = {
+  [CONNECTION_STATES.IGNORED]: {
+    Component: IgnoredChip,
+    avatar: <RemoveCircleIcon />,
+  },
+  [CONNECTION_STATES.CONNECTED]: {
+    Component: ConnectedChip,
+    avatar: <CheckCircleIcon />,
+  },
+  [CONNECTION_STATES.REGISTERED]: {
+    Component: RegisteredChip,
+    avatar: <AssignmentTurnedInIcon />,
+  },
+  [CONNECTION_STATES.DISCOVERED]: {
+    Component: DiscoveredChip,
+    avatar: <ExploreIcon />,
+  },
+  [CONNECTION_STATES.DELETED]: {
+    Component: DeletedChip,
+    avatar: <DeleteForeverIcon />,
+  },
+  [CONNECTION_STATES.MAINTENANCE]: {
+    Component: MaintainanceChip,
+    avatar: <HandymanIcon />,
+  },
+  [CONNECTION_STATES.DISCONNECTED]: {
+    Component: DisconnectedChip,
+    avatar: <DisconnectIcon fill={notificationColors.lightwarning} width={24} height={24} />,
+  },
+  [CONNECTION_STATES.NOTFOUND]: {
+    Component: NotFoundChip,
+    avatar: <NotInterestedRoundedIcon />,
+  },
+} as const;
+
+const DEFAULT_STATE_CHIP = {
+  Component: DiscoveredChip,
+  avatar: <ExploreIcon />,
+};
+
+const getStatusLevel = (status?: string) => {
+  if (!status) {
+    return 'error';
+  }
+
+  const normalizedStatus = status.toLowerCase();
+
+  if (HEALTHY_STATUSES.has(normalizedStatus)) {
+    return 'healthy';
+  }
+
+  if (PARTIAL_STATUSES.has(normalizedStatus)) {
+    return 'partial';
+  }
+
+  return 'error';
+};
+
+const getStatusColor = (theme: ReturnType<typeof useTheme>, status?: string) => {
+  switch (getStatusLevel(status)) {
+    case 'healthy':
+      return theme.palette.background.brand.default;
+    case 'partial':
+      return theme.palette.background.warning.default;
+    default:
+      return theme.palette.text.disabled;
+  }
+};
+
+const ConnectionChip_ = ({
+  handlePing,
+  onDelete,
+  iconSrc,
+  status,
+  title,
+  width,
+  disabled = false,
+}: ConnectionChipProps) => {
   const theme = useTheme();
   const normalizedIconSrc = normalizeStaticImagePath(iconSrc) || undefined;
+  const isPingEnabled = Boolean(handlePing) && !disabled;
 
-  const STATUS_LEVEL_MAP = Object.fromEntries([
-    ...[CONNECTION_STATES.CONNECTED, CONTROLLER_STATES.DEPLOYED].map((status) => [
-      status.toLowerCase(),
-      'healthy',
-    ]),
-    ...[
-      CONTROLLER_STATES.ENABLED,
-      CONTROLLER_STATES.RUNNING,
-      CONTROLLER_STATES.DEPLOYING,
-      CONNECTION_STATES.REGISTERED,
-    ].map((status) => [status.toLowerCase(), 'partial']),
-  ]);
-
-  const getStatusLevel = (status) => {
-    if (!status) return 'error';
-    return STATUS_LEVEL_MAP[status.toLowerCase()] || 'error';
-  };
-
-  const getStatusColor = (statusLevel) => {
-    switch (statusLevel) {
-      case 'healthy':
-        return theme.palette.background.brand.default;
-      case 'partial':
-        return theme.palette.background.warning.default;
-      case 'error':
-      default:
-        return theme.palette.text.disabled;
-    }
-  };
+  const avatar = status ? (
+    <BadgeAvatars color={getStatusColor(theme, status)}>
+      <Avatar src={normalizedIconSrc} sx={iconMedium}>
+        <ConnectionIcon {...iconSmall} />
+      </Avatar>
+    </BadgeAvatars>
+  ) : (
+    <Avatar src={normalizedIconSrc} sx={iconMedium}>
+      <ConnectionIcon {...iconSmall} />
+    </Avatar>
+  );
 
   return (
     <ChipWrapper
       label={title}
-      onClick={(e) => {
-        e.stopPropagation(); // Prevent event propagation
-        handlePing(); // Call your custom handler
-      }}
-      onDelete={onDelete}
-      avatar={
-        status ? (
-          <BadgeAvatars color={getStatusColor(getStatusLevel(status))}>
-            <Avatar
-              src={normalizedIconSrc}
-              style={{ ...(status ? {} : { opacity: 0.2 }), ...iconMedium }}
-            >
-              <ConnectionIcon {...iconSmall} />
-            </Avatar>
-          </BadgeAvatars>
-        ) : (
-          <Avatar src={normalizedIconSrc} sx={iconMedium}>
-            <ConnectionIcon {...iconSmall} />
-          </Avatar>
-        )
+      onClick={
+        isPingEnabled
+          ? (event) => {
+              event.stopPropagation();
+              handlePing?.();
+            }
+          : undefined
       }
-      // variant="filled"
+      onDelete={disabled ? undefined : onDelete}
+      disabled={disabled}
+      avatar={avatar}
       data-cy="chipContextName"
-      style={chipStyle}
+      style={width ? { width } : undefined}
     />
   );
 };
 
-export const TooltipWrappedConnectionChip = (props) => {
+export const ConnectionChip = memo(ConnectionChip_);
+
+const TooltipWrappedConnectionChip_ = ({ tooltip, title, ...props }: ConnectionChipProps) => {
+  const chip = (
+    <span style={{ display: 'inline-block' }}>
+      <ConnectionChip title={title} tooltip={tooltip} {...props} />
+    </span>
+  );
+
+  if (!tooltip && !title) {
+    return chip;
+  }
+
   return (
-    <CustomTooltip title={props.tooltip || props.title} placement="left">
-      <div style={{ display: 'inline-block' }}>
-        <ConnectionChip {...props} />
-      </div>
+    <CustomTooltip title={tooltip || title} placement="left">
+      {chip}
     </CustomTooltip>
   );
 };
 
-const DiscoveredStateChip = ({ value }) => {
-  return (
-    <DiscoveredChip
-      avatar={<ExploreIcon />}
-      label={value}
-      // helpIcon={<HelpToolTip classes={classes} value="7-deleted" />}
-    />
-  );
+export const TooltipWrappedConnectionChip = memo(TooltipWrappedConnectionChip_);
+
+const ConnectionStateChip_ = ({ status, actionable = false }: ConnectionStateChipProps) => {
+  const normalizedStatus = status?.toLowerCase() || '';
+  const value =
+    actionable && normalizedStatus
+      ? CONNECTION_STATE_TO_TRANSITION_MAP[normalizedStatus] || status
+      : status;
+  const { Component, avatar } = STATE_CHIP_CONFIG[normalizedStatus] || DEFAULT_STATE_CHIP;
+
+  return <Component avatar={avatar} label={value || ''} />;
 };
 
-const RegisteredStateChip = ({ value }) => {
-  return (
-    <RegisteredChip
-      avatar={<AssignmentTurnedInIcon />}
-      label={value}
-      // helpIcon={<HelpToolTip classes={classes} value="7-deleted" />}
-    />
-  );
-};
-
-const ConnectedStateChip = ({ value }) => {
-  return (
-    <ConnectedChip
-      avatar={<CheckCircleIcon />}
-      label={value}
-      // helpIcon={<HelpToolTip classes={classes} value="7-deleted" />}
-    />
-  );
-};
-
-const DisconnectedStateChip = ({ value }) => {
-  return (
-    <DisconnectedChip
-      avatar={<DisconnectIcon fill={notificationColors.lightwarning} width={24} height={24} />}
-      label={value}
-      // helpIcon={<HelpToolTip classes={classes} value="7-deleted" />}
-    />
-  );
-};
-
-const IgnoredStateChip = ({ value }) => {
-  // const classes = styles/();
-  return (
-    <IgnoredChip
-      avatar={<RemoveCircleIcon />}
-      label={value}
-      // helpIcon={<HelpToolTip classes={classes} value="7-deleted" />}
-    />
-  );
-};
-
-const DeletedStateChip = ({ value }) => {
-  return (
-    <DeletedChip
-      avatar={<DeleteForeverIcon />}
-      label={value}
-      // helpIcon={<HelpToolTip classes={classes} value="7-deleted" />}
-    />
-  );
-};
-
-const MaintainanceStateChip = ({ value }) => {
-  return (
-    <MaintainanceChip
-      avatar={<HandymanIcon />}
-      label={value}
-      // helpIcon={<HelpToolTip classes={classes} value="7-deleted" />}
-    />
-  );
-};
-
-const NotFoundStateChip = ({ value }) => {
-  return (
-    <NotFoundChip
-      avatar={<NotInterestedRoundedIcon />}
-      label={value}
-      // helpIcon={<HelpToolTip classes={classes} value="7-deleted" />}
-    />
-  );
-};
-
-// const HelpToolTip = ({ classes, value }) => {
-//   const url = `https://docs.meshery.io/concepts/connections#${value}`;
-//   const onClick = () => (e) => {
-//     e.preventDefault();
-//     e.stopPropagation();
-//     window.open(url, '_blank');
-//   };
-//   return (
-//     <Tooltip title={url}>
-//       <IconButton onClick={onClick()} aria-label="help">
-//         <HelpIcon className={classes.helpIcon} style={{ fontSize: '1.45rem', ...iconSmall }} />
-//       </IconButton>
-//     </Tooltip>
-//   );
-// };
-
-const Default = ({ value }) => {
-  return <DiscoveredChip avatar={<ExploreIcon />} label={value} />;
-};
-
-function getStatusChip(status, actionable) {
-  const value = actionable ? CONNECTION_STATE_TO_TRANSITION_MAP[status] : status;
-  switch (status) {
-    case 'ignored':
-      return <IgnoredStateChip value={value} />;
-    case 'connected':
-      return <ConnectedStateChip value={value} />;
-    case 'registered':
-      return <RegisteredStateChip value={value} />;
-    case 'discovered':
-      return <DiscoveredStateChip value={value} />;
-    case 'deleted':
-      return <DeletedStateChip value={value} />;
-    case 'maintenance':
-      return <MaintainanceStateChip value={value} />;
-    case 'disconnected':
-      return <DisconnectedStateChip value={value} />;
-    case 'not found':
-      return <NotFoundStateChip value={value} />;
-    default:
-      return <Default value={value} />;
-  }
-}
-
-export const ConnectionStateChip = ({ status, actionable }) => {
-  return <>{getStatusChip(status, actionable)}</>;
-};
+export const ConnectionStateChip = memo(ConnectionStateChip_);

--- a/ui/components/connections/ConnectionTable.test.tsx
+++ b/ui/components/connections/ConnectionTable.test.tsx
@@ -1,0 +1,360 @@
+import React from 'react';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import ConnectionTable from './ConnectionTable';
+
+const notify = vi.fn();
+const push = vi.fn();
+const ping = vi.fn();
+const modalShow = vi.fn();
+const updateConnectionByIdMutator = vi.fn();
+const addConnectionToEnvironmentMutator = vi.fn();
+const removeConnectionFromEnvironmentMutator = vi.fn();
+const saveEnvironmentMutator = vi.fn();
+const refetchConnections = vi.fn();
+const getConnectionsQuery = vi.fn();
+const getEnvironmentsQuery = vi.fn();
+let dataTableProps: any;
+
+const router = {
+  query: {} as Record<string, unknown>,
+  push,
+};
+
+vi.mock('next/router', () => ({
+  useRouter: () => router,
+}));
+
+vi.mock('@sistent/sistent', () => ({
+  CustomTooltip: ({ children }) => <div>{children}</div>,
+  CustomColumnVisibilityControl: () => <div data-testid="column-visibility-control" />,
+  SearchBar: () => <div data-testid="search-bar" />,
+  UniversalFilter: () => <div data-testid="universal-filter" />,
+  ResponsiveDataTable: (props) => {
+    dataTableProps = props;
+    return <div data-testid="responsive-data-table" />;
+  },
+  PROMPT_VARIANTS: {
+    DANGER: 'danger',
+    WARNING: 'warning',
+  },
+  MenuItem: ({ children }) => <div>{children}</div>,
+  Box: ({ children }) => <div>{children}</div>,
+  IconButton: ({ children, onClick, ...props }) => (
+    <button onClick={onClick} type="button" {...props}>
+      {children}
+    </button>
+  ),
+  Typography: ({ children }) => <span>{children}</span>,
+  Table: ({ children }) => <div>{children}</div>,
+  Grid2: ({ children }) => <div>{children}</div>,
+  Button: ({ children, onClick, disabled, ...props }) => (
+    <button onClick={onClick} disabled={disabled} type="button" {...props}>
+      {children}
+    </button>
+  ),
+  ListItem: ({ children }) => <div>{children}</div>,
+  FormControl: ({ children }) => <div>{children}</div>,
+  styled: (Component) => () => {
+    const StyledComponent = ({ children, ...props }) => (
+      <Component {...props}>{children}</Component>
+    );
+    StyledComponent.displayName = 'StyledSistentMock';
+    return StyledComponent;
+  },
+  accentGrey: 'gray',
+  createTheme: () => ({ breakpoints: {} }),
+  useTheme: () => ({
+    palette: {
+      error: { dark: 'darkred' },
+      common: { white: 'white' },
+    },
+  }),
+  TableCell: ({ children }) => <div>{children}</div>,
+  TableRow: ({ children }) => <div>{children}</div>,
+  Popover: ({ open, children }) => (open ? <div>{children}</div> : null),
+  DeleteIcon: () => <svg data-testid="delete-icon" />,
+}));
+
+vi.mock('./styles', () => ({
+  ContentContainer: ({ children }) => <div>{children}</div>,
+  CreateButton: ({ children }) => <div>{children}</div>,
+  InnerTableContainer: ({ children }) => <div>{children}</div>,
+  ActionListItem: ({ children }) => <div>{children}</div>,
+  ConnectionStyledSelect: ({ children }) => <div>{children}</div>,
+}));
+
+vi.mock('../DataFormatter', () => ({
+  FormatId: ({ id }) => <span>{id}</span>,
+  formatDate: (value) => value,
+}));
+
+vi.mock('../../css/icons.styles', () => ({
+  iconMedium: {},
+  iconSmall: {},
+}));
+
+vi.mock('../LoadingComponents/LoadingComponent', () => ({
+  default: () => <div data-testid="loading-screen" />,
+}));
+
+vi.mock('@/assets/styles/general/tool.styles', () => ({
+  ToolWrapper: ({ children }) => <div>{children}</div>,
+}));
+
+vi.mock('../MesherySettingsEnvButtons', () => ({
+  default: () => <div data-testid="settings-buttons" />,
+}));
+
+vi.mock('../../utils/utils', () => ({
+  getVisibilityColums: (columns) => columns,
+  getColumnValue: (rowData, columnName, columns) => {
+    const columnIndex = columns.findIndex((column) => column.name === columnName);
+    return columnIndex >= 0 ? rowData[columnIndex] : undefined;
+  },
+}));
+
+vi.mock('../graphql/queries/ResetDatabaseQuery', () => ({
+  default: vi.fn(),
+}));
+
+vi.mock('../hooks/useKubernetesHook', () => ({
+  default: () => ping,
+}));
+
+vi.mock('./ConnectionChip', () => ({
+  ConnectionStateChip: () => <div />,
+  TooltipWrappedConnectionChip: () => <div />,
+}));
+
+vi.mock('./common', () => ({
+  DefaultTableCell: () => <div />,
+  SortableTableCell: () => <div />,
+}));
+
+vi.mock('./metadata', () => ({
+  default: () => <div data-testid="connection-metadata" />,
+}));
+
+vi.mock('../../utils/responsive-column', () => ({
+  updateVisibleColumns: (columns) =>
+    Object.fromEntries(columns.map(([columnName]) => [columnName, true])),
+}));
+
+vi.mock('../../utils/dimension', () => ({
+  useWindowDimensions: () => ({ width: 1280 }),
+}));
+
+vi.mock('../multi-select-wrapper', () => ({
+  default: () => <div data-testid="multi-select-wrapper" />,
+}));
+
+vi.mock('../../rtk-query/environments', () => ({
+  useAddConnectionToEnvironmentMutation: () => [addConnectionToEnvironmentMutator],
+  useGetEnvironmentsQuery: (...args) => getEnvironmentsQuery(...args),
+  useRemoveConnectionFromEnvironmentMutation: () => [removeConnectionFromEnvironmentMutator],
+  useSaveEnvironmentMutation: () => [saveEnvironmentMutator],
+}));
+
+vi.mock('../../utils/hooks/useNotification', () => ({
+  useNotification: () => ({ notify }),
+}));
+
+vi.mock('@/store/slices/mesheryUi', () => ({
+  updateProgress: vi.fn(),
+}));
+
+vi.mock('@/utils/can', () => ({
+  default: () => true,
+}));
+
+vi.mock('@/utils/permission_constants', () => ({
+  keys: {
+    ASSIGN_CONNECTIONS_TO_ENVIRONMENT: { action: 'assign', subject: 'environment' },
+    CHANGE_CONNECTION_STATE: { action: 'change', subject: 'connection' },
+    DELETE_A_CONNECTION: { action: 'delete', subject: 'connection' },
+    FLUSH_MESHSYNC_DATA: { action: 'flush', subject: 'meshsync' },
+  },
+}));
+
+vi.mock('@/rtk-query/connection', () => ({
+  useGetConnectionsQuery: (...args) => getConnectionsQuery(...args),
+  useUpdateConnectionByIdMutation: () => [updateConnectionByIdMutator],
+}));
+
+vi.mock('../../assets/icons/InfoOutlined', () => ({
+  default: () => <svg />,
+}));
+
+vi.mock('../../assets/icons/disconnect', () => ({
+  default: () => <svg />,
+}));
+
+vi.mock('../PromptComponent', () => ({
+  default: React.forwardRef(function PromptComponentMock(_, ref) {
+    React.useImperativeHandle(ref, () => ({
+      show: modalShow,
+    }));
+    return <div data-testid="prompt-component" />;
+  }),
+}));
+
+vi.mock('react-redux', () => ({
+  useSelector: (selector) =>
+    selector({
+      ui: {
+        organization: { id: 'org-1' },
+        connectionMetadataState: {
+          kubernetes: { transitions: ['connected'], icon: '/static/img/kubernetes.svg' },
+        },
+        controllerState: {},
+      },
+    }),
+}));
+
+const makeConnection = (overrides = {}) => ({
+  id: 'connection-1',
+  name: 'cluster-a',
+  kind: 'kubernetes',
+  status: 'connected',
+  type: 'cluster',
+  subType: 'managed',
+  metadata: {
+    name: 'cluster-a',
+    server: 'https://cluster-a.local',
+  },
+  environments: [],
+  created_at: '2026-05-08',
+  ...overrides,
+});
+
+describe('ConnectionTable', () => {
+  beforeEach(() => {
+    dataTableProps = undefined;
+    notify.mockReset();
+    push.mockReset();
+    ping.mockReset();
+    modalShow.mockReset();
+    refetchConnections.mockReset();
+
+    updateConnectionByIdMutator.mockReset();
+    addConnectionToEnvironmentMutator.mockReset();
+    removeConnectionFromEnvironmentMutator.mockReset();
+    saveEnvironmentMutator.mockReset();
+    getConnectionsQuery.mockReset();
+    getEnvironmentsQuery.mockReset();
+
+    updateConnectionByIdMutator.mockImplementation(({ connectionId, body }) => ({
+      unwrap: () => Promise.resolve({ connectionId, body }),
+    }));
+    addConnectionToEnvironmentMutator.mockImplementation(() => ({
+      unwrap: () => Promise.resolve({}),
+    }));
+    removeConnectionFromEnvironmentMutator.mockImplementation(() => ({
+      unwrap: () => Promise.resolve({}),
+    }));
+    saveEnvironmentMutator.mockImplementation(() => ({
+      unwrap: () => Promise.resolve({ id: 'env-1', name: 'dev' }),
+    }));
+    modalShow.mockResolvedValue('DELETE');
+
+    router.query = {};
+
+    getConnectionsQuery.mockReturnValue({
+      data: {
+        connections: [
+          makeConnection(),
+          makeConnection({
+            id: 'connection-2',
+            name: 'cluster-b',
+            metadata: { name: 'cluster-b', server: 'https://cluster-b.local' },
+          }),
+        ],
+        totalCount: 2,
+      },
+      isError: false,
+      error: undefined,
+      refetch: refetchConnections,
+      isLoading: false,
+    });
+
+    getEnvironmentsQuery.mockReturnValue({
+      data: { environments: [{ id: 'env-1', name: 'dev' }] },
+      isSuccess: true,
+      isError: false,
+      error: undefined,
+    });
+  });
+
+  it('hydrates search from a string router query and passes it to the connections query', async () => {
+    router.query = { searchText: 'cluster-a' };
+
+    render(<ConnectionTable />);
+
+    await waitFor(() => {
+      expect(getConnectionsQuery).toHaveBeenLastCalledWith(
+        expect.objectContaining({ search: 'cluster-a' }),
+        undefined,
+      );
+    });
+  });
+
+  it('surfaces query failures through notifications', async () => {
+    getConnectionsQuery.mockReturnValue({
+      data: { connections: [], totalCount: 0 },
+      isError: true,
+      error: { data: 'connections unavailable' },
+      refetch: refetchConnections,
+      isLoading: false,
+    });
+    getEnvironmentsQuery.mockReturnValue({
+      data: { environments: [] },
+      isSuccess: false,
+      isError: true,
+      error: { message: 'environments unavailable' },
+    });
+
+    render(<ConnectionTable />);
+
+    await waitFor(() => {
+      expect(notify).toHaveBeenCalledWith(
+        expect.objectContaining({
+          message: 'Failed to fetch environment: environments unavailable',
+        }),
+      );
+      expect(notify).toHaveBeenCalledWith(
+        expect.objectContaining({
+          message: 'Failed to fetch connections: connections unavailable',
+        }),
+      );
+    });
+  });
+
+  it('deletes the selected connections through the toolbar action', async () => {
+    const user = userEvent.setup();
+
+    render(<ConnectionTable />);
+
+    const toolbar = dataTableProps.options.customToolbarSelect({
+      data: [{ index: 0 }, { index: 1 }],
+    });
+    render(toolbar);
+
+    await user.click(screen.getByRole('button', { name: /delete/i }));
+
+    await waitFor(() => {
+      expect(modalShow).toHaveBeenCalled();
+      expect(updateConnectionByIdMutator).toHaveBeenCalledTimes(2);
+    });
+
+    expect(updateConnectionByIdMutator).toHaveBeenNthCalledWith(1, {
+      connectionId: 'connection-1',
+      body: { status: 'deleted' },
+    });
+    expect(updateConnectionByIdMutator).toHaveBeenNthCalledWith(2, {
+      connectionId: 'connection-2',
+      body: { status: 'deleted' },
+    });
+  });
+});

--- a/ui/components/connections/ConnectionTable.test.tsx
+++ b/ui/components/connections/ConnectionTable.test.tsx
@@ -15,7 +15,9 @@ const saveEnvironmentMutator = vi.fn();
 const refetchConnections = vi.fn();
 const getConnectionsQuery = vi.fn();
 const getEnvironmentsQuery = vi.fn();
+const updateVisibleColumns = vi.fn();
 let dataTableProps: any;
+let windowWidth = 1280;
 
 const router = {
   query: {} as Record<string, unknown>,
@@ -138,12 +140,11 @@ vi.mock('./metadata', () => ({
 }));
 
 vi.mock('../../utils/responsive-column', () => ({
-  updateVisibleColumns: (columns) =>
-    Object.fromEntries(columns.map(([columnName]) => [columnName, true])),
+  getResponsiveColumnVisibility: (...args) => updateVisibleColumns(...args),
 }));
 
 vi.mock('../../utils/dimension', () => ({
-  useWindowDimensions: () => ({ width: 1280 }),
+  useWindowDimensions: () => ({ width: windowWidth }),
 }));
 
 vi.mock('../multi-select-wrapper', () => ({
@@ -244,6 +245,8 @@ describe('ConnectionTable', () => {
     saveEnvironmentMutator.mockReset();
     getConnectionsQuery.mockReset();
     getEnvironmentsQuery.mockReset();
+    updateVisibleColumns.mockReset();
+    windowWidth = 1280;
 
     updateConnectionByIdMutator.mockImplementation(({ connectionId, body }) => ({
       unwrap: () => Promise.resolve({ connectionId, body }),
@@ -285,6 +288,11 @@ describe('ConnectionTable', () => {
       isError: false,
       error: undefined,
     });
+    updateVisibleColumns.mockImplementation((columnNames, _colViews, width) =>
+      Object.fromEntries(
+        columnNames.map((columnName) => [columnName, columnName === 'kind' ? width >= 1000 : true]),
+      ),
+    );
   });
 
   it('hydrates search from a string router query and passes it to the connections query', async () => {
@@ -355,6 +363,19 @@ describe('ConnectionTable', () => {
     expect(updateConnectionByIdMutator).toHaveBeenNthCalledWith(2, {
       connectionId: 'connection-2',
       body: { status: 'deleted' },
+    });
+  });
+
+  it('recomputes responsive column visibility when the window width changes', async () => {
+    const { rerender } = render(<ConnectionTable />);
+
+    expect(dataTableProps.columnVisibility.kind).toBe(true);
+
+    windowWidth = 800;
+    rerender(<ConnectionTable />);
+
+    await waitFor(() => {
+      expect(dataTableProps.columnVisibility.kind).toBe(false);
     });
   });
 });

--- a/ui/components/connections/ConnectionTable.tsx
+++ b/ui/components/connections/ConnectionTable.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useRef, useState, useMemo } from 'react';
+import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { useRouter } from 'next/router';
 import {
   CustomTooltip,
@@ -67,6 +67,76 @@ import { getFallbackImageBasedOnKind, normalizeStaticImagePath } from '@/utils/f
 import { useSelector } from 'react-redux';
 import { updateProgress } from '@/store/slices/mesheryUi';
 
+type ConnectionTableProps = {
+  selectedFilter?: string;
+  selectedConnectionId?: string;
+  updateUrlWithConnectionId?: (connectionId: string) => void;
+};
+
+type EnvironmentOption = {
+  label: string;
+  value: string;
+  __isNew__?: boolean;
+};
+
+type ConnectionRow = {
+  id: string;
+  kind: string;
+  status: string;
+  name?: string;
+  kindLogo?: string;
+  nextStatus?: string[];
+  metadata?: Record<string, any>;
+  environments?: Array<{ id: string; name: string }>;
+  [key: string]: any;
+};
+
+type SelectedFilters = {
+  status: string;
+  kind: string;
+};
+
+type SelectedRows = {
+  data?: Array<{ index: number }>;
+};
+
+type RowData = {
+  rowIndex: number;
+};
+
+type ExpansionFlags = {
+  isHandlingExpansion: boolean;
+  isInitialLoad: boolean;
+  isUrlExpansion: boolean;
+  lastProcessedId: string | null;
+};
+
+const getErrorMessage = (error: any, fallback = 'Unknown error') => {
+  if (!error) {
+    return fallback;
+  }
+
+  if (typeof error === 'string') {
+    return error;
+  }
+
+  if (typeof error === 'object') {
+    if ('error' in error && typeof error.error === 'string') {
+      return error.error;
+    }
+
+    if ('message' in error && typeof error.message === 'string') {
+      return error.message;
+    }
+
+    if ('data' in error && typeof error.data === 'string') {
+      return error.data;
+    }
+  }
+
+  return fallback;
+};
+
 const ACTION_TYPES = {
   FETCH_CONNECTIONS: {
     name: 'FETCH_CONNECTIONS',
@@ -130,7 +200,11 @@ const CONNECTION_STATE_TRANSITIONS = {
   kubernetes: kubernetesConnectionTransitions,
 };
 
-const getStatusTransition = (connectionKind, connectionState, transitionState) => {
+const getStatusTransition = (
+  connectionKind: string,
+  connectionState: string,
+  transitionState: string,
+) => {
   // This is for one connection kind that is kubernetes, and adding other connection kinds
   // here will make it more complex.
   // This issue can be resolved if we add the transition messages in the connection schemas
@@ -145,62 +219,78 @@ const getStatusTransition = (connectionKind, connectionState, transitionState) =
   }
 };
 
-const ConnectionTable = ({ selectedFilter, selectedConnectionId, updateUrlWithConnectionId }) => {
+const ConnectionTable = ({
+  selectedFilter,
+  selectedConnectionId,
+  updateUrlWithConnectionId,
+}: ConnectionTableProps) => {
   const router = useRouter();
   const {
     organization,
     connectionMetadataState,
     controllerState: meshsyncControllerState,
-  } = useSelector((state) => state.ui);
+  } = useSelector(
+    (state: {
+      ui: {
+        organization?: { id?: string };
+        connectionMetadataState: Record<string, { transitions?: string[]; icon?: string }>;
+        controllerState: unknown;
+      };
+    }) => state.ui,
+  );
   const ping = useKubernetesHook();
   const { width } = useWindowDimensions();
   const [page, setPage] = useState(0);
   const [pageSize, setPageSize] = useState(10);
   const [sortOrder, setSortOrder] = useState('created_at desc');
-  const [rowData, setRowData] = useState(null);
-  const [rowsExpanded, setRowsExpanded] = useState([]);
+  const [rowData, setRowData] = useState<RowData | null>(null);
+  const [rowsExpanded, setRowsExpanded] = useState<number[]>([]);
   const [isSearchExpanded, setIsSearchExpanded] = useState(false);
-  const [selectedFilters, setSelectedFilters] = useState({
+  const [selectedFilters, setSelectedFilters] = useState<SelectedFilters>({
     status: 'All',
     kind: 'All',
   });
   const [search, setSearch] = useState('');
-  const [statusFilter, setStatusFilter] = useState();
-  const [kindFilter, setKindFilter] = useState();
+  const [statusFilter, setStatusFilter] = useState<string | null>(null);
+  const [kindFilter, setKindFilter] = useState<string | null>(null);
   const [updateConnectionByIdMutator] = useUpdateConnectionByIdMutation();
   const [addConnectionToEnvironmentMutator] = useAddConnectionToEnvironmentMutation();
   const [removeConnectionFromEnvMutator] = useRemoveConnectionFromEnvironmentMutation();
   const [saveEnvironmentMutator] = useSaveEnvironmentMutation();
-  const [anchorEl, setAnchorEl] = useState(null);
-  const [deploymentModeAnchorEl, setDeploymentModeAnchorEl] = useState(null);
+  const [anchorEl, setAnchorEl] = useState<HTMLElement | null>(null);
+  const [deploymentModeAnchorEl, setDeploymentModeAnchorEl] = useState<HTMLElement | null>(null);
   const open = Boolean(anchorEl);
   const deploymentModeOpen = Boolean(deploymentModeAnchorEl);
-  const modalRef = useRef(null);
+  const modalRef = useRef<{ show: (options: unknown) => Promise<string | null> } | null>(null);
 
   useEffect(() => {
-    if (router.query.searchText) {
+    if (typeof router.query.searchText === 'string') {
       setSearch(router.query.searchText);
     }
   }, [router.query.searchText]);
-  const filters = {
-    status: {
-      name: 'Status',
-      options: [
-        { label: 'Connected', value: 'connected' },
-        { label: 'Registered', value: 'registered' },
-        { label: 'Discovered', value: 'discovered' },
-        { label: 'Ignored', value: 'ignored' },
-        { label: 'Deleted', value: 'deleted' },
-        { label: 'Maintenance', value: 'maintenance' },
-        { label: 'Disconnected', value: 'disconnected' },
-        { label: 'Not Found', value: 'not found' },
-      ],
-    },
-    kind: {
-      name: 'Kind',
-      options: Object.entries(CONNECTION_KINDS).map(([key, value]) => ({ label: key, value })),
-    },
-  };
+
+  const filters = useMemo(
+    () => ({
+      status: {
+        name: 'Status',
+        options: [
+          { label: 'Connected', value: 'connected' },
+          { label: 'Registered', value: 'registered' },
+          { label: 'Discovered', value: 'discovered' },
+          { label: 'Ignored', value: 'ignored' },
+          { label: 'Deleted', value: 'deleted' },
+          { label: 'Maintenance', value: 'maintenance' },
+          { label: 'Disconnected', value: 'disconnected' },
+          { label: 'Not Found', value: 'not found' },
+        ],
+      },
+      kind: {
+        name: 'Kind',
+        options: Object.entries(CONNECTION_KINDS).map(([key, value]) => ({ label: key, value })),
+      },
+    }),
+    [],
+  );
 
   const handleApplyFilter = () => {
     const statusFilter = selectedFilters.status === 'All' ? null : selectedFilters.status;
@@ -221,19 +311,21 @@ const ConnectionTable = ({ selectedFilter, selectedConnectionId, updateUrlWithCo
     error: connectionError,
     refetch: getConnections,
     isLoading: isConnectionLoading,
-    isFetching: isConnectionFetching,
-  } = useGetConnectionsQuery({
-    page: page,
-    pagesize: pageSize,
-    search: search,
-    order: sortOrder,
-    status: statusFilter ? JSON.stringify([statusFilter]) : '',
-    kind: selectedFilter
-      ? JSON.stringify([selectedFilter])
-      : kindFilter
-        ? JSON.stringify([kindFilter])
-        : '',
-  });
+  } = useGetConnectionsQuery(
+    {
+      page: page,
+      pagesize: pageSize,
+      search: search,
+      order: sortOrder,
+      status: statusFilter ? JSON.stringify([statusFilter]) : '',
+      kind: selectedFilter
+        ? JSON.stringify([selectedFilter])
+        : kindFilter
+          ? JSON.stringify([kindFilter])
+          : '',
+    },
+    undefined,
+  );
   const {
     data: environmentsResponse,
     isSuccess: isEnvironmentsSuccess,
@@ -246,24 +338,27 @@ const ConnectionTable = ({ selectedFilter, selectedConnectionId, updateUrlWithCo
     },
   );
 
-  let environments = environmentsResponse?.environments || [];
+  const environments = environmentsResponse?.environments || [];
+  const environmentOptions = useMemo(
+    () => environments.map((env) => ({ label: env.name, value: env.id })),
+    [environments],
+  );
 
   useEffect(() => {
-    updateCols(columns);
     if (isEnvironmentsError) {
       notify({
-        message: `${ACTION_TYPES.FETCH_ENVIRONMENT.error_msg}: ${environmentsError.error}`,
+        message: `${ACTION_TYPES.FETCH_ENVIRONMENT.error_msg}: ${getErrorMessage(environmentsError)}`,
         event_type: EVENT_TYPES.ERROR,
       });
     }
 
     if (isConnectionError) {
       notify({
-        message: `${ACTION_TYPES.FETCH_CONNECTIONS.error_msg}: ${connectionError.error}`,
+        message: `${ACTION_TYPES.FETCH_CONNECTIONS.error_msg}: ${getErrorMessage(connectionError)}`,
         event_type: EVENT_TYPES.ERROR,
       });
     }
-  }, [environmentsError, connectionError, isEnvironmentsSuccess]);
+  }, [connectionError, environmentsError, isConnectionError, isEnvironmentsError, notify]);
 
   const enhancedConnections = useMemo(() => {
     if (!connectionData?.connections) return [];
@@ -275,196 +370,294 @@ const ConnectionTable = ({ selectedFilter, selectedConnectionId, updateUrlWithCo
         nextStatus: connection.nextStatus || connectionMetadataState[connection.kind]?.transitions,
         kindLogo: connection.kindLogo || connectionMetadataState[connection.kind]?.icon,
       }));
-  }, [connectionData, isConnectionLoading, isConnectionFetching, connectionMetadataState]);
+  }, [connectionData?.connections, connectionMetadataState]) as ConnectionRow[];
 
-  const filteredConnections = enhancedConnections?.filter(({ status, kind }) => {
-    const statusMatch = selectedFilters.status === 'All' || status === selectedFilters.status;
-    const kindMatch = selectedFilters.kind === 'All' || kind === selectedFilters.kind;
-    return statusMatch && kindMatch;
-  });
+  const filteredConnections = useMemo(
+    () =>
+      enhancedConnections.filter(({ status, kind }) => {
+        const statusMatch = selectedFilters.status === 'All' || status === selectedFilters.status;
+        const kindMatch = selectedFilters.kind === 'All' || kind === selectedFilters.kind;
+        return statusMatch && kindMatch;
+      }),
+    [enhancedConnections, selectedFilters],
+  );
 
   const url = `https://docs.meshery.io/concepts/logical/connections#states-and-the-lifecycle-of-connections`;
   const envUrl = `https://docs.meshery.io/concepts/logical/environments`;
 
-  let colViews = [
-    ['name', 'xs'],
-    ['environments', 'm'],
-    ['kind', 'm'],
-    ['type', 's'],
-    ['sub_type', 'na'],
-    ['created_at', 'na'],
-    ['status', 'xs'],
-    ['Actions', 'xs'],
-    ['ConnectionID', 'na'],
-  ];
-  const addConnectionToEnvironment = async (
-    environmentId,
-    environmentName,
-    connectionId,
-    connectionName,
-  ) => {
-    return addConnectionToEnvironmentMutator({ environmentId, connectionId })
-      .unwrap()
-      .then(() => {
+  const colViews = useMemo(
+    () => [
+      ['name', 'xs'],
+      ['environments', 'm'],
+      ['kind', 'm'],
+      ['type', 's'],
+      ['sub_type', 'na'],
+      ['created_at', 'na'],
+      ['status', 'xs'],
+      ['Actions', 'xs'],
+      ['ConnectionID', 'na'],
+    ],
+    [],
+  );
+  const addConnectionToEnvironment = useCallback(
+    async (
+      environmentId: string,
+      environmentName: string,
+      connectionId: string,
+      connectionName: string,
+    ) => {
+      try {
+        await addConnectionToEnvironmentMutator({ environmentId, connectionId }).unwrap();
         notify({
           message: `Connection: ${connectionName} assigned to environment: ${environmentName}`,
           event_type: EVENT_TYPES.SUCCESS,
         });
-      })
-      .catch((err) => {
+      } catch (error) {
         notify({
-          message: `${ACTION_TYPES.UPDATE_CONNECTION.error_msg}: ${err.error}`,
+          message: `${ACTION_TYPES.UPDATE_CONNECTION.error_msg}: ${getErrorMessage(error)}`,
           event_type: EVENT_TYPES.ERROR,
-          details: err.toString(),
+          details: String(error),
         });
-      });
-  };
+      }
+    },
+    [addConnectionToEnvironmentMutator, notify],
+  );
 
-  const removeConnectionFromEnvironment = async (
-    environmentId,
-    environmentName,
-    connectionId,
-    connectionName,
-  ) => {
-    return removeConnectionFromEnvMutator({ environmentId, connectionId })
-      .unwrap()
-      .then(() => {
+  const removeConnectionFromEnvironment = useCallback(
+    async (
+      environmentId: string,
+      environmentName: string,
+      connectionId: string,
+      connectionName: string,
+    ) => {
+      try {
+        await removeConnectionFromEnvMutator({ environmentId, connectionId }).unwrap();
         notify({
           message: `Connection: ${connectionName} removed from environment: ${environmentName}`,
           event_type: EVENT_TYPES.SUCCESS,
         });
-      })
-      .catch((err) => {
+      } catch (error) {
         notify({
-          message: `${ACTION_TYPES.UPDATE_CONNECTION.error_msg}: ${err.error}`,
+          message: `${ACTION_TYPES.UPDATE_CONNECTION.error_msg}: ${getErrorMessage(error)}`,
           event_type: EVENT_TYPES.ERROR,
-          details: err.toString(),
+          details: String(error),
         });
-      });
-  };
+      }
+    },
+    [notify, removeConnectionFromEnvMutator],
+  );
 
-  const saveEnvironment = async (connectionId, connectionName, environmentName) => {
-    return saveEnvironmentMutator({
-      body: {
-        name: environmentName,
-        organization_id: organization?.id,
-      },
-    })
-      .unwrap()
-      .then((resp) => {
+  const saveEnvironment = useCallback(
+    async (connectionId: string, connectionName: string, environmentName: string) => {
+      try {
+        const response = await saveEnvironmentMutator({
+          body: {
+            name: environmentName,
+            organization_id: organization?.id,
+          },
+        }).unwrap();
+
         notify({
-          message: `Environment "${resp.name}" created`,
+          message: `Environment "${response.name}" created`,
           event_type: EVENT_TYPES.SUCCESS,
         });
-        environments = [...environments, resp];
-        addConnectionToEnvironment(resp.id, resp.name, connectionId, connectionName);
-      })
-      .catch((err) => {
-        notify({
-          message: `${ACTION_TYPES.CREATE_ENVIRONMENT.error_msg}: ${err.error}`,
-          event_type: EVENT_TYPES.ERROR,
-          details: err.toString(),
-        });
-      });
-  };
 
-  const handleDeleteConnection = async (connectionId) => {
-    if (connectionId) {
-      let response = await modalRef.current.show({
+        await addConnectionToEnvironment(response.id, response.name, connectionId, connectionName);
+      } catch (error) {
+        notify({
+          message: `${ACTION_TYPES.CREATE_ENVIRONMENT.error_msg}: ${getErrorMessage(error)}`,
+          event_type: EVENT_TYPES.ERROR,
+          details: String(error),
+        });
+      }
+    },
+    [addConnectionToEnvironment, notify, organization?.id, saveEnvironmentMutator],
+  );
+
+  const updateConnectionStatus = useCallback(
+    async (connectionId: string, newStatus: string) => {
+      try {
+        await updateConnectionByIdMutator({
+          connectionId,
+          body: { status: newStatus },
+        }).unwrap();
+
+        notify({
+          message: `Connection status updated`,
+          event_type: EVENT_TYPES.SUCCESS,
+        });
+      } catch (error) {
+        notify({
+          message: `${ACTION_TYPES.UPDATE_CONNECTION.error_msg}: ${getErrorMessage(error)}`,
+          event_type: EVENT_TYPES.ERROR,
+          details: String(error),
+        });
+      }
+    },
+    [notify, updateConnectionByIdMutator],
+  );
+
+  const handleDeleteConnection = useCallback(
+    async (connectionId: string) => {
+      if (!connectionId || !modalRef.current) {
+        return;
+      }
+
+      const response = await modalRef.current.show({
         title: `Delete Connection`,
         subtitle: `Are you sure that you want to delete the connection?`,
         primaryOption: 'DELETE',
         showInfoIcon: `Learn more about the [lifecycle of connections and the behavior of state transitions](https://docs.meshery.io/concepts/logical/connections) in Meshery Docs.`,
         variant: PROMPT_VARIANTS.DANGER,
       });
+
       if (response === 'DELETE') {
-        UpdateConnectionStatus(connectionId, CONNECTION_STATES.DELETED);
+        await updateConnectionStatus(connectionId, CONNECTION_STATES.DELETED);
       }
-    }
-  };
+    },
+    [updateConnectionStatus],
+  );
 
-  const handleDeleteConnections = async (selected) => {
-    if (!selected?.data?.length) return;
+  const handleDeleteConnections = useCallback(
+    async (selected: SelectedRows) => {
+      if (!selected?.data?.length || !modalRef.current) {
+        return;
+      }
 
-    // Capture the connection IDs up front. The user has to acknowledge the
-    // confirmation modal before delete fires, and `filteredConnections` can
-    // be invalidated/reordered by an in-flight refetch in that window — using
-    // the index after-the-fact dereferenced stale rows and silently no-op'd
-    // (no PUT, no notification), which surfaced as a hung e2e snackbar wait.
-    const ids = selected.data.map(({ index }) => filteredConnections?.[index]?.id).filter(Boolean);
-    if (ids.length === 0) return;
+      // Capture the connection IDs up front. The user has to acknowledge the
+      // confirmation modal before delete fires, and `filteredConnections` can
+      // be invalidated/reordered by an in-flight refetch in that window — using
+      // the index after-the-fact dereferenced stale rows and silently no-op'd
+      // (no PUT, no notification), which surfaced as a hung e2e snackbar wait.
+      const ids = selected.data
+        .map(({ index }) => filteredConnections[index]?.id)
+        .filter(Boolean) as string[];
 
-    const response = await modalRef.current.show({
-      title: `Delete Connections`,
-      subtitle: `Are you sure that you want to delete the connections?`,
-      primaryOption: 'DELETE',
-      showInfoIcon: `Learn more about the [lifecycle of connections and the behavior of state transitions](https://docs.meshery.io/concepts/logical/connections) in Meshery Docs.`,
-      variant: PROMPT_VARIANTS.DANGER,
-    });
-    if (response === 'DELETE') {
-      ids.forEach((id) => UpdateConnectionStatus(id, CONNECTION_STATES.DELETED));
-    }
-  };
+      if (ids.length === 0) {
+        return;
+      }
 
-  const handleError = (action) => (error) => {
-    updateProgress({ showProgress: false });
-    notify({
-      message: `${action.error_msg}: ${error}`,
-      event_type: EVENT_TYPES.ERROR,
-      details: error.toString(),
-    });
-  };
+      const response = await modalRef.current.show({
+        title: `Delete Connections`,
+        subtitle: `Are you sure that you want to delete the connections?`,
+        primaryOption: 'DELETE',
+        showInfoIcon: `Learn more about the [lifecycle of connections and the behavior of state transitions](https://docs.meshery.io/concepts/logical/connections) in Meshery Docs.`,
+        variant: PROMPT_VARIANTS.DANGER,
+      });
 
-  const handleActionMenuClose = () => {
+      if (response === 'DELETE') {
+        await Promise.all(
+          ids.map((connectionId) =>
+            updateConnectionStatus(connectionId, CONNECTION_STATES.DELETED),
+          ),
+        );
+      }
+    },
+    [filteredConnections, updateConnectionStatus],
+  );
+
+  const handleError = useCallback(
+    (action: { error_msg?: string } | string) => (error: unknown) => {
+      updateProgress({ showProgress: false });
+
+      const message =
+        typeof action === 'string'
+          ? action
+          : `${action.error_msg}: ${getErrorMessage(error, 'Request failed')}`;
+
+      notify({
+        message,
+        event_type: EVENT_TYPES.ERROR,
+        details: String(error),
+      });
+    },
+    [notify],
+  );
+
+  const handleActionMenuClose = useCallback(() => {
     setAnchorEl(null);
     setRowData(null);
-  };
+  }, []);
 
-  const handleDeploymentModeMenuClose = () => {
+  const handleDeploymentModeMenuClose = useCallback(() => {
     setDeploymentModeAnchorEl(null);
-  };
+  }, []);
 
-  const handleDeploymentModeChange = async (newMode) => {
-    const connection = filteredConnections[rowData.rowIndex];
+  const getConnectionAtRowIndex = useCallback(
+    (rowIndex?: number | null) => {
+      if (rowIndex == null) {
+        return null;
+      }
 
-    try {
-      await updateConnectionByIdMutator({
-        connectionId: connection.id,
-        body: {
-          ...connection,
-          metadata: {
-            ...connection.metadata,
-            meshsync_deployment_mode: newMode,
+      return filteredConnections[rowIndex] ?? null;
+    },
+    [filteredConnections],
+  );
+
+  const handleDeploymentModeChange = useCallback(
+    async (newMode: string) => {
+      const connection = getConnectionAtRowIndex(rowData?.rowIndex);
+
+      if (!connection) {
+        handleDeploymentModeMenuClose();
+        handleActionMenuClose();
+        return;
+      }
+
+      try {
+        await updateConnectionByIdMutator({
+          connectionId: connection.id,
+          body: {
+            ...connection,
+            metadata: {
+              ...connection.metadata,
+              meshsync_deployment_mode: newMode,
+            },
           },
-        },
-      }).unwrap();
+        }).unwrap();
 
-      notify({
-        message: `Deployment mode changed to ${newMode}`,
-        event_type: EVENT_TYPES.SUCCESS,
-      });
-    } catch (err) {
-      notify({
-        message: `Failed to change deployment mode: ${err.error}`,
-        event_type: EVENT_TYPES.ERROR,
-      });
-    }
+        notify({
+          message: `Deployment mode changed to ${newMode}`,
+          event_type: EVENT_TYPES.SUCCESS,
+        });
+      } catch (error) {
+        notify({
+          message: `Failed to change deployment mode: ${getErrorMessage(error)}`,
+          event_type: EVENT_TYPES.ERROR,
+        });
+      }
 
-    handleDeploymentModeMenuClose();
-    handleActionMenuClose();
-  };
-
-  const handleFlushMeshSync = () => {
-    return async () => {
+      handleDeploymentModeMenuClose();
       handleActionMenuClose();
-      const connection = filteredConnections[rowData.rowIndex];
+    },
+    [
+      getConnectionAtRowIndex,
+      handleActionMenuClose,
+      handleDeploymentModeMenuClose,
+      notify,
+      rowData?.rowIndex,
+      updateConnectionByIdMutator,
+    ],
+  );
 
-      let response = await modalRef.current.show({
-        title: `Flush MeshSync data for ${connection.metadata?.name} ?`,
-        subtitle: `Are you sure to Flush MeshSync data for “${connection.metadata?.name}”? Fresh MeshSync data will be repopulated for this context, if MeshSync is actively running on this cluster.`,
+  const handleFlushMeshSync = useCallback(
+    () => async () => {
+      handleActionMenuClose();
+
+      const connection = getConnectionAtRowIndex(rowData?.rowIndex);
+      const connectionName = connection?.metadata?.name;
+
+      if (!connection || !modalRef.current) {
+        return;
+      }
+
+      const response = await modalRef.current.show({
+        title: `Flush MeshSync data for ${connectionName} ?`,
+        subtitle: `Are you sure to Flush MeshSync data for “${connectionName}”? Fresh MeshSync data will be repopulated for this context, if MeshSync is actively running on this cluster.`,
         primaryOption: 'PROCEED',
         variant: PROMPT_VARIANTS.WARNING,
       });
+
       if (response === 'PROCEED') {
         updateProgress({ showProgress: true });
         resetDatabase({
@@ -473,107 +666,112 @@ const ConnectionTable = ({ selectedFilter, selectedConnectionId, updateUrlWithCo
             ReSync: 'true',
             hardReset: 'false',
           },
-          k8scontextID: connection.metadata?.id,
+          k8scontextID: connection.metadata?.id || '',
         }).subscribe({
-          next: (res) => {
+          next: (result) => {
             updateProgress({ showProgress: false });
-            if (res.resetStatus === 'PROCESSING') {
+            if (result.resetStatus === 'PROCESSING') {
               notify({ message: `Database reset successful.`, event_type: EVENT_TYPES.SUCCESS });
             }
           },
           error: handleError('Database is not reachable, try restarting server.'),
         });
       }
-    };
-  };
+    },
+    [getConnectionAtRowIndex, handleActionMenuClose, handleError, notify, rowData?.rowIndex],
+  );
 
-  const handleEnvironmentSelect = async (
-    connectionId,
-    connName,
-    assignedEnvironments,
-    selectedEnvironments,
-    unSelectedEnvironments,
-  ) => {
-    if (updatingConnection.current) {
-      return;
-    }
+  const handleEnvironmentSelect = useCallback(
+    async (
+      connectionId: string,
+      connName: string,
+      assignedEnvironments: EnvironmentOption[],
+      selectedEnvironments: EnvironmentOption[],
+      unSelectedEnvironments: EnvironmentOption[],
+    ) => {
+      if (updatingConnection.current) {
+        return;
+      }
 
-    updatingConnection.current = true;
+      updatingConnection.current = true;
 
-    try {
-      let newlySelectedEnvironments = selectedEnvironments.filter((env) => {
-        return !assignedEnvironments.some((assignedEnv) => assignedEnv.value === env.value);
+      try {
+        const newlySelectedEnvironments = selectedEnvironments.filter((environment) => {
+          return !assignedEnvironments.some(
+            (assignedEnvironment) => assignedEnvironment.value === environment.value,
+          );
+        });
+
+        const selectedExistingEnvironments = newlySelectedEnvironments.filter(
+          (environment) => !environment.__isNew__,
+        );
+        const selectedNewEnvironments = newlySelectedEnvironments.filter(
+          (environment) => environment.__isNew__,
+        );
+
+        await Promise.all([
+          ...selectedExistingEnvironments.map((environment) =>
+            addConnectionToEnvironment(
+              environment.value || '',
+              environment.label,
+              connectionId,
+              connName,
+            ),
+          ),
+          ...selectedNewEnvironments.map((environment) =>
+            saveEnvironment(connectionId, connName, environment.label),
+          ),
+          ...unSelectedEnvironments.map((environment) =>
+            removeConnectionFromEnvironment(
+              environment.value || '',
+              environment.label,
+              connectionId,
+              connName,
+            ),
+          ),
+        ]);
+      } finally {
+        getConnections();
+        updatingConnection.current = false;
+      }
+    },
+    [addConnectionToEnvironment, getConnections, removeConnectionFromEnvironment, saveEnvironment],
+  );
+
+  const handleStatusChange = useCallback(
+    async (event, connectionId: string, connectionKind: string, connectionStatus: string) => {
+      event.stopPropagation();
+
+      if (!modalRef.current) {
+        return;
+      }
+
+      const status = event.target.value;
+      const subtitle = getStatusTransition(connectionKind, connectionStatus, status.toLowerCase());
+      const response = await modalRef.current.show({
+        title: `Transition connection to ${status.toUpperCase()}?`,
+        subtitle,
+        primaryOption: 'Confirm',
+        showInfoIcon: `Learn more about the [lifecycle of connections and the behavior of state transitions](https://docs.meshery.io/concepts/logical/connections) in Meshery Docs.`,
+        variant: PROMPT_VARIANTS.WARNING,
       });
 
-      for (let environment of newlySelectedEnvironments) {
-        let envName = environment.label;
-        let environmentId = environment.value || '';
-        let isNew = environment.__isNew__ || false;
-
-        if (isNew) {
-          await saveEnvironment(connectionId, connName, envName);
-          return;
-        }
-
-        addConnectionToEnvironment(environmentId, envName, connectionId, connName);
+      if (response === 'Confirm') {
+        await updateConnectionStatus(connectionId, status);
       }
-      for (let environment of unSelectedEnvironments) {
-        let envName = environment.label;
-        let environmentId = environment.value || '';
+    },
+    [updateConnectionStatus],
+  );
 
-        await removeConnectionFromEnvironment(environmentId, envName, connectionId, connName);
-      }
-    } finally {
-      getConnections();
-      updatingConnection.current = false;
-    }
-  };
-
-  const UpdateConnectionStatus = (connectionId, newStatus) => {
-    updateConnectionByIdMutator({
-      connectionId: connectionId,
-      body: { status: newStatus },
-    })
-      .unwrap()
-      .then(() => {
-        notify({
-          message: `Connection status updated`,
-          event_type: EVENT_TYPES.SUCCESS,
-        });
-      })
-      .catch((err) => {
-        notify({
-          message: `${ACTION_TYPES.UPDATE_CONNECTION.error_msg}: ${err.error}`,
-          event_type: EVENT_TYPES.ERROR,
-          details: err.toString(),
-        });
-      });
-  };
-  const handleStatusChange = async (e, connectionId, connectionKind, connectionStatus) => {
-    e.stopPropagation();
-    const status = e.target.value;
-    let subtitle = getStatusTransition(connectionKind, connectionStatus, status.toLowerCase());
-    let response = await modalRef.current.show({
-      title: `Transition connection to ${status.toUpperCase()}?`,
-      subtitle,
-      primaryOption: 'Confirm',
-      showInfoIcon: `Learn more about the [lifecycle of connections and the behavior of state transitions](https://docs.meshery.io/concepts/logical/connections) in Meshery Docs.`,
-      variant: PROMPT_VARIANTS.WARNING,
-    });
-    if (response === 'Confirm') {
-      UpdateConnectionStatus(connectionId, e.target.value);
-    }
-  };
-
-  const handleActionMenuOpen = (event, tableMeta) => {
+  const handleActionMenuOpen = useCallback((event, tableMeta: RowData) => {
     event.stopPropagation();
     setAnchorEl(event.currentTarget);
     setRowData(tableMeta);
-  };
+  }, []);
   const theme = useTheme();
 
   // Consolidate multiple useRef hooks into a single object
-  const expansionFlags = useRef({
+  const expansionFlags = useRef<ExpansionFlags>({
     isHandlingExpansion: false,
     isInitialLoad: true,
     isUrlExpansion: false,
@@ -593,559 +791,593 @@ const ConnectionTable = ({ selectedFilter, selectedConnectionId, updateUrlWithCo
       if (index !== -1) {
         setRowsExpanded([index]);
       } else {
-        updateUrlWithConnectionId('');
+        updateUrlWithConnectionId?.('');
       }
 
       expansionFlags.current.isUrlExpansion = false;
       expansionFlags.current.isInitialLoad = false;
     }
-  }, [selectedConnectionId, filteredConnections]);
+  }, [filteredConnections, selectedConnectionId, updateUrlWithConnectionId]);
 
-  const columns = [
-    {
-      name: 'id',
-      label: 'ID',
-      options: {
-        display: false,
-      },
-    },
-    {
-      name: 'metadata.server_location',
-      label: 'Server Location',
-      options: {
-        display: false,
-      },
-    },
-    {
-      name: 'metadata.server',
-      label: 'Server',
-      options: {
-        display: false,
-      },
-    },
-    {
-      name: 'name',
-      label: 'Name',
-      options: {
-        sort: true,
-        sortThirdClickReset: true,
-        customHeadRender: function CustomHead({ index, ...column }, sortColumn, columnMeta) {
-          return (
-            <SortableTableCell
-              index={index}
-              columnData={column}
-              columnMeta={columnMeta}
-              onSort={() => sortColumn(index)}
-            />
-          );
+  const columns = useMemo(() => {
+    const nextColumns = [
+      {
+        name: 'id',
+        label: 'ID',
+        options: {
+          display: false,
         },
-        customBodyRender: (value, tableMeta) => {
-          const server =
-            getColumnValue(tableMeta.rowData, 'metadata.server', columns) ||
-            getColumnValue(tableMeta.rowData, 'metadata.server_location', columns);
-          const name = getColumnValue(tableMeta.rowData, 'metadata.name', columns);
-          const kind = getColumnValue(tableMeta.rowData, 'kind', columns);
-          const iconSrc = normalizeStaticImagePath(
-            getColumnValue(tableMeta.rowData, 'kindLogo', columns) ||
-              getFallbackImageBasedOnKind(kind),
-          );
-          return (
-            <>
-              <TooltipWrappedConnectionChip
-                tooltip={server && 'Server: ' + server}
-                title={kind === CONNECTION_KINDS.KUBERNETES ? name : value}
-                status={getColumnValue(tableMeta.rowData, 'status', columns)}
-                onDelete={() =>
-                  handleDeleteConnection(
-                    getColumnValue(tableMeta.rowData, 'id', columns),
-                    getColumnValue(tableMeta.rowData, 'kind', columns),
-                  )
-                }
-                handlePing={() => {
-                  // e.stopPropagation();
-                  if (getColumnValue(tableMeta.rowData, 'kind', columns) === 'kubernetes') {
-                    ping(
-                      getColumnValue(tableMeta.rowData, 'metadata.name', columns),
-                      getColumnValue(tableMeta.rowData, 'metadata.server', columns),
-                      getColumnValue(tableMeta.rowData, 'id', columns),
-                    );
-                  }
-                }}
-                iconSrc={iconSrc}
-                width="12rem"
+      },
+      {
+        name: 'metadata.server_location',
+        label: 'Server Location',
+        options: {
+          display: false,
+        },
+      },
+      {
+        name: 'metadata.server',
+        label: 'Server',
+        options: {
+          display: false,
+        },
+      },
+      {
+        name: 'name',
+        label: 'Name',
+        options: {
+          sort: true,
+          sortThirdClickReset: true,
+          customHeadRender: function CustomHead({ index, ...column }, sortColumn, columnMeta) {
+            return (
+              <SortableTableCell
+                index={index}
+                columnData={column}
+                columnMeta={columnMeta}
+                onSort={() => sortColumn(index)}
+                icon={null}
+                tooltip=""
               />
-              {kind == 'kubernetes' && (
-                <CustomTextTooltip
-                  placement="top"
-                  title="Learn more about connection status and how to [troubleshoot Kubernetes connections](https://docs.meshery.io/guides/troubleshooting/meshery-operator-meshsync)"
-                >
-                  <div style={{ display: 'inline-block' }}>
-                    <IconButton
-                      color="default"
-                      onClick={(e) => {
-                        e.stopPropagation();
-                        e.preventDefault();
-                      }}
-                    >
-                      <InfoOutlinedIcon height={20} width={20} />
-                    </IconButton>
-                  </div>
-                </CustomTextTooltip>
-              )}
-            </>
-          );
-        },
-      },
-    },
-    {
-      name: 'environments',
-      label: 'Environments',
-      options: {
-        sort: false,
-        sortThirdClickReset: true,
-        customHeadRender: function CustomHead({ ...column }) {
-          return (
-            <DefaultTableCell
-              columnData={column}
-              icon={
-                <IconButton disableRipple={true} disableFocusRipple={true}>
-                  <InfoOutlinedIcon
-                    style={{
-                      cursor: 'pointer',
-                      height: 20,
-                      width: 20,
-                    }}
-                    onClick={(e) => {
-                      e.stopPropagation();
-                    }}
-                  />
-                </IconButton>
-              }
-              tooltip={`Meshery Environments allow you to logically group related Connections and their associated Credentials. [Learn more](${envUrl})`}
-            />
-          );
-        },
-        customBodyRender: (value, tableMeta) => {
-          const getOptions = () => {
-            return environments.map((env) => ({ label: env.name, value: env.id }));
-          };
-          let cleanedEnvs = value?.map((env) => ({ label: env.name, value: env.id })) || [];
-          let updatingEnvs = updatingConnection.current;
-          return (
-            isEnvironmentsSuccess && (
-              <div onClick={(e) => e.stopPropagation()}>
-                <Grid2 size={{ xs: 12 }} style={{ height: '5rem', width: '15rem' }}>
-                  <Grid2 size={{ xs: 12 }} style={{ marginTop: '2rem', cursor: 'pointer' }}>
-                    <MultiSelectWrapper
-                      updating={updatingEnvs}
-                      onChange={(selected, unselected) =>
-                        handleEnvironmentSelect(
-                          getColumnValue(tableMeta.rowData, 'id', columns),
-                          getColumnValue(tableMeta.rowData, 'name', columns),
-                          cleanedEnvs,
-                          selected,
-                          unselected,
-                        )
-                      }
-                      options={getOptions()}
-                      value={cleanedEnvs}
-                      placeholder={`Assigned Environments`}
-                      isSelectAll={true}
-                      menuPlacement={'bottom'}
-                      disabled={
-                        !CAN(
-                          keys.ASSIGN_CONNECTIONS_TO_ENVIRONMENT.action,
-                          keys.ASSIGN_CONNECTIONS_TO_ENVIRONMENT.subject,
-                        )
-                      }
-                    />
-                  </Grid2>
-                </Grid2>
-              </div>
-            )
-          );
-        },
-      },
-    },
-    {
-      name: 'kind',
-      label: 'Kind',
-      options: {
-        sort: true,
-        sortThirdClickReset: true,
-        customHeadRender: function CustomHead({ index, ...column }, sortColumn, columnMeta) {
-          return (
-            <SortableTableCell
-              index={index}
-              columnData={column}
-              columnMeta={columnMeta}
-              onSort={() => sortColumn(index)}
-            />
-          );
-        },
-      },
-    },
-    {
-      name: 'type',
-      label: 'Category',
-      options: {
-        sort: true,
-        sortThirdClickReset: true,
-        customHeadRender: function CustomHead({ index, ...column }, sortColumn, columnMeta) {
-          return (
-            <SortableTableCell
-              index={index}
-              columnData={column}
-              columnMeta={columnMeta}
-              onSort={() => sortColumn(index)}
-            />
-          );
-        },
-      },
-    },
-    {
-      name: 'sub_type',
-      label: 'Sub Category',
-      options: {
-        sort: true,
-        sortThirdClickReset: true,
-        customHeadRender: function CustomHead({ index, ...column }, sortColumn, columnMeta) {
-          return (
-            <SortableTableCell
-              index={index}
-              columnData={column}
-              columnMeta={columnMeta}
-              onSort={() => sortColumn(index)}
-            />
-          );
-        },
-      },
-    },
-    {
-      name: 'updated_at',
-      label: 'Updated At',
-      options: {
-        sort: true,
-        sortThirdClickReset: true,
-        display: false,
-        customHeadRender: function CustomHead({ index, ...column }, sortColumn, columnMeta) {
-          return (
-            <SortableTableCell
-              index={index}
-              columnData={column}
-              columnMeta={columnMeta}
-              onSort={() => sortColumn(index)}
-            />
-          );
-        },
-      },
-    },
-    {
-      name: 'created_at',
-      label: 'Discovered At',
-      options: {
-        sort: true,
-        sortThirdClickReset: true,
-        customHeadRender: function CustomHead({ index, ...column }, sortColumn, columnMeta) {
-          return (
-            <SortableTableCell
-              index={index}
-              columnData={column}
-              columnMeta={columnMeta}
-              onSort={() => sortColumn(index)}
-            />
-          );
-        },
-        customBodyRender: function CustomBody(value) {
-          const renderValue = formatDate(value);
-          return (
-            <CustomTooltip title={renderValue} placement="top" arrow interactive>
-              {renderValue}
-            </CustomTooltip>
-          );
-        },
-      },
-    },
-    {
-      name: 'ConnectionID',
-      label: 'Connection ID',
-      options: {
-        sort: true,
-        sortThirdClickReset: true,
-        customHeadRender: function CustomHead({ index, ...column }, sortColumn, columnMeta) {
-          return (
-            <SortableTableCell
-              index={index}
-              columnData={column}
-              columnMeta={columnMeta}
-              onSort={() => sortColumn(index)}
-            />
-          );
-        },
-        customBodyRender: (value, tableMeta) => {
-          const connectionId = getColumnValue(tableMeta.rowData, 'id', columns);
-          return <FormatId id={connectionId} />;
-        },
-      },
-    },
-    {
-      name: 'status',
-      label: 'Status',
-      options: {
-        sort: true,
-        sortThirdClickReset: true,
-        customHeadRender: function CustomHead({ index, ...column }, sortColumn, columnMeta) {
-          return (
-            <SortableTableCell
-              index={index}
-              columnData={column}
-              columnMeta={columnMeta}
-              onSort={() => sortColumn(index)}
-              icon={
-                <IconButton disableRipple={true} disableFocusRipple={true}>
-                  <InfoOutlinedIcon
-                    style={{
-                      cursor: 'pointer',
-                      height: 20,
-                      width: 20,
-                    }}
-                    onClick={(e) => {
-                      e.stopPropagation();
-                    }}
-                  />
-                </IconButton>
-              }
-              tooltip={`Every connection can be in one of the states at any given point of time. Eg: Connected, Registered, Discovered, etc. It allow users more control over whether the discovered infrastructure is to be managed or not (registered for use or not). [Learn more](${url})`}
-            />
-          );
-        },
-        customBodyRender: function CustomBody(value, tableMeta) {
-          const currentStatus = value;
-          const kind = getColumnValue(tableMeta.rowData, 'kind', columns);
+            );
+          },
+          customBodyRender: (value, tableMeta) => {
+            const server =
+              getColumnValue(tableMeta.rowData, 'metadata.server', nextColumns) ||
+              getColumnValue(tableMeta.rowData, 'metadata.server_location', nextColumns);
+            const name = getColumnValue(tableMeta.rowData, 'metadata.name', nextColumns);
+            const kind = getColumnValue(tableMeta.rowData, 'kind', nextColumns);
+            const iconSrc = normalizeStaticImagePath(
+              getColumnValue(tableMeta.rowData, 'kindLogo', nextColumns) ||
+                getFallbackImageBasedOnKind(kind),
+            );
 
-          const nextStatus = Object.keys(
-            CONNECTION_STATE_TRANSITIONS?.[kind]?.[currentStatus] ?? {},
-          );
-          nextStatus.push(currentStatus);
-
-          const disabled =
-            value === 'deleted'
-              ? true
-              : !CAN(keys.CHANGE_CONNECTION_STATE.action, keys.CHANGE_CONNECTION_STATE.subject);
-
-          return (
-            <FormControl>
-              <ConnectionStyledSelect
-                labelId="connection-status-select-label"
-                id="connection-status-select"
-                disabled={disabled}
-                value={value}
-                defaultValue={value}
-                onClick={(e) => e.stopPropagation()}
-                onChange={(e) =>
-                  handleStatusChange(
-                    e,
-                    getColumnValue(tableMeta.rowData, 'id', columns),
-                    getColumnValue(tableMeta.rowData, 'kind', columns),
-                    getColumnValue(tableMeta.rowData, 'status', columns),
-                  )
-                }
-                disableUnderline
-                MenuProps={{
-                  anchorOrigin: {
-                    vertical: 'bottom',
-                    horizontal: 'left',
-                  },
-                  transformOrigin: {
-                    vertical: 'top',
-                    horizontal: 'left',
-                  },
-                  getContentAnchorEl: null,
-                  MenuListProps: { disablePadding: true },
-                  PaperProps: { square: true },
-                }}
-              >
-                {/* using 1 because current status is also included */}
-                {nextStatus.length == 1 && <MenuItem disabled>No transitions Available</MenuItem>}
-                {nextStatus.map((status) => (
-                  <MenuItem
-                    disabled={status === value ? true : false}
-                    style={{
-                      padding: 0,
-                      display: status === value ? 'none' : 'flex',
-                      justifyContent: 'center',
-                    }}
-                    value={status}
-                    key={status}
+            return (
+              <>
+                <TooltipWrappedConnectionChip
+                  tooltip={server ? `Server: ${server}` : ''}
+                  title={kind === CONNECTION_KINDS.KUBERNETES ? name : value}
+                  status={getColumnValue(tableMeta.rowData, 'status', nextColumns)}
+                  onDelete={() =>
+                    handleDeleteConnection(getColumnValue(tableMeta.rowData, 'id', nextColumns))
+                  }
+                  handlePing={() => {
+                    if (getColumnValue(tableMeta.rowData, 'kind', nextColumns) === 'kubernetes') {
+                      ping(
+                        getColumnValue(tableMeta.rowData, 'metadata.name', nextColumns),
+                        getColumnValue(tableMeta.rowData, 'metadata.server', nextColumns),
+                        getColumnValue(tableMeta.rowData, 'id', nextColumns),
+                      );
+                    }
+                  }}
+                  iconSrc={iconSrc}
+                  width="12rem"
+                />
+                {kind === 'kubernetes' && (
+                  <CustomTextTooltip
+                    placement="top"
+                    title="Learn more about connection status and how to [troubleshoot Kubernetes connections](https://docs.meshery.io/guides/troubleshooting/meshery-operator-meshsync)"
                   >
-                    <ConnectionStateChip status={status} actionable={status !== value} />
-                  </MenuItem>
-                ))}
-              </ConnectionStyledSelect>
-            </FormControl>
-          );
+                    <div style={{ display: 'inline-block' }}>
+                      <IconButton
+                        color="default"
+                        onClick={(event) => {
+                          event.stopPropagation();
+                          event.preventDefault();
+                        }}
+                      >
+                        <InfoOutlinedIcon height={20} width={20} />
+                      </IconButton>
+                    </div>
+                  </CustomTextTooltip>
+                )}
+              </>
+            );
+          },
         },
       },
-    },
-    {
-      name: 'Actions',
-      label: 'Actions',
-      options: {
-        filter: false,
-        sort: false,
-        searchable: false,
-        customHeadRender: function CustomHead({ ...column }) {
-          return (
-            <TableCell>
-              <b>{column.label}</b>
-            </TableCell>
-          );
+      {
+        name: 'environments',
+        label: 'Environments',
+        options: {
+          sort: false,
+          sortThirdClickReset: true,
+          customHeadRender: function CustomHead({ ...column }) {
+            return (
+              <DefaultTableCell
+                columnData={column}
+                icon={
+                  <IconButton
+                    disableRipple={true}
+                    disableFocusRipple={true}
+                    onClick={(event) => {
+                      event.stopPropagation();
+                    }}
+                  >
+                    <InfoOutlinedIcon
+                      style={{
+                        cursor: 'pointer',
+                        height: 20,
+                        width: 20,
+                      }}
+                    />
+                  </IconButton>
+                }
+                tooltip={`Meshery Environments allow you to logically group related Connections and their associated Credentials. [Learn more](${envUrl})`}
+              />
+            );
+          },
+          customBodyRender: (value, tableMeta) => {
+            const cleanedEnvs =
+              value?.map((environment) => ({
+                label: environment.name,
+                value: environment.id,
+              })) || [];
+
+            return (
+              isEnvironmentsSuccess && (
+                <div onClick={(event) => event.stopPropagation()}>
+                  <Grid2 size={{ xs: 12 }} style={{ height: '5rem', width: '15rem' }}>
+                    <Grid2 size={{ xs: 12 }} style={{ marginTop: '2rem', cursor: 'pointer' }}>
+                      <MultiSelectWrapper
+                        updating={updatingConnection.current}
+                        onChange={(selected, unselected) =>
+                          handleEnvironmentSelect(
+                            getColumnValue(tableMeta.rowData, 'id', nextColumns),
+                            getColumnValue(tableMeta.rowData, 'name', nextColumns),
+                            cleanedEnvs,
+                            selected,
+                            unselected,
+                          )
+                        }
+                        options={environmentOptions}
+                        value={cleanedEnvs}
+                        placeholder={`Assigned Environments`}
+                        isSelectAll={true}
+                        menuPlacement={'bottom'}
+                        disabled={
+                          !CAN(
+                            keys.ASSIGN_CONNECTIONS_TO_ENVIRONMENT.action,
+                            keys.ASSIGN_CONNECTIONS_TO_ENVIRONMENT.subject,
+                          )
+                        }
+                      />
+                    </Grid2>
+                  </Grid2>
+                </div>
+              )
+            );
+          },
         },
-        customBodyRender: function CustomBody(_, tableMeta) {
-          return (
-            <Box display={'flex'} justifyContent={'center'}>
-              {getColumnValue(tableMeta.rowData, 'kind', columns) ===
-              CONNECTION_KINDS.KUBERNETES ? (
-                <IconButton
-                  aria-label="more"
-                  id="long-button"
-                  aria-haspopup="true"
-                  onClick={(e) => handleActionMenuOpen(e, tableMeta)}
+      },
+      {
+        name: 'kind',
+        label: 'Kind',
+        options: {
+          sort: true,
+          sortThirdClickReset: true,
+          customHeadRender: function CustomHead({ index, ...column }, sortColumn, columnMeta) {
+            return (
+              <SortableTableCell
+                index={index}
+                columnData={column}
+                columnMeta={columnMeta}
+                onSort={() => sortColumn(index)}
+                icon={null}
+                tooltip=""
+              />
+            );
+          },
+        },
+      },
+      {
+        name: 'type',
+        label: 'Category',
+        options: {
+          sort: true,
+          sortThirdClickReset: true,
+          customHeadRender: function CustomHead({ index, ...column }, sortColumn, columnMeta) {
+            return (
+              <SortableTableCell
+                index={index}
+                columnData={column}
+                columnMeta={columnMeta}
+                onSort={() => sortColumn(index)}
+                icon={null}
+                tooltip=""
+              />
+            );
+          },
+        },
+      },
+      {
+        name: 'sub_type',
+        label: 'Sub Category',
+        options: {
+          sort: true,
+          sortThirdClickReset: true,
+          customHeadRender: function CustomHead({ index, ...column }, sortColumn, columnMeta) {
+            return (
+              <SortableTableCell
+                index={index}
+                columnData={column}
+                columnMeta={columnMeta}
+                onSort={() => sortColumn(index)}
+                icon={null}
+                tooltip=""
+              />
+            );
+          },
+        },
+      },
+      {
+        name: 'updated_at',
+        label: 'Updated At',
+        options: {
+          sort: true,
+          sortThirdClickReset: true,
+          display: false,
+          customHeadRender: function CustomHead({ index, ...column }, sortColumn, columnMeta) {
+            return (
+              <SortableTableCell
+                index={index}
+                columnData={column}
+                columnMeta={columnMeta}
+                onSort={() => sortColumn(index)}
+                icon={null}
+                tooltip=""
+              />
+            );
+          },
+        },
+      },
+      {
+        name: 'created_at',
+        label: 'Discovered At',
+        options: {
+          sort: true,
+          sortThirdClickReset: true,
+          customHeadRender: function CustomHead({ index, ...column }, sortColumn, columnMeta) {
+            return (
+              <SortableTableCell
+                index={index}
+                columnData={column}
+                columnMeta={columnMeta}
+                onSort={() => sortColumn(index)}
+                icon={null}
+                tooltip=""
+              />
+            );
+          },
+          customBodyRender: function CustomBody(value) {
+            const renderValue = formatDate(value);
+            return (
+              <CustomTooltip title={renderValue} placement="top" arrow interactive>
+                <span>{renderValue}</span>
+              </CustomTooltip>
+            );
+          },
+        },
+      },
+      {
+        name: 'ConnectionID',
+        label: 'Connection ID',
+        options: {
+          sort: true,
+          sortThirdClickReset: true,
+          customHeadRender: function CustomHead({ index, ...column }, sortColumn, columnMeta) {
+            return (
+              <SortableTableCell
+                index={index}
+                columnData={column}
+                columnMeta={columnMeta}
+                onSort={() => sortColumn(index)}
+                icon={null}
+                tooltip=""
+              />
+            );
+          },
+          customBodyRender: (value, tableMeta) => {
+            const connectionId = getColumnValue(tableMeta.rowData, 'id', nextColumns);
+            return <FormatId id={connectionId} />;
+          },
+        },
+      },
+      {
+        name: 'status',
+        label: 'Status',
+        options: {
+          sort: true,
+          sortThirdClickReset: true,
+          customHeadRender: function CustomHead({ index, ...column }, sortColumn, columnMeta) {
+            return (
+              <SortableTableCell
+                index={index}
+                columnData={column}
+                columnMeta={columnMeta}
+                onSort={() => sortColumn(index)}
+                icon={
+                  <IconButton
+                    disableRipple={true}
+                    disableFocusRipple={true}
+                    onClick={(event) => {
+                      event.stopPropagation();
+                    }}
+                  >
+                    <InfoOutlinedIcon
+                      style={{
+                        cursor: 'pointer',
+                        height: 20,
+                        width: 20,
+                      }}
+                    />
+                  </IconButton>
+                }
+                tooltip={`Every connection can be in one of the states at any given point of time. Eg: Connected, Registered, Discovered, etc. It allow users more control over whether the discovered infrastructure is to be managed or not (registered for use or not). [Learn more](${url})`}
+              />
+            );
+          },
+          customBodyRender: function CustomBody(value, tableMeta) {
+            const currentStatus = value;
+            const kind = getColumnValue(tableMeta.rowData, 'kind', nextColumns);
+
+            const nextStatus = Object.keys(
+              CONNECTION_STATE_TRANSITIONS?.[kind]?.[currentStatus] ?? {},
+            );
+            nextStatus.push(currentStatus);
+
+            const disabled =
+              value === 'deleted'
+                ? true
+                : !CAN(keys.CHANGE_CONNECTION_STATE.action, keys.CHANGE_CONNECTION_STATE.subject);
+
+            return (
+              <FormControl>
+                <ConnectionStyledSelect
+                  labelId="connection-status-select-label"
+                  id="connection-status-select"
+                  disabled={disabled}
+                  value={value}
+                  defaultValue={value}
+                  onClick={(event) => event.stopPropagation()}
+                  onChange={(event) =>
+                    handleStatusChange(
+                      event,
+                      getColumnValue(tableMeta.rowData, 'id', nextColumns),
+                      getColumnValue(tableMeta.rowData, 'kind', nextColumns),
+                      getColumnValue(tableMeta.rowData, 'status', nextColumns),
+                    )
+                  }
+                  disableUnderline
+                  MenuProps={{
+                    anchorOrigin: {
+                      vertical: 'bottom',
+                      horizontal: 'left',
+                    },
+                    transformOrigin: {
+                      vertical: 'top',
+                      horizontal: 'left',
+                    },
+                    getContentAnchorEl: null,
+                    MenuListProps: { disablePadding: true },
+                    PaperProps: { square: true },
+                  }}
                 >
-                  <MoreVertIcon style={iconMedium} />
-                </IconButton>
-              ) : (
-                '-'
-              )}
-            </Box>
-          );
+                  {nextStatus.length === 1 && (
+                    <MenuItem disabled>No transitions Available</MenuItem>
+                  )}
+                  {nextStatus.map((status) => (
+                    <MenuItem
+                      disabled={status === value}
+                      style={{
+                        padding: 0,
+                        display: status === value ? 'none' : 'flex',
+                        justifyContent: 'center',
+                      }}
+                      value={status}
+                      key={status}
+                    >
+                      <ConnectionStateChip status={status} actionable={status !== value} />
+                    </MenuItem>
+                  ))}
+                </ConnectionStyledSelect>
+              </FormControl>
+            );
+          },
         },
       },
-    },
-    {
-      name: 'nextStatus',
-      label: 'nextStatus',
-      options: {
-        display: false,
+      {
+        name: 'Actions',
+        label: 'Actions',
+        options: {
+          filter: false,
+          sort: false,
+          searchable: false,
+          customHeadRender: function CustomHead({ ...column }) {
+            return (
+              <TableCell>
+                <b>{column.label}</b>
+              </TableCell>
+            );
+          },
+          customBodyRender: function CustomBody(_, tableMeta) {
+            return (
+              <Box display={'flex'} justifyContent={'center'}>
+                {getColumnValue(tableMeta.rowData, 'kind', nextColumns) ===
+                CONNECTION_KINDS.KUBERNETES ? (
+                  <IconButton
+                    aria-label="more"
+                    id="long-button"
+                    aria-haspopup="true"
+                    onClick={(event) => handleActionMenuOpen(event, tableMeta)}
+                  >
+                    <MoreVertIcon style={iconMedium} />
+                  </IconButton>
+                ) : (
+                  '-'
+                )}
+              </Box>
+            );
+          },
+        },
       },
-    },
-    {
-      name: 'kindLogo',
-      label: 'kindLogo',
-      options: {
-        display: false,
+      {
+        name: 'nextStatus',
+        label: 'nextStatus',
+        options: {
+          display: false,
+        },
       },
-    },
-    {
-      name: 'metadata.name',
-      label: 'Name',
-      options: {
-        display: false,
+      {
+        name: 'kindLogo',
+        label: 'kindLogo',
+        options: {
+          display: false,
+        },
       },
-    },
-  ];
-
-  const options = {
-    filter: false,
-    viewColumns: false,
-    search: false,
-    responsive: 'standard',
-    resizableColumns: true,
-    serverSide: true,
-    count: connectionData?.totalCount,
-    rowsPerPage: pageSize,
-    fixedHeader: true,
-    page,
-    print: false,
-    download: false,
-    textLabels: {
-      selectedRows: {
-        text: 'connection(s) selected',
+      {
+        name: 'metadata.name',
+        label: 'Name',
+        options: {
+          display: false,
+        },
       },
-    },
-    sortOrder: {
-      name: sortOrder.split(' ')[0],
-      direction: sortOrder.split(' ')[1],
-    },
-    customToolbarSelect: (selected) => (
-      <Button
-        color="error"
-        variant="contained"
-        size="large"
-        onClick={() => handleDeleteConnections(selected)}
-        sx={{ backgroundColor: `${theme.palette.error.dark} !important`, marginRight: '10px' }}
-        disabled={!CAN(keys.DELETE_A_CONNECTION.action, keys.DELETE_A_CONNECTION.subject)}
-        data-testid="Button-delete-connections"
-      >
-        <DeleteIcon style={iconMedium} fill={theme.palette.common.white} />
-        Delete
-      </Button>
-    ),
-    enableNestedDataAccess: '.',
-    onTableChange: (action, tableState) => {
-      const sortInfo = tableState.announceText ? tableState.announceText.split(' : ') : [];
-      let order = '';
-      if (tableState.activeColumn) {
-        order = `${columns[tableState.activeColumn].name} desc`;
-      }
-      switch (action) {
-        case 'changePage':
-          setPage(tableState.page.toString());
-          break;
-        case 'changeRowsPerPage':
-          setPageSize(tableState.rowsPerPage.toString());
-          break;
-        case 'sort':
-          if (sortInfo.length == 2) {
-            if (sortInfo[1] === 'ascending') {
-              order = `${columns[tableState.activeColumn].name} asc`;
-            } else {
-              order = `${columns[tableState.activeColumn].name} desc`;
-            }
-          }
-          if (order !== sortOrder) {
-            setSortOrder(order);
-          }
-          break;
-      }
-    },
-    expandableRows: true,
-    expandableRowsHeader: false,
-    expandableRowsOnClick: true,
-    rowsExpanded: rowsExpanded,
-    isRowExpandable: () => {
-      return true;
-    },
-    onRowExpansionChange: (_, allRowsExpanded) => {
-      if (expansionFlags.current.isUrlExpansion) return;
+    ];
 
-      expansionFlags.current.isHandlingExpansion = true;
-      const expandedRows = allRowsExpanded.slice(-1);
-      setRowsExpanded(expandedRows.map((item) => item.index));
+    return nextColumns;
+  }, [
+    envUrl,
+    environmentOptions,
+    handleActionMenuOpen,
+    handleDeleteConnection,
+    handleEnvironmentSelect,
+    handleStatusChange,
+    isEnvironmentsSuccess,
+    ping,
+    url,
+  ]);
 
-      if (expandedRows.length > 0 && filteredConnections) {
-        const index = expandedRows[0].index;
-        const connection = filteredConnections[index];
+  const options = useMemo(
+    () => ({
+      filter: false,
+      viewColumns: false,
+      search: false,
+      responsive: 'standard',
+      resizableColumns: true,
+      serverSide: true,
+      count: connectionData?.totalCount,
+      rowsPerPage: pageSize,
+      fixedHeader: true,
+      page,
+      print: false,
+      download: false,
+      textLabels: {
+        selectedRows: {
+          text: 'connection(s) selected',
+        },
+      },
+      sortOrder: {
+        name: sortOrder.split(' ')[0],
+        direction: sortOrder.split(' ')[1],
+      },
+      customToolbarSelect: (selected) => (
+        <Button
+          color="error"
+          variant="contained"
+          size="large"
+          onClick={() => handleDeleteConnections(selected)}
+          sx={{ backgroundColor: `${theme.palette.error.dark} !important`, marginRight: '10px' }}
+          disabled={!CAN(keys.DELETE_A_CONNECTION.action, keys.DELETE_A_CONNECTION.subject)}
+          data-testid="Button-delete-connections"
+        >
+          <DeleteIcon style={iconMedium} fill={theme.palette.common.white} />
+          Delete
+        </Button>
+      ),
+      enableNestedDataAccess: '.',
+      onTableChange: (action, tableState) => {
+        const sortInfo = tableState.announceText ? tableState.announceText.split(' : ') : [];
+        let order = '';
 
-        if (
-          connection &&
-          updateUrlWithConnectionId &&
-          (!expansionFlags.current.isInitialLoad || connection.id !== selectedConnectionId)
-        ) {
-          updateUrlWithConnectionId(connection.id);
+        if (typeof tableState.activeColumn === 'number') {
+          order = `${columns[tableState.activeColumn].name} desc`;
         }
-      } else if (updateUrlWithConnectionId && !expansionFlags.current.isInitialLoad) {
-        updateUrlWithConnectionId('');
-      }
 
-      expansionFlags.current.isHandlingExpansion = false;
-    },
-    renderExpandableRow: (rowData, tableMeta) => {
-      const colSpan = rowData.length;
-      const connection = filteredConnections && filteredConnections[tableMeta.rowIndex];
-      return (
-        <>
-          <TableCell colSpan={colSpan}>
+        switch (action) {
+          case 'changePage':
+            setPage(tableState.page);
+            break;
+          case 'changeRowsPerPage':
+            setPageSize(tableState.rowsPerPage);
+            break;
+          case 'sort':
+            if (sortInfo.length === 2 && typeof tableState.activeColumn === 'number') {
+              order =
+                sortInfo[1] === 'ascending'
+                  ? `${columns[tableState.activeColumn].name} asc`
+                  : `${columns[tableState.activeColumn].name} desc`;
+            }
+
+            if (order && order !== sortOrder) {
+              setSortOrder(order);
+            }
+            break;
+        }
+      },
+      expandableRows: true,
+      expandableRowsHeader: false,
+      expandableRowsOnClick: true,
+      rowsExpanded,
+      isRowExpandable: () => true,
+      onRowExpansionChange: (_, allRowsExpanded) => {
+        if (expansionFlags.current.isUrlExpansion) {
+          return;
+        }
+
+        expansionFlags.current.isHandlingExpansion = true;
+        const expandedRows = allRowsExpanded.slice(-1);
+        setRowsExpanded(expandedRows.map((item) => item.index));
+
+        if (expandedRows.length > 0) {
+          const index = expandedRows[0].index;
+          const connection = filteredConnections[index];
+
+          if (
+            connection &&
+            updateUrlWithConnectionId &&
+            (!expansionFlags.current.isInitialLoad || connection.id !== selectedConnectionId)
+          ) {
+            updateUrlWithConnectionId(connection.id);
+          }
+        } else if (updateUrlWithConnectionId && !expansionFlags.current.isInitialLoad) {
+          updateUrlWithConnectionId('');
+        }
+
+        expansionFlags.current.isHandlingExpansion = false;
+      },
+      renderExpandableRow: (rowData, tableMeta) => {
+        const connection = filteredConnections[tableMeta.rowIndex];
+        return (
+          <TableCell colSpan={rowData.length}>
             <InnerTableContainer>
               <Table>
                 <TableRow style={{ padding: 0 }}>
@@ -1163,17 +1395,36 @@ const ConnectionTable = ({ selectedFilter, selectedConnectionId, updateUrlWithCo
               </Table>
             </InnerTableContainer>
           </TableCell>
-        </>
-      );
-    },
-  };
+        );
+      },
+    }),
+    [
+      columns,
+      connectionData?.totalCount,
+      filteredConnections,
+      handleDeleteConnections,
+      meshsyncControllerState,
+      page,
+      pageSize,
+      rowsExpanded,
+      selectedConnectionId,
+      sortOrder,
+      theme.palette.common.white,
+      theme.palette.error.dark,
+      updateUrlWithConnectionId,
+    ],
+  );
 
   const [tableCols, updateCols] = useState(columns);
 
+  useEffect(() => {
+    updateCols(columns);
+  }, [columns]);
+
   const [columnVisibility, setColumnVisibility] = useState(() => {
-    let showCols = updateVisibleColumns(colViews, width);
+    const showCols = updateVisibleColumns(colViews, width) as Record<string, boolean>;
     // Initialize column visibility based on the original columns' visibility
-    const initialVisibility = {};
+    const initialVisibility: Record<string, boolean> = {};
     columns.forEach((col) => {
       initialVisibility[col.name] = showCols[col.name];
     });

--- a/ui/components/connections/ConnectionTable.tsx
+++ b/ui/components/connections/ConnectionTable.tsx
@@ -46,7 +46,7 @@ import useKubernetesHook from '../hooks/useKubernetesHook';
 import { ConnectionStateChip, TooltipWrappedConnectionChip } from './ConnectionChip';
 import { DefaultTableCell, SortableTableCell } from './common';
 import { getColumnValue } from '../../utils/utils';
-import { updateVisibleColumns } from '../../utils/responsive-column';
+import { getResponsiveColumnVisibility } from '../../utils/responsive-column';
 import { useWindowDimensions } from '../../utils/dimension';
 import MultiSelectWrapper from '../multi-select-wrapper';
 import {
@@ -1275,6 +1275,7 @@ const ConnectionTable = ({
     ping,
     url,
   ]);
+  const columnNames = useMemo(() => columns.map((column) => column.name), [columns]);
 
   const options = useMemo(
     () => ({
@@ -1421,15 +1422,13 @@ const ConnectionTable = ({
     updateCols(columns);
   }, [columns]);
 
-  const [columnVisibility, setColumnVisibility] = useState(() => {
-    const showCols = updateVisibleColumns(colViews, width) as Record<string, boolean>;
-    // Initialize column visibility based on the original columns' visibility
-    const initialVisibility: Record<string, boolean> = {};
-    columns.forEach((col) => {
-      initialVisibility[col.name] = showCols[col.name];
-    });
-    return initialVisibility;
-  });
+  const [columnVisibility, setColumnVisibility] = useState<Record<string, boolean | undefined>>(
+    () => getResponsiveColumnVisibility(columnNames, colViews, width),
+  );
+
+  useEffect(() => {
+    setColumnVisibility(getResponsiveColumnVisibility(columnNames, colViews, width));
+  }, [colViews, columnNames, width]);
 
   if (isConnectionLoading) {
     return <LoadingScreen animatedIcon="AnimatedMeshery" message="Loading Connections" />;

--- a/ui/components/connections/common/index.test.tsx
+++ b/ui/components/connections/common/index.test.tsx
@@ -1,0 +1,61 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { describe, expect, it, vi } from 'vitest';
+import { DefaultTableCell, SortableTableCell } from './index';
+
+vi.mock('@sistent/sistent', () => ({
+  Grid2: ({ children }) => <div>{children}</div>,
+  Typography: ({ children }) => <span>{children}</span>,
+  TableCell: ({ children, onClick }) => (
+    <button onClick={onClick} type="button">
+      {children}
+    </button>
+  ),
+  TableSortLabel: ({ active, direction }) => (
+    <span data-testid="sort-label" data-active={String(active)} data-direction={direction} />
+  ),
+}));
+
+vi.mock('@/components/MesheryMeshInterface/PatternService/CustomTextTooltip', () => ({
+  CustomTextTooltip: ({ title, children }) => (
+    <div data-testid="custom-text-tooltip" data-title={String(title)}>
+      {children}
+    </div>
+  ),
+}));
+
+describe('SortableTableCell', () => {
+  it('renders the label, tooltip icon, and triggers sorting on click', async () => {
+    const user = userEvent.setup();
+    const onSort = vi.fn();
+
+    render(
+      <SortableTableCell
+        index={0}
+        columnData={{ name: 'name', label: 'Name' }}
+        columnMeta={{ name: 'name', direction: 'desc' }}
+        onSort={onSort}
+        icon={<span>i</span>}
+        tooltip="Sort by name"
+      />,
+    );
+
+    await user.click(screen.getByRole('button'));
+
+    expect(onSort).toHaveBeenCalledTimes(1);
+    expect(screen.getByText('Name')).toBeInTheDocument();
+    expect(screen.getByTestId('custom-text-tooltip')).toHaveAttribute('data-title', 'Sort by name');
+    expect(screen.getByTestId('sort-label')).toHaveAttribute('data-active', 'true');
+    expect(screen.getByTestId('sort-label')).toHaveAttribute('data-direction', 'desc');
+  });
+});
+
+describe('DefaultTableCell', () => {
+  it('renders without a tooltip wrapper when no icon is provided', () => {
+    render(<DefaultTableCell columnData={{ label: 'Status' }} />);
+
+    expect(screen.getByText('Status')).toBeInTheDocument();
+    expect(screen.queryByTestId('custom-text-tooltip')).not.toBeInTheDocument();
+  });
+});

--- a/ui/components/connections/common/index.tsx
+++ b/ui/components/connections/common/index.tsx
@@ -1,52 +1,46 @@
+import React, { memo } from 'react';
 import { CustomTextTooltip } from '@/components/MesheryMeshInterface/PatternService/CustomTextTooltip';
 import { Grid2, Typography, TableCell, TableSortLabel } from '@sistent/sistent';
 
-export const SortableTableCell = ({ index, columnData, columnMeta, onSort, icon, tooltip }) => {
+const HeaderLabel = ({ label, icon, tooltip }) => (
+  <Grid2 style={{ display: 'flex', alignItems: 'center' }}>
+    <Typography>
+      <b>{label}</b>
+    </Typography>
+    {icon && (
+      <CustomTextTooltip interactive={true} title={tooltip || ''} placement="top">
+        <Typography style={{ display: 'flex', marginLeft: '5px' }} variant="span">
+          {icon}
+        </Typography>
+      </CustomTextTooltip>
+    )}
+  </Grid2>
+);
+
+const SortableTableCell_ = ({ index, columnData, columnMeta, onSort, icon, tooltip }) => {
   return (
     <TableCell key={index} onClick={onSort}>
       <Grid2 style={{ display: 'flex' }}>
-        <Grid2 style={{ display: 'flex', alignItems: 'center' }}>
-          <Typography>
-            <b>{columnData.label}</b>
-          </Typography>
-          {icon ? (
-            <CustomTextTooltip interactive={true} title={tooltip ? tooltip : ''} placement="top">
-              <Typography style={{ display: 'flex', marginLeft: '5px' }} variant="span">
-                {icon}
-              </Typography>
-            </CustomTextTooltip>
-          ) : (
-            ''
-          )}
-        </Grid2>
+        <HeaderLabel label={columnData.label} icon={icon} tooltip={tooltip} />
         <TableSortLabel
           active={columnMeta.name === columnData.name}
           direction={columnMeta.direction || 'asc'}
-        ></TableSortLabel>
+        />
       </Grid2>
     </TableCell>
   );
 };
 
-export const DefaultTableCell = ({ columnData, icon, tooltip }) => {
+export const SortableTableCell = memo(SortableTableCell_);
+
+const DefaultTableCell_ = ({ columnData, icon, tooltip }) => {
   return (
     <TableCell>
       <Grid2 style={{ display: 'flex' }}>
-        <Grid2 style={{ display: 'flex', alignItems: 'center' }}>
-          <Typography>
-            <b>{columnData.label}</b>
-          </Typography>
-          {icon ? (
-            <CustomTextTooltip interactive={true} title={tooltip ? tooltip : ''} placement="top">
-              <Typography style={{ display: 'flex', marginLeft: '5px' }} variant="span">
-                {icon}
-              </Typography>
-            </CustomTextTooltip>
-          ) : (
-            ''
-          )}
-        </Grid2>
+        <HeaderLabel label={columnData.label} icon={icon} tooltip={tooltip} />
       </Grid2>
     </TableCell>
   );
 };
+
+export const DefaultTableCell = memo(DefaultTableCell_);

--- a/ui/components/connections/index.test.tsx
+++ b/ui/components/connections/index.test.tsx
@@ -1,0 +1,154 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import ConnectionManagementPageWithErrorBoundary from './index';
+
+const router = {
+  query: {} as Record<string, unknown>,
+  pathname: '/connections',
+  push: vi.fn(),
+  isReady: true,
+};
+
+vi.mock('next/router', () => ({
+  useRouter: () => router,
+}));
+
+vi.mock('@sistent/sistent', () => ({
+  NoSsr: ({ children }) => <>{children}</>,
+  ErrorBoundary: ({ children }) => <>{children}</>,
+  AppBar: ({ children }) => <div>{children}</div>,
+}));
+
+vi.mock('./styles', () => ({
+  ConnectionIconText: ({ children }) => <span>{children}</span>,
+  ConnectionTab: ({ label }) => <div>{label}</div>,
+  ConnectionTabs: ({ children, onChange }) => (
+    <div>
+      <button onClick={(event) => onChange?.(event, 0)} type="button">
+        Connections Tab
+      </button>
+      <button onClick={(event) => onChange?.(event, 1)} type="button">
+        MeshSync Tab
+      </button>
+      {children}
+    </div>
+  ),
+}));
+
+vi.mock('./ConnectionTable', () => ({
+  default: ({ selectedConnectionId, updateUrlWithConnectionId }) => (
+    <div>
+      <div data-testid="connection-table">connection:{selectedConnectionId ?? 'none'}</div>
+      <button onClick={() => updateUrlWithConnectionId?.('cluster-2')} type="button">
+        Update Connection Id
+      </button>
+    </div>
+  ),
+}));
+
+vi.mock('./meshSync', () => ({
+  default: ({ selectedResourceId, updateUrlWithResourceId }) => (
+    <div>
+      <div data-testid="meshsync-table">resource:{selectedResourceId ?? 'none'}</div>
+      <button onClick={() => updateUrlWithResourceId?.('resource-2')} type="button">
+        Update Resource Id
+      </button>
+    </div>
+  ),
+}));
+
+vi.mock('../General/Modals/Modal', () => ({
+  default: () => <div data-testid="create-connection-modal" />,
+}));
+
+vi.mock('@/utils/can', () => ({
+  default: () => true,
+}));
+
+vi.mock('@/rtk-query/schema', () => ({
+  useGetSchemaQuery: () => ({ data: undefined }),
+}));
+
+vi.mock('../General/error-404/index', () => ({
+  default: () => <div data-testid="default-error" />,
+}));
+
+vi.mock('../General/ErrorBoundary', () => ({
+  default: () => <div data-testid="error-fallback" />,
+}));
+
+vi.mock('../../assets/icons/Connection', () => ({
+  default: () => <svg data-testid="connection-icon" />,
+}));
+
+vi.mock('../../assets/icons/Meshsync', () => ({
+  default: () => <svg data-testid="meshsync-icon" />,
+}));
+
+describe('connections index page', () => {
+  beforeEach(() => {
+    router.query = {};
+    router.push.mockReset();
+    router.isReady = true;
+  });
+
+  it('defaults to the connections tab and ignores non-string connection ids', () => {
+    router.query = {
+      tab: ['meshsync'],
+      connectionId: ['cluster-1'],
+    };
+
+    render(<ConnectionManagementPageWithErrorBoundary />);
+
+    expect(screen.getByTestId('connection-table')).toHaveTextContent('connection:none');
+    expect(screen.queryByTestId('meshsync-table')).not.toBeInTheDocument();
+  });
+
+  it('renders the MeshSync tab when the query param is a string', () => {
+    router.query = {
+      tab: 'meshsync',
+      connectionId: 'resource-1',
+    };
+
+    render(<ConnectionManagementPageWithErrorBoundary />);
+
+    expect(screen.getByTestId('meshsync-table')).toHaveTextContent('resource:resource-1');
+    expect(screen.queryByTestId('connection-table')).not.toBeInTheDocument();
+  });
+
+  it('updates the router query when the active tab changes', async () => {
+    const user = userEvent.setup();
+
+    render(<ConnectionManagementPageWithErrorBoundary />);
+
+    await user.click(screen.getByRole('button', { name: 'MeshSync Tab' }));
+
+    expect(router.push).toHaveBeenCalledWith(
+      {
+        pathname: '/connections',
+        query: { tab: 'meshsync' },
+      },
+      undefined,
+      { shallow: true },
+    );
+  });
+
+  it('updates the router query when a child table selects a connection', async () => {
+    const user = userEvent.setup();
+
+    render(<ConnectionManagementPageWithErrorBoundary />);
+
+    await user.click(screen.getByRole('button', { name: 'Update Connection Id' }));
+
+    expect(router.push).toHaveBeenCalledWith(
+      {
+        pathname: '/connections',
+        query: { connectionId: 'cluster-2' },
+      },
+      undefined,
+      { shallow: true },
+    );
+  });
+});

--- a/ui/components/connections/index.tsx
+++ b/ui/components/connections/index.tsx
@@ -1,4 +1,4 @@
-import React, { useRef, useState } from 'react';
+import React, { useCallback, useMemo, useState } from 'react';
 import { NoSsr } from '@sistent/sistent';
 import { ErrorBoundary, AppBar } from '@sistent/sistent';
 import Modal from '../General/Modals/Modal';
@@ -66,45 +66,52 @@ function ConnectionManagementPage(props) {
 }
 function Connections() {
   const router = useRouter();
-  const [_operatorState] = useState([]);
-  const _operatorStateRef = useRef(_operatorState);
-  _operatorStateRef.current = _operatorState;
-
   const { query, pathname, push, isReady } = router;
-  const tabParam = query.tab?.toLowerCase();
-  const connectionId = query.connectionId;
+  const tabParam = typeof query.tab === 'string' ? query.tab.toLowerCase() : undefined;
+  const connectionId = typeof query.connectionId === 'string' ? query.connectionId : undefined;
 
-  const tab = tabParam === 'meshsync' ? 1 : 0;
+  const tab = useMemo(() => (tabParam === 'meshsync' ? 1 : 0), [tabParam]);
 
-  const updateUrlParams = (params) => {
-    const newQuery = { ...query, ...params };
+  const updateUrlParams = useCallback(
+    (params) => {
+      const newQuery = { ...query, ...params };
 
-    Object.keys(newQuery).forEach((key) => {
-      if (newQuery[key] === undefined || newQuery[key] === '') {
-        delete newQuery[key];
-      }
-    });
+      Object.keys(newQuery).forEach((key) => {
+        if (newQuery[key] === undefined || newQuery[key] === '') {
+          delete newQuery[key];
+        }
+      });
 
-    push({ pathname, query: newQuery }, undefined, { shallow: true });
-  };
+      push({ pathname, query: newQuery }, undefined, { shallow: true });
+    },
+    [pathname, push, query],
+  );
 
   // Handle tab change and update URL
-  const handleTabChange = (e, newTab) => {
-    e.stopPropagation();
+  const handleTabChange = useCallback(
+    (event, newTab) => {
+      event.stopPropagation();
 
-    if (newTab !== tab) {
-      updateUrlParams({
-        tab: newTab === 0 ? 'connections' : 'meshsync',
-        connectionId: undefined, // Clear the connection ID when switching tabs
-      });
-    }
-  };
+      if (newTab !== tab) {
+        updateUrlParams({
+          tab: newTab === 0 ? 'connections' : 'meshsync',
+          connectionId: undefined,
+        });
+      }
+    },
+    [tab, updateUrlParams],
+  );
   // Update URL with connection ID
-  const updateUrlWithConnectionId = (id) => {
-    if (id && id === connectionId) return;
+  const updateUrlWithConnectionId = useCallback(
+    (id) => {
+      if (id && id === connectionId) {
+        return;
+      }
 
-    updateUrlParams({ connectionId: id || undefined });
-  };
+      updateUrlParams({ connectionId: id || undefined });
+    },
+    [connectionId, updateUrlParams],
+  );
 
   if (!isReady) return null;
   return (

--- a/ui/components/connections/meshSync/index.test.tsx
+++ b/ui/components/connections/meshSync/index.test.tsx
@@ -1,0 +1,156 @@
+import React from 'react';
+import { render } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import MeshSyncTable from './index';
+
+const notify = vi.fn();
+const getK8sClusterIdsFromCtxId = vi.fn();
+const useGetMeshSyncResourcesQuery = vi.fn();
+const useGetMeshSyncResourceKindsQuery = vi.fn();
+
+vi.mock('@sistent/sistent', () => ({
+  Tooltip: ({ children }) => <div>{children}</div>,
+  Grid2: ({ children }) => <div>{children}</div>,
+  Box: ({ children }) => <div>{children}</div>,
+  Typography: ({ children }) => <span>{children}</span>,
+  FormControl: ({ children }) => <div>{children}</div>,
+  MenuItem: ({ children }) => <div>{children}</div>,
+  Table: ({ children }) => <div>{children}</div>,
+  FormattedTime: ({ date }) => <span>{String(date)}</span>,
+  CustomColumnVisibilityControl: () => <div />,
+  ResponsiveDataTable: () => <div data-testid="mesh-sync-table" />,
+  SearchBar: () => <div />,
+  UniversalFilter: () => <div />,
+  TableCell: ({ children }) => <div>{children}</div>,
+  TableRow: ({ children }) => <div>{children}</div>,
+  styled: (Component) => () => {
+    const StyledComponent = ({ children, ...props }) => (
+      <Component {...props}>{children}</Component>
+    );
+    StyledComponent.displayName = 'StyledSistentMock';
+    return StyledComponent;
+  },
+  accentGrey: 'gray',
+}));
+
+vi.mock('../../../utils/hooks/useNotification', () => ({
+  useNotification: () => ({ notify }),
+}));
+
+vi.mock('../../../utils/multi-ctx', () => ({
+  getK8sClusterIdsFromCtxId: (...args) => getK8sClusterIdsFromCtxId(...args),
+}));
+
+vi.mock('@/rtk-query/meshsync', () => ({
+  useGetMeshSyncResourceKindsQuery: (...args) => useGetMeshSyncResourceKindsQuery(...args),
+  useGetMeshSyncResourcesQuery: (...args) => useGetMeshSyncResourcesQuery(...args),
+}));
+
+vi.mock('../../../utils/dimension', () => ({
+  useWindowDimensions: () => ({ width: 1200 }),
+}));
+
+vi.mock('react-redux', () => ({
+  useSelector: (selector) =>
+    selector({
+      ui: {
+        k8sConfig: { currentContext: 'dev' },
+        selectedK8sContexts: ['all'],
+      },
+    }),
+}));
+
+vi.mock('../metadata', () => ({
+  MeshSyncDataFormatter: () => <div />,
+}));
+
+vi.mock('../common', () => ({
+  DefaultTableCell: () => <div />,
+  SortableTableCell: () => <div />,
+}));
+
+vi.mock('../../../utils/utils', () => ({
+  JsonParse: JSON.parse,
+  camelcaseToSnakecase: (value) => value,
+  getColumnValue: () => null,
+  getVisibilityColums: () => [],
+}));
+
+vi.mock('./RegisterConnectionModal', () => ({
+  default: () => <div />,
+}));
+
+vi.mock('../ConnectionChip', () => ({
+  ConnectionStateChip: () => <div />,
+}));
+
+vi.mock('../styles', () => ({
+  ContentContainer: ({ children }) => <div>{children}</div>,
+  ConnectionStyledSelect: ({ children }) => <div>{children}</div>,
+  InnerTableContainer: ({ children }) => <div>{children}</div>,
+}));
+
+vi.mock('@/assets/styles/general/tool.styles', () => ({
+  ToolWrapper: ({ children }) => <div>{children}</div>,
+}));
+
+vi.mock('@/store/slices/mesheryUi', () => ({
+  updateProgress: vi.fn(),
+}));
+
+vi.mock('./MeshSyncEmptyState', () => ({
+  default: () => <div data-testid="mesh-sync-empty-state" />,
+}));
+
+describe('MeshSyncTable', () => {
+  beforeEach(() => {
+    notify.mockReset();
+    getK8sClusterIdsFromCtxId.mockReset();
+    useGetMeshSyncResourcesQuery.mockReset();
+    useGetMeshSyncResourceKindsQuery.mockReset();
+
+    getK8sClusterIdsFromCtxId.mockReturnValue(['cluster-a', 'cluster-b']);
+    useGetMeshSyncResourcesQuery.mockReturnValue({
+      data: { resources: [], totalCount: 0 },
+      isError: false,
+      error: undefined,
+    });
+    useGetMeshSyncResourceKindsQuery.mockReturnValue({
+      data: { kinds: [], namespaces: [] },
+    });
+  });
+
+  it('passes stable cluster ids to both queries', () => {
+    render(<MeshSyncTable />);
+
+    expect(useGetMeshSyncResourcesQuery).toHaveBeenCalledWith(
+      expect.objectContaining({
+        clusterIds: JSON.stringify(['cluster-a', 'cluster-b']),
+      }),
+    );
+    expect(useGetMeshSyncResourceKindsQuery).toHaveBeenCalledWith(
+      expect.objectContaining({
+        clusterIds: ['cluster-a', 'cluster-b'],
+      }),
+    );
+  });
+
+  it('notifies when fetching mesh sync resources fails', () => {
+    useGetMeshSyncResourcesQuery.mockReturnValue({
+      data: { resources: [], totalCount: 0 },
+      isError: true,
+      error: { data: 'MeshSync unavailable' },
+    });
+
+    render(<MeshSyncTable />);
+
+    expect(notify).toHaveBeenNthCalledWith(
+      1,
+      expect.objectContaining({
+        message: 'Error fetching MeshSync Resources',
+        event_type: expect.objectContaining({ type: 'error' }),
+        details: 'MeshSync unavailable',
+      }),
+    );
+  });
+});

--- a/ui/components/connections/meshSync/index.test.tsx
+++ b/ui/components/connections/meshSync/index.test.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { render } from '@testing-library/react';
+import { render, waitFor } from '@testing-library/react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import MeshSyncTable from './index';
 
@@ -7,6 +7,9 @@ const notify = vi.fn();
 const getK8sClusterIdsFromCtxId = vi.fn();
 const useGetMeshSyncResourcesQuery = vi.fn();
 const useGetMeshSyncResourceKindsQuery = vi.fn();
+const getResponsiveColumnVisibility = vi.fn();
+let dataTableProps: any;
+let windowWidth = 1200;
 
 vi.mock('@sistent/sistent', () => ({
   Tooltip: ({ children }) => <div>{children}</div>,
@@ -18,7 +21,10 @@ vi.mock('@sistent/sistent', () => ({
   Table: ({ children }) => <div>{children}</div>,
   FormattedTime: ({ date }) => <span>{String(date)}</span>,
   CustomColumnVisibilityControl: () => <div />,
-  ResponsiveDataTable: () => <div data-testid="mesh-sync-table" />,
+  ResponsiveDataTable: (props) => {
+    dataTableProps = props;
+    return <div data-testid="mesh-sync-table" />;
+  },
   SearchBar: () => <div />,
   UniversalFilter: () => <div />,
   TableCell: ({ children }) => <div>{children}</div>,
@@ -47,7 +53,7 @@ vi.mock('@/rtk-query/meshsync', () => ({
 }));
 
 vi.mock('../../../utils/dimension', () => ({
-  useWindowDimensions: () => ({ width: 1200 }),
+  useWindowDimensions: () => ({ width: windowWidth }),
 }));
 
 vi.mock('react-redux', () => ({
@@ -74,6 +80,10 @@ vi.mock('../../../utils/utils', () => ({
   camelcaseToSnakecase: (value) => value,
   getColumnValue: () => null,
   getVisibilityColums: () => [],
+}));
+
+vi.mock('../../../utils/responsive-column', () => ({
+  getResponsiveColumnVisibility: (...args) => getResponsiveColumnVisibility(...args),
 }));
 
 vi.mock('./RegisterConnectionModal', () => ({
@@ -104,20 +114,45 @@ vi.mock('./MeshSyncEmptyState', () => ({
 
 describe('MeshSyncTable', () => {
   beforeEach(() => {
+    dataTableProps = undefined;
     notify.mockReset();
     getK8sClusterIdsFromCtxId.mockReset();
     useGetMeshSyncResourcesQuery.mockReset();
     useGetMeshSyncResourceKindsQuery.mockReset();
+    getResponsiveColumnVisibility.mockReset();
+    windowWidth = 1200;
 
     getK8sClusterIdsFromCtxId.mockReturnValue(['cluster-a', 'cluster-b']);
     useGetMeshSyncResourcesQuery.mockReturnValue({
-      data: { resources: [], totalCount: 0 },
+      data: {
+        resources: [
+          {
+            id: 'resource-1',
+            metadata: { name: 'pod-a', namespace: 'default', creationTimestamp: '2026-05-08' },
+            apiVersion: 'v1',
+            kind: 'Pod',
+            model: 'core',
+            cluster_id: 'cluster-a',
+            pattern_resources: '',
+            status: 'discovered',
+          },
+        ],
+        totalCount: 1,
+      },
       isError: false,
       error: undefined,
     });
     useGetMeshSyncResourceKindsQuery.mockReturnValue({
       data: { kinds: [], namespaces: [] },
     });
+    getResponsiveColumnVisibility.mockImplementation((columnNames, _colViews, width) =>
+      Object.fromEntries(
+        columnNames.map((columnName) => [
+          columnName,
+          columnName === 'model' ? width >= 1000 : true,
+        ]),
+      ),
+    );
   });
 
   it('passes stable cluster ids to both queries', () => {
@@ -152,5 +187,18 @@ describe('MeshSyncTable', () => {
         details: 'MeshSync unavailable',
       }),
     );
+  });
+
+  it('recomputes responsive column visibility when the window width changes', async () => {
+    const { rerender } = render(<MeshSyncTable />);
+
+    expect(dataTableProps.columnVisibility.model).toBe(true);
+
+    windowWidth = 900;
+    rerender(<MeshSyncTable />);
+
+    await waitFor(() => {
+      expect(dataTableProps.columnVisibility.model).toBe(false);
+    });
   });
 });

--- a/ui/components/connections/meshSync/index.tsx
+++ b/ui/components/connections/meshSync/index.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useRef, useState } from 'react';
+import React, { useEffect, useMemo, useRef, useState } from 'react';
 import { Tooltip, Grid2, FormControl, MenuItem, Table, FormattedTime } from '@sistent/sistent';
 import { useNotification } from '../../../utils/hooks/useNotification';
 import { EVENT_TYPES } from '../../../lib/event-types';
@@ -68,6 +68,11 @@ export default function MeshSyncTable(props) {
   const { width } = useWindowDimensions();
 
   const { notify } = useNotification();
+  const clusterIds = useMemo(
+    () => getK8sClusterIdsFromCtxId(selectedK8sContexts, k8sConfig),
+    [k8sConfig, selectedK8sContexts],
+  );
+  const serializedClusterIds = useMemo(() => JSON.stringify(clusterIds), [clusterIds]);
 
   const handleRegistrationModalClose = () => {
     setRegistrationModal(false);
@@ -85,23 +90,27 @@ export default function MeshSyncTable(props) {
     kind: kindFilter,
     model: modelFilter,
     namespace: namespaceFilter,
-    clusterIds: JSON.stringify(getK8sClusterIdsFromCtxId(selectedK8sContexts, k8sConfig)),
+    clusterIds: serializedClusterIds,
   });
-  if (isError) {
-    if (isError) {
-      notify({
-        message: 'Error fetching MeshSync Resources',
-        event_type: EVENT_TYPES.ERROR,
-        details: meshSyncError?.data,
-      });
+
+  useEffect(() => {
+    if (!isError) {
+      return;
     }
-  }
+
+    notify({
+      message: 'Error fetching MeshSync Resources',
+      event_type: EVENT_TYPES.ERROR,
+      details: meshSyncError?.data,
+    });
+  }, [isError, meshSyncError?.data, notify]);
+
   const { data: clusterSummary } = useGetMeshSyncResourceKindsQuery({
     page: page,
     pagesize: 'all',
     search: search,
     order: sortOrder,
-    clusterIds: getK8sClusterIdsFromCtxId(selectedK8sContexts, k8sConfig),
+    clusterIds: clusterIds,
   });
   const availableKinds = (clusterSummary?.kinds || []).map((kind) => kind.Kind);
   const availableModels = [
@@ -426,7 +435,7 @@ export default function MeshSyncTable(props) {
     responsive: 'standard',
     serverSide: true,
     selectableRows: 'none',
-    count: meshSyncData?.total_count,
+    count: meshSyncData?.totalCount,
     rowsPerPage: pageSize,
     fixedHeader: true,
     page,

--- a/ui/components/connections/meshSync/index.tsx
+++ b/ui/components/connections/meshSync/index.tsx
@@ -22,7 +22,7 @@ import {
 } from '../../../utils/utils';
 import RegisterConnectionModal from './RegisterConnectionModal';
 import { CONNECTION_STATES, MESHSYNC_STATES } from '../../../utils/Enum';
-import { updateVisibleColumns } from '../../../utils/responsive-column';
+import { getResponsiveColumnVisibility } from '../../../utils/responsive-column';
 import { useWindowDimensions } from '../../../utils/dimension';
 import { FormatId } from '../../DataFormatter';
 import {
@@ -119,18 +119,22 @@ export default function MeshSyncTable(props) {
   const availableNamespaces = clusterSummary?.namespaces || [];
   const meshSyncResources = meshSyncData?.resources || [];
 
-  let colViews = [
-    ['metadata.name', 'xs'],
-    ['apiVersion', 'na'],
-    ['kind', 'm'],
-    ['model', 'm'],
-    ['metadata.namespace', 'xs'],
-    ['cluster_id', 'na'],
-    ['pattern_resources', 'na'],
-    ['metadata.creationTimestamp', 'l'],
-    ['status', 'xs'],
-    ['metadata', 'na'],
-  ];
+  const colViews = useMemo(
+    () => [
+      ['metadata.name', 'xs'],
+      ['apiVersion', 'na'],
+      ['kind', 'm'],
+      ['model', 'm'],
+      ['metadata.namespace', 'xs'],
+      ['cluster_id', 'na'],
+      ['pattern_resources', 'na'],
+      ['metadata.creationTimestamp', 'l'],
+      ['status', 'xs'],
+      ['metadata', 'na'],
+    ],
+    [],
+  );
+  const columnNames = useMemo(() => colViews.map(([columnName]) => columnName), [colViews]);
 
   const columns = [
     {
@@ -629,15 +633,13 @@ export default function MeshSyncTable(props) {
 
   const [tableCols, updateCols] = useState(columns);
 
-  const [columnVisibility, setColumnVisibility] = useState(() => {
-    let showCols = updateVisibleColumns(colViews, width);
-    // Initialize column visibility based on the original columns' visibility
-    const initialVisibility = {};
-    columns.forEach((col) => {
-      initialVisibility[col.name] = showCols[col.name];
-    });
-    return initialVisibility;
-  });
+  const [columnVisibility, setColumnVisibility] = useState(() =>
+    getResponsiveColumnVisibility(columnNames, colViews, width),
+  );
+
+  useEffect(() => {
+    setColumnVisibility(getResponsiveColumnVisibility(columnNames, colViews, width));
+  }, [colViews, columnNames, width]);
 
   return (
     <>

--- a/ui/components/connections/metadata.test.tsx
+++ b/ui/components/connections/metadata.test.tsx
@@ -1,0 +1,176 @@
+import React from 'react';
+import { fireEvent, render, screen } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import FormatConnectionMetadata from './metadata';
+
+const pingKubernetes = vi.fn();
+const pingMesheryOperator = vi.fn();
+const pingMeshSync = vi.fn();
+const pingNats = vi.fn();
+const getControllerStatesByConnectionID = vi.fn();
+
+vi.mock('@sistent/sistent', () => {
+  const styled = (Component) => () => {
+    const StyledComponent = ({ children, ...props }) => (
+      <Component {...props}>{children}</Component>
+    );
+    StyledComponent.displayName = 'StyledSistentMock';
+    return StyledComponent;
+  };
+
+  return {
+    Grid2: ({ children }) => <div>{children}</div>,
+    List: ({ children }) => <div>{children}</div>,
+    ListItem: ({ children }) => <div>{children}</div>,
+    ListItemText: ({ primary, secondary }) => (
+      <div>
+        <span>{primary}</span>
+        <span>{secondary}</span>
+      </div>
+    ),
+    InfoIcon: () => <svg data-testid="info-icon" />,
+    EventBus: class {
+      publish() {}
+      subscribe() {}
+      on() {
+        return { subscribe() {} };
+      }
+    },
+    Box: ({ children }) => <div>{children}</div>,
+    Typography: ({ children }) => <span>{children}</span>,
+    styled,
+    createTheme: () => ({
+      breakpoints: {
+        up: () => 'up',
+        down: () => 'down',
+      },
+    }),
+    useTheme: () => ({
+      palette: { background: { card: 'black' }, text: { tertiary: 'gray' } },
+    }),
+  };
+});
+
+vi.mock('css/icons.styles', () => ({
+  iconMedium: {},
+  iconSmall: {},
+}));
+
+vi.mock('../../utils/utils', () => ({
+  formatToTitleCase: (value) => value,
+}));
+
+vi.mock('../DataFormatter', () => ({
+  FormatId: ({ id }) => <span>{id}</span>,
+  FormatStructuredData: ({ data }) => (
+    <div data-testid="structured-data">{JSON.stringify(data || {})}</div>
+  ),
+  FormattedDate: ({ date }) => <span>{String(date)}</span>,
+  KeyValue: ({ Key, Value }) => (
+    <div>
+      <span>{Key}</span>
+      <span>{Value}</span>
+    </div>
+  ),
+  Link: ({ title }) => <span>{title}</span>,
+  createColumnUiSchema: ({ metadata }) => ({ fields: Object.keys(metadata || {}) }),
+}));
+
+vi.mock('../hooks/useKubernetesHook', () => ({
+  default: () => pingKubernetes,
+  useControllerStatus: () => ({ getControllerStatesByConnectionID }),
+  useMesheryOperator: () => ({ ping: pingMesheryOperator }),
+  useMeshsSyncController: () => ({ ping: pingMeshSync }),
+  useNatsController: () => ({ ping: pingNats }),
+}));
+
+vi.mock('./ConnectionChip', () => ({
+  TooltipWrappedConnectionChip: ({ title, handlePing, disabled }) => (
+    <button disabled={disabled} onClick={handlePing} type="button">
+      {String(title)}
+    </button>
+  ),
+}));
+
+vi.mock('./styles', () => ({
+  ColumnWrapper: ({ children }) => <div>{children}</div>,
+  ContentContainer: ({ children }) => <div>{children}</div>,
+  OperationButton: ({ children }) => <div>{children}</div>,
+  FormatterWrapper: ({ children }) => <div>{children}</div>,
+}));
+
+describe('FormatConnectionMetadata', () => {
+  beforeEach(() => {
+    pingKubernetes.mockReset();
+    pingMesheryOperator.mockReset();
+    pingMeshSync.mockReset();
+    pingNats.mockReset();
+    getControllerStatesByConnectionID.mockReset();
+    getControllerStatesByConnectionID.mockReturnValue({
+      operatorState: 'DEPLOYED',
+      meshSyncState: 'CONNECTED',
+      natsState: 'RUNNING',
+      operatorVersion: 'v1.0.0',
+      meshSyncVersion: 'v2.0.0',
+      natsVersion: 'v3.0.0',
+    });
+  });
+
+  it('wires kubernetes metadata chips to the correct ping handlers', () => {
+    render(
+      <FormatConnectionMetadata
+        meshsyncControllerState={{}}
+        connection={{
+          id: 'connection-1',
+          kind: 'kubernetes',
+          status: 'connected',
+          metadata: {
+            name: 'cluster-a',
+            server: 'https://cluster-a.local',
+            meshsync_deployment_mode: 'operator',
+          },
+        }}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: 'cluster-a' }));
+    fireEvent.click(screen.getByRole('button', { name: 'Operator' }));
+    fireEvent.click(screen.getByRole('button', { name: 'MeshSync' }));
+    fireEvent.click(screen.getByRole('button', { name: 'BROKER' }));
+
+    expect(pingKubernetes).toHaveBeenCalledWith(
+      'cluster-a',
+      'https://cluster-a.local',
+      'connection-1',
+    );
+    expect(pingMesheryOperator).toHaveBeenCalledWith({ connectionID: 'connection-1' });
+    expect(pingMeshSync).toHaveBeenCalledWith({ connectionID: 'connection-1' });
+    expect(pingNats).toHaveBeenCalledWith({ connectionID: 'connection-1' });
+  });
+
+  it('renders structured metadata for meshery connections', () => {
+    render(
+      <FormatConnectionMetadata
+        connection={{
+          kind: 'meshery',
+          metadata: { endpoint: 'https://meshery.local' },
+        }}
+      />,
+    );
+
+    expect(screen.getByTestId('structured-data')).toHaveTextContent('meshery.local');
+  });
+
+  it('falls back to the generic structured formatter for other connection kinds', () => {
+    render(
+      <FormatConnectionMetadata
+        connection={{
+          kind: 'github',
+          metadata: { owner: 'meshery' },
+        }}
+      />,
+    );
+
+    expect(screen.getByTestId('structured-data')).toHaveTextContent('meshery');
+  });
+});

--- a/ui/components/connections/metadata.tsx
+++ b/ui/components/connections/metadata.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useMemo } from 'react';
 import { Grid2, List, ListItem, ListItemText, Box, styled, useTheme } from '@sistent/sistent';
 
 import {
@@ -82,7 +82,9 @@ const KubernetesMetadataFormatter = ({ meshsyncControllerState, connection, meta
   const { operatorState, meshSyncState, natsState, operatorVersion, meshSyncVersion, natsVersion } =
     getControllerStatesByConnectionID(connection.id);
 
-  const isEmbeddedMode = metadata?.meshsync_deployment_mode === MESHSYNC_DEPLOYMENT_TYPE.EMBEDDED;
+  const meshsyncDeploymentMode =
+    metadata?.meshsyncDeploymentMode ?? metadata?.meshsync_deployment_mode;
+  const isEmbeddedMode = meshsyncDeploymentMode === MESHSYNC_DEPLOYMENT_TYPE.EMBEDDED;
 
   return (
     <Grid2 container spacing={1} sx={{ textTransform: 'none' }} size="grow">
@@ -97,7 +99,7 @@ const KubernetesMetadataFormatter = ({ meshsyncControllerState, connection, meta
                     title={metadata.name}
                     status={connection.status}
                     iconSrc={'/static/img/kubernetes.svg'}
-                    handlePing={() => handleKubernetesClick(connection.id)}
+                    handlePing={handleKubernetesClick}
                   />
                 </ListItem>
               </List>
@@ -190,7 +192,7 @@ const KubernetesMetadataFormatter = ({ meshsyncControllerState, connection, meta
                           tooltip={natsState === 'Not Active' ? 'Not Available' : `Reconnect NATS`}
                           title={'BROKER'}
                           status={natsState}
-                          handlePing={() => handleNATSClick()}
+                          handlePing={handleNATSClick}
                           iconSrc="/static/img/nats-icon-color.svg"
                           width="9rem"
                         />
@@ -250,7 +252,7 @@ const KubernetesMetadataFormatter = ({ meshsyncControllerState, connection, meta
                 <ListItem>
                   <StyledListItemText
                     primary="Deployment Mode"
-                    secondary={formatToTitleCase(metadata.meshsync_deployment_mode || 'N/A')}
+                    secondary={formatToTitleCase(meshsyncDeploymentMode || 'N/A')}
                   />
                 </ListItem>
               </List>
@@ -264,13 +266,17 @@ const KubernetesMetadataFormatter = ({ meshsyncControllerState, connection, meta
 
 const MesheryMetadataFormatter = ({ connection }) => {
   const metadata = connection.metadata || {};
-  const uiSchema = createColumnUiSchema({
-    metadata,
-    numCols: {
-      xs: 2,
-      md: 4,
-    },
-  });
+  const uiSchema = useMemo(
+    () =>
+      createColumnUiSchema({
+        metadata,
+        numCols: {
+          xs: 2,
+          md: 4,
+        },
+      }),
+    [metadata],
+  );
 
   return (
     <FormatStructuredData
@@ -283,13 +289,17 @@ const MesheryMetadataFormatter = ({ connection }) => {
 
 export const MeshSyncDataFormatter = ({ metadata }) => {
   const theme = useTheme();
-  const uiSchema = createColumnUiSchema({
-    metadata,
-    numCols: {
-      xs: 3,
-      md: 5,
-    },
-  });
+  const uiSchema = useMemo(
+    () =>
+      createColumnUiSchema({
+        metadata,
+        numCols: {
+          xs: 3,
+          md: 5,
+        },
+      }),
+    [metadata],
+  );
 
   return (
     <Box backgroundColor={theme.palette.background.card} width="100%" padding={'1rem'}>
@@ -305,26 +315,33 @@ export const MeshSyncDataFormatter = ({ metadata }) => {
 const FormatConnectionMetadata = (props) => {
   const theme = useTheme();
   const { connection, meshsyncControllerState } = props;
-  const formatterByKind = {
-    [KUBERNETES]: () => (
-      <KubernetesMetadataFormatter
-        meshsyncControllerState={meshsyncControllerState}
-        connection={connection}
-        metadata={connection.metadata}
-      />
-    ),
-    [MESHERY]: () => <MesheryMetadataFormatter connection={connection} />,
-    default: () => (
-      <FormatStructuredData
-        data={connection.metadata}
-        propertyFormatters={DefaultPropertyFormatters}
-      />
-    ),
-  };
-  const formatter = formatterByKind[connection.kind] || formatterByKind.default;
+  let formatter;
+
+  switch (connection.kind) {
+    case KUBERNETES:
+      formatter = (
+        <KubernetesMetadataFormatter
+          meshsyncControllerState={meshsyncControllerState}
+          connection={connection}
+          metadata={connection.metadata}
+        />
+      );
+      break;
+    case MESHERY:
+      formatter = <MesheryMetadataFormatter connection={connection} />;
+      break;
+    default:
+      formatter = (
+        <FormatStructuredData
+          data={connection.metadata}
+          propertyFormatters={DefaultPropertyFormatters}
+        />
+      );
+  }
+
   return (
     <Box backgroundColor={theme.palette.background.card} padding={'1rem'}>
-      {formatter()}
+      {formatter}
     </Box>
   );
 };

--- a/ui/components/telemetry/grafana/GrafanaCharts.tsx
+++ b/ui/components/telemetry/grafana/GrafanaCharts.tsx
@@ -103,7 +103,7 @@ const GrafanaCharts = ({ grafanaURL, boardPanelConfigs }) => {
                     <Suspense fallback={null}>
                       <LazyGrafanaPanelIframe
                         key={`url_-_-${ind}`}
-                        src={`${adjustedGrafanaURL}/d-solo/${config.board.uid}/${config.board.slug}?theme=light&orgId=${config.board.org_id}&panelId=${panel.id}&refresh=${refresh}&from=${from}&to=${to}&${config.templateVars
+                        src={`${adjustedGrafanaURL}/d-solo/${config.board.uid}/${config.board.slug}?theme=light&orgId=${config.board.orgId ?? config.board.org_id}&panelId=${panel.id}&refresh=${refresh}&from=${from}&to=${to}&${config.templateVars
                           .map((tv) => `var-${tv}`)
                           .join('&')}`}
                         title={`${config.board.title} panel ${panel.id}`}

--- a/ui/components/telemetry/grafana/GrafanaComponent.tsx
+++ b/ui/components/telemetry/grafana/GrafanaComponent.tsx
@@ -189,7 +189,7 @@ const GrafanaComponent = (props) => {
     // Get the connection object from the event value and update configuration
     const grafanaConnectionObj = value;
     try {
-      const res = await fetchCredentialById(grafanaConnectionObj.credential_id).unwrap();
+      const res = await fetchCredentialById(grafanaConnectionObj.credentialId).unwrap();
       const grafanaCfg = {
         grafanaURL: grafanaConnectionObj?.value || '',
         grafanaAPIKey: res?.secret?.secret || '',

--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -21,7 +21,7 @@
         "@emotion/react": "^11.14.0",
         "@emotion/server": "^11.11.0",
         "@emotion/styled": "^11.14.1",
-        "@meshery/schemas": "^1.2.16",
+        "@meshery/schemas": "^1.2.18",
         "@microlink/react-json-view": "^1.31.20",
         "@mui/icons-material": "^9.0.0",
         "@mui/material": "^9.0.0",
@@ -2061,9 +2061,9 @@
       "license": "MIT"
     },
     "node_modules/@meshery/schemas": {
-      "version": "1.2.16",
-      "resolved": "https://registry.npmjs.org/@meshery/schemas/-/schemas-1.2.16.tgz",
-      "integrity": "sha512-iZ3XFuw7ee5uOnSUIHMnn/TRh3xTKc9eurfjzE9kH3GkhhakhC1nMMQzMTq0NC5FYNMaKiPE4Duc+zhwtLVhog==",
+      "version": "1.2.18",
+      "resolved": "https://registry.npmjs.org/@meshery/schemas/-/schemas-1.2.18.tgz",
+      "integrity": "sha512-tE13GTSQ1f5iCfKDip0jC16aHSaHtMM8PvcZbLNXKwXCbJiBlHlYE6s0Iwq9YZjKG8VFyxARe2+9JY1FwLq4xw==",
       "license": "ISC",
       "peerDependencies": {
         "@reduxjs/toolkit": "^2.8.1",

--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -103,6 +103,7 @@
       "devDependencies": {
         "@actions/core": "^3.0.1",
         "@playwright/test": "^1.59.1",
+        "@testing-library/dom": "^10.4.1",
         "@testing-library/jest-dom": "^6.9.1",
         "@testing-library/react": "^16.3.2",
         "@testing-library/user-event": "^14.6.1",
@@ -3338,6 +3339,43 @@
         "tslib": "^2.8.0"
       }
     },
+    "node_modules/@testing-library/dom": {
+      "version": "10.4.1",
+      "resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-10.4.1.tgz",
+      "integrity": "sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.10.4",
+        "@babel/runtime": "^7.12.5",
+        "@types/aria-query": "^5.0.1",
+        "aria-query": "5.3.0",
+        "dom-accessibility-api": "^0.5.9",
+        "lz-string": "^1.5.0",
+        "picocolors": "1.1.1",
+        "pretty-format": "^27.0.2"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@testing-library/dom/node_modules/aria-query": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/aria-query/-/aria-query-5.3.0.tgz",
+      "integrity": "sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "dequal": "^2.0.3"
+      }
+    },
+    "node_modules/@testing-library/dom/node_modules/dom-accessibility-api": {
+      "version": "0.5.16",
+      "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz",
+      "integrity": "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@testing-library/jest-dom": {
       "version": "6.9.1",
       "resolved": "https://registry.npmjs.org/@testing-library/jest-dom/-/jest-dom-6.9.1.tgz",
@@ -3423,6 +3461,13 @@
       "dependencies": {
         "tslib": "^2.4.0"
       }
+    },
+    "node_modules/@types/aria-query": {
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.4.tgz",
+      "integrity": "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/chai": {
       "version": "5.2.3",
@@ -12041,6 +12086,16 @@
         "node": ">=12"
       }
     },
+    "node_modules/lz-string": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/lz-string/-/lz-string-1.5.0.tgz",
+      "integrity": "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "lz-string": "bin/bin.js"
+      }
+    },
     "node_modules/magic-string": {
       "version": "0.30.21",
       "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
@@ -14415,6 +14470,41 @@
       "engines": {
         "node": ">=6.0.0"
       }
+    },
+    "node_modules/pretty-format": {
+      "version": "27.5.1",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-27.5.1.tgz",
+      "integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1",
+        "ansi-styles": "^5.0.0",
+        "react-is": "^17.0.1"
+      },
+      "engines": {
+        "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
+      }
+    },
+    "node_modules/pretty-format/node_modules/ansi-styles": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
+      "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/pretty-format/node_modules/react-is": {
+      "version": "17.0.2",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
+      "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/process": {
       "version": "0.11.10",

--- a/ui/package.json
+++ b/ui/package.json
@@ -128,6 +128,7 @@
   "devDependencies": {
     "@actions/core": "^3.0.1",
     "@playwright/test": "^1.59.1",
+    "@testing-library/dom": "^10.4.1",
     "@testing-library/jest-dom": "^6.9.1",
     "@testing-library/react": "^16.3.2",
     "@testing-library/user-event": "^14.6.1",

--- a/ui/package.json
+++ b/ui/package.json
@@ -46,7 +46,7 @@
     "@emotion/react": "^11.14.0",
     "@emotion/server": "^11.11.0",
     "@emotion/styled": "^11.14.1",
-    "@meshery/schemas": "^1.2.16",
+    "@meshery/schemas": "^1.2.18",
     "@microlink/react-json-view": "^1.31.20",
     "@mui/icons-material": "^9.0.0",
     "@mui/material": "^9.0.0",

--- a/ui/pages/_app.tsx
+++ b/ui/pages/_app.tsx
@@ -178,7 +178,7 @@ const MesheryApp = ({ Component, pageProps, relayEnvironment, emotionCache }) =>
           };
           dispatch(updatePrometheusConfig(promCfg));
         } else {
-          const credentialID = connection?.credential_id;
+          const credentialID = connection?.credentialId;
           fetchCredentialById(credentialID)
             .unwrap()
             .then((credRes) => {
@@ -327,7 +327,7 @@ const MesheryApp = ({ Component, pageProps, relayEnvironment, emotionCache }) =>
       try {
         const ctx = await fetchKubernetesContexts({ pagesize: 10, search }).unwrap();
         setState((prevState) => ({ ...prevState, k8sContexts: ctx }));
-        const active = ctx?.contexts?.find((c) => c.is_current_context === true);
+        const active = ctx?.contexts?.find((c) => c.isCurrentContext === true);
         if (active) {
           setState((prevState) => ({ ...prevState, activeK8sContexts: [active?.id] }));
           activeContextChangeCallback([active?.id]);

--- a/ui/rtk-query/__tests__/transforms.test.ts
+++ b/ui/rtk-query/__tests__/transforms.test.ts
@@ -1,0 +1,82 @@
+import { describe, expect, it } from 'vitest';
+import {
+  normalizeKubernetesContextsResponse,
+  normalizePaginatedCollectionResponse,
+  normalizeProviderCapabilities,
+} from '../transforms';
+
+describe('normalizeProviderCapabilities', () => {
+  it('normalizes snake_case provider fields to camelCase', () => {
+    expect(
+      normalizeProviderCapabilities({
+        provider_name: 'Meshery Cloud',
+        provider_type: 'remote',
+        provider_url: 'https://cloud.meshery.io',
+        provider_description: ['Hosted provider'],
+        capabilities: [],
+      }),
+    ).toEqual(
+      expect.objectContaining({
+        providerName: 'Meshery Cloud',
+        providerType: 'remote',
+        providerUrl: 'https://cloud.meshery.io',
+        providerDescription: ['Hosted provider'],
+      }),
+    );
+  });
+});
+
+describe('normalizePaginatedCollectionResponse', () => {
+  it('normalizes total_count and page_size to camelCase', () => {
+    expect(
+      normalizePaginatedCollectionResponse(
+        {
+          page: 0,
+          page_size: 10,
+          total_count: 42,
+          resources: [{ id: '1' }],
+        },
+        'resources',
+      ),
+    ).toEqual(
+      expect.objectContaining({
+        page: 0,
+        pageSize: 10,
+        totalCount: 42,
+        resources: [{ id: '1' }],
+      }),
+    );
+  });
+});
+
+describe('normalizeKubernetesContextsResponse', () => {
+  it('normalizes context snake_case fields to camelCase', () => {
+    expect(
+      normalizeKubernetesContextsResponse({
+        total_count: 1,
+        contexts: [
+          {
+            id: 'ctx-1',
+            connection_id: 'conn-1',
+            is_current_context: true,
+            created_by: 'meshery',
+            deployment_type: 'in_cluster',
+          },
+        ],
+      }),
+    ).toEqual(
+      expect.objectContaining({
+        totalCount: 1,
+        contexts: [
+          expect.objectContaining({
+            id: 'ctx-1',
+            connectionId: 'conn-1',
+            isCurrentContext: true,
+            createdBy: 'meshery',
+            deploymentType: 'in_cluster',
+          }),
+        ],
+      }),
+    );
+  });
+});

--- a/ui/rtk-query/__tests__/userProfile.test.ts
+++ b/ui/rtk-query/__tests__/userProfile.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it } from 'vitest';
+import { normalizeUserProfileSummary } from '../userProfile';
+
+describe('normalizeUserProfileSummary', () => {
+  it('normalizes snake_case profile fields to camelCase', () => {
+    expect(
+      normalizeUserProfileSummary({
+        id: 'user-id',
+        email: 'owner@meshery.io',
+        user_id: 'user-id',
+        avatar_url: 'https://avatars.example.com/u/1',
+        first_name: 'Mesh',
+        last_name: 'Mate',
+      }),
+    ).toEqual({
+      id: 'user-id',
+      email: 'owner@meshery.io',
+      userId: 'user-id',
+      avatarUrl: 'https://avatars.example.com/u/1',
+      firstName: 'Mesh',
+      lastName: 'Mate',
+    });
+  });
+
+  it('preserves camelCase profile fields', () => {
+    expect(
+      normalizeUserProfileSummary({
+        id: 'user-id',
+        email: 'owner@meshery.io',
+        userId: 'user-id',
+        avatarUrl: 'https://avatars.example.com/u/1',
+        firstName: 'Mesh',
+        lastName: 'Mate',
+      }),
+    ).toEqual({
+      id: 'user-id',
+      email: 'owner@meshery.io',
+      userId: 'user-id',
+      avatarUrl: 'https://avatars.example.com/u/1',
+      firstName: 'Mesh',
+      lastName: 'Mate',
+    });
+  });
+
+  it('returns undefined for empty responses', () => {
+    expect(normalizeUserProfileSummary()).toBeUndefined();
+  });
+});

--- a/ui/rtk-query/ability.tsx
+++ b/ui/rtk-query/ability.tsx
@@ -104,7 +104,7 @@ const SelectedOrganizationProvider = ({ children }) => {
   const prefUpdatedToFallback = useRef(false);
   const isLoading = isFetchingSelectedOrg || isLoadingAbilities;
   const loadingDiagnosticsRef = useRef({
-    providerType: providerCapabilities?.provider_type,
+    providerType: providerCapabilities?.providerType,
     hasSelectedOrganization,
     selectedOrganizationId,
     didFallback,
@@ -116,7 +116,7 @@ const SelectedOrganizationProvider = ({ children }) => {
 
   useEffect(() => {
     loadingDiagnosticsRef.current = {
-      providerType: providerCapabilities?.provider_type,
+      providerType: providerCapabilities?.providerType,
       hasSelectedOrganization,
       selectedOrganizationId,
       didFallback,
@@ -126,7 +126,7 @@ const SelectedOrganizationProvider = ({ children }) => {
       errorLoadingAbilities,
     };
   }, [
-    providerCapabilities?.provider_type,
+    providerCapabilities?.providerType,
     hasSelectedOrganization,
     selectedOrganizationId,
     didFallback,
@@ -210,7 +210,7 @@ const SelectedOrganizationProvider = ({ children }) => {
   }
 
   const loaderMessage = showSlowLoadingNotice
-    ? `Still initializing your ${providerCapabilities?.provider_type === 'local' ? 'local provider session' : 'session'}. Waiting for ${formatPendingSessionBootstrapStep(
+    ? `Still initializing your ${providerCapabilities?.providerType === 'local' ? 'local provider session' : 'session'}. Waiting for ${formatPendingSessionBootstrapStep(
         {
           isFetchingSelectedOrg,
           isLoadingAbilities,

--- a/ui/rtk-query/meshModel.ts
+++ b/ui/rtk-query/meshModel.ts
@@ -166,7 +166,7 @@ export const useGetCategoriesSummary = () => {
         { category: category.name, params: { page: 1, pagesize: 1 } },
         true,
       );
-      categoryMap[category.name] = data?.total_count || 0;
+      categoryMap[category.name] = data?.totalCount ?? data?.total_count ?? 0;
     });
     await Promise.allSettled(requests);
     return categoryMap;

--- a/ui/rtk-query/meshsync.ts
+++ b/ui/rtk-query/meshsync.ts
@@ -1,5 +1,6 @@
 import { urlEncodeParams } from '@/utils/utils';
 import { api, mesheryApiPath } from './index';
+import { normalizePaginatedCollectionResponse } from './transforms';
 
 const TAGS = {
   MESH_SYNC: 'meshsync',
@@ -33,6 +34,8 @@ const meshSyncApi = api
           },
           method: 'GET',
         }),
+        transformResponse: (response) =>
+          normalizePaginatedCollectionResponse(response, 'resources'),
         providesTags: () => [{ type: TAGS.MESH_SYNC }],
       }),
 

--- a/ui/rtk-query/system.ts
+++ b/ui/rtk-query/system.ts
@@ -1,4 +1,5 @@
 import { api, mesheryApiPath } from './index';
+import { normalizeKubernetesContextsResponse } from './transforms';
 
 const TAGS = {
   SYSTEM: 'system',
@@ -65,6 +66,7 @@ const systemApi = api.injectEndpoints({
         },
         method: 'GET',
       }),
+      transformResponse: normalizeKubernetesContextsResponse,
       providesTags: [TAGS.SYSTEM],
     }),
 

--- a/ui/rtk-query/transforms.ts
+++ b/ui/rtk-query/transforms.ts
@@ -1,0 +1,106 @@
+type PaginatedCollectionResponse<TCollectionKey extends string, TItem> = Partial<
+  Record<TCollectionKey, TItem[]>
+> & {
+  page?: number;
+  pageSize?: number;
+  page_size?: number;
+  totalCount?: number;
+  total_count?: number;
+};
+
+type ProviderCapabilitiesResponse = {
+  providerName?: string;
+  provider_name?: string;
+  providerType?: string;
+  provider_type?: string;
+  providerUrl?: string;
+  provider_url?: string;
+  providerDescription?: string[];
+  provider_description?: string[];
+  capabilities?: unknown[];
+  extensions?: Record<string, unknown>;
+  restrictedAccess?: Record<string, unknown>;
+  [key: string]: unknown;
+};
+
+type KubernetesContextResponse = {
+  totalCount?: number;
+  total_count?: number;
+  contexts?: Array<{
+    createdBy?: string;
+    created_by?: string;
+    mesheryInstanceId?: string;
+    meshery_instance_id?: string;
+    kubernetesServerId?: string;
+    kubernetes_server_id?: string;
+    deploymentType?: string;
+    deployment_type?: string;
+    updatedAt?: string;
+    updated_at?: string;
+    createdAt?: string;
+    created_at?: string;
+    connectionId?: string;
+    connection_id?: string;
+    isCurrentContext?: boolean;
+    is_current_context?: boolean;
+    [key: string]: unknown;
+  }>;
+  [key: string]: unknown;
+};
+
+export const normalizePaginatedCollectionResponse = <
+  TCollectionKey extends string,
+  TItem = unknown,
+>(
+  response: PaginatedCollectionResponse<TCollectionKey, TItem> | undefined,
+  collectionKey: TCollectionKey,
+) => {
+  if (!response || typeof response !== 'object') {
+    return response;
+  }
+
+  return {
+    ...response,
+    pageSize: response.pageSize ?? response.page_size,
+    totalCount: response.totalCount ?? response.total_count,
+    [collectionKey]: Array.isArray(response[collectionKey]) ? response[collectionKey] : [],
+  };
+};
+
+export const normalizeProviderCapabilities = (response?: ProviderCapabilitiesResponse) => {
+  if (!response || typeof response !== 'object') {
+    return undefined;
+  }
+
+  return {
+    ...response,
+    providerName: response.providerName ?? response.provider_name,
+    providerType: response.providerType ?? response.provider_type,
+    providerUrl: response.providerUrl ?? response.provider_url,
+    providerDescription: response.providerDescription ?? response.provider_description,
+  };
+};
+
+export const normalizeKubernetesContextsResponse = (response?: KubernetesContextResponse) => {
+  if (!response || typeof response !== 'object') {
+    return undefined;
+  }
+
+  return {
+    ...response,
+    totalCount: response.totalCount ?? response.total_count,
+    contexts: Array.isArray(response.contexts)
+      ? response.contexts.map((context) => ({
+          ...context,
+          createdBy: context.createdBy ?? context.created_by,
+          mesheryInstanceId: context.mesheryInstanceId ?? context.meshery_instance_id,
+          kubernetesServerId: context.kubernetesServerId ?? context.kubernetes_server_id,
+          deploymentType: context.deploymentType ?? context.deployment_type,
+          updatedAt: context.updatedAt ?? context.updated_at,
+          createdAt: context.createdAt ?? context.created_at,
+          connectionId: context.connectionId ?? context.connection_id,
+          isCurrentContext: context.isCurrentContext ?? context.is_current_context,
+        }))
+      : [],
+  };
+};

--- a/ui/rtk-query/user.ts
+++ b/ui/rtk-query/user.ts
@@ -9,6 +9,8 @@ import { initiateQuery } from './utils';
 import { useGetOrgsQuery } from './organization';
 import { useGetWorkspacesQuery } from './workspace';
 import { normalizeLoadTestPrefs } from '../lib/load-test-prefs';
+import { normalizeProviderCapabilities } from './transforms';
+import { normalizeUserProfileSummary } from './userProfile';
 
 const Tags = {
   USER_PREF: 'userPref',
@@ -108,6 +110,7 @@ export const userApi = api
       getProviderCapabilities: builder.query({
         query: () => '/api/provider/capabilities',
         method: 'GET',
+        transformResponse: normalizeProviderCapabilities,
       }),
       getUserProfileSummaryById: builder.query({
         query: (queryArg) => ({
@@ -129,19 +132,7 @@ export const userApi = api
             }
           },
         }),
-        transformResponse: (response) => {
-          if (!response || typeof response !== 'object') {
-            return undefined;
-          }
-          return {
-            id: response.id,
-            email: response.email,
-            user_id: response.user_id,
-            avatar_url: response.avatar_url,
-            first_name: response.first_name,
-            last_name: response.last_name,
-          };
-        },
+        transformResponse: normalizeUserProfileSummary,
       }),
       getExtensionsByType: builder.query({
         query: () => ({

--- a/ui/rtk-query/userProfile.ts
+++ b/ui/rtk-query/userProfile.ts
@@ -1,0 +1,27 @@
+type UserProfileSummaryResponse = {
+  id?: string;
+  email?: string;
+  userId?: string;
+  user_id?: string;
+  avatarUrl?: string;
+  avatar_url?: string;
+  firstName?: string;
+  first_name?: string;
+  lastName?: string;
+  last_name?: string;
+};
+
+export const normalizeUserProfileSummary = (response?: UserProfileSummaryResponse) => {
+  if (!response || typeof response !== 'object') {
+    return undefined;
+  }
+
+  return {
+    id: response.id ?? response.userId ?? response.user_id,
+    email: response.email,
+    userId: response.userId ?? response.user_id ?? response.id,
+    avatarUrl: response.avatarUrl ?? response.avatar_url,
+    firstName: response.firstName ?? response.first_name,
+    lastName: response.lastName ?? response.last_name,
+  };
+};

--- a/ui/rtk-query/workspace.ts
+++ b/ui/rtk-query/workspace.ts
@@ -2,6 +2,8 @@ import { urlEncodeParams } from '@/utils/utils';
 import { mesheryApi } from '@meshery/schemas/mesheryApi';
 import { api, mesheryApiPath } from './index';
 import _ from 'lodash';
+import { normalizePaginatedCollectionResponse } from './transforms';
+import { normalizeUserProfileSummary } from './userProfile';
 
 const TAGS = {
   WORKSPACES: 'workspaces',
@@ -64,10 +66,11 @@ const workspacesApi = api
 
                 return {
                   ...workspace,
-                  designCount: designs.data?.total_count || 0,
-                  environmentCount: environments.data?.total_count || 0,
-                  viewCount: views.data?.total_count || 0,
-                  teamCount: teams.data?.total_count || 0,
+                  designCount: designs.data?.totalCount ?? designs.data?.total_count ?? 0,
+                  environmentCount:
+                    environments.data?.totalCount ?? environments.data?.total_count ?? 0,
+                  viewCount: views.data?.totalCount ?? views.data?.total_count ?? 0,
+                  teamCount: teams.data?.totalCount ?? teams.data?.total_count ?? 0,
                 };
               }),
             );
@@ -124,26 +127,33 @@ const workspacesApi = api
             url: mesheryApiPath(`workspaces/${queryArgs.workspaceId}/designs?${params}`),
             method: 'GET',
           });
-          if (expandUser && designs.data && !designs.error) {
-            const withUsersPromises = designs.data.designs.map(async (design) => {
+          const normalizedDesigns =
+            designs.data && !designs.error
+              ? { ...designs, data: normalizePaginatedCollectionResponse(designs.data, 'designs') }
+              : designs;
+          if (expandUser && normalizedDesigns.data && !normalizedDesigns.error) {
+            const withUsersPromises = normalizedDesigns.data.designs.map(async (design) => {
               const user = await dispatch(
-                mesheryApi.endpoints.getUserProfileById.initiate({ id: design.user_id }),
+                mesheryApi.endpoints.getUserProfileById.initiate({
+                  id: design.userId ?? design.user_id,
+                }),
               );
+              const normalizedUser = normalizeUserProfileSummary(user.data);
               return {
                 ...design,
-                first_name: user.data?.first_name || '[deleted]',
-                last_name: user.data?.last_name || '',
-                avatar_url: user.data?.avatar_url || '',
-                user_id: user.data?.id || '',
-                email: user.data?.email || '',
+                firstName: normalizedUser?.firstName || '[deleted]',
+                lastName: normalizedUser?.lastName || '',
+                avatarUrl: normalizedUser?.avatarUrl || '',
+                userId: normalizedUser?.id || design.userId || design.user_id || '',
+                email: normalizedUser?.email || '',
               };
             });
 
             const modifiedDesigns = await Promise.all(withUsersPromises);
-            return _.merge({}, designs, { data: { designs: modifiedDesigns } });
+            return _.merge({}, normalizedDesigns, { data: { designs: modifiedDesigns } });
           }
 
-          return designs;
+          return normalizedDesigns;
         },
         serializeQueryArgs: ({ endpointName, queryArgs }) => {
           if (queryArgs?.infiniteScroll) {
@@ -198,25 +208,32 @@ const workspacesApi = api
             ),
             method: 'GET',
           });
-          if (expandUser && views.data && !views.error) {
-            const withUsersPromises = views.data.views.map(async (view) => {
+          const normalizedViews =
+            views.data && !views.error
+              ? { ...views, data: normalizePaginatedCollectionResponse(views.data, 'views') }
+              : views;
+          if (expandUser && normalizedViews.data && !normalizedViews.error) {
+            const withUsersPromises = normalizedViews.data.views.map(async (view) => {
               const user = await dispatch(
-                mesheryApi.endpoints.getUserProfileById.initiate({ id: view.user_id }),
+                mesheryApi.endpoints.getUserProfileById.initiate({
+                  id: view.userId ?? view.user_id,
+                }),
               );
+              const normalizedUser = normalizeUserProfileSummary(user.data);
               return {
                 ...view,
-                first_name: user.data?.first_name || '[deleted]',
-                last_name: user.data?.last_name || '',
-                avatar_url: user.data?.avatar_url || '',
-                user_id: user.data?.id || '',
-                email: user.data?.email || '',
+                firstName: normalizedUser?.firstName || '[deleted]',
+                lastName: normalizedUser?.lastName || '',
+                avatarUrl: normalizedUser?.avatarUrl || '',
+                userId: normalizedUser?.id || view.userId || view.user_id || '',
+                email: normalizedUser?.email || '',
               };
             });
             const modifiedViews = await Promise.all(withUsersPromises);
-            return _.merge({}, views, { data: { views: modifiedViews } });
+            return _.merge({}, normalizedViews, { data: { views: modifiedViews } });
           }
 
-          return views;
+          return normalizedViews;
         },
         serializeQueryArgs: ({ endpointName, queryArgs }) => {
           if (queryArgs?.infiniteScroll) {

--- a/ui/utils/responsive-column.ts
+++ b/ui/utils/responsive-column.ts
@@ -48,3 +48,9 @@ export const updateVisibleColumns = (colViews, width) => {
 
   return showCols;
 };
+
+export const getResponsiveColumnVisibility = (columnNames, colViews, width) => {
+  const showCols = updateVisibleColumns(colViews, width);
+
+  return Object.fromEntries(columnNames.map((columnName) => [columnName, showCols[columnName]]));
+};


### PR DESCRIPTION
## Summary
- improve the connections UI components with more stable memoized rendering and callback behavior
- add persistent Vitest coverage for the updated connections surfaces
- add `@testing-library/dom` to support the existing React test setup

## Testing
- cd ui && npm exec -- vitest run components/connections/ConnectionChip.test.tsx components/connections/ConnectionTable.test.tsx components/connections/common/index.test.tsx components/connections/index.test.tsx components/connections/meshSync/index.test.tsx components/connections/metadata.test.tsx
- cd ui && npm exec -- eslint components/connections/ConnectionChip.tsx components/connections/ConnectionTable.tsx components/connections/common/index.tsx components/connections/index.tsx components/connections/meshSync/index.tsx components/connections/metadata.tsx components/connections/ConnectionChip.test.tsx components/connections/ConnectionTable.test.tsx components/connections/common/index.test.tsx components/connections/index.test.tsx components/connections/meshSync/index.test.tsx components/connections/metadata.test.tsx