### PR TITLE
[Server] Range over selector and match-ref slices

### DIFF
--- a/server/policies/engine_test.go
+++ b/server/policies/engine_test.go
@@ -688,3 +688,181 @@ func TestMatchLabelsPolicyIdentificationIsDeterministic(t *testing.T) {
 		}
 	}
 }
+
+// TestMatchLabelsMultiRefIdentifiesAllPaths covers the multi-ref matchLabels
+// fixture: two Pods that share values under both `metadata.labels` and
+// `metadata.annotations`. Pre-fix only the first ref produced groups.
+func TestMatchLabelsMultiRefIdentifiesAllPaths(t *testing.T) {
+	pod := func(idHex string) *component.ComponentDefinition {
+		c := &component.ComponentDefinition{
+			Component: component.Component{Kind: "Pod"},
+			Configuration: map[string]interface{}{
+				"metadata": map[string]interface{}{
+					"labels":      map[string]interface{}{"app": "meshery"},
+					"annotations": map[string]interface{}{"team": "core"},
+				},
+			},
+		}
+		c.ID, _ = uuid.FromString("00000000-0000-0000-0000-" + idHex)
+		return c
+	}
+	podA, podB := pod("00000000aaa1"), pod("00000000bbb2")
+
+	kind := "Pod"
+	multiRefs := [][]string{
+		{"configuration", "metadata", "labels"},
+		{"configuration", "metadata", "annotations"},
+	}
+	singleRefs := multiRefs[:1]
+	makeRel := func(refs *[][]string) *relationship.RelationshipDefinition {
+		ss := relationship.SelectorSetItem{
+			Allow: relationship.Selector{
+				From: []relationship.SelectorItem{{Kind: &kind, Match: &relationship.MatchSelector{Refs: refs}}},
+				To:   []relationship.SelectorItem{{Kind: &kind, Match: &relationship.MatchSelector{Refs: refs}}},
+			},
+		}
+		return &relationship.RelationshipDefinition{
+			Kind:             relationship.RelationshipDefinitionKind("edge"),
+			RelationshipType: "sibling",
+			Selectors:        &relationship.SelectorSet{ss},
+		}
+	}
+
+	design := makePatternFile([]*component.ComponentDefinition{podA, podB}, nil)
+	p := &MatchLabelsPolicy{}
+
+	singleRel := singleRefs
+	single := p.IdentifyRelationship(makeRel((*[][]string)(&singleRel)), design)
+	multi := p.IdentifyRelationship(makeRel(&multiRefs), design)
+
+	if len(single) == 0 {
+		t.Fatal("expected single-ref to identify at least one relationship")
+	}
+	if len(multi) <= len(single) {
+		t.Fatalf("multi-ref should identify more groups than single-ref: single=%d multi=%d", len(single), len(multi))
+	}
+}
+
+// TestPatchBindingSelectorIDsTypedAllItems verifies that every MatchSelectorItem
+// in match.From / match.To receives the ID, not only [0].
+func TestPatchBindingSelectorIDsTypedAllItems(t *testing.T) {
+	from := []relationship.MatchSelectorItem{{Kind: "FromKind"}, {Kind: "FromKind"}}
+	to := []relationship.MatchSelectorItem{{Kind: "ToKind"}, {Kind: "ToKind"}, {Kind: "ToKind"}}
+	sel := &relationship.SelectorItem{
+		Match: &relationship.MatchSelector{From: &from, To: &to},
+	}
+
+	patchBindingSelectorIDsTyped(sel, "00000000-0000-0000-0000-00000000000a", "00000000-0000-0000-0000-00000000000b")
+
+	for i, m := range *sel.Match.From {
+		if m.ID == nil || m.ID.String() != "00000000-0000-0000-0000-00000000000a" {
+			t.Errorf("match.From[%d] ID not patched: %v", i, m.ID)
+		}
+	}
+	for i, m := range *sel.Match.To {
+		if m.ID == nil || m.ID.String() != "00000000-0000-0000-0000-00000000000b" {
+			t.Errorf("match.To[%d] ID not patched: %v", i, m.ID)
+		}
+	}
+}
+
+// TestExtractMutatorMutatedRefsConcatAcrossItems verifies that refs are pulled
+// from every match item, not only [0]. Covers the multi-ref binding fixture.
+func TestExtractMutatorMutatedRefsConcatAcrossItems(t *testing.T) {
+	idA, _ := uuid.FromString("00000000-0000-0000-0000-000000000001")
+	idB, _ := uuid.FromString("00000000-0000-0000-0000-000000000002")
+	compA := &component.ComponentDefinition{Component: component.Component{Kind: "A"}}
+	compA.ID = idA
+	compB := &component.ComponentDefinition{Component: component.Component{Kind: "B"}}
+	compB.ID = idB
+
+	mr1 := relationship.MutatorRef{{"configuration", "spec", "containers", "0", "image"}}
+	mr2 := relationship.MutatorRef{{"configuration", "spec", "containers", "1", "image"}}
+	md1 := relationship.MutatedRef{{"configuration", "image1"}}
+	md2 := relationship.MutatedRef{{"configuration", "image2"}}
+	match := &relationship.MatchSelector{
+		From: &[]relationship.MatchSelectorItem{{MutatorRef: &mr1}, {MutatorRef: &mr2}},
+		To:   &[]relationship.MatchSelectorItem{{MutatedRef: &md1}, {MutatedRef: &md2}},
+	}
+
+	_, mutatorPaths := extractMutatorFromMatch(match, compA, compB)
+	if len(mutatorPaths) != 2 {
+		t.Fatalf("expected 2 mutator paths from multi-item match.From, got %d", len(mutatorPaths))
+	}
+	_, mutatedPaths := extractMutatedFromMatch(match, compA, compB)
+	if len(mutatedPaths) != 2 {
+		t.Fatalf("expected 2 mutated paths from multi-item match.To, got %d", len(mutatedPaths))
+	}
+}
+
+// TestPatchBindingMatchFieldsMultiItemPair verifies the multi-ref binding
+// fixture: two MatchSelectorItems on each side of match produce side-effect
+// actions per paired item.
+func TestPatchBindingMatchFieldsMultiItemPair(t *testing.T) {
+	mutA, _ := uuid.FromString("00000000-0000-0000-0000-000000000001")
+	mutB, _ := uuid.FromString("00000000-0000-0000-0000-000000000002")
+	tgtA, _ := uuid.FromString("00000000-0000-0000-0000-00000000000a")
+	tgtB, _ := uuid.FromString("00000000-0000-0000-0000-00000000000b")
+
+	mutCompA := &component.ComponentDefinition{
+		Component:     component.Component{Kind: "Mutator"},
+		Configuration: map[string]interface{}{"value": "v1"},
+	}
+	mutCompA.ID = mutA
+	mutCompB := &component.ComponentDefinition{
+		Component:     component.Component{Kind: "Mutator"},
+		Configuration: map[string]interface{}{"value": "v2"},
+	}
+	mutCompB.ID = mutB
+	tgtCompA := &component.ComponentDefinition{
+		Component:     component.Component{Kind: "Target"},
+		Configuration: map[string]interface{}{"slot": "old"},
+	}
+	tgtCompA.ID = tgtA
+	tgtCompB := &component.ComponentDefinition{
+		Component:     component.Component{Kind: "Target"},
+		Configuration: map[string]interface{}{"slot": "old"},
+	}
+	tgtCompB.ID = tgtB
+
+	mr := relationship.MutatorRef{{"configuration", "value"}}
+	md := relationship.MutatedRef{{"configuration", "slot"}}
+	match := &relationship.MatchSelector{
+		From: &[]relationship.MatchSelectorItem{
+			{ID: &mutA, Kind: "Mutator", MutatorRef: &mr},
+			{ID: &mutB, Kind: "Mutator", MutatorRef: &mr},
+		},
+		To: &[]relationship.MatchSelectorItem{
+			{ID: &tgtA, Kind: "Target", MutatedRef: &md},
+			{ID: &tgtB, Kind: "Target", MutatedRef: &md},
+		},
+	}
+	bindingID, _ := uuid.FromString("00000000-0000-0000-0000-0000000000ff")
+	bindingComp := &component.ComponentDefinition{Component: component.Component{Kind: "Binding"}}
+	bindingComp.ID = bindingID
+	rel := &relationship.RelationshipDefinition{
+		Kind:             relationship.RelationshipDefinitionKind("edge"),
+		RelationshipType: "binding",
+		Selectors: &relationship.SelectorSet{
+			relationship.SelectorSetItem{
+				Allow: relationship.Selector{
+					From: []relationship.SelectorItem{{ID: &bindingID, Match: match}},
+				},
+			},
+		},
+	}
+
+	design := makePatternFile([]*component.ComponentDefinition{bindingComp, mutCompA, mutCompB, tgtCompA, tgtCompB}, nil)
+	actions := patchBindingMatchFields(rel, design)
+
+	if len(actions) != 2 {
+		t.Fatalf("expected 2 patch actions for 2-item match pair, got %d", len(actions))
+	}
+	seenTargets := map[string]bool{}
+	for _, a := range actions {
+		seenTargets[a.ID] = true
+	}
+	if !seenTargets[tgtA.String()] || !seenTargets[tgtB.String()] {
+		t.Fatalf("expected actions targeting both Target components, got %#v", seenTargets)
+	}
+}

