### PR TITLE
[UI] use stable readiness selector in connections e2e

### DIFF
--- a/ui/tests/e2e/connections.spec.ts
+++ b/ui/tests/e2e/connections.spec.ts
@@ -51,7 +51,8 @@ test.describe.serial('Connection Management Tests', () => {
     const dashboardPage = new DashboardPage(page);
     await dashboardPage.navigateToDashboard();
     await dashboardPage.navigateToConnections();
-    await page.getByTestId('connection-addCluster').waitFor();
+    await page.waitForURL(/\/management\/connections/);
+    await page.getByTestId('ConnectionTable-search').waitFor();
   });
 
   test('Verify that UI components are displayed', async ({ page }) => {

--- a/ui/tests/e2e/connections.spec.ts
+++ b/ui/tests/e2e/connections.spec.ts
@@ -52,7 +52,7 @@ test.describe.serial('Connection Management Tests', () => {
     await dashboardPage.navigateToDashboard();
     await dashboardPage.navigateToConnections();
     await page.waitForURL(/\/management\/connections/);
-    await page.getByTestId('ConnectionTable-search').waitFor();
+    await expect(page.getByTestId('ConnectionTable-search')).toBeVisible();
   });
 
   test('Verify that UI components are displayed', async ({ page }) => {


### PR DESCRIPTION
Fix failing e2e test.

**[Signed commits](https://github.com/meshery/meshery/blob/master/CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [ ] Yes, I signed my commits.

<!--
Thank you for contributing to Meshery! 

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. Sign your commits.
4. Include before and after screenshots/terminal output.

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.
-->
