### PR TITLE
chore: bump @meshery/schemas to v1.2.19

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -51,7 +51,7 @@ require (
 	github.com/meshery/meshery-operator v0.8.11
 	github.com/meshery/meshkit v1.0.8
 	github.com/meshery/meshsync v1.0.0
-	github.com/meshery/schemas v1.2.18
+	github.com/meshery/schemas v1.2.19
 	github.com/nsf/termbox-go v1.1.1
 	github.com/oapi-codegen/runtime v1.4.0
 	github.com/olekukonko/tablewriter v1.1.4

--- a/go.sum
+++ b/go.sum
@@ -1494,8 +1494,8 @@ github.com/meshery/meshkit v1.0.8 h1:cdpSSdwZKV5n4Uh/T1yBbPfJVf0EZClqIn9S8CzDdv8
 github.com/meshery/meshkit v1.0.8/go.mod h1:YQbXQtWnsvv2kt8nlCU6eJPjj5qWDf3heiLgbtZjKF0=
 github.com/meshery/meshsync v1.0.0 h1:BIHEVG4BDjqOnSd3vBt9B4IfWJNTfMRAgdwLroBcCfY=
 github.com/meshery/meshsync v1.0.0/go.mod h1:mFsPXkZRiCSuk5DhxBTrkWdlo6peItRBUoIEEQCovIg=
-github.com/meshery/schemas v1.2.18 h1:VwTFTMR9WCrTzX7tigqIVaCT8DYqmN3q/pN+77ABe8c=
-github.com/meshery/schemas v1.2.18/go.mod h1:JS5V0zTEHbP5I4VZw0mttkY09+0UnFK6qFt33PqK3aY=
+github.com/meshery/schemas v1.2.19 h1:6WGACIOp+aP8mhq7DxY2pxfpFeG+iBu2rFKihf9lK3k=
+github.com/meshery/schemas v1.2.19/go.mod h1:JS5V0zTEHbP5I4VZw0mttkY09+0UnFK6qFt33PqK3aY=
 github.com/miekg/dns v1.1.57 h1:Jzi7ApEIzwEPLHWRcafCN9LZSBbqQpxjt/wpgvg7wcM=
 github.com/miekg/dns v1.1.57/go.mod h1:uqRjCRUuEAA6qsOiJvDd+CFo/vW+y5WR6SNmHE55hZk=
 github.com/miekg/pkcs11 v1.0.2/go.mod h1:XsNlhZGX73bx86s2hdc/FuaLm2CPZJemRLMA+WTFxgs=

--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -21,7 +21,7 @@
         "@emotion/react": "^11.14.0",
         "@emotion/server": "^11.11.0",
         "@emotion/styled": "^11.14.1",
-        "@meshery/schemas": "^1.2.18",
+        "@meshery/schemas": "^1.2.19",
         "@microlink/react-json-view": "^1.31.20",
         "@mui/icons-material": "^9.0.0",
         "@mui/material": "^9.0.0",
@@ -2061,9 +2061,9 @@
       "license": "MIT"
     },
     "node_modules/@meshery/schemas": {
-      "version": "1.2.18",
-      "resolved": "https://registry.npmjs.org/@meshery/schemas/-/schemas-1.2.18.tgz",
-      "integrity": "sha512-tE13GTSQ1f5iCfKDip0jC16aHSaHtMM8PvcZbLNXKwXCbJiBlHlYE6s0Iwq9YZjKG8VFyxARe2+9JY1FwLq4xw==",
+      "version": "1.2.19",
+      "resolved": "https://registry.npmjs.org/@meshery/schemas/-/schemas-1.2.19.tgz",
+      "integrity": "sha512-bosyJpKf4LUZJfa/qcrdRaDqS0KDBrJTsMrfGAqQQo/TICQF/Ks/aYIyJ3V6xwIwm3ydimc02RBV5Om1r2u2Ww==",
       "license": "ISC",
       "peerDependencies": {
         "@reduxjs/toolkit": "^2.8.1",

--- a/ui/package.json
+++ b/ui/package.json
@@ -46,7 +46,7 @@
     "@emotion/react": "^11.14.0",
     "@emotion/server": "^11.11.0",
     "@emotion/styled": "^11.14.1",
-    "@meshery/schemas": "^1.2.18",
+    "@meshery/schemas": "^1.2.19",
     "@microlink/react-json-view": "^1.31.20",
     "@mui/icons-material": "^9.0.0",
     "@mui/material": "^9.0.0",


### PR DESCRIPTION
## Summary

Bumps the schemas dependency in both the Go server and the Next.js UI from v1.2.18 to v1.2.19, in line with the cross-repo workstream:

- [meshery/schemas#893](https://github.com/meshery/schemas/pull/893) — root-cause fix: strip `\$schema: draft-07` from canonical RJSF form schemas
- [layer5io/meshery-cloud#5272](https://github.com/layer5io/meshery-cloud/pull/5272) — cloud-side accommodation (mirrors this PR on the cloud side)

Files touched:

- `go.mod`: `github.com/meshery/schemas v1.2.18` → `v1.2.19`
- `ui/package.json`: `@meshery/schemas` `^1.2.18` → `^1.2.19`

## Why

`@meshery/schemas` v1.2.18 declared `\$schema: "https://json-schema.org/draft-07/schema#"` on every canonical RJSF form schema. The default `@rjsf/validator-ajv8` validator uses Ajv2020 internally, which doesn't ship the draft-07 metaschema, so any consumer that rendered one of those forms hit:

```
Error: no schema with key or ref "https://json-schema.org/draft-07/schema#"
```

…which surfaced as a silent submit failure (the `validateForm()` returned false and the consumer modal swallowed the result).

v1.2.19 removes the `\$schema` declaration — Ajv2020 falls back to its built-in metaschema and validates the form correctly without any consumer-side workaround. Meshery's existing custom `utils/rjsfValidator.ts` (an Ajv instance configured for OpenAPI/k8s formats like `int32`, `int64`, `int-or-string`) is **not** affected — it's serving an unrelated concern and stays.

## Test plan

- [x] `go build ./...` — clean
- [x] `go test ./server/...` — all packages OK
- [x] `npx vitest run` — 14 files / 65 tests pass
- [ ] Smoke check in the UI: an RJSF-rendered form (e.g. design import) renders and submits without DevTools errors — best verified after merge in a deployed environment

## Related

- meshery/schemas#892 — issue: drop \$schema: draft-07 to remove the validator-ajv8 metaschema-registration tax
- meshery/schemas#893 — PR that lands the strip
- layer5io/meshery-cloud#5272 — cross-repo cloud-side accommodation
- layer5io/sistent#1533 — follow-on: centralize the RJSF wrapper in sistent so cloud + meshery + extensions stop maintaining parallel wrappers