### PR TITLE
[UI] Normalize RTK response casing across UI flows

### DIFF
--- a/ui/components/General/ErrorBoundary.tsx
+++ b/ui/components/General/ErrorBoundary.tsx
@@ -35,7 +35,7 @@ const CustomErrorFallback = (props) => {
   const [triggerWebhook] = useSupportWebHookMutation();
   const { data: userData } = useGetLoggedInUserQuery();
   const { data: providerData } = useGetProviderCapabilitiesQuery();
-  const showSupportBasedOnProvider = providerData?.provider_type === 'remote';
+  const showSupportBasedOnProvider = providerData?.providerType === 'remote';
 
   const handleOpenSupportModal = () => {
     setOpenSupportModal(true);

--- a/ui/components/General/Modals/Information/InfoModal.tsx
+++ b/ui/components/General/Modals/Information/InfoModal.tsx
@@ -131,7 +131,7 @@ const InfoModal_ = React.memo((props) => {
 
     const payload = {
       id: selectedResource?.id,
-      catalog_data: {
+      catalogData: {
         ...formData,
         compatibility: compatibilityStore,
         type: _.toLower(formData?.type),
@@ -185,8 +185,8 @@ const InfoModal_ = React.memo((props) => {
 
     body = JSON.stringify({
       name: selectedResource.name,
-      catalog_data: modifiedData,
-      design_file: yaml.load(selectedResource.patternFile),
+      catalogData: modifiedData,
+      designFile: yaml.load(selectedResource.patternFile),
       id: selectedResource.id,
       visibility: visibility,
     });
@@ -240,14 +240,14 @@ const InfoModal_ = React.memo((props) => {
   }
   const handleFormChange = (data) => {
     formStateRef.current = data;
-    setIsCatalogDataEqual(isEqualIgnoringCase(selectedResource?.catalog_data, data));
+    setIsCatalogDataEqual(isEqualIgnoringCase(selectedResource?.catalogData, data));
   };
 
   useEffect(() => {
-    if (selectedResource?.catalog_data && Object.keys(selectedResource?.catalog_data).length > 0) {
+    if (selectedResource?.catalogData && Object.keys(selectedResource?.catalogData).length > 0) {
       if (meshModels) {
         const compatibilitySet = new Set(
-          (selectedResource?.catalog_data?.compatibility || []).map((comp) => comp.toLowerCase()),
+          (selectedResource?.catalogData?.compatibility || []).map((comp) => comp.toLowerCase()),
         );
 
         const filteredCompatibilityArray = _.uniq(
@@ -260,16 +260,16 @@ const InfoModal_ = React.memo((props) => {
         );
 
         let modifiedData = {
-          ...selectedResource.catalog_data,
-          type: _.startCase(selectedResource?.catalog_data?.type),
+          ...selectedResource.catalogData,
+          type: _.startCase(selectedResource?.catalogData?.type),
           compatibility: filteredCompatibilityArray,
         };
         formStateRef.current = filterEmptyFields(modifiedData);
       }
     } else {
-      formStateRef.current = filterEmptyFields(selectedResource?.catalog_data);
+      formStateRef.current = filterEmptyFields(selectedResource?.catalogData);
     }
-  }, [selectedResource?.catalog_data, meshModels]);
+  }, [selectedResource?.catalogData, meshModels]);
 
   useEffect(() => {
     if (publishSchema) {
@@ -343,9 +343,9 @@ const InfoModal_ = React.memo((props) => {
                   alignItems: 'center',
                 }}
               >
-                {selectedResource?.catalog_data?.imageURL && !imageError ? (
+                {selectedResource?.catalogData?.imageURL && !imageError ? (
                   <img
-                    src={selectedResource.catalog_data.imageURL[0]}
+                    src={selectedResource.catalogData.imageURL[0]}
                     width="140"
                     alt={selectedResource?.name}
                     onError={handleError}

--- a/ui/components/MesheryFilters/FiltersGrid.tsx
+++ b/ui/components/MesheryFilters/FiltersGrid.tsx
@@ -26,7 +26,7 @@ type FiltersGridProps = {
     id: string;
     type: string;
     name: string;
-    catalog_data: unknown;
+    catalogData: unknown;
   }) => void;
   setSelectedFilter: (_value: { filter: any; show: boolean }) => void;
   selectedFilter: { show: boolean; filter: any };
@@ -52,7 +52,7 @@ type FilterCardGridItemProps = {
     id: string;
     type: string;
     name: string;
-    catalog_data: unknown;
+    catalogData: unknown;
   }) => void;
   setSelectedFilters: (_value: { filter: any; show: boolean }) => void;
   handleClone: () => void;
@@ -98,7 +98,7 @@ function FilterCardGridItem({
             id: filter.id,
             type: FILE_OPS.DELETE,
             name: filter.name,
-            catalog_data: filter.catalog_data,
+            catalogData: filter.catalogData,
           })
         }
         updateHandler={() =>
@@ -107,7 +107,7 @@ function FilterCardGridItem({
             id: filter.id,
             type: FILE_OPS.UPDATE,
             name: filter.name,
-            catalog_data: filter.catalog_data,
+            catalogData: filter.catalogData,
           })
         }
         setSelectedFilters={() => setSelectedFilters({ filter: filter, show: true })}

--- a/ui/components/Registry/RegistryModal.tsx
+++ b/ui/components/Registry/RegistryModal.tsx
@@ -235,9 +235,9 @@ export const Navigation = ({ setHeaderInfo }) => {
   });
   const counts = {
     models: modelsData ? removeDuplicateVersions(modelsData.models || []).length : 0,
-    components: componentsData?.total_count || 0,
-    relationships: relationshipsData?.total_count || 0,
-    registrants: registrantsData?.total_count || 0,
+    components: componentsData?.totalCount ?? componentsData?.total_count ?? 0,
+    relationships: relationshipsData?.totalCount ?? relationshipsData?.total_count ?? 0,
+    registrants: registrantsData?.totalCount ?? registrantsData?.total_count ?? 0,
   };
   const navConfig = getNavItems(theme, counts);
 

--- a/ui/components/Registry/RegistryModal.tsx
+++ b/ui/components/Registry/RegistryModal.tsx
@@ -235,9 +235,9 @@ export const Navigation = ({ setHeaderInfo }) => {
   });
   const counts = {
     models: modelsData ? removeDuplicateVersions(modelsData.models || []).length : 0,
-    components: componentsData?.totalCount ?? componentsData?.total_count ?? 0,
-    relationships: relationshipsData?.totalCount ?? relationshipsData?.total_count ?? 0,
-    registrants: registrantsData?.totalCount ?? registrantsData?.total_count ?? 0,
+    components: componentsData?.totalCount ?? 0,
+    relationships: relationshipsData?.totalCount ?? 0,
+    registrants: registrantsData?.totalCount ?? 0,
   };
   const navConfig = getNavItems(theme, counts);
 

--- a/ui/components/SpacesSwitcher/WorkspaceModal.tsx
+++ b/ui/components/SpacesSwitcher/WorkspaceModal.tsx
@@ -240,7 +240,7 @@ const Navigation = ({ setHeaderInfo }) => {
   const closeList = useMediaQuery(theme.breakpoints.down('xl'));
   const [open, setOpen] = useState(!closeList);
   const { data: capabilitiesData } = useGetProviderCapabilitiesQuery();
-  const isLocalProvider = capabilitiesData?.provider_type === 'local';
+  const isLocalProvider = capabilitiesData?.providerType === 'local';
   const workspaceSwitcherContext = useContext(WorkspaceModalContext);
   const { selectedWorkspace } = workspaceSwitcherContext;
   const [selectedId, setSelectedId] = useState(selectedWorkspace?.id || 'Recents (Global)');

--- a/ui/components/UserPreferences/index.tsx
+++ b/ui/components/UserPreferences/index.tsx
@@ -82,10 +82,10 @@ interface ProviderExtension {
 }
 
 interface _ProviderInfo {
-  provider_name?: string;
-  provider_type?: string;
-  provider_url?: string;
-  provider_description?: string[];
+  providerName?: string;
+  providerType?: string;
+  providerUrl?: string;
+  providerDescription?: string[];
   capabilities?: ProviderCapability[];
   extensions?: Record<string, ProviderExtension[]>;
   [key: string]: unknown;
@@ -134,7 +134,7 @@ const UserPreference: React.FC<UserPreferenceProps> = (props) => {
   const [capabilitiesLoaded, setCapabilitiesLoaded] = useState(false);
   const { width } = useWindowDimensions();
   const [value, setValue] = useState(0);
-  const [providerInfo, setProviderInfo] = useState({});
+  const [providerInfo, setProviderInfo] = useState<_ProviderInfo>({});
   const theme = useTheme();
   const dispatch = useDispatch();
   const { capabilitiesRegistry } = useSelector((state) => state.ui);
@@ -386,8 +386,8 @@ const UserPreference: React.FC<UserPreferenceProps> = (props) => {
               <CardContent>
                 <Typography>
                   <ul>
-                    {providerInfo.provider_description &&
-                      providerInfo.provider_description.map((desc, index) => (
+                    {providerInfo.providerDescription &&
+                      providerInfo.providerDescription.map((desc, index) => (
                         <li key={index}>
                           <Typography>{desc}</Typography>
                         </li>

--- a/ui/components/connections/meshSync/index.test.tsx
+++ b/ui/components/connections/meshSync/index.test.tsx
@@ -1,0 +1,156 @@
+import React from 'react';
+import { render } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import MeshSyncTable from './index';
+
+const notify = vi.fn();
+const getK8sClusterIdsFromCtxId = vi.fn();
+const useGetMeshSyncResourcesQuery = vi.fn();
+const useGetMeshSyncResourceKindsQuery = vi.fn();
+
+vi.mock('@sistent/sistent', () => ({
+  Tooltip: ({ children }) => <div>{children}</div>,
+  Grid2: ({ children }) => <div>{children}</div>,
+  Box: ({ children }) => <div>{children}</div>,
+  Typography: ({ children }) => <span>{children}</span>,
+  FormControl: ({ children }) => <div>{children}</div>,
+  MenuItem: ({ children }) => <div>{children}</div>,
+  Table: ({ children }) => <div>{children}</div>,
+  FormattedTime: ({ date }) => <span>{String(date)}</span>,
+  CustomColumnVisibilityControl: () => <div />,
+  ResponsiveDataTable: () => <div data-testid="mesh-sync-table" />,
+  SearchBar: () => <div />,
+  UniversalFilter: () => <div />,
+  TableCell: ({ children }) => <div>{children}</div>,
+  TableRow: ({ children }) => <div>{children}</div>,
+  styled: (Component) => () => {
+    const StyledComponent = ({ children, ...props }) => (
+      <Component {...props}>{children}</Component>
+    );
+    StyledComponent.displayName = 'StyledSistentMock';
+    return StyledComponent;
+  },
+  accentGrey: 'gray',
+}));
+
+vi.mock('../../../utils/hooks/useNotification', () => ({
+  useNotification: () => ({ notify }),
+}));
+
+vi.mock('../../../utils/multi-ctx', () => ({
+  getK8sClusterIdsFromCtxId: (...args) => getK8sClusterIdsFromCtxId(...args),
+}));
+
+vi.mock('@/rtk-query/meshsync', () => ({
+  useGetMeshSyncResourceKindsQuery: (...args) => useGetMeshSyncResourceKindsQuery(...args),
+  useGetMeshSyncResourcesQuery: (...args) => useGetMeshSyncResourcesQuery(...args),
+}));
+
+vi.mock('../../../utils/dimension', () => ({
+  useWindowDimensions: () => ({ width: 1200 }),
+}));
+
+vi.mock('react-redux', () => ({
+  useSelector: (selector) =>
+    selector({
+      ui: {
+        k8sConfig: { currentContext: 'dev' },
+        selectedK8sContexts: ['all'],
+      },
+    }),
+}));
+
+vi.mock('../metadata', () => ({
+  MeshSyncDataFormatter: () => <div />,
+}));
+
+vi.mock('../common', () => ({
+  DefaultTableCell: () => <div />,
+  SortableTableCell: () => <div />,
+}));
+
+vi.mock('../../../utils/utils', () => ({
+  JsonParse: JSON.parse,
+  camelcaseToSnakecase: (value) => value,
+  getColumnValue: () => null,
+  getVisibilityColums: () => [],
+}));
+
+vi.mock('./RegisterConnectionModal', () => ({
+  default: () => <div />,
+}));
+
+vi.mock('../ConnectionChip', () => ({
+  ConnectionStateChip: () => <div />,
+}));
+
+vi.mock('../styles', () => ({
+  ContentContainer: ({ children }) => <div>{children}</div>,
+  ConnectionStyledSelect: ({ children }) => <div>{children}</div>,
+  InnerTableContainer: ({ children }) => <div>{children}</div>,
+}));
+
+vi.mock('@/assets/styles/general/tool.styles', () => ({
+  ToolWrapper: ({ children }) => <div>{children}</div>,
+}));
+
+vi.mock('@/store/slices/mesheryUi', () => ({
+  updateProgress: vi.fn(),
+}));
+
+vi.mock('./MeshSyncEmptyState', () => ({
+  default: () => <div data-testid="mesh-sync-empty-state" />,
+}));
+
+describe('MeshSyncTable', () => {
+  beforeEach(() => {
+    notify.mockReset();
+    getK8sClusterIdsFromCtxId.mockReset();
+    useGetMeshSyncResourcesQuery.mockReset();
+    useGetMeshSyncResourceKindsQuery.mockReset();
+
+    getK8sClusterIdsFromCtxId.mockReturnValue(['cluster-a', 'cluster-b']);
+    useGetMeshSyncResourcesQuery.mockReturnValue({
+      data: { resources: [], totalCount: 0 },
+      isError: false,
+      error: undefined,
+    });
+    useGetMeshSyncResourceKindsQuery.mockReturnValue({
+      data: { kinds: [], namespaces: [] },
+    });
+  });
+
+  it('passes stable cluster ids to both queries', () => {
+    render(<MeshSyncTable />);
+
+    expect(useGetMeshSyncResourcesQuery).toHaveBeenCalledWith(
+      expect.objectContaining({
+        clusterIds: JSON.stringify(['cluster-a', 'cluster-b']),
+      }),
+    );
+    expect(useGetMeshSyncResourceKindsQuery).toHaveBeenCalledWith(
+      expect.objectContaining({
+        clusterIds: ['cluster-a', 'cluster-b'],
+      }),
+    );
+  });
+
+  it('notifies when fetching mesh sync resources fails', () => {
+    useGetMeshSyncResourcesQuery.mockReturnValue({
+      data: { resources: [], totalCount: 0 },
+      isError: true,
+      error: { data: 'MeshSync unavailable' },
+    });
+
+    render(<MeshSyncTable />);
+
+    expect(notify).toHaveBeenNthCalledWith(
+      1,
+      expect.objectContaining({
+        message: 'Error fetching MeshSync Resources',
+        event_type: expect.objectContaining({ type: 'error' }),
+        details: 'MeshSync unavailable',
+      }),
+    );
+  });
+});

--- a/ui/components/connections/meshSync/index.test.tsx
+++ b/ui/components/connections/meshSync/index.test.tsx
@@ -144,6 +144,7 @@ describe('MeshSyncTable', () => {
 
     render(<MeshSyncTable />);
 
+    expect(notify).toHaveBeenCalledTimes(1);
     expect(notify).toHaveBeenNthCalledWith(
       1,
       expect.objectContaining({

--- a/ui/components/connections/meshSync/index.tsx
+++ b/ui/components/connections/meshSync/index.tsx
@@ -32,15 +32,7 @@ import {
 import { ConnectionStateChip } from '../ConnectionChip';
 import { ContentContainer, ConnectionStyledSelect, InnerTableContainer } from '../styles';
 import { useSelector } from 'react-redux';
-import { updateProgress } from '@/store/slices/mesheryUi';
 import MeshSyncEmptyState from './MeshSyncEmptyState';
-
-const ACTION_TYPES = {
-  FETCH_MESHSYNC_RESOURCES: {
-    name: 'FETCH_MESHSYNC_RESOURCES',
-    error_msg: 'Failed to fetch meshsync resources',
-  },
-};
 
 export default function MeshSyncTable(props) {
   const { selectedResourceId, updateUrlWithResourceId } = props;
@@ -543,21 +535,6 @@ export default function MeshSyncTable(props) {
       );
     },
   };
-
-  const handleError = (action) => (error) => {
-    updateProgress({ showProgress: false });
-    notify({
-      message: `${action.error_msg}: ${error}`,
-      event_type: EVENT_TYPES.ERROR,
-      details: error.toString(),
-    });
-  };
-
-  useEffect(() => {
-    if (meshSyncError) {
-      handleError(ACTION_TYPES.FETCH_MESHSYNC_RESOURCES)(meshSyncError);
-    }
-  }, [meshSyncError]);
 
   // Consolidate multiple useRef hooks into a single object
   const expansionFlags = useRef({

--- a/ui/components/connections/meshSync/index.tsx
+++ b/ui/components/connections/meshSync/index.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useRef, useState } from 'react';
+import React, { useEffect, useMemo, useRef, useState } from 'react';
 import { Tooltip, Grid2, FormControl, MenuItem, Table, FormattedTime } from '@sistent/sistent';
 import { useNotification } from '../../../utils/hooks/useNotification';
 import { EVENT_TYPES } from '../../../lib/event-types';
@@ -68,6 +68,11 @@ export default function MeshSyncTable(props) {
   const { width } = useWindowDimensions();
 
   const { notify } = useNotification();
+  const clusterIds = useMemo(
+    () => getK8sClusterIdsFromCtxId(selectedK8sContexts, k8sConfig),
+    [k8sConfig, selectedK8sContexts],
+  );
+  const serializedClusterIds = useMemo(() => JSON.stringify(clusterIds), [clusterIds]);
 
   const handleRegistrationModalClose = () => {
     setRegistrationModal(false);
@@ -85,23 +90,27 @@ export default function MeshSyncTable(props) {
     kind: kindFilter,
     model: modelFilter,
     namespace: namespaceFilter,
-    clusterIds: JSON.stringify(getK8sClusterIdsFromCtxId(selectedK8sContexts, k8sConfig)),
+    clusterIds: serializedClusterIds,
   });
-  if (isError) {
-    if (isError) {
-      notify({
-        message: 'Error fetching MeshSync Resources',
-        event_type: EVENT_TYPES.ERROR,
-        details: meshSyncError?.data,
-      });
+
+  useEffect(() => {
+    if (!isError) {
+      return;
     }
-  }
+
+    notify({
+      message: 'Error fetching MeshSync Resources',
+      event_type: EVENT_TYPES.ERROR,
+      details: meshSyncError?.data,
+    });
+  }, [isError, meshSyncError?.data, notify]);
+
   const { data: clusterSummary } = useGetMeshSyncResourceKindsQuery({
     page: page,
     pagesize: 'all',
     search: search,
     order: sortOrder,
-    clusterIds: getK8sClusterIdsFromCtxId(selectedK8sContexts, k8sConfig),
+    clusterIds: clusterIds,
   });
   const availableKinds = (clusterSummary?.kinds || []).map((kind) => kind.Kind);
   const availableModels = [
@@ -426,7 +435,7 @@ export default function MeshSyncTable(props) {
     responsive: 'standard',
     serverSide: true,
     selectableRows: 'none',
-    count: meshSyncData?.total_count,
+    count: meshSyncData?.totalCount,
     rowsPerPage: pageSize,
     fixedHeader: true,
     page,

--- a/ui/components/connections/metadata.tsx
+++ b/ui/components/connections/metadata.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useMemo } from 'react';
 import { Grid2, List, ListItem, ListItemText, Box, styled, useTheme } from '@sistent/sistent';
 
 import {
@@ -82,7 +82,9 @@ const KubernetesMetadataFormatter = ({ meshsyncControllerState, connection, meta
   const { operatorState, meshSyncState, natsState, operatorVersion, meshSyncVersion, natsVersion } =
     getControllerStatesByConnectionID(connection.id);
 
-  const isEmbeddedMode = metadata?.meshsync_deployment_mode === MESHSYNC_DEPLOYMENT_TYPE.EMBEDDED;
+  const meshsyncDeploymentMode =
+    metadata?.meshsyncDeploymentMode ?? metadata?.meshsync_deployment_mode;
+  const isEmbeddedMode = meshsyncDeploymentMode === MESHSYNC_DEPLOYMENT_TYPE.EMBEDDED;
 
   return (
     <Grid2 container spacing={1} sx={{ textTransform: 'none' }} size="grow">
@@ -97,7 +99,7 @@ const KubernetesMetadataFormatter = ({ meshsyncControllerState, connection, meta
                     title={metadata.name}
                     status={connection.status}
                     iconSrc={'/static/img/kubernetes.svg'}
-                    handlePing={() => handleKubernetesClick(connection.id)}
+                    handlePing={handleKubernetesClick}
                   />
                 </ListItem>
               </List>
@@ -190,7 +192,7 @@ const KubernetesMetadataFormatter = ({ meshsyncControllerState, connection, meta
                           tooltip={natsState === 'Not Active' ? 'Not Available' : `Reconnect NATS`}
                           title={'BROKER'}
                           status={natsState}
-                          handlePing={() => handleNATSClick()}
+                          handlePing={handleNATSClick}
                           iconSrc="/static/img/nats-icon-color.svg"
                           width="9rem"
                         />
@@ -250,7 +252,7 @@ const KubernetesMetadataFormatter = ({ meshsyncControllerState, connection, meta
                 <ListItem>
                   <StyledListItemText
                     primary="Deployment Mode"
-                    secondary={formatToTitleCase(metadata.meshsync_deployment_mode || 'N/A')}
+                    secondary={formatToTitleCase(meshsyncDeploymentMode || 'N/A')}
                   />
                 </ListItem>
               </List>
@@ -264,13 +266,17 @@ const KubernetesMetadataFormatter = ({ meshsyncControllerState, connection, meta
 
 const MesheryMetadataFormatter = ({ connection }) => {
   const metadata = connection.metadata || {};
-  const uiSchema = createColumnUiSchema({
-    metadata,
-    numCols: {
-      xs: 2,
-      md: 4,
-    },
-  });
+  const uiSchema = useMemo(
+    () =>
+      createColumnUiSchema({
+        metadata,
+        numCols: {
+          xs: 2,
+          md: 4,
+        },
+      }),
+    [metadata],
+  );
 
   return (
     <FormatStructuredData
@@ -283,13 +289,17 @@ const MesheryMetadataFormatter = ({ connection }) => {
 
 export const MeshSyncDataFormatter = ({ metadata }) => {
   const theme = useTheme();
-  const uiSchema = createColumnUiSchema({
-    metadata,
-    numCols: {
-      xs: 3,
-      md: 5,
-    },
-  });
+  const uiSchema = useMemo(
+    () =>
+      createColumnUiSchema({
+        metadata,
+        numCols: {
+          xs: 3,
+          md: 5,
+        },
+      }),
+    [metadata],
+  );
 
   return (
     <Box backgroundColor={theme.palette.background.card} width="100%" padding={'1rem'}>
@@ -305,26 +315,33 @@ export const MeshSyncDataFormatter = ({ metadata }) => {
 const FormatConnectionMetadata = (props) => {
   const theme = useTheme();
   const { connection, meshsyncControllerState } = props;
-  const formatterByKind = {
-    [KUBERNETES]: () => (
-      <KubernetesMetadataFormatter
-        meshsyncControllerState={meshsyncControllerState}
-        connection={connection}
-        metadata={connection.metadata}
-      />
-    ),
-    [MESHERY]: () => <MesheryMetadataFormatter connection={connection} />,
-    default: () => (
-      <FormatStructuredData
-        data={connection.metadata}
-        propertyFormatters={DefaultPropertyFormatters}
-      />
-    ),
-  };
-  const formatter = formatterByKind[connection.kind] || formatterByKind.default;
+  let formatter;
+
+  switch (connection.kind) {
+    case KUBERNETES:
+      formatter = (
+        <KubernetesMetadataFormatter
+          meshsyncControllerState={meshsyncControllerState}
+          connection={connection}
+          metadata={connection.metadata}
+        />
+      );
+      break;
+    case MESHERY:
+      formatter = <MesheryMetadataFormatter connection={connection} />;
+      break;
+    default:
+      formatter = (
+        <FormatStructuredData
+          data={connection.metadata}
+          propertyFormatters={DefaultPropertyFormatters}
+        />
+      );
+  }
+
   return (
     <Box backgroundColor={theme.palette.background.card} padding={'1rem'}>
-      {formatter()}
+      {formatter}
     </Box>
   );
 };

--- a/ui/components/telemetry/grafana/GrafanaCharts.tsx
+++ b/ui/components/telemetry/grafana/GrafanaCharts.tsx
@@ -103,7 +103,7 @@ const GrafanaCharts = ({ grafanaURL, boardPanelConfigs }) => {
                     <Suspense fallback={null}>
                       <LazyGrafanaPanelIframe
                         key={`url_-_-${ind}`}
-                        src={`${adjustedGrafanaURL}/d-solo/${config.board.uid}/${config.board.slug}?theme=light&orgId=${config.board.org_id}&panelId=${panel.id}&refresh=${refresh}&from=${from}&to=${to}&${config.templateVars
+                        src={`${adjustedGrafanaURL}/d-solo/${config.board.uid}/${config.board.slug}?theme=light&orgId=${config.board.orgId ?? config.board.org_id}&panelId=${panel.id}&refresh=${refresh}&from=${from}&to=${to}&${config.templateVars
                           .map((tv) => `var-${tv}`)
                           .join('&')}`}
                         title={`${config.board.title} panel ${panel.id}`}

--- a/ui/components/telemetry/grafana/GrafanaComponent.tsx
+++ b/ui/components/telemetry/grafana/GrafanaComponent.tsx
@@ -189,7 +189,7 @@ const GrafanaComponent = (props) => {
     // Get the connection object from the event value and update configuration
     const grafanaConnectionObj = value;
     try {
-      const res = await fetchCredentialById(grafanaConnectionObj.credential_id).unwrap();
+      const res = await fetchCredentialById(grafanaConnectionObj.credentialId).unwrap();
       const grafanaCfg = {
         grafanaURL: grafanaConnectionObj?.value || '',
         grafanaAPIKey: res?.secret?.secret || '',

--- a/ui/pages/_app.tsx
+++ b/ui/pages/_app.tsx
@@ -178,7 +178,7 @@ const MesheryApp = ({ Component, pageProps, relayEnvironment, emotionCache }) =>
           };
           dispatch(updatePrometheusConfig(promCfg));
         } else {
-          const credentialID = connection?.credential_id;
+          const credentialID = connection?.credentialId;
           fetchCredentialById(credentialID)
             .unwrap()
             .then((credRes) => {
@@ -327,7 +327,7 @@ const MesheryApp = ({ Component, pageProps, relayEnvironment, emotionCache }) =>
       try {
         const ctx = await fetchKubernetesContexts({ pagesize: 10, search }).unwrap();
         setState((prevState) => ({ ...prevState, k8sContexts: ctx }));
-        const active = ctx?.contexts?.find((c) => c.is_current_context === true);
+        const active = ctx?.contexts?.find((c) => c.isCurrentContext === true);
         if (active) {
           setState((prevState) => ({ ...prevState, activeK8sContexts: [active?.id] }));
           activeContextChangeCallback([active?.id]);

--- a/ui/rtk-query/__tests__/transforms.test.ts
+++ b/ui/rtk-query/__tests__/transforms.test.ts
@@ -1,0 +1,82 @@
+import { describe, expect, it } from 'vitest';
+import {
+  normalizeKubernetesContextsResponse,
+  normalizePaginatedCollectionResponse,
+  normalizeProviderCapabilities,
+} from '../transforms';
+
+describe('normalizeProviderCapabilities', () => {
+  it('normalizes snake_case provider fields to camelCase', () => {
+    expect(
+      normalizeProviderCapabilities({
+        provider_name: 'Meshery Cloud',
+        provider_type: 'remote',
+        provider_url: 'https://cloud.meshery.io',
+        provider_description: ['Hosted provider'],
+        capabilities: [],
+      }),
+    ).toEqual(
+      expect.objectContaining({
+        providerName: 'Meshery Cloud',
+        providerType: 'remote',
+        providerUrl: 'https://cloud.meshery.io',
+        providerDescription: ['Hosted provider'],
+      }),
+    );
+  });
+});
+
+describe('normalizePaginatedCollectionResponse', () => {
+  it('normalizes total_count and page_size to camelCase', () => {
+    expect(
+      normalizePaginatedCollectionResponse(
+        {
+          page: 0,
+          page_size: 10,
+          total_count: 42,
+          resources: [{ id: '1' }],
+        },
+        'resources',
+      ),
+    ).toEqual(
+      expect.objectContaining({
+        page: 0,
+        pageSize: 10,
+        totalCount: 42,
+        resources: [{ id: '1' }],
+      }),
+    );
+  });
+});
+
+describe('normalizeKubernetesContextsResponse', () => {
+  it('normalizes context snake_case fields to camelCase', () => {
+    expect(
+      normalizeKubernetesContextsResponse({
+        total_count: 1,
+        contexts: [
+          {
+            id: 'ctx-1',
+            connection_id: 'conn-1',
+            is_current_context: true,
+            created_by: 'meshery',
+            deployment_type: 'in_cluster',
+          },
+        ],
+      }),
+    ).toEqual(
+      expect.objectContaining({
+        totalCount: 1,
+        contexts: [
+          expect.objectContaining({
+            id: 'ctx-1',
+            connectionId: 'conn-1',
+            isCurrentContext: true,
+            createdBy: 'meshery',
+            deploymentType: 'in_cluster',
+          }),
+        ],
+      }),
+    );
+  });
+});

--- a/ui/rtk-query/__tests__/transforms.test.ts
+++ b/ui/rtk-query/__tests__/transforms.test.ts
@@ -47,6 +47,49 @@ describe('normalizePaginatedCollectionResponse', () => {
       }),
     );
   });
+
+  it('can normalize collection items alongside pagination metadata', () => {
+    expect(
+      normalizePaginatedCollectionResponse(
+        {
+          total_count: 1,
+          designs: [
+            {
+              id: 'design-1',
+              user_id: 'user-1',
+              catalog_data: { type: 'pattern' },
+              pattern_file: 'apiVersion: v1',
+              created_at: '2026-05-08T00:00:00Z',
+              updated_at: '2026-05-08T01:00:00Z',
+            },
+          ],
+        },
+        'designs',
+        (design) => ({
+          ...design,
+          userId: design.userId ?? design.user_id,
+          catalogData: design.catalogData ?? design.catalog_data,
+          patternFile: design.patternFile ?? design.pattern_file,
+          createdAt: design.createdAt ?? design.created_at,
+          updatedAt: design.updatedAt ?? design.updated_at,
+        }),
+      ),
+    ).toEqual(
+      expect.objectContaining({
+        totalCount: 1,
+        designs: [
+          expect.objectContaining({
+            id: 'design-1',
+            userId: 'user-1',
+            catalogData: { type: 'pattern' },
+            patternFile: 'apiVersion: v1',
+            createdAt: '2026-05-08T00:00:00Z',
+            updatedAt: '2026-05-08T01:00:00Z',
+          }),
+        ],
+      }),
+    );
+  });
 });
 
 describe('normalizeKubernetesContextsResponse', () => {

--- a/ui/rtk-query/__tests__/userProfile.test.ts
+++ b/ui/rtk-query/__tests__/userProfile.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it } from 'vitest';
+import { normalizeUserProfileSummary } from '../userProfile';
+
+describe('normalizeUserProfileSummary', () => {
+  it('normalizes snake_case profile fields to camelCase', () => {
+    expect(
+      normalizeUserProfileSummary({
+        id: 'user-id',
+        email: 'owner@meshery.io',
+        user_id: 'user-id',
+        avatar_url: 'https://avatars.example.com/u/1',
+        first_name: 'Mesh',
+        last_name: 'Mate',
+      }),
+    ).toEqual({
+      id: 'user-id',
+      email: 'owner@meshery.io',
+      userId: 'user-id',
+      avatarUrl: 'https://avatars.example.com/u/1',
+      firstName: 'Mesh',
+      lastName: 'Mate',
+    });
+  });
+
+  it('preserves camelCase profile fields', () => {
+    expect(
+      normalizeUserProfileSummary({
+        id: 'user-id',
+        email: 'owner@meshery.io',
+        userId: 'user-id',
+        avatarUrl: 'https://avatars.example.com/u/1',
+        firstName: 'Mesh',
+        lastName: 'Mate',
+      }),
+    ).toEqual({
+      id: 'user-id',
+      email: 'owner@meshery.io',
+      userId: 'user-id',
+      avatarUrl: 'https://avatars.example.com/u/1',
+      firstName: 'Mesh',
+      lastName: 'Mate',
+    });
+  });
+
+  it('returns undefined for empty responses', () => {
+    expect(normalizeUserProfileSummary()).toBeUndefined();
+  });
+});

--- a/ui/rtk-query/ability.tsx
+++ b/ui/rtk-query/ability.tsx
@@ -104,7 +104,7 @@ const SelectedOrganizationProvider = ({ children }) => {
   const prefUpdatedToFallback = useRef(false);
   const isLoading = isFetchingSelectedOrg || isLoadingAbilities;
   const loadingDiagnosticsRef = useRef({
-    providerType: providerCapabilities?.provider_type,
+    providerType: providerCapabilities?.providerType,
     hasSelectedOrganization,
     selectedOrganizationId,
     didFallback,
@@ -116,7 +116,7 @@ const SelectedOrganizationProvider = ({ children }) => {
 
   useEffect(() => {
     loadingDiagnosticsRef.current = {
-      providerType: providerCapabilities?.provider_type,
+      providerType: providerCapabilities?.providerType,
       hasSelectedOrganization,
       selectedOrganizationId,
       didFallback,
@@ -126,7 +126,7 @@ const SelectedOrganizationProvider = ({ children }) => {
       errorLoadingAbilities,
     };
   }, [
-    providerCapabilities?.provider_type,
+    providerCapabilities?.providerType,
     hasSelectedOrganization,
     selectedOrganizationId,
     didFallback,
@@ -210,7 +210,7 @@ const SelectedOrganizationProvider = ({ children }) => {
   }
 
   const loaderMessage = showSlowLoadingNotice
-    ? `Still initializing your ${providerCapabilities?.provider_type === 'local' ? 'local provider session' : 'session'}. Waiting for ${formatPendingSessionBootstrapStep(
+    ? `Still initializing your ${providerCapabilities?.providerType === 'local' ? 'local provider session' : 'session'}. Waiting for ${formatPendingSessionBootstrapStep(
         {
           isFetchingSelectedOrg,
           isLoadingAbilities,

--- a/ui/rtk-query/meshModel.ts
+++ b/ui/rtk-query/meshModel.ts
@@ -166,7 +166,7 @@ export const useGetCategoriesSummary = () => {
         { category: category.name, params: { page: 1, pagesize: 1 } },
         true,
       );
-      categoryMap[category.name] = data?.total_count || 0;
+      categoryMap[category.name] = data?.totalCount ?? data?.total_count ?? 0;
     });
     await Promise.allSettled(requests);
     return categoryMap;

--- a/ui/rtk-query/meshModel.ts
+++ b/ui/rtk-query/meshModel.ts
@@ -2,6 +2,7 @@ import { useEffect, useState } from 'react';
 import { api, mesheryApiPath } from './index';
 import _ from 'lodash';
 import { initiateQuery } from './utils';
+import { normalizePaginatedCollectionResponse } from './transforms';
 
 const TAGS = {
   MESH_MODELS: 'mesh-models',
@@ -26,6 +27,7 @@ const meshModelApi = api
           url: mesheryApiPath(`meshmodels/models`),
           params: _.merge({}, defaultOptions, queryArgs.params),
         }),
+        transformResponse: (response) => normalizePaginatedCollectionResponse(response, 'models'),
         providesTags: () => [{ type: TAGS.MESH_MODELS }],
       }),
       getComponents: builder.query({
@@ -33,6 +35,8 @@ const meshModelApi = api
           url: mesheryApiPath(`meshmodels/components`),
           params: _.merge({}, defaultOptions, queryArgs.params),
         }),
+        transformResponse: (response) =>
+          normalizePaginatedCollectionResponse(response, 'components'),
         providesTags: () => [{ type: TAGS.MESH_MODELS }],
       }),
       getRelationships: builder.query({
@@ -40,6 +44,8 @@ const meshModelApi = api
           url: mesheryApiPath(`meshmodels/relationships`),
           params: _.merge({}, defaultOptions, queryArgs.params),
         }),
+        transformResponse: (response) =>
+          normalizePaginatedCollectionResponse(response, 'relationships'),
         providesTags: () => [{ type: TAGS.MESH_MODELS }],
       }),
       getRegistrants: builder.query({
@@ -47,6 +53,8 @@ const meshModelApi = api
           url: mesheryApiPath(`meshmodels/registrants`),
           params: _.merge({}, defaultOptions, queryArgs.params),
         }),
+        transformResponse: (response) =>
+          normalizePaginatedCollectionResponse(response, 'registrants'),
         providesTags: () => [{ type: TAGS.MESH_MODELS }],
       }),
       getComponentsFromModal: builder.query({
@@ -54,6 +62,8 @@ const meshModelApi = api
           url: mesheryApiPath(`meshmodels/models/${queryArgs.model}/components`),
           params: _.merge({}, defaultOptions, queryArgs.params),
         }),
+        transformResponse: (response) =>
+          normalizePaginatedCollectionResponse(response, 'components'),
         providesTags: () => [{ type: TAGS.MESH_MODELS }],
       }),
       getRelationshipsFromModal: builder.query({
@@ -61,6 +71,8 @@ const meshModelApi = api
           url: mesheryApiPath(`meshmodels/models/${queryArgs.model}/relationships`),
           params: _.merge({}, defaultOptions, queryArgs.params),
         }),
+        transformResponse: (response) =>
+          normalizePaginatedCollectionResponse(response, 'relationships'),
         providesTags: () => [{ type: TAGS.MESH_MODELS }],
       }),
       updateEntityStatus: builder.mutation({
@@ -83,6 +95,7 @@ const meshModelApi = api
           url: mesheryApiPath(`meshmodels/categories/${queryArgs.category}/models`),
           params: _.merge({}, defaultOptions, queryArgs.params),
         }),
+        transformResponse: (response) => normalizePaginatedCollectionResponse(response, 'models'),
         providesTags: () => [{ type: TAGS.MESH_MODELS }],
       }),
       getModelByName: builder.query({
@@ -166,7 +179,7 @@ export const useGetCategoriesSummary = () => {
         { category: category.name, params: { page: 1, pagesize: 1 } },
         true,
       );
-      categoryMap[category.name] = data?.totalCount ?? data?.total_count ?? 0;
+      categoryMap[category.name] = data?.totalCount ?? 0;
     });
     await Promise.allSettled(requests);
     return categoryMap;

--- a/ui/rtk-query/meshsync.ts
+++ b/ui/rtk-query/meshsync.ts
@@ -1,5 +1,6 @@
 import { urlEncodeParams } from '@/utils/utils';
 import { api, mesheryApiPath } from './index';
+import { normalizePaginatedCollectionResponse } from './transforms';
 
 const TAGS = {
   MESH_SYNC: 'meshsync',
@@ -33,6 +34,8 @@ const meshSyncApi = api
           },
           method: 'GET',
         }),
+        transformResponse: (response) =>
+          normalizePaginatedCollectionResponse(response, 'resources'),
         providesTags: () => [{ type: TAGS.MESH_SYNC }],
       }),
 

--- a/ui/rtk-query/system.ts
+++ b/ui/rtk-query/system.ts
@@ -1,4 +1,5 @@
 import { api, mesheryApiPath } from './index';
+import { normalizeKubernetesContextsResponse } from './transforms';
 
 const TAGS = {
   SYSTEM: 'system',
@@ -65,6 +66,7 @@ const systemApi = api.injectEndpoints({
         },
         method: 'GET',
       }),
+      transformResponse: normalizeKubernetesContextsResponse,
       providesTags: [TAGS.SYSTEM],
     }),
 

--- a/ui/rtk-query/transforms.ts
+++ b/ui/rtk-query/transforms.ts
@@ -1,0 +1,106 @@
+type PaginatedCollectionResponse<TCollectionKey extends string, TItem> = Partial<
+  Record<TCollectionKey, TItem[]>
+> & {
+  page?: number;
+  pageSize?: number;
+  page_size?: number;
+  totalCount?: number;
+  total_count?: number;
+};
+
+type ProviderCapabilitiesResponse = {
+  providerName?: string;
+  provider_name?: string;
+  providerType?: string;
+  provider_type?: string;
+  providerUrl?: string;
+  provider_url?: string;
+  providerDescription?: string[];
+  provider_description?: string[];
+  capabilities?: unknown[];
+  extensions?: Record<string, unknown>;
+  restrictedAccess?: Record<string, unknown>;
+  [key: string]: unknown;
+};
+
+type KubernetesContextResponse = {
+  totalCount?: number;
+  total_count?: number;
+  contexts?: Array<{
+    createdBy?: string;
+    created_by?: string;
+    mesheryInstanceId?: string;
+    meshery_instance_id?: string;
+    kubernetesServerId?: string;
+    kubernetes_server_id?: string;
+    deploymentType?: string;
+    deployment_type?: string;
+    updatedAt?: string;
+    updated_at?: string;
+    createdAt?: string;
+    created_at?: string;
+    connectionId?: string;
+    connection_id?: string;
+    isCurrentContext?: boolean;
+    is_current_context?: boolean;
+    [key: string]: unknown;
+  }>;
+  [key: string]: unknown;
+};
+
+export const normalizePaginatedCollectionResponse = <
+  TCollectionKey extends string,
+  TItem = unknown,
+>(
+  response: PaginatedCollectionResponse<TCollectionKey, TItem> | undefined,
+  collectionKey: TCollectionKey,
+) => {
+  if (!response || typeof response !== 'object') {
+    return response;
+  }
+
+  return {
+    ...response,
+    pageSize: response.pageSize ?? response.page_size,
+    totalCount: response.totalCount ?? response.total_count,
+    [collectionKey]: Array.isArray(response[collectionKey]) ? response[collectionKey] : [],
+  };
+};
+
+export const normalizeProviderCapabilities = (response?: ProviderCapabilitiesResponse) => {
+  if (!response || typeof response !== 'object') {
+    return undefined;
+  }
+
+  return {
+    ...response,
+    providerName: response.providerName ?? response.provider_name,
+    providerType: response.providerType ?? response.provider_type,
+    providerUrl: response.providerUrl ?? response.provider_url,
+    providerDescription: response.providerDescription ?? response.provider_description,
+  };
+};
+
+export const normalizeKubernetesContextsResponse = (response?: KubernetesContextResponse) => {
+  if (!response || typeof response !== 'object') {
+    return undefined;
+  }
+
+  return {
+    ...response,
+    totalCount: response.totalCount ?? response.total_count,
+    contexts: Array.isArray(response.contexts)
+      ? response.contexts.map((context) => ({
+          ...context,
+          createdBy: context.createdBy ?? context.created_by,
+          mesheryInstanceId: context.mesheryInstanceId ?? context.meshery_instance_id,
+          kubernetesServerId: context.kubernetesServerId ?? context.kubernetes_server_id,
+          deploymentType: context.deploymentType ?? context.deployment_type,
+          updatedAt: context.updatedAt ?? context.updated_at,
+          createdAt: context.createdAt ?? context.created_at,
+          connectionId: context.connectionId ?? context.connection_id,
+          isCurrentContext: context.isCurrentContext ?? context.is_current_context,
+        }))
+      : [],
+  };
+};

--- a/ui/rtk-query/transforms.ts
+++ b/ui/rtk-query/transforms.ts
@@ -51,19 +51,23 @@ type KubernetesContextResponse = {
 export const normalizePaginatedCollectionResponse = <
   TCollectionKey extends string,
   TItem = unknown,
+  TNormalizedItem = TItem,
 >(
   response: PaginatedCollectionResponse<TCollectionKey, TItem> | undefined,
   collectionKey: TCollectionKey,
+  itemMapper?: (item: TItem) => TNormalizedItem,
 ) => {
   if (!response || typeof response !== 'object') {
     return response;
   }
 
+  const items = Array.isArray(response[collectionKey]) ? response[collectionKey] : [];
+
   return {
     ...response,
     pageSize: response.pageSize ?? response.page_size,
     totalCount: response.totalCount ?? response.total_count,
-    [collectionKey]: Array.isArray(response[collectionKey]) ? response[collectionKey] : [],
+    [collectionKey]: itemMapper ? items.map(itemMapper) : items,
   };
 };
 

--- a/ui/rtk-query/user.ts
+++ b/ui/rtk-query/user.ts
@@ -9,6 +9,8 @@ import { initiateQuery } from './utils';
 import { useGetOrgsQuery } from './organization';
 import { useGetWorkspacesQuery } from './workspace';
 import { normalizeLoadTestPrefs } from '../lib/load-test-prefs';
+import { normalizeProviderCapabilities } from './transforms';
+import { normalizeUserProfileSummary } from './userProfile';
 
 const Tags = {
   USER_PREF: 'userPref',
@@ -108,6 +110,7 @@ export const userApi = api
       getProviderCapabilities: builder.query({
         query: () => '/api/provider/capabilities',
         method: 'GET',
+        transformResponse: normalizeProviderCapabilities,
       }),
       getUserProfileSummaryById: builder.query({
         query: (queryArg) => ({
@@ -129,19 +132,7 @@ export const userApi = api
             }
           },
         }),
-        transformResponse: (response) => {
-          if (!response || typeof response !== 'object') {
-            return undefined;
-          }
-          return {
-            id: response.id,
-            email: response.email,
-            user_id: response.user_id,
-            avatar_url: response.avatar_url,
-            first_name: response.first_name,
-            last_name: response.last_name,
-          };
-        },
+        transformResponse: normalizeUserProfileSummary,
       }),
       getExtensionsByType: builder.query({
         query: () => ({

--- a/ui/rtk-query/user.ts
+++ b/ui/rtk-query/user.ts
@@ -103,6 +103,7 @@ export const userApi = api
           url: '/api/user',
           method: 'GET',
         }),
+        transformResponse: normalizeUserProfileSummary,
         // All callers share one cache entry per user session (client-side Redux store).
         // This does not affect other users—each browser has its own isolated store.
         serializeQueryArgs: ({ endpointName }) => endpointName,

--- a/ui/rtk-query/userProfile.ts
+++ b/ui/rtk-query/userProfile.ts
@@ -1,0 +1,27 @@
+type UserProfileSummaryResponse = {
+  id?: string;
+  email?: string;
+  userId?: string;
+  user_id?: string;
+  avatarUrl?: string;
+  avatar_url?: string;
+  firstName?: string;
+  first_name?: string;
+  lastName?: string;
+  last_name?: string;
+};
+
+export const normalizeUserProfileSummary = (response?: UserProfileSummaryResponse) => {
+  if (!response || typeof response !== 'object') {
+    return undefined;
+  }
+
+  return {
+    id: response.id ?? response.userId ?? response.user_id,
+    email: response.email,
+    userId: response.userId ?? response.user_id ?? response.id,
+    avatarUrl: response.avatarUrl ?? response.avatar_url,
+    firstName: response.firstName ?? response.first_name,
+    lastName: response.lastName ?? response.last_name,
+  };
+};

--- a/ui/rtk-query/workspace.ts
+++ b/ui/rtk-query/workspace.ts
@@ -2,6 +2,8 @@ import { urlEncodeParams } from '@/utils/utils';
 import { mesheryApi } from '@meshery/schemas/mesheryApi';
 import { api, mesheryApiPath } from './index';
 import _ from 'lodash';
+import { normalizePaginatedCollectionResponse } from './transforms';
+import { normalizeUserProfileSummary } from './userProfile';
 
 const TAGS = {
   WORKSPACES: 'workspaces',
@@ -64,10 +66,11 @@ const workspacesApi = api
 
                 return {
                   ...workspace,
-                  designCount: designs.data?.total_count || 0,
-                  environmentCount: environments.data?.total_count || 0,
-                  viewCount: views.data?.total_count || 0,
-                  teamCount: teams.data?.total_count || 0,
+                  designCount: designs.data?.totalCount ?? designs.data?.total_count ?? 0,
+                  environmentCount:
+                    environments.data?.totalCount ?? environments.data?.total_count ?? 0,
+                  viewCount: views.data?.totalCount ?? views.data?.total_count ?? 0,
+                  teamCount: teams.data?.totalCount ?? teams.data?.total_count ?? 0,
                 };
               }),
             );
@@ -124,26 +127,33 @@ const workspacesApi = api
             url: mesheryApiPath(`workspaces/${queryArgs.workspaceId}/designs?${params}`),
             method: 'GET',
           });
-          if (expandUser && designs.data && !designs.error) {
-            const withUsersPromises = designs.data.designs.map(async (design) => {
+          const normalizedDesigns =
+            designs.data && !designs.error
+              ? { ...designs, data: normalizePaginatedCollectionResponse(designs.data, 'designs') }
+              : designs;
+          if (expandUser && normalizedDesigns.data && !normalizedDesigns.error) {
+            const withUsersPromises = normalizedDesigns.data.designs.map(async (design) => {
               const user = await dispatch(
-                mesheryApi.endpoints.getUserProfileById.initiate({ id: design.user_id }),
+                mesheryApi.endpoints.getUserProfileById.initiate({
+                  id: design.userId ?? design.user_id,
+                }),
               );
+              const normalizedUser = normalizeUserProfileSummary(user.data);
               return {
                 ...design,
-                first_name: user.data?.first_name || '[deleted]',
-                last_name: user.data?.last_name || '',
-                avatar_url: user.data?.avatar_url || '',
-                user_id: user.data?.id || '',
-                email: user.data?.email || '',
+                firstName: normalizedUser?.firstName || '[deleted]',
+                lastName: normalizedUser?.lastName || '',
+                avatarUrl: normalizedUser?.avatarUrl || '',
+                userId: normalizedUser?.id || design.userId || design.user_id || '',
+                email: normalizedUser?.email || '',
               };
             });
 
             const modifiedDesigns = await Promise.all(withUsersPromises);
-            return _.merge({}, designs, { data: { designs: modifiedDesigns } });
+            return _.merge({}, normalizedDesigns, { data: { designs: modifiedDesigns } });
           }
 
-          return designs;
+          return normalizedDesigns;
         },
         serializeQueryArgs: ({ endpointName, queryArgs }) => {
           if (queryArgs?.infiniteScroll) {
@@ -198,25 +208,32 @@ const workspacesApi = api
             ),
             method: 'GET',
           });
-          if (expandUser && views.data && !views.error) {
-            const withUsersPromises = views.data.views.map(async (view) => {
+          const normalizedViews =
+            views.data && !views.error
+              ? { ...views, data: normalizePaginatedCollectionResponse(views.data, 'views') }
+              : views;
+          if (expandUser && normalizedViews.data && !normalizedViews.error) {
+            const withUsersPromises = normalizedViews.data.views.map(async (view) => {
               const user = await dispatch(
-                mesheryApi.endpoints.getUserProfileById.initiate({ id: view.user_id }),
+                mesheryApi.endpoints.getUserProfileById.initiate({
+                  id: view.userId ?? view.user_id,
+                }),
               );
+              const normalizedUser = normalizeUserProfileSummary(user.data);
               return {
                 ...view,
-                first_name: user.data?.first_name || '[deleted]',
-                last_name: user.data?.last_name || '',
-                avatar_url: user.data?.avatar_url || '',
-                user_id: user.data?.id || '',
-                email: user.data?.email || '',
+                firstName: normalizedUser?.firstName || '[deleted]',
+                lastName: normalizedUser?.lastName || '',
+                avatarUrl: normalizedUser?.avatarUrl || '',
+                userId: normalizedUser?.id || view.userId || view.user_id || '',
+                email: normalizedUser?.email || '',
               };
             });
             const modifiedViews = await Promise.all(withUsersPromises);
-            return _.merge({}, views, { data: { views: modifiedViews } });
+            return _.merge({}, normalizedViews, { data: { views: modifiedViews } });
           }
 
-          return views;
+          return normalizedViews;
         },
         serializeQueryArgs: ({ endpointName, queryArgs }) => {
           if (queryArgs?.infiniteScroll) {

--- a/ui/rtk-query/workspace.ts
+++ b/ui/rtk-query/workspace.ts
@@ -12,6 +12,17 @@ const TAGS = {
   VIEWS: 'workspaces_views',
   TEAMS: 'workspaces_teams',
 };
+
+const normalizeWorkspaceResource = (resource) => ({
+  ...resource,
+  userId: resource?.userId ?? resource?.user_id,
+  catalogData: resource?.catalogData ?? resource?.catalog_data,
+  patternFile: resource?.patternFile ?? resource?.pattern_file,
+  designFile: resource?.designFile ?? resource?.design_file,
+  createdAt: resource?.createdAt ?? resource?.created_at,
+  updatedAt: resource?.updatedAt ?? resource?.updated_at,
+});
+
 const workspacesApi = api
   .enhanceEndpoints({
     addTagTypes: [TAGS.WORKSPACES, TAGS.DESIGNS, TAGS.ENVIRONMENTS, TAGS.VIEWS, TAGS.TEAMS],
@@ -129,13 +140,20 @@ const workspacesApi = api
           });
           const normalizedDesigns =
             designs.data && !designs.error
-              ? { ...designs, data: normalizePaginatedCollectionResponse(designs.data, 'designs') }
+              ? {
+                  ...designs,
+                  data: normalizePaginatedCollectionResponse(
+                    designs.data,
+                    'designs',
+                    normalizeWorkspaceResource,
+                  ),
+                }
               : designs;
           if (expandUser && normalizedDesigns.data && !normalizedDesigns.error) {
             const withUsersPromises = normalizedDesigns.data.designs.map(async (design) => {
               const user = await dispatch(
                 mesheryApi.endpoints.getUserProfileById.initiate({
-                  id: design.userId ?? design.user_id,
+                  id: design.userId,
                 }),
               );
               const normalizedUser = normalizeUserProfileSummary(user.data);
@@ -144,7 +162,7 @@ const workspacesApi = api
                 firstName: normalizedUser?.firstName || '[deleted]',
                 lastName: normalizedUser?.lastName || '',
                 avatarUrl: normalizedUser?.avatarUrl || '',
-                userId: normalizedUser?.id || design.userId || design.user_id || '',
+                userId: normalizedUser?.id || design.userId || '',
                 email: normalizedUser?.email || '',
               };
             });
@@ -210,13 +228,20 @@ const workspacesApi = api
           });
           const normalizedViews =
             views.data && !views.error
-              ? { ...views, data: normalizePaginatedCollectionResponse(views.data, 'views') }
+              ? {
+                  ...views,
+                  data: normalizePaginatedCollectionResponse(
+                    views.data,
+                    'views',
+                    normalizeWorkspaceResource,
+                  ),
+                }
               : views;
           if (expandUser && normalizedViews.data && !normalizedViews.error) {
             const withUsersPromises = normalizedViews.data.views.map(async (view) => {
               const user = await dispatch(
                 mesheryApi.endpoints.getUserProfileById.initiate({
-                  id: view.userId ?? view.user_id,
+                  id: view.userId,
                 }),
               );
               const normalizedUser = normalizeUserProfileSummary(user.data);
@@ -225,7 +250,7 @@ const workspacesApi = api
                 firstName: normalizedUser?.firstName || '[deleted]',
                 lastName: normalizedUser?.lastName || '',
                 avatarUrl: normalizedUser?.avatarUrl || '',
-                userId: normalizedUser?.id || view.userId || view.user_id || '',
+                userId: normalizedUser?.id || view.userId || '',
                 email: normalizedUser?.email || '',
               };
             });


### PR DESCRIPTION
## Summary
- fix #19200 by normalizing user profile summary data to the camelCase shape expected by the designs UI
- normalize RTK response boundaries for provider capabilities, workspace collections, MeshSync resources, and Kubernetes contexts
- update affected UI consumers and add focused RTK/meshSync test coverage

## Notes
- leaves intentional snake_case GraphQL fields, backend query params, and legacy compatibility fallbacks intact where they are part of the API contract

## Testing
- targeted UI linting and Vitest coverage for the touched casing paths