### PR TITLE
[UI] Fix MenuListContext error in select wrappers

### DIFF
--- a/ui/components/ReactSelectWrapper.tsx
+++ b/ui/components/ReactSelectWrapper.tsx
@@ -7,7 +7,7 @@ import {
   TextField,
   Paper,
   Chip,
-  MenuItem,
+  ListItemButton,
   useTheme,
   styled,
   NoSsr,
@@ -79,7 +79,7 @@ function Control(props) {
 
 function Option(props) {
   return (
-    <MenuItem
+    <ListItemButton
       ref={props.innerRef}
       selected={props.isFocused}
       component="div"
@@ -87,7 +87,7 @@ function Option(props) {
       {...props.innerProps}
     >
       {props.children}
-    </MenuItem>
+    </ListItemButton>
   );
 }
 

--- a/ui/components/multi-select-wrapper.tsx
+++ b/ui/components/multi-select-wrapper.tsx
@@ -2,7 +2,7 @@ import { useState } from 'react';
 import { components } from 'react-select';
 import CreatableSelect from 'react-select/creatable';
 import { Colors } from '../themes/app';
-import { Checkbox, MenuItem, Paper, FormControlLabel } from '@sistent/sistent';
+import { Checkbox, ListItemButton, Paper, FormControlLabel } from '@sistent/sistent';
 import { useTheme } from '@sistent/sistent';
 
 const MultiSelectWrapper = (props) => {
@@ -25,8 +25,8 @@ const MultiSelectWrapper = (props) => {
 
   const Option = (props) => {
     return (
-      <MenuItem
-        buttonRef={props.innerRef}
+      <ListItemButton
+        ref={props.innerRef}
         selected={props.isFocused}
         {...props.innerProps}
         component="div"
@@ -64,7 +64,7 @@ const MultiSelectWrapper = (props) => {
           }
           label={<span style={{ marginLeft: '0.5rem' }}>{props.label}</span>}
         />
-      </MenuItem>
+      </ListItemButton>
     );
   };
 

--- a/ui/components/select-wrappers.test.tsx
+++ b/ui/components/select-wrappers.test.tsx
@@ -1,0 +1,81 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import ReactSelectWrapper from './ReactSelectWrapper';
+import MultiSelectWrapper from './multi-select-wrapper';
+
+let capturedSelectProps: any[] = [];
+
+vi.mock('react-select/creatable', () => ({
+  default: (props) => {
+    capturedSelectProps.push(props);
+    return <div data-testid="creatable-select" />;
+  },
+}));
+
+vi.mock('react-select', () => ({
+  components: {
+    Input: ({ children, ...props }) => <div {...props}>{children}</div>,
+  },
+}));
+
+describe('select wrappers', () => {
+  beforeEach(() => {
+    capturedSelectProps = [];
+  });
+
+  it('renders ReactSelectWrapper option content without a menu context error', () => {
+    render(
+      <ReactSelectWrapper
+        label="Environment"
+        placeholder="Select environment"
+        onChange={vi.fn()}
+        options={[{ label: 'Production', value: 'prod' }]}
+        value={null}
+      />,
+    );
+
+    const Option = capturedSelectProps.at(-1).components.Option;
+
+    render(
+      <Option
+        innerRef={vi.fn()}
+        innerProps={{ onClick: vi.fn(), role: 'option' }}
+        isFocused={false}
+        isSelected={false}
+      >
+        Production
+      </Option>,
+    );
+
+    expect(screen.getByText('Production')).toBeInTheDocument();
+  });
+
+  it('renders MultiSelectWrapper option content without a menu context error', () => {
+    render(
+      <MultiSelectWrapper
+        onChange={vi.fn()}
+        options={[
+          { label: 'All', value: '*' },
+          { label: 'Production', value: 'prod' },
+        ]}
+        value={[]}
+      />,
+    );
+
+    const Option = capturedSelectProps.at(-1).components.Option;
+
+    render(
+      <Option
+        innerRef={vi.fn()}
+        innerProps={{ onClick: vi.fn(), role: 'option' }}
+        isFocused={true}
+        isSelected={true}
+        label="Production"
+        value="prod"
+      />,
+    );
+
+    expect(screen.getByText('Production')).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## Summary
- replace out-of-context `MenuItem` usage in the shared `react-select` wrappers with `ListItemButton`
- preserve the existing option styling and selection behavior
- add regression tests covering both wrappers

## Testing
- cd ui && npx eslint components/ReactSelectWrapper.tsx components/multi-select-wrapper.tsx components/select-wrappers.test.tsx
- cd ui && npm test -- components/select-wrappers.test.tsx