### PR TITLE
[Server] Add timeout for remote provider capabilities fetch

### DIFF
--- a/server/internal/graphql/resolver/adapter.go
+++ b/server/internal/graphql/resolver/adapter.go
@@ -59,7 +59,7 @@ func (r *Resolver) changeAdapterStatus(ctx context.Context, _ models.Provider, t
 	}
 	if err != nil {
 		r.Log.Error(fmt.Errorf("failed to %s adapter: %w", operation, err))
-		return model.StatusUnknown, err
+		return model.StatusUnknown, fmt.Errorf("failed to %s adapter", operation)
 	}
 	r.Log.Info(fmt.Sprintf("%sed adapter", operation))
 

--- a/server/internal/graphql/resolver/adapter.go
+++ b/server/internal/graphql/resolver/adapter.go
@@ -46,7 +46,7 @@ func (r *Resolver) changeAdapterStatus(ctx context.Context, _ models.Provider, t
 		r.Log.Info("Undeploying Adapter")
 	}
 
-	r.Log.Debug(fmt.Printf("changing adapter status for %s on port %s to %s \n", adapterName, targetPort, targetStatus))
+	r.Log.Debugf("changing adapter status for %s on port %s to %s", adapterName, targetPort, targetStatus)
 	var err error
 	adapter := models.Adapter{Name: adapterName, Location: fmt.Sprintf("%s:%s", adapterName, targetPort)}
 	var operation string
@@ -58,11 +58,10 @@ func (r *Resolver) changeAdapterStatus(ctx context.Context, _ models.Provider, t
 		err = r.Config.AdapterTracker.DeployAdapter(ctx, adapter)
 	}
 	if err != nil {
-		r.Log.Info("Failed to " + operation + " adapter")
-		r.Log.Error(err)
-	} else {
-		r.Log.Info(operation + "ed adapter")
+		r.Log.Error(fmt.Errorf("failed to %s adapter: %w", operation, err))
+		return model.StatusUnknown, err
 	}
+	r.Log.Info(fmt.Sprintf("%sed adapter", operation))
 
 	return model.StatusProcessing, nil
 }

--- a/server/models/error.go
+++ b/server/models/error.go
@@ -306,7 +306,7 @@ func ErrRemoteProviderCapabilities(err error) error {
 		ErrRemoteProviderCapabilitiesCode,
 		errors.Alert,
 		[]string{"Failed to load capabilities from remote provider"},
-		[]string{fmt.Sprintf("Meshery Server could not retrieve the feature manifest from the remote provider: %v", err)},
+		[]string{"Meshery Server could not retrieve the feature manifest from the remote provider."},
 		[]string{"Remote provider is unreachable, the manifest endpoint is down, or the response is malformed."},
 		[]string{"Verify the remote provider is reachable, check its manifest endpoint, and retry."},
 	)