--- a/server/policies/engine_test.go
+++ b/server/policies/engine_test.go
@@ -866,3 +866,164 @@ func TestPatchBindingMatchFieldsMultiItemPair(t *testing.T) {
 		t.Fatalf("expected actions targeting both Target components, got %#v", seenTargets)
 	}
 }
+
+// TestPatchMutatorsActionMultiSelectorPairs verifies the shared patchMutatorsAction
+// helper (used by binding / edge-network / wallet SideEffects) pairs every From[i]
+// with To[i] instead of dropping selectors past [0].
+func TestPatchMutatorsActionMultiSelectorPairs(t *testing.T) {
+	fromA, _ := uuid.FromString("00000000-0000-0000-0000-000000000001")
+	fromB, _ := uuid.FromString("00000000-0000-0000-0000-000000000002")
+	toA, _ := uuid.FromString("00000000-0000-0000-0000-00000000000a")
+	toB, _ := uuid.FromString("00000000-0000-0000-0000-00000000000b")
+
+	mkFrom := func(id uuid.UUID, name string) *component.ComponentDefinition {
+		c := &component.ComponentDefinition{
+			Component:     component.Component{Kind: "Namespace"},
+			Configuration: map[string]interface{}{"name": name},
+		}
+		c.ID = id
+		return c
+	}
+	mkTo := func(id uuid.UUID, ns string) *component.ComponentDefinition {
+		c := &component.ComponentDefinition{
+			Component:     component.Component{Kind: "Deployment"},
+			Configuration: map[string]interface{}{"namespace": ns},
+		}
+		c.ID = id
+		return c
+	}
+	nsA := mkFrom(fromA, "alpha")
+	nsB := mkFrom(fromB, "beta")
+	depA := mkTo(toA, "stale-a")
+	depB := mkTo(toB, "stale-b")
+
+	mutatorRef := relationship.MutatorRef{[]string{"configuration", "name"}}
+	mutatedRef := relationship.MutatedRef{[]string{"configuration", "namespace"}}
+	fromSel := func(id uuid.UUID) relationship.SelectorItem {
+		return relationship.SelectorItem{
+			ID: &id,
+			RelationshipDefinitionSelectorsPatch: &relationship.RelationshipDefinitionSelectorsPatch{
+				MutatorRef: &mutatorRef,
+			},
+		}
+	}
+	toSel := func(id uuid.UUID) relationship.SelectorItem {
+		return relationship.SelectorItem{
+			ID: &id,
+			RelationshipDefinitionSelectorsPatch: &relationship.RelationshipDefinitionSelectorsPatch{
+				MutatedRef: &mutatedRef,
+			},
+		}
+	}
+
+	relStatus := relationship.RelationshipDefinitionStatus("approved")
+	rel := &relationship.RelationshipDefinition{
+		Kind:             relationship.RelationshipDefinitionKind("edge"),
+		RelationshipType: "non-binding",
+		Status:           &relStatus,
+		Selectors: &relationship.SelectorSet{
+			relationship.SelectorSetItem{
+				Allow: relationship.Selector{
+					From: []relationship.SelectorItem{fromSel(fromA), fromSel(fromB)},
+					To:   []relationship.SelectorItem{toSel(toA), toSel(toB)},
+				},
+			},
+		},
+	}
+	rel.ID, _ = uuid.FromString("00000000-0000-0000-0000-0000000000ff")
+
+	design := makePatternFile([]*component.ComponentDefinition{nsA, nsB, depA, depB}, nil)
+	actions := patchMutatorsAction(rel, design)
+
+	if len(actions) != 2 {
+		t.Fatalf("expected 2 patch actions for 2-pair selector, got %d", len(actions))
+	}
+	got := map[string]string{}
+	for _, a := range actions {
+		v, _ := a.UpdateValue.(string)
+		got[a.ID] = v
+	}
+	if got[toA.String()] != "alpha" {
+		t.Fatalf("expected to[0] to be patched with from[0] value 'alpha', got %q", got[toA.String()])
+	}
+	if got[toB.String()] != "beta" {
+		t.Fatalf("expected to[1] to be patched with from[1] value 'beta', got %q", got[toB.String()])
+	}
+}
+
+// TestRelationshipsAreSameMultiSelectorDoesNotFalseDedup verifies dedup compares
+// full From/To slices instead of only [0]. Two binding-like relationships that
+// share their first selector but differ at [1] must not collapse into one.
+func TestRelationshipsAreSameMultiSelectorDoesNotFalseDedup(t *testing.T) {
+	idA, _ := uuid.FromString("00000000-0000-0000-0000-000000000001")
+	idB, _ := uuid.FromString("00000000-0000-0000-0000-000000000002")
+	idC, _ := uuid.FromString("00000000-0000-0000-0000-000000000003")
+	idD, _ := uuid.FromString("00000000-0000-0000-0000-000000000004")
+
+	mkRel := func(fromIDs, toIDs []uuid.UUID) *relationship.RelationshipDefinition {
+		from := make([]relationship.SelectorItem, len(fromIDs))
+		for i, id := range fromIDs {
+			id := id
+			from[i] = relationship.SelectorItem{ID: &id}
+		}
+		to := make([]relationship.SelectorItem, len(toIDs))
+		for i, id := range toIDs {
+			id := id
+			to[i] = relationship.SelectorItem{ID: &id}
+		}
+		return &relationship.RelationshipDefinition{
+			Kind:             relationship.RelationshipDefinitionKind("edge"),
+			RelationshipType: "binding",
+			Selectors: &relationship.SelectorSet{
+				relationship.SelectorSetItem{
+					Allow: relationship.Selector{From: from, To: to},
+				},
+			},
+		}
+	}
+
+	relAB := mkRel([]uuid.UUID{idA, idB}, []uuid.UUID{idC, idD})
+	relAOnly := mkRel([]uuid.UUID{idA}, []uuid.UUID{idC})
+	relADifferentTail := mkRel([]uuid.UUID{idA, idC}, []uuid.UUID{idB, idD})
+
+	if RelationshipsAreSame(relAB, relAOnly) {
+		t.Error("relationships with different From lengths must not be equal")
+	}
+	if RelationshipsAreSame(relAB, relADifferentTail) {
+		t.Error("relationships sharing only [0] must not be equal")
+	}
+	if !RelationshipsAreSame(relAB, mkRel([]uuid.UUID{idA, idB}, []uuid.UUID{idC, idD})) {
+		t.Error("identical multi-selector relationships should be equal")
+	}
+}
+
+// TestFromAndToComponentsExistRejectsMissingTailComponent verifies validity check
+// considers every From/To item, not only [0]. A multi-element relationship whose
+// trailing From component has been deleted must be reported as invalid.
+func TestFromAndToComponentsExistRejectsMissingTailComponent(t *testing.T) {
+	keptID, _ := uuid.FromString("00000000-0000-0000-0000-000000000001")
+	missingID, _ := uuid.FromString("00000000-0000-0000-0000-0000000000de")
+	toID, _ := uuid.FromString("00000000-0000-0000-0000-00000000000a")
+
+	keptComp := &component.ComponentDefinition{Component: component.Component{Kind: "Pod"}}
+	keptComp.ID = keptID
+	toComp := &component.ComponentDefinition{Component: component.Component{Kind: "Service"}}
+	toComp.ID = toID
+
+	design := makePatternFile([]*component.ComponentDefinition{keptComp, toComp}, nil)
+
+	rel := &relationship.RelationshipDefinition{
+		Selectors: &relationship.SelectorSet{
+			relationship.SelectorSetItem{
+				Allow: relationship.Selector{
+					From: []relationship.SelectorItem{{ID: &keptID}, {ID: &missingID}},
+					To:   []relationship.SelectorItem{{ID: &toID}},
+				},
+			},
+		},
+	}
+
+	if fromAndToComponentsExist(rel, design) {
+		t.Error("expected relationship referencing a missing tail component to be invalid")
+	}
+}

