### PR TITLE
[Server] Bound Prometheus client HTTP timeout

### DIFF
--- a/server/models/prometheus_helper.go
+++ b/server/models/prometheus_helper.go
@@ -25,16 +25,29 @@ type PrometheusClient struct {
 	promURL string
 }
 
+const defaultPrometheusClientTimeout = 25 * time.Second
+
 // NewPrometheusClient returns a PrometheusClient
 func NewPrometheusClient(log *logger.Handler) *PrometheusClient {
-	return NewPrometheusClientWithHTTPClient(&http.Client{}, log)
+	return NewPrometheusClientWithHTTPClient(&http.Client{Timeout: defaultPrometheusClientTimeout}, log)
 }
 
 // NewPrometheusClientWithHTTPClient returns a PrometheusClient with a given http.Client
 func NewPrometheusClientWithHTTPClient(client *http.Client, log *logger.Handler) *PrometheusClient {
+	if client == nil {
+		client = &http.Client{Timeout: defaultPrometheusClientTimeout}
+	}
 	return &PrometheusClient{
 		grafanaClient: NewGrafanaClientForPrometheusWithHTTPClient(client, log),
 	}
+}
+
+func (p *PrometheusClient) newPromAPIClient(promURL string) (promAPI.Client, error) {
+	cfg := promAPI.Config{Address: promURL}
+	if p != nil && p.grafanaClient != nil && p.grafanaClient.httpClient != nil {
+		cfg.Client = p.grafanaClient.httpClient
+	}
+	return promAPI.NewClient(cfg)
 }
 
 // Validate - helps validate the connection
@@ -116,9 +129,10 @@ func (p *PrometheusClient) GetNodesStaticBoard(ctx context.Context, promURL stri
 
 func (p *PrometheusClient) getAllNodes(ctx context.Context, promURL string) ([]string, error) {
 	// api/datasources/proxy/1/api/v1/series?match[]=node_boot_time_seconds%7Bcluster%3D%22%22%2C%20job%3D%22node-exporter%22%7D&start=1568392571&end=1568396171
-	c, _ := promAPI.NewClient(promAPI.Config{
-		Address: promURL,
-	})
+	c, err := p.newPromAPIClient(promURL)
+	if err != nil {
+		return nil, ErrPrometheusLabelSeries(err)
+	}
 	qc := promQAPI.NewAPI(c)
 	labelSet, _, err := qc.Series(ctx, []string{`node_boot_time_seconds{cluster="", job="node-exporter"}`}, time.Now().Add(-5*time.Minute), time.Now())
 	if err != nil {
@@ -137,9 +151,10 @@ func (p *PrometheusClient) getAllNodes(ctx context.Context, promURL string) ([]s
 
 // QueryRangeUsingClient performs a range query within a window
 func (p *PrometheusClient) QueryRangeUsingClient(ctx context.Context, promURL, query string, startTime, endTime time.Time, step time.Duration) (promModel.Value, error) {
-	c, _ := promAPI.NewClient(promAPI.Config{
-		Address: promURL,
-	})
+	c, err := p.newPromAPIClient(promURL)
+	if err != nil {
+		return nil, ErrPrometheusQueryRange(err, query, startTime, endTime, step)
+	}
 	qc := promQAPI.NewAPI(c)
 	result, _, err := qc.QueryRange(ctx, query, promQAPI.Range{
 		Start: startTime,

--- a/server/models/prometheus_helper_test.go
+++ b/server/models/prometheus_helper_test.go
@@ -1,0 +1,78 @@
+package models
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/meshery/meshkit/logger"
+)
+
+func TestNewPrometheusClient_UsesHTTPTimeout(t *testing.T) {
+	log, err := logger.New("test", logger.Options{})
+	if err != nil {
+		t.Fatalf("logger.New: %v", err)
+	}
+
+	p := NewPrometheusClient(&log)
+	if p == nil {
+		t.Fatalf("NewPrometheusClient returned nil")
+	}
+	if p.grafanaClient == nil {
+		t.Fatalf("grafanaClient is nil")
+	}
+	if p.grafanaClient.httpClient == nil {
+		t.Fatalf("grafanaClient.httpClient is nil")
+	}
+
+	if got := p.grafanaClient.httpClient.Timeout; got != defaultPrometheusClientTimeout {
+		t.Fatalf("http client Timeout = %s; want %s", got, defaultPrometheusClientTimeout)
+	}
+}
+
+func TestPrometheusClient_getAllNodes_UsesConfiguredHTTPClientTimeout(t *testing.T) {
+	log, err := logger.New("test", logger.Options{})
+	if err != nil {
+		t.Fatalf("logger.New: %v", err)
+	}
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// Delay longer than the client's Timeout to prove we actually honor it.
+		time.Sleep(200 * time.Millisecond)
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"status":"success","data":[]}`))
+	}))
+	defer srv.Close()
+
+	p := NewPrometheusClientWithHTTPClient(&http.Client{Timeout: 50 * time.Millisecond}, &log)
+
+	_, err = p.getAllNodes(context.Background(), srv.URL)
+	if err == nil {
+		t.Fatalf("expected timeout error, got nil")
+	}
+}
+
+func TestPrometheusClient_QueryRangeUsingClient_UsesConfiguredHTTPClientTimeout(t *testing.T) {
+	log, err := logger.New("test", logger.Options{})
+	if err != nil {
+		t.Fatalf("logger.New: %v", err)
+	}
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		time.Sleep(200 * time.Millisecond)
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"status":"success","data":{"resultType":"matrix","result":[]}}`))
+	}))
+	defer srv.Close()
+
+	p := NewPrometheusClientWithHTTPClient(&http.Client{Timeout: 50 * time.Millisecond}, &log)
+
+	start := time.Unix(0, 0)
+	end := start.Add(1 * time.Minute)
+	_, err = p.QueryRangeUsingClient(context.Background(), srv.URL, "up", start, end, 15*time.Second)
+	if err == nil {
+		t.Fatalf("expected timeout error, got nil")
+	}
+}


### PR DESCRIPTION
Fixes #19253

**[NewPrometheusClient()]** constructed an **[http.Client]** with no timeout, so Prometheus connection validation and query paths could hang indefinitely when Prometheus is slow/unreachable.

Fix

-  Set a bounded default timeout in **[prometheus_helper.go]** by constructing the Prometheus client with **[http.Client{Timeout: 25 * time.Second}]** (callers that need different limits can still use **[NewPrometheusClientWithHTTPClient]** )
-  Add a regression test in **[prometheus_helper_test.go]**  to pin the default timeout behavior.
