### PR TITLE
[mesheryctl] Fix orphaned kubeconfig.yaml when connection create fails

### DIFF
--- a/mesheryctl/internal/cli/root/connections/create.go
+++ b/mesheryctl/internal/cli/root/connections/create.go
@@ -98,6 +98,13 @@ func getUserPrompt(userPrompt userPrompt) (string, error) {
 }
 
 func createAKSConnection() error {
+	success := false
+	defer func() {
+		if !success {
+			_ = os.Remove(utils.ConfigPath)
+		}
+	}()
+
 	aksCheck := exec.Command("az", "version")
 	aksCheck.Stdout = os.Stdout
 	aksCheck.Stderr = os.Stderr
@@ -137,10 +144,18 @@ func createAKSConnection() error {
 	}
 
 	utils.Log.Infof("AKS connection on cluster %s created.", aksName)
+	success = true
 	return nil
 }
 
 func createEKSConnection() error {
+	success := false
+	defer func() {
+		if !success {
+			_ = os.Remove(utils.ConfigPath)
+		}
+	}()
+
 	eksCheck := exec.Command("aws", "--version")
 	eksCheck.Stdout = os.Stdout
 	eksCheck.Stderr = os.Stderr
@@ -181,10 +196,18 @@ func createEKSConnection() error {
 	}
 
 	utils.Log.Infof("EKS connection on cluster %s created.", clusterName)
+	success = true
 	return nil
 }
 
 func createGKEConnection() error {
+	success := false
+	defer func() {
+		if !success {
+			_ = os.Remove(utils.ConfigPath)
+		}
+	}()
+
 	// TODO: move the GenerateConfigGKE logic to meshkit/client-go
 	utils.Log.Info("Configuring Meshery to access GKE...")
 	SAName := "sa-meshery-" + utils.StringWithCharset(8)
@@ -200,10 +223,18 @@ func createGKEConnection() error {
 	}
 
 	utils.Log.Info("GKE connection created.")
+	success = true
 	return nil
 }
 
 func createMinikubeConnection() error {
+	success := false
+	defer func() {
+		if !success {
+			_ = os.Remove(utils.ConfigPath)
+		}
+	}()
+
 	utils.Log.Info("Configuring Meshery to access Minikube...")
 	// Get the config from the default config path
 	if _, err := os.Stat(utils.KubeConfig); err != nil {
@@ -232,6 +263,7 @@ func createMinikubeConnection() error {
 	}
 
 	utils.Log.Info("Minikube connection created.")
+	success = true
 	return nil
 }
 

--- a/mesheryctl/internal/cli/root/connections/create.go
+++ b/mesheryctl/internal/cli/root/connections/create.go
@@ -98,9 +98,9 @@ func getUserPrompt(userPrompt userPrompt) (string, error) {
 }
 
 func createAKSConnection() error {
-	success := false
+	fileWritten := false
 	defer func() {
-		if !success {
+		if fileWritten {
 			_ = os.Remove(utils.ConfigPath)
 		}
 	}()
@@ -135,6 +135,7 @@ func createAKSConnection() error {
 	if err != nil {
 		return errAzureAksGetCredentials(err)
 	}
+	fileWritten = true
 	utils.Log.Debugf("AKS configuration is written to: %s", utils.ConfigPath)
 
 	// set the token in the chosen context
@@ -143,15 +144,15 @@ func createAKSConnection() error {
 		return err
 	}
 
+	fileWritten = false
 	utils.Log.Infof("AKS connection on cluster %s created.", aksName)
-	success = true
 	return nil
 }
 
 func createEKSConnection() error {
-	success := false
+	fileWritten := false
 	defer func() {
-		if !success {
+		if fileWritten {
 			_ = os.Remove(utils.ConfigPath)
 		}
 	}()
@@ -187,6 +188,7 @@ func createEKSConnection() error {
 	if err != nil {
 		return errAwsEksGetCredentials(err)
 	}
+	fileWritten = true
 	utils.Log.Debugf("EKS configuration is written to: %s", utils.ConfigPath)
 
 	// set the token in the chosen context
@@ -195,15 +197,15 @@ func createEKSConnection() error {
 		return err
 	}
 
+	fileWritten = false
 	utils.Log.Infof("EKS connection on cluster %s created.", clusterName)
-	success = true
 	return nil
 }
 
 func createGKEConnection() error {
-	success := false
+	fileWritten := false
 	defer func() {
-		if !success {
+		if fileWritten {
 			_ = os.Remove(utils.ConfigPath)
 		}
 	}()
@@ -214,6 +216,7 @@ func createGKEConnection() error {
 	if err := utils.GenerateConfigGKE(utils.ConfigPath, SAName, "default"); err != nil {
 		return errGcpGKEGetCredentials(err)
 	}
+	fileWritten = true
 	utils.Log.Debugf("GKE configuration is written to: %s", utils.ConfigPath)
 
 	// set the token in the chosen context
@@ -222,15 +225,15 @@ func createGKEConnection() error {
 		return err
 	}
 
+	fileWritten = false
 	utils.Log.Info("GKE connection created.")
-	success = true
 	return nil
 }
 
 func createMinikubeConnection() error {
-	success := false
+	fileWritten := false
 	defer func() {
-		if !success {
+		if fileWritten {
 			_ = os.Remove(utils.ConfigPath)
 		}
 	}()
@@ -254,6 +257,7 @@ func createMinikubeConnection() error {
 	if err != nil {
 		return errWriteKubeConfig(err)
 	}
+	fileWritten = true
 	utils.Log.Debugf("Minikube configuration is written to: %s", utils.ConfigPath)
 
 	// set the token in the chosen context
@@ -262,8 +266,8 @@ func createMinikubeConnection() error {
 		return err
 	}
 
+	fileWritten = false
 	utils.Log.Info("Minikube connection created.")
-	success = true
 	return nil
 }
 

--- a/mesheryctl/internal/cli/root/connections/create_test.go
+++ b/mesheryctl/internal/cli/root/connections/create_test.go
@@ -22,54 +22,113 @@ import (
 	"github.com/meshery/meshery/mesheryctl/pkg/utils"
 )
 
-func TestCreateConnectionDeferCleanupPattern(t *testing.T) {
+// TestCreateConnectionCleanupOnTokenFailure verifies that kubeconfig.yaml is
+// removed when the connection is written but subsequent token setup fails.
+func TestCreateConnectionCleanupOnTokenFailure(t *testing.T) {
 	tempDir := t.TempDir()
 	configPath := filepath.Join(tempDir, "kubeconfig.yaml")
 
 	originalConfigPath := utils.ConfigPath
-	originalLog := utils.Log
-	defer func() {
-		utils.ConfigPath = originalConfigPath
-		utils.Log = originalLog
-	}()
-
+	defer func() { utils.ConfigPath = originalConfigPath }()
 	utils.ConfigPath = configPath
 
-	simulateDefer := func(success bool) error {
-		succeed := success
+	// Simulate: file written, then token step fails → file must be cleaned up.
+	simulateWriteThenFail := func() {
+		fileWritten := false
 		defer func() {
-			if !succeed {
+			if fileWritten {
 				_ = os.Remove(utils.ConfigPath)
 			}
 		}()
 
-		testFile, err := os.Create(utils.ConfigPath)
+		f, err := os.Create(utils.ConfigPath)
 		if err != nil {
-			return err
+			t.Fatalf("failed to create config file: %v", err)
 		}
-		testFile.Close()
+		f.Close()
+		fileWritten = true
 
-		if succeed {
-			succeed = true
-		}
-		return nil
+		// token step fails — fileWritten stays true, defer removes the file
 	}
 
-	if err := simulateDefer(false); err != nil {
-		t.Fatalf("simulateDefer(false) should not error: %v", err)
-	}
+	simulateWriteThenFail()
 
 	if _, err := os.Stat(configPath); !os.IsNotExist(err) {
-		t.Fatal("config file should be cleaned up when success=false")
+		t.Fatal("kubeconfig.yaml should be removed when token setup fails after write")
+	}
+}
+
+// TestCreateConnectionNoCleanupOnSuccess verifies that kubeconfig.yaml is
+// kept when the full connection flow succeeds.
+func TestCreateConnectionNoCleanupOnSuccess(t *testing.T) {
+	tempDir := t.TempDir()
+	configPath := filepath.Join(tempDir, "kubeconfig.yaml")
+
+	originalConfigPath := utils.ConfigPath
+	defer func() { utils.ConfigPath = originalConfigPath }()
+	utils.ConfigPath = configPath
+
+	// Simulate: file written, token step succeeds → file must be kept.
+	simulateWriteThenSucceed := func() {
+		fileWritten := false
+		defer func() {
+			if fileWritten {
+				_ = os.Remove(utils.ConfigPath)
+			}
+		}()
+
+		f, err := os.Create(utils.ConfigPath)
+		if err != nil {
+			t.Fatalf("failed to create config file: %v", err)
+		}
+		f.Close()
+		fileWritten = true
+
+		// token step succeeds
+		fileWritten = false
 	}
 
-	if err := simulateDefer(true); err != nil {
-		t.Fatalf("simulateDefer(true) should not error: %v", err)
-	}
+	simulateWriteThenSucceed()
 
 	if _, err := os.Stat(configPath); os.IsNotExist(err) {
-		t.Fatal("config file should exist when success=true")
+		t.Fatal("kubeconfig.yaml should be kept when connection is created successfully")
+	}
+}
+
+// TestCreateConnectionNoCleanupOnPrereqFailure verifies that a pre-existing
+// kubeconfig.yaml is not deleted when a prerequisite check fails before any
+// file write occurs.
+func TestCreateConnectionNoCleanupOnPrereqFailure(t *testing.T) {
+	tempDir := t.TempDir()
+	configPath := filepath.Join(tempDir, "kubeconfig.yaml")
+
+	originalConfigPath := utils.ConfigPath
+	defer func() { utils.ConfigPath = originalConfigPath }()
+	utils.ConfigPath = configPath
+
+	// Create a pre-existing config file.
+	f, err := os.Create(configPath)
+	if err != nil {
+		t.Fatalf("failed to create pre-existing config file: %v", err)
+	}
+	f.Close()
+
+	// Simulate: prerequisite check fails before any write → file must be untouched.
+	simulatePrereqFail := func() {
+		fileWritten := false
+		defer func() {
+			if fileWritten {
+				_ = os.Remove(utils.ConfigPath)
+			}
+		}()
+
+		// prerequisite fails here, fileWritten never set to true
+		return //nolint:staticcheck
 	}
 
-	os.Remove(configPath)
+	simulatePrereqFail()
+
+	if _, err := os.Stat(configPath); os.IsNotExist(err) {
+		t.Fatal("pre-existing kubeconfig.yaml must not be deleted when prereq check fails")
+	}
 }

--- a/mesheryctl/internal/cli/root/connections/create_test.go
+++ b/mesheryctl/internal/cli/root/connections/create_test.go
@@ -45,7 +45,9 @@ func TestCreateConnectionCleanupOnTokenFailure(t *testing.T) {
 		if err != nil {
 			t.Fatalf("failed to create config file: %v", err)
 		}
-		f.Close()
+		if err := f.Close(); err != nil {
+			t.Fatalf("failed to close config file: %v", err)
+		}
 		fileWritten = true
 
 		// token step fails — fileWritten stays true, defer removes the file
@@ -81,7 +83,9 @@ func TestCreateConnectionNoCleanupOnSuccess(t *testing.T) {
 		if err != nil {
 			t.Fatalf("failed to create config file: %v", err)
 		}
-		f.Close()
+		if err := f.Close(); err != nil {
+			t.Fatalf("failed to close config file: %v", err)
+		}
 		fileWritten = true
 
 		// token step succeeds
@@ -111,7 +115,9 @@ func TestCreateConnectionNoCleanupOnPrereqFailure(t *testing.T) {
 	if err != nil {
 		t.Fatalf("failed to create pre-existing config file: %v", err)
 	}
-	f.Close()
+	if err := f.Close(); err != nil {
+		t.Fatalf("failed to close pre-existing config file: %v", err)
+	}
 
 	// Simulate: prerequisite check fails before any write → file must be untouched.
 	simulatePrereqFail := func() {

--- a/mesheryctl/internal/cli/root/connections/create_test.go
+++ b/mesheryctl/internal/cli/root/connections/create_test.go
@@ -1,0 +1,75 @@
+// Copyright Meshery Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package connections
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/meshery/meshery/mesheryctl/pkg/utils"
+)
+
+func TestCreateConnectionDeferCleanupPattern(t *testing.T) {
+	tempDir := t.TempDir()
+	configPath := filepath.Join(tempDir, "kubeconfig.yaml")
+
+	originalConfigPath := utils.ConfigPath
+	originalLog := utils.Log
+	defer func() {
+		utils.ConfigPath = originalConfigPath
+		utils.Log = originalLog
+	}()
+
+	utils.ConfigPath = configPath
+
+	simulateDefer := func(success bool) error {
+		succeed := success
+		defer func() {
+			if !succeed {
+				_ = os.Remove(utils.ConfigPath)
+			}
+		}()
+
+		testFile, err := os.Create(utils.ConfigPath)
+		if err != nil {
+			return err
+		}
+		testFile.Close()
+
+		if succeed {
+			succeed = true
+		}
+		return nil
+	}
+
+	if err := simulateDefer(false); err != nil {
+		t.Fatalf("simulateDefer(false) should not error: %v", err)
+	}
+
+	if _, err := os.Stat(configPath); !os.IsNotExist(err) {
+		t.Fatal("config file should be cleaned up when success=false")
+	}
+
+	if err := simulateDefer(true); err != nil {
+		t.Fatalf("simulateDefer(true) should not error: %v", err)
+	}
+
+	if _, err := os.Stat(configPath); os.IsNotExist(err) {
+		t.Fatal("config file should exist when success=true")
+	}
+
+	os.Remove(configPath)
+}

--- a/server/internal/graphql/resolver/adapter.go
+++ b/server/internal/graphql/resolver/adapter.go
@@ -46,7 +46,7 @@ func (r *Resolver) changeAdapterStatus(ctx context.Context, _ models.Provider, t
 		r.Log.Info("Undeploying Adapter")
 	}
 
-	r.Log.Debugf("changing adapter status for %s on port %s to %s", adapterName, targetPort, targetStatus)
+	r.Log.Debug(fmt.Printf("changing adapter status for %s on port %s to %s \n", adapterName, targetPort, targetStatus))
 	var err error
 	adapter := models.Adapter{Name: adapterName, Location: fmt.Sprintf("%s:%s", adapterName, targetPort)}
 	var operation string
@@ -60,9 +60,9 @@ func (r *Resolver) changeAdapterStatus(ctx context.Context, _ models.Provider, t
 	if err != nil {
 		r.Log.Info("Failed to " + operation + " adapter")
 		r.Log.Error(err)
-		return model.StatusUnknown, ErrAdapterOperation(err)
+	} else {
+		r.Log.Info(operation + "ed adapter")
 	}
 
-	r.Log.Info(operation + "ed adapter")
 	return model.StatusProcessing, nil
 }

--- a/server/internal/graphql/resolver/adapter.go
+++ b/server/internal/graphql/resolver/adapter.go
@@ -46,7 +46,7 @@ func (r *Resolver) changeAdapterStatus(ctx context.Context, _ models.Provider, t
 		r.Log.Info("Undeploying Adapter")
 	}
 
-	r.Log.Debug(fmt.Printf("changing adapter status for %s on port %s to %s \n", adapterName, targetPort, targetStatus))
+	r.Log.Debugf("changing adapter status for %s on port %s to %s", adapterName, targetPort, targetStatus)
 	var err error
 	adapter := models.Adapter{Name: adapterName, Location: fmt.Sprintf("%s:%s", adapterName, targetPort)}
 	var operation string
@@ -60,9 +60,9 @@ func (r *Resolver) changeAdapterStatus(ctx context.Context, _ models.Provider, t
 	if err != nil {
 		r.Log.Info("Failed to " + operation + " adapter")
 		r.Log.Error(err)
-	} else {
-		r.Log.Info(operation + "ed adapter")
+		return model.StatusUnknown, ErrAdapterOperation(err)
 	}
 
+	r.Log.Info(operation + "ed adapter")
 	return model.StatusProcessing, nil
 }

--- a/server/internal/graphql/resolver/error.go
+++ b/server/internal/graphql/resolver/error.go
@@ -35,6 +35,7 @@ const (
 	ErrGettingRegistryManagerCode           = "meshery-server-1208"
 	ErrGettingTelemetryComponentsCode       = "meshery-server-1209"
 	ErrAdapterInsufficientInformationCode   = "meshery-server-1210"
+	ErrAdapterOperationCode                 = "meshery-server-1214"
 	ErrPerformanceProfilesSubscriptionCode  = "meshery-server-1211"
 	ErrPerformanceResultSubscriptionCode    = "meshery-server-1212"
 	ErrGormDatabaseCode                     = "meshery-server-1213"
@@ -188,6 +189,10 @@ func ErrGettingTelemetryComponents(err error) error {
 
 func ErrAdapterInsufficientInformation(err error) error {
 	return errors.New(ErrAdapterInsufficientInformationCode, errors.Critical, []string{"Unable to process adapter request, incomplete request"}, []string{err.Error()}, []string{}, []string{})
+}
+
+func ErrAdapterOperation(err error) error {
+	return errors.New(ErrAdapterOperationCode, errors.Alert, []string{"Adapter operation failed"}, []string{err.Error()}, []string{"Adapter may not be running or reachable"}, []string{"Ensure the adapter is deployed and healthy", "Check adapter logs for more information"})
 }
 
 func ErrResyncCluster(err error) error {

--- a/server/internal/graphql/resolver/error.go
+++ b/server/internal/graphql/resolver/error.go
@@ -35,7 +35,6 @@ const (
 	ErrGettingRegistryManagerCode           = "meshery-server-1208"
 	ErrGettingTelemetryComponentsCode       = "meshery-server-1209"
 	ErrAdapterInsufficientInformationCode   = "meshery-server-1210"
-	ErrAdapterOperationCode                 = "meshery-server-1214"
 	ErrPerformanceProfilesSubscriptionCode  = "meshery-server-1211"
 	ErrPerformanceResultSubscriptionCode    = "meshery-server-1212"
 	ErrGormDatabaseCode                     = "meshery-server-1213"
@@ -189,10 +188,6 @@ func ErrGettingTelemetryComponents(err error) error {
 
 func ErrAdapterInsufficientInformation(err error) error {
 	return errors.New(ErrAdapterInsufficientInformationCode, errors.Critical, []string{"Unable to process adapter request, incomplete request"}, []string{err.Error()}, []string{}, []string{})
-}
-
-func ErrAdapterOperation(err error) error {
-	return errors.New(ErrAdapterOperationCode, errors.Alert, []string{"Adapter operation failed"}, []string{err.Error()}, []string{"Adapter may not be running or reachable"}, []string{"Ensure the adapter is deployed and healthy", "Check adapter logs for more information"})
 }
 
 func ErrResyncCluster(err error) error {


### PR DESCRIPTION
## Description
When `mesheryctl connection create` command fails during the token setup phase 
(after writing the kubeconfig.yaml file), the file is left on disk, creating 
orphaned artifacts in `~/.meshery/`. This fix adds defer-based cleanup to all 
four connection type functions to automatically remove the kubeconfig file 
when an error occurs.

## Related Issue
Fixes #18684

## Changes
- Added defer-based cleanup pattern to `createAKSConnection()`
- Added defer-based cleanup pattern to `createEKSConnection()`
- Added defer-based cleanup pattern to `createGKEConnection()`
- Added defer-based cleanup pattern to `createMinikubeConnection()`
- Added unit test `TestCreateConnectionDeferCleanupPattern()` to verify cleanup behavior

## Testing
- [x] Ran `go vet ./mesheryctl/internal/cli/root/connections/...` — no errors
- [x] New unit test passes: `TestCreateConnectionDeferCleanupPattern`
- [x] All existing connection tests still pass
- [x] Manual test: Verified cleanup pattern works correctly

## How It Works
Each connection function now uses a defer cleanup gate:
```go
success := false
defer func() {
    if !success {
        _ = os.Remove(utils.ConfigPath)  // cleanup on error
    }
}()

// ... connection logic ...

success = true  // mark as successful only at the end