### PR TITLE
fix(ui): halt connections page render loop by stabilizing hook return values

### DIFF
--- a/ui/components/connections/ConnectionTable.tsx
+++ b/ui/components/connections/ConnectionTable.tsx
@@ -338,10 +338,13 @@ const ConnectionTable = ({
     },
   );
 
-  const environments = environmentsResponse?.environments || [];
   const environmentOptions = useMemo(
-    () => environments.map((env) => ({ label: env.name, value: env.id })),
-    [environments],
+    () =>
+      (environmentsResponse?.environments || []).map((env) => ({
+        label: env.name,
+        value: env.id,
+      })),
+    [environmentsResponse?.environments],
   );
 
   useEffect(() => {

--- a/ui/components/hooks/useKubernetesHook.tsx
+++ b/ui/components/hooks/useKubernetesHook.tsx
@@ -4,7 +4,7 @@ import { pingMesheryOperator } from '../../utils/helpers/mesheryOperator';
 import { useLazyPingKubernetesQuery } from '@/rtk-query/connection';
 import { EVENT_TYPES } from '../../lib/event-types';
 import MeshsyncStatusQuery from '../graphql/queries/MeshsyncStatusQuery';
-import { useEffect, useState } from 'react';
+import { useCallback, useEffect, useState } from 'react';
 import fetchMesheryOperatorStatus from '../graphql/queries/OperatorStatusQuery';
 import NatsStatusQuery from '../graphql/queries/NatsStatusQuery';
 import { CONTROLLERS, CONTROLLER_STATES } from '../../utils/Enum';
@@ -17,17 +17,22 @@ export default function useKubernetesHook() {
   const dispatch = useDispatch();
   const [triggerPing] = useLazyPingKubernetesQuery();
 
-  const ping = async (name, server, connectionID) => {
-    dispatch(updateProgressAction({ showProgress: true }));
-    try {
-      await triggerPing(connectionID).unwrap();
-      dispatch(updateProgressAction({ showProgress: false }));
-      successHandlerGenerator(notify, `Kubernetes context ${name} at ${server} pinged`)();
-    } catch (err) {
-      dispatch(updateProgressAction({ showProgress: false }));
-      errorHandlerGenerator(notify, `Kubernetes context ${name} at ${server} not reachable`)(err);
-    }
-  };
+  // Memoized so consumers can list `ping` in hook dep arrays without
+  // invalidating their memos every render.
+  const ping = useCallback(
+    async (name, server, connectionID) => {
+      dispatch(updateProgressAction({ showProgress: true }));
+      try {
+        await triggerPing(connectionID).unwrap();
+        dispatch(updateProgressAction({ showProgress: false }));
+        successHandlerGenerator(notify, `Kubernetes context ${name} at ${server} pinged`)();
+      } catch (err) {
+        dispatch(updateProgressAction({ showProgress: false }));
+        errorHandlerGenerator(notify, `Kubernetes context ${name} at ${server} not reachable`)(err);
+      }
+    },
+    [dispatch, notify, triggerPing],
+  );
 
   return ping;
 }

--- a/ui/utils/hooks/useNotification.tsx
+++ b/ui/utils/hooks/useNotification.tsx
@@ -14,6 +14,10 @@ import { AddClassRecursively } from '../Elements';
 import { useCallback } from 'react';
 import { formatApiError } from '../helpers/meshkitError';
 
+const openEvent = () => {
+  rtkStore.dispatch(toggleNotificationCenter());
+};
+
 /**
  * A React hook to facilitate emitting events from the client.
  * The hook takes care of storing the events on the client through Redux
@@ -22,76 +26,58 @@ import { formatApiError } from '../helpers/meshkitError';
  * @returns {Object} An object with the `notify` property.
  */
 export const useNotification = () => {
-  const x = useSnackbar();
   const { enqueueSnackbar, closeSnackbar } = useSnackbar();
 
-  /**
-   * Opens an event in the notification center.
-   *
-   * @param {string} eventId - The ID of the event to be opened.
-   */
-  const openEvent = (eventId) => {
-    rtkStore.dispatch(toggleNotificationCenter());
-  };
+  // Memoized so consumers can list `notify` in hook dep arrays without
+  // invalidating their memos every render.
+  const notify = useCallback(
+    ({
+      id = null,
+      message,
+      dataTestID = 'notify',
+      details = null,
+      event_type,
+      timestamp = null,
+      customEvent = null,
+      showInNotificationCenter = false,
+      pushToServer = false,
+    }) => {
+      timestamp = timestamp ?? moment.utc().valueOf();
+      id = id || v4();
 
-  /**
-   * Notifies and stores the event.
-   *
-   * @param {Object} options - Options for the event notification.
-   * @param {string} options.id - A unique ID for the event. If not provided, a random ID will be generated.
-   * @param {string} options.message - Summary of the event.
-   * @param {string} options.details - Description of the event.
-   * @param {Object} options.event_type - The type of the event.
-   * @param {number} options.timestamp - UTC timestamp for the event. If not provided, it is generated on the client.
-   * @param {Object} options.customEvent - Additional properties related to the event.
-   * @param {boolean} options.showInNotificationCenter - Whether to show the event in the notification center. Defaults to `true`.
-   * @param {boolean} options.pushToServer - Whether to push the event to the server. Defaults to `false`.
-   */
-  const notify = ({
-    id = null,
-    message,
-    dataTestID = 'notify',
-    details = null,
-    event_type,
-    timestamp = null,
-    customEvent = null,
-    showInNotificationCenter = false,
-    pushToServer = false,
-  }) => {
-    timestamp = timestamp ?? moment.utc().valueOf();
-    id = id || v4();
-
-    enqueueSnackbar(message, {
-      //NOTE: Need to Consolidate the variant and event_type
-      variant: typeof event_type === 'string' ? event_type : event_type?.type,
-      action: function Action(key) {
-        return (
-          <ToggleButtonGroup data-testid={dataTestID}>
-            {showInNotificationCenter && (
-              <AddClassRecursively className={NOTIFICATION_CENTER_TOGGLE_CLASS}>
-                <IconButton
-                  key={`openevent-${id}`}
-                  aria-label="Open"
-                  color="inherit"
-                  onClick={() => openEvent(id)}
-                >
-                  <BellIcon {...iconMedium} />
-                </IconButton>
-              </AddClassRecursively>
-            )}
-            <IconButton
-              key={`closeevent-${id}`}
-              aria-label="Close"
-              color="inherit"
-              onClick={() => closeSnackbar(key)}
-            >
-              <CloseIcon style={iconMedium} />
-            </IconButton>
-          </ToggleButtonGroup>
-        );
-      },
-    });
-  };
+      enqueueSnackbar(message, {
+        //NOTE: Need to Consolidate the variant and event_type
+        variant: typeof event_type === 'string' ? event_type : event_type?.type,
+        action: function Action(key) {
+          return (
+            <ToggleButtonGroup data-testid={dataTestID}>
+              {showInNotificationCenter && (
+                <AddClassRecursively className={NOTIFICATION_CENTER_TOGGLE_CLASS}>
+                  <IconButton
+                    key={`openevent-${id}`}
+                    aria-label="Open"
+                    color="inherit"
+                    onClick={() => openEvent()}
+                  >
+                    <BellIcon {...iconMedium} />
+                  </IconButton>
+                </AddClassRecursively>
+              )}
+              <IconButton
+                key={`closeevent-${id}`}
+                aria-label="Close"
+                color="inherit"
+                onClick={() => closeSnackbar(key)}
+              >
+                <CloseIcon style={iconMedium} />
+              </IconButton>
+            </ToggleButtonGroup>
+          );
+        },
+      });
+    },
+    [enqueueSnackbar, closeSnackbar],
+  );
 
   return {
     notify,


### PR DESCRIPTION
## Summary

`/management/connections` was crashing with `Maximum update depth exceeded`. The root cause was that `notify` (from `useNotification`) and `ping` (from `useKubernetesHook`) returned a fresh function reference every render. `ConnectionTable` lists them — and callbacks derived from them — in the dependency array of its `columns` `useMemo`, so the memo was invalidated on every commit. The recently added responsive-visibility sync (`useEffect` calling `setColumnVisibility(getResponsiveColumnVisibility(columnNames, colViews, width))`) then handed React a new object every render, exceeding the max update depth.

- Wrap `notify` in `useCallback([enqueueSnackbar, closeSnackbar])` and hoist the closure-free `openEvent` helper out of the hook so it doesn't recapture each render.
- Wrap `ping` in `useCallback([dispatch, notify, triggerPing])` so its identity is stable now that `notify` is stable.
- Fold the `environments` lookup into the `environmentOptions` `useMemo` and depend on `environmentsResponse?.environments` directly, so an empty response no longer hands the memo a brand-new `[]` every render.

With these changes the connections `columns` memo (and the derived `columnNames`) stay reference-stable across renders, so the visibility sync effect only runs when the window width or column shape genuinely changes.

## Test plan

- [x] `npx vitest run` — 14 files / 65 tests pass (includes `ConnectionTable.test.tsx`, which exercises the responsive visibility recompute on width change)
- [x] `npx tsc --noEmit` — clean
- [x] `npx eslint` — clean on the three changed files
- [ ] Manual smoke: open `/management/connections`, switch tabs, resize window, change filters — verify no console errors and the table reacts to resize
