### PR TITLE
Add accessible labels to icon-only UI controls

### DIFF
--- a/ui/components/CustomToolbarSelect.tsx
+++ b/ui/components/CustomToolbarSelect.tsx
@@ -98,7 +98,10 @@ function CustomToolbarSelect({ setSelectedRows }) {
       <NoSsr>
         <div className="custom-toolbar-select">
           <Tooltip title="Deselect ALL">
-            <StyledIconButton onClick={handleClickDeselectAll}>
+            <StyledIconButton
+              aria-label="Deselect all performance results"
+              onClick={handleClickDeselectAll}
+            >
               <StyledIcon>
                 <IndeterminateCheckBox />
               </StyledIcon>
@@ -108,7 +111,7 @@ function CustomToolbarSelect({ setSelectedRows }) {
             <Tooltip title="Download">
               <StyledIconButton
                 key="download"
-                aria-label="download"
+                aria-label="Download performance test result"
                 color="inherit"
                 href={`/api/perf/profile/result/${encodeURIComponent(fullData[0].meshery_id)}`}
                 download={`${fullData[0].name}_test_result.json`}
@@ -120,7 +123,10 @@ function CustomToolbarSelect({ setSelectedRows }) {
             </Tooltip>
           )}
           <Tooltip title="Compare selected">
-            <StyledIconButton onClick={handleCompareSelected}>
+            <StyledIconButton
+              aria-label="Compare selected performance results"
+              onClick={handleCompareSelected}
+            >
               <StyledIcon>
                 <CompareArrows />
               </StyledIcon>

--- a/ui/components/YamlDialog.tsx
+++ b/ui/components/YamlDialog.tsx
@@ -22,8 +22,12 @@ const YAMLDialog = ({
   setYaml,
   deleteHandler,
   updateHandler,
+  type = 'filter',
   isReadOnly = false,
 }) => {
+  const resourceLabel = type === 'pattern' ? 'pattern' : 'filter';
+  const resourceTitle = type === 'pattern' ? 'Pattern' : 'Filter';
+
   return (
     <Dialog
       aria-labelledby="filter-dialog-title"
@@ -35,7 +39,11 @@ const YAMLDialog = ({
       <StyledDialog disableTypography id="filter-dialog-title">
         <YamlDialogTitleText variant="h6">{name}</YamlDialogTitleText>
         <Tooltip title="Exit Fullscreen" arrow placement="bottom">
-          <IconButton onClick={toggleFullScreen} size="large">
+          <IconButton
+            aria-label={fullScreen ? 'Exit fullscreen YAML editor' : 'Enter fullscreen YAML editor'}
+            onClick={toggleFullScreen}
+            size="large"
+          >
             {fullScreen ? <FullscreenExitIcon /> : <FullscreenIcon />}
           </IconButton>
         </Tooltip>
@@ -61,13 +69,23 @@ const YAMLDialog = ({
       <Divider />
       {!isReadOnly && (
         <DialogActions>
-          <Tooltip title="Update Pattern">
-            <IconButton aria-label="Update" color="primary" onClick={updateHandler} size="large">
+          <Tooltip title={`Update ${resourceTitle}`}>
+            <IconButton
+              aria-label={`Update ${resourceLabel} YAML`}
+              color="primary"
+              onClick={updateHandler}
+              size="large"
+            >
               <SaveIcon />
             </IconButton>
           </Tooltip>
-          <Tooltip title="Delete Filter">
-            <IconButton aria-label="Delete" color="primary" onClick={deleteHandler} size="large">
+          <Tooltip title={`Delete ${resourceTitle}`}>
+            <IconButton
+              aria-label={`Delete ${resourceLabel} YAML`}
+              color="primary"
+              onClick={deleteHandler}
+              size="large"
+            >
               <DeleteIcon />
             </IconButton>
           </Tooltip>

--- a/ui/components/connections/ConnectionTable.columns.tsx
+++ b/ui/components/connections/ConnectionTable.columns.tsx
@@ -140,8 +140,9 @@ export const useConnectionColumns = ({
                     placement="top"
                     title="Learn more about connection status and how to [troubleshoot Kubernetes connections](https://docs.meshery.io/guides/troubleshooting/meshery-operator-meshsync)"
                   >
-                    <div style={{ display: 'inline-block' }}>
+                    <Box display="inline-block">
                       <IconButton
+                        aria-label="View Kubernetes connection troubleshooting help"
                         color="default"
                         onClick={(event) => {
                           event.stopPropagation();
@@ -150,7 +151,7 @@ export const useConnectionColumns = ({
                       >
                         <InfoOutlinedIcon height={20} width={20} />
                       </IconButton>
-                    </div>
+                    </Box>
                   </CustomTextTooltip>
                 )}
               </>
@@ -170,6 +171,7 @@ export const useConnectionColumns = ({
                 columnData={column}
                 icon={
                   <IconButton
+                    aria-label="View environment information"
                     disableRipple={true}
                     disableFocusRipple={true}
                     onClick={(event) => {
@@ -488,7 +490,7 @@ export const useConnectionColumns = ({
                 {getColumnValue(tableMeta.rowData, 'kind', nextColumns) ===
                 CONNECTION_KINDS.KUBERNETES ? (
                   <IconButton
-                    aria-label="more"
+                    aria-label="Open connection actions menu"
                     id="long-button"
                     aria-haspopup="true"
                     onClick={(event) => handleActionMenuOpen(event, tableMeta)}

--- a/ui/components/data-formatter/index.tsx
+++ b/ui/components/data-formatter/index.tsx
@@ -103,7 +103,11 @@ export const FormatId = ({ id }) => {
         </Typography>
       </CustomTooltip>
       <CustomTooltip title={copied ? 'Copied!' : 'Copy'} placement="top">
-        <IconButton onClick={copyToClipboard} style={{ padding: '0.25rem' }}>
+        <IconButton
+          aria-label={`Copy ${id}`}
+          onClick={copyToClipboard}
+          style={{ padding: '0.25rem' }}
+        >
           <CopyIcon width="16px" height="16px" />
         </IconButton>
       </CustomTooltip>

--- a/ui/components/designs/configurator/MeshModel/index.tsx
+++ b/ui/components/designs/configurator/MeshModel/index.tsx
@@ -82,7 +82,7 @@ export default function DesignConfigurator() {
   return (
     <NoSsr>
       <CustomTooltip title="Back" placement="right">
-        <IconButton onClick={() => router.back()}>
+        <IconButton aria-label="Go back" onClick={() => router.back()}>
           <ArrowBack />
         </IconButton>
       </CustomTooltip>
@@ -190,7 +190,7 @@ export default function DesignConfigurator() {
           <CustomTooltip title="Save Design as New File">
             <div>
               <IconButton
-                aria-label="Save"
+                aria-label="Save design as new file"
                 data-testid="design-configurator-save-design-btn"
                 onClick={designSave}
                 disabled={!CAN(keys.CREATE_NEW_DESIGN.action, keys.CREATE_NEW_DESIGN.subject)}
@@ -204,7 +204,7 @@ export default function DesignConfigurator() {
               <CustomTooltip title="Update Design">
                 <div>
                   <IconButton
-                    aria-label="Update"
+                    aria-label="Update design"
                     data-testid="design-configurator-update-design-btn"
                     onClick={designUpdate}
                     disabled={!CAN(keys.EDIT_DESIGN.action, keys.EDIT_DESIGN.subject)}
@@ -216,7 +216,7 @@ export default function DesignConfigurator() {
               <CustomTooltip title="Delete Design">
                 <div>
                   <IconButton
-                    aria-label="Delete"
+                    aria-label="Delete design"
                     data-testid="design-configurator-delete-design-btn"
                     onClick={designDelete}
                     disabled={!CAN(keys.DELETE_A_DESIGN.action, keys.DELETE_A_DESIGN.subject)}

--- a/ui/components/designs/export/ExportDesignModal.tsx
+++ b/ui/components/designs/export/ExportDesignModal.tsx
@@ -95,7 +95,11 @@ const ExportDesignOptionRow: FC<ExportDesignOptionRowProps> = ({
         <OptionIconSlot>{Icon}</OptionIconSlot>
         <ListItemText primary={title} />
         <InfoTooltip placement="top" title={description} content={description} />
-        <OptionDownloadButton disabled={disabled} onClick={onClick}>
+        <OptionDownloadButton
+          aria-label={`Download ${title}`}
+          disabled={disabled}
+          onClick={onClick}
+        >
           <DownloadIcon fill={theme.palette.icon.default} />
         </OptionDownloadButton>
       </OptionRow>

--- a/ui/components/designs/lifecycle/common.tsx
+++ b/ui/components/designs/lifecycle/common.tsx
@@ -107,7 +107,7 @@ export const CheckBoxField = ({
       </Stack>
       {helpText && (
         <CustomTooltip title={helpText} placement="top">
-          <IconButton data-testid={`${testId}-help-icon`}>
+          <IconButton aria-label={`Help for ${label}`} data-testid={`${testId}-help-icon`}>
             <InfoCircleIcon fill={color} />
           </IconButton>
         </CustomTooltip>

--- a/ui/components/designs/patterns/ActionButton.tsx
+++ b/ui/components/designs/patterns/ActionButton.tsx
@@ -37,9 +37,10 @@ export default function ActionButton({ defaultActionClick, options }) {
         variant="outlined"
         style={{ boxShadow: 'none' }}
         ref={anchorRef}
-        aria-label="Button group with a nested menu"
+        aria-label="Design actions"
       >
         <Button
+          aria-label="Run default design action"
           sx={{
             padding: '6px 9px',
             borderRadius: '8px',
@@ -50,6 +51,9 @@ export default function ActionButton({ defaultActionClick, options }) {
           Action
         </Button>
         <Button
+          aria-label="Open design actions menu"
+          aria-haspopup="menu"
+          aria-expanded={open ? 'true' : undefined}
           sx={{
             padding: '6px 9px',
             borderRadius: '8px',

--- a/ui/components/designs/patterns/CustomToolbarSelect.tsx
+++ b/ui/components/designs/patterns/CustomToolbarSelect.tsx
@@ -32,6 +32,7 @@ const CustomToolbarSelect = ({
       <CustomTooltip title={'Delete'}>
         <div>
           <IconButton
+            aria-label="Delete selected designs"
             onClick={handleClickDelete}
             disabled={!CAN(keys.DELETE_A_DESIGN.action, keys.DELETE_A_DESIGN.subject)}
           >

--- a/ui/components/designs/patterns/MesheryPatternCard.tsx
+++ b/ui/components/designs/patterns/MesheryPatternCard.tsx
@@ -191,6 +191,7 @@ function MesheryPatternCard_({
             <CatalogCardButtons>
               {visibility === VISIBILITY.PUBLISHED && (
                 <TooltipButton
+                  aria-label="Unpublish design"
                   variant="outlined"
                   title="Unpublish"
                   style={{
@@ -240,6 +241,7 @@ function MesheryPatternCard_({
                 data-testid="pattern-btn-action-dropdown"
               />
               <TooltipButton
+                aria-label="Download design"
                 title="Download"
                 variant="contained"
                 color="primary"
@@ -258,6 +260,7 @@ function MesheryPatternCard_({
               </TooltipButton>
               {visibility === VISIBILITY.PRIVATE && userCanEdit ? (
                 <TooltipButton
+                  aria-label="Open design in configurator"
                   title="Design"
                   variant="contained"
                   color="primary"
@@ -278,6 +281,7 @@ function MesheryPatternCard_({
                 </TooltipButton>
               ) : (
                 <TooltipButton
+                  aria-label="Clone design"
                   title="Clone"
                   variant="contained"
                   color="primary"
@@ -296,6 +300,7 @@ function MesheryPatternCard_({
 
               {userCanEdit && (
                 <TooltipButton
+                  aria-label="Edit design in configurator"
                   title="Edit In Configurator"
                   variant="contained"
                   color="primary"
@@ -309,6 +314,7 @@ function MesheryPatternCard_({
                 </TooltipButton>
               )}
               <TooltipButton
+                aria-label="View design information"
                 title="Pattern Information"
                 variant="contained"
                 color="primary"
@@ -348,6 +354,9 @@ function MesheryPatternCard_({
                 </Link>
                 <CustomTooltip title="Enter Fullscreen" arrow interactive placement="top">
                   <IconButton
+                    aria-label={
+                      fullScreen ? 'Exit fullscreen pattern view' : 'Enter fullscreen pattern view'
+                    }
                     onClick={(ev) =>
                       genericClickHandler(ev, () => {
                         {
@@ -416,6 +425,7 @@ function MesheryPatternCard_({
                   {/* Save button */}
                   <CustomTooltip title="Save" arrow interactive placement="bottom">
                     <IconButton
+                      aria-label="Save design changes"
                       disabled={!CAN(keys.EDIT_DESIGN.action, keys.EDIT_DESIGN.subject)}
                       onClick={(ev) => genericClickHandler(ev, updateHandler)}
                       data-testid="pattern-btn-save"
@@ -427,6 +437,7 @@ function MesheryPatternCard_({
                   {/* Delete Button */}
                   <CustomTooltip title="Delete" arrow interactive placement="bottom">
                     <IconButton
+                      aria-label="Delete design"
                       disabled={!CAN(keys.DELETE_A_DESIGN.action, keys.DELETE_A_DESIGN.subject)}
                       onClick={(ev) => genericClickHandler(ev, deleteHandler)}
                       data-testid="pattern-btn-delete"

--- a/ui/components/designs/patterns/MesheryPatternsToolbar.tsx
+++ b/ui/components/designs/patterns/MesheryPatternsToolbar.tsx
@@ -57,7 +57,7 @@ function MesheryPatternsToolbar({
                   <TooltipButton
                     title="Create Design"
                     data-testid="meshery-patterns-create-design-btn"
-                    aria-label="Add Pattern"
+                    aria-label="Create design"
                     variant="contained"
                     color="primary"
                     size="large"
@@ -72,7 +72,7 @@ function MesheryPatternsToolbar({
                   <TooltipButton
                     title="Import Design"
                     data-testid="meshery-patterns-import-design-btn"
-                    aria-label="Add Pattern"
+                    aria-label="Import design"
                     variant="contained"
                     color="primary"
                     size="large"

--- a/ui/components/designs/patterns/YAMLEditor.tsx
+++ b/ui/components/designs/patterns/YAMLEditor.tsx
@@ -92,7 +92,7 @@ function YAMLEditor({ pattern, onClose, onSubmit, isReadOnly = false }) {
           <>
             <CustomTooltip title="Update Design">
               <IconButton
-                aria-label="Update"
+                aria-label="Update design"
                 disabled={!CAN(keys.EDIT_DESIGN.action, keys.EDIT_DESIGN.subject)}
                 onClick={() =>
                   onSubmit({
@@ -109,7 +109,7 @@ function YAMLEditor({ pattern, onClose, onSubmit, isReadOnly = false }) {
             </CustomTooltip>
             <CustomTooltip title="Delete Pattern">
               <IconButton
-                aria-label="Delete"
+                aria-label="Delete design"
                 disabled={!CAN(keys.DELETE_A_DESIGN.action, keys.DELETE_A_DESIGN.subject)}
                 onClick={() =>
                   onSubmit({

--- a/ui/components/environments/environment-card.tsx
+++ b/ui/components/environments/environment-card.tsx
@@ -221,6 +221,7 @@ const EnvironmentCard = ({
                 }}
               >
                 <IconButton
+                  aria-label={`Edit environment ${environmentDetails.name}`}
                   onClick={onEdit}
                   disabled={
                     selectedEnvironments?.filter((id) => id == environmentDetails.id).length === 1
@@ -231,6 +232,7 @@ const EnvironmentCard = ({
                   <EditIcon fill="white" style={{ margin: '0 2px' }} />
                 </IconButton>
                 <IconButton
+                  aria-label={`Delete environment ${environmentDetails.name}`}
                   onClick={onDelete}
                   disabled={
                     selectedEnvironments?.filter((id) => id == environmentDetails.id).length === 1

--- a/ui/components/filters/FiltersCard.tsx
+++ b/ui/components/filters/FiltersCard.tsx
@@ -114,6 +114,7 @@ function FiltersCard_({
           setYaml={setYaml}
           deleteHandler={deleteHandler}
           updateHandler={updateHandler}
+          type={'filter'}
         />
       )}
       <FlipCard
@@ -159,6 +160,7 @@ function FiltersCard_({
             <CatalogCardButtons>
               {canPublishFilter && visibility !== VISIBILITY.PUBLISHED ? (
                 <TooltipButton
+                  aria-label="Publish filter"
                   variant="outlined"
                   title="Publish"
                   style={{
@@ -173,6 +175,7 @@ function FiltersCard_({
                 </TooltipButton>
               ) : (
                 <TooltipButton
+                  aria-label="Unpublish filter"
                   variant="outlined"
                   title="Unpublish"
                   style={{
@@ -189,6 +192,7 @@ function FiltersCard_({
                 </TooltipButton>
               )}
               <TooltipButton
+                aria-label="Download filter"
                 title="Download"
                 variant="contained"
                 color="primary"
@@ -207,6 +211,7 @@ function FiltersCard_({
 
               {visibility === VISIBILITY.PUBLISHED ? (
                 <TooltipButton
+                  aria-label="Clone filter"
                   title="Clone"
                   variant="contained"
                   color="primary"
@@ -222,6 +227,7 @@ function FiltersCard_({
                 </TooltipButton>
               ) : null}
               <TooltipButton
+                aria-label="View filter information"
                 title="Filter Information"
                 variant="contained"
                 color="primary"
@@ -255,6 +261,9 @@ function FiltersCard_({
                 </Link>
                 <Tooltip title="Enter Fullscreen" arrow interactive placement="top">
                   <IconButton
+                    aria-label={
+                      fullScreen ? 'Exit fullscreen filter view' : 'Enter fullscreen filter view'
+                    }
                     onClick={(ev) =>
                       genericClickHandler(ev, () => {
                         {
@@ -314,6 +323,7 @@ function FiltersCard_({
                 {/* Save button */}
                 <Tooltip title="Save" arrow interactive placement="bottom">
                   <IconButton
+                    aria-label="Save filter changes"
                     disabled={!CAN(keys.EDIT_WASM_FILTER.action, keys.EDIT_WASM_FILTER.subject)}
                     onClick={(ev) => genericClickHandler(ev, updateHandler)}
                   >
@@ -324,6 +334,7 @@ function FiltersCard_({
                 {/* Delete Button */}
                 <Tooltip title="Delete" arrow interactive placement="bottom">
                   <IconButton
+                    aria-label="Delete filter"
                     disabled={!CAN(keys.DELETE_WASM_FILTER.action, keys.DELETE_WASM_FILTER.subject)}
                     onClick={(ev) => genericClickHandler(ev, deleteHandler)}
                   >

--- a/ui/components/filters/YAMLEditor.tsx
+++ b/ui/components/filters/YAMLEditor.tsx
@@ -101,7 +101,7 @@ function YAMLEditor({ filter, onClose, onSubmit }: YAMLEditorProps) {
       <DialogActions>
         <CustomTooltip title="Update Filter">
           <IconButton
-            aria-label="Update"
+            aria-label="Update filter"
             disabled={!CAN(keys.EDIT_WASM_FILTER.action, keys.EDIT_WASM_FILTER.subject)}
             onClick={() =>
               onSubmit({
@@ -118,7 +118,7 @@ function YAMLEditor({ filter, onClose, onSubmit }: YAMLEditorProps) {
         </CustomTooltip>
         <CustomTooltip title="Delete Filter">
           <IconButton
-            aria-label="Delete"
+            aria-label="Delete filter"
             disabled={!CAN(keys.DELETE_WASM_FILTER.action, keys.DELETE_WASM_FILTER.subject)}
             onClick={() =>
               onSubmit({

--- a/ui/components/layout/Header/Header.tsx
+++ b/ui/components/layout/Header/Header.tsx
@@ -255,7 +255,7 @@ function K8sContextMenu({
       <div>
         <CanShow Key={keys.VIEW_ALL_KUBERNETES_CLUSTERS}>
           <IconButton
-            aria-label="contexts"
+            aria-label="Open Kubernetes contexts menu"
             className="k8s-icon-button"
             onClick={(e) => {
               e.preventDefault();
@@ -289,6 +289,7 @@ function K8sContextMenu({
                 }}
                 width="24px"
                 height="24px"
+                alt="Kubernetes"
                 style={{ objectFit: 'contain' }}
               />
               <CBadge
@@ -377,7 +378,11 @@ function K8sContextMenu({
                         </div>
                         <CustomTooltip title="Configure Connections">
                           <div>
-                            <IconButton size="small" onClick={() => setIsConnectionOpenModal(true)}>
+                            <IconButton
+                              aria-label="Configure connections"
+                              size="small"
+                              onClick={() => setIsConnectionOpenModal(true)}
+                            >
                               <SettingsIcon style={{ ...iconSmall }} />
                             </IconButton>
                           </div>

--- a/ui/components/meshery-mesh-interface/PatternService/RJSFCustomComponents/ArrayFieldTemlate.tsx
+++ b/ui/components/meshery-mesh-interface/PatternService/RJSFCustomComponents/ArrayFieldTemlate.tsx
@@ -70,6 +70,7 @@ const DefaultArrayItem = (props) => {
           <Grid2>
             {(props.hasMoveUp || props.hasMoveDown) && (
               <IconButton
+                aria-label={`Move item ${props.index + 1} up`}
                 icon="arrow-up"
                 className="array-item-move-up"
                 tabIndex={-1}
@@ -82,6 +83,7 @@ const DefaultArrayItem = (props) => {
 
             {(props.hasMoveUp || props.hasMoveDown) && (
               <IconButton
+                aria-label={`Move item ${props.index + 1} down`}
                 icon="arrow-down"
                 tabIndex={-1}
                 style={btnStyle}
@@ -193,6 +195,7 @@ const DefaultNormalArrayFieldTemplate = (props) => {
                 )}
               >
                 <IconButton
+                  aria-label={`Validation errors for item ${props.index + 1}`}
                   component="span"
                   size="small"
                   disableTouchRipple="true"
@@ -214,6 +217,7 @@ const DefaultNormalArrayFieldTemplate = (props) => {
                 <Grid2 item={true}>
                   <Box mt={2}>
                     <IconButton
+                      aria-label="Add array item"
                       className="array-item-add"
                       onClick={
                         typeof props.onAddClick === 'function' ? props.onAddClick : undefined

--- a/ui/components/meshery-mesh-interface/PatternService/RJSFCustomComponents/CustomBaseInput.tsx
+++ b/ui/components/meshery-mesh-interface/PatternService/RJSFCustomComponents/CustomBaseInput.tsx
@@ -114,7 +114,12 @@ const BaseInput = (props) => {
                     title={errorTitle}
                     interactive={true}
                   >
-                    <IconButton component="span" size="small" tabIndex={-1}>
+                    <IconButton
+                      aria-label={`Validation errors for ${props.label}`}
+                      component="span"
+                      size="small"
+                      tabIndex={-1}
+                    >
                       <ErrorOutlineIcon
                         width="14px"
                         height="14px"
@@ -130,7 +135,12 @@ const BaseInput = (props) => {
                     title={descriptionTitle}
                     interactive={true}
                   >
-                    <IconButton component="span" size="small" tabIndex={-1}>
+                    <IconButton
+                      aria-label={`Help for ${props.label}`}
+                      component="span"
+                      size="small"
+                      tabIndex={-1}
+                    >
                       <HelpOutlineIcon
                         width="14px"
                         height="14px"

--- a/ui/components/meshery-mesh-interface/PatternService/RJSFCustomComponents/CustomSelectWidget.tsx
+++ b/ui/components/meshery-mesh-interface/PatternService/RJSFCustomComponents/CustomSelectWidget.tsx
@@ -98,7 +98,11 @@ export default function CustomSelectWidget({
                   title={rawErrors?.join('  ')}
                   interactive={true}
                 >
-                  <IconButton component="span" size="small">
+                  <IconButton
+                    aria-label={`Validation errors for ${label}`}
+                    component="span"
+                    size="small"
+                  >
                     <ErrorOutlineIcon
                       width="14px"
                       height="14px"
@@ -114,7 +118,12 @@ export default function CustomSelectWidget({
                   title={schema.description}
                   interactive={true}
                 >
-                  <IconButton component="span" size="small" style={{ marginRight: '4px' }}>
+                  <IconButton
+                    aria-label={`Help for ${label}`}
+                    component="span"
+                    size="small"
+                    style={{ marginRight: '4px' }}
+                  >
                     <HelpOutlineIcon
                       width="14px"
                       height="14px"

--- a/ui/components/meshery-mesh-interface/PatternService/RJSFCustomComponents/ObjectFieldTemplate.tsx
+++ b/ui/components/meshery-mesh-interface/PatternService/RJSFCustomComponents/ObjectFieldTemplate.tsx
@@ -72,6 +72,7 @@ const ObjectFieldTemplate = ({
               }}
             >
               <IconButton
+                aria-label={`Add ${titleStr || 'object property'}`}
                 className="object-property-expand"
                 onClick={typeof onAddClick === 'function' ? onAddClick(schema) : undefined}
                 disabled={disabled || readonly}
@@ -90,7 +91,11 @@ const ObjectFieldTemplate = ({
           ) : (
             Object.keys(properties).length > 0 && (
               <Grid2>
-                <IconButton className="object-property-expand" onClick={() => setShow(!show)}>
+                <IconButton
+                  aria-label={`${show ? 'Collapse' : 'Expand'} ${titleStr || 'object properties'}`}
+                  className="object-property-expand"
+                  onClick={() => setShow(!show)}
+                >
                   {show ? (
                     <ExpandLessIcon style={iconMedium} fill="gray" />
                   ) : (
@@ -116,6 +121,7 @@ const ObjectFieldTemplate = ({
             {safeStringTitle(descProp ?? safeDescriptionStr) && (
               <CustomTextTooltip title={safeStringTitle(descProp ?? safeDescriptionStr)}>
                 <IconButton
+                  aria-label={`Help for ${titleStr || 'field'}`}
                   disableTouchRipple="true"
                   disableRipple="true"
                   component="span"
@@ -136,6 +142,7 @@ const ObjectFieldTemplate = ({
                 title={safeStringTitle(Array.isArray(rawErrors) ? rawErrors.join('  ') : rawErrors)}
               >
                 <IconButton
+                  aria-label={`Validation errors for ${titleStr || 'field'}`}
                   disableTouchRipple="true"
                   disableRipple="true"
                   component="span"

--- a/ui/components/meshery-mesh-interface/PatternService/RJSFCustomComponents/WrapIfAdditionalTemplate.tsx
+++ b/ui/components/meshery-mesh-interface/PatternService/RJSFCustomComponents/WrapIfAdditionalTemplate.tsx
@@ -53,6 +53,7 @@ const WrapIfAdditionalTemplate = ({
       <Grid2 size={{ xs: 12 }}>{children}</Grid2>
       <Grid2>
         <IconButton
+          aria-label={`Remove ${label}`}
           component="span"
           disabled={disabled || readonly}
           onClick={onDropPropertyClick(label)}

--- a/ui/components/meshery-mesh-interface/PatternServiceForm.tsx
+++ b/ui/components/meshery-mesh-interface/PatternServiceForm.tsx
@@ -110,13 +110,14 @@ function PatternServiceForm({
                 {schemaSet?.workload?.description && (
                   <label htmlFor="help-button">
                     <Tooltip title={schemaSet?.workload?.description} interactive>
-                      <IconButton component="span">
+                      <IconButton aria-label="Show workload description" component="span">
                         <HelpOutline width="22px" style={{ color: '#fff' }} height="22px" />
                       </IconButton>
                     </Tooltip>
                   </label>
                 )}
                 <IconButton
+                  aria-label="Delete workload settings"
                   component="span"
                   onClick={() =>
                     // @ts-ignore

--- a/ui/components/performance/MesheryResults.tsx
+++ b/ui/components/performance/MesheryResults.tsx
@@ -251,7 +251,7 @@ const MesheryResults = () => {
           ),
           customBodyRender: (value, tableMeta) => (
             <IconButton
-              aria-label="more"
+              aria-label="View performance result details"
               color="inherit"
               onClick={() => setSelectedRowData(results[tableMeta.rowIndex])}
             >

--- a/ui/components/performance/PerformanceCard.tsx
+++ b/ui/components/performance/PerformanceCard.tsx
@@ -294,6 +294,7 @@ function PerformanceCard({
             >
               <CustomTooltip title="Edit">
                 <IconButton
+                  aria-label="Edit performance profile"
                   onClick={(ev) => genericClickHandler(ev, handleEdit)}
                   data-testid={dataTestIDs('edit')}
                   disabled={
@@ -305,6 +306,7 @@ function PerformanceCard({
               </CustomTooltip>
               <CustomTooltip title="Delete">
                 <IconButton
+                  aria-label="Delete performance profile"
                   onClick={(ev) => genericClickHandler(ev, handleDelete)}
                   data-testid={dataTestIDs('delete')}
                   disabled={

--- a/ui/components/performance/PerformanceFormActions.tsx
+++ b/ui/components/performance/PerformanceFormActions.tsx
@@ -33,6 +33,7 @@ const PerformanceFormActions: React.FC<PerformanceFormActionsProps> = ({
   return (
     <div style={{ display: 'flex', justifyContent: 'flex-end' }}>
       <Button
+        aria-label="Clear performance test form"
         type="submit"
         variant="contained"
         color="primary"
@@ -45,6 +46,7 @@ const PerformanceFormActions: React.FC<PerformanceFormActionsProps> = ({
       </Button>
       {hasTestResult && (
         <Button
+          aria-label="View performance test results"
           type="submit"
           variant="contained"
           color="primary"
@@ -57,6 +59,7 @@ const PerformanceFormActions: React.FC<PerformanceFormActionsProps> = ({
         </Button>
       )}
       <Button
+        aria-label="Save performance profile"
         type="submit"
         variant="contained"
         color="primary"
@@ -69,6 +72,7 @@ const PerformanceFormActions: React.FC<PerformanceFormActionsProps> = ({
         Save Profile
       </Button>
       <Button
+        aria-label="Run performance test"
         type="submit"
         data-testid="run-performance-test"
         variant="contained"

--- a/ui/components/performance/PerformanceResults.tsx
+++ b/ui/components/performance/PerformanceResults.tsx
@@ -203,7 +203,7 @@ function generateColumnsForDisplay(
         customBodyRender: function CustomBody(value, tableMeta) {
           return (
             <IconButton
-              aria-label="more"
+              aria-label="View performance result chart"
               data-testid="open-performance-result-bar-chart"
               color="inherit"
               onClick={() => setSelectedProfileIdxForChart(tableMeta.rowIndex)}
@@ -226,7 +226,7 @@ function generateColumnsForDisplay(
         customBodyRender: function CustomBody(value, tableMeta) {
           return (
             <IconButton
-              aria-label="more"
+              aria-label="View performance node details"
               color="inherit"
               onClick={() => setSelectedProfileIdxForNodeDetails(tableMeta.rowIndex)}
             >

--- a/ui/components/performance/PerformanceTestResults.tsx
+++ b/ui/components/performance/PerformanceTestResults.tsx
@@ -29,7 +29,7 @@ const PerformanceTestResults: React.FC<PerformanceTestResultsProps> = ({
   return (
     <div>
       <Box display="flex" justifyContent="space-between" alignItems="center">
-        <IconButton onClick={onBack}>
+        <IconButton aria-label="Back to performance test" onClick={onBack}>
           <ArrowBack />
         </IconButton>
         <Typography variant="h6" gutterBottom sx={{ textAlign: 'center' }} id="timerAnchor">
@@ -37,7 +37,7 @@ const PerformanceTestResults: React.FC<PerformanceTestResultsProps> = ({
         </Typography>
         <IconButton
           key="download"
-          aria-label="download"
+          aria-label="Download performance test results"
           color="inherit"
           href={`/api/perf/profile/result/${encodeURIComponent(testResult.meshery_id)}`}
         >

--- a/ui/components/registry/RegistryModal.tsx
+++ b/ui/components/registry/RegistryModal.tsx
@@ -330,7 +330,10 @@ export const Navigation: FC<NavigationProps> = ({ setHeaderInfo }) => {
           ))}
         </List>
         <DrawerHeader open={open}>
-          <IconButton onClick={handleDrawerToggle}>
+          <IconButton
+            aria-label={open ? 'Collapse registry navigation' : 'Expand registry navigation'}
+            onClick={handleDrawerToggle}
+          >
             {open ? <ChevronLeftIcon /> : <ChevronRightIcon />}
           </IconButton>
         </DrawerHeader>

--- a/ui/components/workspaces/SpacesSwitcher/MenuComponent.tsx
+++ b/ui/components/workspaces/SpacesSwitcher/MenuComponent.tsx
@@ -48,6 +48,7 @@ export const MenuComponent = ({ options = [] }) => {
         {options.map((option) => (
           <CustomTooltip key={option.title} title={option.title}>
             <IconButton
+              aria-label={option.title}
               sx={{
                 padding: '0.15rem',
               }}

--- a/ui/components/workspaces/SpacesSwitcher/MobileViewSwitcher.tsx
+++ b/ui/components/workspaces/SpacesSwitcher/MobileViewSwitcher.tsx
@@ -67,7 +67,7 @@ function SwitcherMenu({ organization, router }) {
     <>
       <div>
         <Button
-          aria-label="contexts"
+          aria-label="Open Kubernetes contexts menu"
           className="switcher-icon-button"
           onClick={(e) => {
             e.preventDefault();

--- a/ui/components/workspaces/SpacesSwitcher/components.tsx
+++ b/ui/components/workspaces/SpacesSwitcher/components.tsx
@@ -446,7 +446,10 @@ export const MultiContentSelectToolbar = ({
           paddingInline={'1rem'}
         >
           <Box display={'flex'} alignItems={'center'} gap={'0.5rem'}>
-            <IconButton onClick={() => setMultiSelectedContent([])}>
+            <IconButton
+              aria-label={`Clear selected ${type}`}
+              onClick={() => setMultiSelectedContent([])}
+            >
               <CloseIcon />
             </IconButton>
             <Typography>
@@ -456,6 +459,7 @@ export const MultiContentSelectToolbar = ({
           <Box style={{ display: 'flex', gap: '0.5rem' }}>
             {handleContentMove && (
               <StyledResponsiveButton
+                aria-label={`Move selected ${type}`}
                 variant="contained"
                 startIcon={<MoveFileIcon style={iconMedium} fill={theme.palette.common.white} />}
                 onClick={() => {
@@ -467,6 +471,7 @@ export const MultiContentSelectToolbar = ({
               </StyledResponsiveButton>
             )}
             <StyledResponsiveButton
+              aria-label={`Download selected ${type}`}
               variant="contained"
               startIcon={<ExportIcon style={iconMedium} fill={theme.palette.common.white} />}
               onClick={() => {
@@ -481,6 +486,7 @@ export const MultiContentSelectToolbar = ({
             </StyledResponsiveButton>{' '}
             {handleShare && (
               <StyledResponsiveButton
+                aria-label={`Share selected ${type}`}
                 variant="contained"
                 startIcon={<ShareIcon style={iconMedium} fill={theme.palette.common.white} />}
                 onClick={() => {
@@ -493,6 +499,7 @@ export const MultiContentSelectToolbar = ({
               </StyledResponsiveButton>
             )}
             <StyledResponsiveButton
+              aria-label={`Delete selected ${type}`}
               color="error"
               variant="contained"
               onClick={() => {

--- a/ui/components/workspaces/WorkspaceActionList.tsx
+++ b/ui/components/workspaces/WorkspaceActionList.tsx
@@ -81,7 +81,7 @@ const WorkspaceActionList = ({
       <IconWrapper>
         {isMobile ? (
           <>
-            <IconButton aria-label="more" onClick={handleClick}>
+            <IconButton aria-label="Open workspace actions menu" onClick={handleClick}>
               <MoreVertIcon />
             </IconButton>
             <Menu anchorEl={anchorEl} open={open} onClose={handleClose}>
@@ -104,7 +104,7 @@ const WorkspaceActionList = ({
           <>
             {actionItems.map(({ key, label, icon, onClick, disabled }) => (
               <CustomTooltip title={label} key={key}>
-                <IconButton aria-label={key} onClick={(e) => onClick(e)} disabled={disabled}>
+                <IconButton aria-label={label} onClick={(e) => onClick(e)} disabled={disabled}>
                   {icon}
                 </IconButton>
               </CustomTooltip>

--- a/ui/components/workspaces/WorkspaceDataTable.tsx
+++ b/ui/components/workspaces/WorkspaceDataTable.tsx
@@ -179,7 +179,11 @@ const WorkspaceDataTable = ({
                       title={`Meshery Environments allow you to logically group related Connections and their associated Credentials. [Learn more](https://docs.meshery.io/concepts/logical/environments)`}
                     >
                       <Typography style={{ display: 'flex', marginLeft: '5px' }} variant="span">
-                        <IconButton disableRipple={true} disableFocusRipple={true}>
+                        <IconButton
+                          aria-label="Learn about Meshery environments"
+                          disableRipple={true}
+                          disableFocusRipple={true}
+                        >
                           <InfoIcon
                             style={{
                               cursor: 'pointer',


### PR DESCRIPTION
Description
Adds descriptive accessible names to icon-only and ambiguous action controls across Meshery UI.

Changes
- Added `aria-label`s to pattern, filter, workspace, environment, registry, and spaces switcher controls.
- Improved generic labels like `Update`, `Delete`, `more`, and `download` with action-specific names.
- Added accessible labels to form helper/error icons and performance action buttons.
- Preserved existing visual behavior and layout.


Fixes #19272 