--- a/server/policies/eval_rules.go
+++ b/server/policies/eval_rules.go
@@ -21,7 +21,10 @@ func componentDeclarationByID(design *pattern.PatternFile, id string) *component
 	return nil
 }
 
-// fromComponentID returns the from component ID from a relationship definition.
+// fromComponentID returns the first from component ID from a relationship definition.
+// Engine-generated relationships always have a single-item From/To; callers that
+// need every referenced component (multi-container Pods, multi-ref bindings) should
+// iterate ss.Allow.From themselves.
 func fromComponentID(rel *relationship.RelationshipDefinition) string {
 	if rel.Selectors == nil || len(*rel.Selectors) == 0 {
 		return ""
@@ -36,7 +39,8 @@ func fromComponentID(rel *relationship.RelationshipDefinition) string {
 	return ss.Allow.From[0].ID.String()
 }
 
-// toComponentID returns the to component ID from a relationship definition.
+// toComponentID returns the first to component ID from a relationship definition.
+// See fromComponentID for the multi-item caveat.
 func toComponentID(rel *relationship.RelationshipDefinition) string {
 	if rel.Selectors == nil || len(*rel.Selectors) == 0 {
 		return ""
@@ -51,15 +55,34 @@ func toComponentID(rel *relationship.RelationshipDefinition) string {
 	return ss.Allow.To[0].ID.String()
 }
 
-// fromAndToComponentsExist checks if both from and to components still exist in the design.
+// fromAndToComponentsExist checks that every from and to component still exists in
+// the design. Multi-element From/To slices (multi-container Pods, multi-ref bindings)
+// require all referenced components to be present; if any one is missing the
+// relationship is considered invalid.
 func fromAndToComponentsExist(rel *relationship.RelationshipDefinition, design *pattern.PatternFile) bool {
-	fromID := fromComponentID(rel)
-	toID := toComponentID(rel)
-	if fromID == "" || toID == "" {
+	if rel.Selectors == nil || len(*rel.Selectors) == 0 {
 		return false
 	}
-	return componentDeclarationByID(design, fromID) != nil &&
-		componentDeclarationByID(design, toID) != nil
+	ss := (*rel.Selectors)[0]
+	return allSelectorComponentsExist(ss.Allow.From, design) &&
+		allSelectorComponentsExist(ss.Allow.To, design)
+}
+
+// allSelectorComponentsExist returns true when sels is non-empty and every item has
+// a non-nil ID resolving to a component in design.
+func allSelectorComponentsExist(sels []relationship.SelectorItem, design *pattern.PatternFile) bool {
+	if len(sels) == 0 {
+		return false
+	}
+	for _, sel := range sels {
+		if sel.ID == nil {
+			return false
+		}
+		if componentDeclarationByID(design, sel.ID.String()) == nil {
+			return false
+		}
+	}
+	return true
 }
 
 // fromOrToComponentsDontExist returns true when one or both sides are missing.
@@ -142,6 +165,9 @@ func cleanupActionForPath(mutatedID string, mutatedPath []string, mutatedComp *c
 // When the relationship is in StatusDeleted, it emits reverse patches (schema default when
 // declared, otherwise remove) for fields that still hold the mutator's value, so deletion
 // restores the pre-mutation state.
+//
+// Pairs ss.Allow.From[i] with ss.Allow.To[i] by index so multi-selector relationships
+// (binding/network/wallet) emit actions for every pair rather than only [0].
 func patchMutatorsAction(rel *relationship.RelationshipDefinition, design *pattern.PatternFile) []PolicyAction {
 	if rel.Selectors == nil {
 		return nil
@@ -150,55 +176,52 @@ func patchMutatorsAction(rel *relationship.RelationshipDefinition, design *patte
 	var actions []PolicyAction
 
 	for _, ss := range *rel.Selectors {
-		if len(ss.Allow.From) == 0 || len(ss.Allow.To) == 0 {
-			continue
-		}
-		fromSel := ss.Allow.From[0]
-		toSel := ss.Allow.To[0]
-		if fromSel.RelationshipDefinitionSelectorsPatch == nil || toSel.RelationshipDefinitionSelectorsPatch == nil {
-			continue
-		}
-
-		fromID := selectorItemID(fromSel)
-		toID := selectorItemID(toSel)
-		fromComp := componentDeclarationByID(design, fromID)
-		toComp := componentDeclarationByID(design, toID)
-		if fromComp == nil || toComp == nil {
-			continue
-		}
-
-		mutatorRefs, mutatedRefs, mutatorComp, mutatedComp := resolveMutatorMutatedRefs(fromSel.RelationshipDefinitionSelectorsPatch, toSel.RelationshipDefinitionSelectorsPatch, fromComp, toComp)
-		if mutatorRefs == nil || mutatedRefs == nil {
-			continue
-		}
-
-		mutatedID := toID
-		if mutatedComp.ID == fromComp.ID {
-			mutatedID = fromID
-		}
-
-		count := len(mutatorRefs)
-		if len(mutatedRefs) < count {
-			count = len(mutatedRefs)
-		}
-
-		for i := 0; i < count; i++ {
-			mutatorValue := configurationForComponentAtPath(mutatorRefs[i], mutatorComp, design)
-			oldValue := configurationForComponentAtPath(mutatedRefs[i], mutatedComp, design)
-			if mutatorValue == nil {
+		pairCount := min(len(ss.Allow.From), len(ss.Allow.To))
+		for p := range pairCount {
+			fromSel := ss.Allow.From[p]
+			toSel := ss.Allow.To[p]
+			if fromSel.RelationshipDefinitionSelectorsPatch == nil || toSel.RelationshipDefinitionSelectorsPatch == nil {
 				continue
 			}
-			if reverse {
-				if !deepEqual(mutatorValue, oldValue) {
+
+			fromID := selectorItemID(fromSel)
+			toID := selectorItemID(toSel)
+			fromComp := componentDeclarationByID(design, fromID)
+			toComp := componentDeclarationByID(design, toID)
+			if fromComp == nil || toComp == nil {
+				continue
+			}
+
+			mutatorRefs, mutatedRefs, mutatorComp, mutatedComp := resolveMutatorMutatedRefs(fromSel.RelationshipDefinitionSelectorsPatch, toSel.RelationshipDefinitionSelectorsPatch, fromComp, toComp)
+			if mutatorRefs == nil || mutatedRefs == nil {
+				continue
+			}
+
+			mutatedID := toID
+			if mutatedComp.ID == fromComp.ID {
+				mutatedID = fromID
+			}
+
+			count := min(len(mutatorRefs), len(mutatedRefs))
+
+			for i := range count {
+				mutatorValue := configurationForComponentAtPath(mutatorRefs[i], mutatorComp, design)
+				oldValue := configurationForComponentAtPath(mutatedRefs[i], mutatedComp, design)
+				if mutatorValue == nil {
 					continue
 				}
-				actions = append(actions, cleanupActionForPath(mutatedID, mutatedRefs[i], mutatedComp))
-				continue
+				if reverse {
+					if !deepEqual(mutatorValue, oldValue) {
+						continue
+					}
+					actions = append(actions, cleanupActionForPath(mutatedID, mutatedRefs[i], mutatedComp))
+					continue
+				}
+				if deepEqual(mutatorValue, oldValue) {
+					continue
+				}
+				actions = append(actions, newComponentUpdateAction(getComponentUpdateOp(mutatedRefs[i]), mutatedID, mutatedRefs[i], mutatorValue))
 			}
-			if deepEqual(mutatorValue, oldValue) {
-				continue
-			}
-			actions = append(actions, newComponentUpdateAction(getComponentUpdateOp(mutatedRefs[i]), mutatedID, mutatedRefs[i], mutatorValue))
 		}
 	}
 	return actions
@@ -284,6 +307,9 @@ func sameRelationshipSelectorClause(a, b relationship.SelectorItem) bool {
 }
 
 // RelationshipsAreSame checks if two relationships are equivalent.
+//
+// Two selector sets match when their From and To slices have equal length and every
+// item pairs-equal; comparing only [0] would dedup distinct multi-selector relationships.
 func RelationshipsAreSame(relA, relB *relationship.RelationshipDefinition) bool {
 	if !sameRelationshipIdentifier(relA, relB) {
 		return false
@@ -293,17 +319,30 @@ func RelationshipsAreSame(relA, relB *relationship.RelationshipDefinition) bool 
 	}
 	for _, ssA := range *relA.Selectors {
 		for _, ssB := range *relB.Selectors {
-			if len(ssA.Allow.From) == 0 || len(ssB.Allow.From) == 0 ||
-				len(ssA.Allow.To) == 0 || len(ssB.Allow.To) == 0 {
+			if !sameSelectorItemSlice(ssA.Allow.From, ssB.Allow.From) {
 				continue
 			}
-			if sameRelationshipSelectorClause(ssA.Allow.From[0], ssB.Allow.From[0]) &&
-				sameRelationshipSelectorClause(ssA.Allow.To[0], ssB.Allow.To[0]) {
-				return true
+			if !sameSelectorItemSlice(ssA.Allow.To, ssB.Allow.To) {
+				continue
 			}
+			return true
 		}
 	}
 	return false
+}
+
+// sameSelectorItemSlice returns true when both slices are non-empty, the same length,
+// and every index pair satisfies sameRelationshipSelectorClause.
+func sameSelectorItemSlice(a, b []relationship.SelectorItem) bool {
+	if len(a) == 0 || len(b) == 0 || len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if !sameRelationshipSelectorClause(a[i], b[i]) {
+			return false
+		}
+	}
+	return true
 }
 
 // relationshipAlreadyExists checks if a relationship already exists in the design.

--- a/server/policies/policy_binding.go
+++ b/server/policies/policy_binding.go
@@ -56,20 +56,18 @@ func patchBindingMatchFields(rel *relationship.RelationshipDefinition, design *p
 
 	for _, ss := range *rel.Selectors {
 		for _, selArr := range [][]relationship.SelectorItem{ss.Allow.From, ss.Allow.To} {
-			if len(selArr) == 0 {
-				continue
-			}
-			sel := selArr[0]
-			if sel.Match == nil {
-				continue
-			}
-			compID := selectorItemID(sel)
-			comp := componentDeclarationByID(design, compID)
-			if comp == nil {
-				continue
-			}
+			for _, sel := range selArr {
+				if sel.Match == nil {
+					continue
+				}
+				compID := selectorItemID(sel)
+				comp := componentDeclarationByID(design, compID)
+				if comp == nil {
+					continue
+				}
 
-			actions = append(actions, patchBindingMatchFieldsForSelector(sel.Match, comp, design, reverse)...)
+				actions = append(actions, patchBindingMatchFieldsForSelector(sel.Match, comp, design, reverse)...)
+			}
 		}
 	}
 	return actions
@@ -93,50 +91,53 @@ func patchBindingMatchFieldsForSelector(match *relationship.MatchSelector, _ *co
 		if ms.self == nil || len(*ms.self) == 0 {
 			continue
 		}
-		mSel := (*ms.self)[0]
-		if mSel.MutatorRef == nil {
-			continue
-		}
-		matchComp := findMatchSelectorComponent(mSel, design)
-		if matchComp == nil {
-			continue
-		}
-
 		if ms.other == nil || len(*ms.other) == 0 {
 			continue
 		}
-		otherSel := (*ms.other)[0]
-		if otherSel.MutatedRef == nil {
-			continue
-		}
-		otherComp := findMatchSelectorComponent(otherSel, design)
-		if otherComp == nil {
-			continue
-		}
-
-		count := min(len(*mSel.MutatorRef), len(*otherSel.MutatedRef))
-
-		for i := range count {
-			mutatorPath := (*mSel.MutatorRef)[i]
-			mutatedPath := (*otherSel.MutatedRef)[i]
-
-			mutatorValue := configurationForComponentAtPath(mutatorPath, matchComp, design)
-			oldValue := configurationForComponentAtPath(mutatedPath, otherComp, design)
-
-			if mutatorValue == nil {
+		pairCount := min(len(*ms.self), len(*ms.other))
+		for p := range pairCount {
+			mSel := (*ms.self)[p]
+			if mSel.MutatorRef == nil {
 				continue
 			}
-			if reverse {
-				if !deepEqual(mutatorValue, oldValue) {
+			matchComp := findMatchSelectorComponent(mSel, design)
+			if matchComp == nil {
+				continue
+			}
+
+			otherSel := (*ms.other)[p]
+			if otherSel.MutatedRef == nil {
+				continue
+			}
+			otherComp := findMatchSelectorComponent(otherSel, design)
+			if otherComp == nil {
+				continue
+			}
+
+			count := min(len(*mSel.MutatorRef), len(*otherSel.MutatedRef))
+
+			for i := range count {
+				mutatorPath := (*mSel.MutatorRef)[i]
+				mutatedPath := (*otherSel.MutatedRef)[i]
+
+				mutatorValue := configurationForComponentAtPath(mutatorPath, matchComp, design)
+				oldValue := configurationForComponentAtPath(mutatedPath, otherComp, design)
+
+				if mutatorValue == nil {
 					continue
 				}
-				actions = append(actions, cleanupActionForPath(otherComp.ID.String(), mutatedPath, otherComp))
-				continue
+				if reverse {
+					if !deepEqual(mutatorValue, oldValue) {
+						continue
+					}
+					actions = append(actions, cleanupActionForPath(otherComp.ID.String(), mutatedPath, otherComp))
+					continue
+				}
+				if deepEqual(mutatorValue, oldValue) {
+					continue
+				}
+				actions = append(actions, newComponentUpdateAction(getComponentUpdateOp(mutatedPath), otherComp.ID.String(), mutatedPath, mutatorValue))
 			}
-			if deepEqual(mutatorValue, oldValue) {
-				continue
-			}
-			actions = append(actions, newComponentUpdateAction(getComponentUpdateOp(mutatedPath), otherComp.ID.String(), mutatedPath, mutatorValue))
 		}
 	}
 	return actions
@@ -318,11 +319,15 @@ func patchBindingSelectorIDsTyped(sel *relationship.SelectorItem, matchFromID, m
 	}
 	fromUUID, _ := uuidFromString(matchFromID)
 	toUUID, _ := uuidFromString(matchToID)
-	if sel.Match.From != nil && len(*sel.Match.From) > 0 {
-		(*sel.Match.From)[0].ID = &fromUUID
+	if sel.Match.From != nil {
+		for i := range *sel.Match.From {
+			(*sel.Match.From)[i].ID = &fromUUID
+		}
 	}
-	if sel.Match.To != nil && len(*sel.Match.To) > 0 {
-		(*sel.Match.To)[0].ID = &toUUID
+	if sel.Match.To != nil {
+		for i := range *sel.Match.To {
+			(*sel.Match.To)[i].ID = &toUUID
+		}
 	}
 }
 
@@ -356,33 +361,51 @@ func isValidBindingTyped(comp1, comp2 *component.ComponentDefinition, sel relati
 }
 
 // extractMutatorFromMatch finds the mutator component and ref paths from a match field.
+// Concatenates refs across every match item that declares a MutatorRef so multi-ref
+// bindings produce a complete path list instead of dropping items past [0].
 func extractMutatorFromMatch(match *relationship.MatchSelector, comp1, comp2 *component.ComponentDefinition) (*component.ComponentDefinition, [][]string) {
-	if match.From != nil && len(*match.From) > 0 {
-		if (*match.From)[0].MutatorRef != nil {
-			return comp1, *(*match.From)[0].MutatorRef
+	if match.From != nil {
+		if refs := collectRefs(*match.From, func(m relationship.MatchSelectorItem) *relationship.MutatorRef { return m.MutatorRef }); len(refs) > 0 {
+			return comp1, refs
 		}
 	}
-	if match.To != nil && len(*match.To) > 0 {
-		if (*match.To)[0].MutatorRef != nil {
-			return comp2, *(*match.To)[0].MutatorRef
+	if match.To != nil {
+		if refs := collectRefs(*match.To, func(m relationship.MatchSelectorItem) *relationship.MutatorRef { return m.MutatorRef }); len(refs) > 0 {
+			return comp2, refs
 		}
 	}
 	return nil, nil
 }
 
 // extractMutatedFromMatch finds the mutated component and ref paths from a match field.
+// Concatenates refs across every match item that declares a MutatedRef so multi-ref
+// bindings produce a complete path list instead of dropping items past [0].
 func extractMutatedFromMatch(match *relationship.MatchSelector, comp1, comp2 *component.ComponentDefinition) (*component.ComponentDefinition, [][]string) {
-	if match.From != nil && len(*match.From) > 0 {
-		if (*match.From)[0].MutatedRef != nil {
-			return comp1, *(*match.From)[0].MutatedRef
+	if match.From != nil {
+		if refs := collectRefs(*match.From, func(m relationship.MatchSelectorItem) *relationship.MutatedRef { return m.MutatedRef }); len(refs) > 0 {
+			return comp1, refs
 		}
 	}
-	if match.To != nil && len(*match.To) > 0 {
-		if (*match.To)[0].MutatedRef != nil {
-			return comp2, *(*match.To)[0].MutatedRef
+	if match.To != nil {
+		if refs := collectRefs(*match.To, func(m relationship.MatchSelectorItem) *relationship.MutatedRef { return m.MutatedRef }); len(refs) > 0 {
+			return comp2, refs
 		}
 	}
 	return nil, nil
+}
+
+// collectRefs flattens the [][]string entries from a slice of match items using
+// the supplied accessor (MutatorRef or MutatedRef).
+func collectRefs(items []relationship.MatchSelectorItem, ref func(relationship.MatchSelectorItem) *[][]string) [][]string {
+	var out [][]string
+	for _, m := range items {
+		r := ref(m)
+		if r == nil {
+			continue
+		}
+		out = append(out, (*r)...)
+	}
+	return out
 }
 
 // filterComponentsByKindTyped returns components matching the given kind.


### PR DESCRIPTION
Fixes follow-up (1) in #19149.

Selector and match-ref slices were read at `[0]` only, so multi-container Pods, multi-port containers, and multi-ref bindings silently dropped every element after the first.

## Changes

- `policy_matchlabels.go`: range over every path in `Match.Refs`.
- `policy_binding.go`:
  - `patchBindingMatchFields` ranges over each selector in `ss.Allow.From` / `ss.Allow.To`.
  - `patchBindingMatchFieldsForSelector` pairs `match.From` / `match.To` items by index (`min(len(self), len(other))`).
  - `patchBindingSelectorIDsTyped` assigns IDs to every From/To item.
  - `extractMutator/MutatedFromMatch` (via new `collectRefs` helper) concatenates refs across every match item.

Single-element behaviour stays byte-equal.

## Tests

- `TestMatchLabelsMultiRefIdentifiesAllPaths`: multi-ref matchLabels produces more groups than single-ref.
- `TestPatchBindingSelectorIDsTypedAllItems`: every match item receives the ID.
- `TestExtractMutatorMutatedRefsConcatAcrossItems`: refs flattened across items.
- `TestPatchBindingMatchFieldsMultiItemPair`: two-item match pair emits two patch actions.

`go test ./server/policies/...` — 142 passed.