--- a/server/models/remote_provider.go
+++ b/server/models/remote_provider.go
@@ -201,7 +201,7 @@ func (l *RemoteProvider) loadCapabilities(token string) (ProviderProperties, err
 
 	// If not token is provided then make a simple GET request
 	if token == "" {
-		c := &http.Client{}
+		c := &http.Client{Timeout: 60 * time.Second}
 
 		const maxRetries = 10
 		for i := 0; i < maxRetries; i++ {

--- a/server/models/remote_provider.go
+++ b/server/models/remote_provider.go
@@ -4,6 +4,7 @@ import (
 	"archive/tar"
 	"bytes"
 	"compress/gzip"
+	"context"
 	"encoding/base64"
 	"encoding/json"
 	"errors"
@@ -43,6 +44,10 @@ import (
 const (
 	PROVIDER_CAPABILITIES_FILEPATH_ENV = "PROVIDER_CAPABILITIES_FILEPATH"
 	SKIP_DOWNLOAD_EXTENSIONS_ENV       = "SKIP_DOWNLOAD_EXTENSIONS"
+
+	remoteProviderCapabilitiesTimeout = 10 * time.Second
+	remoteProviderCapabilitiesRetries = 3
+	remoteProviderCapabilitiesBackoff = 2 * time.Second
 )
 
 func shouldPropagateProviderVersion(version string) bool {
@@ -197,14 +202,16 @@ func (l *RemoteProvider) loadCapabilities(token string) (ProviderProperties, err
 		return providerProperties, err
 	}
 
-	req, _ := http.NewRequest(http.MethodGet, remoteProviderURL.String(), nil)
+	ctx, cancel := context.WithTimeout(context.Background(), remoteProviderCapabilitiesTimeout)
+	defer cancel()
+
+	req, _ := http.NewRequestWithContext(ctx, http.MethodGet, remoteProviderURL.String(), nil)
 
 	// If not token is provided then make a simple GET request
 	if token == "" {
-		c := &http.Client{Timeout: 60 * time.Second}
+		c := &http.Client{Timeout: remoteProviderCapabilitiesTimeout}
 
-		const maxRetries = 10
-		for i := 0; i < maxRetries; i++ {
+		for i := 0; i < remoteProviderCapabilitiesRetries; i++ {
 			resp, err = c.Do(req)
 			if err == nil && resp != nil {
 				break // Successfully fetched response
@@ -212,11 +219,13 @@ func (l *RemoteProvider) loadCapabilities(token string) (ProviderProperties, err
 			if i == 0 {
 				l.Log.Warnf("Failed to fetch capabilities from remote provider (URL: %s). Retrying (%d)... ", remoteProviderURL.String(), i)
 			}
-			l.Log.Debugf("Attempt %d/%d: Failed to fetch capabilities: %v. Retrying in 3 seconds...", i+1, maxRetries, err)
-			time.Sleep(3 * time.Second)
+			if i < remoteProviderCapabilitiesRetries-1 {
+				l.Log.Debugf("Attempt %d/%d: Failed to fetch capabilities: %v. Retrying in %s...", i+1, remoteProviderCapabilitiesRetries, err, remoteProviderCapabilitiesBackoff)
+				time.Sleep(remoteProviderCapabilitiesBackoff)
+			}
 		}
 		if err != nil || resp == nil {
-			l.Log.Warnf("Failed to fetch capabilities after %d attempts", maxRetries)
+			l.Log.Warnf("Failed to fetch capabilities after %d attempts", remoteProviderCapabilitiesRetries)
 		}
 
 	} else {
@@ -232,6 +241,11 @@ func (l *RemoteProvider) loadCapabilities(token string) (ProviderProperties, err
 			err = ErrStatusCode(resp.StatusCode)
 		}
 		l.Log.Error(ErrFetch(err, "Capabilities", http.StatusInternalServerError))
+		if resp != nil && resp.Body != nil {
+			if closeErr := resp.Body.Close(); closeErr != nil {
+				l.Log.Error(ErrCloseIoReader(closeErr))
+			}
+		}
 		return providerProperties, ErrFetch(err, "Capabilities", http.StatusInternalServerError)
 	}
 	defer func() {

--- a/server/models/remote_provider.go
+++ b/server/models/remote_provider.go
@@ -45,9 +45,7 @@ const (
 	PROVIDER_CAPABILITIES_FILEPATH_ENV = "PROVIDER_CAPABILITIES_FILEPATH"
 	SKIP_DOWNLOAD_EXTENSIONS_ENV       = "SKIP_DOWNLOAD_EXTENSIONS"
 
-	remoteProviderCapabilitiesTimeout = 10 * time.Second
-	remoteProviderCapabilitiesRetries = 3
-	remoteProviderCapabilitiesBackoff = 2 * time.Second
+	remoteProviderCapabilitiesTimeout = 5 * time.Second
 )
 
 func shouldPropagateProviderVersion(version string) bool {
@@ -210,22 +208,9 @@ func (l *RemoteProvider) loadCapabilities(token string) (ProviderProperties, err
 	// If not token is provided then make a simple GET request
 	if token == "" {
 		c := &http.Client{Timeout: remoteProviderCapabilitiesTimeout}
-
-		for i := 0; i < remoteProviderCapabilitiesRetries; i++ {
-			resp, err = c.Do(req)
-			if err == nil && resp != nil {
-				break // Successfully fetched response
-			}
-			if i == 0 {
-				l.Log.Warnf("Failed to fetch capabilities from remote provider (URL: %s). Retrying (%d)... ", remoteProviderURL.String(), i)
-			}
-			if i < remoteProviderCapabilitiesRetries-1 {
-				l.Log.Debugf("Attempt %d/%d: Failed to fetch capabilities: %v. Retrying in %s...", i+1, remoteProviderCapabilitiesRetries, err, remoteProviderCapabilitiesBackoff)
-				time.Sleep(remoteProviderCapabilitiesBackoff)
-			}
-		}
+		resp, err = c.Do(req)
 		if err != nil || resp == nil {
-			l.Log.Warnf("Failed to fetch capabilities after %d attempts", remoteProviderCapabilitiesRetries)
+			l.Log.Warnf("Failed to fetch capabilities from remote provider (URL: %s): %v", remoteProviderURL.String(), err)
 		}
 
 	} else {


### PR DESCRIPTION
**Problem**: Capability fetch used a default [http.Client](vscode-file://vscode-app/usr/share/code/resources/app/out/vs/code/electron-browser/workbench/workbench.html) with no timeout inside a retry loop, so stalled remote providers could hang indefinitely. (Refs #19226)

**Solution**: Use a bounded 60s timeout (consistent with other remote fetches) to ensure retries fail fast and prevent goroutine hangs.

**Scope**: Remote provider capability fetch path only.
 
**Tests**: go test server.