### PR TITLE
[Server] Fix pattern metadata alias bridge

### DIFF
--- a/server/models/pattern/utils/patternfile_version_bridge.go
+++ b/server/models/pattern/utils/patternfile_version_bridge.go
@@ -14,9 +14,11 @@
 package utils
 
 import (
+	core "github.com/meshery/schemas/models/core"
 	componentv1beta1 "github.com/meshery/schemas/models/v1beta1/component"
 	patternv1beta1 "github.com/meshery/schemas/models/v1beta1/pattern"
 	componentv1beta2 "github.com/meshery/schemas/models/v1beta2/component"
+	corev1beta2 "github.com/meshery/schemas/models/v1beta2/core"
 	designv1beta3 "github.com/meshery/schemas/models/v1beta3/design"
 )
 
@@ -76,7 +78,7 @@ func patternMetadataV1beta1ToV1beta3(src *patternv1beta1.PatternFile_Metadata) *
 		return nil
 	}
 	return &designv1beta3.PatternFile_Metadata{
-		ResolvedAliases:      src.ResolvedAliases,
+		ResolvedAliases:      resolvedAliasesV1beta1ToV1beta3(src.ResolvedAliases),
 		AdditionalProperties: src.AdditionalProperties,
 	}
 }
@@ -86,9 +88,47 @@ func patternMetadataV1beta3ToV1beta1(src *designv1beta3.PatternFile_Metadata) *p
 		return nil
 	}
 	return &patternv1beta1.PatternFile_Metadata{
-		ResolvedAliases:      src.ResolvedAliases,
+		ResolvedAliases:      resolvedAliasesV1beta3ToV1beta1(src.ResolvedAliases),
 		AdditionalProperties: src.AdditionalProperties,
 	}
+}
+
+// ResolvedAliases cannot be shared directly because the generated schemas use
+// different map value types in v1beta1/pattern and v1beta3/design.
+func resolvedAliasesV1beta1ToV1beta3(src *map[string]core.ResolvedAlias) *map[string]corev1beta2.ResolvedAlias {
+	if src == nil {
+		return nil
+	}
+	dst := make(map[string]corev1beta2.ResolvedAlias, len(*src))
+	for key, alias := range *src {
+		dst[key] = corev1beta2.ResolvedAlias{
+			AliasComponentId:      alias.AliasComponentId,
+			ImmediateParentId:     alias.ImmediateParentId,
+			ImmediateRefFieldPath: alias.ImmediateRefFieldPath,
+			RelationshipId:        alias.RelationshipId,
+			ResolvedParentId:      alias.ResolvedParentId,
+			ResolvedRefFieldPath:  alias.ResolvedRefFieldPath,
+		}
+	}
+	return &dst
+}
+
+func resolvedAliasesV1beta3ToV1beta1(src *map[string]corev1beta2.ResolvedAlias) *map[string]core.ResolvedAlias {
+	if src == nil {
+		return nil
+	}
+	dst := make(map[string]core.ResolvedAlias, len(*src))
+	for key, alias := range *src {
+		dst[key] = core.ResolvedAlias{
+			AliasComponentId:      alias.AliasComponentId,
+			ImmediateParentId:     alias.ImmediateParentId,
+			ImmediateRefFieldPath: alias.ImmediateRefFieldPath,
+			RelationshipId:        alias.RelationshipId,
+			ResolvedParentId:      alias.ResolvedParentId,
+			ResolvedRefFieldPath:  alias.ResolvedRefFieldPath,
+		}
+	}
+	return &dst
 }
 
 func designPreferencesV1beta1ToV1beta3(src *patternv1beta1.DesignPreferences) *designv1beta3.DesignPreferences {

--- a/server/models/pattern/utils/patternfile_version_bridge_test.go
+++ b/server/models/pattern/utils/patternfile_version_bridge_test.go
@@ -4,6 +4,8 @@ import (
 	"encoding/json"
 	"testing"
 
+	"github.com/gofrs/uuid"
+	core "github.com/meshery/schemas/models/core"
 	componentv1beta1 "github.com/meshery/schemas/models/v1beta1/component"
 	modelv1beta1 "github.com/meshery/schemas/models/v1beta1/model"
 	patternv1beta1 "github.com/meshery/schemas/models/v1beta1/pattern"
@@ -33,6 +35,9 @@ func TestPatternV1beta1ToV1beta3_PreservesAliasedFields(t *testing.T) {
 	if got := dst.Metadata.AdditionalProperties["team"]; got != "meshery" {
 		t.Fatalf("metadata additionalProperties not preserved, got %#v", got)
 	}
+	if got := (*dst.Metadata.ResolvedAliases)["service"].ImmediateParentId.String(); got != "11111111-1111-1111-1111-111111111111" {
+		t.Fatalf("resolved alias metadata not preserved, got %q", got)
+	}
 	if got := dst.Components[0].Metadata.AdditionalProperties["componentKey"]; got != "componentValue" {
 		t.Fatalf("component metadata additionalProperties not preserved, got %#v", got)
 	}
@@ -45,6 +50,11 @@ func TestPatternV1beta1ToV1beta3_PreservesAliasedFields(t *testing.T) {
 	dst.Metadata.AdditionalProperties["owner"] = "catalog"
 	if got := src.Metadata.AdditionalProperties["owner"]; got != "catalog" {
 		t.Fatalf("metadata alias lost, got %#v", got)
+	}
+	resolvedAlias := (*dst.Metadata.ResolvedAliases)["service"]
+	resolvedAlias.ImmediateRefFieldPath[0] = "spec.template.metadata.labels.app"
+	if got := (*src.Metadata.ResolvedAliases)["service"].ImmediateRefFieldPath[0]; got != "spec.template.metadata.labels.app" {
+		t.Fatalf("resolved alias slice alias lost, got %#v", got)
 	}
 
 	dst.Components[0].Configuration["replicas"] = 3
@@ -114,6 +124,16 @@ func newPatternV1beta1Fixture() *patternv1beta1.PatternFile {
 		SchemaVersion: "designs.meshery.io/v1beta1",
 		Version:       "0.0.1",
 		Metadata: &patternv1beta1.PatternFile_Metadata{
+			ResolvedAliases: &map[string]core.ResolvedAlias{
+				"service": {
+					AliasComponentId:      uuid.Must(uuid.FromString("00000000-0000-0000-0000-000000000001")),
+					ImmediateParentId:     uuid.Must(uuid.FromString("11111111-1111-1111-1111-111111111111")),
+					ImmediateRefFieldPath: []string{"spec.template.spec.containers.0.image"},
+					RelationshipId:        uuid.Must(uuid.FromString("22222222-2222-2222-2222-222222222222")),
+					ResolvedParentId:      uuid.Must(uuid.FromString("33333333-3333-3333-3333-333333333333")),
+					ResolvedRefFieldPath:  []string{"spec.template.metadata.labels"},
+				},
+			},
 			AdditionalProperties: map[string]interface{}{
 				"team": "meshery",
 			},


### PR DESCRIPTION
## Summary
- explicitly convert pattern metadata `ResolvedAliases` between schemas core packages in the v1beta1<->v1beta3 bridge
- preserve the existing shallow-copy behavior for the nested alias slices and metadata maps
- extend the pattern bridge tests to cover `ResolvedAliases` round-tripping

## Testing
- go test ./server/models/pattern/utils
- cd server/cmd && GOPROXY=https://proxy.golang.org GOSUMDB=off go build -tags draft .