### PR TITLE
[Docs] Prevent indexing of previous documentation versions

### DIFF
--- a/docs/layouts/robots.txt
+++ b/docs/layouts/robots.txt
@@ -1,9 +1,8 @@
 User-agent: *
 Allow: /
 Disallow: /pr-preview/
-Disallow: /v0.4/
-Disallow: /v0.5/
-Disallow: /v0.6/
-Disallow: /v0.7/
-Disallow: /v0.8/
-Disallow: /v0.9/
+
+# Previous documentation versions are crawlable but emit a
+# `<meta name="robots" content="noindex, follow">` tag in each page's HTML
+# head so search engines drop them from indexes while still following links
+# back to current docs. See meshery/meshery#19250.

--- a/docs/static/v0.4/404/index.html
+++ b/docs/static/v0.4/404/index.html
@@ -7,7 +7,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
 <meta name="generator" content="Hugo 0.55.6" />
 
-<META NAME="ROBOTS" CONTENT="INDEX, FOLLOW">
+<meta name="robots" content="noindex, follow" />
 
 <link rel="alternate" type="application/rss&#43;xml" href="/v0.4/index.xml">
 

--- a/docs/static/v0.4/archive/index.html
+++ b/docs/static/v0.4/archive/index.html
@@ -7,7 +7,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
 <meta name="generator" content="Hugo 0.55.6" />
 
-<META NAME="ROBOTS" CONTENT="INDEX, FOLLOW">
+<meta name="robots" content="noindex, follow" />
 
 <link rel="alternate" type="application/rss&#43;xml" href="/v0.4/index.xml">
 

--- a/docs/static/v0.4/concepts/architecture/adapters/index.html
+++ b/docs/static/v0.4/concepts/architecture/adapters/index.html
@@ -7,7 +7,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
 <meta name="generator" content="Hugo 0.55.6" />
 
-<META NAME="ROBOTS" CONTENT="INDEX, FOLLOW">
+<meta name="robots" content="noindex, follow" />
 
 <link rel="alternate" type="application/rss&#43;xml" href="/v0.4/index.xml">
 

--- a/docs/static/v0.4/concepts/architecture/broker/index.html
+++ b/docs/static/v0.4/concepts/architecture/broker/index.html
@@ -7,7 +7,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
 <meta name="generator" content="Hugo 0.55.6" />
 
-<META NAME="ROBOTS" CONTENT="INDEX, FOLLOW">
+<meta name="robots" content="noindex, follow" />
 
 <link rel="alternate" type="application/rss&#43;xml" href="/v0.4/index.xml">
 

--- a/docs/static/v0.4/concepts/architecture/database/index.html
+++ b/docs/static/v0.4/concepts/architecture/database/index.html
@@ -7,7 +7,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
 <meta name="generator" content="Hugo 0.55.6" />
 
-<META NAME="ROBOTS" CONTENT="INDEX, FOLLOW">
+<meta name="robots" content="noindex, follow" />
 
 <link rel="alternate" type="application/rss&#43;xml" href="/v0.4/index.xml">
 

--- a/docs/static/v0.4/concepts/architecture/index.html
+++ b/docs/static/v0.4/concepts/architecture/index.html
@@ -7,7 +7,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
 <meta name="generator" content="Hugo 0.55.6" />
 
-<META NAME="ROBOTS" CONTENT="INDEX, FOLLOW">
+<meta name="robots" content="noindex, follow" />
 
 <link rel="alternate" type="application/rss&#43;xml" href="/v0.4/index.xml">
 

--- a/docs/static/v0.4/concepts/architecture/meshsync/index.html
+++ b/docs/static/v0.4/concepts/architecture/meshsync/index.html
@@ -7,7 +7,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
 <meta name="generator" content="Hugo 0.55.6" />
 
-<META NAME="ROBOTS" CONTENT="INDEX, FOLLOW">
+<meta name="robots" content="noindex, follow" />
 
 <link rel="alternate" type="application/rss&#43;xml" href="/v0.4/index.xml">
 

--- a/docs/static/v0.4/concepts/architecture/operator/index.html
+++ b/docs/static/v0.4/concepts/architecture/operator/index.html
@@ -7,7 +7,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
 <meta name="generator" content="Hugo 0.55.6" />
 
-<META NAME="ROBOTS" CONTENT="INDEX, FOLLOW">
+<meta name="robots" content="noindex, follow" />
 
 <link rel="alternate" type="application/rss&#43;xml" href="/v0.4/index.xml">
 

--- a/docs/static/v0.4/concepts/index.html
+++ b/docs/static/v0.4/concepts/index.html
@@ -7,7 +7,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
 <meta name="generator" content="Hugo 0.55.6" />
 
-<META NAME="ROBOTS" CONTENT="INDEX, FOLLOW">
+<meta name="robots" content="noindex, follow" />
 
 <link rel="alternate" type="application/rss&#43;xml" href="/v0.4/index.xml">
 

--- a/docs/static/v0.4/es/architecture/index.html
+++ b/docs/static/v0.4/es/architecture/index.html
@@ -7,7 +7,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
 <meta name="generator" content="Hugo 0.55.6" />
 
-<META NAME="ROBOTS" CONTENT="INDEX, FOLLOW">
+<meta name="robots" content="noindex, follow" />
 
 <link rel="alternate" type="application/rss&#43;xml" href="/v0.4/index.xml">
 

--- a/docs/static/v0.4/es/functionality/index.html
+++ b/docs/static/v0.4/es/functionality/index.html
@@ -7,7 +7,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
 <meta name="generator" content="Hugo 0.55.6" />
 
-<META NAME="ROBOTS" CONTENT="INDEX, FOLLOW">
+<meta name="robots" content="noindex, follow" />
 
 <link rel="alternate" type="application/rss&#43;xml" href="/v0.4/index.xml">
 

--- a/docs/static/v0.4/es/functionality/lifecycle-management/index.html
+++ b/docs/static/v0.4/es/functionality/lifecycle-management/index.html
@@ -7,7 +7,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
 <meta name="generator" content="Hugo 0.55.6" />
 
-<META NAME="ROBOTS" CONTENT="INDEX, FOLLOW">
+<meta name="robots" content="noindex, follow" />
 
 <link rel="alternate" type="application/rss&#43;xml" href="/v0.4/index.xml">
 

--- a/docs/static/v0.4/es/functionality/performance-management/index.html
+++ b/docs/static/v0.4/es/functionality/performance-management/index.html
@@ -7,7 +7,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
 <meta name="generator" content="Hugo 0.55.6" />
 
-<META NAME="ROBOTS" CONTENT="INDEX, FOLLOW">
+<meta name="robots" content="noindex, follow" />
 
 <link rel="alternate" type="application/rss&#43;xml" href="/v0.4/index.xml">
 

--- a/docs/static/v0.4/es/functionality/smi-conformance/index.html
+++ b/docs/static/v0.4/es/functionality/smi-conformance/index.html
@@ -7,7 +7,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
 <meta name="generator" content="Hugo 0.55.6" />
 
-<META NAME="ROBOTS" CONTENT="INDEX, FOLLOW">
+<meta name="robots" content="noindex, follow" />
 
 <link rel="alternate" type="application/rss&#43;xml" href="/v0.4/index.xml">
 

--- a/docs/static/v0.4/es/index.html
+++ b/docs/static/v0.4/es/index.html
@@ -7,7 +7,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
 <meta name="generator" content="Hugo 0.55.6" />
 
-<META NAME="ROBOTS" CONTENT="INDEX, FOLLOW">
+<meta name="robots" content="noindex, follow" />
 
 <link rel="alternate" type="application/rss&#43;xml" href="/v0.4/index.xml">
 

--- a/docs/static/v0.4/es/installation/index.html
+++ b/docs/static/v0.4/es/installation/index.html
@@ -7,7 +7,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
 <meta name="generator" content="Hugo 0.55.6" />
 
-<META NAME="ROBOTS" CONTENT="INDEX, FOLLOW">
+<meta name="robots" content="noindex, follow" />
 
 <link rel="alternate" type="application/rss&#43;xml" href="/v0.4/index.xml">
 

--- a/docs/static/v0.4/es/installation/platforms/aks/index.html
+++ b/docs/static/v0.4/es/installation/platforms/aks/index.html
@@ -7,7 +7,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
 <meta name="generator" content="Hugo 0.55.6" />
 
-<META NAME="ROBOTS" CONTENT="INDEX, FOLLOW">
+<meta name="robots" content="noindex, follow" />
 
 <link rel="alternate" type="application/rss&#43;xml" href="/v0.4/index.xml">
 

--- a/docs/static/v0.4/es/installation/platforms/docker/index.html
+++ b/docs/static/v0.4/es/installation/platforms/docker/index.html
@@ -7,7 +7,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
 <meta name="generator" content="Hugo 0.55.6" />
 
-<META NAME="ROBOTS" CONTENT="INDEX, FOLLOW">
+<meta name="robots" content="noindex, follow" />
 
 <link rel="alternate" type="application/rss&#43;xml" href="/v0.4/index.xml">
 

--- a/docs/static/v0.4/es/installation/platforms/eks/index.html
+++ b/docs/static/v0.4/es/installation/platforms/eks/index.html
@@ -7,7 +7,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
 <meta name="generator" content="Hugo 0.55.6" />
 
-<META NAME="ROBOTS" CONTENT="INDEX, FOLLOW">
+<meta name="robots" content="noindex, follow" />
 
 <link rel="alternate" type="application/rss&#43;xml" href="/v0.4/index.xml">
 

--- a/docs/static/v0.4/es/installation/platforms/gke/index.html
+++ b/docs/static/v0.4/es/installation/platforms/gke/index.html
@@ -7,7 +7,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
 <meta name="generator" content="Hugo 0.55.6" />
 
-<META NAME="ROBOTS" CONTENT="INDEX, FOLLOW">
+<meta name="robots" content="noindex, follow" />
 
 <link rel="alternate" type="application/rss&#43;xml" href="/v0.4/index.xml">
 

--- a/docs/static/v0.4/es/installation/platforms/index.html
+++ b/docs/static/v0.4/es/installation/platforms/index.html
@@ -7,7 +7,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
 <meta name="generator" content="Hugo 0.55.6" />
 
-<META NAME="ROBOTS" CONTENT="INDEX, FOLLOW">
+<meta name="robots" content="noindex, follow" />
 
 <link rel="alternate" type="application/rss&#43;xml" href="/v0.4/index.xml">
 

--- a/docs/static/v0.4/es/installation/platforms/kind/index.html
+++ b/docs/static/v0.4/es/installation/platforms/kind/index.html
@@ -7,7 +7,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
 <meta name="generator" content="Hugo 0.55.6" />
 
-<META NAME="ROBOTS" CONTENT="INDEX, FOLLOW">
+<meta name="robots" content="noindex, follow" />
 
 <link rel="alternate" type="application/rss&#43;xml" href="/v0.4/index.xml">
 

--- a/docs/static/v0.4/es/installation/platforms/kubernetes/index.html
+++ b/docs/static/v0.4/es/installation/platforms/kubernetes/index.html
@@ -7,7 +7,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
 <meta name="generator" content="Hugo 0.55.6" />
 
-<META NAME="ROBOTS" CONTENT="INDEX, FOLLOW">
+<meta name="robots" content="noindex, follow" />
 
 <link rel="alternate" type="application/rss&#43;xml" href="/v0.4/index.xml">
 

--- a/docs/static/v0.4/es/installation/platforms/minikube/index.html
+++ b/docs/static/v0.4/es/installation/platforms/minikube/index.html
@@ -7,7 +7,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
 <meta name="generator" content="Hugo 0.55.6" />
 
-<META NAME="ROBOTS" CONTENT="INDEX, FOLLOW">
+<meta name="robots" content="noindex, follow" />
 
 <link rel="alternate" type="application/rss&#43;xml" href="/v0.4/index.xml">
 

--- a/docs/static/v0.4/es/installation/platforms/windows/index.html
+++ b/docs/static/v0.4/es/installation/platforms/windows/index.html
@@ -7,7 +7,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
 <meta name="generator" content="Hugo 0.55.6" />
 
-<META NAME="ROBOTS" CONTENT="INDEX, FOLLOW">
+<meta name="robots" content="noindex, follow" />
 
 <link rel="alternate" type="application/rss&#43;xml" href="/v0.4/index.xml">
 

--- a/docs/static/v0.4/es/overview/index.html
+++ b/docs/static/v0.4/es/overview/index.html
@@ -7,7 +7,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
 <meta name="generator" content="Hugo 0.55.6" />
 
-<META NAME="ROBOTS" CONTENT="INDEX, FOLLOW">
+<meta name="robots" content="noindex, follow" />
 
 <link rel="alternate" type="application/rss&#43;xml" href="/v0.4/index.xml">
 

--- a/docs/static/v0.4/es/project/contributing-flow/index.html
+++ b/docs/static/v0.4/es/project/contributing-flow/index.html
@@ -7,7 +7,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
 <meta name="generator" content="Hugo 0.55.6" />
 
-<META NAME="ROBOTS" CONTENT="INDEX, FOLLOW">
+<meta name="robots" content="noindex, follow" />
 
 <link rel="alternate" type="application/rss&#43;xml" href="/v0.4/index.xml">
 

--- a/docs/static/v0.4/es/project/contributing/index.html
+++ b/docs/static/v0.4/es/project/contributing/index.html
@@ -7,7 +7,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
 <meta name="generator" content="Hugo 0.55.6" />
 
-<META NAME="ROBOTS" CONTENT="INDEX, FOLLOW">
+<meta name="robots" content="noindex, follow" />
 
 <link rel="alternate" type="application/rss&#43;xml" href="/v0.4/index.xml">
 

--- a/docs/static/v0.4/es/project/index.html
+++ b/docs/static/v0.4/es/project/index.html
@@ -7,7 +7,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
 <meta name="generator" content="Hugo 0.55.6" />
 
-<META NAME="ROBOTS" CONTENT="INDEX, FOLLOW">
+<meta name="robots" content="noindex, follow" />
 
 <link rel="alternate" type="application/rss&#43;xml" href="/v0.4/index.xml">
 

--- a/docs/static/v0.4/es/project/releases/index.html
+++ b/docs/static/v0.4/es/project/releases/index.html
@@ -7,7 +7,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
 <meta name="generator" content="Hugo 0.55.6" />
 
-<META NAME="ROBOTS" CONTENT="INDEX, FOLLOW">
+<meta name="robots" content="noindex, follow" />
 
 <link rel="alternate" type="application/rss&#43;xml" href="/v0.4/index.xml">
 

--- a/docs/static/v0.4/es/project/security-vulnerabilities/index.html
+++ b/docs/static/v0.4/es/project/security-vulnerabilities/index.html
@@ -7,7 +7,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
 <meta name="generator" content="Hugo 0.55.6" />
 
-<META NAME="ROBOTS" CONTENT="INDEX, FOLLOW">
+<meta name="robots" content="noindex, follow" />
 
 <link rel="alternate" type="application/rss&#43;xml" href="/v0.4/index.xml">
 

--- a/docs/static/v0.4/extensibility/adapters/index.html
+++ b/docs/static/v0.4/extensibility/adapters/index.html
@@ -7,7 +7,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
 <meta name="generator" content="Hugo 0.55.6" />
 
-<META NAME="ROBOTS" CONTENT="INDEX, FOLLOW">
+<meta name="robots" content="noindex, follow" />
 
 <link rel="alternate" type="application/rss&#43;xml" href="/v0.4/index.xml">
 

--- a/docs/static/v0.4/extensibility/api/index.html
+++ b/docs/static/v0.4/extensibility/api/index.html
@@ -7,7 +7,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
 <meta name="generator" content="Hugo 0.55.6" />
 
-<META NAME="ROBOTS" CONTENT="INDEX, FOLLOW">
+<meta name="robots" content="noindex, follow" />
 
 <link rel="alternate" type="application/rss&#43;xml" href="/v0.4/index.xml">
 

--- a/docs/static/v0.4/extensibility/index.html
+++ b/docs/static/v0.4/extensibility/index.html
@@ -7,7 +7,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
 <meta name="generator" content="Hugo 0.55.6" />
 
-<META NAME="ROBOTS" CONTENT="INDEX, FOLLOW">
+<meta name="robots" content="noindex, follow" />
 
 <link rel="alternate" type="application/rss&#43;xml" href="/v0.4/index.xml">
 

--- a/docs/static/v0.4/extensibility/load-generators/index.html
+++ b/docs/static/v0.4/extensibility/load-generators/index.html
@@ -7,7 +7,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
 <meta name="generator" content="Hugo 0.55.6" />
 
-<META NAME="ROBOTS" CONTENT="INDEX, FOLLOW">
+<meta name="robots" content="noindex, follow" />
 
 <link rel="alternate" type="application/rss&#43;xml" href="/v0.4/index.xml">
 

--- a/docs/static/v0.4/extensibility/providers/index.html
+++ b/docs/static/v0.4/extensibility/providers/index.html
@@ -7,7 +7,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
 <meta name="generator" content="Hugo 0.55.6" />
 
-<META NAME="ROBOTS" CONTENT="INDEX, FOLLOW">
+<meta name="robots" content="noindex, follow" />
 
 <link rel="alternate" type="application/rss&#43;xml" href="/v0.4/index.xml">
 

--- a/docs/static/v0.4/functionality/index.html
+++ b/docs/static/v0.4/functionality/index.html
@@ -7,7 +7,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
 <meta name="generator" content="Hugo 0.55.6" />
 
-<META NAME="ROBOTS" CONTENT="INDEX, FOLLOW">
+<meta name="robots" content="noindex, follow" />
 
 <link rel="alternate" type="application/rss&#43;xml" href="/v0.4/index.xml">
 

--- a/docs/static/v0.4/functionality/lifecycle-management/index.html
+++ b/docs/static/v0.4/functionality/lifecycle-management/index.html
@@ -7,7 +7,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
 <meta name="generator" content="Hugo 0.55.6" />
 
-<META NAME="ROBOTS" CONTENT="INDEX, FOLLOW">
+<meta name="robots" content="noindex, follow" />
 
 <link rel="alternate" type="application/rss&#43;xml" href="/v0.4/index.xml">
 

--- a/docs/static/v0.4/functionality/performance-management/index.html
+++ b/docs/static/v0.4/functionality/performance-management/index.html
@@ -7,7 +7,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
 <meta name="generator" content="Hugo 0.55.6" />
 
-<META NAME="ROBOTS" CONTENT="INDEX, FOLLOW">
+<meta name="robots" content="noindex, follow" />
 
 <link rel="alternate" type="application/rss&#43;xml" href="/v0.4/index.xml">
 

--- a/docs/static/v0.4/functionality/service-mesh-interface/index.html
+++ b/docs/static/v0.4/functionality/service-mesh-interface/index.html
@@ -7,7 +7,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
 <meta name="generator" content="Hugo 0.55.6" />
 
-<META NAME="ROBOTS" CONTENT="INDEX, FOLLOW">
+<meta name="robots" content="noindex, follow" />
 
 <link rel="alternate" type="application/rss&#43;xml" href="/v0.4/index.xml">
 

--- a/docs/static/v0.4/guides/index.html
+++ b/docs/static/v0.4/guides/index.html
@@ -7,7 +7,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
 <meta name="generator" content="Hugo 0.55.6" />
 
-<META NAME="ROBOTS" CONTENT="INDEX, FOLLOW">
+<meta name="robots" content="noindex, follow" />
 
 <link rel="alternate" type="application/rss&#43;xml" href="/v0.4/index.xml">
 

--- a/docs/static/v0.4/guides/interpreting-performance-test-results/index.html
+++ b/docs/static/v0.4/guides/interpreting-performance-test-results/index.html
@@ -7,7 +7,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
 <meta name="generator" content="Hugo 0.55.6" />
 
-<META NAME="ROBOTS" CONTENT="INDEX, FOLLOW">
+<meta name="robots" content="noindex, follow" />
 
 <link rel="alternate" type="application/rss&#43;xml" href="/v0.4/index.xml">
 

--- a/docs/static/v0.4/guides/meshery-metrics/index.html
+++ b/docs/static/v0.4/guides/meshery-metrics/index.html
@@ -7,7 +7,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
 <meta name="generator" content="Hugo 0.55.6" />
 
-<META NAME="ROBOTS" CONTENT="INDEX, FOLLOW">
+<meta name="robots" content="noindex, follow" />
 
 <link rel="alternate" type="application/rss&#43;xml" href="/v0.4/index.xml">
 

--- a/docs/static/v0.4/guides/multiple-adapters/index.html
+++ b/docs/static/v0.4/guides/multiple-adapters/index.html
@@ -7,7 +7,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
 <meta name="generator" content="Hugo 0.55.6" />
 
-<META NAME="ROBOTS" CONTENT="INDEX, FOLLOW">
+<meta name="robots" content="noindex, follow" />
 
 <link rel="alternate" type="application/rss&#43;xml" href="/v0.4/index.xml">
 

--- a/docs/static/v0.4/guides/sample-apps/index.html
+++ b/docs/static/v0.4/guides/sample-apps/index.html
@@ -7,7 +7,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
 <meta name="generator" content="Hugo 0.55.6" />
 
-<META NAME="ROBOTS" CONTENT="INDEX, FOLLOW">
+<meta name="robots" content="noindex, follow" />
 
 <link rel="alternate" type="application/rss&#43;xml" href="/v0.4/index.xml">
 

--- a/docs/static/v0.4/guides/upgrade/index.html
+++ b/docs/static/v0.4/guides/upgrade/index.html
@@ -7,7 +7,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
 <meta name="generator" content="Hugo 0.55.6" />
 
-<META NAME="ROBOTS" CONTENT="INDEX, FOLLOW">
+<meta name="robots" content="noindex, follow" />
 
 <link rel="alternate" type="application/rss&#43;xml" href="/v0.4/index.xml">
 

--- a/docs/static/v0.4/installation/mesheryctl/index.html
+++ b/docs/static/v0.4/installation/mesheryctl/index.html
@@ -7,7 +7,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
 <meta name="generator" content="Hugo 0.55.6" />
 
-<META NAME="ROBOTS" CONTENT="INDEX, FOLLOW">
+<meta name="robots" content="noindex, follow" />
 
 <link rel="alternate" type="application/rss&#43;xml" href="/v0.4/index.xml">
 

--- a/docs/static/v0.4/installation/platforms/aks/index.html
+++ b/docs/static/v0.4/installation/platforms/aks/index.html
@@ -7,7 +7,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
 <meta name="generator" content="Hugo 0.55.6" />
 
-<META NAME="ROBOTS" CONTENT="INDEX, FOLLOW">
+<meta name="robots" content="noindex, follow" />
 
 <link rel="alternate" type="application/rss&#43;xml" href="/v0.4/index.xml">
 

--- a/docs/static/v0.4/installation/platforms/docker/index.html
+++ b/docs/static/v0.4/installation/platforms/docker/index.html
@@ -7,7 +7,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
 <meta name="generator" content="Hugo 0.55.6" />
 
-<META NAME="ROBOTS" CONTENT="INDEX, FOLLOW">
+<meta name="robots" content="noindex, follow" />
 
 <link rel="alternate" type="application/rss&#43;xml" href="/v0.4/index.xml">
 

--- a/docs/static/v0.4/installation/platforms/eks/index.html
+++ b/docs/static/v0.4/installation/platforms/eks/index.html
@@ -7,7 +7,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
 <meta name="generator" content="Hugo 0.55.6" />
 
-<META NAME="ROBOTS" CONTENT="INDEX, FOLLOW">
+<meta name="robots" content="noindex, follow" />
 
 <link rel="alternate" type="application/rss&#43;xml" href="/v0.4/index.xml">
 

--- a/docs/static/v0.4/installation/platforms/gke/index.html
+++ b/docs/static/v0.4/installation/platforms/gke/index.html
@@ -7,7 +7,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
 <meta name="generator" content="Hugo 0.55.6" />
 
-<META NAME="ROBOTS" CONTENT="INDEX, FOLLOW">
+<meta name="robots" content="noindex, follow" />
 
 <link rel="alternate" type="application/rss&#43;xml" href="/v0.4/index.xml">
 

--- a/docs/static/v0.4/installation/platforms/index.html
+++ b/docs/static/v0.4/installation/platforms/index.html
@@ -7,7 +7,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
 <meta name="generator" content="Hugo 0.55.6" />
 
-<META NAME="ROBOTS" CONTENT="INDEX, FOLLOW">
+<meta name="robots" content="noindex, follow" />
 
 <link rel="alternate" type="application/rss&#43;xml" href="/v0.4/index.xml">
 

--- a/docs/static/v0.4/installation/platforms/kind/index.html
+++ b/docs/static/v0.4/installation/platforms/kind/index.html
@@ -7,7 +7,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
 <meta name="generator" content="Hugo 0.55.6" />
 
-<META NAME="ROBOTS" CONTENT="INDEX, FOLLOW">
+<meta name="robots" content="noindex, follow" />
 
 <link rel="alternate" type="application/rss&#43;xml" href="/v0.4/index.xml">
 

--- a/docs/static/v0.4/installation/platforms/kubernetes/index.html
+++ b/docs/static/v0.4/installation/platforms/kubernetes/index.html
@@ -7,7 +7,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
 <meta name="generator" content="Hugo 0.55.6" />
 
-<META NAME="ROBOTS" CONTENT="INDEX, FOLLOW">
+<meta name="robots" content="noindex, follow" />
 
 <link rel="alternate" type="application/rss&#43;xml" href="/v0.4/index.xml">
 

--- a/docs/static/v0.4/installation/platforms/minikube/index.html
+++ b/docs/static/v0.4/installation/platforms/minikube/index.html
@@ -7,7 +7,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
 <meta name="generator" content="Hugo 0.55.6" />
 
-<META NAME="ROBOTS" CONTENT="INDEX, FOLLOW">
+<meta name="robots" content="noindex, follow" />
 
 <link rel="alternate" type="application/rss&#43;xml" href="/v0.4/index.xml">
 

--- a/docs/static/v0.4/installation/platforms/scoop/index.html
+++ b/docs/static/v0.4/installation/platforms/scoop/index.html
@@ -7,7 +7,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
 <meta name="generator" content="Hugo 0.55.6" />
 
-<META NAME="ROBOTS" CONTENT="INDEX, FOLLOW">
+<meta name="robots" content="noindex, follow" />
 
 <link rel="alternate" type="application/rss&#43;xml" href="/v0.4/index.xml">
 

--- a/docs/static/v0.4/installation/platforms/windows/index.html
+++ b/docs/static/v0.4/installation/platforms/windows/index.html
@@ -7,7 +7,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
 <meta name="generator" content="Hugo 0.55.6" />
 
-<META NAME="ROBOTS" CONTENT="INDEX, FOLLOW">
+<meta name="robots" content="noindex, follow" />
 
 <link rel="alternate" type="application/rss&#43;xml" href="/v0.4/index.xml">
 

--- a/docs/static/v0.4/installation/quick-start/index.html
+++ b/docs/static/v0.4/installation/quick-start/index.html
@@ -7,7 +7,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
 <meta name="generator" content="Hugo 0.55.6" />
 
-<META NAME="ROBOTS" CONTENT="INDEX, FOLLOW">
+<meta name="robots" content="noindex, follow" />
 
 <link rel="alternate" type="application/rss&#43;xml" href="/v0.4/index.xml">
 

--- a/docs/static/v0.4/news/index.html
+++ b/docs/static/v0.4/news/index.html
@@ -7,7 +7,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
 <meta name="generator" content="Hugo 0.55.6" />
 
-<META NAME="ROBOTS" CONTENT="INDEX, FOLLOW">
+<meta name="robots" content="noindex, follow" />
 
 <link rel="alternate" type="application/rss&#43;xml" href="/v0.4/index.xml">
 

--- a/docs/static/v0.4/overview/index.html
+++ b/docs/static/v0.4/overview/index.html
@@ -7,7 +7,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
 <meta name="generator" content="Hugo 0.55.6" />
 
-<META NAME="ROBOTS" CONTENT="INDEX, FOLLOW">
+<meta name="robots" content="noindex, follow" />
 
 <link rel="alternate" type="application/rss&#43;xml" href="/v0.4/index.xml">
 

--- a/docs/static/v0.4/pages/project/CONTRIBUTING-gitflow/index.html
+++ b/docs/static/v0.4/pages/project/CONTRIBUTING-gitflow/index.html
@@ -7,7 +7,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
 <meta name="generator" content="Hugo 0.55.6" />
 
-<META NAME="ROBOTS" CONTENT="INDEX, FOLLOW">
+<meta name="robots" content="noindex, follow" />
 
 <link rel="alternate" type="application/rss&#43;xml" href="/v0.4/index.xml">
 

--- a/docs/static/v0.4/project/build-and-release/index.html
+++ b/docs/static/v0.4/project/build-and-release/index.html
@@ -7,7 +7,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
 <meta name="generator" content="Hugo 0.55.6" />
 
-<META NAME="ROBOTS" CONTENT="INDEX, FOLLOW">
+<meta name="robots" content="noindex, follow" />
 
 <link rel="alternate" type="application/rss&#43;xml" href="/v0.4/index.xml">
 

--- a/docs/static/v0.4/project/contributing/index.html
+++ b/docs/static/v0.4/project/contributing/index.html
@@ -7,7 +7,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
 <meta name="generator" content="Hugo 0.55.6" />
 
-<META NAME="ROBOTS" CONTENT="INDEX, FOLLOW">
+<meta name="robots" content="noindex, follow" />
 
 <link rel="alternate" type="application/rss&#43;xml" href="/v0.4/index.xml">
 

--- a/docs/static/v0.4/project/faq/index.html
+++ b/docs/static/v0.4/project/faq/index.html
@@ -7,7 +7,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
 <meta name="generator" content="Hugo 0.55.6" />
 
-<META NAME="ROBOTS" CONTENT="INDEX, FOLLOW">
+<meta name="robots" content="noindex, follow" />
 
 <link rel="alternate" type="application/rss&#43;xml" href="/v0.4/index.xml">
 

--- a/docs/static/v0.4/project/index.html
+++ b/docs/static/v0.4/project/index.html
@@ -7,7 +7,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
 <meta name="generator" content="Hugo 0.55.6" />
 
-<META NAME="ROBOTS" CONTENT="INDEX, FOLLOW">
+<meta name="robots" content="noindex, follow" />
 
 <link rel="alternate" type="application/rss&#43;xml" href="/v0.4/index.xml">
 

--- a/docs/static/v0.4/project/releases/index.html
+++ b/docs/static/v0.4/project/releases/index.html
@@ -7,7 +7,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
 <meta name="generator" content="Hugo 0.55.6" />
 
-<META NAME="ROBOTS" CONTENT="INDEX, FOLLOW">
+<meta name="robots" content="noindex, follow" />
 
 <link rel="alternate" type="application/rss&#43;xml" href="/v0.4/index.xml">
 

--- a/docs/static/v0.4/project/releases/v0.0.1/index.html
+++ b/docs/static/v0.4/project/releases/v0.0.1/index.html
@@ -7,7 +7,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
 <meta name="generator" content="Hugo 0.55.6" />
 
-<META NAME="ROBOTS" CONTENT="INDEX, FOLLOW">
+<meta name="robots" content="noindex, follow" />
 
 <link rel="alternate" type="application/rss&#43;xml" href="/v0.4/index.xml">
 

--- a/docs/static/v0.4/project/releases/v0.0.2/index.html
+++ b/docs/static/v0.4/project/releases/v0.0.2/index.html
@@ -7,7 +7,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
 <meta name="generator" content="Hugo 0.55.6" />
 
-<META NAME="ROBOTS" CONTENT="INDEX, FOLLOW">
+<meta name="robots" content="noindex, follow" />
 
 <link rel="alternate" type="application/rss&#43;xml" href="/v0.4/index.xml">
 

--- a/docs/static/v0.4/project/releases/v0.0.3/index.html
+++ b/docs/static/v0.4/project/releases/v0.0.3/index.html
@@ -7,7 +7,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
 <meta name="generator" content="Hugo 0.55.6" />
 
-<META NAME="ROBOTS" CONTENT="INDEX, FOLLOW">
+<meta name="robots" content="noindex, follow" />
 
 <link rel="alternate" type="application/rss&#43;xml" href="/v0.4/index.xml">
 

--- a/docs/static/v0.4/project/releases/v0.0.4/index.html
+++ b/docs/static/v0.4/project/releases/v0.0.4/index.html
@@ -7,7 +7,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
 <meta name="generator" content="Hugo 0.55.6" />
 
-<META NAME="ROBOTS" CONTENT="INDEX, FOLLOW">
+<meta name="robots" content="noindex, follow" />
 
 <link rel="alternate" type="application/rss&#43;xml" href="/v0.4/index.xml">
 

--- a/docs/static/v0.4/project/releases/v0.0.5/index.html
+++ b/docs/static/v0.4/project/releases/v0.0.5/index.html
@@ -7,7 +7,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
 <meta name="generator" content="Hugo 0.55.6" />
 
-<META NAME="ROBOTS" CONTENT="INDEX, FOLLOW">
+<meta name="robots" content="noindex, follow" />
 
 <link rel="alternate" type="application/rss&#43;xml" href="/v0.4/index.xml">
 

--- a/docs/static/v0.4/project/releases/v0.0.6/index.html
+++ b/docs/static/v0.4/project/releases/v0.0.6/index.html
@@ -7,7 +7,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
 <meta name="generator" content="Hugo 0.55.6" />
 
-<META NAME="ROBOTS" CONTENT="INDEX, FOLLOW">
+<meta name="robots" content="noindex, follow" />
 
 <link rel="alternate" type="application/rss&#43;xml" href="/v0.4/index.xml">
 

--- a/docs/static/v0.4/project/releases/v0.0.7/index.html
+++ b/docs/static/v0.4/project/releases/v0.0.7/index.html
@@ -7,7 +7,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
 <meta name="generator" content="Hugo 0.55.6" />
 
-<META NAME="ROBOTS" CONTENT="INDEX, FOLLOW">
+<meta name="robots" content="noindex, follow" />
 
 <link rel="alternate" type="application/rss&#43;xml" href="/v0.4/index.xml">
 

--- a/docs/static/v0.4/project/releases/v0.0.8/index.html
+++ b/docs/static/v0.4/project/releases/v0.0.8/index.html
@@ -7,7 +7,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
 <meta name="generator" content="Hugo 0.55.6" />
 
-<META NAME="ROBOTS" CONTENT="INDEX, FOLLOW">
+<meta name="robots" content="noindex, follow" />
 
 <link rel="alternate" type="application/rss&#43;xml" href="/v0.4/index.xml">
 

--- a/docs/static/v0.4/project/releases/v0.0.9/index.html
+++ b/docs/static/v0.4/project/releases/v0.0.9/index.html
@@ -7,7 +7,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
 <meta name="generator" content="Hugo 0.55.6" />
 
-<META NAME="ROBOTS" CONTENT="INDEX, FOLLOW">
+<meta name="robots" content="noindex, follow" />
 
 <link rel="alternate" type="application/rss&#43;xml" href="/v0.4/index.xml">
 

--- a/docs/static/v0.4/project/releases/v0.1.0/index.html
+++ b/docs/static/v0.4/project/releases/v0.1.0/index.html
@@ -7,7 +7,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
 <meta name="generator" content="Hugo 0.55.6" />
 
-<META NAME="ROBOTS" CONTENT="INDEX, FOLLOW">
+<meta name="robots" content="noindex, follow" />
 
 <link rel="alternate" type="application/rss&#43;xml" href="/v0.4/index.xml">
 

--- a/docs/static/v0.4/project/releases/v0.1.1/index.html
+++ b/docs/static/v0.4/project/releases/v0.1.1/index.html
@@ -7,7 +7,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
 <meta name="generator" content="Hugo 0.55.6" />
 
-<META NAME="ROBOTS" CONTENT="INDEX, FOLLOW">
+<meta name="robots" content="noindex, follow" />
 
 <link rel="alternate" type="application/rss&#43;xml" href="/v0.4/index.xml">
 

--- a/docs/static/v0.4/project/releases/v0.1.2/index.html
+++ b/docs/static/v0.4/project/releases/v0.1.2/index.html
@@ -7,7 +7,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
 <meta name="generator" content="Hugo 0.55.6" />
 
-<META NAME="ROBOTS" CONTENT="INDEX, FOLLOW">
+<meta name="robots" content="noindex, follow" />
 
 <link rel="alternate" type="application/rss&#43;xml" href="/v0.4/index.xml">
 

--- a/docs/static/v0.4/project/releases/v0.1.3/index.html
+++ b/docs/static/v0.4/project/releases/v0.1.3/index.html
@@ -7,7 +7,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
 <meta name="generator" content="Hugo 0.55.6" />
 
-<META NAME="ROBOTS" CONTENT="INDEX, FOLLOW">
+<meta name="robots" content="noindex, follow" />
 
 <link rel="alternate" type="application/rss&#43;xml" href="/v0.4/index.xml">
 

--- a/docs/static/v0.4/project/releases/v0.1.4/index.html
+++ b/docs/static/v0.4/project/releases/v0.1.4/index.html
@@ -7,7 +7,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
 <meta name="generator" content="Hugo 0.55.6" />
 
-<META NAME="ROBOTS" CONTENT="INDEX, FOLLOW">
+<meta name="robots" content="noindex, follow" />
 
 <link rel="alternate" type="application/rss&#43;xml" href="/v0.4/index.xml">
 

--- a/docs/static/v0.4/project/releases/v0.1.5/index.html
+++ b/docs/static/v0.4/project/releases/v0.1.5/index.html
@@ -7,7 +7,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
 <meta name="generator" content="Hugo 0.55.6" />
 
-<META NAME="ROBOTS" CONTENT="INDEX, FOLLOW">
+<meta name="robots" content="noindex, follow" />
 
 <link rel="alternate" type="application/rss&#43;xml" href="/v0.4/index.xml">
 

--- a/docs/static/v0.4/project/releases/v0.1.6/index.html
+++ b/docs/static/v0.4/project/releases/v0.1.6/index.html
@@ -7,7 +7,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
 <meta name="generator" content="Hugo 0.55.6" />
 
-<META NAME="ROBOTS" CONTENT="INDEX, FOLLOW">
+<meta name="robots" content="noindex, follow" />
 
 <link rel="alternate" type="application/rss&#43;xml" href="/v0.4/index.xml">
 

--- a/docs/static/v0.4/project/releases/v0.2.0/index.html
+++ b/docs/static/v0.4/project/releases/v0.2.0/index.html
@@ -7,7 +7,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
 <meta name="generator" content="Hugo 0.55.6" />
 
-<META NAME="ROBOTS" CONTENT="INDEX, FOLLOW">
+<meta name="robots" content="noindex, follow" />
 
 <link rel="alternate" type="application/rss&#43;xml" href="/v0.4/index.xml">
 

--- a/docs/static/v0.4/project/releases/v0.2.1/index.html
+++ b/docs/static/v0.4/project/releases/v0.2.1/index.html
@@ -7,7 +7,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
 <meta name="generator" content="Hugo 0.55.6" />
 
-<META NAME="ROBOTS" CONTENT="INDEX, FOLLOW">
+<meta name="robots" content="noindex, follow" />
 
 <link rel="alternate" type="application/rss&#43;xml" href="/v0.4/index.xml">
 

--- a/docs/static/v0.4/project/releases/v0.2.2/index.html
+++ b/docs/static/v0.4/project/releases/v0.2.2/index.html
@@ -7,7 +7,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
 <meta name="generator" content="Hugo 0.55.6" />
 
-<META NAME="ROBOTS" CONTENT="INDEX, FOLLOW">
+<meta name="robots" content="noindex, follow" />
 
 <link rel="alternate" type="application/rss&#43;xml" href="/v0.4/index.xml">
 

--- a/docs/static/v0.4/project/releases/v0.2.3/index.html
+++ b/docs/static/v0.4/project/releases/v0.2.3/index.html
@@ -7,7 +7,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
 <meta name="generator" content="Hugo 0.55.6" />
 
-<META NAME="ROBOTS" CONTENT="INDEX, FOLLOW">
+<meta name="robots" content="noindex, follow" />
 
 <link rel="alternate" type="application/rss&#43;xml" href="/v0.4/index.xml">
 

--- a/docs/static/v0.4/project/releases/v0.2.4/index.html
+++ b/docs/static/v0.4/project/releases/v0.2.4/index.html
@@ -7,7 +7,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
 <meta name="generator" content="Hugo 0.55.6" />
 
-<META NAME="ROBOTS" CONTENT="INDEX, FOLLOW">
+<meta name="robots" content="noindex, follow" />
 
 <link rel="alternate" type="application/rss&#43;xml" href="/v0.4/index.xml">
 

--- a/docs/static/v0.4/project/releases/v0.3.1/index.html
+++ b/docs/static/v0.4/project/releases/v0.3.1/index.html
@@ -7,7 +7,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
 <meta name="generator" content="Hugo 0.55.6" />
 
-<META NAME="ROBOTS" CONTENT="INDEX, FOLLOW">
+<meta name="robots" content="noindex, follow" />
 
 <link rel="alternate" type="application/rss&#43;xml" href="/v0.4/index.xml">
 

--- a/docs/static/v0.4/project/releases/v0.3.10/index.html
+++ b/docs/static/v0.4/project/releases/v0.3.10/index.html
@@ -7,7 +7,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
 <meta name="generator" content="Hugo 0.55.6" />
 
-<META NAME="ROBOTS" CONTENT="INDEX, FOLLOW">
+<meta name="robots" content="noindex, follow" />
 
 <link rel="alternate" type="application/rss&#43;xml" href="/v0.4/index.xml">
 

--- a/docs/static/v0.4/project/releases/v0.3.11/index.html
+++ b/docs/static/v0.4/project/releases/v0.3.11/index.html
@@ -7,7 +7,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
 <meta name="generator" content="Hugo 0.55.6" />
 
-<META NAME="ROBOTS" CONTENT="INDEX, FOLLOW">
+<meta name="robots" content="noindex, follow" />
 
 <link rel="alternate" type="application/rss&#43;xml" href="/v0.4/index.xml">
 

--- a/docs/static/v0.4/project/releases/v0.3.12/index.html
+++ b/docs/static/v0.4/project/releases/v0.3.12/index.html
@@ -7,7 +7,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
 <meta name="generator" content="Hugo 0.55.6" />
 
-<META NAME="ROBOTS" CONTENT="INDEX, FOLLOW">
+<meta name="robots" content="noindex, follow" />
 
 <link rel="alternate" type="application/rss&#43;xml" href="/v0.4/index.xml">
 

--- a/docs/static/v0.4/project/releases/v0.3.13/index.html
+++ b/docs/static/v0.4/project/releases/v0.3.13/index.html
@@ -7,7 +7,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
 <meta name="generator" content="Hugo 0.55.6" />
 
-<META NAME="ROBOTS" CONTENT="INDEX, FOLLOW">
+<meta name="robots" content="noindex, follow" />
 
 <link rel="alternate" type="application/rss&#43;xml" href="/v0.4/index.xml">
 

--- a/docs/static/v0.4/project/releases/v0.3.14/index.html
+++ b/docs/static/v0.4/project/releases/v0.3.14/index.html
@@ -7,7 +7,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
 <meta name="generator" content="Hugo 0.55.6" />
 
-<META NAME="ROBOTS" CONTENT="INDEX, FOLLOW">
+<meta name="robots" content="noindex, follow" />
 
 <link rel="alternate" type="application/rss&#43;xml" href="/v0.4/index.xml">
 

--- a/docs/static/v0.4/project/releases/v0.3.15/index.html
+++ b/docs/static/v0.4/project/releases/v0.3.15/index.html
@@ -7,7 +7,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
 <meta name="generator" content="Hugo 0.55.6" />
 
-<META NAME="ROBOTS" CONTENT="INDEX, FOLLOW">
+<meta name="robots" content="noindex, follow" />
 
 <link rel="alternate" type="application/rss&#43;xml" href="/v0.4/index.xml">
 

--- a/docs/static/v0.4/project/releases/v0.3.16/index.html
+++ b/docs/static/v0.4/project/releases/v0.3.16/index.html
@@ -7,7 +7,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
 <meta name="generator" content="Hugo 0.55.6" />
 
-<META NAME="ROBOTS" CONTENT="INDEX, FOLLOW">
+<meta name="robots" content="noindex, follow" />
 
 <link rel="alternate" type="application/rss&#43;xml" href="/v0.4/index.xml">
 

--- a/docs/static/v0.4/project/releases/v0.3.17/index.html
+++ b/docs/static/v0.4/project/releases/v0.3.17/index.html
@@ -7,7 +7,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
 <meta name="generator" content="Hugo 0.55.6" />
 
-<META NAME="ROBOTS" CONTENT="INDEX, FOLLOW">
+<meta name="robots" content="noindex, follow" />
 
 <link rel="alternate" type="application/rss&#43;xml" href="/v0.4/index.xml">
 

--- a/docs/static/v0.4/project/releases/v0.3.18/index.html
+++ b/docs/static/v0.4/project/releases/v0.3.18/index.html
@@ -7,7 +7,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
 <meta name="generator" content="Hugo 0.55.6" />
 
-<META NAME="ROBOTS" CONTENT="INDEX, FOLLOW">
+<meta name="robots" content="noindex, follow" />
 
 <link rel="alternate" type="application/rss&#43;xml" href="/v0.4/index.xml">
 

--- a/docs/static/v0.4/project/releases/v0.3.19/index.html
+++ b/docs/static/v0.4/project/releases/v0.3.19/index.html
@@ -7,7 +7,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
 <meta name="generator" content="Hugo 0.55.6" />
 
-<META NAME="ROBOTS" CONTENT="INDEX, FOLLOW">
+<meta name="robots" content="noindex, follow" />
 
 <link rel="alternate" type="application/rss&#43;xml" href="/v0.4/index.xml">
 

--- a/docs/static/v0.4/project/releases/v0.3.2/index.html
+++ b/docs/static/v0.4/project/releases/v0.3.2/index.html
@@ -7,7 +7,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
 <meta name="generator" content="Hugo 0.55.6" />
 
-<META NAME="ROBOTS" CONTENT="INDEX, FOLLOW">
+<meta name="robots" content="noindex, follow" />
 
 <link rel="alternate" type="application/rss&#43;xml" href="/v0.4/index.xml">
 

--- a/docs/static/v0.4/project/releases/v0.3.3/index.html
+++ b/docs/static/v0.4/project/releases/v0.3.3/index.html
@@ -7,7 +7,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
 <meta name="generator" content="Hugo 0.55.6" />
 
-<META NAME="ROBOTS" CONTENT="INDEX, FOLLOW">
+<meta name="robots" content="noindex, follow" />
 
 <link rel="alternate" type="application/rss&#43;xml" href="/v0.4/index.xml">
 

--- a/docs/static/v0.4/project/releases/v0.3.4/index.html
+++ b/docs/static/v0.4/project/releases/v0.3.4/index.html
@@ -7,7 +7,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
 <meta name="generator" content="Hugo 0.55.6" />
 
-<META NAME="ROBOTS" CONTENT="INDEX, FOLLOW">
+<meta name="robots" content="noindex, follow" />
 
 <link rel="alternate" type="application/rss&#43;xml" href="/v0.4/index.xml">
 

--- a/docs/static/v0.4/project/releases/v0.3.5/index.html
+++ b/docs/static/v0.4/project/releases/v0.3.5/index.html
@@ -7,7 +7,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
 <meta name="generator" content="Hugo 0.55.6" />
 
-<META NAME="ROBOTS" CONTENT="INDEX, FOLLOW">
+<meta name="robots" content="noindex, follow" />
 
 <link rel="alternate" type="application/rss&#43;xml" href="/v0.4/index.xml">
 

--- a/docs/static/v0.4/project/releases/v0.3.6/index.html
+++ b/docs/static/v0.4/project/releases/v0.3.6/index.html
@@ -7,7 +7,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
 <meta name="generator" content="Hugo 0.55.6" />
 
-<META NAME="ROBOTS" CONTENT="INDEX, FOLLOW">
+<meta name="robots" content="noindex, follow" />
 
 <link rel="alternate" type="application/rss&#43;xml" href="/v0.4/index.xml">
 

--- a/docs/static/v0.4/project/releases/v0.3.7/index.html
+++ b/docs/static/v0.4/project/releases/v0.3.7/index.html
@@ -7,7 +7,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
 <meta name="generator" content="Hugo 0.55.6" />
 
-<META NAME="ROBOTS" CONTENT="INDEX, FOLLOW">
+<meta name="robots" content="noindex, follow" />
 
 <link rel="alternate" type="application/rss&#43;xml" href="/v0.4/index.xml">
 

--- a/docs/static/v0.4/project/releases/v0.3.8/index.html
+++ b/docs/static/v0.4/project/releases/v0.3.8/index.html
@@ -7,7 +7,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
 <meta name="generator" content="Hugo 0.55.6" />
 
-<META NAME="ROBOTS" CONTENT="INDEX, FOLLOW">
+<meta name="robots" content="noindex, follow" />
 
 <link rel="alternate" type="application/rss&#43;xml" href="/v0.4/index.xml">
 

--- a/docs/static/v0.4/project/releases/v0.3.9/index.html
+++ b/docs/static/v0.4/project/releases/v0.3.9/index.html
@@ -7,7 +7,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
 <meta name="generator" content="Hugo 0.55.6" />
 
-<META NAME="ROBOTS" CONTENT="INDEX, FOLLOW">
+<meta name="robots" content="noindex, follow" />
 
 <link rel="alternate" type="application/rss&#43;xml" href="/v0.4/index.xml">
 

--- a/docs/static/v0.4/project/releases/v0.4.0-beta.1/index.html
+++ b/docs/static/v0.4/project/releases/v0.4.0-beta.1/index.html
@@ -7,7 +7,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
 <meta name="generator" content="Hugo 0.55.6" />
 
-<META NAME="ROBOTS" CONTENT="INDEX, FOLLOW">
+<meta name="robots" content="noindex, follow" />
 
 <link rel="alternate" type="application/rss&#43;xml" href="/v0.4/index.xml">
 

--- a/docs/static/v0.4/project/releases/v0.4.0-beta.2/index.html
+++ b/docs/static/v0.4/project/releases/v0.4.0-beta.2/index.html
@@ -7,7 +7,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
 <meta name="generator" content="Hugo 0.55.6" />
 
-<META NAME="ROBOTS" CONTENT="INDEX, FOLLOW">
+<meta name="robots" content="noindex, follow" />
 
 <link rel="alternate" type="application/rss&#43;xml" href="/v0.4/index.xml">
 

--- a/docs/static/v0.4/project/releases/v0.4.0-beta.3/index.html
+++ b/docs/static/v0.4/project/releases/v0.4.0-beta.3/index.html
@@ -7,7 +7,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
 <meta name="generator" content="Hugo 0.55.6" />
 
-<META NAME="ROBOTS" CONTENT="INDEX, FOLLOW">
+<meta name="robots" content="noindex, follow" />
 
 <link rel="alternate" type="application/rss&#43;xml" href="/v0.4/index.xml">
 

--- a/docs/static/v0.4/project/releases/v0.4.0-beta.4/index.html
+++ b/docs/static/v0.4/project/releases/v0.4.0-beta.4/index.html
@@ -7,7 +7,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
 <meta name="generator" content="Hugo 0.55.6" />
 
-<META NAME="ROBOTS" CONTENT="INDEX, FOLLOW">
+<meta name="robots" content="noindex, follow" />
 
 <link rel="alternate" type="application/rss&#43;xml" href="/v0.4/index.xml">
 

--- a/docs/static/v0.4/project/releases/v0.4.1/index.html
+++ b/docs/static/v0.4/project/releases/v0.4.1/index.html
@@ -7,7 +7,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
 <meta name="generator" content="Hugo 0.55.6" />
 
-<META NAME="ROBOTS" CONTENT="INDEX, FOLLOW">
+<meta name="robots" content="noindex, follow" />
 
 <link rel="alternate" type="application/rss&#43;xml" href="/v0.4/index.xml">
 

--- a/docs/static/v0.4/project/releases/v0.4.10/index.html
+++ b/docs/static/v0.4/project/releases/v0.4.10/index.html
@@ -7,7 +7,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
 <meta name="generator" content="Hugo 0.55.6" />
 
-<META NAME="ROBOTS" CONTENT="INDEX, FOLLOW">
+<meta name="robots" content="noindex, follow" />
 
 <link rel="alternate" type="application/rss&#43;xml" href="/v0.4/index.xml">
 

--- a/docs/static/v0.4/project/releases/v0.4.11/index.html
+++ b/docs/static/v0.4/project/releases/v0.4.11/index.html
@@ -7,7 +7,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
 <meta name="generator" content="Hugo 0.55.6" />
 
-<META NAME="ROBOTS" CONTENT="INDEX, FOLLOW">
+<meta name="robots" content="noindex, follow" />
 
 <link rel="alternate" type="application/rss&#43;xml" href="/v0.4/index.xml">
 

--- a/docs/static/v0.4/project/releases/v0.4.12/index.html
+++ b/docs/static/v0.4/project/releases/v0.4.12/index.html
@@ -7,7 +7,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
 <meta name="generator" content="Hugo 0.55.6" />
 
-<META NAME="ROBOTS" CONTENT="INDEX, FOLLOW">
+<meta name="robots" content="noindex, follow" />
 
 <link rel="alternate" type="application/rss&#43;xml" href="/v0.4/index.xml">
 

--- a/docs/static/v0.4/project/releases/v0.4.13/index.html
+++ b/docs/static/v0.4/project/releases/v0.4.13/index.html
@@ -7,7 +7,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
 <meta name="generator" content="Hugo 0.55.6" />
 
-<META NAME="ROBOTS" CONTENT="INDEX, FOLLOW">
+<meta name="robots" content="noindex, follow" />
 
 <link rel="alternate" type="application/rss&#43;xml" href="/v0.4/index.xml">
 

--- a/docs/static/v0.4/project/releases/v0.4.14/index.html
+++ b/docs/static/v0.4/project/releases/v0.4.14/index.html
@@ -7,7 +7,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
 <meta name="generator" content="Hugo 0.55.6" />
 
-<META NAME="ROBOTS" CONTENT="INDEX, FOLLOW">
+<meta name="robots" content="noindex, follow" />
 
 <link rel="alternate" type="application/rss&#43;xml" href="/v0.4/index.xml">
 

--- a/docs/static/v0.4/project/releases/v0.4.15/index.html
+++ b/docs/static/v0.4/project/releases/v0.4.15/index.html
@@ -7,7 +7,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
 <meta name="generator" content="Hugo 0.55.6" />
 
-<META NAME="ROBOTS" CONTENT="INDEX, FOLLOW">
+<meta name="robots" content="noindex, follow" />
 
 <link rel="alternate" type="application/rss&#43;xml" href="/v0.4/index.xml">
 

--- a/docs/static/v0.4/project/releases/v0.4.16/index.html
+++ b/docs/static/v0.4/project/releases/v0.4.16/index.html
@@ -7,7 +7,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
 <meta name="generator" content="Hugo 0.55.6" />
 
-<META NAME="ROBOTS" CONTENT="INDEX, FOLLOW">
+<meta name="robots" content="noindex, follow" />
 
 <link rel="alternate" type="application/rss&#43;xml" href="/v0.4/index.xml">
 

--- a/docs/static/v0.4/project/releases/v0.4.17/index.html
+++ b/docs/static/v0.4/project/releases/v0.4.17/index.html
@@ -7,7 +7,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
 <meta name="generator" content="Hugo 0.55.6" />
 
-<META NAME="ROBOTS" CONTENT="INDEX, FOLLOW">
+<meta name="robots" content="noindex, follow" />
 
 <link rel="alternate" type="application/rss&#43;xml" href="/v0.4/index.xml">
 

--- a/docs/static/v0.4/project/releases/v0.4.18/index.html
+++ b/docs/static/v0.4/project/releases/v0.4.18/index.html
@@ -7,7 +7,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
 <meta name="generator" content="Hugo 0.55.6" />
 
-<META NAME="ROBOTS" CONTENT="INDEX, FOLLOW">
+<meta name="robots" content="noindex, follow" />
 
 <link rel="alternate" type="application/rss&#43;xml" href="/v0.4/index.xml">
 

--- a/docs/static/v0.4/project/releases/v0.4.19/index.html
+++ b/docs/static/v0.4/project/releases/v0.4.19/index.html
@@ -7,7 +7,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
 <meta name="generator" content="Hugo 0.55.6" />
 
-<META NAME="ROBOTS" CONTENT="INDEX, FOLLOW">
+<meta name="robots" content="noindex, follow" />
 
 <link rel="alternate" type="application/rss&#43;xml" href="/v0.4/index.xml">
 

--- a/docs/static/v0.4/project/releases/v0.4.2/index.html
+++ b/docs/static/v0.4/project/releases/v0.4.2/index.html
@@ -7,7 +7,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
 <meta name="generator" content="Hugo 0.55.6" />
 
-<META NAME="ROBOTS" CONTENT="INDEX, FOLLOW">
+<meta name="robots" content="noindex, follow" />
 
 <link rel="alternate" type="application/rss&#43;xml" href="/v0.4/index.xml">
 

--- a/docs/static/v0.4/project/releases/v0.4.20/index.html
+++ b/docs/static/v0.4/project/releases/v0.4.20/index.html
@@ -7,7 +7,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
 <meta name="generator" content="Hugo 0.55.6" />
 
-<META NAME="ROBOTS" CONTENT="INDEX, FOLLOW">
+<meta name="robots" content="noindex, follow" />
 
 <link rel="alternate" type="application/rss&#43;xml" href="/v0.4/index.xml">
 

--- a/docs/static/v0.4/project/releases/v0.4.21/index.html
+++ b/docs/static/v0.4/project/releases/v0.4.21/index.html
@@ -7,7 +7,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
 <meta name="generator" content="Hugo 0.55.6" />
 
-<META NAME="ROBOTS" CONTENT="INDEX, FOLLOW">
+<meta name="robots" content="noindex, follow" />
 
 <link rel="alternate" type="application/rss&#43;xml" href="/v0.4/index.xml">
 

--- a/docs/static/v0.4/project/releases/v0.4.22/index.html
+++ b/docs/static/v0.4/project/releases/v0.4.22/index.html
@@ -7,7 +7,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
 <meta name="generator" content="Hugo 0.55.6" />
 
-<META NAME="ROBOTS" CONTENT="INDEX, FOLLOW">
+<meta name="robots" content="noindex, follow" />
 
 <link rel="alternate" type="application/rss&#43;xml" href="/v0.4/index.xml">
 

--- a/docs/static/v0.4/project/releases/v0.4.3/index.html
+++ b/docs/static/v0.4/project/releases/v0.4.3/index.html
@@ -7,7 +7,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
 <meta name="generator" content="Hugo 0.55.6" />
 
-<META NAME="ROBOTS" CONTENT="INDEX, FOLLOW">
+<meta name="robots" content="noindex, follow" />
 
 <link rel="alternate" type="application/rss&#43;xml" href="/v0.4/index.xml">
 

--- a/docs/static/v0.4/project/releases/v0.4.4/index.html
+++ b/docs/static/v0.4/project/releases/v0.4.4/index.html
@@ -7,7 +7,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
 <meta name="generator" content="Hugo 0.55.6" />
 
-<META NAME="ROBOTS" CONTENT="INDEX, FOLLOW">
+<meta name="robots" content="noindex, follow" />
 
 <link rel="alternate" type="application/rss&#43;xml" href="/v0.4/index.xml">
 

--- a/docs/static/v0.4/project/releases/v0.4.5/index.html
+++ b/docs/static/v0.4/project/releases/v0.4.5/index.html
@@ -7,7 +7,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
 <meta name="generator" content="Hugo 0.55.6" />
 
-<META NAME="ROBOTS" CONTENT="INDEX, FOLLOW">
+<meta name="robots" content="noindex, follow" />
 
 <link rel="alternate" type="application/rss&#43;xml" href="/v0.4/index.xml">
 

--- a/docs/static/v0.4/project/releases/v0.4.6/index.html
+++ b/docs/static/v0.4/project/releases/v0.4.6/index.html
@@ -7,7 +7,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
 <meta name="generator" content="Hugo 0.55.6" />
 
-<META NAME="ROBOTS" CONTENT="INDEX, FOLLOW">
+<meta name="robots" content="noindex, follow" />
 
 <link rel="alternate" type="application/rss&#43;xml" href="/v0.4/index.xml">
 

--- a/docs/static/v0.4/project/releases/v0.4.7/index.html
+++ b/docs/static/v0.4/project/releases/v0.4.7/index.html
@@ -7,7 +7,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
 <meta name="generator" content="Hugo 0.55.6" />
 
-<META NAME="ROBOTS" CONTENT="INDEX, FOLLOW">
+<meta name="robots" content="noindex, follow" />
 
 <link rel="alternate" type="application/rss&#43;xml" href="/v0.4/index.xml">
 

--- a/docs/static/v0.4/project/releases/v0.4.8/index.html
+++ b/docs/static/v0.4/project/releases/v0.4.8/index.html
@@ -7,7 +7,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
 <meta name="generator" content="Hugo 0.55.6" />
 
-<META NAME="ROBOTS" CONTENT="INDEX, FOLLOW">
+<meta name="robots" content="noindex, follow" />
 
 <link rel="alternate" type="application/rss&#43;xml" href="/v0.4/index.xml">
 

--- a/docs/static/v0.4/project/releases/v0.4.9/index.html
+++ b/docs/static/v0.4/project/releases/v0.4.9/index.html
@@ -7,7 +7,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
 <meta name="generator" content="Hugo 0.55.6" />
 
-<META NAME="ROBOTS" CONTENT="INDEX, FOLLOW">
+<meta name="robots" content="noindex, follow" />
 
 <link rel="alternate" type="application/rss&#43;xml" href="/v0.4/index.xml">
 

--- a/docs/static/v0.4/project/security-vulnerabilities/index.html
+++ b/docs/static/v0.4/project/security-vulnerabilities/index.html
@@ -7,7 +7,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
 <meta name="generator" content="Hugo 0.55.6" />
 
-<META NAME="ROBOTS" CONTENT="INDEX, FOLLOW">
+<meta name="robots" content="noindex, follow" />
 
 <link rel="alternate" type="application/rss&#43;xml" href="/v0.4/index.xml">
 

--- a/docs/static/v0.4/reference/index.html
+++ b/docs/static/v0.4/reference/index.html
@@ -7,7 +7,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
 <meta name="generator" content="Hugo 0.55.6" />
 
-<META NAME="ROBOTS" CONTENT="INDEX, FOLLOW">
+<meta name="robots" content="noindex, follow" />
 
 <link rel="alternate" type="application/rss&#43;xml" href="/v0.4/index.xml">
 

--- a/docs/static/v0.4/reference/mesheryctl/commands/command_name_template/index.html
+++ b/docs/static/v0.4/reference/mesheryctl/commands/command_name_template/index.html
@@ -7,7 +7,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
 <meta name="generator" content="Hugo 0.55.6" />
 
-<META NAME="ROBOTS" CONTENT="INDEX, FOLLOW">
+<meta name="robots" content="noindex, follow" />
 
 <link rel="alternate" type="application/rss&#43;xml" href="/v0.4/index.xml">
 

--- a/docs/static/v0.4/reference/mesheryctl/index.html
+++ b/docs/static/v0.4/reference/mesheryctl/index.html
@@ -7,7 +7,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
 <meta name="generator" content="Hugo 0.55.6" />
 
-<META NAME="ROBOTS" CONTENT="INDEX, FOLLOW">
+<meta name="robots" content="noindex, follow" />
 
 <link rel="alternate" type="application/rss&#43;xml" href="/v0.4/index.xml">
 

--- a/docs/static/v0.4/search/index.html
+++ b/docs/static/v0.4/search/index.html
@@ -7,7 +7,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
 <meta name="generator" content="Hugo 0.55.6" />
 
-<META NAME="ROBOTS" CONTENT="INDEX, FOLLOW">
+<meta name="robots" content="noindex, follow" />
 
 <link rel="alternate" type="application/rss&#43;xml" href="/v0.4/index.xml">
 

--- a/docs/static/v0.4/service-meshes/adapters/app-mesh/index.html
+++ b/docs/static/v0.4/service-meshes/adapters/app-mesh/index.html
@@ -7,7 +7,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
 <meta name="generator" content="Hugo 0.55.6" />
 
-<META NAME="ROBOTS" CONTENT="INDEX, FOLLOW">
+<meta name="robots" content="noindex, follow" />
 
 <link rel="alternate" type="application/rss&#43;xml" href="/v0.4/index.xml">
 

--- a/docs/static/v0.4/service-meshes/adapters/consul/index.html
+++ b/docs/static/v0.4/service-meshes/adapters/consul/index.html
@@ -7,7 +7,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
 <meta name="generator" content="Hugo 0.55.6" />
 
-<META NAME="ROBOTS" CONTENT="INDEX, FOLLOW">
+<meta name="robots" content="noindex, follow" />
 
 <link rel="alternate" type="application/rss&#43;xml" href="/v0.4/index.xml">
 

--- a/docs/static/v0.4/service-meshes/adapters/cpx/index.html
+++ b/docs/static/v0.4/service-meshes/adapters/cpx/index.html
@@ -7,7 +7,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
 <meta name="generator" content="Hugo 0.55.6" />
 
-<META NAME="ROBOTS" CONTENT="INDEX, FOLLOW">
+<meta name="robots" content="noindex, follow" />
 
 <link rel="alternate" type="application/rss&#43;xml" href="/v0.4/index.xml">
 

--- a/docs/static/v0.4/service-meshes/adapters/istio/index.html
+++ b/docs/static/v0.4/service-meshes/adapters/istio/index.html
@@ -7,7 +7,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
 <meta name="generator" content="Hugo 0.55.6" />
 
-<META NAME="ROBOTS" CONTENT="INDEX, FOLLOW">
+<meta name="robots" content="noindex, follow" />
 
 <link rel="alternate" type="application/rss&#43;xml" href="/v0.4/index.xml">
 

--- a/docs/static/v0.4/service-meshes/adapters/kuma/index.html
+++ b/docs/static/v0.4/service-meshes/adapters/kuma/index.html
@@ -7,7 +7,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
 <meta name="generator" content="Hugo 0.55.6" />
 
-<META NAME="ROBOTS" CONTENT="INDEX, FOLLOW">
+<meta name="robots" content="noindex, follow" />
 
 <link rel="alternate" type="application/rss&#43;xml" href="/v0.4/index.xml">
 

--- a/docs/static/v0.4/service-meshes/adapters/linkerd/index.html
+++ b/docs/static/v0.4/service-meshes/adapters/linkerd/index.html
@@ -7,7 +7,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
 <meta name="generator" content="Hugo 0.55.6" />
 
-<META NAME="ROBOTS" CONTENT="INDEX, FOLLOW">
+<meta name="robots" content="noindex, follow" />
 
 <link rel="alternate" type="application/rss&#43;xml" href="/v0.4/index.xml">
 

--- a/docs/static/v0.4/service-meshes/adapters/nginx-sm/index.html
+++ b/docs/static/v0.4/service-meshes/adapters/nginx-sm/index.html
@@ -7,7 +7,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
 <meta name="generator" content="Hugo 0.55.6" />
 
-<META NAME="ROBOTS" CONTENT="INDEX, FOLLOW">
+<meta name="robots" content="noindex, follow" />
 
 <link rel="alternate" type="application/rss&#43;xml" href="/v0.4/index.xml">
 

--- a/docs/static/v0.4/service-meshes/adapters/nsm/index.html
+++ b/docs/static/v0.4/service-meshes/adapters/nsm/index.html
@@ -7,7 +7,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
 <meta name="generator" content="Hugo 0.55.6" />
 
-<META NAME="ROBOTS" CONTENT="INDEX, FOLLOW">
+<meta name="robots" content="noindex, follow" />
 
 <link rel="alternate" type="application/rss&#43;xml" href="/v0.4/index.xml">
 

--- a/docs/static/v0.4/service-meshes/adapters/octarine/index.html
+++ b/docs/static/v0.4/service-meshes/adapters/octarine/index.html
@@ -7,7 +7,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
 <meta name="generator" content="Hugo 0.55.6" />
 
-<META NAME="ROBOTS" CONTENT="INDEX, FOLLOW">
+<meta name="robots" content="noindex, follow" />
 
 <link rel="alternate" type="application/rss&#43;xml" href="/v0.4/index.xml">
 

--- a/docs/static/v0.4/service-meshes/adapters/osm/index.html
+++ b/docs/static/v0.4/service-meshes/adapters/osm/index.html
@@ -7,7 +7,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
 <meta name="generator" content="Hugo 0.55.6" />
 
-<META NAME="ROBOTS" CONTENT="INDEX, FOLLOW">
+<meta name="robots" content="noindex, follow" />
 
 <link rel="alternate" type="application/rss&#43;xml" href="/v0.4/index.xml">
 

--- a/docs/static/v0.4/service-meshes/adapters/sofamesh/index.html
+++ b/docs/static/v0.4/service-meshes/adapters/sofamesh/index.html
@@ -7,7 +7,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
 <meta name="generator" content="Hugo 0.55.6" />
 
-<META NAME="ROBOTS" CONTENT="INDEX, FOLLOW">
+<meta name="robots" content="noindex, follow" />
 
 <link rel="alternate" type="application/rss&#43;xml" href="/v0.4/index.xml">
 

--- a/docs/static/v0.4/service-meshes/adapters/tanzu-sm/index.html
+++ b/docs/static/v0.4/service-meshes/adapters/tanzu-sm/index.html
@@ -7,7 +7,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
 <meta name="generator" content="Hugo 0.55.6" />
 
-<META NAME="ROBOTS" CONTENT="INDEX, FOLLOW">
+<meta name="robots" content="noindex, follow" />
 
 <link rel="alternate" type="application/rss&#43;xml" href="/v0.4/index.xml">
 

--- a/docs/static/v0.4/service-meshes/adapters/traefik-mesh/index.html
+++ b/docs/static/v0.4/service-meshes/adapters/traefik-mesh/index.html
@@ -7,7 +7,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
 <meta name="generator" content="Hugo 0.55.6" />
 
-<META NAME="ROBOTS" CONTENT="INDEX, FOLLOW">
+<meta name="robots" content="noindex, follow" />
 
 <link rel="alternate" type="application/rss&#43;xml" href="/v0.4/index.xml">
 

--- a/docs/static/v0.4/service-meshes/index.html
+++ b/docs/static/v0.4/service-meshes/index.html
@@ -7,7 +7,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
 <meta name="generator" content="Hugo 0.55.6" />
 
-<META NAME="ROBOTS" CONTENT="INDEX, FOLLOW">
+<meta name="robots" content="noindex, follow" />
 
 <link rel="alternate" type="application/rss&#43;xml" href="/v0.4/index.xml">
 

--- a/docs/static/v0.4/tags/index.html
+++ b/docs/static/v0.4/tags/index.html
@@ -7,7 +7,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
 <meta name="generator" content="Hugo 0.55.6" />
 
-<META NAME="ROBOTS" CONTENT="INDEX, FOLLOW">
+<meta name="robots" content="noindex, follow" />
 
 <link rel="alternate" type="application/rss&#43;xml" href="/v0.4/index.xml">
 

--- a/docs/static/v0.5/404/index.html
+++ b/docs/static/v0.5/404/index.html
@@ -7,7 +7,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
 <meta name="generator" content="Hugo 0.55.6" />
 
-<META NAME="ROBOTS" CONTENT="INDEX, FOLLOW">
+<meta name="robots" content="noindex, follow" />
 
 <link rel="alternate" type="application/rss&#43;xml" href="/v0.5/index.xml">
 

--- a/docs/static/v0.5/CONTRIBUTING-gitflow/index.html
+++ b/docs/static/v0.5/CONTRIBUTING-gitflow/index.html
@@ -7,7 +7,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
 <meta name="generator" content="Hugo 0.55.6" />
 
-<META NAME="ROBOTS" CONTENT="INDEX, FOLLOW">
+<meta name="robots" content="noindex, follow" />
 
 <link rel="alternate" type="application/rss&#43;xml" href="/v0.5/index.xml">
 

--- a/docs/static/v0.5/concepts/architecture/adapters/index.html
+++ b/docs/static/v0.5/concepts/architecture/adapters/index.html
@@ -7,7 +7,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
 <meta name="generator" content="Hugo 0.55.6" />
 
-<META NAME="ROBOTS" CONTENT="INDEX, FOLLOW">
+<meta name="robots" content="noindex, follow" />
 
 <link rel="alternate" type="application/rss&#43;xml" href="/v0.5/index.xml">
 

--- a/docs/static/v0.5/concepts/architecture/broker/index.html
+++ b/docs/static/v0.5/concepts/architecture/broker/index.html
@@ -7,7 +7,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
 <meta name="generator" content="Hugo 0.55.6" />
 
-<META NAME="ROBOTS" CONTENT="INDEX, FOLLOW">
+<meta name="robots" content="noindex, follow" />
 
 <link rel="alternate" type="application/rss&#43;xml" href="/v0.5/index.xml">
 

--- a/docs/static/v0.5/concepts/architecture/database/index.html
+++ b/docs/static/v0.5/concepts/architecture/database/index.html
@@ -7,7 +7,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
 <meta name="generator" content="Hugo 0.55.6" />
 
-<META NAME="ROBOTS" CONTENT="INDEX, FOLLOW">
+<meta name="robots" content="noindex, follow" />
 
 <link rel="alternate" type="application/rss&#43;xml" href="/v0.5/index.xml">
 

--- a/docs/static/v0.5/concepts/architecture/index.html
+++ b/docs/static/v0.5/concepts/architecture/index.html
@@ -7,7 +7,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
 <meta name="generator" content="Hugo 0.55.6" />
 
-<META NAME="ROBOTS" CONTENT="INDEX, FOLLOW">
+<meta name="robots" content="noindex, follow" />
 
 <link rel="alternate" type="application/rss&#43;xml" href="/v0.5/index.xml">
 

--- a/docs/static/v0.5/concepts/architecture/meshsync/index.html
+++ b/docs/static/v0.5/concepts/architecture/meshsync/index.html
@@ -7,7 +7,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
 <meta name="generator" content="Hugo 0.55.6" />
 
-<META NAME="ROBOTS" CONTENT="INDEX, FOLLOW">
+<meta name="robots" content="noindex, follow" />
 
 <link rel="alternate" type="application/rss&#43;xml" href="/v0.5/index.xml">
 

--- a/docs/static/v0.5/concepts/architecture/operator/index.html
+++ b/docs/static/v0.5/concepts/architecture/operator/index.html
@@ -7,7 +7,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
 <meta name="generator" content="Hugo 0.55.6" />
 
-<META NAME="ROBOTS" CONTENT="INDEX, FOLLOW">
+<meta name="robots" content="noindex, follow" />
 
 <link rel="alternate" type="application/rss&#43;xml" href="/v0.5/index.xml">
 

--- a/docs/static/v0.5/concepts/index.html
+++ b/docs/static/v0.5/concepts/index.html
@@ -7,7 +7,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
 <meta name="generator" content="Hugo 0.55.6" />
 
-<META NAME="ROBOTS" CONTENT="INDEX, FOLLOW">
+<meta name="robots" content="noindex, follow" />
 
 <link rel="alternate" type="application/rss&#43;xml" href="/v0.5/index.xml">
 

--- a/docs/static/v0.5/es/404/index.html
+++ b/docs/static/v0.5/es/404/index.html
@@ -7,7 +7,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
 <meta name="generator" content="Hugo 0.55.6" />
 
-<META NAME="ROBOTS" CONTENT="INDEX, FOLLOW">
+<meta name="robots" content="noindex, follow" />
 
 <link rel="alternate" type="application/rss&#43;xml" href="/v0.5/index.xml">
 

--- a/docs/static/v0.5/es/architecture/index.html
+++ b/docs/static/v0.5/es/architecture/index.html
@@ -7,7 +7,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
 <meta name="generator" content="Hugo 0.55.6" />
 
-<META NAME="ROBOTS" CONTENT="INDEX, FOLLOW">
+<meta name="robots" content="noindex, follow" />
 
 <link rel="alternate" type="application/rss&#43;xml" href="/v0.5/index.xml">
 

--- a/docs/static/v0.5/es/archive/index.html
+++ b/docs/static/v0.5/es/archive/index.html
@@ -7,7 +7,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
 <meta name="generator" content="Hugo 0.55.6" />
 
-<META NAME="ROBOTS" CONTENT="INDEX, FOLLOW">
+<meta name="robots" content="noindex, follow" />
 
 <link rel="alternate" type="application/rss&#43;xml" href="/v0.5/index.xml">
 

--- a/docs/static/v0.5/es/concepts/architecture/adapters/index.html
+++ b/docs/static/v0.5/es/concepts/architecture/adapters/index.html
@@ -7,7 +7,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
 <meta name="generator" content="Hugo 0.55.6" />
 
-<META NAME="ROBOTS" CONTENT="INDEX, FOLLOW">
+<meta name="robots" content="noindex, follow" />
 
 <link rel="alternate" type="application/rss&#43;xml" href="/v0.5/index.xml">
 

--- a/docs/static/v0.5/es/concepts/architecture/broker/index.html
+++ b/docs/static/v0.5/es/concepts/architecture/broker/index.html
@@ -7,7 +7,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
 <meta name="generator" content="Hugo 0.55.6" />
 
-<META NAME="ROBOTS" CONTENT="INDEX, FOLLOW">
+<meta name="robots" content="noindex, follow" />
 
 <link rel="alternate" type="application/rss&#43;xml" href="/v0.5/index.xml">
 

--- a/docs/static/v0.5/es/concepts/architecture/database/index.html
+++ b/docs/static/v0.5/es/concepts/architecture/database/index.html
@@ -7,7 +7,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
 <meta name="generator" content="Hugo 0.55.6" />
 
-<META NAME="ROBOTS" CONTENT="INDEX, FOLLOW">
+<meta name="robots" content="noindex, follow" />
 
 <link rel="alternate" type="application/rss&#43;xml" href="/v0.5/index.xml">
 

--- a/docs/static/v0.5/es/concepts/architecture/index.html
+++ b/docs/static/v0.5/es/concepts/architecture/index.html
@@ -7,7 +7,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
 <meta name="generator" content="Hugo 0.55.6" />
 
-<META NAME="ROBOTS" CONTENT="INDEX, FOLLOW">
+<meta name="robots" content="noindex, follow" />
 
 <link rel="alternate" type="application/rss&#43;xml" href="/v0.5/index.xml">
 

--- a/docs/static/v0.5/es/concepts/architecture/meshsync/index.html
+++ b/docs/static/v0.5/es/concepts/architecture/meshsync/index.html
@@ -7,7 +7,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
 <meta name="generator" content="Hugo 0.55.6" />
 
-<META NAME="ROBOTS" CONTENT="INDEX, FOLLOW">
+<meta name="robots" content="noindex, follow" />
 
 <link rel="alternate" type="application/rss&#43;xml" href="/v0.5/index.xml">
 

--- a/docs/static/v0.5/es/concepts/architecture/operator/index.html
+++ b/docs/static/v0.5/es/concepts/architecture/operator/index.html
@@ -7,7 +7,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
 <meta name="generator" content="Hugo 0.55.6" />
 
-<META NAME="ROBOTS" CONTENT="INDEX, FOLLOW">
+<meta name="robots" content="noindex, follow" />
 
 <link rel="alternate" type="application/rss&#43;xml" href="/v0.5/index.xml">
 

--- a/docs/static/v0.5/es/concepts/index.html
+++ b/docs/static/v0.5/es/concepts/index.html
@@ -7,7 +7,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
 <meta name="generator" content="Hugo 0.55.6" />
 
-<META NAME="ROBOTS" CONTENT="INDEX, FOLLOW">
+<meta name="robots" content="noindex, follow" />
 
 <link rel="alternate" type="application/rss&#43;xml" href="/v0.5/index.xml">
 

--- a/docs/static/v0.5/es/extensibility/adapters/index.html
+++ b/docs/static/v0.5/es/extensibility/adapters/index.html
@@ -7,7 +7,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
 <meta name="generator" content="Hugo 0.55.6" />
 
-<META NAME="ROBOTS" CONTENT="INDEX, FOLLOW">
+<meta name="robots" content="noindex, follow" />
 
 <link rel="alternate" type="application/rss&#43;xml" href="/v0.5/index.xml">
 

--- a/docs/static/v0.5/es/extensibility/api/index.html
+++ b/docs/static/v0.5/es/extensibility/api/index.html
@@ -7,7 +7,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
 <meta name="generator" content="Hugo 0.55.6" />
 
-<META NAME="ROBOTS" CONTENT="INDEX, FOLLOW">
+<meta name="robots" content="noindex, follow" />
 
 <link rel="alternate" type="application/rss&#43;xml" href="/v0.5/index.xml">
 

--- a/docs/static/v0.5/es/extensibility/index.html
+++ b/docs/static/v0.5/es/extensibility/index.html
@@ -7,7 +7,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
 <meta name="generator" content="Hugo 0.55.6" />
 
-<META NAME="ROBOTS" CONTENT="INDEX, FOLLOW">
+<meta name="robots" content="noindex, follow" />
 
 <link rel="alternate" type="application/rss&#43;xml" href="/v0.5/index.xml">
 

--- a/docs/static/v0.5/es/extensibility/load-generators/index.html
+++ b/docs/static/v0.5/es/extensibility/load-generators/index.html
@@ -7,7 +7,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
 <meta name="generator" content="Hugo 0.55.6" />
 
-<META NAME="ROBOTS" CONTENT="INDEX, FOLLOW">
+<meta name="robots" content="noindex, follow" />
 
 <link rel="alternate" type="application/rss&#43;xml" href="/v0.5/index.xml">
 

--- a/docs/static/v0.5/es/extensibility/providers/index.html
+++ b/docs/static/v0.5/es/extensibility/providers/index.html
@@ -7,7 +7,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
 <meta name="generator" content="Hugo 0.55.6" />
 
-<META NAME="ROBOTS" CONTENT="INDEX, FOLLOW">
+<meta name="robots" content="noindex, follow" />
 
 <link rel="alternate" type="application/rss&#43;xml" href="/v0.5/index.xml">
 

--- a/docs/static/v0.5/es/functionality/index.html
+++ b/docs/static/v0.5/es/functionality/index.html
@@ -7,7 +7,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
 <meta name="generator" content="Hugo 0.55.6" />
 
-<META NAME="ROBOTS" CONTENT="INDEX, FOLLOW">
+<meta name="robots" content="noindex, follow" />
 
 <link rel="alternate" type="application/rss&#43;xml" href="/v0.5/index.xml">
 

--- a/docs/static/v0.5/es/functionality/lifecycle-management/index.html
+++ b/docs/static/v0.5/es/functionality/lifecycle-management/index.html
@@ -7,7 +7,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
 <meta name="generator" content="Hugo 0.55.6" />
 
-<META NAME="ROBOTS" CONTENT="INDEX, FOLLOW">
+<meta name="robots" content="noindex, follow" />
 
 <link rel="alternate" type="application/rss&#43;xml" href="/v0.5/index.xml">
 

--- a/docs/static/v0.5/es/functionality/performance-management/index.html
+++ b/docs/static/v0.5/es/functionality/performance-management/index.html
@@ -7,7 +7,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
 <meta name="generator" content="Hugo 0.55.6" />
 
-<META NAME="ROBOTS" CONTENT="INDEX, FOLLOW">
+<meta name="robots" content="noindex, follow" />
 
 <link rel="alternate" type="application/rss&#43;xml" href="/v0.5/index.xml">
 

--- a/docs/static/v0.5/es/functionality/smi-conformance/index.html
+++ b/docs/static/v0.5/es/functionality/smi-conformance/index.html
@@ -7,7 +7,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
 <meta name="generator" content="Hugo 0.55.6" />
 
-<META NAME="ROBOTS" CONTENT="INDEX, FOLLOW">
+<meta name="robots" content="noindex, follow" />
 
 <link rel="alternate" type="application/rss&#43;xml" href="/v0.5/index.xml">
 

--- a/docs/static/v0.5/es/guides/index.html
+++ b/docs/static/v0.5/es/guides/index.html
@@ -7,7 +7,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
 <meta name="generator" content="Hugo 0.55.6" />
 
-<META NAME="ROBOTS" CONTENT="INDEX, FOLLOW">
+<meta name="robots" content="noindex, follow" />
 
 <link rel="alternate" type="application/rss&#43;xml" href="/v0.5/index.xml">
 

--- a/docs/static/v0.5/es/guides/interpreting-performance-test-results/index.html
+++ b/docs/static/v0.5/es/guides/interpreting-performance-test-results/index.html
@@ -7,7 +7,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
 <meta name="generator" content="Hugo 0.55.6" />
 
-<META NAME="ROBOTS" CONTENT="INDEX, FOLLOW">
+<meta name="robots" content="noindex, follow" />
 
 <link rel="alternate" type="application/rss&#43;xml" href="/v0.5/index.xml">
 

--- a/docs/static/v0.5/es/guides/meshery-metrics/index.html
+++ b/docs/static/v0.5/es/guides/meshery-metrics/index.html
@@ -7,7 +7,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
 <meta name="generator" content="Hugo 0.55.6" />
 
-<META NAME="ROBOTS" CONTENT="INDEX, FOLLOW">
+<meta name="robots" content="noindex, follow" />
 
 <link rel="alternate" type="application/rss&#43;xml" href="/v0.5/index.xml">
 

--- a/docs/static/v0.5/es/guides/multiple-adapters/index.html
+++ b/docs/static/v0.5/es/guides/multiple-adapters/index.html
@@ -7,7 +7,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
 <meta name="generator" content="Hugo 0.55.6" />
 
-<META NAME="ROBOTS" CONTENT="INDEX, FOLLOW">
+<meta name="robots" content="noindex, follow" />
 
 <link rel="alternate" type="application/rss&#43;xml" href="/v0.5/index.xml">
 

--- a/docs/static/v0.5/es/guides/sample-apps/index.html
+++ b/docs/static/v0.5/es/guides/sample-apps/index.html
@@ -7,7 +7,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
 <meta name="generator" content="Hugo 0.55.6" />
 
-<META NAME="ROBOTS" CONTENT="INDEX, FOLLOW">
+<meta name="robots" content="noindex, follow" />
 
 <link rel="alternate" type="application/rss&#43;xml" href="/v0.5/index.xml">
 

--- a/docs/static/v0.5/es/guides/upgrade/index.html
+++ b/docs/static/v0.5/es/guides/upgrade/index.html
@@ -7,7 +7,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
 <meta name="generator" content="Hugo 0.55.6" />
 
-<META NAME="ROBOTS" CONTENT="INDEX, FOLLOW">
+<meta name="robots" content="noindex, follow" />
 
 <link rel="alternate" type="application/rss&#43;xml" href="/v0.5/index.xml">
 

--- a/docs/static/v0.5/es/index.html
+++ b/docs/static/v0.5/es/index.html
@@ -7,7 +7,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
 <meta name="generator" content="Hugo 0.55.6" />
 
-<META NAME="ROBOTS" CONTENT="INDEX, FOLLOW">
+<meta name="robots" content="noindex, follow" />
 
 <link rel="alternate" type="application/rss&#43;xml" href="/v0.5/index.xml">
 

--- a/docs/static/v0.5/es/installation/index.html
+++ b/docs/static/v0.5/es/installation/index.html
@@ -7,7 +7,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
 <meta name="generator" content="Hugo 0.55.6" />
 
-<META NAME="ROBOTS" CONTENT="INDEX, FOLLOW">
+<meta name="robots" content="noindex, follow" />
 
 <link rel="alternate" type="application/rss&#43;xml" href="/v0.5/index.xml">
 

--- a/docs/static/v0.5/es/installation/platforms/aks/index.html
+++ b/docs/static/v0.5/es/installation/platforms/aks/index.html
@@ -7,7 +7,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
 <meta name="generator" content="Hugo 0.55.6" />
 
-<META NAME="ROBOTS" CONTENT="INDEX, FOLLOW">
+<meta name="robots" content="noindex, follow" />
 
 <link rel="alternate" type="application/rss&#43;xml" href="/v0.5/index.xml">
 

--- a/docs/static/v0.5/es/installation/platforms/docker/index.html
+++ b/docs/static/v0.5/es/installation/platforms/docker/index.html
@@ -7,7 +7,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
 <meta name="generator" content="Hugo 0.55.6" />
 
-<META NAME="ROBOTS" CONTENT="INDEX, FOLLOW">
+<meta name="robots" content="noindex, follow" />
 
 <link rel="alternate" type="application/rss&#43;xml" href="/v0.5/index.xml">
 

--- a/docs/static/v0.5/es/installation/platforms/eks/index.html
+++ b/docs/static/v0.5/es/installation/platforms/eks/index.html
@@ -7,7 +7,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
 <meta name="generator" content="Hugo 0.55.6" />
 
-<META NAME="ROBOTS" CONTENT="INDEX, FOLLOW">
+<meta name="robots" content="noindex, follow" />
 
 <link rel="alternate" type="application/rss&#43;xml" href="/v0.5/index.xml">
 

--- a/docs/static/v0.5/es/installation/platforms/gke/index.html
+++ b/docs/static/v0.5/es/installation/platforms/gke/index.html
@@ -7,7 +7,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
 <meta name="generator" content="Hugo 0.55.6" />
 
-<META NAME="ROBOTS" CONTENT="INDEX, FOLLOW">
+<meta name="robots" content="noindex, follow" />
 
 <link rel="alternate" type="application/rss&#43;xml" href="/v0.5/index.xml">
 

--- a/docs/static/v0.5/es/installation/platforms/index.html
+++ b/docs/static/v0.5/es/installation/platforms/index.html
@@ -7,7 +7,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
 <meta name="generator" content="Hugo 0.55.6" />
 
-<META NAME="ROBOTS" CONTENT="INDEX, FOLLOW">
+<meta name="robots" content="noindex, follow" />
 
 <link rel="alternate" type="application/rss&#43;xml" href="/v0.5/index.xml">
 

--- a/docs/static/v0.5/es/installation/platforms/kind/index.html
+++ b/docs/static/v0.5/es/installation/platforms/kind/index.html
@@ -7,7 +7,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
 <meta name="generator" content="Hugo 0.55.6" />
 
-<META NAME="ROBOTS" CONTENT="INDEX, FOLLOW">
+<meta name="robots" content="noindex, follow" />
 
 <link rel="alternate" type="application/rss&#43;xml" href="/v0.5/index.xml">
 

--- a/docs/static/v0.5/es/installation/platforms/kubernetes/index.html
+++ b/docs/static/v0.5/es/installation/platforms/kubernetes/index.html
@@ -7,7 +7,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
 <meta name="generator" content="Hugo 0.55.6" />
 
-<META NAME="ROBOTS" CONTENT="INDEX, FOLLOW">
+<meta name="robots" content="noindex, follow" />
 
 <link rel="alternate" type="application/rss&#43;xml" href="/v0.5/index.xml">
 

--- a/docs/static/v0.5/es/installation/platforms/minikube/index.html
+++ b/docs/static/v0.5/es/installation/platforms/minikube/index.html
@@ -7,7 +7,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
 <meta name="generator" content="Hugo 0.55.6" />
 
-<META NAME="ROBOTS" CONTENT="INDEX, FOLLOW">
+<meta name="robots" content="noindex, follow" />
 
 <link rel="alternate" type="application/rss&#43;xml" href="/v0.5/index.xml">
 

--- a/docs/static/v0.5/es/installation/platforms/windows/index.html
+++ b/docs/static/v0.5/es/installation/platforms/windows/index.html
@@ -7,7 +7,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
 <meta name="generator" content="Hugo 0.55.6" />
 
-<META NAME="ROBOTS" CONTENT="INDEX, FOLLOW">
+<meta name="robots" content="noindex, follow" />
 
 <link rel="alternate" type="application/rss&#43;xml" href="/v0.5/index.xml">
 

--- a/docs/static/v0.5/es/news/index.html
+++ b/docs/static/v0.5/es/news/index.html
@@ -7,7 +7,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
 <meta name="generator" content="Hugo 0.55.6" />
 
-<META NAME="ROBOTS" CONTENT="INDEX, FOLLOW">
+<meta name="robots" content="noindex, follow" />
 
 <link rel="alternate" type="application/rss&#43;xml" href="/v0.5/index.xml">
 

--- a/docs/static/v0.5/es/overview/index.html
+++ b/docs/static/v0.5/es/overview/index.html
@@ -7,7 +7,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
 <meta name="generator" content="Hugo 0.55.6" />
 
-<META NAME="ROBOTS" CONTENT="INDEX, FOLLOW">
+<meta name="robots" content="noindex, follow" />
 
 <link rel="alternate" type="application/rss&#43;xml" href="/v0.5/index.xml">
 

--- a/docs/static/v0.5/es/project/build-and-release/index.html
+++ b/docs/static/v0.5/es/project/build-and-release/index.html
@@ -7,7 +7,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
 <meta name="generator" content="Hugo 0.55.6" />
 
-<META NAME="ROBOTS" CONTENT="INDEX, FOLLOW">
+<meta name="robots" content="noindex, follow" />
 
 <link rel="alternate" type="application/rss&#43;xml" href="/v0.5/index.xml">
 

--- a/docs/static/v0.5/es/project/contributing-flow/index.html
+++ b/docs/static/v0.5/es/project/contributing-flow/index.html
@@ -7,7 +7,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
 <meta name="generator" content="Hugo 0.55.6" />
 
-<META NAME="ROBOTS" CONTENT="INDEX, FOLLOW">
+<meta name="robots" content="noindex, follow" />
 
 <link rel="alternate" type="application/rss&#43;xml" href="/v0.5/index.xml">
 

--- a/docs/static/v0.5/es/project/contributing/contributing-docs/index.html
+++ b/docs/static/v0.5/es/project/contributing/contributing-docs/index.html
@@ -7,7 +7,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
 <meta name="generator" content="Hugo 0.55.6" />
 
-<META NAME="ROBOTS" CONTENT="INDEX, FOLLOW">
+<meta name="robots" content="noindex, follow" />
 
 <link rel="alternate" type="application/rss&#43;xml" href="/v0.5/index.xml">
 

--- a/docs/static/v0.5/es/project/contributing/index.html
+++ b/docs/static/v0.5/es/project/contributing/index.html
@@ -7,7 +7,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
 <meta name="generator" content="Hugo 0.55.6" />
 
-<META NAME="ROBOTS" CONTENT="INDEX, FOLLOW">
+<meta name="robots" content="noindex, follow" />
 
 <link rel="alternate" type="application/rss&#43;xml" href="/v0.5/index.xml">
 

--- a/docs/static/v0.5/es/project/faq/index.html
+++ b/docs/static/v0.5/es/project/faq/index.html
@@ -7,7 +7,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
 <meta name="generator" content="Hugo 0.55.6" />
 
-<META NAME="ROBOTS" CONTENT="INDEX, FOLLOW">
+<meta name="robots" content="noindex, follow" />
 
 <link rel="alternate" type="application/rss&#43;xml" href="/v0.5/index.xml">
 

--- a/docs/static/v0.5/es/project/index.html
+++ b/docs/static/v0.5/es/project/index.html
@@ -7,7 +7,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
 <meta name="generator" content="Hugo 0.55.6" />
 
-<META NAME="ROBOTS" CONTENT="INDEX, FOLLOW">
+<meta name="robots" content="noindex, follow" />
 
 <link rel="alternate" type="application/rss&#43;xml" href="/v0.5/index.xml">
 

--- a/docs/static/v0.5/es/project/releases/index.html
+++ b/docs/static/v0.5/es/project/releases/index.html
@@ -7,7 +7,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
 <meta name="generator" content="Hugo 0.55.6" />
 
-<META NAME="ROBOTS" CONTENT="INDEX, FOLLOW">
+<meta name="robots" content="noindex, follow" />
 
 <link rel="alternate" type="application/rss&#43;xml" href="/v0.5/index.xml">
 

--- a/docs/static/v0.5/es/project/security-vulnerabilities/index.html
+++ b/docs/static/v0.5/es/project/security-vulnerabilities/index.html
@@ -7,7 +7,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
 <meta name="generator" content="Hugo 0.55.6" />
 
-<META NAME="ROBOTS" CONTENT="INDEX, FOLLOW">
+<meta name="robots" content="noindex, follow" />
 
 <link rel="alternate" type="application/rss&#43;xml" href="/v0.5/index.xml">
 

--- a/docs/static/v0.5/es/reference/index.html
+++ b/docs/static/v0.5/es/reference/index.html
@@ -7,7 +7,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
 <meta name="generator" content="Hugo 0.55.6" />
 
-<META NAME="ROBOTS" CONTENT="INDEX, FOLLOW">
+<meta name="robots" content="noindex, follow" />
 
 <link rel="alternate" type="application/rss&#43;xml" href="/v0.5/index.xml">
 

--- a/docs/static/v0.5/es/reference/mesheryctl/index.html
+++ b/docs/static/v0.5/es/reference/mesheryctl/index.html
@@ -7,7 +7,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
 <meta name="generator" content="Hugo 0.55.6" />
 
-<META NAME="ROBOTS" CONTENT="INDEX, FOLLOW">
+<meta name="robots" content="noindex, follow" />
 
 <link rel="alternate" type="application/rss&#43;xml" href="/v0.5/index.xml">
 

--- a/docs/static/v0.5/es/service-meshes/index.html
+++ b/docs/static/v0.5/es/service-meshes/index.html
@@ -7,7 +7,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
 <meta name="generator" content="Hugo 0.55.6" />
 
-<META NAME="ROBOTS" CONTENT="INDEX, FOLLOW">
+<meta name="robots" content="noindex, follow" />
 
 <link rel="alternate" type="application/rss&#43;xml" href="/v0.5/index.xml">
 

--- a/docs/static/v0.5/extensibility/adapters/index.html
+++ b/docs/static/v0.5/extensibility/adapters/index.html
@@ -7,7 +7,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
 <meta name="generator" content="Hugo 0.55.6" />
 
-<META NAME="ROBOTS" CONTENT="INDEX, FOLLOW">
+<meta name="robots" content="noindex, follow" />
 
 <link rel="alternate" type="application/rss&#43;xml" href="/v0.5/index.xml">
 

--- a/docs/static/v0.5/extensibility/api/index.html
+++ b/docs/static/v0.5/extensibility/api/index.html
@@ -7,7 +7,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
 <meta name="generator" content="Hugo 0.55.6" />
 
-<META NAME="ROBOTS" CONTENT="INDEX, FOLLOW">
+<meta name="robots" content="noindex, follow" />
 
 <link rel="alternate" type="application/rss&#43;xml" href="/v0.5/index.xml">
 

--- a/docs/static/v0.5/extensibility/index.html
+++ b/docs/static/v0.5/extensibility/index.html
@@ -7,7 +7,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
 <meta name="generator" content="Hugo 0.55.6" />
 
-<META NAME="ROBOTS" CONTENT="INDEX, FOLLOW">
+<meta name="robots" content="noindex, follow" />
 
 <link rel="alternate" type="application/rss&#43;xml" href="/v0.5/index.xml">
 

--- a/docs/static/v0.5/extensibility/load-generators/index.html
+++ b/docs/static/v0.5/extensibility/load-generators/index.html
@@ -7,7 +7,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
 <meta name="generator" content="Hugo 0.55.6" />
 
-<META NAME="ROBOTS" CONTENT="INDEX, FOLLOW">
+<meta name="robots" content="noindex, follow" />
 
 <link rel="alternate" type="application/rss&#43;xml" href="/v0.5/index.xml">
 

--- a/docs/static/v0.5/extensibility/providers/index.html
+++ b/docs/static/v0.5/extensibility/providers/index.html
@@ -7,7 +7,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
 <meta name="generator" content="Hugo 0.55.6" />
 
-<META NAME="ROBOTS" CONTENT="INDEX, FOLLOW">
+<meta name="robots" content="noindex, follow" />
 
 <link rel="alternate" type="application/rss&#43;xml" href="/v0.5/index.xml">
 

--- a/docs/static/v0.5/extensibility/ui/index.html
+++ b/docs/static/v0.5/extensibility/ui/index.html
@@ -7,7 +7,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
 <meta name="generator" content="Hugo 0.55.6" />
 
-<META NAME="ROBOTS" CONTENT="INDEX, FOLLOW">
+<meta name="robots" content="noindex, follow" />
 
 <link rel="alternate" type="application/rss&#43;xml" href="/v0.5/index.xml">
 

--- a/docs/static/v0.5/functionality/application-management/index.html
+++ b/docs/static/v0.5/functionality/application-management/index.html
@@ -7,7 +7,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
 <meta name="generator" content="Hugo 0.55.6" />
 
-<META NAME="ROBOTS" CONTENT="INDEX, FOLLOW">
+<meta name="robots" content="noindex, follow" />
 
 <link rel="alternate" type="application/rss&#43;xml" href="/index.xml">
 

--- a/docs/static/v0.5/functionality/filter-management/index.html
+++ b/docs/static/v0.5/functionality/filter-management/index.html
@@ -7,7 +7,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
 <meta name="generator" content="Hugo 0.55.6" />
 
-<META NAME="ROBOTS" CONTENT="INDEX, FOLLOW">
+<meta name="robots" content="noindex, follow" />
 
 <link rel="alternate" type="application/rss&#43;xml" href="/index.xml">
 

--- a/docs/static/v0.5/functionality/index.html
+++ b/docs/static/v0.5/functionality/index.html
@@ -7,7 +7,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
 <meta name="generator" content="Hugo 0.55.6" />
 
-<META NAME="ROBOTS" CONTENT="INDEX, FOLLOW">
+<meta name="robots" content="noindex, follow" />
 
 <link rel="alternate" type="application/rss&#43;xml" href="/v0.5/index.xml">
 

--- a/docs/static/v0.5/functionality/lifecycle-management/index.html
+++ b/docs/static/v0.5/functionality/lifecycle-management/index.html
@@ -7,7 +7,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
 <meta name="generator" content="Hugo 0.55.6" />
 
-<META NAME="ROBOTS" CONTENT="INDEX, FOLLOW">
+<meta name="robots" content="noindex, follow" />
 
 <link rel="alternate" type="application/rss&#43;xml" href="/index.xml">
 

--- a/docs/static/v0.5/functionality/pattern-management/index.html
+++ b/docs/static/v0.5/functionality/pattern-management/index.html
@@ -7,7 +7,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
 <meta name="generator" content="Hugo 0.55.6" />
 
-<META NAME="ROBOTS" CONTENT="INDEX, FOLLOW">
+<meta name="robots" content="noindex, follow" />
 
 <link rel="alternate" type="application/rss&#43;xml" href="/index.xml">
 

--- a/docs/static/v0.5/functionality/performance-management/index.html
+++ b/docs/static/v0.5/functionality/performance-management/index.html
@@ -7,7 +7,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
 <meta name="generator" content="Hugo 0.55.6" />
 
-<META NAME="ROBOTS" CONTENT="INDEX, FOLLOW">
+<meta name="robots" content="noindex, follow" />
 
 <link rel="alternate" type="application/rss&#43;xml" href="/index.xml">
 

--- a/docs/static/v0.5/functionality/service-mesh-interface/index.html
+++ b/docs/static/v0.5/functionality/service-mesh-interface/index.html
@@ -7,7 +7,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
 <meta name="generator" content="Hugo 0.55.6" />
 
-<META NAME="ROBOTS" CONTENT="INDEX, FOLLOW">
+<meta name="robots" content="noindex, follow" />
 
 <link rel="alternate" type="application/rss&#43;xml" href="/index.xml">
 

--- a/docs/static/v0.5/getting-started/overview/index.html
+++ b/docs/static/v0.5/getting-started/overview/index.html
@@ -7,7 +7,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
 <meta name="generator" content="Hugo 0.55.6" />
 
-<META NAME="ROBOTS" CONTENT="INDEX, FOLLOW">
+<meta name="robots" content="noindex, follow" />
 
 <link rel="alternate" type="application/rss&#43;xml" href="/v0.5/index.xml">
 

--- a/docs/static/v0.5/guides/configuration-management/index.html
+++ b/docs/static/v0.5/guides/configuration-management/index.html
@@ -7,7 +7,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
 <meta name="generator" content="Hugo 0.55.6" />
 
-<META NAME="ROBOTS" CONTENT="INDEX, FOLLOW">
+<meta name="robots" content="noindex, follow" />
 
 <link rel="alternate" type="application/rss&#43;xml" href="/v0.5/index.xml">
 

--- a/docs/static/v0.5/guides/index.html
+++ b/docs/static/v0.5/guides/index.html
@@ -7,7 +7,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
 <meta name="generator" content="Hugo 0.55.6" />
 
-<META NAME="ROBOTS" CONTENT="INDEX, FOLLOW">
+<meta name="robots" content="noindex, follow" />
 
 <link rel="alternate" type="application/rss&#43;xml" href="/v0.5/index.xml">
 

--- a/docs/static/v0.5/guides/interpreting-performance-test-results/index.html
+++ b/docs/static/v0.5/guides/interpreting-performance-test-results/index.html
@@ -7,7 +7,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
 <meta name="generator" content="Hugo 0.55.6" />
 
-<META NAME="ROBOTS" CONTENT="INDEX, FOLLOW">
+<meta name="robots" content="noindex, follow" />
 
 <link rel="alternate" type="application/rss&#43;xml" href="/v0.5/index.xml">
 

--- a/docs/static/v0.5/guides/meshery-metrics/index.html
+++ b/docs/static/v0.5/guides/meshery-metrics/index.html
@@ -7,7 +7,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
 <meta name="generator" content="Hugo 0.55.6" />
 
-<META NAME="ROBOTS" CONTENT="INDEX, FOLLOW">
+<meta name="robots" content="noindex, follow" />
 
 <link rel="alternate" type="application/rss&#43;xml" href="/v0.5/index.xml">
 

--- a/docs/static/v0.5/guides/mesheryctl/authenticate-with-meshery-via-cli/index.html
+++ b/docs/static/v0.5/guides/mesheryctl/authenticate-with-meshery-via-cli/index.html
@@ -7,7 +7,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
 <meta name="generator" content="Hugo 0.55.6" />
 
-<META NAME="ROBOTS" CONTENT="INDEX, FOLLOW">
+<meta name="robots" content="noindex, follow" />
 
 <link rel="alternate" type="application/rss&#43;xml" href="/v0.5/index.xml">
 

--- a/docs/static/v0.5/guides/mesheryctl/configuring-autocompletion-for-mesheryctl/index.html
+++ b/docs/static/v0.5/guides/mesheryctl/configuring-autocompletion-for-mesheryctl/index.html
@@ -7,7 +7,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
 <meta name="generator" content="Hugo 0.55.6" />
 
-<META NAME="ROBOTS" CONTENT="INDEX, FOLLOW">
+<meta name="robots" content="noindex, follow" />
 
 <link rel="alternate" type="application/rss&#43;xml" href="/v0.5/index.xml">
 

--- a/docs/static/v0.5/guides/mesheryctl/index.html
+++ b/docs/static/v0.5/guides/mesheryctl/index.html
@@ -7,7 +7,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
 <meta name="generator" content="Hugo 0.55.6" />
 
-<META NAME="ROBOTS" CONTENT="INDEX, FOLLOW">
+<meta name="robots" content="noindex, follow" />
 
 <link rel="alternate" type="application/rss&#43;xml" href="/v0.5/index.xml">
 

--- a/docs/static/v0.5/guides/mesheryctl/running-system-checks-using-mesheryctl/index.html
+++ b/docs/static/v0.5/guides/mesheryctl/running-system-checks-using-mesheryctl/index.html
@@ -7,7 +7,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
 <meta name="generator" content="Hugo 0.55.6" />
 
-<META NAME="ROBOTS" CONTENT="INDEX, FOLLOW">
+<meta name="robots" content="noindex, follow" />
 
 <link rel="alternate" type="application/rss&#43;xml" href="/v0.5/index.xml">
 

--- a/docs/static/v0.5/guides/mesheryctl/working-with-mesheryctl/index.html
+++ b/docs/static/v0.5/guides/mesheryctl/working-with-mesheryctl/index.html
@@ -7,7 +7,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
 <meta name="generator" content="Hugo 0.55.6" />
 
-<META NAME="ROBOTS" CONTENT="INDEX, FOLLOW">
+<meta name="robots" content="noindex, follow" />
 
 <link rel="alternate" type="application/rss&#43;xml" href="/v0.5/index.xml">
 

--- a/docs/static/v0.5/guides/multiple-adapters/index.html
+++ b/docs/static/v0.5/guides/multiple-adapters/index.html
@@ -7,7 +7,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
 <meta name="generator" content="Hugo 0.55.6" />
 
-<META NAME="ROBOTS" CONTENT="INDEX, FOLLOW">
+<meta name="robots" content="noindex, follow" />
 
 <link rel="alternate" type="application/rss&#43;xml" href="/v0.5/index.xml">
 

--- a/docs/static/v0.5/guides/performance-management/index.html
+++ b/docs/static/v0.5/guides/performance-management/index.html
@@ -7,7 +7,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
 <meta name="generator" content="Hugo 0.55.6" />
 
-<META NAME="ROBOTS" CONTENT="INDEX, FOLLOW">
+<meta name="robots" content="noindex, follow" />
 
 <link rel="alternate" type="application/rss&#43;xml" href="/v0.5/index.xml">
 

--- a/docs/static/v0.5/guides/sample-apps/index.html
+++ b/docs/static/v0.5/guides/sample-apps/index.html
@@ -7,7 +7,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
 <meta name="generator" content="Hugo 0.55.6" />
 
-<META NAME="ROBOTS" CONTENT="INDEX, FOLLOW">
+<meta name="robots" content="noindex, follow" />
 
 <link rel="alternate" type="application/rss&#43;xml" href="/v0.5/index.xml">
 

--- a/docs/static/v0.5/guides/smi-conformance/index.html
+++ b/docs/static/v0.5/guides/smi-conformance/index.html
@@ -7,7 +7,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
 <meta name="generator" content="Hugo 0.55.6" />
 
-<META NAME="ROBOTS" CONTENT="INDEX, FOLLOW">
+<meta name="robots" content="noindex, follow" />
 
 <link rel="alternate" type="application/rss&#43;xml" href="/v0.5/index.xml">
 

--- a/docs/static/v0.5/guides/troubleshooting/index.html
+++ b/docs/static/v0.5/guides/troubleshooting/index.html
@@ -7,7 +7,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
 <meta name="generator" content="Hugo 0.55.6" />
 
-<META NAME="ROBOTS" CONTENT="INDEX, FOLLOW">
+<meta name="robots" content="noindex, follow" />
 
 <link rel="alternate" type="application/rss&#43;xml" href="/v0.5/index.xml">
 

--- a/docs/static/v0.5/guides/troubleshooting/installation/index.html
+++ b/docs/static/v0.5/guides/troubleshooting/installation/index.html
@@ -7,7 +7,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
 <meta name="generator" content="Hugo 0.55.6" />
 
-<META NAME="ROBOTS" CONTENT="INDEX, FOLLOW">
+<meta name="robots" content="noindex, follow" />
 
 <link rel="alternate" type="application/rss&#43;xml" href="/v0.5/index.xml">
 

--- a/docs/static/v0.5/guides/troubleshooting/running/index.html
+++ b/docs/static/v0.5/guides/troubleshooting/running/index.html
@@ -7,7 +7,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
 <meta name="generator" content="Hugo 0.55.6" />
 
-<META NAME="ROBOTS" CONTENT="INDEX, FOLLOW">
+<meta name="robots" content="noindex, follow" />
 
 <link rel="alternate" type="application/rss&#43;xml" href="/v0.5/index.xml">
 

--- a/docs/static/v0.5/guides/upgrade/index.html
+++ b/docs/static/v0.5/guides/upgrade/index.html
@@ -7,7 +7,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
 <meta name="generator" content="Hugo 0.55.6" />
 
-<META NAME="ROBOTS" CONTENT="INDEX, FOLLOW">
+<meta name="robots" content="noindex, follow" />
 
 <link rel="alternate" type="application/rss&#43;xml" href="/v0.5/index.xml">
 

--- a/docs/static/v0.5/installation/index.html
+++ b/docs/static/v0.5/installation/index.html
@@ -7,7 +7,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
 <meta name="generator" content="Hugo 0.55.6" />
 
-<META NAME="ROBOTS" CONTENT="INDEX, FOLLOW">
+<meta name="robots" content="noindex, follow" />
 
 <link rel="alternate" type="application/rss&#43;xml" href="/v0.5/index.xml">
 

--- a/docs/static/v0.5/installation/mesheryctl/index.html
+++ b/docs/static/v0.5/installation/mesheryctl/index.html
@@ -7,7 +7,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
 <meta name="generator" content="Hugo 0.55.6" />
 
-<META NAME="ROBOTS" CONTENT="INDEX, FOLLOW">
+<meta name="robots" content="noindex, follow" />
 
 <link rel="alternate" type="application/rss&#43;xml" href="/index.xml">
 

--- a/docs/static/v0.5/installation/platforms/aks/index.html
+++ b/docs/static/v0.5/installation/platforms/aks/index.html
@@ -7,7 +7,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
 <meta name="generator" content="Hugo 0.55.6" />
 
-<META NAME="ROBOTS" CONTENT="INDEX, FOLLOW">
+<meta name="robots" content="noindex, follow" />
 
 <link rel="alternate" type="application/rss&#43;xml" href="/index.xml">
 

--- a/docs/static/v0.5/installation/platforms/docker-extension/index.html
+++ b/docs/static/v0.5/installation/platforms/docker-extension/index.html
@@ -7,7 +7,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
 <meta name="generator" content="Hugo 0.55.6" />
 
-<META NAME="ROBOTS" CONTENT="INDEX, FOLLOW">
+<meta name="robots" content="noindex, follow" />
 
 <link rel="alternate" type="application/rss&#43;xml" href="/index.xml">
 

--- a/docs/static/v0.5/installation/platforms/docker/index.html
+++ b/docs/static/v0.5/installation/platforms/docker/index.html
@@ -7,7 +7,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
 <meta name="generator" content="Hugo 0.55.6" />
 
-<META NAME="ROBOTS" CONTENT="INDEX, FOLLOW">
+<meta name="robots" content="noindex, follow" />
 
 <link rel="alternate" type="application/rss&#43;xml" href="/index.xml">
 

--- a/docs/static/v0.5/installation/platforms/eks/index.html
+++ b/docs/static/v0.5/installation/platforms/eks/index.html
@@ -7,7 +7,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
 <meta name="generator" content="Hugo 0.55.6" />
 
-<META NAME="ROBOTS" CONTENT="INDEX, FOLLOW">
+<meta name="robots" content="noindex, follow" />
 
 <link rel="alternate" type="application/rss&#43;xml" href="/index.xml">
 

--- a/docs/static/v0.5/installation/platforms/gke/index.html
+++ b/docs/static/v0.5/installation/platforms/gke/index.html
@@ -7,7 +7,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
 <meta name="generator" content="Hugo 0.55.6" />
 
-<META NAME="ROBOTS" CONTENT="INDEX, FOLLOW">
+<meta name="robots" content="noindex, follow" />
 
 <link rel="alternate" type="application/rss&#43;xml" href="/index.xml">
 

--- a/docs/static/v0.5/installation/platforms/index.html
+++ b/docs/static/v0.5/installation/platforms/index.html
@@ -7,7 +7,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
 <meta name="generator" content="Hugo 0.55.6" />
 
-<META NAME="ROBOTS" CONTENT="INDEX, FOLLOW">
+<meta name="robots" content="noindex, follow" />
 
 <link rel="alternate" type="application/rss&#43;xml" href="/index.xml">
 

--- a/docs/static/v0.5/installation/platforms/kind/index.html
+++ b/docs/static/v0.5/installation/platforms/kind/index.html
@@ -7,7 +7,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
 <meta name="generator" content="Hugo 0.55.6" />
 
-<META NAME="ROBOTS" CONTENT="INDEX, FOLLOW">
+<meta name="robots" content="noindex, follow" />
 
 <link rel="alternate" type="application/rss&#43;xml" href="/index.xml">
 

--- a/docs/static/v0.5/installation/platforms/kubernetes/index.html
+++ b/docs/static/v0.5/installation/platforms/kubernetes/index.html
@@ -7,7 +7,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
 <meta name="generator" content="Hugo 0.55.6" />
 
-<META NAME="ROBOTS" CONTENT="INDEX, FOLLOW">
+<meta name="robots" content="noindex, follow" />
 
 <link rel="alternate" type="application/rss&#43;xml" href="/index.xml">
 

--- a/docs/static/v0.5/installation/platforms/kubesphere/index.html
+++ b/docs/static/v0.5/installation/platforms/kubesphere/index.html
@@ -7,7 +7,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
 <meta name="generator" content="Hugo 0.55.6" />
 
-<META NAME="ROBOTS" CONTENT="INDEX, FOLLOW">
+<meta name="robots" content="noindex, follow" />
 
 <link rel="alternate" type="application/rss&#43;xml" href="/index.xml">
 

--- a/docs/static/v0.5/installation/platforms/minikube/index.html
+++ b/docs/static/v0.5/installation/platforms/minikube/index.html
@@ -7,7 +7,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
 <meta name="generator" content="Hugo 0.55.6" />
 
-<META NAME="ROBOTS" CONTENT="INDEX, FOLLOW">
+<meta name="robots" content="noindex, follow" />
 
 <link rel="alternate" type="application/rss&#43;xml" href="/index.xml">
 

--- a/docs/static/v0.5/installation/platforms/scoop/index.html
+++ b/docs/static/v0.5/installation/platforms/scoop/index.html
@@ -7,7 +7,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
 <meta name="generator" content="Hugo 0.55.6" />
 
-<META NAME="ROBOTS" CONTENT="INDEX, FOLLOW">
+<meta name="robots" content="noindex, follow" />
 
 <link rel="alternate" type="application/rss&#43;xml" href="/index.xml">
 

--- a/docs/static/v0.5/installation/platforms/windows/index.html
+++ b/docs/static/v0.5/installation/platforms/windows/index.html
@@ -7,7 +7,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
 <meta name="generator" content="Hugo 0.55.6" />
 
-<META NAME="ROBOTS" CONTENT="INDEX, FOLLOW">
+<meta name="robots" content="noindex, follow" />
 
 <link rel="alternate" type="application/rss&#43;xml" href="/index.xml">
 

--- a/docs/static/v0.5/installation/quick-start/index.html
+++ b/docs/static/v0.5/installation/quick-start/index.html
@@ -7,7 +7,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
 <meta name="generator" content="Hugo 0.55.6" />
 
-<META NAME="ROBOTS" CONTENT="INDEX, FOLLOW">
+<meta name="robots" content="noindex, follow" />
 
 <link rel="alternate" type="application/rss&#43;xml" href="/index.xml">
 

--- a/docs/static/v0.5/news/index.html
+++ b/docs/static/v0.5/news/index.html
@@ -7,7 +7,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
 <meta name="generator" content="Hugo 0.55.6" />
 
-<META NAME="ROBOTS" CONTENT="INDEX, FOLLOW">
+<meta name="robots" content="noindex, follow" />
 
 <link rel="alternate" type="application/rss&#43;xml" href="/v0.5/index.xml">
 

--- a/docs/static/v0.5/project/build-and-release/index.html
+++ b/docs/static/v0.5/project/build-and-release/index.html
@@ -7,7 +7,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
 <meta name="generator" content="Hugo 0.55.6" />
 
-<META NAME="ROBOTS" CONTENT="INDEX, FOLLOW">
+<meta name="robots" content="noindex, follow" />
 
 <link rel="alternate" type="application/rss&#43;xml" href="/v0.5/index.xml">
 

--- a/docs/static/v0.5/project/community/index.html
+++ b/docs/static/v0.5/project/community/index.html
@@ -7,7 +7,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
 <meta name="generator" content="Hugo 0.55.6" />
 
-<META NAME="ROBOTS" CONTENT="INDEX, FOLLOW">
+<meta name="robots" content="noindex, follow" />
 
 <link rel="alternate" type="application/rss&#43;xml" href="/v0.5/index.xml">
 

--- a/docs/static/v0.5/project/compatibility-matrix/index.html
+++ b/docs/static/v0.5/project/compatibility-matrix/index.html
@@ -7,7 +7,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
 <meta name="generator" content="Hugo 0.55.6" />
 
-<META NAME="ROBOTS" CONTENT="INDEX, FOLLOW">
+<meta name="robots" content="noindex, follow" />
 
 <link rel="alternate" type="application/rss&#43;xml" href="/v0.5/index.xml">
 

--- a/docs/static/v0.5/project/compatibility-matrix/meshery-cilium-past-results/index.html
+++ b/docs/static/v0.5/project/compatibility-matrix/meshery-cilium-past-results/index.html
@@ -7,7 +7,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
 <meta name="generator" content="Hugo 0.55.6" />
 
-<META NAME="ROBOTS" CONTENT="INDEX, FOLLOW">
+<meta name="robots" content="noindex, follow" />
 
 <link rel="alternate" type="application/rss&#43;xml" href="/v0.5/index.xml">
 

--- a/docs/static/v0.5/project/compatibility-matrix/meshery-istio-past-results/index.html
+++ b/docs/static/v0.5/project/compatibility-matrix/meshery-istio-past-results/index.html
@@ -7,7 +7,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
 <meta name="generator" content="Hugo 0.55.6" />
 
-<META NAME="ROBOTS" CONTENT="INDEX, FOLLOW">
+<meta name="robots" content="noindex, follow" />
 
 <link rel="alternate" type="application/rss&#43;xml" href="/v0.5/index.xml">
 

--- a/docs/static/v0.5/project/compatibility-matrix/meshery-kuma-past-results/index.html
+++ b/docs/static/v0.5/project/compatibility-matrix/meshery-kuma-past-results/index.html
@@ -7,7 +7,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
 <meta name="generator" content="Hugo 0.55.6" />
 
-<META NAME="ROBOTS" CONTENT="INDEX, FOLLOW">
+<meta name="robots" content="noindex, follow" />
 
 <link rel="alternate" type="application/rss&#43;xml" href="/v0.5/index.xml">
 

--- a/docs/static/v0.5/project/compatibility-matrix/meshery-linkerd-past-results/index.html
+++ b/docs/static/v0.5/project/compatibility-matrix/meshery-linkerd-past-results/index.html
@@ -7,7 +7,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
 <meta name="generator" content="Hugo 0.55.6" />
 
-<META NAME="ROBOTS" CONTENT="INDEX, FOLLOW">
+<meta name="robots" content="noindex, follow" />
 
 <link rel="alternate" type="application/rss&#43;xml" href="/v0.5/index.xml">
 

--- a/docs/static/v0.5/project/compatibility-matrix/meshery-nginx-sm-past-results/index.html
+++ b/docs/static/v0.5/project/compatibility-matrix/meshery-nginx-sm-past-results/index.html
@@ -7,7 +7,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
 <meta name="generator" content="Hugo 0.55.6" />
 
-<META NAME="ROBOTS" CONTENT="INDEX, FOLLOW">
+<meta name="robots" content="noindex, follow" />
 
 <link rel="alternate" type="application/rss&#43;xml" href="/v0.5/index.xml">
 

--- a/docs/static/v0.5/project/compatibility-matrix/meshery-osm-past-results/index.html
+++ b/docs/static/v0.5/project/compatibility-matrix/meshery-osm-past-results/index.html
@@ -7,7 +7,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
 <meta name="generator" content="Hugo 0.55.6" />
 
-<META NAME="ROBOTS" CONTENT="INDEX, FOLLOW">
+<meta name="robots" content="noindex, follow" />
 
 <link rel="alternate" type="application/rss&#43;xml" href="/v0.5/index.xml">
 

--- a/docs/static/v0.5/project/compatibility-matrix/meshery-traefik-mesh-past-results/index.html
+++ b/docs/static/v0.5/project/compatibility-matrix/meshery-traefik-mesh-past-results/index.html
@@ -7,7 +7,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
 <meta name="generator" content="Hugo 0.55.6" />
 
-<META NAME="ROBOTS" CONTENT="INDEX, FOLLOW">
+<meta name="robots" content="noindex, follow" />
 
 <link rel="alternate" type="application/rss&#43;xml" href="/v0.5/index.xml">
 

--- a/docs/static/v0.5/project/contributing/contributing-adapters/index.html
+++ b/docs/static/v0.5/project/contributing/contributing-adapters/index.html
@@ -7,7 +7,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
 <meta name="generator" content="Hugo 0.55.6" />
 
-<META NAME="ROBOTS" CONTENT="INDEX, FOLLOW">
+<meta name="robots" content="noindex, follow" />
 
 <link rel="alternate" type="application/rss&#43;xml" href="/v0.5/index.xml">
 

--- a/docs/static/v0.5/project/contributing/contributing-cli/index.html
+++ b/docs/static/v0.5/project/contributing/contributing-cli/index.html
@@ -7,7 +7,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
 <meta name="generator" content="Hugo 0.55.6" />
 
-<META NAME="ROBOTS" CONTENT="INDEX, FOLLOW">
+<meta name="robots" content="noindex, follow" />
 
 <link rel="alternate" type="application/rss&#43;xml" href="/v0.5/index.xml">
 

--- a/docs/static/v0.5/project/contributing/contributing-cypress/index.html
+++ b/docs/static/v0.5/project/contributing/contributing-cypress/index.html
@@ -7,7 +7,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
 <meta name="generator" content="Hugo 0.55.6" />
 
-<META NAME="ROBOTS" CONTENT="INDEX, FOLLOW">
+<meta name="robots" content="noindex, follow" />
 
 <link rel="alternate" type="application/rss&#43;xml" href="/v0.5/index.xml">
 

--- a/docs/static/v0.5/project/contributing/contributing-docs/index.html
+++ b/docs/static/v0.5/project/contributing/contributing-docs/index.html
@@ -7,7 +7,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
 <meta name="generator" content="Hugo 0.55.6" />
 
-<META NAME="ROBOTS" CONTENT="INDEX, FOLLOW">
+<meta name="robots" content="noindex, follow" />
 
 <link rel="alternate" type="application/rss&#43;xml" href="/v0.5/index.xml">
 

--- a/docs/static/v0.5/project/contributing/contributing-error/index.html
+++ b/docs/static/v0.5/project/contributing/contributing-error/index.html
@@ -7,7 +7,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
 <meta name="generator" content="Hugo 0.55.6" />
 
-<META NAME="ROBOTS" CONTENT="INDEX, FOLLOW">
+<meta name="robots" content="noindex, follow" />
 
 <link rel="alternate" type="application/rss&#43;xml" href="/v0.5/index.xml">
 

--- a/docs/static/v0.5/project/contributing/contributing-gitflow/index.html
+++ b/docs/static/v0.5/project/contributing/contributing-gitflow/index.html
@@ -7,7 +7,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
 <meta name="generator" content="Hugo 0.55.6" />
 
-<META NAME="ROBOTS" CONTENT="INDEX, FOLLOW">
+<meta name="robots" content="noindex, follow" />
 
 <link rel="alternate" type="application/rss&#43;xml" href="/v0.5/index.xml">
 

--- a/docs/static/v0.5/project/contributing/contributing-guide/index.html
+++ b/docs/static/v0.5/project/contributing/contributing-guide/index.html
@@ -7,7 +7,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
 <meta name="generator" content="Hugo 0.55.6" />
 
-<META NAME="ROBOTS" CONTENT="INDEX, FOLLOW">
+<meta name="robots" content="noindex, follow" />
 
 <link rel="alternate" type="application/rss&#43;xml" href="/v0.5/index.xml">
 

--- a/docs/static/v0.5/project/contributing/contributing-server/index.html
+++ b/docs/static/v0.5/project/contributing/contributing-server/index.html
@@ -7,7 +7,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
 <meta name="generator" content="Hugo 0.55.6" />
 
-<META NAME="ROBOTS" CONTENT="INDEX, FOLLOW">
+<meta name="robots" content="noindex, follow" />
 
 <link rel="alternate" type="application/rss&#43;xml" href="/v0.5/index.xml">
 

--- a/docs/static/v0.5/project/contributing/contributing-ui/index.html
+++ b/docs/static/v0.5/project/contributing/contributing-ui/index.html
@@ -7,7 +7,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
 <meta name="generator" content="Hugo 0.55.6" />
 
-<META NAME="ROBOTS" CONTENT="INDEX, FOLLOW">
+<meta name="robots" content="noindex, follow" />
 
 <link rel="alternate" type="application/rss&#43;xml" href="/v0.5/index.xml">
 

--- a/docs/static/v0.5/project/contributing/index.html
+++ b/docs/static/v0.5/project/contributing/index.html
@@ -7,7 +7,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
 <meta name="generator" content="Hugo 0.55.6" />
 
-<META NAME="ROBOTS" CONTENT="INDEX, FOLLOW">
+<meta name="robots" content="noindex, follow" />
 
 <link rel="alternate" type="application/rss&#43;xml" href="/v0.5/index.xml">
 

--- a/docs/static/v0.5/project/faq/index.html
+++ b/docs/static/v0.5/project/faq/index.html
@@ -7,7 +7,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
 <meta name="generator" content="Hugo 0.55.6" />
 
-<META NAME="ROBOTS" CONTENT="INDEX, FOLLOW">
+<meta name="robots" content="noindex, follow" />
 
 <link rel="alternate" type="application/rss&#43;xml" href="/v0.5/index.xml">
 

--- a/docs/static/v0.5/project/index.html
+++ b/docs/static/v0.5/project/index.html
@@ -7,7 +7,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
 <meta name="generator" content="Hugo 0.55.6" />
 
-<META NAME="ROBOTS" CONTENT="INDEX, FOLLOW">
+<meta name="robots" content="noindex, follow" />
 
 <link rel="alternate" type="application/rss&#43;xml" href="/v0.5/index.xml">
 

--- a/docs/static/v0.5/project/releases/index.html
+++ b/docs/static/v0.5/project/releases/index.html
@@ -7,7 +7,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
 <meta name="generator" content="Hugo 0.55.6" />
 
-<META NAME="ROBOTS" CONTENT="INDEX, FOLLOW">
+<meta name="robots" content="noindex, follow" />
 
 <link rel="alternate" type="application/rss&#43;xml" href="/v0.5/index.xml">
 

--- a/docs/static/v0.5/project/releases/v0.0.1/index.html
+++ b/docs/static/v0.5/project/releases/v0.0.1/index.html
@@ -7,7 +7,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
 <meta name="generator" content="Hugo 0.55.6" />
 
-<META NAME="ROBOTS" CONTENT="INDEX, FOLLOW">
+<meta name="robots" content="noindex, follow" />
 
 <link rel="alternate" type="application/rss&#43;xml" href="/index.xml">
 

--- a/docs/static/v0.5/project/releases/v0.0.2/index.html
+++ b/docs/static/v0.5/project/releases/v0.0.2/index.html
@@ -7,7 +7,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
 <meta name="generator" content="Hugo 0.55.6" />
 
-<META NAME="ROBOTS" CONTENT="INDEX, FOLLOW">
+<meta name="robots" content="noindex, follow" />
 
 <link rel="alternate" type="application/rss&#43;xml" href="/v0.5/index.xml">
 

--- a/docs/static/v0.5/project/releases/v0.0.3/index.html
+++ b/docs/static/v0.5/project/releases/v0.0.3/index.html
@@ -7,7 +7,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
 <meta name="generator" content="Hugo 0.55.6" />
 
-<META NAME="ROBOTS" CONTENT="INDEX, FOLLOW">
+<meta name="robots" content="noindex, follow" />
 
 <link rel="alternate" type="application/rss&#43;xml" href="/index.xml">
 

--- a/docs/static/v0.5/project/releases/v0.0.4/index.html
+++ b/docs/static/v0.5/project/releases/v0.0.4/index.html
@@ -7,7 +7,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
 <meta name="generator" content="Hugo 0.55.6" />
 
-<META NAME="ROBOTS" CONTENT="INDEX, FOLLOW">
+<meta name="robots" content="noindex, follow" />
 
 <link rel="alternate" type="application/rss&#43;xml" href="/v0.5/index.xml">
 

--- a/docs/static/v0.5/project/releases/v0.0.5/index.html
+++ b/docs/static/v0.5/project/releases/v0.0.5/index.html
@@ -7,7 +7,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
 <meta name="generator" content="Hugo 0.55.6" />
 
-<META NAME="ROBOTS" CONTENT="INDEX, FOLLOW">
+<meta name="robots" content="noindex, follow" />
 
 <link rel="alternate" type="application/rss&#43;xml" href="/v0.5/index.xml">
 

--- a/docs/static/v0.5/project/releases/v0.0.6/index.html
+++ b/docs/static/v0.5/project/releases/v0.0.6/index.html
@@ -7,7 +7,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
 <meta name="generator" content="Hugo 0.55.6" />
 
-<META NAME="ROBOTS" CONTENT="INDEX, FOLLOW">
+<meta name="robots" content="noindex, follow" />
 
 <link rel="alternate" type="application/rss&#43;xml" href="/index.xml">
 

--- a/docs/static/v0.5/project/releases/v0.0.7/index.html
+++ b/docs/static/v0.5/project/releases/v0.0.7/index.html
@@ -7,7 +7,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
 <meta name="generator" content="Hugo 0.55.6" />
 
-<META NAME="ROBOTS" CONTENT="INDEX, FOLLOW">
+<meta name="robots" content="noindex, follow" />
 
 <link rel="alternate" type="application/rss&#43;xml" href="/index.xml">
 

--- a/docs/static/v0.5/project/releases/v0.0.8/index.html
+++ b/docs/static/v0.5/project/releases/v0.0.8/index.html
@@ -7,7 +7,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
 <meta name="generator" content="Hugo 0.55.6" />
 
-<META NAME="ROBOTS" CONTENT="INDEX, FOLLOW">
+<meta name="robots" content="noindex, follow" />
 
 <link rel="alternate" type="application/rss&#43;xml" href="/v0.5/index.xml">
 

--- a/docs/static/v0.5/project/releases/v0.0.9/index.html
+++ b/docs/static/v0.5/project/releases/v0.0.9/index.html
@@ -7,7 +7,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
 <meta name="generator" content="Hugo 0.55.6" />
 
-<META NAME="ROBOTS" CONTENT="INDEX, FOLLOW">
+<meta name="robots" content="noindex, follow" />
 
 <link rel="alternate" type="application/rss&#43;xml" href="/v0.5/index.xml">
 

--- a/docs/static/v0.5/project/releases/v0.1.0/index.html
+++ b/docs/static/v0.5/project/releases/v0.1.0/index.html
@@ -7,7 +7,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
 <meta name="generator" content="Hugo 0.55.6" />
 
-<META NAME="ROBOTS" CONTENT="INDEX, FOLLOW">
+<meta name="robots" content="noindex, follow" />
 
 <link rel="alternate" type="application/rss&#43;xml" href="/v0.5/index.xml">
 

--- a/docs/static/v0.5/project/releases/v0.1.1/index.html
+++ b/docs/static/v0.5/project/releases/v0.1.1/index.html
@@ -7,7 +7,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
 <meta name="generator" content="Hugo 0.55.6" />
 
-<META NAME="ROBOTS" CONTENT="INDEX, FOLLOW">
+<meta name="robots" content="noindex, follow" />
 
 <link rel="alternate" type="application/rss&#43;xml" href="/v0.5/index.xml">
 

--- a/docs/static/v0.5/project/releases/v0.1.2/index.html
+++ b/docs/static/v0.5/project/releases/v0.1.2/index.html
@@ -7,7 +7,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
 <meta name="generator" content="Hugo 0.55.6" />
 
-<META NAME="ROBOTS" CONTENT="INDEX, FOLLOW">
+<meta name="robots" content="noindex, follow" />
 
 <link rel="alternate" type="application/rss&#43;xml" href="/index.xml">
 

--- a/docs/static/v0.5/project/releases/v0.1.3/index.html
+++ b/docs/static/v0.5/project/releases/v0.1.3/index.html
@@ -7,7 +7,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
 <meta name="generator" content="Hugo 0.55.6" />
 
-<META NAME="ROBOTS" CONTENT="INDEX, FOLLOW">
+<meta name="robots" content="noindex, follow" />
 
 <link rel="alternate" type="application/rss&#43;xml" href="/index.xml">
 

--- a/docs/static/v0.5/project/releases/v0.1.4/index.html
+++ b/docs/static/v0.5/project/releases/v0.1.4/index.html
@@ -7,7 +7,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
 <meta name="generator" content="Hugo 0.55.6" />
 
-<META NAME="ROBOTS" CONTENT="INDEX, FOLLOW">
+<meta name="robots" content="noindex, follow" />
 
 <link rel="alternate" type="application/rss&#43;xml" href="/index.xml">
 

--- a/docs/static/v0.5/project/releases/v0.1.5/index.html
+++ b/docs/static/v0.5/project/releases/v0.1.5/index.html
@@ -7,7 +7,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
 <meta name="generator" content="Hugo 0.55.6" />
 
-<META NAME="ROBOTS" CONTENT="INDEX, FOLLOW">
+<meta name="robots" content="noindex, follow" />
 
 <link rel="alternate" type="application/rss&#43;xml" href="/index.xml">
 

--- a/docs/static/v0.5/project/releases/v0.1.6/index.html
+++ b/docs/static/v0.5/project/releases/v0.1.6/index.html
@@ -7,7 +7,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
 <meta name="generator" content="Hugo 0.55.6" />
 
-<META NAME="ROBOTS" CONTENT="INDEX, FOLLOW">
+<meta name="robots" content="noindex, follow" />
 
 <link rel="alternate" type="application/rss&#43;xml" href="/v0.5/index.xml">
 

--- a/docs/static/v0.5/project/releases/v0.2.0/index.html
+++ b/docs/static/v0.5/project/releases/v0.2.0/index.html
@@ -7,7 +7,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
 <meta name="generator" content="Hugo 0.55.6" />
 
-<META NAME="ROBOTS" CONTENT="INDEX, FOLLOW">
+<meta name="robots" content="noindex, follow" />
 
 <link rel="alternate" type="application/rss&#43;xml" href="/index.xml">
 

--- a/docs/static/v0.5/project/releases/v0.2.1/index.html
+++ b/docs/static/v0.5/project/releases/v0.2.1/index.html
@@ -7,7 +7,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
 <meta name="generator" content="Hugo 0.55.6" />
 
-<META NAME="ROBOTS" CONTENT="INDEX, FOLLOW">
+<meta name="robots" content="noindex, follow" />
 
 <link rel="alternate" type="application/rss&#43;xml" href="/index.xml">
 

--- a/docs/static/v0.5/project/releases/v0.2.2/index.html
+++ b/docs/static/v0.5/project/releases/v0.2.2/index.html
@@ -7,7 +7,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
 <meta name="generator" content="Hugo 0.55.6" />
 
-<META NAME="ROBOTS" CONTENT="INDEX, FOLLOW">
+<meta name="robots" content="noindex, follow" />
 
 <link rel="alternate" type="application/rss&#43;xml" href="/index.xml">
 

--- a/docs/static/v0.5/project/releases/v0.2.3/index.html
+++ b/docs/static/v0.5/project/releases/v0.2.3/index.html
@@ -7,7 +7,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
 <meta name="generator" content="Hugo 0.55.6" />
 
-<META NAME="ROBOTS" CONTENT="INDEX, FOLLOW">
+<meta name="robots" content="noindex, follow" />
 
 <link rel="alternate" type="application/rss&#43;xml" href="/v0.5/index.xml">
 

--- a/docs/static/v0.5/project/releases/v0.2.4/index.html
+++ b/docs/static/v0.5/project/releases/v0.2.4/index.html
@@ -7,7 +7,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
 <meta name="generator" content="Hugo 0.55.6" />
 
-<META NAME="ROBOTS" CONTENT="INDEX, FOLLOW">
+<meta name="robots" content="noindex, follow" />
 
 <link rel="alternate" type="application/rss&#43;xml" href="/v0.5/index.xml">
 

--- a/docs/static/v0.5/project/releases/v0.3.1/index.html
+++ b/docs/static/v0.5/project/releases/v0.3.1/index.html
@@ -7,7 +7,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
 <meta name="generator" content="Hugo 0.55.6" />
 
-<META NAME="ROBOTS" CONTENT="INDEX, FOLLOW">
+<meta name="robots" content="noindex, follow" />
 
 <link rel="alternate" type="application/rss&#43;xml" href="/v0.5/index.xml">
 

--- a/docs/static/v0.5/project/releases/v0.3.10/index.html
+++ b/docs/static/v0.5/project/releases/v0.3.10/index.html
@@ -7,7 +7,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
 <meta name="generator" content="Hugo 0.55.6" />
 
-<META NAME="ROBOTS" CONTENT="INDEX, FOLLOW">
+<meta name="robots" content="noindex, follow" />
 
 <link rel="alternate" type="application/rss&#43;xml" href="/index.xml">
 

--- a/docs/static/v0.5/project/releases/v0.3.11/index.html
+++ b/docs/static/v0.5/project/releases/v0.3.11/index.html
@@ -7,7 +7,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
 <meta name="generator" content="Hugo 0.55.6" />
 
-<META NAME="ROBOTS" CONTENT="INDEX, FOLLOW">
+<meta name="robots" content="noindex, follow" />
 
 <link rel="alternate" type="application/rss&#43;xml" href="/index.xml">
 

--- a/docs/static/v0.5/project/releases/v0.3.12/index.html
+++ b/docs/static/v0.5/project/releases/v0.3.12/index.html
@@ -7,7 +7,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
 <meta name="generator" content="Hugo 0.55.6" />
 
-<META NAME="ROBOTS" CONTENT="INDEX, FOLLOW">
+<meta name="robots" content="noindex, follow" />
 
 <link rel="alternate" type="application/rss&#43;xml" href="/v0.5/index.xml">
 

--- a/docs/static/v0.5/project/releases/v0.3.13/index.html
+++ b/docs/static/v0.5/project/releases/v0.3.13/index.html
@@ -7,7 +7,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
 <meta name="generator" content="Hugo 0.55.6" />
 
-<META NAME="ROBOTS" CONTENT="INDEX, FOLLOW">
+<meta name="robots" content="noindex, follow" />
 
 <link rel="alternate" type="application/rss&#43;xml" href="/index.xml">
 

--- a/docs/static/v0.5/project/releases/v0.3.14/index.html
+++ b/docs/static/v0.5/project/releases/v0.3.14/index.html
@@ -7,7 +7,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
 <meta name="generator" content="Hugo 0.55.6" />
 
-<META NAME="ROBOTS" CONTENT="INDEX, FOLLOW">
+<meta name="robots" content="noindex, follow" />
 
 <link rel="alternate" type="application/rss&#43;xml" href="/v0.5/index.xml">
 

--- a/docs/static/v0.5/project/releases/v0.3.15/index.html
+++ b/docs/static/v0.5/project/releases/v0.3.15/index.html
@@ -7,7 +7,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
 <meta name="generator" content="Hugo 0.55.6" />
 
-<META NAME="ROBOTS" CONTENT="INDEX, FOLLOW">
+<meta name="robots" content="noindex, follow" />
 
 <link rel="alternate" type="application/rss&#43;xml" href="/v0.5/index.xml">
 

--- a/docs/static/v0.5/project/releases/v0.3.16/index.html
+++ b/docs/static/v0.5/project/releases/v0.3.16/index.html
@@ -7,7 +7,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
 <meta name="generator" content="Hugo 0.55.6" />
 
-<META NAME="ROBOTS" CONTENT="INDEX, FOLLOW">
+<meta name="robots" content="noindex, follow" />
 
 <link rel="alternate" type="application/rss&#43;xml" href="/index.xml">
 

--- a/docs/static/v0.5/project/releases/v0.3.17/index.html
+++ b/docs/static/v0.5/project/releases/v0.3.17/index.html
@@ -7,7 +7,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
 <meta name="generator" content="Hugo 0.55.6" />
 
-<META NAME="ROBOTS" CONTENT="INDEX, FOLLOW">
+<meta name="robots" content="noindex, follow" />
 
 <link rel="alternate" type="application/rss&#43;xml" href="/index.xml">
 

--- a/docs/static/v0.5/project/releases/v0.3.18/index.html
+++ b/docs/static/v0.5/project/releases/v0.3.18/index.html
@@ -7,7 +7,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
 <meta name="generator" content="Hugo 0.55.6" />
 
-<META NAME="ROBOTS" CONTENT="INDEX, FOLLOW">
+<meta name="robots" content="noindex, follow" />
 
 <link rel="alternate" type="application/rss&#43;xml" href="/v0.5/index.xml">
 

--- a/docs/static/v0.5/project/releases/v0.3.19/index.html
+++ b/docs/static/v0.5/project/releases/v0.3.19/index.html
@@ -7,7 +7,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
 <meta name="generator" content="Hugo 0.55.6" />
 
-<META NAME="ROBOTS" CONTENT="INDEX, FOLLOW">
+<meta name="robots" content="noindex, follow" />
 
 <link rel="alternate" type="application/rss&#43;xml" href="/v0.5/index.xml">
 

--- a/docs/static/v0.5/project/releases/v0.3.2/index.html
+++ b/docs/static/v0.5/project/releases/v0.3.2/index.html
@@ -7,7 +7,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
 <meta name="generator" content="Hugo 0.55.6" />
 
-<META NAME="ROBOTS" CONTENT="INDEX, FOLLOW">
+<meta name="robots" content="noindex, follow" />
 
 <link rel="alternate" type="application/rss&#43;xml" href="/index.xml">
 

--- a/docs/static/v0.5/project/releases/v0.3.3/index.html
+++ b/docs/static/v0.5/project/releases/v0.3.3/index.html
@@ -7,7 +7,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
 <meta name="generator" content="Hugo 0.55.6" />
 
-<META NAME="ROBOTS" CONTENT="INDEX, FOLLOW">
+<meta name="robots" content="noindex, follow" />
 
 <link rel="alternate" type="application/rss&#43;xml" href="/index.xml">
 

--- a/docs/static/v0.5/project/releases/v0.3.4/index.html
+++ b/docs/static/v0.5/project/releases/v0.3.4/index.html
@@ -7,7 +7,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
 <meta name="generator" content="Hugo 0.55.6" />
 
-<META NAME="ROBOTS" CONTENT="INDEX, FOLLOW">
+<meta name="robots" content="noindex, follow" />
 
 <link rel="alternate" type="application/rss&#43;xml" href="/index.xml">
 

--- a/docs/static/v0.5/project/releases/v0.3.5/index.html
+++ b/docs/static/v0.5/project/releases/v0.3.5/index.html
@@ -7,7 +7,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
 <meta name="generator" content="Hugo 0.55.6" />
 
-<META NAME="ROBOTS" CONTENT="INDEX, FOLLOW">
+<meta name="robots" content="noindex, follow" />
 
 <link rel="alternate" type="application/rss&#43;xml" href="/index.xml">
 

--- a/docs/static/v0.5/project/releases/v0.3.6/index.html
+++ b/docs/static/v0.5/project/releases/v0.3.6/index.html
@@ -7,7 +7,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
 <meta name="generator" content="Hugo 0.55.6" />
 
-<META NAME="ROBOTS" CONTENT="INDEX, FOLLOW">
+<meta name="robots" content="noindex, follow" />
 
 <link rel="alternate" type="application/rss&#43;xml" href="/index.xml">
 

--- a/docs/static/v0.5/project/releases/v0.3.7/index.html
+++ b/docs/static/v0.5/project/releases/v0.3.7/index.html
@@ -7,7 +7,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
 <meta name="generator" content="Hugo 0.55.6" />
 
-<META NAME="ROBOTS" CONTENT="INDEX, FOLLOW">
+<meta name="robots" content="noindex, follow" />
 
 <link rel="alternate" type="application/rss&#43;xml" href="/v0.5/index.xml">
 

--- a/docs/static/v0.5/project/releases/v0.3.8/index.html
+++ b/docs/static/v0.5/project/releases/v0.3.8/index.html
@@ -7,7 +7,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
 <meta name="generator" content="Hugo 0.55.6" />
 
-<META NAME="ROBOTS" CONTENT="INDEX, FOLLOW">
+<meta name="robots" content="noindex, follow" />
 
 <link rel="alternate" type="application/rss&#43;xml" href="/index.xml">
 

--- a/docs/static/v0.5/project/releases/v0.3.9/index.html
+++ b/docs/static/v0.5/project/releases/v0.3.9/index.html
@@ -7,7 +7,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
 <meta name="generator" content="Hugo 0.55.6" />
 
-<META NAME="ROBOTS" CONTENT="INDEX, FOLLOW">
+<meta name="robots" content="noindex, follow" />
 
 <link rel="alternate" type="application/rss&#43;xml" href="/index.xml">
 

--- a/docs/static/v0.5/project/releases/v0.4.0-beta.1/index.html
+++ b/docs/static/v0.5/project/releases/v0.4.0-beta.1/index.html
@@ -7,7 +7,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
 <meta name="generator" content="Hugo 0.55.6" />
 
-<META NAME="ROBOTS" CONTENT="INDEX, FOLLOW">
+<meta name="robots" content="noindex, follow" />
 
 <link rel="alternate" type="application/rss&#43;xml" href="/index.xml">
 

--- a/docs/static/v0.5/project/releases/v0.4.0-beta.2/index.html
+++ b/docs/static/v0.5/project/releases/v0.4.0-beta.2/index.html
@@ -7,7 +7,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
 <meta name="generator" content="Hugo 0.55.6" />
 
-<META NAME="ROBOTS" CONTENT="INDEX, FOLLOW">
+<meta name="robots" content="noindex, follow" />
 
 <link rel="alternate" type="application/rss&#43;xml" href="/index.xml">
 

--- a/docs/static/v0.5/project/releases/v0.4.0-beta.3/index.html
+++ b/docs/static/v0.5/project/releases/v0.4.0-beta.3/index.html
@@ -7,7 +7,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
 <meta name="generator" content="Hugo 0.55.6" />
 
-<META NAME="ROBOTS" CONTENT="INDEX, FOLLOW">
+<meta name="robots" content="noindex, follow" />
 
 <link rel="alternate" type="application/rss&#43;xml" href="/v0.5/index.xml">
 

--- a/docs/static/v0.5/project/releases/v0.4.0-beta.4/index.html
+++ b/docs/static/v0.5/project/releases/v0.4.0-beta.4/index.html
@@ -7,7 +7,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
 <meta name="generator" content="Hugo 0.55.6" />
 
-<META NAME="ROBOTS" CONTENT="INDEX, FOLLOW">
+<meta name="robots" content="noindex, follow" />
 
 <link rel="alternate" type="application/rss&#43;xml" href="/v0.5/index.xml">
 

--- a/docs/static/v0.5/project/releases/v0.4.1/index.html
+++ b/docs/static/v0.5/project/releases/v0.4.1/index.html
@@ -7,7 +7,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
 <meta name="generator" content="Hugo 0.55.6" />
 
-<META NAME="ROBOTS" CONTENT="INDEX, FOLLOW">
+<meta name="robots" content="noindex, follow" />
 
 <link rel="alternate" type="application/rss&#43;xml" href="/index.xml">
 

--- a/docs/static/v0.5/project/releases/v0.4.10/index.html
+++ b/docs/static/v0.5/project/releases/v0.4.10/index.html
@@ -7,7 +7,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
 <meta name="generator" content="Hugo 0.55.6" />
 
-<META NAME="ROBOTS" CONTENT="INDEX, FOLLOW">
+<meta name="robots" content="noindex, follow" />
 
 <link rel="alternate" type="application/rss&#43;xml" href="/v0.5/index.xml">
 

--- a/docs/static/v0.5/project/releases/v0.4.11/index.html
+++ b/docs/static/v0.5/project/releases/v0.4.11/index.html
@@ -7,7 +7,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
 <meta name="generator" content="Hugo 0.55.6" />
 
-<META NAME="ROBOTS" CONTENT="INDEX, FOLLOW">
+<meta name="robots" content="noindex, follow" />
 
 <link rel="alternate" type="application/rss&#43;xml" href="/v0.5/index.xml">
 

--- a/docs/static/v0.5/project/releases/v0.4.12/index.html
+++ b/docs/static/v0.5/project/releases/v0.4.12/index.html
@@ -7,7 +7,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
 <meta name="generator" content="Hugo 0.55.6" />
 
-<META NAME="ROBOTS" CONTENT="INDEX, FOLLOW">
+<meta name="robots" content="noindex, follow" />
 
 <link rel="alternate" type="application/rss&#43;xml" href="/index.xml">
 

--- a/docs/static/v0.5/project/releases/v0.4.13/index.html
+++ b/docs/static/v0.5/project/releases/v0.4.13/index.html
@@ -7,7 +7,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
 <meta name="generator" content="Hugo 0.55.6" />
 
-<META NAME="ROBOTS" CONTENT="INDEX, FOLLOW">
+<meta name="robots" content="noindex, follow" />
 
 <link rel="alternate" type="application/rss&#43;xml" href="/index.xml">
 

--- a/docs/static/v0.5/project/releases/v0.4.14/index.html
+++ b/docs/static/v0.5/project/releases/v0.4.14/index.html
@@ -7,7 +7,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
 <meta name="generator" content="Hugo 0.55.6" />
 
-<META NAME="ROBOTS" CONTENT="INDEX, FOLLOW">
+<meta name="robots" content="noindex, follow" />
 
 <link rel="alternate" type="application/rss&#43;xml" href="/index.xml">
 

--- a/docs/static/v0.5/project/releases/v0.4.15/index.html
+++ b/docs/static/v0.5/project/releases/v0.4.15/index.html
@@ -7,7 +7,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
 <meta name="generator" content="Hugo 0.55.6" />
 
-<META NAME="ROBOTS" CONTENT="INDEX, FOLLOW">
+<meta name="robots" content="noindex, follow" />
 
 <link rel="alternate" type="application/rss&#43;xml" href="/index.xml">
 

--- a/docs/static/v0.5/project/releases/v0.4.16/index.html
+++ b/docs/static/v0.5/project/releases/v0.4.16/index.html
@@ -7,7 +7,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
 <meta name="generator" content="Hugo 0.55.6" />
 
-<META NAME="ROBOTS" CONTENT="INDEX, FOLLOW">
+<meta name="robots" content="noindex, follow" />
 
 <link rel="alternate" type="application/rss&#43;xml" href="/v0.5/index.xml">
 

--- a/docs/static/v0.5/project/releases/v0.4.17/index.html
+++ b/docs/static/v0.5/project/releases/v0.4.17/index.html
@@ -7,7 +7,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
 <meta name="generator" content="Hugo 0.55.6" />
 
-<META NAME="ROBOTS" CONTENT="INDEX, FOLLOW">
+<meta name="robots" content="noindex, follow" />
 
 <link rel="alternate" type="application/rss&#43;xml" href="/index.xml">
 

--- a/docs/static/v0.5/project/releases/v0.4.18/index.html
+++ b/docs/static/v0.5/project/releases/v0.4.18/index.html
@@ -7,7 +7,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
 <meta name="generator" content="Hugo 0.55.6" />
 
-<META NAME="ROBOTS" CONTENT="INDEX, FOLLOW">
+<meta name="robots" content="noindex, follow" />
 
 <link rel="alternate" type="application/rss&#43;xml" href="/index.xml">
 

--- a/docs/static/v0.5/project/releases/v0.4.19/index.html
+++ b/docs/static/v0.5/project/releases/v0.4.19/index.html
@@ -7,7 +7,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
 <meta name="generator" content="Hugo 0.55.6" />
 
-<META NAME="ROBOTS" CONTENT="INDEX, FOLLOW">
+<meta name="robots" content="noindex, follow" />
 
 <link rel="alternate" type="application/rss&#43;xml" href="/index.xml">
 

--- a/docs/static/v0.5/project/releases/v0.4.2/index.html
+++ b/docs/static/v0.5/project/releases/v0.4.2/index.html
@@ -7,7 +7,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
 <meta name="generator" content="Hugo 0.55.6" />
 
-<META NAME="ROBOTS" CONTENT="INDEX, FOLLOW">
+<meta name="robots" content="noindex, follow" />
 
 <link rel="alternate" type="application/rss&#43;xml" href="/v0.5/index.xml">
 

--- a/docs/static/v0.5/project/releases/v0.4.20/index.html
+++ b/docs/static/v0.5/project/releases/v0.4.20/index.html
@@ -7,7 +7,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
 <meta name="generator" content="Hugo 0.55.6" />
 
-<META NAME="ROBOTS" CONTENT="INDEX, FOLLOW">
+<meta name="robots" content="noindex, follow" />
 
 <link rel="alternate" type="application/rss&#43;xml" href="/index.xml">
 

--- a/docs/static/v0.5/project/releases/v0.4.21/index.html
+++ b/docs/static/v0.5/project/releases/v0.4.21/index.html
@@ -7,7 +7,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
 <meta name="generator" content="Hugo 0.55.6" />
 
-<META NAME="ROBOTS" CONTENT="INDEX, FOLLOW">
+<meta name="robots" content="noindex, follow" />
 
 <link rel="alternate" type="application/rss&#43;xml" href="/index.xml">
 

--- a/docs/static/v0.5/project/releases/v0.4.22/index.html
+++ b/docs/static/v0.5/project/releases/v0.4.22/index.html
@@ -7,7 +7,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
 <meta name="generator" content="Hugo 0.55.6" />
 
-<META NAME="ROBOTS" CONTENT="INDEX, FOLLOW">
+<meta name="robots" content="noindex, follow" />
 
 <link rel="alternate" type="application/rss&#43;xml" href="/index.xml">
 

--- a/docs/static/v0.5/project/releases/v0.4.23/index.html
+++ b/docs/static/v0.5/project/releases/v0.4.23/index.html
@@ -7,7 +7,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
 <meta name="generator" content="Hugo 0.55.6" />
 
-<META NAME="ROBOTS" CONTENT="INDEX, FOLLOW">
+<meta name="robots" content="noindex, follow" />
 
 <link rel="alternate" type="application/rss&#43;xml" href="/index.xml">
 

--- a/docs/static/v0.5/project/releases/v0.4.24/index.html
+++ b/docs/static/v0.5/project/releases/v0.4.24/index.html
@@ -7,7 +7,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
 <meta name="generator" content="Hugo 0.55.6" />
 
-<META NAME="ROBOTS" CONTENT="INDEX, FOLLOW">
+<meta name="robots" content="noindex, follow" />
 
 <link rel="alternate" type="application/rss&#43;xml" href="/index.xml">
 

--- a/docs/static/v0.5/project/releases/v0.4.25/index.html
+++ b/docs/static/v0.5/project/releases/v0.4.25/index.html
@@ -7,7 +7,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
 <meta name="generator" content="Hugo 0.55.6" />
 
-<META NAME="ROBOTS" CONTENT="INDEX, FOLLOW">
+<meta name="robots" content="noindex, follow" />
 
 <link rel="alternate" type="application/rss&#43;xml" href="/index.xml">
 

--- a/docs/static/v0.5/project/releases/v0.4.26/index.html
+++ b/docs/static/v0.5/project/releases/v0.4.26/index.html
@@ -7,7 +7,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
 <meta name="generator" content="Hugo 0.55.6" />
 
-<META NAME="ROBOTS" CONTENT="INDEX, FOLLOW">
+<meta name="robots" content="noindex, follow" />
 
 <link rel="alternate" type="application/rss&#43;xml" href="/v0.5/index.xml">
 

--- a/docs/static/v0.5/project/releases/v0.4.27/index.html
+++ b/docs/static/v0.5/project/releases/v0.4.27/index.html
@@ -7,7 +7,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
 <meta name="generator" content="Hugo 0.55.6" />
 
-<META NAME="ROBOTS" CONTENT="INDEX, FOLLOW">
+<meta name="robots" content="noindex, follow" />
 
 <link rel="alternate" type="application/rss&#43;xml" href="/v0.5/index.xml">
 

--- a/docs/static/v0.5/project/releases/v0.4.3/index.html
+++ b/docs/static/v0.5/project/releases/v0.4.3/index.html
@@ -7,7 +7,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
 <meta name="generator" content="Hugo 0.55.6" />
 
-<META NAME="ROBOTS" CONTENT="INDEX, FOLLOW">
+<meta name="robots" content="noindex, follow" />
 
 <link rel="alternate" type="application/rss&#43;xml" href="/v0.5/index.xml">
 

--- a/docs/static/v0.5/project/releases/v0.4.4/index.html
+++ b/docs/static/v0.5/project/releases/v0.4.4/index.html
@@ -7,7 +7,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
 <meta name="generator" content="Hugo 0.55.6" />
 
-<META NAME="ROBOTS" CONTENT="INDEX, FOLLOW">
+<meta name="robots" content="noindex, follow" />
 
 <link rel="alternate" type="application/rss&#43;xml" href="/index.xml">
 

--- a/docs/static/v0.5/project/releases/v0.4.5/index.html
+++ b/docs/static/v0.5/project/releases/v0.4.5/index.html
@@ -7,7 +7,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
 <meta name="generator" content="Hugo 0.55.6" />
 
-<META NAME="ROBOTS" CONTENT="INDEX, FOLLOW">
+<meta name="robots" content="noindex, follow" />
 
 <link rel="alternate" type="application/rss&#43;xml" href="/v0.5/index.xml">
 

--- a/docs/static/v0.5/project/releases/v0.4.6/index.html
+++ b/docs/static/v0.5/project/releases/v0.4.6/index.html
@@ -7,7 +7,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
 <meta name="generator" content="Hugo 0.55.6" />
 
-<META NAME="ROBOTS" CONTENT="INDEX, FOLLOW">
+<meta name="robots" content="noindex, follow" />
 
 <link rel="alternate" type="application/rss&#43;xml" href="/index.xml">
 

--- a/docs/static/v0.5/project/releases/v0.4.7/index.html
+++ b/docs/static/v0.5/project/releases/v0.4.7/index.html
@@ -7,7 +7,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
 <meta name="generator" content="Hugo 0.55.6" />
 
-<META NAME="ROBOTS" CONTENT="INDEX, FOLLOW">
+<meta name="robots" content="noindex, follow" />
 
 <link rel="alternate" type="application/rss&#43;xml" href="/index.xml">
 

--- a/docs/static/v0.5/project/releases/v0.4.8/index.html
+++ b/docs/static/v0.5/project/releases/v0.4.8/index.html
@@ -7,7 +7,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
 <meta name="generator" content="Hugo 0.55.6" />
 
-<META NAME="ROBOTS" CONTENT="INDEX, FOLLOW">
+<meta name="robots" content="noindex, follow" />
 
 <link rel="alternate" type="application/rss&#43;xml" href="/index.xml">
 

--- a/docs/static/v0.5/project/releases/v0.4.9/index.html
+++ b/docs/static/v0.5/project/releases/v0.4.9/index.html
@@ -7,7 +7,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
 <meta name="generator" content="Hugo 0.55.6" />
 
-<META NAME="ROBOTS" CONTENT="INDEX, FOLLOW">
+<meta name="robots" content="noindex, follow" />
 
 <link rel="alternate" type="application/rss&#43;xml" href="/index.xml">
 

--- a/docs/static/v0.5/project/releases/v0.5.0-beta-1/index.html
+++ b/docs/static/v0.5/project/releases/v0.5.0-beta-1/index.html
@@ -7,7 +7,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
 <meta name="generator" content="Hugo 0.55.6" />
 
-<META NAME="ROBOTS" CONTENT="INDEX, FOLLOW">
+<meta name="robots" content="noindex, follow" />
 
 <link rel="alternate" type="application/rss&#43;xml" href="/v0.5/index.xml">
 

--- a/docs/static/v0.5/project/releases/v0.5.0-beta-2/index.html
+++ b/docs/static/v0.5/project/releases/v0.5.0-beta-2/index.html
@@ -7,7 +7,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
 <meta name="generator" content="Hugo 0.55.6" />
 
-<META NAME="ROBOTS" CONTENT="INDEX, FOLLOW">
+<meta name="robots" content="noindex, follow" />
 
 <link rel="alternate" type="application/rss&#43;xml" href="/index.xml">
 

--- a/docs/static/v0.5/project/releases/v0.5.0-beta-3/index.html
+++ b/docs/static/v0.5/project/releases/v0.5.0-beta-3/index.html
@@ -7,7 +7,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
 <meta name="generator" content="Hugo 0.55.6" />
 
-<META NAME="ROBOTS" CONTENT="INDEX, FOLLOW">
+<meta name="robots" content="noindex, follow" />
 
 <link rel="alternate" type="application/rss&#43;xml" href="/index.xml">
 

--- a/docs/static/v0.5/project/releases/v0.5.0-beta-4/index.html
+++ b/docs/static/v0.5/project/releases/v0.5.0-beta-4/index.html
@@ -7,7 +7,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
 <meta name="generator" content="Hugo 0.55.6" />
 
-<META NAME="ROBOTS" CONTENT="INDEX, FOLLOW">
+<meta name="robots" content="noindex, follow" />
 
 <link rel="alternate" type="application/rss&#43;xml" href="/index.xml">
 

--- a/docs/static/v0.5/project/releases/v0.5.0-rc-1/index.html
+++ b/docs/static/v0.5/project/releases/v0.5.0-rc-1/index.html
@@ -7,7 +7,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
 <meta name="generator" content="Hugo 0.55.6" />
 
-<META NAME="ROBOTS" CONTENT="INDEX, FOLLOW">
+<meta name="robots" content="noindex, follow" />
 
 <link rel="alternate" type="application/rss&#43;xml" href="/index.xml">
 

--- a/docs/static/v0.5/project/releases/v0.5.0-rc-2/index.html
+++ b/docs/static/v0.5/project/releases/v0.5.0-rc-2/index.html
@@ -7,7 +7,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
 <meta name="generator" content="Hugo 0.55.6" />
 
-<META NAME="ROBOTS" CONTENT="INDEX, FOLLOW">
+<meta name="robots" content="noindex, follow" />
 
 <link rel="alternate" type="application/rss&#43;xml" href="/index.xml">
 

--- a/docs/static/v0.5/project/releases/v0.5.0-rc-3/index.html
+++ b/docs/static/v0.5/project/releases/v0.5.0-rc-3/index.html
@@ -7,7 +7,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
 <meta name="generator" content="Hugo 0.55.6" />
 
-<META NAME="ROBOTS" CONTENT="INDEX, FOLLOW">
+<meta name="robots" content="noindex, follow" />
 
 <link rel="alternate" type="application/rss&#43;xml" href="/index.xml">
 

--- a/docs/static/v0.5/project/releases/v0.5.0-rc-4/index.html
+++ b/docs/static/v0.5/project/releases/v0.5.0-rc-4/index.html
@@ -7,7 +7,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
 <meta name="generator" content="Hugo 0.55.6" />
 
-<META NAME="ROBOTS" CONTENT="INDEX, FOLLOW">
+<meta name="robots" content="noindex, follow" />
 
 <link rel="alternate" type="application/rss&#43;xml" href="/v0.5/index.xml">
 

--- a/docs/static/v0.5/project/releases/v0.5.0-rc-5/index.html
+++ b/docs/static/v0.5/project/releases/v0.5.0-rc-5/index.html
@@ -7,7 +7,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
 <meta name="generator" content="Hugo 0.55.6" />
 
-<META NAME="ROBOTS" CONTENT="INDEX, FOLLOW">
+<meta name="robots" content="noindex, follow" />
 
 <link rel="alternate" type="application/rss&#43;xml" href="/v0.5/index.xml">
 

--- a/docs/static/v0.5/project/releases/v0.5.0-rc-5g/index.html
+++ b/docs/static/v0.5/project/releases/v0.5.0-rc-5g/index.html
@@ -7,7 +7,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
 <meta name="generator" content="Hugo 0.55.6" />
 
-<META NAME="ROBOTS" CONTENT="INDEX, FOLLOW">
+<meta name="robots" content="noindex, follow" />
 
 <link rel="alternate" type="application/rss&#43;xml" href="/index.xml">
 

--- a/docs/static/v0.5/project/releases/v0.5.0-rc-6/index.html
+++ b/docs/static/v0.5/project/releases/v0.5.0-rc-6/index.html
@@ -7,7 +7,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
 <meta name="generator" content="Hugo 0.55.6" />
 
-<META NAME="ROBOTS" CONTENT="INDEX, FOLLOW">
+<meta name="robots" content="noindex, follow" />
 
 <link rel="alternate" type="application/rss&#43;xml" href="/index.xml">
 

--- a/docs/static/v0.5/project/releases/v0.5.0/index.html
+++ b/docs/static/v0.5/project/releases/v0.5.0/index.html
@@ -7,7 +7,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
 <meta name="generator" content="Hugo 0.55.6" />
 
-<META NAME="ROBOTS" CONTENT="INDEX, FOLLOW">
+<meta name="robots" content="noindex, follow" />
 
 <link rel="alternate" type="application/rss&#43;xml" href="/index.xml">
 

--- a/docs/static/v0.5/project/releases/v0.5.1/index.html
+++ b/docs/static/v0.5/project/releases/v0.5.1/index.html
@@ -7,7 +7,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
 <meta name="generator" content="Hugo 0.55.6" />
 
-<META NAME="ROBOTS" CONTENT="INDEX, FOLLOW">
+<meta name="robots" content="noindex, follow" />
 
 <link rel="alternate" type="application/rss&#43;xml" href="/v0.5/index.xml">
 

--- a/docs/static/v0.5/project/releases/v0.5.10/index.html
+++ b/docs/static/v0.5/project/releases/v0.5.10/index.html
@@ -7,7 +7,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
 <meta name="generator" content="Hugo 0.55.6" />
 
-<META NAME="ROBOTS" CONTENT="INDEX, FOLLOW">
+<meta name="robots" content="noindex, follow" />
 
 <link rel="alternate" type="application/rss&#43;xml" href="/v0.5/index.xml">
 

--- a/docs/static/v0.5/project/releases/v0.5.11/index.html
+++ b/docs/static/v0.5/project/releases/v0.5.11/index.html
@@ -7,7 +7,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
 <meta name="generator" content="Hugo 0.55.6" />
 
-<META NAME="ROBOTS" CONTENT="INDEX, FOLLOW">
+<meta name="robots" content="noindex, follow" />
 
 <link rel="alternate" type="application/rss&#43;xml" href="/v0.5/index.xml">
 

--- a/docs/static/v0.5/project/releases/v0.5.12/index.html
+++ b/docs/static/v0.5/project/releases/v0.5.12/index.html
@@ -7,7 +7,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
 <meta name="generator" content="Hugo 0.55.6" />
 
-<META NAME="ROBOTS" CONTENT="INDEX, FOLLOW">
+<meta name="robots" content="noindex, follow" />
 
 <link rel="alternate" type="application/rss&#43;xml" href="/index.xml">
 

--- a/docs/static/v0.5/project/releases/v0.5.13/index.html
+++ b/docs/static/v0.5/project/releases/v0.5.13/index.html
@@ -7,7 +7,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
 <meta name="generator" content="Hugo 0.55.6" />
 
-<META NAME="ROBOTS" CONTENT="INDEX, FOLLOW">
+<meta name="robots" content="noindex, follow" />
 
 <link rel="alternate" type="application/rss&#43;xml" href="/index.xml">
 

--- a/docs/static/v0.5/project/releases/v0.5.14/index.html
+++ b/docs/static/v0.5/project/releases/v0.5.14/index.html
@@ -7,7 +7,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
 <meta name="generator" content="Hugo 0.55.6" />
 
-<META NAME="ROBOTS" CONTENT="INDEX, FOLLOW">
+<meta name="robots" content="noindex, follow" />
 
 <link rel="alternate" type="application/rss&#43;xml" href="/index.xml">
 

--- a/docs/static/v0.5/project/releases/v0.5.15/index.html
+++ b/docs/static/v0.5/project/releases/v0.5.15/index.html
@@ -7,7 +7,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
 <meta name="generator" content="Hugo 0.55.6" />
 
-<META NAME="ROBOTS" CONTENT="INDEX, FOLLOW">
+<meta name="robots" content="noindex, follow" />
 
 <link rel="alternate" type="application/rss&#43;xml" href="/index.xml">
 

--- a/docs/static/v0.5/project/releases/v0.5.16/index.html
+++ b/docs/static/v0.5/project/releases/v0.5.16/index.html
@@ -7,7 +7,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
 <meta name="generator" content="Hugo 0.55.6" />
 
-<META NAME="ROBOTS" CONTENT="INDEX, FOLLOW">
+<meta name="robots" content="noindex, follow" />
 
 <link rel="alternate" type="application/rss&#43;xml" href="/index.xml">
 

--- a/docs/static/v0.5/project/releases/v0.5.17/index.html
+++ b/docs/static/v0.5/project/releases/v0.5.17/index.html
@@ -7,7 +7,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
 <meta name="generator" content="Hugo 0.55.6" />
 
-<META NAME="ROBOTS" CONTENT="INDEX, FOLLOW">
+<meta name="robots" content="noindex, follow" />
 
 <link rel="alternate" type="application/rss&#43;xml" href="/v0.5/index.xml">
 

--- a/docs/static/v0.5/project/releases/v0.5.18/index.html
+++ b/docs/static/v0.5/project/releases/v0.5.18/index.html
@@ -7,7 +7,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
 <meta name="generator" content="Hugo 0.55.6" />
 
-<META NAME="ROBOTS" CONTENT="INDEX, FOLLOW">
+<meta name="robots" content="noindex, follow" />
 
 <link rel="alternate" type="application/rss&#43;xml" href="/index.xml">
 

--- a/docs/static/v0.5/project/releases/v0.5.19/index.html
+++ b/docs/static/v0.5/project/releases/v0.5.19/index.html
@@ -7,7 +7,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
 <meta name="generator" content="Hugo 0.55.6" />
 
-<META NAME="ROBOTS" CONTENT="INDEX, FOLLOW">
+<meta name="robots" content="noindex, follow" />
 
 <link rel="alternate" type="application/rss&#43;xml" href="/index.xml">
 

--- a/docs/static/v0.5/project/releases/v0.5.2/index.html
+++ b/docs/static/v0.5/project/releases/v0.5.2/index.html
@@ -7,7 +7,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
 <meta name="generator" content="Hugo 0.55.6" />
 
-<META NAME="ROBOTS" CONTENT="INDEX, FOLLOW">
+<meta name="robots" content="noindex, follow" />
 
 <link rel="alternate" type="application/rss&#43;xml" href="/index.xml">
 

--- a/docs/static/v0.5/project/releases/v0.5.20/index.html
+++ b/docs/static/v0.5/project/releases/v0.5.20/index.html
@@ -7,7 +7,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
 <meta name="generator" content="Hugo 0.55.6" />
 
-<META NAME="ROBOTS" CONTENT="INDEX, FOLLOW">
+<meta name="robots" content="noindex, follow" />
 
 <link rel="alternate" type="application/rss&#43;xml" href="/index.xml">
 

--- a/docs/static/v0.5/project/releases/v0.5.21/index.html
+++ b/docs/static/v0.5/project/releases/v0.5.21/index.html
@@ -7,7 +7,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
 <meta name="generator" content="Hugo 0.55.6" />
 
-<META NAME="ROBOTS" CONTENT="INDEX, FOLLOW">
+<meta name="robots" content="noindex, follow" />
 
 <link rel="alternate" type="application/rss&#43;xml" href="/v0.5/index.xml">
 

--- a/docs/static/v0.5/project/releases/v0.5.22/index.html
+++ b/docs/static/v0.5/project/releases/v0.5.22/index.html
@@ -7,7 +7,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
 <meta name="generator" content="Hugo 0.55.6" />
 
-<META NAME="ROBOTS" CONTENT="INDEX, FOLLOW">
+<meta name="robots" content="noindex, follow" />
 
 <link rel="alternate" type="application/rss&#43;xml" href="/index.xml">
 

--- a/docs/static/v0.5/project/releases/v0.5.23/index.html
+++ b/docs/static/v0.5/project/releases/v0.5.23/index.html
@@ -7,7 +7,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
 <meta name="generator" content="Hugo 0.55.6" />
 
-<META NAME="ROBOTS" CONTENT="INDEX, FOLLOW">
+<meta name="robots" content="noindex, follow" />
 
 <link rel="alternate" type="application/rss&#43;xml" href="/index.xml">
 

--- a/docs/static/v0.5/project/releases/v0.5.24/index.html
+++ b/docs/static/v0.5/project/releases/v0.5.24/index.html
@@ -7,7 +7,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
 <meta name="generator" content="Hugo 0.55.6" />
 
-<META NAME="ROBOTS" CONTENT="INDEX, FOLLOW">
+<meta name="robots" content="noindex, follow" />
 
 <link rel="alternate" type="application/rss&#43;xml" href="/index.xml">
 

--- a/docs/static/v0.5/project/releases/v0.5.25/index.html
+++ b/docs/static/v0.5/project/releases/v0.5.25/index.html
@@ -7,7 +7,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
 <meta name="generator" content="Hugo 0.55.6" />
 
-<META NAME="ROBOTS" CONTENT="INDEX, FOLLOW">
+<meta name="robots" content="noindex, follow" />
 
 <link rel="alternate" type="application/rss&#43;xml" href="/index.xml">
 

--- a/docs/static/v0.5/project/releases/v0.5.26/index.html
+++ b/docs/static/v0.5/project/releases/v0.5.26/index.html
@@ -7,7 +7,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
 <meta name="generator" content="Hugo 0.55.6" />
 
-<META NAME="ROBOTS" CONTENT="INDEX, FOLLOW">
+<meta name="robots" content="noindex, follow" />
 
 <link rel="alternate" type="application/rss&#43;xml" href="/v0.5/index.xml">
 

--- a/docs/static/v0.5/project/releases/v0.5.27/index.html
+++ b/docs/static/v0.5/project/releases/v0.5.27/index.html
@@ -7,7 +7,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
 <meta name="generator" content="Hugo 0.55.6" />
 
-<META NAME="ROBOTS" CONTENT="INDEX, FOLLOW">
+<meta name="robots" content="noindex, follow" />
 
 <link rel="alternate" type="application/rss&#43;xml" href="/v0.5/index.xml">
 

--- a/docs/static/v0.5/project/releases/v0.5.28/index.html
+++ b/docs/static/v0.5/project/releases/v0.5.28/index.html
@@ -7,7 +7,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
 <meta name="generator" content="Hugo 0.55.6" />
 
-<META NAME="ROBOTS" CONTENT="INDEX, FOLLOW">
+<meta name="robots" content="noindex, follow" />
 
 <link rel="alternate" type="application/rss&#43;xml" href="/index.xml">
 

--- a/docs/static/v0.5/project/releases/v0.5.29/index.html
+++ b/docs/static/v0.5/project/releases/v0.5.29/index.html
@@ -7,7 +7,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
 <meta name="generator" content="Hugo 0.55.6" />
 
-<META NAME="ROBOTS" CONTENT="INDEX, FOLLOW">
+<meta name="robots" content="noindex, follow" />
 
 <link rel="alternate" type="application/rss&#43;xml" href="/index.xml">
 

--- a/docs/static/v0.5/project/releases/v0.5.3/index.html
+++ b/docs/static/v0.5/project/releases/v0.5.3/index.html
@@ -7,7 +7,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
 <meta name="generator" content="Hugo 0.55.6" />
 
-<META NAME="ROBOTS" CONTENT="INDEX, FOLLOW">
+<meta name="robots" content="noindex, follow" />
 
 <link rel="alternate" type="application/rss&#43;xml" href="/index.xml">
 

--- a/docs/static/v0.5/project/releases/v0.5.30/index.html
+++ b/docs/static/v0.5/project/releases/v0.5.30/index.html
@@ -7,7 +7,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
 <meta name="generator" content="Hugo 0.55.6" />
 
-<META NAME="ROBOTS" CONTENT="INDEX, FOLLOW">
+<meta name="robots" content="noindex, follow" />
 
 <link rel="alternate" type="application/rss&#43;xml" href="/v0.5/index.xml">
 

--- a/docs/static/v0.5/project/releases/v0.5.31/index.html
+++ b/docs/static/v0.5/project/releases/v0.5.31/index.html
@@ -7,7 +7,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
 <meta name="generator" content="Hugo 0.55.6" />
 
-<META NAME="ROBOTS" CONTENT="INDEX, FOLLOW">
+<meta name="robots" content="noindex, follow" />
 
 <link rel="alternate" type="application/rss&#43;xml" href="/v0.5/index.xml">
 

--- a/docs/static/v0.5/project/releases/v0.5.32/index.html
+++ b/docs/static/v0.5/project/releases/v0.5.32/index.html
@@ -7,7 +7,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
 <meta name="generator" content="Hugo 0.55.6" />
 
-<META NAME="ROBOTS" CONTENT="INDEX, FOLLOW">
+<meta name="robots" content="noindex, follow" />
 
 <link rel="alternate" type="application/rss&#43;xml" href="/index.xml">
 

--- a/docs/static/v0.5/project/releases/v0.5.33/index.html
+++ b/docs/static/v0.5/project/releases/v0.5.33/index.html
@@ -7,7 +7,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
 <meta name="generator" content="Hugo 0.55.6" />
 
-<META NAME="ROBOTS" CONTENT="INDEX, FOLLOW">
+<meta name="robots" content="noindex, follow" />
 
 <link rel="alternate" type="application/rss&#43;xml" href="/index.xml">
 

--- a/docs/static/v0.5/project/releases/v0.5.34/index.html
+++ b/docs/static/v0.5/project/releases/v0.5.34/index.html
@@ -7,7 +7,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
 <meta name="generator" content="Hugo 0.55.6" />
 
-<META NAME="ROBOTS" CONTENT="INDEX, FOLLOW">
+<meta name="robots" content="noindex, follow" />
 
 <link rel="alternate" type="application/rss&#43;xml" href="/index.xml">
 

--- a/docs/static/v0.5/project/releases/v0.5.35/index.html
+++ b/docs/static/v0.5/project/releases/v0.5.35/index.html
@@ -7,7 +7,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
 <meta name="generator" content="Hugo 0.55.6" />
 
-<META NAME="ROBOTS" CONTENT="INDEX, FOLLOW">
+<meta name="robots" content="noindex, follow" />
 
 <link rel="alternate" type="application/rss&#43;xml" href="/index.xml">
 

--- a/docs/static/v0.5/project/releases/v0.5.36/index.html
+++ b/docs/static/v0.5/project/releases/v0.5.36/index.html
@@ -7,7 +7,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
 <meta name="generator" content="Hugo 0.55.6" />
 
-<META NAME="ROBOTS" CONTENT="INDEX, FOLLOW">
+<meta name="robots" content="noindex, follow" />
 
 <link rel="alternate" type="application/rss&#43;xml" href="/index.xml">
 

--- a/docs/static/v0.5/project/releases/v0.5.37/index.html
+++ b/docs/static/v0.5/project/releases/v0.5.37/index.html
@@ -7,7 +7,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
 <meta name="generator" content="Hugo 0.55.6" />
 
-<META NAME="ROBOTS" CONTENT="INDEX, FOLLOW">
+<meta name="robots" content="noindex, follow" />
 
 <link rel="alternate" type="application/rss&#43;xml" href="/v0.5/index.xml">
 

--- a/docs/static/v0.5/project/releases/v0.5.38/index.html
+++ b/docs/static/v0.5/project/releases/v0.5.38/index.html
@@ -7,7 +7,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
 <meta name="generator" content="Hugo 0.55.6" />
 
-<META NAME="ROBOTS" CONTENT="INDEX, FOLLOW">
+<meta name="robots" content="noindex, follow" />
 
 <link rel="alternate" type="application/rss&#43;xml" href="/index.xml">
 

--- a/docs/static/v0.5/project/releases/v0.5.39/index.html
+++ b/docs/static/v0.5/project/releases/v0.5.39/index.html
@@ -7,7 +7,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
 <meta name="generator" content="Hugo 0.55.6" />
 
-<META NAME="ROBOTS" CONTENT="INDEX, FOLLOW">
+<meta name="robots" content="noindex, follow" />
 
 <link rel="alternate" type="application/rss&#43;xml" href="/index.xml">
 

--- a/docs/static/v0.5/project/releases/v0.5.4/index.html
+++ b/docs/static/v0.5/project/releases/v0.5.4/index.html
@@ -7,7 +7,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
 <meta name="generator" content="Hugo 0.55.6" />
 
-<META NAME="ROBOTS" CONTENT="INDEX, FOLLOW">
+<meta name="robots" content="noindex, follow" />
 
 <link rel="alternate" type="application/rss&#43;xml" href="/index.xml">
 

--- a/docs/static/v0.5/project/releases/v0.5.40/index.html
+++ b/docs/static/v0.5/project/releases/v0.5.40/index.html
@@ -7,7 +7,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
 <meta name="generator" content="Hugo 0.55.6" />
 
-<META NAME="ROBOTS" CONTENT="INDEX, FOLLOW">
+<meta name="robots" content="noindex, follow" />
 
 <link rel="alternate" type="application/rss&#43;xml" href="/v0.5/index.xml">
 

--- a/docs/static/v0.5/project/releases/v0.5.41/index.html
+++ b/docs/static/v0.5/project/releases/v0.5.41/index.html
@@ -7,7 +7,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
 <meta name="generator" content="Hugo 0.55.6" />
 
-<META NAME="ROBOTS" CONTENT="INDEX, FOLLOW">
+<meta name="robots" content="noindex, follow" />
 
 <link rel="alternate" type="application/rss&#43;xml" href="/index.xml">
 

--- a/docs/static/v0.5/project/releases/v0.5.42/index.html
+++ b/docs/static/v0.5/project/releases/v0.5.42/index.html
@@ -7,7 +7,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
 <meta name="generator" content="Hugo 0.55.6" />
 
-<META NAME="ROBOTS" CONTENT="INDEX, FOLLOW">
+<meta name="robots" content="noindex, follow" />
 
 <link rel="alternate" type="application/rss&#43;xml" href="/index.xml">
 

--- a/docs/static/v0.5/project/releases/v0.5.43/index.html
+++ b/docs/static/v0.5/project/releases/v0.5.43/index.html
@@ -7,7 +7,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
 <meta name="generator" content="Hugo 0.55.6" />
 
-<META NAME="ROBOTS" CONTENT="INDEX, FOLLOW">
+<meta name="robots" content="noindex, follow" />
 
 <link rel="alternate" type="application/rss&#43;xml" href="/index.xml">
 

--- a/docs/static/v0.5/project/releases/v0.5.44/index.html
+++ b/docs/static/v0.5/project/releases/v0.5.44/index.html
@@ -7,7 +7,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
 <meta name="generator" content="Hugo 0.55.6" />
 
-<META NAME="ROBOTS" CONTENT="INDEX, FOLLOW">
+<meta name="robots" content="noindex, follow" />
 
 <link rel="alternate" type="application/rss&#43;xml" href="/index.xml">
 

--- a/docs/static/v0.5/project/releases/v0.5.45/index.html
+++ b/docs/static/v0.5/project/releases/v0.5.45/index.html
@@ -7,7 +7,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
 <meta name="generator" content="Hugo 0.55.6" />
 
-<META NAME="ROBOTS" CONTENT="INDEX, FOLLOW">
+<meta name="robots" content="noindex, follow" />
 
 <link rel="alternate" type="application/rss&#43;xml" href="/index.xml">
 

--- a/docs/static/v0.5/project/releases/v0.5.46/index.html
+++ b/docs/static/v0.5/project/releases/v0.5.46/index.html
@@ -7,7 +7,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
 <meta name="generator" content="Hugo 0.55.6" />
 
-<META NAME="ROBOTS" CONTENT="INDEX, FOLLOW">
+<meta name="robots" content="noindex, follow" />
 
 <link rel="alternate" type="application/rss&#43;xml" href="/v0.5/index.xml">
 

--- a/docs/static/v0.5/project/releases/v0.5.47/index.html
+++ b/docs/static/v0.5/project/releases/v0.5.47/index.html
@@ -7,7 +7,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
 <meta name="generator" content="Hugo 0.55.6" />
 
-<META NAME="ROBOTS" CONTENT="INDEX, FOLLOW">
+<meta name="robots" content="noindex, follow" />
 
 <link rel="alternate" type="application/rss&#43;xml" href="/v0.5/index.xml">
 

--- a/docs/static/v0.5/project/releases/v0.5.48/index.html
+++ b/docs/static/v0.5/project/releases/v0.5.48/index.html
@@ -7,7 +7,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
 <meta name="generator" content="Hugo 0.55.6" />
 
-<META NAME="ROBOTS" CONTENT="INDEX, FOLLOW">
+<meta name="robots" content="noindex, follow" />
 
 <link rel="alternate" type="application/rss&#43;xml" href="/index.xml">
 

--- a/docs/static/v0.5/project/releases/v0.5.49/index.html
+++ b/docs/static/v0.5/project/releases/v0.5.49/index.html
@@ -7,7 +7,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
 <meta name="generator" content="Hugo 0.55.6" />
 
-<META NAME="ROBOTS" CONTENT="INDEX, FOLLOW">
+<meta name="robots" content="noindex, follow" />
 
 <link rel="alternate" type="application/rss&#43;xml" href="/index.xml">
 

--- a/docs/static/v0.5/project/releases/v0.5.5/index.html
+++ b/docs/static/v0.5/project/releases/v0.5.5/index.html
@@ -7,7 +7,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
 <meta name="generator" content="Hugo 0.55.6" />
 
-<META NAME="ROBOTS" CONTENT="INDEX, FOLLOW">
+<meta name="robots" content="noindex, follow" />
 
 <link rel="alternate" type="application/rss&#43;xml" href="/index.xml">
 

--- a/docs/static/v0.5/project/releases/v0.5.50/index.html
+++ b/docs/static/v0.5/project/releases/v0.5.50/index.html
@@ -7,7 +7,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
 <meta name="generator" content="Hugo 0.55.6" />
 
-<META NAME="ROBOTS" CONTENT="INDEX, FOLLOW">
+<meta name="robots" content="noindex, follow" />
 
 <link rel="alternate" type="application/rss&#43;xml" href="/v0.5/index.xml">
 

--- a/docs/static/v0.5/project/releases/v0.5.51/index.html
+++ b/docs/static/v0.5/project/releases/v0.5.51/index.html
@@ -7,7 +7,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
 <meta name="generator" content="Hugo 0.55.6" />
 
-<META NAME="ROBOTS" CONTENT="INDEX, FOLLOW">
+<meta name="robots" content="noindex, follow" />
 
 <link rel="alternate" type="application/rss&#43;xml" href="/v0.5/index.xml">
 

--- a/docs/static/v0.5/project/releases/v0.5.52/index.html
+++ b/docs/static/v0.5/project/releases/v0.5.52/index.html
@@ -7,7 +7,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
 <meta name="generator" content="Hugo 0.55.6" />
 
-<META NAME="ROBOTS" CONTENT="INDEX, FOLLOW">
+<meta name="robots" content="noindex, follow" />
 
 <link rel="alternate" type="application/rss&#43;xml" href="/index.xml">
 

--- a/docs/static/v0.5/project/releases/v0.5.53/index.html
+++ b/docs/static/v0.5/project/releases/v0.5.53/index.html
@@ -7,7 +7,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
 <meta name="generator" content="Hugo 0.55.6" />
 
-<META NAME="ROBOTS" CONTENT="INDEX, FOLLOW">
+<meta name="robots" content="noindex, follow" />
 
 <link rel="alternate" type="application/rss&#43;xml" href="/index.xml">
 

--- a/docs/static/v0.5/project/releases/v0.5.54/index.html
+++ b/docs/static/v0.5/project/releases/v0.5.54/index.html
@@ -7,7 +7,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
 <meta name="generator" content="Hugo 0.55.6" />
 
-<META NAME="ROBOTS" CONTENT="INDEX, FOLLOW">
+<meta name="robots" content="noindex, follow" />
 
 <link rel="alternate" type="application/rss&#43;xml" href="/index.xml">
 

--- a/docs/static/v0.5/project/releases/v0.5.55/index.html
+++ b/docs/static/v0.5/project/releases/v0.5.55/index.html
@@ -7,7 +7,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
 <meta name="generator" content="Hugo 0.55.6" />
 
-<META NAME="ROBOTS" CONTENT="INDEX, FOLLOW">
+<meta name="robots" content="noindex, follow" />
 
 <link rel="alternate" type="application/rss&#43;xml" href="/index.xml">
 

--- a/docs/static/v0.5/project/releases/v0.5.56/index.html
+++ b/docs/static/v0.5/project/releases/v0.5.56/index.html
@@ -7,7 +7,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
 <meta name="generator" content="Hugo 0.55.6" />
 
-<META NAME="ROBOTS" CONTENT="INDEX, FOLLOW">
+<meta name="robots" content="noindex, follow" />
 
 <link rel="alternate" type="application/rss&#43;xml" href="/v0.5/index.xml">
 

--- a/docs/static/v0.5/project/releases/v0.5.57/index.html
+++ b/docs/static/v0.5/project/releases/v0.5.57/index.html
@@ -7,7 +7,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
 <meta name="generator" content="Hugo 0.55.6" />
 
-<META NAME="ROBOTS" CONTENT="INDEX, FOLLOW">
+<meta name="robots" content="noindex, follow" />
 
 <link rel="alternate" type="application/rss&#43;xml" href="/index.xml">
 

--- a/docs/static/v0.5/project/releases/v0.5.58/index.html
+++ b/docs/static/v0.5/project/releases/v0.5.58/index.html
@@ -7,7 +7,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
 <meta name="generator" content="Hugo 0.55.6" />
 
-<META NAME="ROBOTS" CONTENT="INDEX, FOLLOW">
+<meta name="robots" content="noindex, follow" />
 
 <link rel="alternate" type="application/rss&#43;xml" href="/index.xml">
 

--- a/docs/static/v0.5/project/releases/v0.5.59/index.html
+++ b/docs/static/v0.5/project/releases/v0.5.59/index.html
@@ -7,7 +7,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
 <meta name="generator" content="Hugo 0.55.6" />
 
-<META NAME="ROBOTS" CONTENT="INDEX, FOLLOW">
+<meta name="robots" content="noindex, follow" />
 
 <link rel="alternate" type="application/rss&#43;xml" href="/index.xml">
 

--- a/docs/static/v0.5/project/releases/v0.5.6/index.html
+++ b/docs/static/v0.5/project/releases/v0.5.6/index.html
@@ -7,7 +7,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
 <meta name="generator" content="Hugo 0.55.6" />
 
-<META NAME="ROBOTS" CONTENT="INDEX, FOLLOW">
+<meta name="robots" content="noindex, follow" />
 
 <link rel="alternate" type="application/rss&#43;xml" href="/v0.5/index.xml">
 

--- a/docs/static/v0.5/project/releases/v0.5.60/index.html
+++ b/docs/static/v0.5/project/releases/v0.5.60/index.html
@@ -7,7 +7,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
 <meta name="generator" content="Hugo 0.55.6" />
 
-<META NAME="ROBOTS" CONTENT="INDEX, FOLLOW">
+<meta name="robots" content="noindex, follow" />
 
 <link rel="alternate" type="application/rss&#43;xml" href="/v0.5/index.xml">
 

--- a/docs/static/v0.5/project/releases/v0.5.61/index.html
+++ b/docs/static/v0.5/project/releases/v0.5.61/index.html
@@ -7,7 +7,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
 <meta name="generator" content="Hugo 0.55.6" />
 
-<META NAME="ROBOTS" CONTENT="INDEX, FOLLOW">
+<meta name="robots" content="noindex, follow" />
 
 <link rel="alternate" type="application/rss&#43;xml" href="/index.xml">
 

--- a/docs/static/v0.5/project/releases/v0.5.62/index.html
+++ b/docs/static/v0.5/project/releases/v0.5.62/index.html
@@ -7,7 +7,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
 <meta name="generator" content="Hugo 0.55.6" />
 
-<META NAME="ROBOTS" CONTENT="INDEX, FOLLOW">
+<meta name="robots" content="noindex, follow" />
 
 <link rel="alternate" type="application/rss&#43;xml" href="/index.xml">
 

--- a/docs/static/v0.5/project/releases/v0.5.63-rc-1/index.html
+++ b/docs/static/v0.5/project/releases/v0.5.63-rc-1/index.html
@@ -7,7 +7,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
 <meta name="generator" content="Hugo 0.55.6" />
 
-<META NAME="ROBOTS" CONTENT="INDEX, FOLLOW">
+<meta name="robots" content="noindex, follow" />
 
 <link rel="alternate" type="application/rss&#43;xml" href="/index.xml">
 

--- a/docs/static/v0.5/project/releases/v0.5.64-rc-2/index.html
+++ b/docs/static/v0.5/project/releases/v0.5.64-rc-2/index.html
@@ -7,7 +7,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
 <meta name="generator" content="Hugo 0.55.6" />
 
-<META NAME="ROBOTS" CONTENT="INDEX, FOLLOW">
+<meta name="robots" content="noindex, follow" />
 
 <link rel="alternate" type="application/rss&#43;xml" href="/v0.5/index.xml">
 

--- a/docs/static/v0.5/project/releases/v0.5.64/index.html
+++ b/docs/static/v0.5/project/releases/v0.5.64/index.html
@@ -7,7 +7,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
 <meta name="generator" content="Hugo 0.55.6" />
 
-<META NAME="ROBOTS" CONTENT="INDEX, FOLLOW">
+<meta name="robots" content="noindex, follow" />
 
 <link rel="alternate" type="application/rss&#43;xml" href="/index.xml">
 

--- a/docs/static/v0.5/project/releases/v0.5.65/index.html
+++ b/docs/static/v0.5/project/releases/v0.5.65/index.html
@@ -7,7 +7,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
 <meta name="generator" content="Hugo 0.55.6" />
 
-<META NAME="ROBOTS" CONTENT="INDEX, FOLLOW">
+<meta name="robots" content="noindex, follow" />
 
 <link rel="alternate" type="application/rss&#43;xml" href="/index.xml">
 

--- a/docs/static/v0.5/project/releases/v0.5.66/index.html
+++ b/docs/static/v0.5/project/releases/v0.5.66/index.html
@@ -7,7 +7,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
 <meta name="generator" content="Hugo 0.55.6" />
 
-<META NAME="ROBOTS" CONTENT="INDEX, FOLLOW">
+<meta name="robots" content="noindex, follow" />
 
 <link rel="alternate" type="application/rss&#43;xml" href="/v0.5/index.xml">
 

--- a/docs/static/v0.5/project/releases/v0.5.67/index.html
+++ b/docs/static/v0.5/project/releases/v0.5.67/index.html
@@ -7,7 +7,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
 <meta name="generator" content="Hugo 0.55.6" />
 
-<META NAME="ROBOTS" CONTENT="INDEX, FOLLOW">
+<meta name="robots" content="noindex, follow" />
 
 <link rel="alternate" type="application/rss&#43;xml" href="/v0.5/index.xml">
 

--- a/docs/static/v0.5/project/releases/v0.5.68/index.html
+++ b/docs/static/v0.5/project/releases/v0.5.68/index.html
@@ -7,7 +7,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
 <meta name="generator" content="Hugo 0.55.6" />
 
-<META NAME="ROBOTS" CONTENT="INDEX, FOLLOW">
+<meta name="robots" content="noindex, follow" />
 
 <link rel="alternate" type="application/rss&#43;xml" href="/index.xml">
 

--- a/docs/static/v0.5/project/releases/v0.5.69/index.html
+++ b/docs/static/v0.5/project/releases/v0.5.69/index.html
@@ -7,7 +7,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
 <meta name="generator" content="Hugo 0.55.6" />
 
-<META NAME="ROBOTS" CONTENT="INDEX, FOLLOW">
+<meta name="robots" content="noindex, follow" />
 
 <link rel="alternate" type="application/rss&#43;xml" href="/index.xml">
 

--- a/docs/static/v0.5/project/releases/v0.5.7/index.html
+++ b/docs/static/v0.5/project/releases/v0.5.7/index.html
@@ -7,7 +7,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
 <meta name="generator" content="Hugo 0.55.6" />
 
-<META NAME="ROBOTS" CONTENT="INDEX, FOLLOW">
+<meta name="robots" content="noindex, follow" />
 
 <link rel="alternate" type="application/rss&#43;xml" href="/v0.5/index.xml">
 

--- a/docs/static/v0.5/project/releases/v0.5.70/index.html
+++ b/docs/static/v0.5/project/releases/v0.5.70/index.html
@@ -7,7 +7,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
 <meta name="generator" content="Hugo 0.55.6" />
 
-<META NAME="ROBOTS" CONTENT="INDEX, FOLLOW">
+<meta name="robots" content="noindex, follow" />
 
 <link rel="alternate" type="application/rss&#43;xml" href="/v0.5/index.xml">
 

--- a/docs/static/v0.5/project/releases/v0.5.71/index.html
+++ b/docs/static/v0.5/project/releases/v0.5.71/index.html
@@ -7,7 +7,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
 <meta name="generator" content="Hugo 0.55.6" />
 
-<META NAME="ROBOTS" CONTENT="INDEX, FOLLOW">
+<meta name="robots" content="noindex, follow" />
 
 <link rel="alternate" type="application/rss&#43;xml" href="/v0.5/index.xml">
 

--- a/docs/static/v0.5/project/releases/v0.5.72/index.html
+++ b/docs/static/v0.5/project/releases/v0.5.72/index.html
@@ -7,7 +7,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
 <meta name="generator" content="Hugo 0.55.6" />
 
-<META NAME="ROBOTS" CONTENT="INDEX, FOLLOW">
+<meta name="robots" content="noindex, follow" />
 
 <link rel="alternate" type="application/rss&#43;xml" href="/index.xml">
 

--- a/docs/static/v0.5/project/releases/v0.5.8/index.html
+++ b/docs/static/v0.5/project/releases/v0.5.8/index.html
@@ -7,7 +7,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
 <meta name="generator" content="Hugo 0.55.6" />
 
-<META NAME="ROBOTS" CONTENT="INDEX, FOLLOW">
+<meta name="robots" content="noindex, follow" />
 
 <link rel="alternate" type="application/rss&#43;xml" href="/index.xml">
 

--- a/docs/static/v0.5/project/releases/v0.5.9/index.html
+++ b/docs/static/v0.5/project/releases/v0.5.9/index.html
@@ -7,7 +7,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
 <meta name="generator" content="Hugo 0.55.6" />
 
-<META NAME="ROBOTS" CONTENT="INDEX, FOLLOW">
+<meta name="robots" content="noindex, follow" />
 
 <link rel="alternate" type="application/rss&#43;xml" href="/index.xml">
 

--- a/docs/static/v0.5/project/releases/v0.6.0-rc-1/index.html
+++ b/docs/static/v0.5/project/releases/v0.6.0-rc-1/index.html
@@ -7,7 +7,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
 <meta name="generator" content="Hugo 0.55.6" />
 
-<META NAME="ROBOTS" CONTENT="INDEX, FOLLOW">
+<meta name="robots" content="noindex, follow" />
 
 <link rel="alternate" type="application/rss&#43;xml" href="/index.xml">
 

--- a/docs/static/v0.5/project/releases/v0.6.0-rc-2/index.html
+++ b/docs/static/v0.5/project/releases/v0.6.0-rc-2/index.html
@@ -7,7 +7,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
 <meta name="generator" content="Hugo 0.55.6" />
 
-<META NAME="ROBOTS" CONTENT="INDEX, FOLLOW">
+<meta name="robots" content="noindex, follow" />
 
 <link rel="alternate" type="application/rss&#43;xml" href="/v0.5/index.xml">
 

--- a/docs/static/v0.5/project/releases/v0.6.0-rc-3/index.html
+++ b/docs/static/v0.5/project/releases/v0.6.0-rc-3/index.html
@@ -7,7 +7,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
 <meta name="generator" content="Hugo 0.55.6" />
 
-<META NAME="ROBOTS" CONTENT="INDEX, FOLLOW">
+<meta name="robots" content="noindex, follow" />
 
 <link rel="alternate" type="application/rss&#43;xml" href="/v0.5/index.xml">
 

--- a/docs/static/v0.5/project/releases/v0.6.0-rc-4/index.html
+++ b/docs/static/v0.5/project/releases/v0.6.0-rc-4/index.html
@@ -7,7 +7,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
 <meta name="generator" content="Hugo 0.55.6" />
 
-<META NAME="ROBOTS" CONTENT="INDEX, FOLLOW">
+<meta name="robots" content="noindex, follow" />
 
 <link rel="alternate" type="application/rss&#43;xml" href="/index.xml">
 

--- a/docs/static/v0.5/project/releases/v0.6.0-rc-5/index.html
+++ b/docs/static/v0.5/project/releases/v0.6.0-rc-5/index.html
@@ -7,7 +7,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
 <meta name="generator" content="Hugo 0.55.6" />
 
-<META NAME="ROBOTS" CONTENT="INDEX, FOLLOW">
+<meta name="robots" content="noindex, follow" />
 
 <link rel="alternate" type="application/rss&#43;xml" href="/v0.5/index.xml">
 

--- a/docs/static/v0.5/project/releases/v0.6.0-rc-5a/index.html
+++ b/docs/static/v0.5/project/releases/v0.6.0-rc-5a/index.html
@@ -7,7 +7,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
 <meta name="generator" content="Hugo 0.55.6" />
 
-<META NAME="ROBOTS" CONTENT="INDEX, FOLLOW">
+<meta name="robots" content="noindex, follow" />
 
 <link rel="alternate" type="application/rss&#43;xml" href="/v0.5/index.xml">
 

--- a/docs/static/v0.5/project/releases/v0.6.0-rc-5b/index.html
+++ b/docs/static/v0.5/project/releases/v0.6.0-rc-5b/index.html
@@ -7,7 +7,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
 <meta name="generator" content="Hugo 0.55.6" />
 
-<META NAME="ROBOTS" CONTENT="INDEX, FOLLOW">
+<meta name="robots" content="noindex, follow" />
 
 <link rel="alternate" type="application/rss&#43;xml" href="/index.xml">
 

--- a/docs/static/v0.5/project/releases/v0.6.0-rc-5c/index.html
+++ b/docs/static/v0.5/project/releases/v0.6.0-rc-5c/index.html
@@ -7,7 +7,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
 <meta name="generator" content="Hugo 0.55.6" />
 
-<META NAME="ROBOTS" CONTENT="INDEX, FOLLOW">
+<meta name="robots" content="noindex, follow" />
 
 <link rel="alternate" type="application/rss&#43;xml" href="/index.xml">
 

--- a/docs/static/v0.5/project/releases/v0.6.0-rc-5d/index.html
+++ b/docs/static/v0.5/project/releases/v0.6.0-rc-5d/index.html
@@ -7,7 +7,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
 <meta name="generator" content="Hugo 0.55.6" />
 
-<META NAME="ROBOTS" CONTENT="INDEX, FOLLOW">
+<meta name="robots" content="noindex, follow" />
 
 <link rel="alternate" type="application/rss&#43;xml" href="/index.xml">
 

--- a/docs/static/v0.5/project/releases/v0.6.0-rc-5f/index.html
+++ b/docs/static/v0.5/project/releases/v0.6.0-rc-5f/index.html
@@ -7,7 +7,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
 <meta name="generator" content="Hugo 0.55.6" />
 
-<META NAME="ROBOTS" CONTENT="INDEX, FOLLOW">
+<meta name="robots" content="noindex, follow" />
 
 <link rel="alternate" type="application/rss&#43;xml" href="/v0.5/index.xml">
 

--- a/docs/static/v0.5/project/releases/v0.6.0-rc-5g/index.html
+++ b/docs/static/v0.5/project/releases/v0.6.0-rc-5g/index.html
@@ -7,7 +7,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
 <meta name="generator" content="Hugo 0.55.6" />
 
-<META NAME="ROBOTS" CONTENT="INDEX, FOLLOW">
+<meta name="robots" content="noindex, follow" />
 
 <link rel="alternate" type="application/rss&#43;xml" href="/index.xml">
 

--- a/docs/static/v0.5/project/releases/v0.6.0-rc-5h/index.html
+++ b/docs/static/v0.5/project/releases/v0.6.0-rc-5h/index.html
@@ -7,7 +7,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
 <meta name="generator" content="Hugo 0.55.6" />
 
-<META NAME="ROBOTS" CONTENT="INDEX, FOLLOW">
+<meta name="robots" content="noindex, follow" />
 
 <link rel="alternate" type="application/rss&#43;xml" href="/index.xml">
 

--- a/docs/static/v0.5/project/releases/v0.6.0-rc-5i/index.html
+++ b/docs/static/v0.5/project/releases/v0.6.0-rc-5i/index.html
@@ -7,7 +7,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
 <meta name="generator" content="Hugo 0.55.6" />
 
-<META NAME="ROBOTS" CONTENT="INDEX, FOLLOW">
+<meta name="robots" content="noindex, follow" />
 
 <link rel="alternate" type="application/rss&#43;xml" href="/index.xml">
 

--- a/docs/static/v0.5/project/releases/v0.6.0-rc-5j/index.html
+++ b/docs/static/v0.5/project/releases/v0.6.0-rc-5j/index.html
@@ -7,7 +7,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
 <meta name="generator" content="Hugo 0.55.6" />
 
-<META NAME="ROBOTS" CONTENT="INDEX, FOLLOW">
+<meta name="robots" content="noindex, follow" />
 
 <link rel="alternate" type="application/rss&#43;xml" href="/v0.5/index.xml">
 

--- a/docs/static/v0.5/project/releases/v0.6.0-rc-5t/index.html
+++ b/docs/static/v0.5/project/releases/v0.6.0-rc-5t/index.html
@@ -7,7 +7,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
 <meta name="generator" content="Hugo 0.55.6" />
 
-<META NAME="ROBOTS" CONTENT="INDEX, FOLLOW">
+<meta name="robots" content="noindex, follow" />
 
 <link rel="alternate" type="application/rss&#43;xml" href="/v0.5/index.xml">
 

--- a/docs/static/v0.5/project/releases/v0.6.0-rc.5aa/index.html
+++ b/docs/static/v0.5/project/releases/v0.6.0-rc.5aa/index.html
@@ -7,7 +7,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
 <meta name="generator" content="Hugo 0.55.6" />
 
-<META NAME="ROBOTS" CONTENT="INDEX, FOLLOW">
+<meta name="robots" content="noindex, follow" />
 
 <link rel="alternate" type="application/rss&#43;xml" href="/v0.5/index.xml">
 

--- a/docs/static/v0.5/project/releases/v0.6.0-rc.5k/index.html
+++ b/docs/static/v0.5/project/releases/v0.6.0-rc.5k/index.html
@@ -7,7 +7,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
 <meta name="generator" content="Hugo 0.55.6" />
 
-<META NAME="ROBOTS" CONTENT="INDEX, FOLLOW">
+<meta name="robots" content="noindex, follow" />
 
 <link rel="alternate" type="application/rss&#43;xml" href="/index.xml">
 

--- a/docs/static/v0.5/project/releases/v0.6.0-rc.5l/index.html
+++ b/docs/static/v0.5/project/releases/v0.6.0-rc.5l/index.html
@@ -7,7 +7,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
 <meta name="generator" content="Hugo 0.55.6" />
 
-<META NAME="ROBOTS" CONTENT="INDEX, FOLLOW">
+<meta name="robots" content="noindex, follow" />
 
 <link rel="alternate" type="application/rss&#43;xml" href="/index.xml">
 

--- a/docs/static/v0.5/project/releases/v0.6.0-rc.5m/index.html
+++ b/docs/static/v0.5/project/releases/v0.6.0-rc.5m/index.html
@@ -7,7 +7,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
 <meta name="generator" content="Hugo 0.55.6" />
 
-<META NAME="ROBOTS" CONTENT="INDEX, FOLLOW">
+<meta name="robots" content="noindex, follow" />
 
 <link rel="alternate" type="application/rss&#43;xml" href="/index.xml">
 

--- a/docs/static/v0.5/project/releases/v0.6.0-rc.5n/index.html
+++ b/docs/static/v0.5/project/releases/v0.6.0-rc.5n/index.html
@@ -7,7 +7,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
 <meta name="generator" content="Hugo 0.55.6" />
 
-<META NAME="ROBOTS" CONTENT="INDEX, FOLLOW">
+<meta name="robots" content="noindex, follow" />
 
 <link rel="alternate" type="application/rss&#43;xml" href="/index.xml">
 

--- a/docs/static/v0.5/project/releases/v0.6.0-rc.5o/index.html
+++ b/docs/static/v0.5/project/releases/v0.6.0-rc.5o/index.html
@@ -7,7 +7,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
 <meta name="generator" content="Hugo 0.55.6" />
 
-<META NAME="ROBOTS" CONTENT="INDEX, FOLLOW">
+<meta name="robots" content="noindex, follow" />
 
 <link rel="alternate" type="application/rss&#43;xml" href="/v0.5/index.xml">
 

--- a/docs/static/v0.5/project/releases/v0.6.0-rc.5p/index.html
+++ b/docs/static/v0.5/project/releases/v0.6.0-rc.5p/index.html
@@ -7,7 +7,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
 <meta name="generator" content="Hugo 0.55.6" />
 
-<META NAME="ROBOTS" CONTENT="INDEX, FOLLOW">
+<meta name="robots" content="noindex, follow" />
 
 <link rel="alternate" type="application/rss&#43;xml" href="/v0.5/index.xml">
 

--- a/docs/static/v0.5/project/releases/v0.6.0-rc.5q/index.html
+++ b/docs/static/v0.5/project/releases/v0.6.0-rc.5q/index.html
@@ -7,7 +7,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
 <meta name="generator" content="Hugo 0.55.6" />
 
-<META NAME="ROBOTS" CONTENT="INDEX, FOLLOW">
+<meta name="robots" content="noindex, follow" />
 
 <link rel="alternate" type="application/rss&#43;xml" href="/v0.5/index.xml">
 

--- a/docs/static/v0.5/project/releases/v0.6.0-rc.5r/index.html
+++ b/docs/static/v0.5/project/releases/v0.6.0-rc.5r/index.html
@@ -7,7 +7,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
 <meta name="generator" content="Hugo 0.55.6" />
 
-<META NAME="ROBOTS" CONTENT="INDEX, FOLLOW">
+<meta name="robots" content="noindex, follow" />
 
 <link rel="alternate" type="application/rss&#43;xml" href="/index.xml">
 

--- a/docs/static/v0.5/project/releases/v0.6.0-rc.5s/index.html
+++ b/docs/static/v0.5/project/releases/v0.6.0-rc.5s/index.html
@@ -7,7 +7,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
 <meta name="generator" content="Hugo 0.55.6" />
 
-<META NAME="ROBOTS" CONTENT="INDEX, FOLLOW">
+<meta name="robots" content="noindex, follow" />
 
 <link rel="alternate" type="application/rss&#43;xml" href="/index.xml">
 

--- a/docs/static/v0.5/project/releases/v0.6.0-rc.5t/index.html
+++ b/docs/static/v0.5/project/releases/v0.6.0-rc.5t/index.html
@@ -7,7 +7,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
 <meta name="generator" content="Hugo 0.55.6" />
 
-<META NAME="ROBOTS" CONTENT="INDEX, FOLLOW">
+<meta name="robots" content="noindex, follow" />
 
 <link rel="alternate" type="application/rss&#43;xml" href="/index.xml">
 

--- a/docs/static/v0.5/project/releases/v0.6.0-rc.5u/index.html
+++ b/docs/static/v0.5/project/releases/v0.6.0-rc.5u/index.html
@@ -7,7 +7,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
 <meta name="generator" content="Hugo 0.55.6" />
 
-<META NAME="ROBOTS" CONTENT="INDEX, FOLLOW">
+<meta name="robots" content="noindex, follow" />
 
 <link rel="alternate" type="application/rss&#43;xml" href="/index.xml">
 

--- a/docs/static/v0.5/project/releases/v0.6.0-rc.5v/index.html
+++ b/docs/static/v0.5/project/releases/v0.6.0-rc.5v/index.html
@@ -7,7 +7,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
 <meta name="generator" content="Hugo 0.55.6" />
 
-<META NAME="ROBOTS" CONTENT="INDEX, FOLLOW">
+<meta name="robots" content="noindex, follow" />
 
 <link rel="alternate" type="application/rss&#43;xml" href="/v0.5/index.xml">
 

--- a/docs/static/v0.5/project/releases/v0.6.0-rc.5w/index.html
+++ b/docs/static/v0.5/project/releases/v0.6.0-rc.5w/index.html
@@ -7,7 +7,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
 <meta name="generator" content="Hugo 0.55.6" />
 
-<META NAME="ROBOTS" CONTENT="INDEX, FOLLOW">
+<meta name="robots" content="noindex, follow" />
 
 <link rel="alternate" type="application/rss&#43;xml" href="/index.xml">
 

--- a/docs/static/v0.5/project/releases/v0.6.0-rc.5x/index.html
+++ b/docs/static/v0.5/project/releases/v0.6.0-rc.5x/index.html
@@ -7,7 +7,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
 <meta name="generator" content="Hugo 0.55.6" />
 
-<META NAME="ROBOTS" CONTENT="INDEX, FOLLOW">
+<meta name="robots" content="noindex, follow" />
 
 <link rel="alternate" type="application/rss&#43;xml" href="/index.xml">
 

--- a/docs/static/v0.5/project/releases/v0.6.0-rc.5y/index.html
+++ b/docs/static/v0.5/project/releases/v0.6.0-rc.5y/index.html
@@ -7,7 +7,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
 <meta name="generator" content="Hugo 0.55.6" />
 
-<META NAME="ROBOTS" CONTENT="INDEX, FOLLOW">
+<meta name="robots" content="noindex, follow" />
 
 <link rel="alternate" type="application/rss&#43;xml" href="/index.xml">
 

--- a/docs/static/v0.5/project/releases/v0.6.0-rc.5z/index.html
+++ b/docs/static/v0.5/project/releases/v0.6.0-rc.5z/index.html
@@ -7,7 +7,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
 <meta name="generator" content="Hugo 0.55.6" />
 
-<META NAME="ROBOTS" CONTENT="INDEX, FOLLOW">
+<meta name="robots" content="noindex, follow" />
 
 <link rel="alternate" type="application/rss&#43;xml" href="/v0.5/index.xml">
 

--- a/docs/static/v0.5/project/releases/v0.6.0-rc.6/index.html
+++ b/docs/static/v0.5/project/releases/v0.6.0-rc.6/index.html
@@ -7,7 +7,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
 <meta name="generator" content="Hugo 0.55.6" />
 
-<META NAME="ROBOTS" CONTENT="INDEX, FOLLOW">
+<meta name="robots" content="noindex, follow" />
 
 <link rel="alternate" type="application/rss&#43;xml" href="/index.xml">
 

--- a/docs/static/v0.5/project/releases/v0.6.0-rc.6a/index.html
+++ b/docs/static/v0.5/project/releases/v0.6.0-rc.6a/index.html
@@ -7,7 +7,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
 <meta name="generator" content="Hugo 0.55.6" />
 
-<META NAME="ROBOTS" CONTENT="INDEX, FOLLOW">
+<meta name="robots" content="noindex, follow" />
 
 <link rel="alternate" type="application/rss&#43;xml" href="/index.xml">
 

--- a/docs/static/v0.5/project/releases/v0.6.0-rc.6b/index.html
+++ b/docs/static/v0.5/project/releases/v0.6.0-rc.6b/index.html
@@ -7,7 +7,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
 <meta name="generator" content="Hugo 0.55.6" />
 
-<META NAME="ROBOTS" CONTENT="INDEX, FOLLOW">
+<meta name="robots" content="noindex, follow" />
 
 <link rel="alternate" type="application/rss&#43;xml" href="/v0.5/index.xml">
 

--- a/docs/static/v0.5/project/releases/v0.6.0-rc.6c/index.html
+++ b/docs/static/v0.5/project/releases/v0.6.0-rc.6c/index.html
@@ -7,7 +7,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
 <meta name="generator" content="Hugo 0.55.6" />
 
-<META NAME="ROBOTS" CONTENT="INDEX, FOLLOW">
+<meta name="robots" content="noindex, follow" />
 
 <link rel="alternate" type="application/rss&#43;xml" href="/v0.5/index.xml">
 

--- a/docs/static/v0.5/project/releases/v0.6.0-rc.6d/index.html
+++ b/docs/static/v0.5/project/releases/v0.6.0-rc.6d/index.html
@@ -7,7 +7,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
 <meta name="generator" content="Hugo 0.55.6" />
 
-<META NAME="ROBOTS" CONTENT="INDEX, FOLLOW">
+<meta name="robots" content="noindex, follow" />
 
 <link rel="alternate" type="application/rss&#43;xml" href="/index.xml">
 

--- a/docs/static/v0.5/project/releases/v0.6.0-rc.6e/index.html
+++ b/docs/static/v0.5/project/releases/v0.6.0-rc.6e/index.html
@@ -7,7 +7,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
 <meta name="generator" content="Hugo 0.55.6" />
 
-<META NAME="ROBOTS" CONTENT="INDEX, FOLLOW">
+<meta name="robots" content="noindex, follow" />
 
 <link rel="alternate" type="application/rss&#43;xml" href="/v0.5/index.xml">
 

--- a/docs/static/v0.5/project/releases/v0.6.0-rc.6f/index.html
+++ b/docs/static/v0.5/project/releases/v0.6.0-rc.6f/index.html
@@ -7,7 +7,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
 <meta name="generator" content="Hugo 0.55.6" />
 
-<META NAME="ROBOTS" CONTENT="INDEX, FOLLOW">
+<meta name="robots" content="noindex, follow" />
 
 <link rel="alternate" type="application/rss&#43;xml" href="/index.xml">
 

--- a/docs/static/v0.5/project/releases/v0.6.0-rc.6fa/index.html
+++ b/docs/static/v0.5/project/releases/v0.6.0-rc.6fa/index.html
@@ -7,7 +7,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
 <meta name="generator" content="Hugo 0.55.6" />
 
-<META NAME="ROBOTS" CONTENT="INDEX, FOLLOW">
+<meta name="robots" content="noindex, follow" />
 
 <link rel="alternate" type="application/rss&#43;xml" href="/index.xml">
 

--- a/docs/static/v0.5/project/releases/v0.6.0-rc.6fb/index.html
+++ b/docs/static/v0.5/project/releases/v0.6.0-rc.6fb/index.html
@@ -7,7 +7,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
 <meta name="generator" content="Hugo 0.55.6" />
 
-<META NAME="ROBOTS" CONTENT="INDEX, FOLLOW">
+<meta name="robots" content="noindex, follow" />
 
 <link rel="alternate" type="application/rss&#43;xml" href="/v0.5/index.xml">
 

--- a/docs/static/v0.5/project/releases/v0.6.0-rc.6fc/index.html
+++ b/docs/static/v0.5/project/releases/v0.6.0-rc.6fc/index.html
@@ -7,7 +7,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
 <meta name="generator" content="Hugo 0.55.6" />
 
-<META NAME="ROBOTS" CONTENT="INDEX, FOLLOW">
+<meta name="robots" content="noindex, follow" />
 
 <link rel="alternate" type="application/rss&#43;xml" href="/v0.5/index.xml">
 

--- a/docs/static/v0.5/project/releases/v0.6.0-rc.6fd/index.html
+++ b/docs/static/v0.5/project/releases/v0.6.0-rc.6fd/index.html
@@ -7,7 +7,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
 <meta name="generator" content="Hugo 0.55.6" />
 
-<META NAME="ROBOTS" CONTENT="INDEX, FOLLOW">
+<meta name="robots" content="noindex, follow" />
 
 <link rel="alternate" type="application/rss&#43;xml" href="/index.xml">
 

--- a/docs/static/v0.5/project/releases/v0.6.0-rc.6fe/index.html
+++ b/docs/static/v0.5/project/releases/v0.6.0-rc.6fe/index.html
@@ -7,7 +7,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
 <meta name="generator" content="Hugo 0.55.6" />
 
-<META NAME="ROBOTS" CONTENT="INDEX, FOLLOW">
+<meta name="robots" content="noindex, follow" />
 
 <link rel="alternate" type="application/rss&#43;xml" href="/index.xml">
 

--- a/docs/static/v0.5/project/releases/v0.6.0/index.html
+++ b/docs/static/v0.5/project/releases/v0.6.0/index.html
@@ -7,7 +7,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
 <meta name="generator" content="Hugo 0.55.6" />
 
-<META NAME="ROBOTS" CONTENT="INDEX, FOLLOW">
+<meta name="robots" content="noindex, follow" />
 
 <link rel="alternate" type="application/rss&#43;xml" href="/index.xml">
 

--- a/docs/static/v0.5/project/security-vulnerabilities/index.html
+++ b/docs/static/v0.5/project/security-vulnerabilities/index.html
@@ -7,7 +7,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
 <meta name="generator" content="Hugo 0.55.6" />
 
-<META NAME="ROBOTS" CONTENT="INDEX, FOLLOW">
+<meta name="robots" content="noindex, follow" />
 
 <link rel="alternate" type="application/rss&#43;xml" href="/v0.5/index.xml">
 

--- a/docs/static/v0.5/reference/error-codes/index.html
+++ b/docs/static/v0.5/reference/error-codes/index.html
@@ -7,7 +7,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
 <meta name="generator" content="Hugo 0.55.6" />
 
-<META NAME="ROBOTS" CONTENT="INDEX, FOLLOW">
+<meta name="robots" content="noindex, follow" />
 
 <link rel="alternate" type="application/rss&#43;xml" href="/v0.5/index.xml">
 

--- a/docs/static/v0.5/reference/graphql-apis/index.html
+++ b/docs/static/v0.5/reference/graphql-apis/index.html
@@ -7,7 +7,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
 <meta name="generator" content="Hugo 0.55.6" />
 
-<META NAME="ROBOTS" CONTENT="INDEX, FOLLOW">
+<meta name="robots" content="noindex, follow" />
 
 <link rel="alternate" type="application/rss&#43;xml" href="/v0.5/index.xml">
 

--- a/docs/static/v0.5/reference/index.html
+++ b/docs/static/v0.5/reference/index.html
@@ -7,7 +7,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
 <meta name="generator" content="Hugo 0.55.6" />
 
-<META NAME="ROBOTS" CONTENT="INDEX, FOLLOW">
+<meta name="robots" content="noindex, follow" />
 
 <link rel="alternate" type="application/rss&#43;xml" href="/v0.5/index.xml">
 

--- a/docs/static/v0.5/reference/mesheryctl/app/index.html
+++ b/docs/static/v0.5/reference/mesheryctl/app/index.html
@@ -7,7 +7,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
 <meta name="generator" content="Hugo 0.55.6" />
 
-<META NAME="ROBOTS" CONTENT="INDEX, FOLLOW">
+<meta name="robots" content="noindex, follow" />
 
 <link rel="alternate" type="application/rss&#43;xml" href="/v0.5/index.xml">
 

--- a/docs/static/v0.5/reference/mesheryctl/app/list/index.html
+++ b/docs/static/v0.5/reference/mesheryctl/app/list/index.html
@@ -7,7 +7,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
 <meta name="generator" content="Hugo 0.55.6" />
 
-<META NAME="ROBOTS" CONTENT="INDEX, FOLLOW">
+<meta name="robots" content="noindex, follow" />
 
 <link rel="alternate" type="application/rss&#43;xml" href="/v0.5/index.xml">
 

--- a/docs/static/v0.5/reference/mesheryctl/app/offboard/index.html
+++ b/docs/static/v0.5/reference/mesheryctl/app/offboard/index.html
@@ -7,7 +7,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
 <meta name="generator" content="Hugo 0.55.6" />
 
-<META NAME="ROBOTS" CONTENT="INDEX, FOLLOW">
+<meta name="robots" content="noindex, follow" />
 
 <link rel="alternate" type="application/rss&#43;xml" href="/v0.5/index.xml">
 

--- a/docs/static/v0.5/reference/mesheryctl/app/onboard/index.html
+++ b/docs/static/v0.5/reference/mesheryctl/app/onboard/index.html
@@ -7,7 +7,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
 <meta name="generator" content="Hugo 0.55.6" />
 
-<META NAME="ROBOTS" CONTENT="INDEX, FOLLOW">
+<meta name="robots" content="noindex, follow" />
 
 <link rel="alternate" type="application/rss&#43;xml" href="/v0.5/index.xml">
 

--- a/docs/static/v0.5/reference/mesheryctl/app/view/index.html
+++ b/docs/static/v0.5/reference/mesheryctl/app/view/index.html
@@ -7,7 +7,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
 <meta name="generator" content="Hugo 0.55.6" />
 
-<META NAME="ROBOTS" CONTENT="INDEX, FOLLOW">
+<meta name="robots" content="noindex, follow" />
 
 <link rel="alternate" type="application/rss&#43;xml" href="/v0.5/index.xml">
 

--- a/docs/static/v0.5/reference/mesheryctl/completion/index.html
+++ b/docs/static/v0.5/reference/mesheryctl/completion/index.html
@@ -7,7 +7,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
 <meta name="generator" content="Hugo 0.55.6" />
 
-<META NAME="ROBOTS" CONTENT="INDEX, FOLLOW">
+<meta name="robots" content="noindex, follow" />
 
 <link rel="alternate" type="application/rss&#43;xml" href="/v0.5/index.xml">
 

--- a/docs/static/v0.5/reference/mesheryctl/exp/filter/apply/index.html
+++ b/docs/static/v0.5/reference/mesheryctl/exp/filter/apply/index.html
@@ -7,7 +7,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
 <meta name="generator" content="Hugo 0.55.6" />
 
-<META NAME="ROBOTS" CONTENT="INDEX, FOLLOW">
+<meta name="robots" content="noindex, follow" />
 
 <link rel="alternate" type="application/rss&#43;xml" href="/v0.5/index.xml">
 

--- a/docs/static/v0.5/reference/mesheryctl/exp/filter/delete/index.html
+++ b/docs/static/v0.5/reference/mesheryctl/exp/filter/delete/index.html
@@ -7,7 +7,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
 <meta name="generator" content="Hugo 0.55.6" />
 
-<META NAME="ROBOTS" CONTENT="INDEX, FOLLOW">
+<meta name="robots" content="noindex, follow" />
 
 <link rel="alternate" type="application/rss&#43;xml" href="/v0.5/index.xml">
 

--- a/docs/static/v0.5/reference/mesheryctl/exp/filter/index.html
+++ b/docs/static/v0.5/reference/mesheryctl/exp/filter/index.html
@@ -7,7 +7,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
 <meta name="generator" content="Hugo 0.55.6" />
 
-<META NAME="ROBOTS" CONTENT="INDEX, FOLLOW">
+<meta name="robots" content="noindex, follow" />
 
 <link rel="alternate" type="application/rss&#43;xml" href="/v0.5/index.xml">
 

--- a/docs/static/v0.5/reference/mesheryctl/exp/filter/list/index.html
+++ b/docs/static/v0.5/reference/mesheryctl/exp/filter/list/index.html
@@ -7,7 +7,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
 <meta name="generator" content="Hugo 0.55.6" />
 
-<META NAME="ROBOTS" CONTENT="INDEX, FOLLOW">
+<meta name="robots" content="noindex, follow" />
 
 <link rel="alternate" type="application/rss&#43;xml" href="/v0.5/index.xml">
 

--- a/docs/static/v0.5/reference/mesheryctl/exp/filter/view/index.html
+++ b/docs/static/v0.5/reference/mesheryctl/exp/filter/view/index.html
@@ -7,7 +7,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
 <meta name="generator" content="Hugo 0.55.6" />
 
-<META NAME="ROBOTS" CONTENT="INDEX, FOLLOW">
+<meta name="robots" content="noindex, follow" />
 
 <link rel="alternate" type="application/rss&#43;xml" href="/v0.5/index.xml">
 

--- a/docs/static/v0.5/reference/mesheryctl/exp/index.html
+++ b/docs/static/v0.5/reference/mesheryctl/exp/index.html
@@ -7,7 +7,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
 <meta name="generator" content="Hugo 0.55.6" />
 
-<META NAME="ROBOTS" CONTENT="INDEX, FOLLOW">
+<meta name="robots" content="noindex, follow" />
 
 <link rel="alternate" type="application/rss&#43;xml" href="/v0.5/index.xml">
 

--- a/docs/static/v0.5/reference/mesheryctl/index.html
+++ b/docs/static/v0.5/reference/mesheryctl/index.html
@@ -7,7 +7,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
 <meta name="generator" content="Hugo 0.55.6" />
 
-<META NAME="ROBOTS" CONTENT="INDEX, FOLLOW">
+<meta name="robots" content="noindex, follow" />
 
 <link rel="alternate" type="application/rss&#43;xml" href="/v0.5/index.xml">
 

--- a/docs/static/v0.5/reference/mesheryctl/mesh/deploy/index.html
+++ b/docs/static/v0.5/reference/mesheryctl/mesh/deploy/index.html
@@ -7,7 +7,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
 <meta name="generator" content="Hugo 0.55.6" />
 
-<META NAME="ROBOTS" CONTENT="INDEX, FOLLOW">
+<meta name="robots" content="noindex, follow" />
 
 <link rel="alternate" type="application/rss&#43;xml" href="/v0.5/index.xml">
 

--- a/docs/static/v0.5/reference/mesheryctl/mesh/index.html
+++ b/docs/static/v0.5/reference/mesheryctl/mesh/index.html
@@ -7,7 +7,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
 <meta name="generator" content="Hugo 0.55.6" />
 
-<META NAME="ROBOTS" CONTENT="INDEX, FOLLOW">
+<meta name="robots" content="noindex, follow" />
 
 <link rel="alternate" type="application/rss&#43;xml" href="/v0.5/index.xml">
 

--- a/docs/static/v0.5/reference/mesheryctl/mesh/remove/index.html
+++ b/docs/static/v0.5/reference/mesheryctl/mesh/remove/index.html
@@ -7,7 +7,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
 <meta name="generator" content="Hugo 0.55.6" />
 
-<META NAME="ROBOTS" CONTENT="INDEX, FOLLOW">
+<meta name="robots" content="noindex, follow" />
 
 <link rel="alternate" type="application/rss&#43;xml" href="/v0.5/index.xml">
 

--- a/docs/static/v0.5/reference/mesheryctl/mesh/validate/index.html
+++ b/docs/static/v0.5/reference/mesheryctl/mesh/validate/index.html
@@ -7,7 +7,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
 <meta name="generator" content="Hugo 0.55.6" />
 
-<META NAME="ROBOTS" CONTENT="INDEX, FOLLOW">
+<meta name="robots" content="noindex, follow" />
 
 <link rel="alternate" type="application/rss&#43;xml" href="/v0.5/index.xml">
 

--- a/docs/static/v0.5/reference/mesheryctl/pattern/apply/index.html
+++ b/docs/static/v0.5/reference/mesheryctl/pattern/apply/index.html
@@ -7,7 +7,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
 <meta name="generator" content="Hugo 0.55.6" />
 
-<META NAME="ROBOTS" CONTENT="INDEX, FOLLOW">
+<meta name="robots" content="noindex, follow" />
 
 <link rel="alternate" type="application/rss&#43;xml" href="/v0.5/index.xml">
 

--- a/docs/static/v0.5/reference/mesheryctl/pattern/delete/index.html
+++ b/docs/static/v0.5/reference/mesheryctl/pattern/delete/index.html
@@ -7,7 +7,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
 <meta name="generator" content="Hugo 0.55.6" />
 
-<META NAME="ROBOTS" CONTENT="INDEX, FOLLOW">
+<meta name="robots" content="noindex, follow" />
 
 <link rel="alternate" type="application/rss&#43;xml" href="/v0.5/index.xml">
 

--- a/docs/static/v0.5/reference/mesheryctl/pattern/index.html
+++ b/docs/static/v0.5/reference/mesheryctl/pattern/index.html
@@ -7,7 +7,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
 <meta name="generator" content="Hugo 0.55.6" />
 
-<META NAME="ROBOTS" CONTENT="INDEX, FOLLOW">
+<meta name="robots" content="noindex, follow" />
 
 <link rel="alternate" type="application/rss&#43;xml" href="/v0.5/index.xml">
 

--- a/docs/static/v0.5/reference/mesheryctl/pattern/list/index.html
+++ b/docs/static/v0.5/reference/mesheryctl/pattern/list/index.html
@@ -7,7 +7,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
 <meta name="generator" content="Hugo 0.55.6" />
 
-<META NAME="ROBOTS" CONTENT="INDEX, FOLLOW">
+<meta name="robots" content="noindex, follow" />
 
 <link rel="alternate" type="application/rss&#43;xml" href="/v0.5/index.xml">
 

--- a/docs/static/v0.5/reference/mesheryctl/pattern/view/index.html
+++ b/docs/static/v0.5/reference/mesheryctl/pattern/view/index.html
@@ -7,7 +7,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
 <meta name="generator" content="Hugo 0.55.6" />
 
-<META NAME="ROBOTS" CONTENT="INDEX, FOLLOW">
+<meta name="robots" content="noindex, follow" />
 
 <link rel="alternate" type="application/rss&#43;xml" href="/v0.5/index.xml">
 

--- a/docs/static/v0.5/reference/mesheryctl/perf/apply/index.html
+++ b/docs/static/v0.5/reference/mesheryctl/perf/apply/index.html
@@ -7,7 +7,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
 <meta name="generator" content="Hugo 0.55.6" />
 
-<META NAME="ROBOTS" CONTENT="INDEX, FOLLOW">
+<meta name="robots" content="noindex, follow" />
 
 <link rel="alternate" type="application/rss&#43;xml" href="/v0.5/index.xml">
 

--- a/docs/static/v0.5/reference/mesheryctl/perf/index.html
+++ b/docs/static/v0.5/reference/mesheryctl/perf/index.html
@@ -7,7 +7,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
 <meta name="generator" content="Hugo 0.55.6" />
 
-<META NAME="ROBOTS" CONTENT="INDEX, FOLLOW">
+<meta name="robots" content="noindex, follow" />
 
 <link rel="alternate" type="application/rss&#43;xml" href="/v0.5/index.xml">
 

--- a/docs/static/v0.5/reference/mesheryctl/perf/profile/index.html
+++ b/docs/static/v0.5/reference/mesheryctl/perf/profile/index.html
@@ -7,7 +7,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
 <meta name="generator" content="Hugo 0.55.6" />
 
-<META NAME="ROBOTS" CONTENT="INDEX, FOLLOW">
+<meta name="robots" content="noindex, follow" />
 
 <link rel="alternate" type="application/rss&#43;xml" href="/v0.5/index.xml">
 

--- a/docs/static/v0.5/reference/mesheryctl/perf/result/index.html
+++ b/docs/static/v0.5/reference/mesheryctl/perf/result/index.html
@@ -7,7 +7,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
 <meta name="generator" content="Hugo 0.55.6" />
 
-<META NAME="ROBOTS" CONTENT="INDEX, FOLLOW">
+<meta name="robots" content="noindex, follow" />
 
 <link rel="alternate" type="application/rss&#43;xml" href="/v0.5/index.xml">
 

--- a/docs/static/v0.5/reference/mesheryctl/system/channel/index.html
+++ b/docs/static/v0.5/reference/mesheryctl/system/channel/index.html
@@ -7,7 +7,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
 <meta name="generator" content="Hugo 0.55.6" />
 
-<META NAME="ROBOTS" CONTENT="INDEX, FOLLOW">
+<meta name="robots" content="noindex, follow" />
 
 <link rel="alternate" type="application/rss&#43;xml" href="/v0.5/index.xml">
 

--- a/docs/static/v0.5/reference/mesheryctl/system/channel/set/index.html
+++ b/docs/static/v0.5/reference/mesheryctl/system/channel/set/index.html
@@ -7,7 +7,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
 <meta name="generator" content="Hugo 0.55.6" />
 
-<META NAME="ROBOTS" CONTENT="INDEX, FOLLOW">
+<meta name="robots" content="noindex, follow" />
 
 <link rel="alternate" type="application/rss&#43;xml" href="/v0.5/index.xml">
 

--- a/docs/static/v0.5/reference/mesheryctl/system/channel/switch/index.html
+++ b/docs/static/v0.5/reference/mesheryctl/system/channel/switch/index.html
@@ -7,7 +7,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
 <meta name="generator" content="Hugo 0.55.6" />
 
-<META NAME="ROBOTS" CONTENT="INDEX, FOLLOW">
+<meta name="robots" content="noindex, follow" />
 
 <link rel="alternate" type="application/rss&#43;xml" href="/v0.5/index.xml">
 

--- a/docs/static/v0.5/reference/mesheryctl/system/channel/view/index.html
+++ b/docs/static/v0.5/reference/mesheryctl/system/channel/view/index.html
@@ -7,7 +7,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
 <meta name="generator" content="Hugo 0.55.6" />
 
-<META NAME="ROBOTS" CONTENT="INDEX, FOLLOW">
+<meta name="robots" content="noindex, follow" />
 
 <link rel="alternate" type="application/rss&#43;xml" href="/v0.5/index.xml">
 

--- a/docs/static/v0.5/reference/mesheryctl/system/check/index.html
+++ b/docs/static/v0.5/reference/mesheryctl/system/check/index.html
@@ -7,7 +7,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
 <meta name="generator" content="Hugo 0.55.6" />
 
-<META NAME="ROBOTS" CONTENT="INDEX, FOLLOW">
+<meta name="robots" content="noindex, follow" />
 
 <link rel="alternate" type="application/rss&#43;xml" href="/v0.5/index.xml">
 

--- a/docs/static/v0.5/reference/mesheryctl/system/completion/index.html
+++ b/docs/static/v0.5/reference/mesheryctl/system/completion/index.html
@@ -7,7 +7,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
 <meta name="generator" content="Hugo 0.55.6" />
 
-<META NAME="ROBOTS" CONTENT="INDEX, FOLLOW">
+<meta name="robots" content="noindex, follow" />
 
 <link rel="alternate" type="application/rss&#43;xml" href="/v0.5/index.xml">
 

--- a/docs/static/v0.5/reference/mesheryctl/system/context/create/index.html
+++ b/docs/static/v0.5/reference/mesheryctl/system/context/create/index.html
@@ -7,7 +7,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
 <meta name="generator" content="Hugo 0.55.6" />
 
-<META NAME="ROBOTS" CONTENT="INDEX, FOLLOW">
+<meta name="robots" content="noindex, follow" />
 
 <link rel="alternate" type="application/rss&#43;xml" href="/v0.5/index.xml">
 

--- a/docs/static/v0.5/reference/mesheryctl/system/context/delete/index.html
+++ b/docs/static/v0.5/reference/mesheryctl/system/context/delete/index.html
@@ -7,7 +7,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
 <meta name="generator" content="Hugo 0.55.6" />
 
-<META NAME="ROBOTS" CONTENT="INDEX, FOLLOW">
+<meta name="robots" content="noindex, follow" />
 
 <link rel="alternate" type="application/rss&#43;xml" href="/v0.5/index.xml">
 

--- a/docs/static/v0.5/reference/mesheryctl/system/context/index.html
+++ b/docs/static/v0.5/reference/mesheryctl/system/context/index.html
@@ -7,7 +7,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
 <meta name="generator" content="Hugo 0.55.6" />
 
-<META NAME="ROBOTS" CONTENT="INDEX, FOLLOW">
+<meta name="robots" content="noindex, follow" />
 
 <link rel="alternate" type="application/rss&#43;xml" href="/v0.5/index.xml">
 

--- a/docs/static/v0.5/reference/mesheryctl/system/context/list/index.html
+++ b/docs/static/v0.5/reference/mesheryctl/system/context/list/index.html
@@ -7,7 +7,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
 <meta name="generator" content="Hugo 0.55.6" />
 
-<META NAME="ROBOTS" CONTENT="INDEX, FOLLOW">
+<meta name="robots" content="noindex, follow" />
 
 <link rel="alternate" type="application/rss&#43;xml" href="/v0.5/index.xml">
 

--- a/docs/static/v0.5/reference/mesheryctl/system/context/switch/index.html
+++ b/docs/static/v0.5/reference/mesheryctl/system/context/switch/index.html
@@ -7,7 +7,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
 <meta name="generator" content="Hugo 0.55.6" />
 
-<META NAME="ROBOTS" CONTENT="INDEX, FOLLOW">
+<meta name="robots" content="noindex, follow" />
 
 <link rel="alternate" type="application/rss&#43;xml" href="/v0.5/index.xml">
 

--- a/docs/static/v0.5/reference/mesheryctl/system/context/view/index.html
+++ b/docs/static/v0.5/reference/mesheryctl/system/context/view/index.html
@@ -7,7 +7,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
 <meta name="generator" content="Hugo 0.55.6" />
 
-<META NAME="ROBOTS" CONTENT="INDEX, FOLLOW">
+<meta name="robots" content="noindex, follow" />
 
 <link rel="alternate" type="application/rss&#43;xml" href="/v0.5/index.xml">
 

--- a/docs/static/v0.5/reference/mesheryctl/system/dashboard/index.html
+++ b/docs/static/v0.5/reference/mesheryctl/system/dashboard/index.html
@@ -7,7 +7,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
 <meta name="generator" content="Hugo 0.55.6" />
 
-<META NAME="ROBOTS" CONTENT="INDEX, FOLLOW">
+<meta name="robots" content="noindex, follow" />
 
 <link rel="alternate" type="application/rss&#43;xml" href="/v0.5/index.xml">
 

--- a/docs/static/v0.5/reference/mesheryctl/system/index.html
+++ b/docs/static/v0.5/reference/mesheryctl/system/index.html
@@ -7,7 +7,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
 <meta name="generator" content="Hugo 0.55.6" />
 
-<META NAME="ROBOTS" CONTENT="INDEX, FOLLOW">
+<meta name="robots" content="noindex, follow" />
 
 <link rel="alternate" type="application/rss&#43;xml" href="/v0.5/index.xml">
 

--- a/docs/static/v0.5/reference/mesheryctl/system/login/index.html
+++ b/docs/static/v0.5/reference/mesheryctl/system/login/index.html
@@ -7,7 +7,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
 <meta name="generator" content="Hugo 0.55.6" />
 
-<META NAME="ROBOTS" CONTENT="INDEX, FOLLOW">
+<meta name="robots" content="noindex, follow" />
 
 <link rel="alternate" type="application/rss&#43;xml" href="/v0.5/index.xml">
 

--- a/docs/static/v0.5/reference/mesheryctl/system/logout/index.html
+++ b/docs/static/v0.5/reference/mesheryctl/system/logout/index.html
@@ -7,7 +7,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
 <meta name="generator" content="Hugo 0.55.6" />
 
-<META NAME="ROBOTS" CONTENT="INDEX, FOLLOW">
+<meta name="robots" content="noindex, follow" />
 
 <link rel="alternate" type="application/rss&#43;xml" href="/v0.5/index.xml">
 

--- a/docs/static/v0.5/reference/mesheryctl/system/logs/index.html
+++ b/docs/static/v0.5/reference/mesheryctl/system/logs/index.html
@@ -7,7 +7,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
 <meta name="generator" content="Hugo 0.55.6" />
 
-<META NAME="ROBOTS" CONTENT="INDEX, FOLLOW">
+<meta name="robots" content="noindex, follow" />
 
 <link rel="alternate" type="application/rss&#43;xml" href="/v0.5/index.xml">
 

--- a/docs/static/v0.5/reference/mesheryctl/system/reset/index.html
+++ b/docs/static/v0.5/reference/mesheryctl/system/reset/index.html
@@ -7,7 +7,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
 <meta name="generator" content="Hugo 0.55.6" />
 
-<META NAME="ROBOTS" CONTENT="INDEX, FOLLOW">
+<meta name="robots" content="noindex, follow" />
 
 <link rel="alternate" type="application/rss&#43;xml" href="/v0.5/index.xml">
 

--- a/docs/static/v0.5/reference/mesheryctl/system/restart/index.html
+++ b/docs/static/v0.5/reference/mesheryctl/system/restart/index.html
@@ -7,7 +7,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
 <meta name="generator" content="Hugo 0.55.6" />
 
-<META NAME="ROBOTS" CONTENT="INDEX, FOLLOW">
+<meta name="robots" content="noindex, follow" />
 
 <link rel="alternate" type="application/rss&#43;xml" href="/v0.5/index.xml">
 

--- a/docs/static/v0.5/reference/mesheryctl/system/start/index.html
+++ b/docs/static/v0.5/reference/mesheryctl/system/start/index.html
@@ -7,7 +7,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
 <meta name="generator" content="Hugo 0.55.6" />
 
-<META NAME="ROBOTS" CONTENT="INDEX, FOLLOW">
+<meta name="robots" content="noindex, follow" />
 
 <link rel="alternate" type="application/rss&#43;xml" href="/v0.5/index.xml">
 

--- a/docs/static/v0.5/reference/mesheryctl/system/status/index.html
+++ b/docs/static/v0.5/reference/mesheryctl/system/status/index.html
@@ -7,7 +7,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
 <meta name="generator" content="Hugo 0.55.6" />
 
-<META NAME="ROBOTS" CONTENT="INDEX, FOLLOW">
+<meta name="robots" content="noindex, follow" />
 
 <link rel="alternate" type="application/rss&#43;xml" href="/v0.5/index.xml">
 

--- a/docs/static/v0.5/reference/mesheryctl/system/stop/index.html
+++ b/docs/static/v0.5/reference/mesheryctl/system/stop/index.html
@@ -7,7 +7,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
 <meta name="generator" content="Hugo 0.55.6" />
 
-<META NAME="ROBOTS" CONTENT="INDEX, FOLLOW">
+<meta name="robots" content="noindex, follow" />
 
 <link rel="alternate" type="application/rss&#43;xml" href="/v0.5/index.xml">
 

--- a/docs/static/v0.5/reference/mesheryctl/system/token/create/index.html
+++ b/docs/static/v0.5/reference/mesheryctl/system/token/create/index.html
@@ -7,7 +7,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
 <meta name="generator" content="Hugo 0.55.6" />
 
-<META NAME="ROBOTS" CONTENT="INDEX, FOLLOW">
+<meta name="robots" content="noindex, follow" />
 
 <link rel="alternate" type="application/rss&#43;xml" href="/v0.5/index.xml">
 

--- a/docs/static/v0.5/reference/mesheryctl/system/token/delete/index.html
+++ b/docs/static/v0.5/reference/mesheryctl/system/token/delete/index.html
@@ -7,7 +7,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
 <meta name="generator" content="Hugo 0.55.6" />
 
-<META NAME="ROBOTS" CONTENT="INDEX, FOLLOW">
+<meta name="robots" content="noindex, follow" />
 
 <link rel="alternate" type="application/rss&#43;xml" href="/v0.5/index.xml">
 

--- a/docs/static/v0.5/reference/mesheryctl/system/token/index.html
+++ b/docs/static/v0.5/reference/mesheryctl/system/token/index.html
@@ -7,7 +7,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
 <meta name="generator" content="Hugo 0.55.6" />
 
-<META NAME="ROBOTS" CONTENT="INDEX, FOLLOW">
+<meta name="robots" content="noindex, follow" />
 
 <link rel="alternate" type="application/rss&#43;xml" href="/v0.5/index.xml">
 

--- a/docs/static/v0.5/reference/mesheryctl/system/token/list/index.html
+++ b/docs/static/v0.5/reference/mesheryctl/system/token/list/index.html
@@ -7,7 +7,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
 <meta name="generator" content="Hugo 0.55.6" />
 
-<META NAME="ROBOTS" CONTENT="INDEX, FOLLOW">
+<meta name="robots" content="noindex, follow" />
 
 <link rel="alternate" type="application/rss&#43;xml" href="/v0.5/index.xml">
 

--- a/docs/static/v0.5/reference/mesheryctl/system/token/set/index.html
+++ b/docs/static/v0.5/reference/mesheryctl/system/token/set/index.html
@@ -7,7 +7,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
 <meta name="generator" content="Hugo 0.55.6" />
 
-<META NAME="ROBOTS" CONTENT="INDEX, FOLLOW">
+<meta name="robots" content="noindex, follow" />
 
 <link rel="alternate" type="application/rss&#43;xml" href="/v0.5/index.xml">
 

--- a/docs/static/v0.5/reference/mesheryctl/system/token/view/index.html
+++ b/docs/static/v0.5/reference/mesheryctl/system/token/view/index.html
@@ -7,7 +7,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
 <meta name="generator" content="Hugo 0.55.6" />
 
-<META NAME="ROBOTS" CONTENT="INDEX, FOLLOW">
+<meta name="robots" content="noindex, follow" />
 
 <link rel="alternate" type="application/rss&#43;xml" href="/v0.5/index.xml">
 

--- a/docs/static/v0.5/reference/mesheryctl/system/update/index.html
+++ b/docs/static/v0.5/reference/mesheryctl/system/update/index.html
@@ -7,7 +7,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
 <meta name="generator" content="Hugo 0.55.6" />
 
-<META NAME="ROBOTS" CONTENT="INDEX, FOLLOW">
+<meta name="robots" content="noindex, follow" />
 
 <link rel="alternate" type="application/rss&#43;xml" href="/v0.5/index.xml">
 

--- a/docs/static/v0.5/reference/mesheryctl/version/index.html
+++ b/docs/static/v0.5/reference/mesheryctl/version/index.html
@@ -7,7 +7,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
 <meta name="generator" content="Hugo 0.55.6" />
 
-<META NAME="ROBOTS" CONTENT="INDEX, FOLLOW">
+<meta name="robots" content="noindex, follow" />
 
 <link rel="alternate" type="application/rss&#43;xml" href="/v0.5/index.xml">
 

--- a/docs/static/v0.5/reference/rest-apis/index.html
+++ b/docs/static/v0.5/reference/rest-apis/index.html
@@ -7,7 +7,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
 <meta name="generator" content="Hugo 0.55.6" />
 
-<META NAME="ROBOTS" CONTENT="INDEX, FOLLOW">
+<meta name="robots" content="noindex, follow" />
 
 <link rel="alternate" type="application/rss&#43;xml" href="/v0.5/index.xml">
 

--- a/docs/static/v0.5/search/index.html
+++ b/docs/static/v0.5/search/index.html
@@ -7,7 +7,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
 <meta name="generator" content="Hugo 0.55.6" />
 
-<META NAME="ROBOTS" CONTENT="INDEX, FOLLOW">
+<meta name="robots" content="noindex, follow" />
 
 <link rel="alternate" type="application/rss&#43;xml" href="/index.xml">
 

--- a/docs/static/v0.5/service-meshes/adapters/app-mesh/index.html
+++ b/docs/static/v0.5/service-meshes/adapters/app-mesh/index.html
@@ -7,7 +7,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
 <meta name="generator" content="Hugo 0.55.6" />
 
-<META NAME="ROBOTS" CONTENT="INDEX, FOLLOW">
+<meta name="robots" content="noindex, follow" />
 
 <link rel="alternate" type="application/rss&#43;xml" href="/v0.5/index.xml">
 

--- a/docs/static/v0.5/service-meshes/adapters/cilium/index.html
+++ b/docs/static/v0.5/service-meshes/adapters/cilium/index.html
@@ -7,7 +7,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
 <meta name="generator" content="Hugo 0.55.6" />
 
-<META NAME="ROBOTS" CONTENT="INDEX, FOLLOW">
+<meta name="robots" content="noindex, follow" />
 
 <link rel="alternate" type="application/rss&#43;xml" href="/v0.5/index.xml">
 

--- a/docs/static/v0.5/service-meshes/adapters/consul/index.html
+++ b/docs/static/v0.5/service-meshes/adapters/consul/index.html
@@ -7,7 +7,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
 <meta name="generator" content="Hugo 0.55.6" />
 
-<META NAME="ROBOTS" CONTENT="INDEX, FOLLOW">
+<meta name="robots" content="noindex, follow" />
 
 <link rel="alternate" type="application/rss&#43;xml" href="/v0.5/index.xml">
 

--- a/docs/static/v0.5/service-meshes/adapters/cpx/index.html
+++ b/docs/static/v0.5/service-meshes/adapters/cpx/index.html
@@ -7,7 +7,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
 <meta name="generator" content="Hugo 0.55.6" />
 
-<META NAME="ROBOTS" CONTENT="INDEX, FOLLOW">
+<meta name="robots" content="noindex, follow" />
 
 <link rel="alternate" type="application/rss&#43;xml" href="/v0.5/index.xml">
 

--- a/docs/static/v0.5/service-meshes/adapters/istio/index.html
+++ b/docs/static/v0.5/service-meshes/adapters/istio/index.html
@@ -7,7 +7,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
 <meta name="generator" content="Hugo 0.55.6" />
 
-<META NAME="ROBOTS" CONTENT="INDEX, FOLLOW">
+<meta name="robots" content="noindex, follow" />
 
 <link rel="alternate" type="application/rss&#43;xml" href="/v0.5/index.xml">
 

--- a/docs/static/v0.5/service-meshes/adapters/kuma/index.html
+++ b/docs/static/v0.5/service-meshes/adapters/kuma/index.html
@@ -7,7 +7,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
 <meta name="generator" content="Hugo 0.55.6" />
 
-<META NAME="ROBOTS" CONTENT="INDEX, FOLLOW">
+<meta name="robots" content="noindex, follow" />
 
 <link rel="alternate" type="application/rss&#43;xml" href="/v0.5/index.xml">
 

--- a/docs/static/v0.5/service-meshes/adapters/linkerd/index.html
+++ b/docs/static/v0.5/service-meshes/adapters/linkerd/index.html
@@ -7,7 +7,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
 <meta name="generator" content="Hugo 0.55.6" />
 
-<META NAME="ROBOTS" CONTENT="INDEX, FOLLOW">
+<meta name="robots" content="noindex, follow" />
 
 <link rel="alternate" type="application/rss&#43;xml" href="/v0.5/index.xml">
 

--- a/docs/static/v0.5/service-meshes/adapters/nginx-sm/index.html
+++ b/docs/static/v0.5/service-meshes/adapters/nginx-sm/index.html
@@ -7,7 +7,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
 <meta name="generator" content="Hugo 0.55.6" />
 
-<META NAME="ROBOTS" CONTENT="INDEX, FOLLOW">
+<meta name="robots" content="noindex, follow" />
 
 <link rel="alternate" type="application/rss&#43;xml" href="/v0.5/index.xml">
 

--- a/docs/static/v0.5/service-meshes/adapters/nsm/index.html
+++ b/docs/static/v0.5/service-meshes/adapters/nsm/index.html
@@ -7,7 +7,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
 <meta name="generator" content="Hugo 0.55.6" />
 
-<META NAME="ROBOTS" CONTENT="INDEX, FOLLOW">
+<meta name="robots" content="noindex, follow" />
 
 <link rel="alternate" type="application/rss&#43;xml" href="/v0.5/index.xml">
 

--- a/docs/static/v0.5/service-meshes/adapters/osm/index.html
+++ b/docs/static/v0.5/service-meshes/adapters/osm/index.html
@@ -7,7 +7,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
 <meta name="generator" content="Hugo 0.55.6" />
 
-<META NAME="ROBOTS" CONTENT="INDEX, FOLLOW">
+<meta name="robots" content="noindex, follow" />
 
 <link rel="alternate" type="application/rss&#43;xml" href="/v0.5/index.xml">
 

--- a/docs/static/v0.5/service-meshes/adapters/sofamesh/index.html
+++ b/docs/static/v0.5/service-meshes/adapters/sofamesh/index.html
@@ -7,7 +7,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
 <meta name="generator" content="Hugo 0.55.6" />
 
-<META NAME="ROBOTS" CONTENT="INDEX, FOLLOW">
+<meta name="robots" content="noindex, follow" />
 
 <link rel="alternate" type="application/rss&#43;xml" href="/v0.5/index.xml">
 

--- a/docs/static/v0.5/service-meshes/adapters/tanzu-sm/index.html
+++ b/docs/static/v0.5/service-meshes/adapters/tanzu-sm/index.html
@@ -7,7 +7,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
 <meta name="generator" content="Hugo 0.55.6" />
 
-<META NAME="ROBOTS" CONTENT="INDEX, FOLLOW">
+<meta name="robots" content="noindex, follow" />
 
 <link rel="alternate" type="application/rss&#43;xml" href="/v0.5/index.xml">
 

--- a/docs/static/v0.5/service-meshes/adapters/traefik-mesh/index.html
+++ b/docs/static/v0.5/service-meshes/adapters/traefik-mesh/index.html
@@ -7,7 +7,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
 <meta name="generator" content="Hugo 0.55.6" />
 
-<META NAME="ROBOTS" CONTENT="INDEX, FOLLOW">
+<meta name="robots" content="noindex, follow" />
 
 <link rel="alternate" type="application/rss&#43;xml" href="/v0.5/index.xml">
 

--- a/docs/static/v0.5/service-meshes/index.html
+++ b/docs/static/v0.5/service-meshes/index.html
@@ -7,7 +7,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
 <meta name="generator" content="Hugo 0.55.6" />
 
-<META NAME="ROBOTS" CONTENT="INDEX, FOLLOW">
+<meta name="robots" content="noindex, follow" />
 
 <link rel="alternate" type="application/rss&#43;xml" href="/v0.5/index.xml">
 

--- a/docs/static/v0.5/tags/index.html
+++ b/docs/static/v0.5/tags/index.html
@@ -7,7 +7,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
 <meta name="generator" content="Hugo 0.55.6" />
 
-<META NAME="ROBOTS" CONTENT="INDEX, FOLLOW">
+<meta name="robots" content="noindex, follow" />
 
 <link rel="alternate" type="application/rss&#43;xml" href="/index.xml">
 

--- a/docs/static/v0.6/404/index.html
+++ b/docs/static/v0.6/404/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.6/CONTRIBUTING-gitflow/index.html
+++ b/docs/static/v0.6/CONTRIBUTING-gitflow/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.6/archive/index.html
+++ b/docs/static/v0.6/archive/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.6/concepts/architecture/adapters/index.html
+++ b/docs/static/v0.6/concepts/architecture/adapters/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/v0.6/index.xml" />
 

--- a/docs/static/v0.6/concepts/architecture/broker/index.html
+++ b/docs/static/v0.6/concepts/architecture/broker/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/v0.6/index.xml" />
 

--- a/docs/static/v0.6/concepts/architecture/database/index.html
+++ b/docs/static/v0.6/concepts/architecture/database/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/v0.6/index.xml" />
 

--- a/docs/static/v0.6/concepts/architecture/index.html
+++ b/docs/static/v0.6/concepts/architecture/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/v0.6/index.xml" />
 

--- a/docs/static/v0.6/concepts/architecture/meshsync/index.html
+++ b/docs/static/v0.6/concepts/architecture/meshsync/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/v0.6/index.xml" />
 

--- a/docs/static/v0.6/concepts/architecture/operator/index.html
+++ b/docs/static/v0.6/concepts/architecture/operator/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/v0.6/index.xml" />
 

--- a/docs/static/v0.6/concepts/catalog/index.html
+++ b/docs/static/v0.6/concepts/catalog/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/v0.6/index.xml" />
 

--- a/docs/static/v0.6/concepts/components/index.html
+++ b/docs/static/v0.6/concepts/components/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/v0.6/index.xml" />
 

--- a/docs/static/v0.6/concepts/connections/index.html
+++ b/docs/static/v0.6/concepts/connections/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/v0.6/index.xml" />
 

--- a/docs/static/v0.6/concepts/credentials/index.html
+++ b/docs/static/v0.6/concepts/credentials/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/v0.6/index.xml" />
 

--- a/docs/static/v0.6/concepts/designs/index.html
+++ b/docs/static/v0.6/concepts/designs/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/v0.6/index.xml" />
 

--- a/docs/static/v0.6/concepts/environments/index.html
+++ b/docs/static/v0.6/concepts/environments/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/v0.6/index.xml" />
 

--- a/docs/static/v0.6/concepts/index.html
+++ b/docs/static/v0.6/concepts/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/v0.6/index.xml" />
 

--- a/docs/static/v0.6/concepts/logical/index.html
+++ b/docs/static/v0.6/concepts/logical/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/v0.6/index.xml" />
 

--- a/docs/static/v0.6/concepts/models/index.html
+++ b/docs/static/v0.6/concepts/models/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/v0.6/index.xml" />
 

--- a/docs/static/v0.6/concepts/policies/index.html
+++ b/docs/static/v0.6/concepts/policies/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/v0.6/index.xml" />
 

--- a/docs/static/v0.6/concepts/relationshps/index.html
+++ b/docs/static/v0.6/concepts/relationshps/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/v0.6/index.xml" />
 

--- a/docs/static/v0.6/concepts/workspaces/index.html
+++ b/docs/static/v0.6/concepts/workspaces/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/v0.6/index.xml" />
 

--- a/docs/static/v0.6/extensibility/adapters/index.html
+++ b/docs/static/v0.6/extensibility/adapters/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/v0.6/index.xml" />
 

--- a/docs/static/v0.6/extensibility/api/index.html
+++ b/docs/static/v0.6/extensibility/api/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/v0.6/index.xml" />
 

--- a/docs/static/v0.6/extensibility/index.html
+++ b/docs/static/v0.6/extensibility/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.6/extensibility/integrations/index.html
+++ b/docs/static/v0.6/extensibility/integrations/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/v0.6/index.xml" />
 

--- a/docs/static/v0.6/extensibility/load-generators/index.html
+++ b/docs/static/v0.6/extensibility/load-generators/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/v0.6/index.xml" />
 

--- a/docs/static/v0.6/extensibility/providers/index.html
+++ b/docs/static/v0.6/extensibility/providers/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/v0.6/index.xml" />
 

--- a/docs/static/v0.6/extensibility/ui/index.html
+++ b/docs/static/v0.6/extensibility/ui/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/v0.6/index.xml" />
 

--- a/docs/static/v0.6/extensions/component-shape-guide/index.html
+++ b/docs/static/v0.6/extensions/component-shape-guide/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.6/extensions/importing-a-design/index.html
+++ b/docs/static/v0.6/extensions/importing-a-design/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.6/extensions/importing-an-application/index.html
+++ b/docs/static/v0.6/extensions/importing-an-application/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.6/extensions/index.html
+++ b/docs/static/v0.6/extensions/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.6/extensions/merging-design/index.html
+++ b/docs/static/v0.6/extensions/merging-design/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.6/extensions/meshmap/index.html
+++ b/docs/static/v0.6/extensions/meshmap/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.6/extensions/publishing-a-design/index.html
+++ b/docs/static/v0.6/extensions/publishing-a-design/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.6/extensions/sharing-a-design/index.html
+++ b/docs/static/v0.6/extensions/sharing-a-design/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.6/extensions/snapshot/index.html
+++ b/docs/static/v0.6/extensions/snapshot/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.6/extensions/team-management/index.html
+++ b/docs/static/v0.6/extensions/team-management/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.6/getting-started/overview/index.html
+++ b/docs/static/v0.6/getting-started/overview/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/v0.6/index.xml" />
 

--- a/docs/static/v0.6/guides/configuration-management/index.html
+++ b/docs/static/v0.6/guides/configuration-management/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/v0.6/index.xml" />
 

--- a/docs/static/v0.6/guides/importing-apps/index.html
+++ b/docs/static/v0.6/guides/importing-apps/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/v0.6/index.xml" />
 

--- a/docs/static/v0.6/guides/index.html
+++ b/docs/static/v0.6/guides/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/v0.6/index.xml" />
 

--- a/docs/static/v0.6/guides/interpreting-performance-test-results/index.html
+++ b/docs/static/v0.6/guides/interpreting-performance-test-results/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/v0.6/index.xml" />
 

--- a/docs/static/v0.6/guides/meshery-design/index.html
+++ b/docs/static/v0.6/guides/meshery-design/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/v0.6/index.xml" />
 

--- a/docs/static/v0.6/guides/meshery-metrics/index.html
+++ b/docs/static/v0.6/guides/meshery-metrics/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/v0.6/index.xml" />
 

--- a/docs/static/v0.6/guides/mesheryctl/authenticate-with-meshery-via-cli/index.html
+++ b/docs/static/v0.6/guides/mesheryctl/authenticate-with-meshery-via-cli/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/v0.6/index.xml" />
 

--- a/docs/static/v0.6/guides/mesheryctl/configuring-autocompletion-for-mesheryctl/index.html
+++ b/docs/static/v0.6/guides/mesheryctl/configuring-autocompletion-for-mesheryctl/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/v0.6/index.xml" />
 

--- a/docs/static/v0.6/guides/mesheryctl/index.html
+++ b/docs/static/v0.6/guides/mesheryctl/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/v0.6/index.xml" />
 

--- a/docs/static/v0.6/guides/mesheryctl/running-system-checks-using-mesheryctl/index.html
+++ b/docs/static/v0.6/guides/mesheryctl/running-system-checks-using-mesheryctl/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/v0.6/index.xml" />
 

--- a/docs/static/v0.6/guides/mesheryctl/system-commands/index.html
+++ b/docs/static/v0.6/guides/mesheryctl/system-commands/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/v0.6/index.xml" />
 

--- a/docs/static/v0.6/guides/mesheryctl/working-with-mesheryctl/index.html
+++ b/docs/static/v0.6/guides/mesheryctl/working-with-mesheryctl/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/v0.6/index.xml" />
 

--- a/docs/static/v0.6/guides/multiple-adapters/index.html
+++ b/docs/static/v0.6/guides/multiple-adapters/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/v0.6/index.xml" />
 

--- a/docs/static/v0.6/guides/performance-management/index.html
+++ b/docs/static/v0.6/guides/performance-management/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/v0.6/index.xml" />
 

--- a/docs/static/v0.6/guides/pipelining-service-mesh-specifications/index.html
+++ b/docs/static/v0.6/guides/pipelining-service-mesh-specifications/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/v0.6/index.xml" />
 

--- a/docs/static/v0.6/guides/sample-apps/index.html
+++ b/docs/static/v0.6/guides/sample-apps/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/v0.6/index.xml" />
 

--- a/docs/static/v0.6/guides/smi-conformance/index.html
+++ b/docs/static/v0.6/guides/smi-conformance/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/v0.6/index.xml" />
 

--- a/docs/static/v0.6/guides/troubleshooting/index.html
+++ b/docs/static/v0.6/guides/troubleshooting/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/v0.6/index.xml" />
 

--- a/docs/static/v0.6/guides/troubleshooting/installation/index.html
+++ b/docs/static/v0.6/guides/troubleshooting/installation/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/v0.6/index.xml" />
 

--- a/docs/static/v0.6/guides/troubleshooting/running/index.html
+++ b/docs/static/v0.6/guides/troubleshooting/running/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/v0.6/index.xml" />
 

--- a/docs/static/v0.6/guides/upgrade/index.html
+++ b/docs/static/v0.6/guides/upgrade/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/v0.6/index.xml" />
 

--- a/docs/static/v0.6/installation/codespaces/index.html
+++ b/docs/static/v0.6/installation/codespaces/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.6/installation/compatibility-matrix/index.html
+++ b/docs/static/v0.6/installation/compatibility-matrix/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.6/installation/compatibility-matrix/meshery-cilium-past-results/index.html
+++ b/docs/static/v0.6/installation/compatibility-matrix/meshery-cilium-past-results/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.6/installation/compatibility-matrix/meshery-consul-past-results/index.html
+++ b/docs/static/v0.6/installation/compatibility-matrix/meshery-consul-past-results/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.6/installation/compatibility-matrix/meshery-istio-past-results/index.html
+++ b/docs/static/v0.6/installation/compatibility-matrix/meshery-istio-past-results/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.6/installation/compatibility-matrix/meshery-kuma-past-results/index.html
+++ b/docs/static/v0.6/installation/compatibility-matrix/meshery-kuma-past-results/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.6/installation/compatibility-matrix/meshery-linkerd-past-results/index.html
+++ b/docs/static/v0.6/installation/compatibility-matrix/meshery-linkerd-past-results/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.6/installation/compatibility-matrix/meshery-nginx-sm-past-results/index.html
+++ b/docs/static/v0.6/installation/compatibility-matrix/meshery-nginx-sm-past-results/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.6/installation/compatibility-matrix/meshery-osm-past-results/index.html
+++ b/docs/static/v0.6/installation/compatibility-matrix/meshery-osm-past-results/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.6/installation/compatibility-matrix/meshery-traefik-mesh-past-results/index.html
+++ b/docs/static/v0.6/installation/compatibility-matrix/meshery-traefik-mesh-past-results/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.6/installation/docker/docker-extension/index.html
+++ b/docs/static/v0.6/installation/docker/docker-extension/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.6/installation/docker/index.html
+++ b/docs/static/v0.6/installation/docker/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.6/installation/index.html
+++ b/docs/static/v0.6/installation/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/v0.6/index.xml" />
 

--- a/docs/static/v0.6/installation/kubernetes/aks/index.html
+++ b/docs/static/v0.6/installation/kubernetes/aks/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.6/installation/kubernetes/eks/index.html
+++ b/docs/static/v0.6/installation/kubernetes/eks/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.6/installation/kubernetes/gke/index.html
+++ b/docs/static/v0.6/installation/kubernetes/gke/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.6/installation/kubernetes/helm/index.html
+++ b/docs/static/v0.6/installation/kubernetes/helm/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.6/installation/kubernetes/index.html
+++ b/docs/static/v0.6/installation/kubernetes/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.6/installation/kubernetes/kind/index.html
+++ b/docs/static/v0.6/installation/kubernetes/kind/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.6/installation/kubernetes/minikube/index.html
+++ b/docs/static/v0.6/installation/kubernetes/minikube/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.6/installation/kubesphere/index.html
+++ b/docs/static/v0.6/installation/kubesphere/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.6/installation/linux-mac/bash/index.html
+++ b/docs/static/v0.6/installation/linux-mac/bash/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.6/installation/linux-mac/brew/index.html
+++ b/docs/static/v0.6/installation/linux-mac/brew/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.6/installation/linux-mac/index.html
+++ b/docs/static/v0.6/installation/linux-mac/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.6/installation/mesheryctl/index.html
+++ b/docs/static/v0.6/installation/mesheryctl/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.6/installation/quick-start/index.html
+++ b/docs/static/v0.6/installation/quick-start/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.6/installation/windows/index.html
+++ b/docs/static/v0.6/installation/windows/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.6/installation/windows/scoop/index.html
+++ b/docs/static/v0.6/installation/windows/scoop/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.6/news/index.html
+++ b/docs/static/v0.6/news/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/v0.6/index.xml" />
 

--- a/docs/static/v0.6/pages/extensions/mesheryCatalog/index.html
+++ b/docs/static/v0.6/pages/extensions/mesheryCatalog/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/v0.6/index.xml" />
 

--- a/docs/static/v0.6/pages/installation/compatibility-matrix/index.html
+++ b/docs/static/v0.6/pages/installation/compatibility-matrix/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/v0.6/index.xml" />
 

--- a/docs/static/v0.6/pages/project/mesheryctl/installation-bash/index.html
+++ b/docs/static/v0.6/pages/project/mesheryctl/installation-bash/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/v0.6/index.xml" />
 

--- a/docs/static/v0.6/pages/project/mesheryctl/installation-brew/index.html
+++ b/docs/static/v0.6/pages/project/mesheryctl/installation-brew/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/v0.6/index.xml" />
 

--- a/docs/static/v0.6/pages/project/mesheryctl/installation-scoop/index.html
+++ b/docs/static/v0.6/pages/project/mesheryctl/installation-scoop/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/v0.6/index.xml" />
 

--- a/docs/static/v0.6/playground/index.html
+++ b/docs/static/v0.6/playground/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/v0.6/index.xml" />
 

--- a/docs/static/v0.6/project/community/index.html
+++ b/docs/static/v0.6/project/community/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/v0.6/index.xml" />
 

--- a/docs/static/v0.6/project/contributing/build-and-release/index.html
+++ b/docs/static/v0.6/project/contributing/build-and-release/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/v0.6/index.xml" />
 

--- a/docs/static/v0.6/project/contributing/contributing-adapters/index.html
+++ b/docs/static/v0.6/project/contributing/contributing-adapters/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/v0.6/index.xml" />
 

--- a/docs/static/v0.6/project/contributing/contributing-cli-guide/index.html
+++ b/docs/static/v0.6/project/contributing/contributing-cli-guide/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/v0.6/index.xml" />
 

--- a/docs/static/v0.6/project/contributing/contributing-cli/index.html
+++ b/docs/static/v0.6/project/contributing/contributing-cli/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/v0.6/index.xml" />
 

--- a/docs/static/v0.6/project/contributing/contributing-cypress/index.html
+++ b/docs/static/v0.6/project/contributing/contributing-cypress/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/v0.6/index.xml" />
 

--- a/docs/static/v0.6/project/contributing/contributing-docker-extension/index.html
+++ b/docs/static/v0.6/project/contributing/contributing-docker-extension/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/v0.6/index.xml" />
 

--- a/docs/static/v0.6/project/contributing/contributing-docs/index.html
+++ b/docs/static/v0.6/project/contributing/contributing-docs/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/v0.6/index.xml" />
 

--- a/docs/static/v0.6/project/contributing/contributing-error/index.html
+++ b/docs/static/v0.6/project/contributing/contributing-error/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/v0.6/index.xml" />
 

--- a/docs/static/v0.6/project/contributing/contributing-gitflow/index.html
+++ b/docs/static/v0.6/project/contributing/contributing-gitflow/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/v0.6/index.xml" />
 

--- a/docs/static/v0.6/project/contributing/contributing-models/index.html
+++ b/docs/static/v0.6/project/contributing/contributing-models/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/v0.6/index.xml" />
 

--- a/docs/static/v0.6/project/contributing/contributing-server-events/index.html
+++ b/docs/static/v0.6/project/contributing/contributing-server-events/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/v0.6/index.xml" />
 

--- a/docs/static/v0.6/project/contributing/contributing-server/index.html
+++ b/docs/static/v0.6/project/contributing/contributing-server/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/v0.6/index.xml" />
 

--- a/docs/static/v0.6/project/contributing/contributing-ui-notification-center/index.html
+++ b/docs/static/v0.6/project/contributing/contributing-ui-notification-center/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/v0.6/index.xml" />
 

--- a/docs/static/v0.6/project/contributing/contributing-ui/index.html
+++ b/docs/static/v0.6/project/contributing/contributing-ui/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/v0.6/index.xml" />
 

--- a/docs/static/v0.6/project/contributing/index.html
+++ b/docs/static/v0.6/project/contributing/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/v0.6/index.xml" />
 

--- a/docs/static/v0.6/project/contributing/meshery-windows/index.html
+++ b/docs/static/v0.6/project/contributing/meshery-windows/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/v0.6/index.xml" />
 

--- a/docs/static/v0.6/project/faq/index.html
+++ b/docs/static/v0.6/project/faq/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/v0.6/index.xml" />
 

--- a/docs/static/v0.6/project/index.html
+++ b/docs/static/v0.6/project/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/v0.6/index.xml" />
 

--- a/docs/static/v0.6/project/overview/index.html
+++ b/docs/static/v0.6/project/overview/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/v0.6/index.xml" />
 

--- a/docs/static/v0.6/project/releases/index.html
+++ b/docs/static/v0.6/project/releases/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/v0.6/index.xml" />
 

--- a/docs/static/v0.6/project/releases/null/index.html
+++ b/docs/static/v0.6/project/releases/null/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.6/project/releases/v0.0.1/index.html
+++ b/docs/static/v0.6/project/releases/v0.0.1/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.6/project/releases/v0.0.2/index.html
+++ b/docs/static/v0.6/project/releases/v0.0.2/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/v0.6/index.xml" />
 

--- a/docs/static/v0.6/project/releases/v0.0.3/index.html
+++ b/docs/static/v0.6/project/releases/v0.0.3/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.6/project/releases/v0.0.4/index.html
+++ b/docs/static/v0.6/project/releases/v0.0.4/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/v0.6/index.xml" />
 

--- a/docs/static/v0.6/project/releases/v0.0.5/index.html
+++ b/docs/static/v0.6/project/releases/v0.0.5/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/v0.6/index.xml" />
 

--- a/docs/static/v0.6/project/releases/v0.0.6/index.html
+++ b/docs/static/v0.6/project/releases/v0.0.6/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.6/project/releases/v0.0.7/index.html
+++ b/docs/static/v0.6/project/releases/v0.0.7/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.6/project/releases/v0.0.8/index.html
+++ b/docs/static/v0.6/project/releases/v0.0.8/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/v0.6/index.xml" />
 

--- a/docs/static/v0.6/project/releases/v0.0.9/index.html
+++ b/docs/static/v0.6/project/releases/v0.0.9/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/v0.6/index.xml" />
 

--- a/docs/static/v0.6/project/releases/v0.1.0/index.html
+++ b/docs/static/v0.6/project/releases/v0.1.0/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/v0.6/index.xml" />
 

--- a/docs/static/v0.6/project/releases/v0.1.1/index.html
+++ b/docs/static/v0.6/project/releases/v0.1.1/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/v0.6/index.xml" />
 

--- a/docs/static/v0.6/project/releases/v0.1.2/index.html
+++ b/docs/static/v0.6/project/releases/v0.1.2/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.6/project/releases/v0.1.3/index.html
+++ b/docs/static/v0.6/project/releases/v0.1.3/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.6/project/releases/v0.1.4/index.html
+++ b/docs/static/v0.6/project/releases/v0.1.4/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.6/project/releases/v0.1.5/index.html
+++ b/docs/static/v0.6/project/releases/v0.1.5/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.6/project/releases/v0.1.6/index.html
+++ b/docs/static/v0.6/project/releases/v0.1.6/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/v0.6/index.xml" />
 

--- a/docs/static/v0.6/project/releases/v0.2.0/index.html
+++ b/docs/static/v0.6/project/releases/v0.2.0/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.6/project/releases/v0.2.1/index.html
+++ b/docs/static/v0.6/project/releases/v0.2.1/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.6/project/releases/v0.2.2/index.html
+++ b/docs/static/v0.6/project/releases/v0.2.2/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.6/project/releases/v0.2.3/index.html
+++ b/docs/static/v0.6/project/releases/v0.2.3/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/v0.6/index.xml" />
 

--- a/docs/static/v0.6/project/releases/v0.2.4/index.html
+++ b/docs/static/v0.6/project/releases/v0.2.4/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/v0.6/index.xml" />
 

--- a/docs/static/v0.6/project/releases/v0.3.1/index.html
+++ b/docs/static/v0.6/project/releases/v0.3.1/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/v0.6/index.xml" />
 

--- a/docs/static/v0.6/project/releases/v0.3.10/index.html
+++ b/docs/static/v0.6/project/releases/v0.3.10/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.6/project/releases/v0.3.11/index.html
+++ b/docs/static/v0.6/project/releases/v0.3.11/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.6/project/releases/v0.3.12/index.html
+++ b/docs/static/v0.6/project/releases/v0.3.12/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/v0.6/index.xml" />
 

--- a/docs/static/v0.6/project/releases/v0.3.13/index.html
+++ b/docs/static/v0.6/project/releases/v0.3.13/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.6/project/releases/v0.3.14/index.html
+++ b/docs/static/v0.6/project/releases/v0.3.14/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/v0.6/index.xml" />
 

--- a/docs/static/v0.6/project/releases/v0.3.15/index.html
+++ b/docs/static/v0.6/project/releases/v0.3.15/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/v0.6/index.xml" />
 

--- a/docs/static/v0.6/project/releases/v0.3.16/index.html
+++ b/docs/static/v0.6/project/releases/v0.3.16/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.6/project/releases/v0.3.17/index.html
+++ b/docs/static/v0.6/project/releases/v0.3.17/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.6/project/releases/v0.3.18/index.html
+++ b/docs/static/v0.6/project/releases/v0.3.18/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/v0.6/index.xml" />
 

--- a/docs/static/v0.6/project/releases/v0.3.19/index.html
+++ b/docs/static/v0.6/project/releases/v0.3.19/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/v0.6/index.xml" />
 

--- a/docs/static/v0.6/project/releases/v0.3.2/index.html
+++ b/docs/static/v0.6/project/releases/v0.3.2/index.html
@@ -8,7 +8,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.6/project/releases/v0.3.3/index.html
+++ b/docs/static/v0.6/project/releases/v0.3.3/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.6/project/releases/v0.3.4/index.html
+++ b/docs/static/v0.6/project/releases/v0.3.4/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.6/project/releases/v0.3.5/index.html
+++ b/docs/static/v0.6/project/releases/v0.3.5/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.6/project/releases/v0.3.6/index.html
+++ b/docs/static/v0.6/project/releases/v0.3.6/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.6/project/releases/v0.3.7/index.html
+++ b/docs/static/v0.6/project/releases/v0.3.7/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/v0.6/index.xml" />
 

--- a/docs/static/v0.6/project/releases/v0.3.8/index.html
+++ b/docs/static/v0.6/project/releases/v0.3.8/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.6/project/releases/v0.3.9/index.html
+++ b/docs/static/v0.6/project/releases/v0.3.9/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.6/project/releases/v0.4.0-beta.1/index.html
+++ b/docs/static/v0.6/project/releases/v0.4.0-beta.1/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.6/project/releases/v0.4.0-beta.2/index.html
+++ b/docs/static/v0.6/project/releases/v0.4.0-beta.2/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.6/project/releases/v0.4.0-beta.3/index.html
+++ b/docs/static/v0.6/project/releases/v0.4.0-beta.3/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/v0.6/index.xml" />
 

--- a/docs/static/v0.6/project/releases/v0.4.0-beta.4/index.html
+++ b/docs/static/v0.6/project/releases/v0.4.0-beta.4/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/v0.6/index.xml" />
 

--- a/docs/static/v0.6/project/releases/v0.4.1/index.html
+++ b/docs/static/v0.6/project/releases/v0.4.1/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.6/project/releases/v0.4.10/index.html
+++ b/docs/static/v0.6/project/releases/v0.4.10/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/v0.6/index.xml" />
 

--- a/docs/static/v0.6/project/releases/v0.4.11/index.html
+++ b/docs/static/v0.6/project/releases/v0.4.11/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/v0.6/index.xml" />
 

--- a/docs/static/v0.6/project/releases/v0.4.12/index.html
+++ b/docs/static/v0.6/project/releases/v0.4.12/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.6/project/releases/v0.4.13/index.html
+++ b/docs/static/v0.6/project/releases/v0.4.13/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.6/project/releases/v0.4.14/index.html
+++ b/docs/static/v0.6/project/releases/v0.4.14/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.6/project/releases/v0.4.15/index.html
+++ b/docs/static/v0.6/project/releases/v0.4.15/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.6/project/releases/v0.4.16/index.html
+++ b/docs/static/v0.6/project/releases/v0.4.16/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/v0.6/index.xml" />
 

--- a/docs/static/v0.6/project/releases/v0.4.17/index.html
+++ b/docs/static/v0.6/project/releases/v0.4.17/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.6/project/releases/v0.4.18/index.html
+++ b/docs/static/v0.6/project/releases/v0.4.18/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.6/project/releases/v0.4.19/index.html
+++ b/docs/static/v0.6/project/releases/v0.4.19/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.6/project/releases/v0.4.2/index.html
+++ b/docs/static/v0.6/project/releases/v0.4.2/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/v0.6/index.xml" />
 

--- a/docs/static/v0.6/project/releases/v0.4.20/index.html
+++ b/docs/static/v0.6/project/releases/v0.4.20/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.6/project/releases/v0.4.21/index.html
+++ b/docs/static/v0.6/project/releases/v0.4.21/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.6/project/releases/v0.4.22/index.html
+++ b/docs/static/v0.6/project/releases/v0.4.22/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.6/project/releases/v0.4.23/index.html
+++ b/docs/static/v0.6/project/releases/v0.4.23/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.6/project/releases/v0.4.24/index.html
+++ b/docs/static/v0.6/project/releases/v0.4.24/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.6/project/releases/v0.4.25/index.html
+++ b/docs/static/v0.6/project/releases/v0.4.25/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.6/project/releases/v0.4.26/index.html
+++ b/docs/static/v0.6/project/releases/v0.4.26/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/v0.6/index.xml" />
 

--- a/docs/static/v0.6/project/releases/v0.4.27/index.html
+++ b/docs/static/v0.6/project/releases/v0.4.27/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/v0.6/index.xml" />
 

--- a/docs/static/v0.6/project/releases/v0.4.3/index.html
+++ b/docs/static/v0.6/project/releases/v0.4.3/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/v0.6/index.xml" />
 

--- a/docs/static/v0.6/project/releases/v0.4.4/index.html
+++ b/docs/static/v0.6/project/releases/v0.4.4/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.6/project/releases/v0.4.5/index.html
+++ b/docs/static/v0.6/project/releases/v0.4.5/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/v0.6/index.xml" />
 

--- a/docs/static/v0.6/project/releases/v0.4.6/index.html
+++ b/docs/static/v0.6/project/releases/v0.4.6/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.6/project/releases/v0.4.7/index.html
+++ b/docs/static/v0.6/project/releases/v0.4.7/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.6/project/releases/v0.4.8/index.html
+++ b/docs/static/v0.6/project/releases/v0.4.8/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.6/project/releases/v0.4.9/index.html
+++ b/docs/static/v0.6/project/releases/v0.4.9/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.6/project/releases/v0.5.0-beta-1/index.html
+++ b/docs/static/v0.6/project/releases/v0.5.0-beta-1/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/v0.6/index.xml" />
 

--- a/docs/static/v0.6/project/releases/v0.5.0-beta-2/index.html
+++ b/docs/static/v0.6/project/releases/v0.5.0-beta-2/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.6/project/releases/v0.5.0-beta-3/index.html
+++ b/docs/static/v0.6/project/releases/v0.5.0-beta-3/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.6/project/releases/v0.5.0-beta-4/index.html
+++ b/docs/static/v0.6/project/releases/v0.5.0-beta-4/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.6/project/releases/v0.5.0-rc-1/index.html
+++ b/docs/static/v0.6/project/releases/v0.5.0-rc-1/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.6/project/releases/v0.5.0-rc-2/index.html
+++ b/docs/static/v0.6/project/releases/v0.5.0-rc-2/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.6/project/releases/v0.5.0-rc-3/index.html
+++ b/docs/static/v0.6/project/releases/v0.5.0-rc-3/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.6/project/releases/v0.5.0-rc-4/index.html
+++ b/docs/static/v0.6/project/releases/v0.5.0-rc-4/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/v0.6/index.xml" />
 

--- a/docs/static/v0.6/project/releases/v0.5.0-rc-5/index.html
+++ b/docs/static/v0.6/project/releases/v0.5.0-rc-5/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/v0.6/index.xml" />
 

--- a/docs/static/v0.6/project/releases/v0.5.0-rc-5g/index.html
+++ b/docs/static/v0.6/project/releases/v0.5.0-rc-5g/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.6/project/releases/v0.5.0-rc-6/index.html
+++ b/docs/static/v0.6/project/releases/v0.5.0-rc-6/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.6/project/releases/v0.5.0/index.html
+++ b/docs/static/v0.6/project/releases/v0.5.0/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.6/project/releases/v0.5.1/index.html
+++ b/docs/static/v0.6/project/releases/v0.5.1/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/v0.6/index.xml" />
 

--- a/docs/static/v0.6/project/releases/v0.5.10/index.html
+++ b/docs/static/v0.6/project/releases/v0.5.10/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/v0.6/index.xml" />
 

--- a/docs/static/v0.6/project/releases/v0.5.11/index.html
+++ b/docs/static/v0.6/project/releases/v0.5.11/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/v0.6/index.xml" />
 

--- a/docs/static/v0.6/project/releases/v0.5.12/index.html
+++ b/docs/static/v0.6/project/releases/v0.5.12/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.6/project/releases/v0.5.13/index.html
+++ b/docs/static/v0.6/project/releases/v0.5.13/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.6/project/releases/v0.5.14/index.html
+++ b/docs/static/v0.6/project/releases/v0.5.14/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.6/project/releases/v0.5.15/index.html
+++ b/docs/static/v0.6/project/releases/v0.5.15/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.6/project/releases/v0.5.16/index.html
+++ b/docs/static/v0.6/project/releases/v0.5.16/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.6/project/releases/v0.5.17/index.html
+++ b/docs/static/v0.6/project/releases/v0.5.17/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/v0.6/index.xml" />
 

--- a/docs/static/v0.6/project/releases/v0.5.18/index.html
+++ b/docs/static/v0.6/project/releases/v0.5.18/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.6/project/releases/v0.5.19/index.html
+++ b/docs/static/v0.6/project/releases/v0.5.19/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.6/project/releases/v0.5.2/index.html
+++ b/docs/static/v0.6/project/releases/v0.5.2/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.6/project/releases/v0.5.20/index.html
+++ b/docs/static/v0.6/project/releases/v0.5.20/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.6/project/releases/v0.5.21/index.html
+++ b/docs/static/v0.6/project/releases/v0.5.21/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.6/project/releases/v0.5.22/index.html
+++ b/docs/static/v0.6/project/releases/v0.5.22/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.6/project/releases/v0.5.23/index.html
+++ b/docs/static/v0.6/project/releases/v0.5.23/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.6/project/releases/v0.5.24/index.html
+++ b/docs/static/v0.6/project/releases/v0.5.24/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.6/project/releases/v0.5.25/index.html
+++ b/docs/static/v0.6/project/releases/v0.5.25/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.6/project/releases/v0.5.26/index.html
+++ b/docs/static/v0.6/project/releases/v0.5.26/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/v0.6/index.xml" />
 

--- a/docs/static/v0.6/project/releases/v0.5.27/index.html
+++ b/docs/static/v0.6/project/releases/v0.5.27/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/v0.6/index.xml" />
 

--- a/docs/static/v0.6/project/releases/v0.5.28/index.html
+++ b/docs/static/v0.6/project/releases/v0.5.28/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.6/project/releases/v0.5.29/index.html
+++ b/docs/static/v0.6/project/releases/v0.5.29/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.6/project/releases/v0.5.3/index.html
+++ b/docs/static/v0.6/project/releases/v0.5.3/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.6/project/releases/v0.5.30/index.html
+++ b/docs/static/v0.6/project/releases/v0.5.30/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/v0.6/index.xml" />
 

--- a/docs/static/v0.6/project/releases/v0.5.31/index.html
+++ b/docs/static/v0.6/project/releases/v0.5.31/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/v0.6/index.xml" />
 

--- a/docs/static/v0.6/project/releases/v0.5.32/index.html
+++ b/docs/static/v0.6/project/releases/v0.5.32/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.6/project/releases/v0.5.33/index.html
+++ b/docs/static/v0.6/project/releases/v0.5.33/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.6/project/releases/v0.5.34/index.html
+++ b/docs/static/v0.6/project/releases/v0.5.34/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.6/project/releases/v0.5.35/index.html
+++ b/docs/static/v0.6/project/releases/v0.5.35/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.6/project/releases/v0.5.36/index.html
+++ b/docs/static/v0.6/project/releases/v0.5.36/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.6/project/releases/v0.5.37/index.html
+++ b/docs/static/v0.6/project/releases/v0.5.37/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/v0.6/index.xml" />
 

--- a/docs/static/v0.6/project/releases/v0.5.38/index.html
+++ b/docs/static/v0.6/project/releases/v0.5.38/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.6/project/releases/v0.5.39/index.html
+++ b/docs/static/v0.6/project/releases/v0.5.39/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.6/project/releases/v0.5.4/index.html
+++ b/docs/static/v0.6/project/releases/v0.5.4/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.6/project/releases/v0.5.40/index.html
+++ b/docs/static/v0.6/project/releases/v0.5.40/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/v0.6/index.xml" />
 

--- a/docs/static/v0.6/project/releases/v0.5.41/index.html
+++ b/docs/static/v0.6/project/releases/v0.5.41/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.6/project/releases/v0.5.42/index.html
+++ b/docs/static/v0.6/project/releases/v0.5.42/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.6/project/releases/v0.5.43/index.html
+++ b/docs/static/v0.6/project/releases/v0.5.43/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.6/project/releases/v0.5.44/index.html
+++ b/docs/static/v0.6/project/releases/v0.5.44/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.6/project/releases/v0.5.45/index.html
+++ b/docs/static/v0.6/project/releases/v0.5.45/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.6/project/releases/v0.5.46/index.html
+++ b/docs/static/v0.6/project/releases/v0.5.46/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/v0.6/index.xml" />
 

--- a/docs/static/v0.6/project/releases/v0.5.47/index.html
+++ b/docs/static/v0.6/project/releases/v0.5.47/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/v0.6/index.xml" />
 

--- a/docs/static/v0.6/project/releases/v0.5.48/index.html
+++ b/docs/static/v0.6/project/releases/v0.5.48/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.6/project/releases/v0.5.49/index.html
+++ b/docs/static/v0.6/project/releases/v0.5.49/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.6/project/releases/v0.5.5/index.html
+++ b/docs/static/v0.6/project/releases/v0.5.5/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.6/project/releases/v0.5.50/index.html
+++ b/docs/static/v0.6/project/releases/v0.5.50/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/v0.6/index.xml" />
 

--- a/docs/static/v0.6/project/releases/v0.5.51/index.html
+++ b/docs/static/v0.6/project/releases/v0.5.51/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/v0.6/index.xml" />
 

--- a/docs/static/v0.6/project/releases/v0.5.52/index.html
+++ b/docs/static/v0.6/project/releases/v0.5.52/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.6/project/releases/v0.5.53/index.html
+++ b/docs/static/v0.6/project/releases/v0.5.53/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.6/project/releases/v0.5.54/index.html
+++ b/docs/static/v0.6/project/releases/v0.5.54/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.6/project/releases/v0.5.55/index.html
+++ b/docs/static/v0.6/project/releases/v0.5.55/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.6/project/releases/v0.5.56/index.html
+++ b/docs/static/v0.6/project/releases/v0.5.56/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/v0.6/index.xml" />
 

--- a/docs/static/v0.6/project/releases/v0.5.57/index.html
+++ b/docs/static/v0.6/project/releases/v0.5.57/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.6/project/releases/v0.5.58/index.html
+++ b/docs/static/v0.6/project/releases/v0.5.58/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.6/project/releases/v0.5.59/index.html
+++ b/docs/static/v0.6/project/releases/v0.5.59/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.6/project/releases/v0.5.6/index.html
+++ b/docs/static/v0.6/project/releases/v0.5.6/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/v0.6/index.xml" />
 

--- a/docs/static/v0.6/project/releases/v0.5.60/index.html
+++ b/docs/static/v0.6/project/releases/v0.5.60/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/v0.6/index.xml" />
 

--- a/docs/static/v0.6/project/releases/v0.5.61/index.html
+++ b/docs/static/v0.6/project/releases/v0.5.61/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.6/project/releases/v0.5.62/index.html
+++ b/docs/static/v0.6/project/releases/v0.5.62/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.6/project/releases/v0.5.63-rc-1/index.html
+++ b/docs/static/v0.6/project/releases/v0.5.63-rc-1/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.6/project/releases/v0.5.64-rc-2/index.html
+++ b/docs/static/v0.6/project/releases/v0.5.64-rc-2/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/v0.6/index.xml" />
 

--- a/docs/static/v0.6/project/releases/v0.5.64/index.html
+++ b/docs/static/v0.6/project/releases/v0.5.64/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.6/project/releases/v0.5.65/index.html
+++ b/docs/static/v0.6/project/releases/v0.5.65/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.6/project/releases/v0.5.66/index.html
+++ b/docs/static/v0.6/project/releases/v0.5.66/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/v0.6/index.xml" />
 

--- a/docs/static/v0.6/project/releases/v0.5.67/index.html
+++ b/docs/static/v0.6/project/releases/v0.5.67/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/v0.6/index.xml" />
 

--- a/docs/static/v0.6/project/releases/v0.5.68/index.html
+++ b/docs/static/v0.6/project/releases/v0.5.68/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.6/project/releases/v0.5.69/index.html
+++ b/docs/static/v0.6/project/releases/v0.5.69/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.6/project/releases/v0.5.7/index.html
+++ b/docs/static/v0.6/project/releases/v0.5.7/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/v0.6/index.xml" />
 

--- a/docs/static/v0.6/project/releases/v0.5.70/index.html
+++ b/docs/static/v0.6/project/releases/v0.5.70/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/v0.6/index.xml" />
 

--- a/docs/static/v0.6/project/releases/v0.5.71/index.html
+++ b/docs/static/v0.6/project/releases/v0.5.71/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/v0.6/index.xml" />
 

--- a/docs/static/v0.6/project/releases/v0.5.72/index.html
+++ b/docs/static/v0.6/project/releases/v0.5.72/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.6/project/releases/v0.5.8/index.html
+++ b/docs/static/v0.6/project/releases/v0.5.8/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.6/project/releases/v0.5.9/index.html
+++ b/docs/static/v0.6/project/releases/v0.5.9/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.6/project/releases/v0.6.0-rc-1/index.html
+++ b/docs/static/v0.6/project/releases/v0.6.0-rc-1/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.6/project/releases/v0.6.0-rc-2/index.html
+++ b/docs/static/v0.6/project/releases/v0.6.0-rc-2/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/v0.6/index.xml" />
 

--- a/docs/static/v0.6/project/releases/v0.6.0-rc-3/index.html
+++ b/docs/static/v0.6/project/releases/v0.6.0-rc-3/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/v0.6/index.xml" />
 

--- a/docs/static/v0.6/project/releases/v0.6.0-rc-4/index.html
+++ b/docs/static/v0.6/project/releases/v0.6.0-rc-4/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.6/project/releases/v0.6.0-rc-5/index.html
+++ b/docs/static/v0.6/project/releases/v0.6.0-rc-5/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/v0.6/index.xml" />
 

--- a/docs/static/v0.6/project/releases/v0.6.0-rc-5a/index.html
+++ b/docs/static/v0.6/project/releases/v0.6.0-rc-5a/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/v0.6/index.xml" />
 

--- a/docs/static/v0.6/project/releases/v0.6.0-rc-5b/index.html
+++ b/docs/static/v0.6/project/releases/v0.6.0-rc-5b/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.6/project/releases/v0.6.0-rc-5c/index.html
+++ b/docs/static/v0.6/project/releases/v0.6.0-rc-5c/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.6/project/releases/v0.6.0-rc-5d/index.html
+++ b/docs/static/v0.6/project/releases/v0.6.0-rc-5d/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.6/project/releases/v0.6.0-rc-5f/index.html
+++ b/docs/static/v0.6/project/releases/v0.6.0-rc-5f/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.6/project/releases/v0.6.0-rc-5g/index.html
+++ b/docs/static/v0.6/project/releases/v0.6.0-rc-5g/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.6/project/releases/v0.6.0-rc-5h/index.html
+++ b/docs/static/v0.6/project/releases/v0.6.0-rc-5h/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.6/project/releases/v0.6.0-rc-5i/index.html
+++ b/docs/static/v0.6/project/releases/v0.6.0-rc-5i/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.6/project/releases/v0.6.0-rc-5j/index.html
+++ b/docs/static/v0.6/project/releases/v0.6.0-rc-5j/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/v0.6/index.xml" />
 

--- a/docs/static/v0.6/project/releases/v0.6.0-rc-5t/index.html
+++ b/docs/static/v0.6/project/releases/v0.6.0-rc-5t/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/v0.6/index.xml" />
 

--- a/docs/static/v0.6/project/releases/v0.6.0-rc.5aa/index.html
+++ b/docs/static/v0.6/project/releases/v0.6.0-rc.5aa/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/v0.6/index.xml" />
 

--- a/docs/static/v0.6/project/releases/v0.6.0-rc.5k/index.html
+++ b/docs/static/v0.6/project/releases/v0.6.0-rc.5k/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.6/project/releases/v0.6.0-rc.5l/index.html
+++ b/docs/static/v0.6/project/releases/v0.6.0-rc.5l/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.6/project/releases/v0.6.0-rc.5m/index.html
+++ b/docs/static/v0.6/project/releases/v0.6.0-rc.5m/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.6/project/releases/v0.6.0-rc.5n/index.html
+++ b/docs/static/v0.6/project/releases/v0.6.0-rc.5n/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.6/project/releases/v0.6.0-rc.5o/index.html
+++ b/docs/static/v0.6/project/releases/v0.6.0-rc.5o/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/v0.6/index.xml" />
 

--- a/docs/static/v0.6/project/releases/v0.6.0-rc.5p/index.html
+++ b/docs/static/v0.6/project/releases/v0.6.0-rc.5p/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/v0.6/index.xml" />
 

--- a/docs/static/v0.6/project/releases/v0.6.0-rc.5q/index.html
+++ b/docs/static/v0.6/project/releases/v0.6.0-rc.5q/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/v0.6/index.xml" />
 

--- a/docs/static/v0.6/project/releases/v0.6.0-rc.5r/index.html
+++ b/docs/static/v0.6/project/releases/v0.6.0-rc.5r/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.6/project/releases/v0.6.0-rc.5s/index.html
+++ b/docs/static/v0.6/project/releases/v0.6.0-rc.5s/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.6/project/releases/v0.6.0-rc.5t/index.html
+++ b/docs/static/v0.6/project/releases/v0.6.0-rc.5t/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.6/project/releases/v0.6.0-rc.5u/index.html
+++ b/docs/static/v0.6/project/releases/v0.6.0-rc.5u/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.6/project/releases/v0.6.0-rc.5v/index.html
+++ b/docs/static/v0.6/project/releases/v0.6.0-rc.5v/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.6/project/releases/v0.6.0-rc.5w/index.html
+++ b/docs/static/v0.6/project/releases/v0.6.0-rc.5w/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.6/project/releases/v0.6.0-rc.5x/index.html
+++ b/docs/static/v0.6/project/releases/v0.6.0-rc.5x/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.6/project/releases/v0.6.0-rc.5y/index.html
+++ b/docs/static/v0.6/project/releases/v0.6.0-rc.5y/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.6/project/releases/v0.6.0-rc.5z/index.html
+++ b/docs/static/v0.6/project/releases/v0.6.0-rc.5z/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/v0.6/index.xml" />
 

--- a/docs/static/v0.6/project/releases/v0.6.0-rc.6/index.html
+++ b/docs/static/v0.6/project/releases/v0.6.0-rc.6/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.6/project/releases/v0.6.0-rc.6a/index.html
+++ b/docs/static/v0.6/project/releases/v0.6.0-rc.6a/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.6/project/releases/v0.6.0-rc.6b/index.html
+++ b/docs/static/v0.6/project/releases/v0.6.0-rc.6b/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/v0.6/index.xml" />
 

--- a/docs/static/v0.6/project/releases/v0.6.0-rc.6c/index.html
+++ b/docs/static/v0.6/project/releases/v0.6.0-rc.6c/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/v0.6/index.xml" />
 

--- a/docs/static/v0.6/project/releases/v0.6.0-rc.6d/index.html
+++ b/docs/static/v0.6/project/releases/v0.6.0-rc.6d/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.6/project/releases/v0.6.0-rc.6e/index.html
+++ b/docs/static/v0.6/project/releases/v0.6.0-rc.6e/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/v0.6/index.xml" />
 

--- a/docs/static/v0.6/project/releases/v0.6.0-rc.6f/index.html
+++ b/docs/static/v0.6/project/releases/v0.6.0-rc.6f/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.6/project/releases/v0.6.0-rc.6fa/index.html
+++ b/docs/static/v0.6/project/releases/v0.6.0-rc.6fa/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.6/project/releases/v0.6.0-rc.6fb/index.html
+++ b/docs/static/v0.6/project/releases/v0.6.0-rc.6fb/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/v0.6/index.xml" />
 

--- a/docs/static/v0.6/project/releases/v0.6.0-rc.6fc/index.html
+++ b/docs/static/v0.6/project/releases/v0.6.0-rc.6fc/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/v0.6/index.xml" />
 

--- a/docs/static/v0.6/project/releases/v0.6.0-rc.6fd/index.html
+++ b/docs/static/v0.6/project/releases/v0.6.0-rc.6fd/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.6/project/releases/v0.6.0-rc.6fe/index.html
+++ b/docs/static/v0.6/project/releases/v0.6.0-rc.6fe/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.6/project/releases/v0.6.0-rc.6ff/index.html
+++ b/docs/static/v0.6/project/releases/v0.6.0-rc.6ff/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.6/project/releases/v0.6.0/index.html
+++ b/docs/static/v0.6/project/releases/v0.6.0/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.6/project/releases/v0.6.10/index.html
+++ b/docs/static/v0.6/project/releases/v0.6.10/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.6/project/releases/v0.6.100/index.html
+++ b/docs/static/v0.6/project/releases/v0.6.100/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.6/project/releases/v0.6.102/index.html
+++ b/docs/static/v0.6/project/releases/v0.6.102/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.6/project/releases/v0.6.103/index.html
+++ b/docs/static/v0.6/project/releases/v0.6.103/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.6/project/releases/v0.6.104/index.html
+++ b/docs/static/v0.6/project/releases/v0.6.104/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.6/project/releases/v0.6.105/index.html
+++ b/docs/static/v0.6/project/releases/v0.6.105/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.6/project/releases/v0.6.107/index.html
+++ b/docs/static/v0.6/project/releases/v0.6.107/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/v0.6/index.xml" />
 

--- a/docs/static/v0.6/project/releases/v0.6.108/index.html
+++ b/docs/static/v0.6/project/releases/v0.6.108/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.6/project/releases/v0.6.109/index.html
+++ b/docs/static/v0.6/project/releases/v0.6.109/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.6/project/releases/v0.6.110/index.html
+++ b/docs/static/v0.6/project/releases/v0.6.110/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/v0.6/index.xml" />
 

--- a/docs/static/v0.6/project/releases/v0.6.111/index.html
+++ b/docs/static/v0.6/project/releases/v0.6.111/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/v0.6/index.xml" />
 

--- a/docs/static/v0.6/project/releases/v0.6.112/index.html
+++ b/docs/static/v0.6/project/releases/v0.6.112/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.6/project/releases/v0.6.113/index.html
+++ b/docs/static/v0.6/project/releases/v0.6.113/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.6/project/releases/v0.6.114/index.html
+++ b/docs/static/v0.6/project/releases/v0.6.114/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.6/project/releases/v0.6.115/index.html
+++ b/docs/static/v0.6/project/releases/v0.6.115/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.6/project/releases/v0.6.116/index.html
+++ b/docs/static/v0.6/project/releases/v0.6.116/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.6/project/releases/v0.6.117/index.html
+++ b/docs/static/v0.6/project/releases/v0.6.117/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.6/project/releases/v0.6.118/index.html
+++ b/docs/static/v0.6/project/releases/v0.6.118/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.6/project/releases/v0.6.119/index.html
+++ b/docs/static/v0.6/project/releases/v0.6.119/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.6/project/releases/v0.6.12/index.html
+++ b/docs/static/v0.6/project/releases/v0.6.12/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.6/project/releases/v0.6.120/index.html
+++ b/docs/static/v0.6/project/releases/v0.6.120/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.6/project/releases/v0.6.121/index.html
+++ b/docs/static/v0.6/project/releases/v0.6.121/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/v0.6/index.xml" />
 

--- a/docs/static/v0.6/project/releases/v0.6.122/index.html
+++ b/docs/static/v0.6/project/releases/v0.6.122/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.6/project/releases/v0.6.123/index.html
+++ b/docs/static/v0.6/project/releases/v0.6.123/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.6/project/releases/v0.6.124/index.html
+++ b/docs/static/v0.6/project/releases/v0.6.124/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.6/project/releases/v0.6.125/index.html
+++ b/docs/static/v0.6/project/releases/v0.6.125/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.6/project/releases/v0.6.126/index.html
+++ b/docs/static/v0.6/project/releases/v0.6.126/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/v0.6/index.xml" />
 

--- a/docs/static/v0.6/project/releases/v0.6.127/index.html
+++ b/docs/static/v0.6/project/releases/v0.6.127/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/v0.6/index.xml" />
 

--- a/docs/static/v0.6/project/releases/v0.6.128/index.html
+++ b/docs/static/v0.6/project/releases/v0.6.128/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.6/project/releases/v0.6.129/index.html
+++ b/docs/static/v0.6/project/releases/v0.6.129/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.6/project/releases/v0.6.13/index.html
+++ b/docs/static/v0.6/project/releases/v0.6.13/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.6/project/releases/v0.6.130/index.html
+++ b/docs/static/v0.6/project/releases/v0.6.130/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/v0.6/index.xml" />
 

--- a/docs/static/v0.6/project/releases/v0.6.131/index.html
+++ b/docs/static/v0.6/project/releases/v0.6.131/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/v0.6/index.xml" />
 

--- a/docs/static/v0.6/project/releases/v0.6.132/index.html
+++ b/docs/static/v0.6/project/releases/v0.6.132/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.6/project/releases/v0.6.133/index.html
+++ b/docs/static/v0.6/project/releases/v0.6.133/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.6/project/releases/v0.6.134/index.html
+++ b/docs/static/v0.6/project/releases/v0.6.134/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.6/project/releases/v0.6.135/index.html
+++ b/docs/static/v0.6/project/releases/v0.6.135/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.6/project/releases/v0.6.136/index.html
+++ b/docs/static/v0.6/project/releases/v0.6.136/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.6/project/releases/v0.6.137/index.html
+++ b/docs/static/v0.6/project/releases/v0.6.137/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/v0.6/index.xml" />
 

--- a/docs/static/v0.6/project/releases/v0.6.138/index.html
+++ b/docs/static/v0.6/project/releases/v0.6.138/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.6/project/releases/v0.6.139/index.html
+++ b/docs/static/v0.6/project/releases/v0.6.139/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.6/project/releases/v0.6.14/index.html
+++ b/docs/static/v0.6/project/releases/v0.6.14/index.html
@@ -9,7 +9,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.6/project/releases/v0.6.140/index.html
+++ b/docs/static/v0.6/project/releases/v0.6.140/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/v0.6/index.xml" />
 

--- a/docs/static/v0.6/project/releases/v0.6.141/index.html
+++ b/docs/static/v0.6/project/releases/v0.6.141/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.6/project/releases/v0.6.142/index.html
+++ b/docs/static/v0.6/project/releases/v0.6.142/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.6/project/releases/v0.6.143/index.html
+++ b/docs/static/v0.6/project/releases/v0.6.143/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.6/project/releases/v0.6.144/index.html
+++ b/docs/static/v0.6/project/releases/v0.6.144/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.6/project/releases/v0.6.145/index.html
+++ b/docs/static/v0.6/project/releases/v0.6.145/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.6/project/releases/v0.6.146/index.html
+++ b/docs/static/v0.6/project/releases/v0.6.146/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/v0.6/index.xml" />
 

--- a/docs/static/v0.6/project/releases/v0.6.147/index.html
+++ b/docs/static/v0.6/project/releases/v0.6.147/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/v0.6/index.xml" />
 

--- a/docs/static/v0.6/project/releases/v0.6.148/index.html
+++ b/docs/static/v0.6/project/releases/v0.6.148/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.6/project/releases/v0.6.149/index.html
+++ b/docs/static/v0.6/project/releases/v0.6.149/index.html
@@ -8,7 +8,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.6/project/releases/v0.6.15/index.html
+++ b/docs/static/v0.6/project/releases/v0.6.15/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.6/project/releases/v0.6.150/index.html
+++ b/docs/static/v0.6/project/releases/v0.6.150/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/v0.6/index.xml" />
 

--- a/docs/static/v0.6/project/releases/v0.6.151/index.html
+++ b/docs/static/v0.6/project/releases/v0.6.151/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/v0.6/index.xml" />
 

--- a/docs/static/v0.6/project/releases/v0.6.152/index.html
+++ b/docs/static/v0.6/project/releases/v0.6.152/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.6/project/releases/v0.6.153/index.html
+++ b/docs/static/v0.6/project/releases/v0.6.153/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.6/project/releases/v0.6.154/index.html
+++ b/docs/static/v0.6/project/releases/v0.6.154/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.6/project/releases/v0.6.155/index.html
+++ b/docs/static/v0.6/project/releases/v0.6.155/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.6/project/releases/v0.6.156/index.html
+++ b/docs/static/v0.6/project/releases/v0.6.156/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/v0.6/index.xml" />
 

--- a/docs/static/v0.6/project/releases/v0.6.157/index.html
+++ b/docs/static/v0.6/project/releases/v0.6.157/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.6/project/releases/v0.6.158/index.html
+++ b/docs/static/v0.6/project/releases/v0.6.158/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.6/project/releases/v0.6.159/index.html
+++ b/docs/static/v0.6/project/releases/v0.6.159/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.6/project/releases/v0.6.16/index.html
+++ b/docs/static/v0.6/project/releases/v0.6.16/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/v0.6/index.xml" />
 

--- a/docs/static/v0.6/project/releases/v0.6.160/index.html
+++ b/docs/static/v0.6/project/releases/v0.6.160/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/v0.6/index.xml" />
 

--- a/docs/static/v0.6/project/releases/v0.6.161/index.html
+++ b/docs/static/v0.6/project/releases/v0.6.161/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.6/project/releases/v0.6.162/index.html
+++ b/docs/static/v0.6/project/releases/v0.6.162/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.6/project/releases/v0.6.163/index.html
+++ b/docs/static/v0.6/project/releases/v0.6.163/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.6/project/releases/v0.6.17/index.html
+++ b/docs/static/v0.6/project/releases/v0.6.17/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/v0.6/index.xml" />
 

--- a/docs/static/v0.6/project/releases/v0.6.18/index.html
+++ b/docs/static/v0.6/project/releases/v0.6.18/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.6/project/releases/v0.6.19/index.html
+++ b/docs/static/v0.6/project/releases/v0.6.19/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.6/project/releases/v0.6.2/index.html
+++ b/docs/static/v0.6/project/releases/v0.6.2/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/v0.6/index.xml" />
 

--- a/docs/static/v0.6/project/releases/v0.6.20/index.html
+++ b/docs/static/v0.6/project/releases/v0.6.20/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/v0.6/index.xml" />
 

--- a/docs/static/v0.6/project/releases/v0.6.21/index.html
+++ b/docs/static/v0.6/project/releases/v0.6.21/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/v0.6/index.xml" />
 

--- a/docs/static/v0.6/project/releases/v0.6.22/index.html
+++ b/docs/static/v0.6/project/releases/v0.6.22/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.6/project/releases/v0.6.23/index.html
+++ b/docs/static/v0.6/project/releases/v0.6.23/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.6/project/releases/v0.6.24/index.html
+++ b/docs/static/v0.6/project/releases/v0.6.24/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.6/project/releases/v0.6.25/index.html
+++ b/docs/static/v0.6/project/releases/v0.6.25/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.6/project/releases/v0.6.26/index.html
+++ b/docs/static/v0.6/project/releases/v0.6.26/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.6/project/releases/v0.6.27/index.html
+++ b/docs/static/v0.6/project/releases/v0.6.27/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/v0.6/index.xml" />
 

--- a/docs/static/v0.6/project/releases/v0.6.28/index.html
+++ b/docs/static/v0.6/project/releases/v0.6.28/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.6/project/releases/v0.6.29/index.html
+++ b/docs/static/v0.6/project/releases/v0.6.29/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.6/project/releases/v0.6.3/index.html
+++ b/docs/static/v0.6/project/releases/v0.6.3/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/v0.6/index.xml" />
 

--- a/docs/static/v0.6/project/releases/v0.6.30/index.html
+++ b/docs/static/v0.6/project/releases/v0.6.30/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.6/project/releases/v0.6.31/index.html
+++ b/docs/static/v0.6/project/releases/v0.6.31/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.6/project/releases/v0.6.32/index.html
+++ b/docs/static/v0.6/project/releases/v0.6.32/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.6/project/releases/v0.6.33/index.html
+++ b/docs/static/v0.6/project/releases/v0.6.33/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.6/project/releases/v0.6.34/index.html
+++ b/docs/static/v0.6/project/releases/v0.6.34/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.6/project/releases/v0.6.35/index.html
+++ b/docs/static/v0.6/project/releases/v0.6.35/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.6/project/releases/v0.6.36/index.html
+++ b/docs/static/v0.6/project/releases/v0.6.36/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/v0.6/index.xml" />
 

--- a/docs/static/v0.6/project/releases/v0.6.37/index.html
+++ b/docs/static/v0.6/project/releases/v0.6.37/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/v0.6/index.xml" />
 

--- a/docs/static/v0.6/project/releases/v0.6.38/index.html
+++ b/docs/static/v0.6/project/releases/v0.6.38/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.6/project/releases/v0.6.39/index.html
+++ b/docs/static/v0.6/project/releases/v0.6.39/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.6/project/releases/v0.6.4/index.html
+++ b/docs/static/v0.6/project/releases/v0.6.4/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/v0.6/index.xml" />
 

--- a/docs/static/v0.6/project/releases/v0.6.40/index.html
+++ b/docs/static/v0.6/project/releases/v0.6.40/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/v0.6/index.xml" />
 

--- a/docs/static/v0.6/project/releases/v0.6.41/index.html
+++ b/docs/static/v0.6/project/releases/v0.6.41/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/v0.6/index.xml" />
 

--- a/docs/static/v0.6/project/releases/v0.6.42/index.html
+++ b/docs/static/v0.6/project/releases/v0.6.42/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.6/project/releases/v0.6.43/index.html
+++ b/docs/static/v0.6/project/releases/v0.6.43/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.6/project/releases/v0.6.44/index.html
+++ b/docs/static/v0.6/project/releases/v0.6.44/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.6/project/releases/v0.6.45/index.html
+++ b/docs/static/v0.6/project/releases/v0.6.45/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.6/project/releases/v0.6.46/index.html
+++ b/docs/static/v0.6/project/releases/v0.6.46/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/v0.6/index.xml" />
 

--- a/docs/static/v0.6/project/releases/v0.6.47/index.html
+++ b/docs/static/v0.6/project/releases/v0.6.47/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.6/project/releases/v0.6.48/index.html
+++ b/docs/static/v0.6/project/releases/v0.6.48/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.6/project/releases/v0.6.49/index.html
+++ b/docs/static/v0.6/project/releases/v0.6.49/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.6/project/releases/v0.6.5/index.html
+++ b/docs/static/v0.6/project/releases/v0.6.5/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.6/project/releases/v0.6.50/index.html
+++ b/docs/static/v0.6/project/releases/v0.6.50/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/v0.6/index.xml" />
 

--- a/docs/static/v0.6/project/releases/v0.6.51/index.html
+++ b/docs/static/v0.6/project/releases/v0.6.51/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.6/project/releases/v0.6.52/index.html
+++ b/docs/static/v0.6/project/releases/v0.6.52/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.6/project/releases/v0.6.53/index.html
+++ b/docs/static/v0.6/project/releases/v0.6.53/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.6/project/releases/v0.6.54/index.html
+++ b/docs/static/v0.6/project/releases/v0.6.54/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.6/project/releases/v0.6.55/index.html
+++ b/docs/static/v0.6/project/releases/v0.6.55/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.6/project/releases/v0.6.56/index.html
+++ b/docs/static/v0.6/project/releases/v0.6.56/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/v0.6/index.xml" />
 

--- a/docs/static/v0.6/project/releases/v0.6.57/index.html
+++ b/docs/static/v0.6/project/releases/v0.6.57/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/v0.6/index.xml" />
 

--- a/docs/static/v0.6/project/releases/v0.6.58/index.html
+++ b/docs/static/v0.6/project/releases/v0.6.58/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.6/project/releases/v0.6.59/index.html
+++ b/docs/static/v0.6/project/releases/v0.6.59/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.6/project/releases/v0.6.6/index.html
+++ b/docs/static/v0.6/project/releases/v0.6.6/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.6/project/releases/v0.6.61/index.html
+++ b/docs/static/v0.6/project/releases/v0.6.61/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/v0.6/index.xml" />
 

--- a/docs/static/v0.6/project/releases/v0.6.62/index.html
+++ b/docs/static/v0.6/project/releases/v0.6.62/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.6/project/releases/v0.6.63/index.html
+++ b/docs/static/v0.6/project/releases/v0.6.63/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.6/project/releases/v0.6.64/index.html
+++ b/docs/static/v0.6/project/releases/v0.6.64/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.6/project/releases/v0.6.65/index.html
+++ b/docs/static/v0.6/project/releases/v0.6.65/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.6/project/releases/v0.6.66/index.html
+++ b/docs/static/v0.6/project/releases/v0.6.66/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/v0.6/index.xml" />
 

--- a/docs/static/v0.6/project/releases/v0.6.67/index.html
+++ b/docs/static/v0.6/project/releases/v0.6.67/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.6/project/releases/v0.6.68/index.html
+++ b/docs/static/v0.6/project/releases/v0.6.68/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.6/project/releases/v0.6.69/index.html
+++ b/docs/static/v0.6/project/releases/v0.6.69/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.6/project/releases/v0.6.7/index.html
+++ b/docs/static/v0.6/project/releases/v0.6.7/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.6/project/releases/v0.6.70/index.html
+++ b/docs/static/v0.6/project/releases/v0.6.70/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/v0.6/index.xml" />
 

--- a/docs/static/v0.6/project/releases/v0.6.71/index.html
+++ b/docs/static/v0.6/project/releases/v0.6.71/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.6/project/releases/v0.6.72/index.html
+++ b/docs/static/v0.6/project/releases/v0.6.72/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.6/project/releases/v0.6.73/index.html
+++ b/docs/static/v0.6/project/releases/v0.6.73/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.6/project/releases/v0.6.74/index.html
+++ b/docs/static/v0.6/project/releases/v0.6.74/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.6/project/releases/v0.6.75/index.html
+++ b/docs/static/v0.6/project/releases/v0.6.75/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.6/project/releases/v0.6.76/index.html
+++ b/docs/static/v0.6/project/releases/v0.6.76/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/v0.6/index.xml" />
 

--- a/docs/static/v0.6/project/releases/v0.6.77/index.html
+++ b/docs/static/v0.6/project/releases/v0.6.77/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/v0.6/index.xml" />
 

--- a/docs/static/v0.6/project/releases/v0.6.78/index.html
+++ b/docs/static/v0.6/project/releases/v0.6.78/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.6/project/releases/v0.6.79/index.html
+++ b/docs/static/v0.6/project/releases/v0.6.79/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.6/project/releases/v0.6.8/index.html
+++ b/docs/static/v0.6/project/releases/v0.6.8/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.6/project/releases/v0.6.80/index.html
+++ b/docs/static/v0.6/project/releases/v0.6.80/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.6/project/releases/v0.6.81/index.html
+++ b/docs/static/v0.6/project/releases/v0.6.81/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.6/project/releases/v0.6.82/index.html
+++ b/docs/static/v0.6/project/releases/v0.6.82/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/v0.6/index.xml" />
 

--- a/docs/static/v0.6/project/releases/v0.6.83/index.html
+++ b/docs/static/v0.6/project/releases/v0.6.83/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/v0.6/index.xml" />
 

--- a/docs/static/v0.6/project/releases/v0.6.84/index.html
+++ b/docs/static/v0.6/project/releases/v0.6.84/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.6/project/releases/v0.6.85/index.html
+++ b/docs/static/v0.6/project/releases/v0.6.85/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/v0.6/index.xml" />
 

--- a/docs/static/v0.6/project/releases/v0.6.86/index.html
+++ b/docs/static/v0.6/project/releases/v0.6.86/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.6/project/releases/v0.6.87/index.html
+++ b/docs/static/v0.6/project/releases/v0.6.87/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.6/project/releases/v0.6.88/index.html
+++ b/docs/static/v0.6/project/releases/v0.6.88/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.6/project/releases/v0.6.89/index.html
+++ b/docs/static/v0.6/project/releases/v0.6.89/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/v0.6/index.xml" />
 

--- a/docs/static/v0.6/project/releases/v0.6.9/index.html
+++ b/docs/static/v0.6/project/releases/v0.6.9/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.6/project/releases/v0.6.90/index.html
+++ b/docs/static/v0.6/project/releases/v0.6.90/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.6/project/releases/v0.6.91/index.html
+++ b/docs/static/v0.6/project/releases/v0.6.91/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.6/project/releases/v0.6.92/index.html
+++ b/docs/static/v0.6/project/releases/v0.6.92/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.6/project/releases/v0.6.93/index.html
+++ b/docs/static/v0.6/project/releases/v0.6.93/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/v0.6/index.xml" />
 

--- a/docs/static/v0.6/project/releases/v0.6.94/index.html
+++ b/docs/static/v0.6/project/releases/v0.6.94/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/v0.6/index.xml" />
 

--- a/docs/static/v0.6/project/releases/v0.6.95/index.html
+++ b/docs/static/v0.6/project/releases/v0.6.95/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/v0.6/index.xml" />
 

--- a/docs/static/v0.6/project/releases/v0.6.96/index.html
+++ b/docs/static/v0.6/project/releases/v0.6.96/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.6/project/releases/v0.6.97/index.html
+++ b/docs/static/v0.6/project/releases/v0.6.97/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.6/project/releases/v0.6.98/index.html
+++ b/docs/static/v0.6/project/releases/v0.6.98/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/v0.6/index.xml" />
 

--- a/docs/static/v0.6/project/releases/v0.6.99/index.html
+++ b/docs/static/v0.6/project/releases/v0.6.99/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/v0.6/index.xml" />
 

--- a/docs/static/v0.6/project/security-vulnerabilities/index.html
+++ b/docs/static/v0.6/project/security-vulnerabilities/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/v0.6/index.xml" />
 

--- a/docs/static/v0.6/reference/error-codes/index.html
+++ b/docs/static/v0.6/reference/error-codes/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/v0.6/index.xml" />
 

--- a/docs/static/v0.6/reference/graphql-apis/index.html
+++ b/docs/static/v0.6/reference/graphql-apis/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/v0.6/index.xml" />
 

--- a/docs/static/v0.6/reference/index.html
+++ b/docs/static/v0.6/reference/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.6/reference/mesheryctl/app/import/index.html
+++ b/docs/static/v0.6/reference/mesheryctl/app/import/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/v0.6/index.xml" />
 

--- a/docs/static/v0.6/reference/mesheryctl/app/index.html
+++ b/docs/static/v0.6/reference/mesheryctl/app/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/v0.6/index.xml" />
 

--- a/docs/static/v0.6/reference/mesheryctl/app/list/index.html
+++ b/docs/static/v0.6/reference/mesheryctl/app/list/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/v0.6/index.xml" />
 

--- a/docs/static/v0.6/reference/mesheryctl/app/offboard/index.html
+++ b/docs/static/v0.6/reference/mesheryctl/app/offboard/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/v0.6/index.xml" />
 

--- a/docs/static/v0.6/reference/mesheryctl/app/onboard/index.html
+++ b/docs/static/v0.6/reference/mesheryctl/app/onboard/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/v0.6/index.xml" />
 

--- a/docs/static/v0.6/reference/mesheryctl/app/view/index.html
+++ b/docs/static/v0.6/reference/mesheryctl/app/view/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/v0.6/index.xml" />
 

--- a/docs/static/v0.6/reference/mesheryctl/completion/index.html
+++ b/docs/static/v0.6/reference/mesheryctl/completion/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/v0.6/index.xml" />
 

--- a/docs/static/v0.6/reference/mesheryctl/exp/filter/apply/index.html
+++ b/docs/static/v0.6/reference/mesheryctl/exp/filter/apply/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/v0.6/index.xml" />
 

--- a/docs/static/v0.6/reference/mesheryctl/exp/filter/delete/index.html
+++ b/docs/static/v0.6/reference/mesheryctl/exp/filter/delete/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/v0.6/index.xml" />
 

--- a/docs/static/v0.6/reference/mesheryctl/exp/filter/index.html
+++ b/docs/static/v0.6/reference/mesheryctl/exp/filter/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/v0.6/index.xml" />
 

--- a/docs/static/v0.6/reference/mesheryctl/exp/filter/list/index.html
+++ b/docs/static/v0.6/reference/mesheryctl/exp/filter/list/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/v0.6/index.xml" />
 

--- a/docs/static/v0.6/reference/mesheryctl/exp/filter/view/index.html
+++ b/docs/static/v0.6/reference/mesheryctl/exp/filter/view/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/v0.6/index.xml" />
 

--- a/docs/static/v0.6/reference/mesheryctl/exp/index.html
+++ b/docs/static/v0.6/reference/mesheryctl/exp/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/v0.6/index.xml" />
 

--- a/docs/static/v0.6/reference/mesheryctl/filter/delete/index.html
+++ b/docs/static/v0.6/reference/mesheryctl/filter/delete/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/v0.6/index.xml" />
 

--- a/docs/static/v0.6/reference/mesheryctl/filter/import/index.html
+++ b/docs/static/v0.6/reference/mesheryctl/filter/import/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/v0.6/index.xml" />
 

--- a/docs/static/v0.6/reference/mesheryctl/filter/index.html
+++ b/docs/static/v0.6/reference/mesheryctl/filter/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/v0.6/index.xml" />
 

--- a/docs/static/v0.6/reference/mesheryctl/filter/list/index.html
+++ b/docs/static/v0.6/reference/mesheryctl/filter/list/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/v0.6/index.xml" />
 

--- a/docs/static/v0.6/reference/mesheryctl/filter/view/index.html
+++ b/docs/static/v0.6/reference/mesheryctl/filter/view/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/v0.6/index.xml" />
 

--- a/docs/static/v0.6/reference/mesheryctl/index.html
+++ b/docs/static/v0.6/reference/mesheryctl/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/v0.6/index.xml" />
 

--- a/docs/static/v0.6/reference/mesheryctl/mesh/deploy/index.html
+++ b/docs/static/v0.6/reference/mesheryctl/mesh/deploy/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/v0.6/index.xml" />
 

--- a/docs/static/v0.6/reference/mesheryctl/mesh/index.html
+++ b/docs/static/v0.6/reference/mesheryctl/mesh/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/v0.6/index.xml" />
 

--- a/docs/static/v0.6/reference/mesheryctl/mesh/remove/index.html
+++ b/docs/static/v0.6/reference/mesheryctl/mesh/remove/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/v0.6/index.xml" />
 

--- a/docs/static/v0.6/reference/mesheryctl/mesh/validate/index.html
+++ b/docs/static/v0.6/reference/mesheryctl/mesh/validate/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/v0.6/index.xml" />
 

--- a/docs/static/v0.6/reference/mesheryctl/pattern/apply/index.html
+++ b/docs/static/v0.6/reference/mesheryctl/pattern/apply/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/v0.6/index.xml" />
 

--- a/docs/static/v0.6/reference/mesheryctl/pattern/delete/index.html
+++ b/docs/static/v0.6/reference/mesheryctl/pattern/delete/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/v0.6/index.xml" />
 

--- a/docs/static/v0.6/reference/mesheryctl/pattern/index.html
+++ b/docs/static/v0.6/reference/mesheryctl/pattern/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/v0.6/index.xml" />
 

--- a/docs/static/v0.6/reference/mesheryctl/pattern/list/index.html
+++ b/docs/static/v0.6/reference/mesheryctl/pattern/list/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/v0.6/index.xml" />
 

--- a/docs/static/v0.6/reference/mesheryctl/pattern/view/index.html
+++ b/docs/static/v0.6/reference/mesheryctl/pattern/view/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/v0.6/index.xml" />
 

--- a/docs/static/v0.6/reference/mesheryctl/perf/apply/index.html
+++ b/docs/static/v0.6/reference/mesheryctl/perf/apply/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/v0.6/index.xml" />
 

--- a/docs/static/v0.6/reference/mesheryctl/perf/index.html
+++ b/docs/static/v0.6/reference/mesheryctl/perf/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/v0.6/index.xml" />
 

--- a/docs/static/v0.6/reference/mesheryctl/perf/profile/index.html
+++ b/docs/static/v0.6/reference/mesheryctl/perf/profile/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/v0.6/index.xml" />
 

--- a/docs/static/v0.6/reference/mesheryctl/perf/result/index.html
+++ b/docs/static/v0.6/reference/mesheryctl/perf/result/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/v0.6/index.xml" />
 

--- a/docs/static/v0.6/reference/mesheryctl/system/channel/index.html
+++ b/docs/static/v0.6/reference/mesheryctl/system/channel/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/v0.6/index.xml" />
 

--- a/docs/static/v0.6/reference/mesheryctl/system/channel/set/index.html
+++ b/docs/static/v0.6/reference/mesheryctl/system/channel/set/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/v0.6/index.xml" />
 

--- a/docs/static/v0.6/reference/mesheryctl/system/channel/switch/index.html
+++ b/docs/static/v0.6/reference/mesheryctl/system/channel/switch/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/v0.6/index.xml" />
 

--- a/docs/static/v0.6/reference/mesheryctl/system/channel/view/index.html
+++ b/docs/static/v0.6/reference/mesheryctl/system/channel/view/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/v0.6/index.xml" />
 

--- a/docs/static/v0.6/reference/mesheryctl/system/check/index.html
+++ b/docs/static/v0.6/reference/mesheryctl/system/check/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/v0.6/index.xml" />
 

--- a/docs/static/v0.6/reference/mesheryctl/system/completion/index.html
+++ b/docs/static/v0.6/reference/mesheryctl/system/completion/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/v0.6/index.xml" />
 

--- a/docs/static/v0.6/reference/mesheryctl/system/context/create/index.html
+++ b/docs/static/v0.6/reference/mesheryctl/system/context/create/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/v0.6/index.xml" />
 

--- a/docs/static/v0.6/reference/mesheryctl/system/context/delete/index.html
+++ b/docs/static/v0.6/reference/mesheryctl/system/context/delete/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/v0.6/index.xml" />
 

--- a/docs/static/v0.6/reference/mesheryctl/system/context/index.html
+++ b/docs/static/v0.6/reference/mesheryctl/system/context/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/v0.6/index.xml" />
 

--- a/docs/static/v0.6/reference/mesheryctl/system/context/list/index.html
+++ b/docs/static/v0.6/reference/mesheryctl/system/context/list/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/v0.6/index.xml" />
 

--- a/docs/static/v0.6/reference/mesheryctl/system/context/switch/index.html
+++ b/docs/static/v0.6/reference/mesheryctl/system/context/switch/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/v0.6/index.xml" />
 

--- a/docs/static/v0.6/reference/mesheryctl/system/context/view/index.html
+++ b/docs/static/v0.6/reference/mesheryctl/system/context/view/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/v0.6/index.xml" />
 

--- a/docs/static/v0.6/reference/mesheryctl/system/dashboard/index.html
+++ b/docs/static/v0.6/reference/mesheryctl/system/dashboard/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/v0.6/index.xml" />
 

--- a/docs/static/v0.6/reference/mesheryctl/system/index.html
+++ b/docs/static/v0.6/reference/mesheryctl/system/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/v0.6/index.xml" />
 

--- a/docs/static/v0.6/reference/mesheryctl/system/login/index.html
+++ b/docs/static/v0.6/reference/mesheryctl/system/login/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/v0.6/index.xml" />
 

--- a/docs/static/v0.6/reference/mesheryctl/system/logout/index.html
+++ b/docs/static/v0.6/reference/mesheryctl/system/logout/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/v0.6/index.xml" />
 

--- a/docs/static/v0.6/reference/mesheryctl/system/logs/index.html
+++ b/docs/static/v0.6/reference/mesheryctl/system/logs/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/v0.6/index.xml" />
 

--- a/docs/static/v0.6/reference/mesheryctl/system/provider/index.html
+++ b/docs/static/v0.6/reference/mesheryctl/system/provider/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/v0.6/index.xml" />
 

--- a/docs/static/v0.6/reference/mesheryctl/system/provider/list/index.html
+++ b/docs/static/v0.6/reference/mesheryctl/system/provider/list/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/v0.6/index.xml" />
 

--- a/docs/static/v0.6/reference/mesheryctl/system/provider/reset/index.html
+++ b/docs/static/v0.6/reference/mesheryctl/system/provider/reset/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/v0.6/index.xml" />
 

--- a/docs/static/v0.6/reference/mesheryctl/system/provider/set/index.html
+++ b/docs/static/v0.6/reference/mesheryctl/system/provider/set/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/v0.6/index.xml" />
 

--- a/docs/static/v0.6/reference/mesheryctl/system/provider/switch/index.html
+++ b/docs/static/v0.6/reference/mesheryctl/system/provider/switch/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/v0.6/index.xml" />
 

--- a/docs/static/v0.6/reference/mesheryctl/system/provider/view/index.html
+++ b/docs/static/v0.6/reference/mesheryctl/system/provider/view/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/v0.6/index.xml" />
 

--- a/docs/static/v0.6/reference/mesheryctl/system/reset/index.html
+++ b/docs/static/v0.6/reference/mesheryctl/system/reset/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/v0.6/index.xml" />
 

--- a/docs/static/v0.6/reference/mesheryctl/system/restart/index.html
+++ b/docs/static/v0.6/reference/mesheryctl/system/restart/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/v0.6/index.xml" />
 

--- a/docs/static/v0.6/reference/mesheryctl/system/start/index.html
+++ b/docs/static/v0.6/reference/mesheryctl/system/start/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/v0.6/index.xml" />
 

--- a/docs/static/v0.6/reference/mesheryctl/system/status/index.html
+++ b/docs/static/v0.6/reference/mesheryctl/system/status/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/v0.6/index.xml" />
 

--- a/docs/static/v0.6/reference/mesheryctl/system/stop/index.html
+++ b/docs/static/v0.6/reference/mesheryctl/system/stop/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/v0.6/index.xml" />
 

--- a/docs/static/v0.6/reference/mesheryctl/system/token/create/index.html
+++ b/docs/static/v0.6/reference/mesheryctl/system/token/create/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/v0.6/index.xml" />
 

--- a/docs/static/v0.6/reference/mesheryctl/system/token/delete/index.html
+++ b/docs/static/v0.6/reference/mesheryctl/system/token/delete/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/v0.6/index.xml" />
 

--- a/docs/static/v0.6/reference/mesheryctl/system/token/index.html
+++ b/docs/static/v0.6/reference/mesheryctl/system/token/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/v0.6/index.xml" />
 

--- a/docs/static/v0.6/reference/mesheryctl/system/token/list/index.html
+++ b/docs/static/v0.6/reference/mesheryctl/system/token/list/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/v0.6/index.xml" />
 

--- a/docs/static/v0.6/reference/mesheryctl/system/token/set/index.html
+++ b/docs/static/v0.6/reference/mesheryctl/system/token/set/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/v0.6/index.xml" />
 

--- a/docs/static/v0.6/reference/mesheryctl/system/token/view/index.html
+++ b/docs/static/v0.6/reference/mesheryctl/system/token/view/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/v0.6/index.xml" />
 

--- a/docs/static/v0.6/reference/mesheryctl/system/update/index.html
+++ b/docs/static/v0.6/reference/mesheryctl/system/update/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/v0.6/index.xml" />
 

--- a/docs/static/v0.6/reference/mesheryctl/version/index.html
+++ b/docs/static/v0.6/reference/mesheryctl/version/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/v0.6/index.xml" />
 

--- a/docs/static/v0.6/reference/rest-apis/index.html
+++ b/docs/static/v0.6/reference/rest-apis/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/v0.6/index.xml" />
 

--- a/docs/static/v0.6/search/index.html
+++ b/docs/static/v0.6/search/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/v0.6/index.xml" />
 

--- a/docs/static/v0.6/service-meshes/adapters/app-mesh/index.html
+++ b/docs/static/v0.6/service-meshes/adapters/app-mesh/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/v0.6/index.xml" />
 

--- a/docs/static/v0.6/service-meshes/adapters/cilium/index.html
+++ b/docs/static/v0.6/service-meshes/adapters/cilium/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/v0.6/index.xml" />
 

--- a/docs/static/v0.6/service-meshes/adapters/consul/index.html
+++ b/docs/static/v0.6/service-meshes/adapters/consul/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/v0.6/index.xml" />
 

--- a/docs/static/v0.6/service-meshes/adapters/istio/index.html
+++ b/docs/static/v0.6/service-meshes/adapters/istio/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/v0.6/index.xml" />
 

--- a/docs/static/v0.6/service-meshes/adapters/kuma/index.html
+++ b/docs/static/v0.6/service-meshes/adapters/kuma/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/v0.6/index.xml" />
 

--- a/docs/static/v0.6/service-meshes/adapters/linkerd/index.html
+++ b/docs/static/v0.6/service-meshes/adapters/linkerd/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/v0.6/index.xml" />
 

--- a/docs/static/v0.6/service-meshes/adapters/nginx-sm/index.html
+++ b/docs/static/v0.6/service-meshes/adapters/nginx-sm/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/v0.6/index.xml" />
 

--- a/docs/static/v0.6/service-meshes/adapters/nsm/index.html
+++ b/docs/static/v0.6/service-meshes/adapters/nsm/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/v0.6/index.xml" />
 

--- a/docs/static/v0.6/service-meshes/adapters/osm/index.html
+++ b/docs/static/v0.6/service-meshes/adapters/osm/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/v0.6/index.xml" />
 

--- a/docs/static/v0.6/service-meshes/adapters/sofamesh/index.html
+++ b/docs/static/v0.6/service-meshes/adapters/sofamesh/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/v0.6/index.xml" />
 

--- a/docs/static/v0.6/service-meshes/adapters/tanzu-sm/index.html
+++ b/docs/static/v0.6/service-meshes/adapters/tanzu-sm/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/v0.6/index.xml" />
 

--- a/docs/static/v0.6/service-meshes/adapters/traefik-mesh/index.html
+++ b/docs/static/v0.6/service-meshes/adapters/traefik-mesh/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/v0.6/index.xml" />
 

--- a/docs/static/v0.6/service-meshes/index.html
+++ b/docs/static/v0.6/service-meshes/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.6/tags/index.html
+++ b/docs/static/v0.6/tags/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.6/tasks/accessing-meshery-ui/index.html
+++ b/docs/static/v0.6/tasks/accessing-meshery-ui/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/v0.6/index.xml" />
 

--- a/docs/static/v0.6/tasks/application-management/index.html
+++ b/docs/static/v0.6/tasks/application-management/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.6/tasks/filter-management/index.html
+++ b/docs/static/v0.6/tasks/filter-management/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.6/tasks/index.html
+++ b/docs/static/v0.6/tasks/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/v0.6/index.xml" />
 

--- a/docs/static/v0.6/tasks/lifecycle-management/index.html
+++ b/docs/static/v0.6/tasks/lifecycle-management/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.6/tasks/pattern-management/index.html
+++ b/docs/static/v0.6/tasks/pattern-management/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/v0.6/index.xml" />
 

--- a/docs/static/v0.6/tasks/performance-management/index.html
+++ b/docs/static/v0.6/tasks/performance-management/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.6/tasks/service-mesh-interface/index.html
+++ b/docs/static/v0.6/tasks/service-mesh-interface/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/v0.6/index.xml" />
 

--- a/docs/static/v0.7/404/index.html
+++ b/docs/static/v0.7/404/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/CONTRIBUTING-gitflow/index.html
+++ b/docs/static/v0.7/CONTRIBUTING-gitflow/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/concepts/architecture/adapters/index.html
+++ b/docs/static/v0.7/concepts/architecture/adapters/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/concepts/architecture/broker/index.html
+++ b/docs/static/v0.7/concepts/architecture/broker/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/concepts/architecture/database/index.html
+++ b/docs/static/v0.7/concepts/architecture/database/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/concepts/architecture/index.html
+++ b/docs/static/v0.7/concepts/architecture/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/concepts/architecture/meshsync/index.html
+++ b/docs/static/v0.7/concepts/architecture/meshsync/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/concepts/architecture/operator/index.html
+++ b/docs/static/v0.7/concepts/architecture/operator/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/concepts/catalog/index.html
+++ b/docs/static/v0.7/concepts/catalog/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/concepts/index.html
+++ b/docs/static/v0.7/concepts/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/concepts/logical/components/index.html
+++ b/docs/static/v0.7/concepts/logical/components/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/concepts/logical/connections/index.html
+++ b/docs/static/v0.7/concepts/logical/connections/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/concepts/logical/credentials/index.html
+++ b/docs/static/v0.7/concepts/logical/credentials/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/concepts/logical/designs/index.html
+++ b/docs/static/v0.7/concepts/logical/designs/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/concepts/logical/environments/index.html
+++ b/docs/static/v0.7/concepts/logical/environments/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/concepts/logical/index.html
+++ b/docs/static/v0.7/concepts/logical/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/concepts/logical/models/index.html
+++ b/docs/static/v0.7/concepts/logical/models/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/concepts/logical/patterns/index.html
+++ b/docs/static/v0.7/concepts/logical/patterns/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/concepts/logical/policies/index.html
+++ b/docs/static/v0.7/concepts/logical/policies/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/concepts/logical/registry/index.html
+++ b/docs/static/v0.7/concepts/logical/registry/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/concepts/logical/relationships/index.html
+++ b/docs/static/v0.7/concepts/logical/relationships/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/concepts/logical/workspaces/index.html
+++ b/docs/static/v0.7/concepts/logical/workspaces/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/extensibility/adapters/app-mesh/index.html
+++ b/docs/static/v0.7/extensibility/adapters/app-mesh/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/extensibility/adapters/cilium/index.html
+++ b/docs/static/v0.7/extensibility/adapters/cilium/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/extensibility/adapters/consul/index.html
+++ b/docs/static/v0.7/extensibility/adapters/consul/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/extensibility/adapters/index.html
+++ b/docs/static/v0.7/extensibility/adapters/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/extensibility/adapters/istio/index.html
+++ b/docs/static/v0.7/extensibility/adapters/istio/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/extensibility/adapters/kuma/index.html
+++ b/docs/static/v0.7/extensibility/adapters/kuma/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/extensibility/adapters/linkerd/index.html
+++ b/docs/static/v0.7/extensibility/adapters/linkerd/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/extensibility/adapters/nginx-sm/index.html
+++ b/docs/static/v0.7/extensibility/adapters/nginx-sm/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/extensibility/adapters/nighthawk/index.html
+++ b/docs/static/v0.7/extensibility/adapters/nighthawk/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/extensibility/adapters/nsm/index.html
+++ b/docs/static/v0.7/extensibility/adapters/nsm/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/extensibility/adapters/osm/index.html
+++ b/docs/static/v0.7/extensibility/adapters/osm/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/extensibility/adapters/tanzu-sm/index.html
+++ b/docs/static/v0.7/extensibility/adapters/tanzu-sm/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/extensibility/adapters/traefik-mesh/index.html
+++ b/docs/static/v0.7/extensibility/adapters/traefik-mesh/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/extensibility/api/index.html
+++ b/docs/static/v0.7/extensibility/api/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/extensibility/authorization/index.html
+++ b/docs/static/v0.7/extensibility/authorization/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/extensibility/index.html
+++ b/docs/static/v0.7/extensibility/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/extensibility/integrations/aad-pod-identity/index.html
+++ b/docs/static/v0.7/extensibility/integrations/aad-pod-identity/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/extensibility/integrations/accurate/index.html
+++ b/docs/static/v0.7/extensibility/integrations/accurate/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/extensibility/integrations/actions-runner-controller/index.html
+++ b/docs/static/v0.7/extensibility/integrations/actions-runner-controller/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/extensibility/integrations/admin-console-operator/index.html
+++ b/docs/static/v0.7/extensibility/integrations/admin-console-operator/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/extensibility/integrations/akri/index.html
+++ b/docs/static/v0.7/extensibility/integrations/akri/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/extensibility/integrations/aks-appgw-fe/index.html
+++ b/docs/static/v0.7/extensibility/integrations/aks-appgw-fe/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/extensibility/integrations/altinity-clickhouse-operator/index.html
+++ b/docs/static/v0.7/extensibility/integrations/altinity-clickhouse-operator/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/extensibility/integrations/ambassador/index.html
+++ b/docs/static/v0.7/extensibility/integrations/ambassador/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/extensibility/integrations/amd-gpu/index.html
+++ b/docs/static/v0.7/extensibility/integrations/amd-gpu/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/extensibility/integrations/antrea/index.html
+++ b/docs/static/v0.7/extensibility/integrations/antrea/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/extensibility/integrations/apache-shardingsphere-operator-charts/index.html
+++ b/docs/static/v0.7/extensibility/integrations/apache-shardingsphere-operator-charts/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/extensibility/integrations/aperture-agent/index.html
+++ b/docs/static/v0.7/extensibility/integrations/aperture-agent/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/extensibility/integrations/aperture-controller/index.html
+++ b/docs/static/v0.7/extensibility/integrations/aperture-controller/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/extensibility/integrations/apisix-ingress-controller/index.html
+++ b/docs/static/v0.7/extensibility/integrations/apisix-ingress-controller/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/extensibility/integrations/apisix/index.html
+++ b/docs/static/v0.7/extensibility/integrations/apisix/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/extensibility/integrations/appmesh-controller/index.html
+++ b/docs/static/v0.7/extensibility/integrations/appmesh-controller/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/extensibility/integrations/argo-cd/index.html
+++ b/docs/static/v0.7/extensibility/integrations/argo-cd/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/extensibility/integrations/argo-workflows/index.html
+++ b/docs/static/v0.7/extensibility/integrations/argo-workflows/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/extensibility/integrations/argocd-operator/index.html
+++ b/docs/static/v0.7/extensibility/integrations/argocd-operator/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/extensibility/integrations/armory-spinnaker-operator/index.html
+++ b/docs/static/v0.7/extensibility/integrations/armory-spinnaker-operator/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/extensibility/integrations/artifact-hub/index.html
+++ b/docs/static/v0.7/extensibility/integrations/artifact-hub/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/extensibility/integrations/athenz/index.html
+++ b/docs/static/v0.7/extensibility/integrations/athenz/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/extensibility/integrations/aws-api-gateway-operator/index.html
+++ b/docs/static/v0.7/extensibility/integrations/aws-api-gateway-operator/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/extensibility/integrations/aws-apigatewayv2-controller/index.html
+++ b/docs/static/v0.7/extensibility/integrations/aws-apigatewayv2-controller/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/extensibility/integrations/aws-applicationautoscaling-controller/index.html
+++ b/docs/static/v0.7/extensibility/integrations/aws-applicationautoscaling-controller/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/extensibility/integrations/aws-cloudfront-controller/index.html
+++ b/docs/static/v0.7/extensibility/integrations/aws-cloudfront-controller/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/extensibility/integrations/aws-cloudtrail-controller/index.html
+++ b/docs/static/v0.7/extensibility/integrations/aws-cloudtrail-controller/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/extensibility/integrations/aws-cloudwatch-controller/index.html
+++ b/docs/static/v0.7/extensibility/integrations/aws-cloudwatch-controller/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/extensibility/integrations/aws-cloudwatchlogs-controller/index.html
+++ b/docs/static/v0.7/extensibility/integrations/aws-cloudwatchlogs-controller/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/extensibility/integrations/aws-documentdb-controller/index.html
+++ b/docs/static/v0.7/extensibility/integrations/aws-documentdb-controller/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/extensibility/integrations/aws-dynamodb-controller/index.html
+++ b/docs/static/v0.7/extensibility/integrations/aws-dynamodb-controller/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/extensibility/integrations/aws-ec2-controller/index.html
+++ b/docs/static/v0.7/extensibility/integrations/aws-ec2-controller/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/extensibility/integrations/aws-ecr-controller/index.html
+++ b/docs/static/v0.7/extensibility/integrations/aws-ecr-controller/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/extensibility/integrations/aws-ecs-controller/index.html
+++ b/docs/static/v0.7/extensibility/integrations/aws-ecs-controller/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/extensibility/integrations/aws-efs-controller/index.html
+++ b/docs/static/v0.7/extensibility/integrations/aws-efs-controller/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/extensibility/integrations/aws-eks-controller/index.html
+++ b/docs/static/v0.7/extensibility/integrations/aws-eks-controller/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/extensibility/integrations/aws-elasticache-controller/index.html
+++ b/docs/static/v0.7/extensibility/integrations/aws-elasticache-controller/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/extensibility/integrations/aws-elasticsearchservice-controller/index.html
+++ b/docs/static/v0.7/extensibility/integrations/aws-elasticsearchservice-controller/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/extensibility/integrations/aws-emrcontainers-controller/index.html
+++ b/docs/static/v0.7/extensibility/integrations/aws-emrcontainers-controller/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/extensibility/integrations/aws-eventbridge-controller/index.html
+++ b/docs/static/v0.7/extensibility/integrations/aws-eventbridge-controller/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/extensibility/integrations/aws-iam-controller/index.html
+++ b/docs/static/v0.7/extensibility/integrations/aws-iam-controller/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/extensibility/integrations/aws-kinesis-controller/index.html
+++ b/docs/static/v0.7/extensibility/integrations/aws-kinesis-controller/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/extensibility/integrations/aws-kms-controller/index.html
+++ b/docs/static/v0.7/extensibility/integrations/aws-kms-controller/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/extensibility/integrations/aws-lambda-controller/index.html
+++ b/docs/static/v0.7/extensibility/integrations/aws-lambda-controller/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/extensibility/integrations/aws-load-balancer-controller/index.html
+++ b/docs/static/v0.7/extensibility/integrations/aws-load-balancer-controller/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/extensibility/integrations/aws-memorydb-controller/index.html
+++ b/docs/static/v0.7/extensibility/integrations/aws-memorydb-controller/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/extensibility/integrations/aws-mq-controller/index.html
+++ b/docs/static/v0.7/extensibility/integrations/aws-mq-controller/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/extensibility/integrations/aws-node-termination-handler-2/index.html
+++ b/docs/static/v0.7/extensibility/integrations/aws-node-termination-handler-2/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/extensibility/integrations/aws-prometheusservice-controller/index.html
+++ b/docs/static/v0.7/extensibility/integrations/aws-prometheusservice-controller/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/extensibility/integrations/aws-rds-controller/index.html
+++ b/docs/static/v0.7/extensibility/integrations/aws-rds-controller/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/extensibility/integrations/aws-route53-controller/index.html
+++ b/docs/static/v0.7/extensibility/integrations/aws-route53-controller/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/extensibility/integrations/aws-route53resolver-controller/index.html
+++ b/docs/static/v0.7/extensibility/integrations/aws-route53resolver-controller/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/extensibility/integrations/aws-s3-controller/index.html
+++ b/docs/static/v0.7/extensibility/integrations/aws-s3-controller/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/extensibility/integrations/aws-sagemaker-controller/index.html
+++ b/docs/static/v0.7/extensibility/integrations/aws-sagemaker-controller/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/extensibility/integrations/aws-secretsmanager-controller/index.html
+++ b/docs/static/v0.7/extensibility/integrations/aws-secretsmanager-controller/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/extensibility/integrations/aws-sfn-controller/index.html
+++ b/docs/static/v0.7/extensibility/integrations/aws-sfn-controller/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/extensibility/integrations/aws-sns-controller/index.html
+++ b/docs/static/v0.7/extensibility/integrations/aws-sns-controller/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/extensibility/integrations/aws-target-group-binding/index.html
+++ b/docs/static/v0.7/extensibility/integrations/aws-target-group-binding/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/extensibility/integrations/aws-vpc-cni/index.html
+++ b/docs/static/v0.7/extensibility/integrations/aws-vpc-cni/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/extensibility/integrations/aws/index.html
+++ b/docs/static/v0.7/extensibility/integrations/aws/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/extensibility/integrations/awx-operator/index.html
+++ b/docs/static/v0.7/extensibility/integrations/awx-operator/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/extensibility/integrations/azureorkestra/index.html
+++ b/docs/static/v0.7/extensibility/integrations/azureorkestra/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/extensibility/integrations/backstage/index.html
+++ b/docs/static/v0.7/extensibility/integrations/backstage/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/extensibility/integrations/bfe/index.html
+++ b/docs/static/v0.7/extensibility/integrations/bfe/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/extensibility/integrations/bitwarden-crd-operator/index.html
+++ b/docs/static/v0.7/extensibility/integrations/bitwarden-crd-operator/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/extensibility/integrations/brigade/index.html
+++ b/docs/static/v0.7/extensibility/integrations/brigade/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/extensibility/integrations/buildpacks/index.html
+++ b/docs/static/v0.7/extensibility/integrations/buildpacks/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/extensibility/integrations/camel-k/index.html
+++ b/docs/static/v0.7/extensibility/integrations/camel-k/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/extensibility/integrations/capsule-proxy/index.html
+++ b/docs/static/v0.7/extensibility/integrations/capsule-proxy/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/extensibility/integrations/cass-operator/index.html
+++ b/docs/static/v0.7/extensibility/integrations/cass-operator/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/extensibility/integrations/cd-pipeline-operator/index.html
+++ b/docs/static/v0.7/extensibility/integrations/cd-pipeline-operator/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/extensibility/integrations/cdk8s/index.html
+++ b/docs/static/v0.7/extensibility/integrations/cdk8s/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/extensibility/integrations/cert-manager-crds/index.html
+++ b/docs/static/v0.7/extensibility/integrations/cert-manager-crds/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/extensibility/integrations/cert-manager-csi-driver-cacerts/index.html
+++ b/docs/static/v0.7/extensibility/integrations/cert-manager-csi-driver-cacerts/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/extensibility/integrations/cert-manager/index.html
+++ b/docs/static/v0.7/extensibility/integrations/cert-manager/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/extensibility/integrations/chaos-mesh/index.html
+++ b/docs/static/v0.7/extensibility/integrations/chaos-mesh/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/extensibility/integrations/chaos/index.html
+++ b/docs/static/v0.7/extensibility/integrations/chaos/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/extensibility/integrations/chaosblade-operator/index.html
+++ b/docs/static/v0.7/extensibility/integrations/chaosblade-operator/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/extensibility/integrations/cilium/index.html
+++ b/docs/static/v0.7/extensibility/integrations/cilium/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/extensibility/integrations/clickhouse/index.html
+++ b/docs/static/v0.7/extensibility/integrations/clickhouse/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/extensibility/integrations/cloud-custodian/index.html
+++ b/docs/static/v0.7/extensibility/integrations/cloud-custodian/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/extensibility/integrations/cloudbees-previews/index.html
+++ b/docs/static/v0.7/extensibility/integrations/cloudbees-previews/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/extensibility/integrations/cloudcore/index.html
+++ b/docs/static/v0.7/extensibility/integrations/cloudcore/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/extensibility/integrations/cloudevents/index.html
+++ b/docs/static/v0.7/extensibility/integrations/cloudevents/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/extensibility/integrations/cloudnative-pg/index.html
+++ b/docs/static/v0.7/extensibility/integrations/cloudnative-pg/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/extensibility/integrations/cluster-api-provider-openstack/index.html
+++ b/docs/static/v0.7/extensibility/integrations/cluster-api-provider-openstack/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/extensibility/integrations/clusterpedia/index.html
+++ b/docs/static/v0.7/extensibility/integrations/clusterpedia/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/extensibility/integrations/cni-hostnic/index.html
+++ b/docs/static/v0.7/extensibility/integrations/cni-hostnic/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/extensibility/integrations/cockroachdb-operator/index.html
+++ b/docs/static/v0.7/extensibility/integrations/cockroachdb-operator/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/extensibility/integrations/confidential-containers/index.html
+++ b/docs/static/v0.7/extensibility/integrations/confidential-containers/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/extensibility/integrations/consul/index.html
+++ b/docs/static/v0.7/extensibility/integrations/consul/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/extensibility/integrations/containerd/index.html
+++ b/docs/static/v0.7/extensibility/integrations/containerd/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/extensibility/integrations/containerssh/index.html
+++ b/docs/static/v0.7/extensibility/integrations/containerssh/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/extensibility/integrations/contour-operator/index.html
+++ b/docs/static/v0.7/extensibility/integrations/contour-operator/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/extensibility/integrations/contrail-analytics/index.html
+++ b/docs/static/v0.7/extensibility/integrations/contrail-analytics/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/extensibility/integrations/coredns/index.html
+++ b/docs/static/v0.7/extensibility/integrations/coredns/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/extensibility/integrations/cortex/index.html
+++ b/docs/static/v0.7/extensibility/integrations/cortex/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/extensibility/integrations/couchbase-monitor-stack/index.html
+++ b/docs/static/v0.7/extensibility/integrations/couchbase-monitor-stack/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/extensibility/integrations/couchbase-operator/index.html
+++ b/docs/static/v0.7/extensibility/integrations/couchbase-operator/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/extensibility/integrations/cpx/index.html
+++ b/docs/static/v0.7/extensibility/integrations/cpx/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/extensibility/integrations/cri-o/index.html
+++ b/docs/static/v0.7/extensibility/integrations/cri-o/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/extensibility/integrations/crossplane-provider-openstack/index.html
+++ b/docs/static/v0.7/extensibility/integrations/crossplane-provider-openstack/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/extensibility/integrations/crossplane/index.html
+++ b/docs/static/v0.7/extensibility/integrations/crossplane/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/extensibility/integrations/cubefs/index.html
+++ b/docs/static/v0.7/extensibility/integrations/cubefs/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/extensibility/integrations/curiefense/index.html
+++ b/docs/static/v0.7/extensibility/integrations/curiefense/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/extensibility/integrations/dapr/index.html
+++ b/docs/static/v0.7/extensibility/integrations/dapr/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/extensibility/integrations/datadog-operator/index.html
+++ b/docs/static/v0.7/extensibility/integrations/datadog-operator/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/extensibility/integrations/devfile/index.html
+++ b/docs/static/v0.7/extensibility/integrations/devfile/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/extensibility/integrations/devstream/index.html
+++ b/docs/static/v0.7/extensibility/integrations/devstream/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/extensibility/integrations/dex/index.html
+++ b/docs/static/v0.7/extensibility/integrations/dex/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/extensibility/integrations/distribution/index.html
+++ b/docs/static/v0.7/extensibility/integrations/distribution/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/extensibility/integrations/docker/index.html
+++ b/docs/static/v0.7/extensibility/integrations/docker/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/extensibility/integrations/dragonfly/index.html
+++ b/docs/static/v0.7/extensibility/integrations/dragonfly/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/extensibility/integrations/edp-argocd-operator/index.html
+++ b/docs/static/v0.7/extensibility/integrations/edp-argocd-operator/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/extensibility/integrations/edp-component-operator/index.html
+++ b/docs/static/v0.7/extensibility/integrations/edp-component-operator/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/extensibility/integrations/edp-install/index.html
+++ b/docs/static/v0.7/extensibility/integrations/edp-install/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/extensibility/integrations/eks/index.html
+++ b/docs/static/v0.7/extensibility/integrations/eks/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/extensibility/integrations/elasticsearch-operator/index.html
+++ b/docs/static/v0.7/extensibility/integrations/elasticsearch-operator/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/extensibility/integrations/emissary-ingress/index.html
+++ b/docs/static/v0.7/extensibility/integrations/emissary-ingress/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/extensibility/integrations/envoy/index.html
+++ b/docs/static/v0.7/extensibility/integrations/envoy/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/extensibility/integrations/etcd-cluster-operator/index.html
+++ b/docs/static/v0.7/extensibility/integrations/etcd-cluster-operator/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/extensibility/integrations/external-secrets-operator/index.html
+++ b/docs/static/v0.7/extensibility/integrations/external-secrets-operator/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/extensibility/integrations/fabedge/index.html
+++ b/docs/static/v0.7/extensibility/integrations/fabedge/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/extensibility/integrations/falco/index.html
+++ b/docs/static/v0.7/extensibility/integrations/falco/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/extensibility/integrations/flagger/index.html
+++ b/docs/static/v0.7/extensibility/integrations/flagger/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/extensibility/integrations/fluent-operator/index.html
+++ b/docs/static/v0.7/extensibility/integrations/fluent-operator/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/extensibility/integrations/fluentbit-operator/index.html
+++ b/docs/static/v0.7/extensibility/integrations/fluentbit-operator/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/extensibility/integrations/fluentbit-skt/index.html
+++ b/docs/static/v0.7/extensibility/integrations/fluentbit-skt/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/extensibility/integrations/fluentd-operator/index.html
+++ b/docs/static/v0.7/extensibility/integrations/fluentd-operator/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/extensibility/integrations/fluentd/index.html
+++ b/docs/static/v0.7/extensibility/integrations/fluentd/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/extensibility/integrations/flux/index.html
+++ b/docs/static/v0.7/extensibility/integrations/flux/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/extensibility/integrations/flyte-sandbox/index.html
+++ b/docs/static/v0.7/extensibility/integrations/flyte-sandbox/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/extensibility/integrations/fonio/index.html
+++ b/docs/static/v0.7/extensibility/integrations/fonio/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/extensibility/integrations/gatekeeper/index.html
+++ b/docs/static/v0.7/extensibility/integrations/gatekeeper/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/extensibility/integrations/gcp/index.html
+++ b/docs/static/v0.7/extensibility/integrations/gcp/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/extensibility/integrations/gerrit-operator/index.html
+++ b/docs/static/v0.7/extensibility/integrations/gerrit-operator/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/extensibility/integrations/github-actions-runner-operator/index.html
+++ b/docs/static/v0.7/extensibility/integrations/github-actions-runner-operator/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/extensibility/integrations/github-actions-runners/index.html
+++ b/docs/static/v0.7/extensibility/integrations/github-actions-runners/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/extensibility/integrations/github/index.html
+++ b/docs/static/v0.7/extensibility/integrations/github/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/extensibility/integrations/gitlab-controller/index.html
+++ b/docs/static/v0.7/extensibility/integrations/gitlab-controller/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/extensibility/integrations/gitlab-runner-operator/index.html
+++ b/docs/static/v0.7/extensibility/integrations/gitlab-runner-operator/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/extensibility/integrations/gitlab/index.html
+++ b/docs/static/v0.7/extensibility/integrations/gitlab/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/extensibility/integrations/grafana-agent-operator/index.html
+++ b/docs/static/v0.7/extensibility/integrations/grafana-agent-operator/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/extensibility/integrations/grafana-agent/index.html
+++ b/docs/static/v0.7/extensibility/integrations/grafana-agent/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/extensibility/integrations/grafana-operator/index.html
+++ b/docs/static/v0.7/extensibility/integrations/grafana-operator/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/extensibility/integrations/grafana-ui-server/index.html
+++ b/docs/static/v0.7/extensibility/integrations/grafana-ui-server/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/extensibility/integrations/harbor-operator/index.html
+++ b/docs/static/v0.7/extensibility/integrations/harbor-operator/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/extensibility/integrations/helm-controller/index.html
+++ b/docs/static/v0.7/extensibility/integrations/helm-controller/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/extensibility/integrations/hexa/index.html
+++ b/docs/static/v0.7/extensibility/integrations/hexa/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/extensibility/integrations/hybridnet/index.html
+++ b/docs/static/v0.7/extensibility/integrations/hybridnet/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/extensibility/integrations/identity-manager/index.html
+++ b/docs/static/v0.7/extensibility/integrations/identity-manager/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/extensibility/integrations/in-toto/index.html
+++ b/docs/static/v0.7/extensibility/integrations/in-toto/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/extensibility/integrations/inclavare-containers/index.html
+++ b/docs/static/v0.7/extensibility/integrations/inclavare-containers/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/extensibility/integrations/index.html
+++ b/docs/static/v0.7/extensibility/integrations/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/extensibility/integrations/ingress-azure/index.html
+++ b/docs/static/v0.7/extensibility/integrations/ingress-azure/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/extensibility/integrations/inlets-operator/index.html
+++ b/docs/static/v0.7/extensibility/integrations/inlets-operator/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/extensibility/integrations/intel-device-plugins-operator/index.html
+++ b/docs/static/v0.7/extensibility/integrations/intel-device-plugins-operator/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/extensibility/integrations/istio-base/index.html
+++ b/docs/static/v0.7/extensibility/integrations/istio-base/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/extensibility/integrations/istio-operator/index.html
+++ b/docs/static/v0.7/extensibility/integrations/istio-operator/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/extensibility/integrations/istio-ratelimit-operator/index.html
+++ b/docs/static/v0.7/extensibility/integrations/istio-ratelimit-operator/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/extensibility/integrations/jaeger-operator/index.html
+++ b/docs/static/v0.7/extensibility/integrations/jaeger-operator/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/extensibility/integrations/jaeger/index.html
+++ b/docs/static/v0.7/extensibility/integrations/jaeger/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/extensibility/integrations/jenkins-operator/index.html
+++ b/docs/static/v0.7/extensibility/integrations/jenkins-operator/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/extensibility/integrations/jira-service-desk-operator/index.html
+++ b/docs/static/v0.7/extensibility/integrations/jira-service-desk-operator/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/extensibility/integrations/jitsi/index.html
+++ b/docs/static/v0.7/extensibility/integrations/jitsi/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/extensibility/integrations/k3s/index.html
+++ b/docs/static/v0.7/extensibility/integrations/k3s/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/extensibility/integrations/k6-operator/index.html
+++ b/docs/static/v0.7/extensibility/integrations/k6-operator/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/extensibility/integrations/k8gb/index.html
+++ b/docs/static/v0.7/extensibility/integrations/k8gb/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/extensibility/integrations/k8s-config-connector/index.html
+++ b/docs/static/v0.7/extensibility/integrations/k8s-config-connector/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/extensibility/integrations/k8svault-controller/index.html
+++ b/docs/static/v0.7/extensibility/integrations/k8svault-controller/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/extensibility/integrations/kanister-operator/index.html
+++ b/docs/static/v0.7/extensibility/integrations/kanister-operator/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/extensibility/integrations/karmada/index.html
+++ b/docs/static/v0.7/extensibility/integrations/karmada/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/extensibility/integrations/karpenter/index.html
+++ b/docs/static/v0.7/extensibility/integrations/karpenter/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/extensibility/integrations/katib/index.html
+++ b/docs/static/v0.7/extensibility/integrations/katib/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/extensibility/integrations/keda-http-scaler/index.html
+++ b/docs/static/v0.7/extensibility/integrations/keda-http-scaler/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/extensibility/integrations/keda/index.html
+++ b/docs/static/v0.7/extensibility/integrations/keda/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/extensibility/integrations/keycloak-operator/index.html
+++ b/docs/static/v0.7/extensibility/integrations/keycloak-operator/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/extensibility/integrations/keylime/index.html
+++ b/docs/static/v0.7/extensibility/integrations/keylime/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/extensibility/integrations/kiali-operator/index.html
+++ b/docs/static/v0.7/extensibility/integrations/kiali-operator/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/extensibility/integrations/knative-serving/index.html
+++ b/docs/static/v0.7/extensibility/integrations/knative-serving/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/extensibility/integrations/knative/index.html
+++ b/docs/static/v0.7/extensibility/integrations/knative/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/extensibility/integrations/kommander/index.html
+++ b/docs/static/v0.7/extensibility/integrations/kommander/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/extensibility/integrations/kong-mesh/index.html
+++ b/docs/static/v0.7/extensibility/integrations/kong-mesh/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/extensibility/integrations/kong/index.html
+++ b/docs/static/v0.7/extensibility/integrations/kong/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/extensibility/integrations/kube-arangodb/index.html
+++ b/docs/static/v0.7/extensibility/integrations/kube-arangodb/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/extensibility/integrations/kube-prometheus-stack/index.html
+++ b/docs/static/v0.7/extensibility/integrations/kube-prometheus-stack/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/extensibility/integrations/kube-prometheus/index.html
+++ b/docs/static/v0.7/extensibility/integrations/kube-prometheus/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/extensibility/integrations/kube-rs/index.html
+++ b/docs/static/v0.7/extensibility/integrations/kube-rs/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/extensibility/integrations/kube-ui-server/index.html
+++ b/docs/static/v0.7/extensibility/integrations/kube-ui-server/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/extensibility/integrations/kubedb-catalog/index.html
+++ b/docs/static/v0.7/extensibility/integrations/kubedb-catalog/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/extensibility/integrations/kubedb-crds/index.html
+++ b/docs/static/v0.7/extensibility/integrations/kubedb-crds/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/extensibility/integrations/kubedb-grafana-dashboards/index.html
+++ b/docs/static/v0.7/extensibility/integrations/kubedb-grafana-dashboards/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/extensibility/integrations/kubedb-metrics/index.html
+++ b/docs/static/v0.7/extensibility/integrations/kubedb-metrics/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/extensibility/integrations/kubedb-ops-manager/index.html
+++ b/docs/static/v0.7/extensibility/integrations/kubedb-ops-manager/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/extensibility/integrations/kubedb-opscenter/index.html
+++ b/docs/static/v0.7/extensibility/integrations/kubedb-opscenter/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/extensibility/integrations/kubedb-ui-server/index.html
+++ b/docs/static/v0.7/extensibility/integrations/kubedb-ui-server/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/extensibility/integrations/kubedb/index.html
+++ b/docs/static/v0.7/extensibility/integrations/kubedb/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/extensibility/integrations/kubedl/index.html
+++ b/docs/static/v0.7/extensibility/integrations/kubedl/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/extensibility/integrations/kubeflow/index.html
+++ b/docs/static/v0.7/extensibility/integrations/kubeflow/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/extensibility/integrations/kubeform-provider-aws/index.html
+++ b/docs/static/v0.7/extensibility/integrations/kubeform-provider-aws/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/extensibility/integrations/kubegems-edge/index.html
+++ b/docs/static/v0.7/extensibility/integrations/kubegems-edge/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/extensibility/integrations/kubegems-installer/index.html
+++ b/docs/static/v0.7/extensibility/integrations/kubegems-installer/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/extensibility/integrations/kubegems-local/index.html
+++ b/docs/static/v0.7/extensibility/integrations/kubegems-local/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/extensibility/integrations/kubegems-models/index.html
+++ b/docs/static/v0.7/extensibility/integrations/kubegems-models/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/extensibility/integrations/kubegems/index.html
+++ b/docs/static/v0.7/extensibility/integrations/kubegems/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/extensibility/integrations/kuberhealthy/index.html
+++ b/docs/static/v0.7/extensibility/integrations/kuberhealthy/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/extensibility/integrations/kubernetes-ingress/index.html
+++ b/docs/static/v0.7/extensibility/integrations/kubernetes-ingress/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/extensibility/integrations/kubernetes-secret-generator/index.html
+++ b/docs/static/v0.7/extensibility/integrations/kubernetes-secret-generator/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/extensibility/integrations/kubernetes/index.html
+++ b/docs/static/v0.7/extensibility/integrations/kubernetes/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/extensibility/integrations/kubeslice-worker/index.html
+++ b/docs/static/v0.7/extensibility/integrations/kubeslice-worker/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/extensibility/integrations/kubesphere/index.html
+++ b/docs/static/v0.7/extensibility/integrations/kubesphere/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/extensibility/integrations/kubevault-catalog/index.html
+++ b/docs/static/v0.7/extensibility/integrations/kubevault-catalog/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/extensibility/integrations/kubevault-crds/index.html
+++ b/docs/static/v0.7/extensibility/integrations/kubevault-crds/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/extensibility/integrations/kubevault-metrics/index.html
+++ b/docs/static/v0.7/extensibility/integrations/kubevault-metrics/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/extensibility/integrations/kubevault-operator/index.html
+++ b/docs/static/v0.7/extensibility/integrations/kubevault-operator/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/extensibility/integrations/kubevault/index.html
+++ b/docs/static/v0.7/extensibility/integrations/kubevault/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/extensibility/integrations/kubevela/index.html
+++ b/docs/static/v0.7/extensibility/integrations/kubevela/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/extensibility/integrations/kubevirt/index.html
+++ b/docs/static/v0.7/extensibility/integrations/kubevirt/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/extensibility/integrations/kuma/index.html
+++ b/docs/static/v0.7/extensibility/integrations/kuma/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/extensibility/integrations/kured/index.html
+++ b/docs/static/v0.7/extensibility/integrations/kured/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/extensibility/integrations/kusk-gateway/index.html
+++ b/docs/static/v0.7/extensibility/integrations/kusk-gateway/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/extensibility/integrations/kyverno-monitor/index.html
+++ b/docs/static/v0.7/extensibility/integrations/kyverno-monitor/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/extensibility/integrations/kyverno-operator/index.html
+++ b/docs/static/v0.7/extensibility/integrations/kyverno-operator/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/extensibility/integrations/kyverno/index.html
+++ b/docs/static/v0.7/extensibility/integrations/kyverno/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/extensibility/integrations/linkerd/index.html
+++ b/docs/static/v0.7/extensibility/integrations/linkerd/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/extensibility/integrations/linux/index.html
+++ b/docs/static/v0.7/extensibility/integrations/linux/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/extensibility/integrations/litmus-core/index.html
+++ b/docs/static/v0.7/extensibility/integrations/litmus-core/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/extensibility/integrations/loki-simple-scalable/index.html
+++ b/docs/static/v0.7/extensibility/integrations/loki-simple-scalable/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/extensibility/integrations/loki/index.html
+++ b/docs/static/v0.7/extensibility/integrations/loki/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/extensibility/integrations/longhorn/index.html
+++ b/docs/static/v0.7/extensibility/integrations/longhorn/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/extensibility/integrations/mattermost-operator/index.html
+++ b/docs/static/v0.7/extensibility/integrations/mattermost-operator/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/extensibility/integrations/meshery-core/index.html
+++ b/docs/static/v0.7/extensibility/integrations/meshery-core/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/extensibility/integrations/metallb/index.html
+++ b/docs/static/v0.7/extensibility/integrations/metallb/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/extensibility/integrations/metrics-server/index.html
+++ b/docs/static/v0.7/extensibility/integrations/metrics-server/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/extensibility/integrations/mimir-distributed/index.html
+++ b/docs/static/v0.7/extensibility/integrations/mimir-distributed/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/extensibility/integrations/minio-operator/index.html
+++ b/docs/static/v0.7/extensibility/integrations/minio-operator/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/extensibility/integrations/mpi-operator/index.html
+++ b/docs/static/v0.7/extensibility/integrations/mpi-operator/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/extensibility/integrations/mysql-operator/index.html
+++ b/docs/static/v0.7/extensibility/integrations/mysql-operator/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/extensibility/integrations/nats-operator/index.html
+++ b/docs/static/v0.7/extensibility/integrations/nats-operator/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/extensibility/integrations/newrelic-operator/index.html
+++ b/docs/static/v0.7/extensibility/integrations/newrelic-operator/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/extensibility/integrations/nginx-ingress/index.html
+++ b/docs/static/v0.7/extensibility/integrations/nginx-ingress/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/extensibility/integrations/nginx-service-mesh/index.html
+++ b/docs/static/v0.7/extensibility/integrations/nginx-service-mesh/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/extensibility/integrations/nginx/index.html
+++ b/docs/static/v0.7/extensibility/integrations/nginx/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/extensibility/integrations/nirmata-aws-adapter/index.html
+++ b/docs/static/v0.7/extensibility/integrations/nirmata-aws-adapter/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/extensibility/integrations/nirmata-venafi-adapter/index.html
+++ b/docs/static/v0.7/extensibility/integrations/nirmata-venafi-adapter/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/extensibility/integrations/nocalhost/index.html
+++ b/docs/static/v0.7/extensibility/integrations/nocalhost/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/extensibility/integrations/notary/index.html
+++ b/docs/static/v0.7/extensibility/integrations/notary/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/extensibility/integrations/ondat-operator/index.html
+++ b/docs/static/v0.7/extensibility/integrations/ondat-operator/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/extensibility/integrations/open-cluster-management/index.html
+++ b/docs/static/v0.7/extensibility/integrations/open-cluster-management/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/extensibility/integrations/open-policy-agent-(opa)/index.html
+++ b/docs/static/v0.7/extensibility/integrations/open-policy-agent-(opa)/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/extensibility/integrations/open-service-mesh/index.html
+++ b/docs/static/v0.7/extensibility/integrations/open-service-mesh/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/extensibility/integrations/openebs/index.html
+++ b/docs/static/v0.7/extensibility/integrations/openebs/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/extensibility/integrations/openelb/index.html
+++ b/docs/static/v0.7/extensibility/integrations/openelb/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/extensibility/integrations/openfeature/index.html
+++ b/docs/static/v0.7/extensibility/integrations/openfeature/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/extensibility/integrations/opengitops/index.html
+++ b/docs/static/v0.7/extensibility/integrations/opengitops/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/extensibility/integrations/openkruise/index.html
+++ b/docs/static/v0.7/extensibility/integrations/openkruise/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/extensibility/integrations/openmetrics/index.html
+++ b/docs/static/v0.7/extensibility/integrations/openmetrics/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/extensibility/integrations/opentelemetry-operator/index.html
+++ b/docs/static/v0.7/extensibility/integrations/opentelemetry-operator/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/extensibility/integrations/operator-framework/index.html
+++ b/docs/static/v0.7/extensibility/integrations/operator-framework/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/extensibility/integrations/oras/index.html
+++ b/docs/static/v0.7/extensibility/integrations/oras/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/extensibility/integrations/parsec/index.html
+++ b/docs/static/v0.7/extensibility/integrations/parsec/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/extensibility/integrations/pg-db/index.html
+++ b/docs/static/v0.7/extensibility/integrations/pg-db/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/extensibility/integrations/pg-operator/index.html
+++ b/docs/static/v0.7/extensibility/integrations/pg-operator/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/extensibility/integrations/pgo/index.html
+++ b/docs/static/v0.7/extensibility/integrations/pgo/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/extensibility/integrations/piraeus-datastore/index.html
+++ b/docs/static/v0.7/extensibility/integrations/piraeus-datastore/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/extensibility/integrations/pixie/index.html
+++ b/docs/static/v0.7/extensibility/integrations/pixie/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/extensibility/integrations/porter/index.html
+++ b/docs/static/v0.7/extensibility/integrations/porter/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/extensibility/integrations/postgres-controller/index.html
+++ b/docs/static/v0.7/extensibility/integrations/postgres-controller/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/extensibility/integrations/postgres-operator/index.html
+++ b/docs/static/v0.7/extensibility/integrations/postgres-operator/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/extensibility/integrations/postgres-with-operator/index.html
+++ b/docs/static/v0.7/extensibility/integrations/postgres-with-operator/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/extensibility/integrations/posthog/index.html
+++ b/docs/static/v0.7/extensibility/integrations/posthog/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/extensibility/integrations/pravega/index.html
+++ b/docs/static/v0.7/extensibility/integrations/pravega/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/extensibility/integrations/prometheus-operator-crds/index.html
+++ b/docs/static/v0.7/extensibility/integrations/prometheus-operator-crds/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/extensibility/integrations/prometheus/index.html
+++ b/docs/static/v0.7/extensibility/integrations/prometheus/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/extensibility/integrations/ps-db/index.html
+++ b/docs/static/v0.7/extensibility/integrations/ps-db/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/extensibility/integrations/ps-operator/index.html
+++ b/docs/static/v0.7/extensibility/integrations/ps-operator/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/extensibility/integrations/psmdb-db/index.html
+++ b/docs/static/v0.7/extensibility/integrations/psmdb-db/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/extensibility/integrations/psmdb-operator/index.html
+++ b/docs/static/v0.7/extensibility/integrations/psmdb-operator/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/extensibility/integrations/pulsar-operator/index.html
+++ b/docs/static/v0.7/extensibility/integrations/pulsar-operator/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/extensibility/integrations/pulsar-resources-operator/index.html
+++ b/docs/static/v0.7/extensibility/integrations/pulsar-resources-operator/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/extensibility/integrations/rabbitmq-cluster-operator/index.html
+++ b/docs/static/v0.7/extensibility/integrations/rabbitmq-cluster-operator/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/extensibility/integrations/rabbitmq-operator/index.html
+++ b/docs/static/v0.7/extensibility/integrations/rabbitmq-operator/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/extensibility/integrations/redis-operator/index.html
+++ b/docs/static/v0.7/extensibility/integrations/redis-operator/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/extensibility/integrations/rook-ceph-cluster/index.html
+++ b/docs/static/v0.7/extensibility/integrations/rook-ceph-cluster/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/extensibility/integrations/rook/index.html
+++ b/docs/static/v0.7/extensibility/integrations/rook/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/extensibility/integrations/saferwall/index.html
+++ b/docs/static/v0.7/extensibility/integrations/saferwall/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/extensibility/integrations/scheduler-plugins/index.html
+++ b/docs/static/v0.7/extensibility/integrations/scheduler-plugins/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/extensibility/integrations/schemahero/index.html
+++ b/docs/static/v0.7/extensibility/integrations/schemahero/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/extensibility/integrations/security-role-perm-operator-svc/index.html
+++ b/docs/static/v0.7/extensibility/integrations/security-role-perm-operator-svc/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/extensibility/integrations/serverless-workflow/index.html
+++ b/docs/static/v0.7/extensibility/integrations/serverless-workflow/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/extensibility/integrations/sidekick/index.html
+++ b/docs/static/v0.7/extensibility/integrations/sidekick/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/extensibility/integrations/skooner/index.html
+++ b/docs/static/v0.7/extensibility/integrations/skooner/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/extensibility/integrations/slack-operator/index.html
+++ b/docs/static/v0.7/extensibility/integrations/slack-operator/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/extensibility/integrations/sm-kubernetes/index.html
+++ b/docs/static/v0.7/extensibility/integrations/sm-kubernetes/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/extensibility/integrations/solr-operator/index.html
+++ b/docs/static/v0.7/extensibility/integrations/solr-operator/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/extensibility/integrations/spiffe/index.html
+++ b/docs/static/v0.7/extensibility/integrations/spiffe/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/extensibility/integrations/spire/index.html
+++ b/docs/static/v0.7/extensibility/integrations/spire/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/extensibility/integrations/stackgres-operator/index.html
+++ b/docs/static/v0.7/extensibility/integrations/stackgres-operator/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/extensibility/integrations/strimzi-kafka-operator/index.html
+++ b/docs/static/v0.7/extensibility/integrations/strimzi-kafka-operator/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/extensibility/integrations/strimzi-registry-operator/index.html
+++ b/docs/static/v0.7/extensibility/integrations/strimzi-registry-operator/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/extensibility/integrations/submariner/index.html
+++ b/docs/static/v0.7/extensibility/integrations/submariner/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/extensibility/integrations/supabase/index.html
+++ b/docs/static/v0.7/extensibility/integrations/supabase/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/extensibility/integrations/superedge/index.html
+++ b/docs/static/v0.7/extensibility/integrations/superedge/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/extensibility/integrations/telepresence/index.html
+++ b/docs/static/v0.7/extensibility/integrations/telepresence/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/extensibility/integrations/teller/index.html
+++ b/docs/static/v0.7/extensibility/integrations/teller/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/extensibility/integrations/tenant-operator/index.html
+++ b/docs/static/v0.7/extensibility/integrations/tenant-operator/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/extensibility/integrations/terraform/index.html
+++ b/docs/static/v0.7/extensibility/integrations/terraform/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/extensibility/integrations/thanos-operator/index.html
+++ b/docs/static/v0.7/extensibility/integrations/thanos-operator/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/extensibility/integrations/thanos/index.html
+++ b/docs/static/v0.7/extensibility/integrations/thanos/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/extensibility/integrations/tikv-operator/index.html
+++ b/docs/static/v0.7/extensibility/integrations/tikv-operator/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/extensibility/integrations/tinkerbell/index.html
+++ b/docs/static/v0.7/extensibility/integrations/tinkerbell/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/extensibility/integrations/tremor/index.html
+++ b/docs/static/v0.7/extensibility/integrations/tremor/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/extensibility/integrations/trickster/index.html
+++ b/docs/static/v0.7/extensibility/integrations/trickster/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/extensibility/integrations/tuf/index.html
+++ b/docs/static/v0.7/extensibility/integrations/tuf/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/extensibility/integrations/vald-helm-operator/index.html
+++ b/docs/static/v0.7/extensibility/integrations/vald-helm-operator/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/extensibility/integrations/vald/index.html
+++ b/docs/static/v0.7/extensibility/integrations/vald/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/extensibility/integrations/vault-config-operator/index.html
+++ b/docs/static/v0.7/extensibility/integrations/vault-config-operator/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/extensibility/integrations/vault-operator/index.html
+++ b/docs/static/v0.7/extensibility/integrations/vault-operator/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/extensibility/integrations/vault-secrets/index.html
+++ b/docs/static/v0.7/extensibility/integrations/vault-secrets/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/extensibility/integrations/vela-workflow/index.html
+++ b/docs/static/v0.7/extensibility/integrations/vela-workflow/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/extensibility/integrations/velero-s3-deployment/index.html
+++ b/docs/static/v0.7/extensibility/integrations/velero-s3-deployment/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/extensibility/integrations/victoria-metrics-k8s-stack/index.html
+++ b/docs/static/v0.7/extensibility/integrations/victoria-metrics-k8s-stack/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/extensibility/integrations/vineyard/index.html
+++ b/docs/static/v0.7/extensibility/integrations/vineyard/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/extensibility/integrations/virtual-kubelet/index.html
+++ b/docs/static/v0.7/extensibility/integrations/virtual-kubelet/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/extensibility/integrations/vitess/index.html
+++ b/docs/static/v0.7/extensibility/integrations/vitess/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/extensibility/integrations/volcano/index.html
+++ b/docs/static/v0.7/extensibility/integrations/volcano/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/extensibility/integrations/wasmcloud/index.html
+++ b/docs/static/v0.7/extensibility/integrations/wasmcloud/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/extensibility/integrations/wasmedgeruntime/index.html
+++ b/docs/static/v0.7/extensibility/integrations/wasmedgeruntime/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/extensibility/integrations/whereabouts/index.html
+++ b/docs/static/v0.7/extensibility/integrations/whereabouts/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/extensibility/integrations/windows/index.html
+++ b/docs/static/v0.7/extensibility/integrations/windows/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/extensibility/integrations/wordpress-operator/index.html
+++ b/docs/static/v0.7/extensibility/integrations/wordpress-operator/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/extensibility/load-generators/index.html
+++ b/docs/static/v0.7/extensibility/load-generators/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/extensibility/providers/index.html
+++ b/docs/static/v0.7/extensibility/providers/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/extensibility/ui/index.html
+++ b/docs/static/v0.7/extensibility/ui/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/extensions/component-shape-guide/index.html
+++ b/docs/static/v0.7/extensions/component-shape-guide/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/extensions/edges-shape-guide/index.html
+++ b/docs/static/v0.7/extensions/edges-shape-guide/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/extensions/importing-a-design/index.html
+++ b/docs/static/v0.7/extensions/importing-a-design/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/extensions/importing-an-application/index.html
+++ b/docs/static/v0.7/extensions/importing-an-application/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/extensions/index.html
+++ b/docs/static/v0.7/extensions/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/extensions/kanvas-snapshot/index.html
+++ b/docs/static/v0.7/extensions/kanvas-snapshot/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/extensions/kanvas/index.html
+++ b/docs/static/v0.7/extensions/kanvas/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/extensions/kubectl-kanvas-snapshot/index.html
+++ b/docs/static/v0.7/extensions/kubectl-kanvas-snapshot/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/extensions/kubectl-meshsync-snapshot/index.html
+++ b/docs/static/v0.7/extensions/kubectl-meshsync-snapshot/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/extensions/merging-design/index.html
+++ b/docs/static/v0.7/extensions/merging-design/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/extensions/publishing-a-design/index.html
+++ b/docs/static/v0.7/extensions/publishing-a-design/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/extensions/sharing-a-design/index.html
+++ b/docs/static/v0.7/extensions/sharing-a-design/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/extensions/working-with-tags/index.html
+++ b/docs/static/v0.7/extensions/working-with-tags/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/getting-started/overview/index.html
+++ b/docs/static/v0.7/getting-started/overview/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/guides/configuration-management/creating-a-meshery-design/index.html
+++ b/docs/static/v0.7/guides/configuration-management/creating-a-meshery-design/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/guides/configuration-management/exporting-models/index.html
+++ b/docs/static/v0.7/guides/configuration-management/exporting-models/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/guides/configuration-management/filter-management/index.html
+++ b/docs/static/v0.7/guides/configuration-management/filter-management/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/guides/configuration-management/generating-models/index.html
+++ b/docs/static/v0.7/guides/configuration-management/generating-models/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/guides/configuration-management/importing-designs/index.html
+++ b/docs/static/v0.7/guides/configuration-management/importing-designs/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/guides/configuration-management/importing-models/index.html
+++ b/docs/static/v0.7/guides/configuration-management/importing-models/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/guides/configuration-management/index.html
+++ b/docs/static/v0.7/guides/configuration-management/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/guides/configuration-management/pattern-management/index.html
+++ b/docs/static/v0.7/guides/configuration-management/pattern-management/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/guides/configuration-management/push-pull-model-image/index.html
+++ b/docs/static/v0.7/guides/configuration-management/push-pull-model-image/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/guides/configuration-management/working-with-designs/index.html
+++ b/docs/static/v0.7/guides/configuration-management/working-with-designs/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/guides/events-management/index.html
+++ b/docs/static/v0.7/guides/events-management/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/guides/index.html
+++ b/docs/static/v0.7/guides/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/guides/infrastructure-management/gitops-with-meshery/index.html
+++ b/docs/static/v0.7/guides/infrastructure-management/gitops-with-meshery/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/guides/infrastructure-management/index.html
+++ b/docs/static/v0.7/guides/infrastructure-management/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/guides/infrastructure-management/lifecycle-management/index.html
+++ b/docs/static/v0.7/guides/infrastructure-management/lifecycle-management/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/guides/infrastructure-management/notification-management/index.html
+++ b/docs/static/v0.7/guides/infrastructure-management/notification-management/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/guides/infrastructure-management/overview/index.html
+++ b/docs/static/v0.7/guides/infrastructure-management/overview/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/guides/infrastructure-management/registering-a-connection/index.html
+++ b/docs/static/v0.7/guides/infrastructure-management/registering-a-connection/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/guides/infrastructure-management/sample-apps/index.html
+++ b/docs/static/v0.7/guides/infrastructure-management/sample-apps/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/guides/mesheryctl/authenticate-with-meshery-via-cli/index.html
+++ b/docs/static/v0.7/guides/mesheryctl/authenticate-with-meshery-via-cli/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/guides/mesheryctl/configuring-autocompletion-for-mesheryctl/index.html
+++ b/docs/static/v0.7/guides/mesheryctl/configuring-autocompletion-for-mesheryctl/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/guides/mesheryctl/index.html
+++ b/docs/static/v0.7/guides/mesheryctl/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/guides/mesheryctl/running-system-checks-using-mesheryctl/index.html
+++ b/docs/static/v0.7/guides/mesheryctl/running-system-checks-using-mesheryctl/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/guides/mesheryctl/system-commands/index.html
+++ b/docs/static/v0.7/guides/mesheryctl/system-commands/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/guides/mesheryctl/working-with-mesheryctl/index.html
+++ b/docs/static/v0.7/guides/mesheryctl/working-with-mesheryctl/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/guides/operating/model-generation/index.html
+++ b/docs/static/v0.7/guides/operating/model-generation/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/guides/performance-management/index.html
+++ b/docs/static/v0.7/guides/performance-management/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/guides/performance-management/interpreting-performance-test-results/index.html
+++ b/docs/static/v0.7/guides/performance-management/interpreting-performance-test-results/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/guides/performance-management/managing-performance/index.html
+++ b/docs/static/v0.7/guides/performance-management/managing-performance/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/guides/performance-management/meshery-metrics/index.html
+++ b/docs/static/v0.7/guides/performance-management/meshery-metrics/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/guides/performance-management/performance-management/index.html
+++ b/docs/static/v0.7/guides/performance-management/performance-management/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/guides/troubleshooting/index.html
+++ b/docs/static/v0.7/guides/troubleshooting/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/guides/troubleshooting/installation/index.html
+++ b/docs/static/v0.7/guides/troubleshooting/installation/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/guides/troubleshooting/meshery-operator-meshsync/index.html
+++ b/docs/static/v0.7/guides/troubleshooting/meshery-operator-meshsync/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/guides/troubleshooting/meshery-server/index.html
+++ b/docs/static/v0.7/guides/troubleshooting/meshery-server/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/guides/tutorials/deploy-apache-cassandra-with-statefulset/index.html
+++ b/docs/static/v0.7/guides/tutorials/deploy-apache-cassandra-with-statefulset/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/guides/tutorials/deploy-aws-ec2-instances-with-meshery/index.html
+++ b/docs/static/v0.7/guides/tutorials/deploy-aws-ec2-instances-with-meshery/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/guides/tutorials/deploy-php-redis/index.html
+++ b/docs/static/v0.7/guides/tutorials/deploy-php-redis/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/guides/tutorials/exploring-kubernetes-cronjobs/index.html
+++ b/docs/static/v0.7/guides/tutorials/exploring-kubernetes-cronjobs/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/guides/tutorials/index.html
+++ b/docs/static/v0.7/guides/tutorials/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/guides/tutorials/kubernetes-configmaps-secrets/index.html
+++ b/docs/static/v0.7/guides/tutorials/kubernetes-configmaps-secrets/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/guides/tutorials/kubernetes-pods/index.html
+++ b/docs/static/v0.7/guides/tutorials/kubernetes-pods/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/guides/tutorials/publish-to-artifacthub/index.html
+++ b/docs/static/v0.7/guides/tutorials/publish-to-artifacthub/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/guides/tutorials/wordpress-mysql-persistentvolume/index.html
+++ b/docs/static/v0.7/guides/tutorials/wordpress-mysql-persistentvolume/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/installation/accessing-meshery-ui/index.html
+++ b/docs/static/v0.7/installation/accessing-meshery-ui/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/installation/codespaces/index.html
+++ b/docs/static/v0.7/installation/codespaces/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/installation/compatibility-matrix/index.html
+++ b/docs/static/v0.7/installation/compatibility-matrix/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/installation/compatibility-matrix/meshery-cilium-past-results/index.html
+++ b/docs/static/v0.7/installation/compatibility-matrix/meshery-cilium-past-results/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/installation/compatibility-matrix/meshery-consul-past-results/index.html
+++ b/docs/static/v0.7/installation/compatibility-matrix/meshery-consul-past-results/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/installation/compatibility-matrix/meshery-istio-past-results/index.html
+++ b/docs/static/v0.7/installation/compatibility-matrix/meshery-istio-past-results/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/installation/compatibility-matrix/meshery-kuma-past-results/index.html
+++ b/docs/static/v0.7/installation/compatibility-matrix/meshery-kuma-past-results/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/installation/compatibility-matrix/meshery-linkerd-past-results/index.html
+++ b/docs/static/v0.7/installation/compatibility-matrix/meshery-linkerd-past-results/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/installation/compatibility-matrix/meshery-nginx-sm-past-results/index.html
+++ b/docs/static/v0.7/installation/compatibility-matrix/meshery-nginx-sm-past-results/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/installation/compatibility-matrix/meshery-osm-past-results/index.html
+++ b/docs/static/v0.7/installation/compatibility-matrix/meshery-osm-past-results/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/installation/compatibility-matrix/meshery-traefik-mesh-past-results/index.html
+++ b/docs/static/v0.7/installation/compatibility-matrix/meshery-traefik-mesh-past-results/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/installation/docker/docker-extension/index.html
+++ b/docs/static/v0.7/installation/docker/docker-extension/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/installation/docker/index.html
+++ b/docs/static/v0.7/installation/docker/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/installation/index.html
+++ b/docs/static/v0.7/installation/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/installation/kubernetes/aks/index.html
+++ b/docs/static/v0.7/installation/kubernetes/aks/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/installation/kubernetes/eks/index.html
+++ b/docs/static/v0.7/installation/kubernetes/eks/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/installation/kubernetes/gke/index.html
+++ b/docs/static/v0.7/installation/kubernetes/gke/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/installation/kubernetes/helm/index.html
+++ b/docs/static/v0.7/installation/kubernetes/helm/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/installation/kubernetes/index.html
+++ b/docs/static/v0.7/installation/kubernetes/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/installation/kubernetes/kind/index.html
+++ b/docs/static/v0.7/installation/kubernetes/kind/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/installation/kubernetes/kubesphere/index.html
+++ b/docs/static/v0.7/installation/kubernetes/kubesphere/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/installation/kubernetes/minikube/index.html
+++ b/docs/static/v0.7/installation/kubernetes/minikube/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/installation/linux-mac/bash/index.html
+++ b/docs/static/v0.7/installation/linux-mac/bash/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/installation/linux-mac/brew/index.html
+++ b/docs/static/v0.7/installation/linux-mac/brew/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/installation/linux-mac/index.html
+++ b/docs/static/v0.7/installation/linux-mac/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/installation/mesheryctl/index.html
+++ b/docs/static/v0.7/installation/mesheryctl/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/installation/multiple-adapters/index.html
+++ b/docs/static/v0.7/installation/multiple-adapters/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/installation/playground/index.html
+++ b/docs/static/v0.7/installation/playground/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/installation/quick-start/index.html
+++ b/docs/static/v0.7/installation/quick-start/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/installation/upgrades/index.html
+++ b/docs/static/v0.7/installation/upgrades/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/installation/windows/index.html
+++ b/docs/static/v0.7/installation/windows/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/installation/windows/scoop/index.html
+++ b/docs/static/v0.7/installation/windows/scoop/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/news/index.html
+++ b/docs/static/v0.7/news/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/pages/extensibility/integrations/index.html
+++ b/docs/static/v0.7/pages/extensibility/integrations/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/pages/guides/smi-conformance/index.html
+++ b/docs/static/v0.7/pages/guides/smi-conformance/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/pages/installation/compatibility-matrix/index.html
+++ b/docs/static/v0.7/pages/installation/compatibility-matrix/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/pages/installation/platforms/index.html
+++ b/docs/static/v0.7/pages/installation/platforms/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/pages/project/mesheryctl/installation-bash/index.html
+++ b/docs/static/v0.7/pages/project/mesheryctl/installation-bash/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/pages/project/mesheryctl/installation-brew/index.html
+++ b/docs/static/v0.7/pages/project/mesheryctl/installation-brew/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/pages/project/mesheryctl/installation-scoop/index.html
+++ b/docs/static/v0.7/pages/project/mesheryctl/installation-scoop/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/pages/tasks/service-mesh-interface/index.html
+++ b/docs/static/v0.7/pages/tasks/service-mesh-interface/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/project/community/index.html
+++ b/docs/static/v0.7/project/community/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/project/contributing/build-and-release/index.html
+++ b/docs/static/v0.7/project/contributing/build-and-release/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/project/contributing/contributing-adapters/index.html
+++ b/docs/static/v0.7/project/contributing/contributing-adapters/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/project/contributing/contributing-cli-guide/index.html
+++ b/docs/static/v0.7/project/contributing/contributing-cli-guide/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/project/contributing/contributing-cli/index.html
+++ b/docs/static/v0.7/project/contributing/contributing-cli/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/project/contributing/contributing-components/index.html
+++ b/docs/static/v0.7/project/contributing/contributing-components/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/project/contributing/contributing-cypress/index.html
+++ b/docs/static/v0.7/project/contributing/contributing-cypress/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/project/contributing/contributing-docker-extension/index.html
+++ b/docs/static/v0.7/project/contributing/contributing-docker-extension/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/project/contributing/contributing-docs/index.html
+++ b/docs/static/v0.7/project/contributing/contributing-docs/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/project/contributing/contributing-error/index.html
+++ b/docs/static/v0.7/project/contributing/contributing-error/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/project/contributing/contributing-gitflow/index.html
+++ b/docs/static/v0.7/project/contributing/contributing-gitflow/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/project/contributing/contributing-models-quick-start/index.html
+++ b/docs/static/v0.7/project/contributing/contributing-models-quick-start/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/project/contributing/contributing-models/index.html
+++ b/docs/static/v0.7/project/contributing/contributing-models/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/project/contributing/contributing-policies/index.html
+++ b/docs/static/v0.7/project/contributing/contributing-policies/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/project/contributing/contributing-relationships/index.html
+++ b/docs/static/v0.7/project/contributing/contributing-relationships/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/project/contributing/contributing-server-events/index.html
+++ b/docs/static/v0.7/project/contributing/contributing-server-events/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/project/contributing/contributing-server/index.html
+++ b/docs/static/v0.7/project/contributing/contributing-server/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/project/contributing/contributing-ui-notification-center/index.html
+++ b/docs/static/v0.7/project/contributing/contributing-ui-notification-center/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/project/contributing/contributing-ui-sistent/index.html
+++ b/docs/static/v0.7/project/contributing/contributing-ui-sistent/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/project/contributing/contributing-ui-tests/index.html
+++ b/docs/static/v0.7/project/contributing/contributing-ui-tests/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/project/contributing/contributing-ui/index.html
+++ b/docs/static/v0.7/project/contributing/contributing-ui/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/project/contributing/index.html
+++ b/docs/static/v0.7/project/contributing/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/project/contributing/meshery-windows/index.html
+++ b/docs/static/v0.7/project/contributing/meshery-windows/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/project/contributing/test-status/index.html
+++ b/docs/static/v0.7/project/contributing/test-status/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/project/faq/index.html
+++ b/docs/static/v0.7/project/faq/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/project/index.html
+++ b/docs/static/v0.7/project/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/project/overview/index.html
+++ b/docs/static/v0.7/project/overview/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/project/releases/index.html
+++ b/docs/static/v0.7/project/releases/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/project/releases/null/index.html
+++ b/docs/static/v0.7/project/releases/null/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/project/releases/v0.0.1/index.html
+++ b/docs/static/v0.7/project/releases/v0.0.1/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/project/releases/v0.0.2/index.html
+++ b/docs/static/v0.7/project/releases/v0.0.2/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/project/releases/v0.0.3/index.html
+++ b/docs/static/v0.7/project/releases/v0.0.3/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/project/releases/v0.0.4/index.html
+++ b/docs/static/v0.7/project/releases/v0.0.4/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/project/releases/v0.0.5/index.html
+++ b/docs/static/v0.7/project/releases/v0.0.5/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/project/releases/v0.0.6/index.html
+++ b/docs/static/v0.7/project/releases/v0.0.6/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/project/releases/v0.0.7/index.html
+++ b/docs/static/v0.7/project/releases/v0.0.7/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/project/releases/v0.0.8/index.html
+++ b/docs/static/v0.7/project/releases/v0.0.8/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/project/releases/v0.0.9/index.html
+++ b/docs/static/v0.7/project/releases/v0.0.9/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/project/releases/v0.1.0/index.html
+++ b/docs/static/v0.7/project/releases/v0.1.0/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/project/releases/v0.1.1/index.html
+++ b/docs/static/v0.7/project/releases/v0.1.1/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/project/releases/v0.1.2/index.html
+++ b/docs/static/v0.7/project/releases/v0.1.2/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/project/releases/v0.1.3/index.html
+++ b/docs/static/v0.7/project/releases/v0.1.3/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/project/releases/v0.1.4/index.html
+++ b/docs/static/v0.7/project/releases/v0.1.4/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/project/releases/v0.1.5/index.html
+++ b/docs/static/v0.7/project/releases/v0.1.5/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/project/releases/v0.1.6/index.html
+++ b/docs/static/v0.7/project/releases/v0.1.6/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/project/releases/v0.2.0/index.html
+++ b/docs/static/v0.7/project/releases/v0.2.0/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/project/releases/v0.2.1/index.html
+++ b/docs/static/v0.7/project/releases/v0.2.1/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/project/releases/v0.2.2/index.html
+++ b/docs/static/v0.7/project/releases/v0.2.2/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/project/releases/v0.2.3/index.html
+++ b/docs/static/v0.7/project/releases/v0.2.3/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/project/releases/v0.2.4/index.html
+++ b/docs/static/v0.7/project/releases/v0.2.4/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/project/releases/v0.3.1/index.html
+++ b/docs/static/v0.7/project/releases/v0.3.1/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/project/releases/v0.3.10/index.html
+++ b/docs/static/v0.7/project/releases/v0.3.10/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/project/releases/v0.3.11/index.html
+++ b/docs/static/v0.7/project/releases/v0.3.11/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/project/releases/v0.3.12/index.html
+++ b/docs/static/v0.7/project/releases/v0.3.12/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/project/releases/v0.3.13/index.html
+++ b/docs/static/v0.7/project/releases/v0.3.13/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/project/releases/v0.3.14/index.html
+++ b/docs/static/v0.7/project/releases/v0.3.14/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/project/releases/v0.3.15/index.html
+++ b/docs/static/v0.7/project/releases/v0.3.15/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/project/releases/v0.3.16/index.html
+++ b/docs/static/v0.7/project/releases/v0.3.16/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/project/releases/v0.3.17/index.html
+++ b/docs/static/v0.7/project/releases/v0.3.17/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/project/releases/v0.3.18/index.html
+++ b/docs/static/v0.7/project/releases/v0.3.18/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/project/releases/v0.3.19/index.html
+++ b/docs/static/v0.7/project/releases/v0.3.19/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/project/releases/v0.3.2/index.html
+++ b/docs/static/v0.7/project/releases/v0.3.2/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/project/releases/v0.3.3/index.html
+++ b/docs/static/v0.7/project/releases/v0.3.3/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/project/releases/v0.3.4/index.html
+++ b/docs/static/v0.7/project/releases/v0.3.4/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/project/releases/v0.3.5/index.html
+++ b/docs/static/v0.7/project/releases/v0.3.5/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/project/releases/v0.3.6/index.html
+++ b/docs/static/v0.7/project/releases/v0.3.6/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/project/releases/v0.3.7/index.html
+++ b/docs/static/v0.7/project/releases/v0.3.7/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/project/releases/v0.3.8/index.html
+++ b/docs/static/v0.7/project/releases/v0.3.8/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/project/releases/v0.3.9/index.html
+++ b/docs/static/v0.7/project/releases/v0.3.9/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/project/releases/v0.4.0-beta.1/index.html
+++ b/docs/static/v0.7/project/releases/v0.4.0-beta.1/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/project/releases/v0.4.0-beta.2/index.html
+++ b/docs/static/v0.7/project/releases/v0.4.0-beta.2/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/project/releases/v0.4.0-beta.3/index.html
+++ b/docs/static/v0.7/project/releases/v0.4.0-beta.3/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/project/releases/v0.4.0-beta.4/index.html
+++ b/docs/static/v0.7/project/releases/v0.4.0-beta.4/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/project/releases/v0.4.1/index.html
+++ b/docs/static/v0.7/project/releases/v0.4.1/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/project/releases/v0.4.10/index.html
+++ b/docs/static/v0.7/project/releases/v0.4.10/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/project/releases/v0.4.11/index.html
+++ b/docs/static/v0.7/project/releases/v0.4.11/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/project/releases/v0.4.12/index.html
+++ b/docs/static/v0.7/project/releases/v0.4.12/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/project/releases/v0.4.13/index.html
+++ b/docs/static/v0.7/project/releases/v0.4.13/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/project/releases/v0.4.14/index.html
+++ b/docs/static/v0.7/project/releases/v0.4.14/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/project/releases/v0.4.15/index.html
+++ b/docs/static/v0.7/project/releases/v0.4.15/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/project/releases/v0.4.16/index.html
+++ b/docs/static/v0.7/project/releases/v0.4.16/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/project/releases/v0.4.17/index.html
+++ b/docs/static/v0.7/project/releases/v0.4.17/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/project/releases/v0.4.18/index.html
+++ b/docs/static/v0.7/project/releases/v0.4.18/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/project/releases/v0.4.19/index.html
+++ b/docs/static/v0.7/project/releases/v0.4.19/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/project/releases/v0.4.2/index.html
+++ b/docs/static/v0.7/project/releases/v0.4.2/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/project/releases/v0.4.20/index.html
+++ b/docs/static/v0.7/project/releases/v0.4.20/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/project/releases/v0.4.21/index.html
+++ b/docs/static/v0.7/project/releases/v0.4.21/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/project/releases/v0.4.22/index.html
+++ b/docs/static/v0.7/project/releases/v0.4.22/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/project/releases/v0.4.23/index.html
+++ b/docs/static/v0.7/project/releases/v0.4.23/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/project/releases/v0.4.24/index.html
+++ b/docs/static/v0.7/project/releases/v0.4.24/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/project/releases/v0.4.25/index.html
+++ b/docs/static/v0.7/project/releases/v0.4.25/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/project/releases/v0.4.26/index.html
+++ b/docs/static/v0.7/project/releases/v0.4.26/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/project/releases/v0.4.27/index.html
+++ b/docs/static/v0.7/project/releases/v0.4.27/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/project/releases/v0.4.3/index.html
+++ b/docs/static/v0.7/project/releases/v0.4.3/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/project/releases/v0.4.4/index.html
+++ b/docs/static/v0.7/project/releases/v0.4.4/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/project/releases/v0.4.5/index.html
+++ b/docs/static/v0.7/project/releases/v0.4.5/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/project/releases/v0.4.6/index.html
+++ b/docs/static/v0.7/project/releases/v0.4.6/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/project/releases/v0.4.7/index.html
+++ b/docs/static/v0.7/project/releases/v0.4.7/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/project/releases/v0.4.8/index.html
+++ b/docs/static/v0.7/project/releases/v0.4.8/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/project/releases/v0.4.9/index.html
+++ b/docs/static/v0.7/project/releases/v0.4.9/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/project/releases/v0.5.0-beta-1/index.html
+++ b/docs/static/v0.7/project/releases/v0.5.0-beta-1/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/project/releases/v0.5.0-beta-2/index.html
+++ b/docs/static/v0.7/project/releases/v0.5.0-beta-2/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/project/releases/v0.5.0-beta-3/index.html
+++ b/docs/static/v0.7/project/releases/v0.5.0-beta-3/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/project/releases/v0.5.0-beta-4/index.html
+++ b/docs/static/v0.7/project/releases/v0.5.0-beta-4/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/project/releases/v0.5.0-rc-1/index.html
+++ b/docs/static/v0.7/project/releases/v0.5.0-rc-1/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/project/releases/v0.5.0-rc-2/index.html
+++ b/docs/static/v0.7/project/releases/v0.5.0-rc-2/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/project/releases/v0.5.0-rc-3/index.html
+++ b/docs/static/v0.7/project/releases/v0.5.0-rc-3/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/project/releases/v0.5.0-rc-4/index.html
+++ b/docs/static/v0.7/project/releases/v0.5.0-rc-4/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/project/releases/v0.5.0-rc-5/index.html
+++ b/docs/static/v0.7/project/releases/v0.5.0-rc-5/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/project/releases/v0.5.0-rc-5g/index.html
+++ b/docs/static/v0.7/project/releases/v0.5.0-rc-5g/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/project/releases/v0.5.0-rc-6/index.html
+++ b/docs/static/v0.7/project/releases/v0.5.0-rc-6/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/project/releases/v0.5.0/index.html
+++ b/docs/static/v0.7/project/releases/v0.5.0/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/project/releases/v0.5.1/index.html
+++ b/docs/static/v0.7/project/releases/v0.5.1/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/project/releases/v0.5.10/index.html
+++ b/docs/static/v0.7/project/releases/v0.5.10/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/project/releases/v0.5.11/index.html
+++ b/docs/static/v0.7/project/releases/v0.5.11/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/project/releases/v0.5.12/index.html
+++ b/docs/static/v0.7/project/releases/v0.5.12/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/project/releases/v0.5.13/index.html
+++ b/docs/static/v0.7/project/releases/v0.5.13/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/project/releases/v0.5.14/index.html
+++ b/docs/static/v0.7/project/releases/v0.5.14/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/project/releases/v0.5.15/index.html
+++ b/docs/static/v0.7/project/releases/v0.5.15/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/project/releases/v0.5.16/index.html
+++ b/docs/static/v0.7/project/releases/v0.5.16/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/project/releases/v0.5.17/index.html
+++ b/docs/static/v0.7/project/releases/v0.5.17/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/project/releases/v0.5.18/index.html
+++ b/docs/static/v0.7/project/releases/v0.5.18/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/project/releases/v0.5.19/index.html
+++ b/docs/static/v0.7/project/releases/v0.5.19/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/project/releases/v0.5.2/index.html
+++ b/docs/static/v0.7/project/releases/v0.5.2/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/project/releases/v0.5.20/index.html
+++ b/docs/static/v0.7/project/releases/v0.5.20/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/project/releases/v0.5.21/index.html
+++ b/docs/static/v0.7/project/releases/v0.5.21/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/project/releases/v0.5.22/index.html
+++ b/docs/static/v0.7/project/releases/v0.5.22/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/project/releases/v0.5.23/index.html
+++ b/docs/static/v0.7/project/releases/v0.5.23/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/project/releases/v0.5.24/index.html
+++ b/docs/static/v0.7/project/releases/v0.5.24/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/project/releases/v0.5.25/index.html
+++ b/docs/static/v0.7/project/releases/v0.5.25/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/project/releases/v0.5.26/index.html
+++ b/docs/static/v0.7/project/releases/v0.5.26/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/project/releases/v0.5.27/index.html
+++ b/docs/static/v0.7/project/releases/v0.5.27/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/project/releases/v0.5.28/index.html
+++ b/docs/static/v0.7/project/releases/v0.5.28/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/project/releases/v0.5.29/index.html
+++ b/docs/static/v0.7/project/releases/v0.5.29/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/project/releases/v0.5.3/index.html
+++ b/docs/static/v0.7/project/releases/v0.5.3/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/project/releases/v0.5.30/index.html
+++ b/docs/static/v0.7/project/releases/v0.5.30/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/project/releases/v0.5.31/index.html
+++ b/docs/static/v0.7/project/releases/v0.5.31/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/project/releases/v0.5.32/index.html
+++ b/docs/static/v0.7/project/releases/v0.5.32/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/project/releases/v0.5.33/index.html
+++ b/docs/static/v0.7/project/releases/v0.5.33/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/project/releases/v0.5.34/index.html
+++ b/docs/static/v0.7/project/releases/v0.5.34/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/project/releases/v0.5.35/index.html
+++ b/docs/static/v0.7/project/releases/v0.5.35/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/project/releases/v0.5.36/index.html
+++ b/docs/static/v0.7/project/releases/v0.5.36/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/project/releases/v0.5.37/index.html
+++ b/docs/static/v0.7/project/releases/v0.5.37/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/project/releases/v0.5.38/index.html
+++ b/docs/static/v0.7/project/releases/v0.5.38/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/project/releases/v0.5.39/index.html
+++ b/docs/static/v0.7/project/releases/v0.5.39/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/project/releases/v0.5.4/index.html
+++ b/docs/static/v0.7/project/releases/v0.5.4/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/project/releases/v0.5.40/index.html
+++ b/docs/static/v0.7/project/releases/v0.5.40/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/project/releases/v0.5.41/index.html
+++ b/docs/static/v0.7/project/releases/v0.5.41/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/project/releases/v0.5.42/index.html
+++ b/docs/static/v0.7/project/releases/v0.5.42/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/project/releases/v0.5.43/index.html
+++ b/docs/static/v0.7/project/releases/v0.5.43/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/project/releases/v0.5.44/index.html
+++ b/docs/static/v0.7/project/releases/v0.5.44/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/project/releases/v0.5.45/index.html
+++ b/docs/static/v0.7/project/releases/v0.5.45/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/project/releases/v0.5.46/index.html
+++ b/docs/static/v0.7/project/releases/v0.5.46/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/project/releases/v0.5.47/index.html
+++ b/docs/static/v0.7/project/releases/v0.5.47/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/project/releases/v0.5.48/index.html
+++ b/docs/static/v0.7/project/releases/v0.5.48/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/project/releases/v0.5.49/index.html
+++ b/docs/static/v0.7/project/releases/v0.5.49/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/project/releases/v0.5.5/index.html
+++ b/docs/static/v0.7/project/releases/v0.5.5/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/project/releases/v0.5.50/index.html
+++ b/docs/static/v0.7/project/releases/v0.5.50/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/project/releases/v0.5.51/index.html
+++ b/docs/static/v0.7/project/releases/v0.5.51/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/project/releases/v0.5.52/index.html
+++ b/docs/static/v0.7/project/releases/v0.5.52/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/project/releases/v0.5.53/index.html
+++ b/docs/static/v0.7/project/releases/v0.5.53/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/project/releases/v0.5.54/index.html
+++ b/docs/static/v0.7/project/releases/v0.5.54/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/project/releases/v0.5.55/index.html
+++ b/docs/static/v0.7/project/releases/v0.5.55/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/project/releases/v0.5.56/index.html
+++ b/docs/static/v0.7/project/releases/v0.5.56/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/project/releases/v0.5.57/index.html
+++ b/docs/static/v0.7/project/releases/v0.5.57/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/project/releases/v0.5.58/index.html
+++ b/docs/static/v0.7/project/releases/v0.5.58/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/project/releases/v0.5.59/index.html
+++ b/docs/static/v0.7/project/releases/v0.5.59/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/project/releases/v0.5.6/index.html
+++ b/docs/static/v0.7/project/releases/v0.5.6/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/project/releases/v0.5.60/index.html
+++ b/docs/static/v0.7/project/releases/v0.5.60/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/project/releases/v0.5.61/index.html
+++ b/docs/static/v0.7/project/releases/v0.5.61/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/project/releases/v0.5.62/index.html
+++ b/docs/static/v0.7/project/releases/v0.5.62/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/project/releases/v0.5.63-rc-1/index.html
+++ b/docs/static/v0.7/project/releases/v0.5.63-rc-1/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/project/releases/v0.5.64-rc-2/index.html
+++ b/docs/static/v0.7/project/releases/v0.5.64-rc-2/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/project/releases/v0.5.64/index.html
+++ b/docs/static/v0.7/project/releases/v0.5.64/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/project/releases/v0.5.65/index.html
+++ b/docs/static/v0.7/project/releases/v0.5.65/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/project/releases/v0.5.66/index.html
+++ b/docs/static/v0.7/project/releases/v0.5.66/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/project/releases/v0.5.67/index.html
+++ b/docs/static/v0.7/project/releases/v0.5.67/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/project/releases/v0.5.68/index.html
+++ b/docs/static/v0.7/project/releases/v0.5.68/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/project/releases/v0.5.69/index.html
+++ b/docs/static/v0.7/project/releases/v0.5.69/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/project/releases/v0.5.7/index.html
+++ b/docs/static/v0.7/project/releases/v0.5.7/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/project/releases/v0.5.70/index.html
+++ b/docs/static/v0.7/project/releases/v0.5.70/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/project/releases/v0.5.71/index.html
+++ b/docs/static/v0.7/project/releases/v0.5.71/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/project/releases/v0.5.72/index.html
+++ b/docs/static/v0.7/project/releases/v0.5.72/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/project/releases/v0.5.8/index.html
+++ b/docs/static/v0.7/project/releases/v0.5.8/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/project/releases/v0.5.9/index.html
+++ b/docs/static/v0.7/project/releases/v0.5.9/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/project/releases/v0.6.0-rc-1/index.html
+++ b/docs/static/v0.7/project/releases/v0.6.0-rc-1/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/project/releases/v0.6.0-rc-2/index.html
+++ b/docs/static/v0.7/project/releases/v0.6.0-rc-2/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/project/releases/v0.6.0-rc-3/index.html
+++ b/docs/static/v0.7/project/releases/v0.6.0-rc-3/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/project/releases/v0.6.0-rc-4/index.html
+++ b/docs/static/v0.7/project/releases/v0.6.0-rc-4/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/project/releases/v0.6.0-rc-5/index.html
+++ b/docs/static/v0.7/project/releases/v0.6.0-rc-5/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/project/releases/v0.6.0-rc-5a/index.html
+++ b/docs/static/v0.7/project/releases/v0.6.0-rc-5a/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/project/releases/v0.6.0-rc-5b/index.html
+++ b/docs/static/v0.7/project/releases/v0.6.0-rc-5b/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/project/releases/v0.6.0-rc-5c/index.html
+++ b/docs/static/v0.7/project/releases/v0.6.0-rc-5c/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/project/releases/v0.6.0-rc-5d/index.html
+++ b/docs/static/v0.7/project/releases/v0.6.0-rc-5d/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/project/releases/v0.6.0-rc-5f/index.html
+++ b/docs/static/v0.7/project/releases/v0.6.0-rc-5f/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/project/releases/v0.6.0-rc-5g/index.html
+++ b/docs/static/v0.7/project/releases/v0.6.0-rc-5g/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/project/releases/v0.6.0-rc-5h/index.html
+++ b/docs/static/v0.7/project/releases/v0.6.0-rc-5h/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/project/releases/v0.6.0-rc-5i/index.html
+++ b/docs/static/v0.7/project/releases/v0.6.0-rc-5i/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/project/releases/v0.6.0-rc-5j/index.html
+++ b/docs/static/v0.7/project/releases/v0.6.0-rc-5j/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/project/releases/v0.6.0-rc-5t/index.html
+++ b/docs/static/v0.7/project/releases/v0.6.0-rc-5t/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/project/releases/v0.6.0-rc.5aa/index.html
+++ b/docs/static/v0.7/project/releases/v0.6.0-rc.5aa/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/project/releases/v0.6.0-rc.5k/index.html
+++ b/docs/static/v0.7/project/releases/v0.6.0-rc.5k/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/project/releases/v0.6.0-rc.5l/index.html
+++ b/docs/static/v0.7/project/releases/v0.6.0-rc.5l/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/project/releases/v0.6.0-rc.5m/index.html
+++ b/docs/static/v0.7/project/releases/v0.6.0-rc.5m/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/project/releases/v0.6.0-rc.5n/index.html
+++ b/docs/static/v0.7/project/releases/v0.6.0-rc.5n/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/project/releases/v0.6.0-rc.5o/index.html
+++ b/docs/static/v0.7/project/releases/v0.6.0-rc.5o/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/project/releases/v0.6.0-rc.5p/index.html
+++ b/docs/static/v0.7/project/releases/v0.6.0-rc.5p/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/project/releases/v0.6.0-rc.5q/index.html
+++ b/docs/static/v0.7/project/releases/v0.6.0-rc.5q/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/project/releases/v0.6.0-rc.5r/index.html
+++ b/docs/static/v0.7/project/releases/v0.6.0-rc.5r/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/project/releases/v0.6.0-rc.5s/index.html
+++ b/docs/static/v0.7/project/releases/v0.6.0-rc.5s/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/project/releases/v0.6.0-rc.5t/index.html
+++ b/docs/static/v0.7/project/releases/v0.6.0-rc.5t/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/project/releases/v0.6.0-rc.5u/index.html
+++ b/docs/static/v0.7/project/releases/v0.6.0-rc.5u/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/project/releases/v0.6.0-rc.5v/index.html
+++ b/docs/static/v0.7/project/releases/v0.6.0-rc.5v/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/project/releases/v0.6.0-rc.5w/index.html
+++ b/docs/static/v0.7/project/releases/v0.6.0-rc.5w/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/project/releases/v0.6.0-rc.5x/index.html
+++ b/docs/static/v0.7/project/releases/v0.6.0-rc.5x/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/project/releases/v0.6.0-rc.5y/index.html
+++ b/docs/static/v0.7/project/releases/v0.6.0-rc.5y/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/project/releases/v0.6.0-rc.5z/index.html
+++ b/docs/static/v0.7/project/releases/v0.6.0-rc.5z/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/project/releases/v0.6.0-rc.6/index.html
+++ b/docs/static/v0.7/project/releases/v0.6.0-rc.6/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/project/releases/v0.6.0-rc.6a/index.html
+++ b/docs/static/v0.7/project/releases/v0.6.0-rc.6a/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/project/releases/v0.6.0-rc.6b/index.html
+++ b/docs/static/v0.7/project/releases/v0.6.0-rc.6b/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/project/releases/v0.6.0-rc.6c/index.html
+++ b/docs/static/v0.7/project/releases/v0.6.0-rc.6c/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/project/releases/v0.6.0-rc.6d/index.html
+++ b/docs/static/v0.7/project/releases/v0.6.0-rc.6d/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/project/releases/v0.6.0-rc.6e/index.html
+++ b/docs/static/v0.7/project/releases/v0.6.0-rc.6e/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/project/releases/v0.6.0-rc.6f/index.html
+++ b/docs/static/v0.7/project/releases/v0.6.0-rc.6f/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/project/releases/v0.6.0-rc.6fa/index.html
+++ b/docs/static/v0.7/project/releases/v0.6.0-rc.6fa/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/project/releases/v0.6.0-rc.6fb/index.html
+++ b/docs/static/v0.7/project/releases/v0.6.0-rc.6fb/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/project/releases/v0.6.0-rc.6fc/index.html
+++ b/docs/static/v0.7/project/releases/v0.6.0-rc.6fc/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/project/releases/v0.6.0-rc.6fd/index.html
+++ b/docs/static/v0.7/project/releases/v0.6.0-rc.6fd/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/project/releases/v0.6.0-rc.6fe/index.html
+++ b/docs/static/v0.7/project/releases/v0.6.0-rc.6fe/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/project/releases/v0.6.0-rc.6ff/index.html
+++ b/docs/static/v0.7/project/releases/v0.6.0-rc.6ff/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/project/releases/v0.6.0/index.html
+++ b/docs/static/v0.7/project/releases/v0.6.0/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/project/releases/v0.6.10/index.html
+++ b/docs/static/v0.7/project/releases/v0.6.10/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/project/releases/v0.6.100/index.html
+++ b/docs/static/v0.7/project/releases/v0.6.100/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/project/releases/v0.6.102/index.html
+++ b/docs/static/v0.7/project/releases/v0.6.102/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/project/releases/v0.6.103/index.html
+++ b/docs/static/v0.7/project/releases/v0.6.103/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/project/releases/v0.6.104/index.html
+++ b/docs/static/v0.7/project/releases/v0.6.104/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/project/releases/v0.6.105/index.html
+++ b/docs/static/v0.7/project/releases/v0.6.105/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/project/releases/v0.6.107/index.html
+++ b/docs/static/v0.7/project/releases/v0.6.107/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/project/releases/v0.6.108/index.html
+++ b/docs/static/v0.7/project/releases/v0.6.108/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/project/releases/v0.6.109/index.html
+++ b/docs/static/v0.7/project/releases/v0.6.109/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/project/releases/v0.6.110/index.html
+++ b/docs/static/v0.7/project/releases/v0.6.110/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/project/releases/v0.6.111/index.html
+++ b/docs/static/v0.7/project/releases/v0.6.111/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/project/releases/v0.6.112/index.html
+++ b/docs/static/v0.7/project/releases/v0.6.112/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/project/releases/v0.6.113/index.html
+++ b/docs/static/v0.7/project/releases/v0.6.113/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/project/releases/v0.6.114/index.html
+++ b/docs/static/v0.7/project/releases/v0.6.114/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/project/releases/v0.6.115/index.html
+++ b/docs/static/v0.7/project/releases/v0.6.115/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/project/releases/v0.6.116/index.html
+++ b/docs/static/v0.7/project/releases/v0.6.116/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/project/releases/v0.6.117/index.html
+++ b/docs/static/v0.7/project/releases/v0.6.117/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/project/releases/v0.6.118/index.html
+++ b/docs/static/v0.7/project/releases/v0.6.118/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/project/releases/v0.6.119/index.html
+++ b/docs/static/v0.7/project/releases/v0.6.119/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/project/releases/v0.6.12/index.html
+++ b/docs/static/v0.7/project/releases/v0.6.12/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/project/releases/v0.6.120/index.html
+++ b/docs/static/v0.7/project/releases/v0.6.120/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/project/releases/v0.6.121/index.html
+++ b/docs/static/v0.7/project/releases/v0.6.121/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/project/releases/v0.6.122/index.html
+++ b/docs/static/v0.7/project/releases/v0.6.122/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/project/releases/v0.6.123/index.html
+++ b/docs/static/v0.7/project/releases/v0.6.123/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/project/releases/v0.6.124/index.html
+++ b/docs/static/v0.7/project/releases/v0.6.124/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/project/releases/v0.6.125/index.html
+++ b/docs/static/v0.7/project/releases/v0.6.125/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/project/releases/v0.6.126/index.html
+++ b/docs/static/v0.7/project/releases/v0.6.126/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/project/releases/v0.6.127/index.html
+++ b/docs/static/v0.7/project/releases/v0.6.127/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/project/releases/v0.6.128/index.html
+++ b/docs/static/v0.7/project/releases/v0.6.128/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/project/releases/v0.6.129/index.html
+++ b/docs/static/v0.7/project/releases/v0.6.129/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/project/releases/v0.6.13/index.html
+++ b/docs/static/v0.7/project/releases/v0.6.13/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/project/releases/v0.6.130/index.html
+++ b/docs/static/v0.7/project/releases/v0.6.130/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/project/releases/v0.6.131/index.html
+++ b/docs/static/v0.7/project/releases/v0.6.131/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/project/releases/v0.6.132/index.html
+++ b/docs/static/v0.7/project/releases/v0.6.132/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/project/releases/v0.6.133/index.html
+++ b/docs/static/v0.7/project/releases/v0.6.133/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/project/releases/v0.6.134/index.html
+++ b/docs/static/v0.7/project/releases/v0.6.134/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/project/releases/v0.6.135/index.html
+++ b/docs/static/v0.7/project/releases/v0.6.135/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/project/releases/v0.6.136/index.html
+++ b/docs/static/v0.7/project/releases/v0.6.136/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/project/releases/v0.6.137/index.html
+++ b/docs/static/v0.7/project/releases/v0.6.137/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/project/releases/v0.6.138/index.html
+++ b/docs/static/v0.7/project/releases/v0.6.138/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/project/releases/v0.6.139/index.html
+++ b/docs/static/v0.7/project/releases/v0.6.139/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/project/releases/v0.6.14/index.html
+++ b/docs/static/v0.7/project/releases/v0.6.14/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/project/releases/v0.6.140/index.html
+++ b/docs/static/v0.7/project/releases/v0.6.140/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/project/releases/v0.6.141/index.html
+++ b/docs/static/v0.7/project/releases/v0.6.141/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/project/releases/v0.6.142/index.html
+++ b/docs/static/v0.7/project/releases/v0.6.142/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/project/releases/v0.6.143/index.html
+++ b/docs/static/v0.7/project/releases/v0.6.143/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/project/releases/v0.6.144/index.html
+++ b/docs/static/v0.7/project/releases/v0.6.144/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/project/releases/v0.6.145/index.html
+++ b/docs/static/v0.7/project/releases/v0.6.145/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/project/releases/v0.6.146/index.html
+++ b/docs/static/v0.7/project/releases/v0.6.146/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/project/releases/v0.6.147/index.html
+++ b/docs/static/v0.7/project/releases/v0.6.147/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/project/releases/v0.6.148/index.html
+++ b/docs/static/v0.7/project/releases/v0.6.148/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/project/releases/v0.6.149/index.html
+++ b/docs/static/v0.7/project/releases/v0.6.149/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/project/releases/v0.6.15/index.html
+++ b/docs/static/v0.7/project/releases/v0.6.15/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/project/releases/v0.6.150/index.html
+++ b/docs/static/v0.7/project/releases/v0.6.150/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/project/releases/v0.6.151/index.html
+++ b/docs/static/v0.7/project/releases/v0.6.151/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/project/releases/v0.6.152/index.html
+++ b/docs/static/v0.7/project/releases/v0.6.152/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/project/releases/v0.6.153/index.html
+++ b/docs/static/v0.7/project/releases/v0.6.153/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/project/releases/v0.6.154/index.html
+++ b/docs/static/v0.7/project/releases/v0.6.154/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/project/releases/v0.6.155/index.html
+++ b/docs/static/v0.7/project/releases/v0.6.155/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/project/releases/v0.6.156/index.html
+++ b/docs/static/v0.7/project/releases/v0.6.156/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/project/releases/v0.6.157/index.html
+++ b/docs/static/v0.7/project/releases/v0.6.157/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/project/releases/v0.6.158/index.html
+++ b/docs/static/v0.7/project/releases/v0.6.158/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/project/releases/v0.6.159/index.html
+++ b/docs/static/v0.7/project/releases/v0.6.159/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/project/releases/v0.6.16/index.html
+++ b/docs/static/v0.7/project/releases/v0.6.16/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/project/releases/v0.6.160/index.html
+++ b/docs/static/v0.7/project/releases/v0.6.160/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/project/releases/v0.6.161/index.html
+++ b/docs/static/v0.7/project/releases/v0.6.161/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/project/releases/v0.6.162/index.html
+++ b/docs/static/v0.7/project/releases/v0.6.162/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/project/releases/v0.6.163/index.html
+++ b/docs/static/v0.7/project/releases/v0.6.163/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/project/releases/v0.6.164/index.html
+++ b/docs/static/v0.7/project/releases/v0.6.164/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/project/releases/v0.6.165/index.html
+++ b/docs/static/v0.7/project/releases/v0.6.165/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/project/releases/v0.6.166/index.html
+++ b/docs/static/v0.7/project/releases/v0.6.166/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/project/releases/v0.6.167/index.html
+++ b/docs/static/v0.7/project/releases/v0.6.167/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/project/releases/v0.6.168/index.html
+++ b/docs/static/v0.7/project/releases/v0.6.168/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/project/releases/v0.6.169/index.html
+++ b/docs/static/v0.7/project/releases/v0.6.169/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/project/releases/v0.6.17/index.html
+++ b/docs/static/v0.7/project/releases/v0.6.17/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/project/releases/v0.6.171/index.html
+++ b/docs/static/v0.7/project/releases/v0.6.171/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/project/releases/v0.6.172/index.html
+++ b/docs/static/v0.7/project/releases/v0.6.172/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/project/releases/v0.6.173/index.html
+++ b/docs/static/v0.7/project/releases/v0.6.173/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/project/releases/v0.6.174/index.html
+++ b/docs/static/v0.7/project/releases/v0.6.174/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/project/releases/v0.6.175/index.html
+++ b/docs/static/v0.7/project/releases/v0.6.175/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/project/releases/v0.6.176/index.html
+++ b/docs/static/v0.7/project/releases/v0.6.176/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/project/releases/v0.6.177/index.html
+++ b/docs/static/v0.7/project/releases/v0.6.177/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/project/releases/v0.6.178/index.html
+++ b/docs/static/v0.7/project/releases/v0.6.178/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/project/releases/v0.6.179/index.html
+++ b/docs/static/v0.7/project/releases/v0.6.179/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/project/releases/v0.6.18/index.html
+++ b/docs/static/v0.7/project/releases/v0.6.18/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/project/releases/v0.6.180/index.html
+++ b/docs/static/v0.7/project/releases/v0.6.180/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/project/releases/v0.6.181/index.html
+++ b/docs/static/v0.7/project/releases/v0.6.181/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/project/releases/v0.6.182/index.html
+++ b/docs/static/v0.7/project/releases/v0.6.182/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/project/releases/v0.6.183/index.html
+++ b/docs/static/v0.7/project/releases/v0.6.183/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/project/releases/v0.6.184/index.html
+++ b/docs/static/v0.7/project/releases/v0.6.184/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/project/releases/v0.6.185/index.html
+++ b/docs/static/v0.7/project/releases/v0.6.185/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/project/releases/v0.6.19/index.html
+++ b/docs/static/v0.7/project/releases/v0.6.19/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/project/releases/v0.6.2/index.html
+++ b/docs/static/v0.7/project/releases/v0.6.2/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/project/releases/v0.6.20/index.html
+++ b/docs/static/v0.7/project/releases/v0.6.20/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/project/releases/v0.6.21/index.html
+++ b/docs/static/v0.7/project/releases/v0.6.21/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/project/releases/v0.6.22/index.html
+++ b/docs/static/v0.7/project/releases/v0.6.22/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/project/releases/v0.6.23/index.html
+++ b/docs/static/v0.7/project/releases/v0.6.23/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/project/releases/v0.6.24/index.html
+++ b/docs/static/v0.7/project/releases/v0.6.24/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/project/releases/v0.6.25/index.html
+++ b/docs/static/v0.7/project/releases/v0.6.25/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/project/releases/v0.6.26/index.html
+++ b/docs/static/v0.7/project/releases/v0.6.26/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/project/releases/v0.6.27/index.html
+++ b/docs/static/v0.7/project/releases/v0.6.27/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/project/releases/v0.6.28/index.html
+++ b/docs/static/v0.7/project/releases/v0.6.28/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/project/releases/v0.6.29/index.html
+++ b/docs/static/v0.7/project/releases/v0.6.29/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/project/releases/v0.6.3/index.html
+++ b/docs/static/v0.7/project/releases/v0.6.3/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/project/releases/v0.6.30/index.html
+++ b/docs/static/v0.7/project/releases/v0.6.30/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/project/releases/v0.6.31/index.html
+++ b/docs/static/v0.7/project/releases/v0.6.31/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/project/releases/v0.6.32/index.html
+++ b/docs/static/v0.7/project/releases/v0.6.32/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/project/releases/v0.6.33/index.html
+++ b/docs/static/v0.7/project/releases/v0.6.33/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/project/releases/v0.6.34/index.html
+++ b/docs/static/v0.7/project/releases/v0.6.34/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/project/releases/v0.6.35/index.html
+++ b/docs/static/v0.7/project/releases/v0.6.35/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/project/releases/v0.6.36/index.html
+++ b/docs/static/v0.7/project/releases/v0.6.36/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/project/releases/v0.6.37/index.html
+++ b/docs/static/v0.7/project/releases/v0.6.37/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/project/releases/v0.6.38/index.html
+++ b/docs/static/v0.7/project/releases/v0.6.38/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/project/releases/v0.6.39/index.html
+++ b/docs/static/v0.7/project/releases/v0.6.39/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/project/releases/v0.6.4/index.html
+++ b/docs/static/v0.7/project/releases/v0.6.4/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/project/releases/v0.6.40/index.html
+++ b/docs/static/v0.7/project/releases/v0.6.40/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/project/releases/v0.6.41/index.html
+++ b/docs/static/v0.7/project/releases/v0.6.41/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/project/releases/v0.6.42/index.html
+++ b/docs/static/v0.7/project/releases/v0.6.42/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/project/releases/v0.6.43/index.html
+++ b/docs/static/v0.7/project/releases/v0.6.43/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/project/releases/v0.6.44/index.html
+++ b/docs/static/v0.7/project/releases/v0.6.44/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/project/releases/v0.6.45/index.html
+++ b/docs/static/v0.7/project/releases/v0.6.45/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/project/releases/v0.6.46/index.html
+++ b/docs/static/v0.7/project/releases/v0.6.46/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/project/releases/v0.6.47/index.html
+++ b/docs/static/v0.7/project/releases/v0.6.47/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/project/releases/v0.6.48/index.html
+++ b/docs/static/v0.7/project/releases/v0.6.48/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/project/releases/v0.6.49/index.html
+++ b/docs/static/v0.7/project/releases/v0.6.49/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/project/releases/v0.6.5/index.html
+++ b/docs/static/v0.7/project/releases/v0.6.5/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/project/releases/v0.6.50/index.html
+++ b/docs/static/v0.7/project/releases/v0.6.50/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/project/releases/v0.6.51/index.html
+++ b/docs/static/v0.7/project/releases/v0.6.51/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/project/releases/v0.6.52/index.html
+++ b/docs/static/v0.7/project/releases/v0.6.52/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/project/releases/v0.6.53/index.html
+++ b/docs/static/v0.7/project/releases/v0.6.53/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/project/releases/v0.6.54/index.html
+++ b/docs/static/v0.7/project/releases/v0.6.54/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/project/releases/v0.6.55/index.html
+++ b/docs/static/v0.7/project/releases/v0.6.55/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/project/releases/v0.6.56/index.html
+++ b/docs/static/v0.7/project/releases/v0.6.56/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/project/releases/v0.6.57/index.html
+++ b/docs/static/v0.7/project/releases/v0.6.57/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/project/releases/v0.6.58/index.html
+++ b/docs/static/v0.7/project/releases/v0.6.58/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/project/releases/v0.6.59/index.html
+++ b/docs/static/v0.7/project/releases/v0.6.59/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/project/releases/v0.6.6/index.html
+++ b/docs/static/v0.7/project/releases/v0.6.6/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/project/releases/v0.6.61/index.html
+++ b/docs/static/v0.7/project/releases/v0.6.61/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/project/releases/v0.6.62/index.html
+++ b/docs/static/v0.7/project/releases/v0.6.62/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/project/releases/v0.6.63/index.html
+++ b/docs/static/v0.7/project/releases/v0.6.63/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/project/releases/v0.6.64/index.html
+++ b/docs/static/v0.7/project/releases/v0.6.64/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/project/releases/v0.6.65/index.html
+++ b/docs/static/v0.7/project/releases/v0.6.65/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/project/releases/v0.6.66/index.html
+++ b/docs/static/v0.7/project/releases/v0.6.66/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/project/releases/v0.6.67/index.html
+++ b/docs/static/v0.7/project/releases/v0.6.67/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/project/releases/v0.6.68/index.html
+++ b/docs/static/v0.7/project/releases/v0.6.68/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/project/releases/v0.6.69/index.html
+++ b/docs/static/v0.7/project/releases/v0.6.69/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/project/releases/v0.6.7/index.html
+++ b/docs/static/v0.7/project/releases/v0.6.7/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/project/releases/v0.6.70/index.html
+++ b/docs/static/v0.7/project/releases/v0.6.70/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/project/releases/v0.6.71/index.html
+++ b/docs/static/v0.7/project/releases/v0.6.71/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/project/releases/v0.6.72/index.html
+++ b/docs/static/v0.7/project/releases/v0.6.72/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/project/releases/v0.6.73/index.html
+++ b/docs/static/v0.7/project/releases/v0.6.73/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/project/releases/v0.6.74/index.html
+++ b/docs/static/v0.7/project/releases/v0.6.74/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/project/releases/v0.6.75/index.html
+++ b/docs/static/v0.7/project/releases/v0.6.75/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/project/releases/v0.6.76/index.html
+++ b/docs/static/v0.7/project/releases/v0.6.76/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/project/releases/v0.6.77/index.html
+++ b/docs/static/v0.7/project/releases/v0.6.77/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/project/releases/v0.6.78/index.html
+++ b/docs/static/v0.7/project/releases/v0.6.78/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/project/releases/v0.6.79/index.html
+++ b/docs/static/v0.7/project/releases/v0.6.79/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/project/releases/v0.6.8/index.html
+++ b/docs/static/v0.7/project/releases/v0.6.8/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/project/releases/v0.6.80/index.html
+++ b/docs/static/v0.7/project/releases/v0.6.80/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/project/releases/v0.6.81/index.html
+++ b/docs/static/v0.7/project/releases/v0.6.81/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/project/releases/v0.6.82/index.html
+++ b/docs/static/v0.7/project/releases/v0.6.82/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/project/releases/v0.6.83/index.html
+++ b/docs/static/v0.7/project/releases/v0.6.83/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/project/releases/v0.6.84/index.html
+++ b/docs/static/v0.7/project/releases/v0.6.84/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/project/releases/v0.6.85/index.html
+++ b/docs/static/v0.7/project/releases/v0.6.85/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/project/releases/v0.6.86/index.html
+++ b/docs/static/v0.7/project/releases/v0.6.86/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/project/releases/v0.6.87/index.html
+++ b/docs/static/v0.7/project/releases/v0.6.87/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/project/releases/v0.6.88/index.html
+++ b/docs/static/v0.7/project/releases/v0.6.88/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/project/releases/v0.6.89/index.html
+++ b/docs/static/v0.7/project/releases/v0.6.89/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/project/releases/v0.6.9/index.html
+++ b/docs/static/v0.7/project/releases/v0.6.9/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/project/releases/v0.6.90/index.html
+++ b/docs/static/v0.7/project/releases/v0.6.90/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/project/releases/v0.6.91/index.html
+++ b/docs/static/v0.7/project/releases/v0.6.91/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/project/releases/v0.6.92/index.html
+++ b/docs/static/v0.7/project/releases/v0.6.92/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/project/releases/v0.6.93/index.html
+++ b/docs/static/v0.7/project/releases/v0.6.93/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/project/releases/v0.6.94/index.html
+++ b/docs/static/v0.7/project/releases/v0.6.94/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/project/releases/v0.6.95/index.html
+++ b/docs/static/v0.7/project/releases/v0.6.95/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/project/releases/v0.6.96/index.html
+++ b/docs/static/v0.7/project/releases/v0.6.96/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/project/releases/v0.6.97/index.html
+++ b/docs/static/v0.7/project/releases/v0.6.97/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/project/releases/v0.6.98/index.html
+++ b/docs/static/v0.7/project/releases/v0.6.98/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/project/releases/v0.6.99/index.html
+++ b/docs/static/v0.7/project/releases/v0.6.99/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/project/releases/v0.7.0-beta-1/index.html
+++ b/docs/static/v0.7/project/releases/v0.7.0-beta-1/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/project/releases/v0.7.0-beta-2/index.html
+++ b/docs/static/v0.7/project/releases/v0.7.0-beta-2/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/project/releases/v0.7.0-beta-3/index.html
+++ b/docs/static/v0.7/project/releases/v0.7.0-beta-3/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/project/releases/v0.7.0-beta-4/index.html
+++ b/docs/static/v0.7/project/releases/v0.7.0-beta-4/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/project/releases/v0.7.0/index.html
+++ b/docs/static/v0.7/project/releases/v0.7.0/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/project/releases/v0.7.1/index.html
+++ b/docs/static/v0.7/project/releases/v0.7.1/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/project/releases/v0.7.10/index.html
+++ b/docs/static/v0.7/project/releases/v0.7.10/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/project/releases/v0.7.101/index.html
+++ b/docs/static/v0.7/project/releases/v0.7.101/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/project/releases/v0.7.102/index.html
+++ b/docs/static/v0.7/project/releases/v0.7.102/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/project/releases/v0.7.103/index.html
+++ b/docs/static/v0.7/project/releases/v0.7.103/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/project/releases/v0.7.104/index.html
+++ b/docs/static/v0.7/project/releases/v0.7.104/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/project/releases/v0.7.105/index.html
+++ b/docs/static/v0.7/project/releases/v0.7.105/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/project/releases/v0.7.106/index.html
+++ b/docs/static/v0.7/project/releases/v0.7.106/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/project/releases/v0.7.107/index.html
+++ b/docs/static/v0.7/project/releases/v0.7.107/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/project/releases/v0.7.108/index.html
+++ b/docs/static/v0.7/project/releases/v0.7.108/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/project/releases/v0.7.109/index.html
+++ b/docs/static/v0.7/project/releases/v0.7.109/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/project/releases/v0.7.11-patch.1/index.html
+++ b/docs/static/v0.7/project/releases/v0.7.11-patch.1/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/project/releases/v0.7.11-patch.2/index.html
+++ b/docs/static/v0.7/project/releases/v0.7.11-patch.2/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/project/releases/v0.7.11-patch.3/index.html
+++ b/docs/static/v0.7/project/releases/v0.7.11-patch.3/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/project/releases/v0.7.11/index.html
+++ b/docs/static/v0.7/project/releases/v0.7.11/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/project/releases/v0.7.110/index.html
+++ b/docs/static/v0.7/project/releases/v0.7.110/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/project/releases/v0.7.111/index.html
+++ b/docs/static/v0.7/project/releases/v0.7.111/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/project/releases/v0.7.112/index.html
+++ b/docs/static/v0.7/project/releases/v0.7.112/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/project/releases/v0.7.113/index.html
+++ b/docs/static/v0.7/project/releases/v0.7.113/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/project/releases/v0.7.114/index.html
+++ b/docs/static/v0.7/project/releases/v0.7.114/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/project/releases/v0.7.115/index.html
+++ b/docs/static/v0.7/project/releases/v0.7.115/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/project/releases/v0.7.116/index.html
+++ b/docs/static/v0.7/project/releases/v0.7.116/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/project/releases/v0.7.117/index.html
+++ b/docs/static/v0.7/project/releases/v0.7.117/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/project/releases/v0.7.118/index.html
+++ b/docs/static/v0.7/project/releases/v0.7.118/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/project/releases/v0.7.119/index.html
+++ b/docs/static/v0.7/project/releases/v0.7.119/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/project/releases/v0.7.12/index.html
+++ b/docs/static/v0.7/project/releases/v0.7.12/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/project/releases/v0.7.120/index.html
+++ b/docs/static/v0.7/project/releases/v0.7.120/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/project/releases/v0.7.121/index.html
+++ b/docs/static/v0.7/project/releases/v0.7.121/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/project/releases/v0.7.122/index.html
+++ b/docs/static/v0.7/project/releases/v0.7.122/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/project/releases/v0.7.123/index.html
+++ b/docs/static/v0.7/project/releases/v0.7.123/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/project/releases/v0.7.124/index.html
+++ b/docs/static/v0.7/project/releases/v0.7.124/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/project/releases/v0.7.125/index.html
+++ b/docs/static/v0.7/project/releases/v0.7.125/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/project/releases/v0.7.126/index.html
+++ b/docs/static/v0.7/project/releases/v0.7.126/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/project/releases/v0.7.127/index.html
+++ b/docs/static/v0.7/project/releases/v0.7.127/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/project/releases/v0.7.128/index.html
+++ b/docs/static/v0.7/project/releases/v0.7.128/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/project/releases/v0.7.129/index.html
+++ b/docs/static/v0.7/project/releases/v0.7.129/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/project/releases/v0.7.13/index.html
+++ b/docs/static/v0.7/project/releases/v0.7.13/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/project/releases/v0.7.130/index.html
+++ b/docs/static/v0.7/project/releases/v0.7.130/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/project/releases/v0.7.131/index.html
+++ b/docs/static/v0.7/project/releases/v0.7.131/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/project/releases/v0.7.132/index.html
+++ b/docs/static/v0.7/project/releases/v0.7.132/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/project/releases/v0.7.133/index.html
+++ b/docs/static/v0.7/project/releases/v0.7.133/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/project/releases/v0.7.134/index.html
+++ b/docs/static/v0.7/project/releases/v0.7.134/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/project/releases/v0.7.135/index.html
+++ b/docs/static/v0.7/project/releases/v0.7.135/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/project/releases/v0.7.136/index.html
+++ b/docs/static/v0.7/project/releases/v0.7.136/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/project/releases/v0.7.137/index.html
+++ b/docs/static/v0.7/project/releases/v0.7.137/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/project/releases/v0.7.138/index.html
+++ b/docs/static/v0.7/project/releases/v0.7.138/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/project/releases/v0.7.139/index.html
+++ b/docs/static/v0.7/project/releases/v0.7.139/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/project/releases/v0.7.14/index.html
+++ b/docs/static/v0.7/project/releases/v0.7.14/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/project/releases/v0.7.140/index.html
+++ b/docs/static/v0.7/project/releases/v0.7.140/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/project/releases/v0.7.141/index.html
+++ b/docs/static/v0.7/project/releases/v0.7.141/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/project/releases/v0.7.142/index.html
+++ b/docs/static/v0.7/project/releases/v0.7.142/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/project/releases/v0.7.143/index.html
+++ b/docs/static/v0.7/project/releases/v0.7.143/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/project/releases/v0.7.144/index.html
+++ b/docs/static/v0.7/project/releases/v0.7.144/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/project/releases/v0.7.145/index.html
+++ b/docs/static/v0.7/project/releases/v0.7.145/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/project/releases/v0.7.146/index.html
+++ b/docs/static/v0.7/project/releases/v0.7.146/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/project/releases/v0.7.147/index.html
+++ b/docs/static/v0.7/project/releases/v0.7.147/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/project/releases/v0.7.148/index.html
+++ b/docs/static/v0.7/project/releases/v0.7.148/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/project/releases/v0.7.149/index.html
+++ b/docs/static/v0.7/project/releases/v0.7.149/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/project/releases/v0.7.15/index.html
+++ b/docs/static/v0.7/project/releases/v0.7.15/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/project/releases/v0.7.150/index.html
+++ b/docs/static/v0.7/project/releases/v0.7.150/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/project/releases/v0.7.151/index.html
+++ b/docs/static/v0.7/project/releases/v0.7.151/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/project/releases/v0.7.152/index.html
+++ b/docs/static/v0.7/project/releases/v0.7.152/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/project/releases/v0.7.153/index.html
+++ b/docs/static/v0.7/project/releases/v0.7.153/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/project/releases/v0.7.154/index.html
+++ b/docs/static/v0.7/project/releases/v0.7.154/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/project/releases/v0.7.155/index.html
+++ b/docs/static/v0.7/project/releases/v0.7.155/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/project/releases/v0.7.156/index.html
+++ b/docs/static/v0.7/project/releases/v0.7.156/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/project/releases/v0.7.157/index.html
+++ b/docs/static/v0.7/project/releases/v0.7.157/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/project/releases/v0.7.158/index.html
+++ b/docs/static/v0.7/project/releases/v0.7.158/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/project/releases/v0.7.159/index.html
+++ b/docs/static/v0.7/project/releases/v0.7.159/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/project/releases/v0.7.16/index.html
+++ b/docs/static/v0.7/project/releases/v0.7.16/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/project/releases/v0.7.160/index.html
+++ b/docs/static/v0.7/project/releases/v0.7.160/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/project/releases/v0.7.161/index.html
+++ b/docs/static/v0.7/project/releases/v0.7.161/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/project/releases/v0.7.162/index.html
+++ b/docs/static/v0.7/project/releases/v0.7.162/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/project/releases/v0.7.163/index.html
+++ b/docs/static/v0.7/project/releases/v0.7.163/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/project/releases/v0.7.164/index.html
+++ b/docs/static/v0.7/project/releases/v0.7.164/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/project/releases/v0.7.165/index.html
+++ b/docs/static/v0.7/project/releases/v0.7.165/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/project/releases/v0.7.166/index.html
+++ b/docs/static/v0.7/project/releases/v0.7.166/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/project/releases/v0.7.167/index.html
+++ b/docs/static/v0.7/project/releases/v0.7.167/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/project/releases/v0.7.168/index.html
+++ b/docs/static/v0.7/project/releases/v0.7.168/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/project/releases/v0.7.169/index.html
+++ b/docs/static/v0.7/project/releases/v0.7.169/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/project/releases/v0.7.17/index.html
+++ b/docs/static/v0.7/project/releases/v0.7.17/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/project/releases/v0.7.170/index.html
+++ b/docs/static/v0.7/project/releases/v0.7.170/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/project/releases/v0.7.171/index.html
+++ b/docs/static/v0.7/project/releases/v0.7.171/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/project/releases/v0.7.172/index.html
+++ b/docs/static/v0.7/project/releases/v0.7.172/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/project/releases/v0.7.18/index.html
+++ b/docs/static/v0.7/project/releases/v0.7.18/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/project/releases/v0.7.19/index.html
+++ b/docs/static/v0.7/project/releases/v0.7.19/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/project/releases/v0.7.2-rc-1/index.html
+++ b/docs/static/v0.7/project/releases/v0.7.2-rc-1/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/project/releases/v0.7.2-rc-2/index.html
+++ b/docs/static/v0.7/project/releases/v0.7.2-rc-2/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/project/releases/v0.7.2.1/index.html
+++ b/docs/static/v0.7/project/releases/v0.7.2.1/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/project/releases/v0.7.2.2/index.html
+++ b/docs/static/v0.7/project/releases/v0.7.2.2/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/project/releases/v0.7.2.4/index.html
+++ b/docs/static/v0.7/project/releases/v0.7.2.4/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/project/releases/v0.7.2/index.html
+++ b/docs/static/v0.7/project/releases/v0.7.2/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/project/releases/v0.7.20/index.html
+++ b/docs/static/v0.7/project/releases/v0.7.20/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/project/releases/v0.7.21/index.html
+++ b/docs/static/v0.7/project/releases/v0.7.21/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/project/releases/v0.7.22/index.html
+++ b/docs/static/v0.7/project/releases/v0.7.22/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/project/releases/v0.7.24/index.html
+++ b/docs/static/v0.7/project/releases/v0.7.24/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/project/releases/v0.7.25/index.html
+++ b/docs/static/v0.7/project/releases/v0.7.25/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/project/releases/v0.7.26/index.html
+++ b/docs/static/v0.7/project/releases/v0.7.26/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/project/releases/v0.7.27/index.html
+++ b/docs/static/v0.7/project/releases/v0.7.27/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/project/releases/v0.7.28/index.html
+++ b/docs/static/v0.7/project/releases/v0.7.28/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/project/releases/v0.7.29/index.html
+++ b/docs/static/v0.7/project/releases/v0.7.29/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/project/releases/v0.7.3-patch.1/index.html
+++ b/docs/static/v0.7/project/releases/v0.7.3-patch.1/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/project/releases/v0.7.3-patch.2/index.html
+++ b/docs/static/v0.7/project/releases/v0.7.3-patch.2/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/project/releases/v0.7.3-patch.3/index.html
+++ b/docs/static/v0.7/project/releases/v0.7.3-patch.3/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/project/releases/v0.7.3-patch.4/index.html
+++ b/docs/static/v0.7/project/releases/v0.7.3-patch.4/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/project/releases/v0.7.3/index.html
+++ b/docs/static/v0.7/project/releases/v0.7.3/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/project/releases/v0.7.30/index.html
+++ b/docs/static/v0.7/project/releases/v0.7.30/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/project/releases/v0.7.31/index.html
+++ b/docs/static/v0.7/project/releases/v0.7.31/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/project/releases/v0.7.32/index.html
+++ b/docs/static/v0.7/project/releases/v0.7.32/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/project/releases/v0.7.33/index.html
+++ b/docs/static/v0.7/project/releases/v0.7.33/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/project/releases/v0.7.34/index.html
+++ b/docs/static/v0.7/project/releases/v0.7.34/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/project/releases/v0.7.35/index.html
+++ b/docs/static/v0.7/project/releases/v0.7.35/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/project/releases/v0.7.36/index.html
+++ b/docs/static/v0.7/project/releases/v0.7.36/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/project/releases/v0.7.37/index.html
+++ b/docs/static/v0.7/project/releases/v0.7.37/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/project/releases/v0.7.38/index.html
+++ b/docs/static/v0.7/project/releases/v0.7.38/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/project/releases/v0.7.39/index.html
+++ b/docs/static/v0.7/project/releases/v0.7.39/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/project/releases/v0.7.4-patch.1/index.html
+++ b/docs/static/v0.7/project/releases/v0.7.4-patch.1/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/project/releases/v0.7.4/index.html
+++ b/docs/static/v0.7/project/releases/v0.7.4/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/project/releases/v0.7.40/index.html
+++ b/docs/static/v0.7/project/releases/v0.7.40/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/project/releases/v0.7.41/index.html
+++ b/docs/static/v0.7/project/releases/v0.7.41/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/project/releases/v0.7.42/index.html
+++ b/docs/static/v0.7/project/releases/v0.7.42/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/project/releases/v0.7.43/index.html
+++ b/docs/static/v0.7/project/releases/v0.7.43/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/project/releases/v0.7.44/index.html
+++ b/docs/static/v0.7/project/releases/v0.7.44/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/project/releases/v0.7.45/index.html
+++ b/docs/static/v0.7/project/releases/v0.7.45/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/project/releases/v0.7.46/index.html
+++ b/docs/static/v0.7/project/releases/v0.7.46/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/project/releases/v0.7.47/index.html
+++ b/docs/static/v0.7/project/releases/v0.7.47/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/project/releases/v0.7.48/index.html
+++ b/docs/static/v0.7/project/releases/v0.7.48/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/project/releases/v0.7.49/index.html
+++ b/docs/static/v0.7/project/releases/v0.7.49/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/project/releases/v0.7.5/index.html
+++ b/docs/static/v0.7/project/releases/v0.7.5/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/project/releases/v0.7.50/index.html
+++ b/docs/static/v0.7/project/releases/v0.7.50/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/project/releases/v0.7.51/index.html
+++ b/docs/static/v0.7/project/releases/v0.7.51/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/project/releases/v0.7.52/index.html
+++ b/docs/static/v0.7/project/releases/v0.7.52/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/project/releases/v0.7.53/index.html
+++ b/docs/static/v0.7/project/releases/v0.7.53/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/project/releases/v0.7.54/index.html
+++ b/docs/static/v0.7/project/releases/v0.7.54/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/project/releases/v0.7.55/index.html
+++ b/docs/static/v0.7/project/releases/v0.7.55/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/project/releases/v0.7.56/index.html
+++ b/docs/static/v0.7/project/releases/v0.7.56/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/project/releases/v0.7.57/index.html
+++ b/docs/static/v0.7/project/releases/v0.7.57/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/project/releases/v0.7.58/index.html
+++ b/docs/static/v0.7/project/releases/v0.7.58/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/project/releases/v0.7.59/index.html
+++ b/docs/static/v0.7/project/releases/v0.7.59/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/project/releases/v0.7.6/index.html
+++ b/docs/static/v0.7/project/releases/v0.7.6/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/project/releases/v0.7.60/index.html
+++ b/docs/static/v0.7/project/releases/v0.7.60/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/project/releases/v0.7.61/index.html
+++ b/docs/static/v0.7/project/releases/v0.7.61/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/project/releases/v0.7.62/index.html
+++ b/docs/static/v0.7/project/releases/v0.7.62/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/project/releases/v0.7.63/index.html
+++ b/docs/static/v0.7/project/releases/v0.7.63/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/project/releases/v0.7.64/index.html
+++ b/docs/static/v0.7/project/releases/v0.7.64/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/project/releases/v0.7.65/index.html
+++ b/docs/static/v0.7/project/releases/v0.7.65/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/project/releases/v0.7.66/index.html
+++ b/docs/static/v0.7/project/releases/v0.7.66/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/project/releases/v0.7.67/index.html
+++ b/docs/static/v0.7/project/releases/v0.7.67/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/project/releases/v0.7.68/index.html
+++ b/docs/static/v0.7/project/releases/v0.7.68/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/project/releases/v0.7.69/index.html
+++ b/docs/static/v0.7/project/releases/v0.7.69/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/project/releases/v0.7.7/index.html
+++ b/docs/static/v0.7/project/releases/v0.7.7/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/project/releases/v0.7.70/index.html
+++ b/docs/static/v0.7/project/releases/v0.7.70/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/project/releases/v0.7.71/index.html
+++ b/docs/static/v0.7/project/releases/v0.7.71/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/project/releases/v0.7.72/index.html
+++ b/docs/static/v0.7/project/releases/v0.7.72/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/project/releases/v0.7.73/index.html
+++ b/docs/static/v0.7/project/releases/v0.7.73/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/project/releases/v0.7.74/index.html
+++ b/docs/static/v0.7/project/releases/v0.7.74/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/project/releases/v0.7.75/index.html
+++ b/docs/static/v0.7/project/releases/v0.7.75/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/project/releases/v0.7.76/index.html
+++ b/docs/static/v0.7/project/releases/v0.7.76/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/project/releases/v0.7.77/index.html
+++ b/docs/static/v0.7/project/releases/v0.7.77/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/project/releases/v0.7.78/index.html
+++ b/docs/static/v0.7/project/releases/v0.7.78/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/project/releases/v0.7.79/index.html
+++ b/docs/static/v0.7/project/releases/v0.7.79/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/project/releases/v0.7.8/index.html
+++ b/docs/static/v0.7/project/releases/v0.7.8/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/project/releases/v0.7.80/index.html
+++ b/docs/static/v0.7/project/releases/v0.7.80/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/project/releases/v0.7.81/index.html
+++ b/docs/static/v0.7/project/releases/v0.7.81/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/project/releases/v0.7.82/index.html
+++ b/docs/static/v0.7/project/releases/v0.7.82/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/project/releases/v0.7.83/index.html
+++ b/docs/static/v0.7/project/releases/v0.7.83/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/project/releases/v0.7.84/index.html
+++ b/docs/static/v0.7/project/releases/v0.7.84/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/project/releases/v0.7.85/index.html
+++ b/docs/static/v0.7/project/releases/v0.7.85/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/project/releases/v0.7.86/index.html
+++ b/docs/static/v0.7/project/releases/v0.7.86/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/project/releases/v0.7.87/index.html
+++ b/docs/static/v0.7/project/releases/v0.7.87/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/project/releases/v0.7.88/index.html
+++ b/docs/static/v0.7/project/releases/v0.7.88/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/project/releases/v0.7.89/index.html
+++ b/docs/static/v0.7/project/releases/v0.7.89/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/project/releases/v0.7.9/index.html
+++ b/docs/static/v0.7/project/releases/v0.7.9/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/project/releases/v0.7.90/index.html
+++ b/docs/static/v0.7/project/releases/v0.7.90/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/project/releases/v0.7.91/index.html
+++ b/docs/static/v0.7/project/releases/v0.7.91/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/project/releases/v0.7.92/index.html
+++ b/docs/static/v0.7/project/releases/v0.7.92/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/project/releases/v0.7.93/index.html
+++ b/docs/static/v0.7/project/releases/v0.7.93/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/project/releases/v0.7.94/index.html
+++ b/docs/static/v0.7/project/releases/v0.7.94/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/project/releases/v0.7.95/index.html
+++ b/docs/static/v0.7/project/releases/v0.7.95/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/project/releases/v0.7.96/index.html
+++ b/docs/static/v0.7/project/releases/v0.7.96/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/project/releases/v0.7.97/index.html
+++ b/docs/static/v0.7/project/releases/v0.7.97/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/project/releases/v0.7.99/index.html
+++ b/docs/static/v0.7/project/releases/v0.7.99/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/project/releases/v0.8.0/index.html
+++ b/docs/static/v0.7/project/releases/v0.8.0/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/project/releases/v0.8.1/index.html
+++ b/docs/static/v0.7/project/releases/v0.8.1/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/project/releases/v0.8.2/index.html
+++ b/docs/static/v0.7/project/releases/v0.8.2/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/project/releases/v0.8.3/index.html
+++ b/docs/static/v0.7/project/releases/v0.8.3/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/project/security-vulnerabilities/index.html
+++ b/docs/static/v0.7/project/security-vulnerabilities/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/reference/error-codes/index.html
+++ b/docs/static/v0.7/reference/error-codes/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/reference/graphql-apis/index.html
+++ b/docs/static/v0.7/reference/graphql-apis/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/reference/index.html
+++ b/docs/static/v0.7/reference/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/reference/meshery-operator-crds/index.html
+++ b/docs/static/v0.7/reference/meshery-operator-crds/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/reference/mesheryctl/adapter/deploy/index.html
+++ b/docs/static/v0.7/reference/mesheryctl/adapter/deploy/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/reference/mesheryctl/adapter/index.html
+++ b/docs/static/v0.7/reference/mesheryctl/adapter/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/reference/mesheryctl/adapter/remove/index.html
+++ b/docs/static/v0.7/reference/mesheryctl/adapter/remove/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/reference/mesheryctl/adapter/validate/index.html
+++ b/docs/static/v0.7/reference/mesheryctl/adapter/validate/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/reference/mesheryctl/completion/index.html
+++ b/docs/static/v0.7/reference/mesheryctl/completion/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/reference/mesheryctl/components/index.html
+++ b/docs/static/v0.7/reference/mesheryctl/components/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/reference/mesheryctl/components/list/index.html
+++ b/docs/static/v0.7/reference/mesheryctl/components/list/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/reference/mesheryctl/components/search/index.html
+++ b/docs/static/v0.7/reference/mesheryctl/components/search/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/reference/mesheryctl/components/view/index.html
+++ b/docs/static/v0.7/reference/mesheryctl/components/view/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/reference/mesheryctl/design/apply/index.html
+++ b/docs/static/v0.7/reference/mesheryctl/design/apply/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/reference/mesheryctl/design/delete/index.html
+++ b/docs/static/v0.7/reference/mesheryctl/design/delete/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/reference/mesheryctl/design/import/index.html
+++ b/docs/static/v0.7/reference/mesheryctl/design/import/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/reference/mesheryctl/design/index.html
+++ b/docs/static/v0.7/reference/mesheryctl/design/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/reference/mesheryctl/design/list/index.html
+++ b/docs/static/v0.7/reference/mesheryctl/design/list/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/reference/mesheryctl/design/offboard/index.html
+++ b/docs/static/v0.7/reference/mesheryctl/design/offboard/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/reference/mesheryctl/design/onboard/index.html
+++ b/docs/static/v0.7/reference/mesheryctl/design/onboard/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/reference/mesheryctl/design/view/index.html
+++ b/docs/static/v0.7/reference/mesheryctl/design/view/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/reference/mesheryctl/environment/create/index.html
+++ b/docs/static/v0.7/reference/mesheryctl/environment/create/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/reference/mesheryctl/environment/delete/index.html
+++ b/docs/static/v0.7/reference/mesheryctl/environment/delete/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/reference/mesheryctl/environment/index.html
+++ b/docs/static/v0.7/reference/mesheryctl/environment/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/reference/mesheryctl/environment/list/index.html
+++ b/docs/static/v0.7/reference/mesheryctl/environment/list/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/reference/mesheryctl/environment/view/index.html
+++ b/docs/static/v0.7/reference/mesheryctl/environment/view/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/reference/mesheryctl/exp/components/index.html
+++ b/docs/static/v0.7/reference/mesheryctl/exp/components/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/reference/mesheryctl/exp/components/list/index.html
+++ b/docs/static/v0.7/reference/mesheryctl/exp/components/list/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/reference/mesheryctl/exp/components/search/index.html
+++ b/docs/static/v0.7/reference/mesheryctl/exp/components/search/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/reference/mesheryctl/exp/components/view/index.html
+++ b/docs/static/v0.7/reference/mesheryctl/exp/components/view/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/reference/mesheryctl/exp/connections/delete/index.html
+++ b/docs/static/v0.7/reference/mesheryctl/exp/connections/delete/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/reference/mesheryctl/exp/connections/index.html
+++ b/docs/static/v0.7/reference/mesheryctl/exp/connections/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/reference/mesheryctl/exp/connections/list/index.html
+++ b/docs/static/v0.7/reference/mesheryctl/exp/connections/list/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/reference/mesheryctl/exp/environment/create/index.html
+++ b/docs/static/v0.7/reference/mesheryctl/exp/environment/create/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/reference/mesheryctl/exp/environment/delete/index.html
+++ b/docs/static/v0.7/reference/mesheryctl/exp/environment/delete/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/reference/mesheryctl/exp/environment/index.html
+++ b/docs/static/v0.7/reference/mesheryctl/exp/environment/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/reference/mesheryctl/exp/environment/list/index.html
+++ b/docs/static/v0.7/reference/mesheryctl/exp/environment/list/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/reference/mesheryctl/exp/environment/view/index.html
+++ b/docs/static/v0.7/reference/mesheryctl/exp/environment/view/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/reference/mesheryctl/exp/index.html
+++ b/docs/static/v0.7/reference/mesheryctl/exp/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/reference/mesheryctl/exp/relationship/generate/index.html
+++ b/docs/static/v0.7/reference/mesheryctl/exp/relationship/generate/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/reference/mesheryctl/exp/relationship/index.html
+++ b/docs/static/v0.7/reference/mesheryctl/exp/relationship/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/reference/mesheryctl/exp/relationship/list/index.html
+++ b/docs/static/v0.7/reference/mesheryctl/exp/relationship/list/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/reference/mesheryctl/exp/relationship/search/index.html
+++ b/docs/static/v0.7/reference/mesheryctl/exp/relationship/search/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/reference/mesheryctl/exp/relationship/view/index.html
+++ b/docs/static/v0.7/reference/mesheryctl/exp/relationship/view/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/reference/mesheryctl/exp/workspace/create/index.html
+++ b/docs/static/v0.7/reference/mesheryctl/exp/workspace/create/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/reference/mesheryctl/exp/workspace/index.html
+++ b/docs/static/v0.7/reference/mesheryctl/exp/workspace/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/reference/mesheryctl/exp/workspace/list/index.html
+++ b/docs/static/v0.7/reference/mesheryctl/exp/workspace/list/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/reference/mesheryctl/filter/delete/index.html
+++ b/docs/static/v0.7/reference/mesheryctl/filter/delete/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/reference/mesheryctl/filter/import/index.html
+++ b/docs/static/v0.7/reference/mesheryctl/filter/import/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/reference/mesheryctl/filter/index.html
+++ b/docs/static/v0.7/reference/mesheryctl/filter/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/reference/mesheryctl/filter/list/index.html
+++ b/docs/static/v0.7/reference/mesheryctl/filter/list/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/reference/mesheryctl/filter/view/index.html
+++ b/docs/static/v0.7/reference/mesheryctl/filter/view/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/reference/mesheryctl/index.html
+++ b/docs/static/v0.7/reference/mesheryctl/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/reference/mesheryctl/mesh/deploy/index.html
+++ b/docs/static/v0.7/reference/mesheryctl/mesh/deploy/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/reference/mesheryctl/mesh/index.html
+++ b/docs/static/v0.7/reference/mesheryctl/mesh/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/reference/mesheryctl/mesh/remove/index.html
+++ b/docs/static/v0.7/reference/mesheryctl/mesh/remove/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/reference/mesheryctl/mesh/validate/index.html
+++ b/docs/static/v0.7/reference/mesheryctl/mesh/validate/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/reference/mesheryctl/model/export/index.html
+++ b/docs/static/v0.7/reference/mesheryctl/model/export/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/reference/mesheryctl/model/import/index.html
+++ b/docs/static/v0.7/reference/mesheryctl/model/import/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/reference/mesheryctl/model/index.html
+++ b/docs/static/v0.7/reference/mesheryctl/model/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/reference/mesheryctl/model/list/index.html
+++ b/docs/static/v0.7/reference/mesheryctl/model/list/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/reference/mesheryctl/model/search/index.html
+++ b/docs/static/v0.7/reference/mesheryctl/model/search/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/reference/mesheryctl/model/view/index.html
+++ b/docs/static/v0.7/reference/mesheryctl/model/view/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/reference/mesheryctl/pattern/apply/index.html
+++ b/docs/static/v0.7/reference/mesheryctl/pattern/apply/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/reference/mesheryctl/pattern/delete/index.html
+++ b/docs/static/v0.7/reference/mesheryctl/pattern/delete/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/reference/mesheryctl/pattern/export/index.html
+++ b/docs/static/v0.7/reference/mesheryctl/pattern/export/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/reference/mesheryctl/pattern/import/index.html
+++ b/docs/static/v0.7/reference/mesheryctl/pattern/import/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/reference/mesheryctl/pattern/index.html
+++ b/docs/static/v0.7/reference/mesheryctl/pattern/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/reference/mesheryctl/pattern/list/index.html
+++ b/docs/static/v0.7/reference/mesheryctl/pattern/list/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/reference/mesheryctl/pattern/offboard/index.html
+++ b/docs/static/v0.7/reference/mesheryctl/pattern/offboard/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/reference/mesheryctl/pattern/onboard/index.html
+++ b/docs/static/v0.7/reference/mesheryctl/pattern/onboard/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/reference/mesheryctl/pattern/view/index.html
+++ b/docs/static/v0.7/reference/mesheryctl/pattern/view/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/reference/mesheryctl/perf/apply/index.html
+++ b/docs/static/v0.7/reference/mesheryctl/perf/apply/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/reference/mesheryctl/perf/index.html
+++ b/docs/static/v0.7/reference/mesheryctl/perf/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/reference/mesheryctl/perf/profile/index.html
+++ b/docs/static/v0.7/reference/mesheryctl/perf/profile/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/reference/mesheryctl/perf/result/index.html
+++ b/docs/static/v0.7/reference/mesheryctl/perf/result/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/reference/mesheryctl/registry/generate/index.html
+++ b/docs/static/v0.7/reference/mesheryctl/registry/generate/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/reference/mesheryctl/registry/index.html
+++ b/docs/static/v0.7/reference/mesheryctl/registry/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/reference/mesheryctl/registry/publish/index.html
+++ b/docs/static/v0.7/reference/mesheryctl/registry/publish/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/reference/mesheryctl/registry/update/index.html
+++ b/docs/static/v0.7/reference/mesheryctl/registry/update/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/reference/mesheryctl/system/channel/index.html
+++ b/docs/static/v0.7/reference/mesheryctl/system/channel/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/reference/mesheryctl/system/channel/set/index.html
+++ b/docs/static/v0.7/reference/mesheryctl/system/channel/set/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/reference/mesheryctl/system/channel/switch/index.html
+++ b/docs/static/v0.7/reference/mesheryctl/system/channel/switch/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/reference/mesheryctl/system/channel/view/index.html
+++ b/docs/static/v0.7/reference/mesheryctl/system/channel/view/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/reference/mesheryctl/system/check/index.html
+++ b/docs/static/v0.7/reference/mesheryctl/system/check/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/reference/mesheryctl/system/completion/index.html
+++ b/docs/static/v0.7/reference/mesheryctl/system/completion/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/reference/mesheryctl/system/context/create/index.html
+++ b/docs/static/v0.7/reference/mesheryctl/system/context/create/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/reference/mesheryctl/system/context/delete/index.html
+++ b/docs/static/v0.7/reference/mesheryctl/system/context/delete/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/reference/mesheryctl/system/context/index.html
+++ b/docs/static/v0.7/reference/mesheryctl/system/context/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/reference/mesheryctl/system/context/list/index.html
+++ b/docs/static/v0.7/reference/mesheryctl/system/context/list/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/reference/mesheryctl/system/context/switch/index.html
+++ b/docs/static/v0.7/reference/mesheryctl/system/context/switch/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/reference/mesheryctl/system/context/view/index.html
+++ b/docs/static/v0.7/reference/mesheryctl/system/context/view/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/reference/mesheryctl/system/dashboard/index.html
+++ b/docs/static/v0.7/reference/mesheryctl/system/dashboard/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/reference/mesheryctl/system/index.html
+++ b/docs/static/v0.7/reference/mesheryctl/system/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/reference/mesheryctl/system/login/index.html
+++ b/docs/static/v0.7/reference/mesheryctl/system/login/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/reference/mesheryctl/system/logout/index.html
+++ b/docs/static/v0.7/reference/mesheryctl/system/logout/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/reference/mesheryctl/system/logs/index.html
+++ b/docs/static/v0.7/reference/mesheryctl/system/logs/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/reference/mesheryctl/system/provider/index.html
+++ b/docs/static/v0.7/reference/mesheryctl/system/provider/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/reference/mesheryctl/system/provider/list/index.html
+++ b/docs/static/v0.7/reference/mesheryctl/system/provider/list/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/reference/mesheryctl/system/provider/reset/index.html
+++ b/docs/static/v0.7/reference/mesheryctl/system/provider/reset/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/reference/mesheryctl/system/provider/set/index.html
+++ b/docs/static/v0.7/reference/mesheryctl/system/provider/set/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/reference/mesheryctl/system/provider/switch/index.html
+++ b/docs/static/v0.7/reference/mesheryctl/system/provider/switch/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/reference/mesheryctl/system/provider/view/index.html
+++ b/docs/static/v0.7/reference/mesheryctl/system/provider/view/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/reference/mesheryctl/system/reset/index.html
+++ b/docs/static/v0.7/reference/mesheryctl/system/reset/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/reference/mesheryctl/system/restart/index.html
+++ b/docs/static/v0.7/reference/mesheryctl/system/restart/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/reference/mesheryctl/system/start/index.html
+++ b/docs/static/v0.7/reference/mesheryctl/system/start/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/reference/mesheryctl/system/status/index.html
+++ b/docs/static/v0.7/reference/mesheryctl/system/status/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/reference/mesheryctl/system/stop/index.html
+++ b/docs/static/v0.7/reference/mesheryctl/system/stop/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/reference/mesheryctl/system/token/create/index.html
+++ b/docs/static/v0.7/reference/mesheryctl/system/token/create/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/reference/mesheryctl/system/token/delete/index.html
+++ b/docs/static/v0.7/reference/mesheryctl/system/token/delete/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/reference/mesheryctl/system/token/index.html
+++ b/docs/static/v0.7/reference/mesheryctl/system/token/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/reference/mesheryctl/system/token/list/index.html
+++ b/docs/static/v0.7/reference/mesheryctl/system/token/list/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/reference/mesheryctl/system/token/set/index.html
+++ b/docs/static/v0.7/reference/mesheryctl/system/token/set/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/reference/mesheryctl/system/token/view/index.html
+++ b/docs/static/v0.7/reference/mesheryctl/system/token/view/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/reference/mesheryctl/system/update/index.html
+++ b/docs/static/v0.7/reference/mesheryctl/system/update/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/reference/mesheryctl/version/index.html
+++ b/docs/static/v0.7/reference/mesheryctl/version/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/reference/permissions/index.html
+++ b/docs/static/v0.7/reference/permissions/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/reference/rest-apis/index.html
+++ b/docs/static/v0.7/reference/rest-apis/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/search/index.html
+++ b/docs/static/v0.7/search/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.7/tags/index.html
+++ b/docs/static/v0.7/tags/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/404/index.html
+++ b/docs/static/v0.8/404/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/CONTRIBUTING-gitflow/index.html
+++ b/docs/static/v0.8/CONTRIBUTING-gitflow/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/concepts/architecture/adapters/index.html
+++ b/docs/static/v0.8/concepts/architecture/adapters/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/concepts/architecture/broker/index.html
+++ b/docs/static/v0.8/concepts/architecture/broker/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/concepts/architecture/catalog/index.html
+++ b/docs/static/v0.8/concepts/architecture/catalog/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/concepts/architecture/database/index.html
+++ b/docs/static/v0.8/concepts/architecture/database/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/concepts/architecture/index.html
+++ b/docs/static/v0.8/concepts/architecture/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/concepts/architecture/meshsync/index.html
+++ b/docs/static/v0.8/concepts/architecture/meshsync/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/concepts/architecture/operator/index.html
+++ b/docs/static/v0.8/concepts/architecture/operator/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/concepts/index.html
+++ b/docs/static/v0.8/concepts/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/concepts/logical/components/index.html
+++ b/docs/static/v0.8/concepts/logical/components/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/concepts/logical/connections/index.html
+++ b/docs/static/v0.8/concepts/logical/connections/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/concepts/logical/credentials/index.html
+++ b/docs/static/v0.8/concepts/logical/credentials/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/concepts/logical/designs/index.html
+++ b/docs/static/v0.8/concepts/logical/designs/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/concepts/logical/environments/index.html
+++ b/docs/static/v0.8/concepts/logical/environments/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/concepts/logical/index.html
+++ b/docs/static/v0.8/concepts/logical/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/concepts/logical/models/index.html
+++ b/docs/static/v0.8/concepts/logical/models/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/concepts/logical/patterns/index.html
+++ b/docs/static/v0.8/concepts/logical/patterns/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/concepts/logical/policies/index.html
+++ b/docs/static/v0.8/concepts/logical/policies/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/concepts/logical/registry/index.html
+++ b/docs/static/v0.8/concepts/logical/registry/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/concepts/logical/relationships/index.html
+++ b/docs/static/v0.8/concepts/logical/relationships/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/concepts/logical/workspaces/index.html
+++ b/docs/static/v0.8/concepts/logical/workspaces/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/extensibility/adapters/app-mesh/index.html
+++ b/docs/static/v0.8/extensibility/adapters/app-mesh/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/extensibility/adapters/cilium/index.html
+++ b/docs/static/v0.8/extensibility/adapters/cilium/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/extensibility/adapters/consul/index.html
+++ b/docs/static/v0.8/extensibility/adapters/consul/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/extensibility/adapters/index.html
+++ b/docs/static/v0.8/extensibility/adapters/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/extensibility/adapters/istio/index.html
+++ b/docs/static/v0.8/extensibility/adapters/istio/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/extensibility/adapters/kuma/index.html
+++ b/docs/static/v0.8/extensibility/adapters/kuma/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/extensibility/adapters/linkerd/index.html
+++ b/docs/static/v0.8/extensibility/adapters/linkerd/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/extensibility/adapters/nginx-sm/index.html
+++ b/docs/static/v0.8/extensibility/adapters/nginx-sm/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/extensibility/adapters/nighthawk/index.html
+++ b/docs/static/v0.8/extensibility/adapters/nighthawk/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/extensibility/adapters/nsm/index.html
+++ b/docs/static/v0.8/extensibility/adapters/nsm/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/extensibility/adapters/tanzu-sm/index.html
+++ b/docs/static/v0.8/extensibility/adapters/tanzu-sm/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/extensibility/adapters/traefik-mesh/index.html
+++ b/docs/static/v0.8/extensibility/adapters/traefik-mesh/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/extensibility/api/index.html
+++ b/docs/static/v0.8/extensibility/api/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/extensibility/authorization/index.html
+++ b/docs/static/v0.8/extensibility/authorization/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/extensibility/build-time/index.html
+++ b/docs/static/v0.8/extensibility/build-time/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/extensibility/index.html
+++ b/docs/static/v0.8/extensibility/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/extensibility/integrations/azure-operator/index.html
+++ b/docs/static/v0.8/extensibility/integrations/azure-operator/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/extensibility/integrations/cert-manager-crds/index.html
+++ b/docs/static/v0.8/extensibility/integrations/cert-manager-crds/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/extensibility/integrations/crossplane-provider-exoscale/index.html
+++ b/docs/static/v0.8/extensibility/integrations/crossplane-provider-exoscale/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/extensibility/integrations/knative/index.html
+++ b/docs/static/v0.8/extensibility/integrations/knative/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/extensibility/integrations/kubernetes/index.html
+++ b/docs/static/v0.8/extensibility/integrations/kubernetes/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/extensibility/integrations/notary/index.html
+++ b/docs/static/v0.8/extensibility/integrations/notary/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/extensibility/integrations/open-policy-agent-(opa)/index.html
+++ b/docs/static/v0.8/extensibility/integrations/open-policy-agent-(opa)/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/extensibility/integrations/open-service-mesh/index.html
+++ b/docs/static/v0.8/extensibility/integrations/open-service-mesh/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/extensibility/integrations/openfeature/index.html
+++ b/docs/static/v0.8/extensibility/integrations/openfeature/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/extensibility/integrations/serverless-workflow/index.html
+++ b/docs/static/v0.8/extensibility/integrations/serverless-workflow/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/extensibility/load-generators/index.html
+++ b/docs/static/v0.8/extensibility/load-generators/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/extensibility/providers/index.html
+++ b/docs/static/v0.8/extensibility/providers/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/extensibility/ui/index.html
+++ b/docs/static/v0.8/extensibility/ui/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/extensibility/verify-compatibility/index.html
+++ b/docs/static/v0.8/extensibility/verify-compatibility/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/extensions/helm-kanvas-snapshot/index.html
+++ b/docs/static/v0.8/extensions/helm-kanvas-snapshot/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/extensions/import-export-designs/index.html
+++ b/docs/static/v0.8/extensions/import-export-designs/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/extensions/index.html
+++ b/docs/static/v0.8/extensions/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/extensions/integrations/index.html
+++ b/docs/static/v0.8/extensions/integrations/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/extensions/kanvas-snapshot/index.html
+++ b/docs/static/v0.8/extensions/kanvas-snapshot/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/extensions/kanvas/index.html
+++ b/docs/static/v0.8/extensions/kanvas/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/extensions/kubectl-meshsync-snapshot/index.html
+++ b/docs/static/v0.8/extensions/kubectl-meshsync-snapshot/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/guides/configuration-management/creating-a-meshery-design/index.html
+++ b/docs/static/v0.8/guides/configuration-management/creating-a-meshery-design/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/guides/configuration-management/creating-models/index.html
+++ b/docs/static/v0.8/guides/configuration-management/creating-models/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/guides/configuration-management/edges-guide/index.html
+++ b/docs/static/v0.8/guides/configuration-management/edges-guide/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/guides/configuration-management/exporting-models/index.html
+++ b/docs/static/v0.8/guides/configuration-management/exporting-models/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/guides/configuration-management/identifying-components/index.html
+++ b/docs/static/v0.8/guides/configuration-management/identifying-components/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/guides/configuration-management/importing-models/index.html
+++ b/docs/static/v0.8/guides/configuration-management/importing-models/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/guides/configuration-management/index.html
+++ b/docs/static/v0.8/guides/configuration-management/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/guides/configuration-management/pattern-management/index.html
+++ b/docs/static/v0.8/guides/configuration-management/pattern-management/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/guides/configuration-management/push-pull-model-image/index.html
+++ b/docs/static/v0.8/guides/configuration-management/push-pull-model-image/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/guides/configuration-management/working-with-designs/index.html
+++ b/docs/static/v0.8/guides/configuration-management/working-with-designs/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/guides/index.html
+++ b/docs/static/v0.8/guides/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/guides/infrastructure-management/filter-management/index.html
+++ b/docs/static/v0.8/guides/infrastructure-management/filter-management/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/guides/infrastructure-management/gitops-with-meshery/index.html
+++ b/docs/static/v0.8/guides/infrastructure-management/gitops-with-meshery/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/guides/infrastructure-management/index.html
+++ b/docs/static/v0.8/guides/infrastructure-management/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/guides/infrastructure-management/lifecycle-management/index.html
+++ b/docs/static/v0.8/guides/infrastructure-management/lifecycle-management/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/guides/infrastructure-management/notification-management/index.html
+++ b/docs/static/v0.8/guides/infrastructure-management/notification-management/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/guides/infrastructure-management/overview/index.html
+++ b/docs/static/v0.8/guides/infrastructure-management/overview/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/guides/infrastructure-management/registering-a-connection/index.html
+++ b/docs/static/v0.8/guides/infrastructure-management/registering-a-connection/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/guides/infrastructure-management/sample-apps/index.html
+++ b/docs/static/v0.8/guides/infrastructure-management/sample-apps/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/guides/mesheryctl/authenticate-with-meshery-via-cli/index.html
+++ b/docs/static/v0.8/guides/mesheryctl/authenticate-with-meshery-via-cli/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/guides/mesheryctl/configuring-autocompletion-for-mesheryctl/index.html
+++ b/docs/static/v0.8/guides/mesheryctl/configuring-autocompletion-for-mesheryctl/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/guides/mesheryctl/index.html
+++ b/docs/static/v0.8/guides/mesheryctl/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/guides/mesheryctl/running-system-checks-using-mesheryctl/index.html
+++ b/docs/static/v0.8/guides/mesheryctl/running-system-checks-using-mesheryctl/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/guides/mesheryctl/system-commands/index.html
+++ b/docs/static/v0.8/guides/mesheryctl/system-commands/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/guides/mesheryctl/working-with-mesheryctl/index.html
+++ b/docs/static/v0.8/guides/mesheryctl/working-with-mesheryctl/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/guides/performance-management/index.html
+++ b/docs/static/v0.8/guides/performance-management/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/guides/performance-management/interpreting-performance-test-results/index.html
+++ b/docs/static/v0.8/guides/performance-management/interpreting-performance-test-results/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/guides/performance-management/managing-performance/index.html
+++ b/docs/static/v0.8/guides/performance-management/managing-performance/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/guides/performance-management/meshery-metrics/index.html
+++ b/docs/static/v0.8/guides/performance-management/meshery-metrics/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/guides/performance-management/performance-management/index.html
+++ b/docs/static/v0.8/guides/performance-management/performance-management/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/guides/troubleshooting/enabling-extensions-locally/index.html
+++ b/docs/static/v0.8/guides/troubleshooting/enabling-extensions-locally/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/guides/troubleshooting/index.html
+++ b/docs/static/v0.8/guides/troubleshooting/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/guides/troubleshooting/installation/index.html
+++ b/docs/static/v0.8/guides/troubleshooting/installation/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/guides/troubleshooting/meshery-operator-meshsync/index.html
+++ b/docs/static/v0.8/guides/troubleshooting/meshery-operator-meshsync/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/guides/troubleshooting/meshery-server/index.html
+++ b/docs/static/v0.8/guides/troubleshooting/meshery-server/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/guides/tutorials/deploy-apache-cassandra-with-statefulset/index.html
+++ b/docs/static/v0.8/guides/tutorials/deploy-apache-cassandra-with-statefulset/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/guides/tutorials/deploy-aws-ec2-instances-with-meshery/index.html
+++ b/docs/static/v0.8/guides/tutorials/deploy-aws-ec2-instances-with-meshery/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/guides/tutorials/deploy-azure-resources-with-meshery/index.html
+++ b/docs/static/v0.8/guides/tutorials/deploy-azure-resources-with-meshery/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/guides/tutorials/deploy-azure-storage-account-with-meshery/index.html
+++ b/docs/static/v0.8/guides/tutorials/deploy-azure-storage-account-with-meshery/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/guides/tutorials/deploy-php-redis/index.html
+++ b/docs/static/v0.8/guides/tutorials/deploy-php-redis/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/guides/tutorials/embedding-meshery-design-in-wordpress/index.html
+++ b/docs/static/v0.8/guides/tutorials/embedding-meshery-design-in-wordpress/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/guides/tutorials/exploring-kubernetes-cronjobs/index.html
+++ b/docs/static/v0.8/guides/tutorials/exploring-kubernetes-cronjobs/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/guides/tutorials/index.html
+++ b/docs/static/v0.8/guides/tutorials/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/guides/tutorials/kubernetes-configmaps-secrets/index.html
+++ b/docs/static/v0.8/guides/tutorials/kubernetes-configmaps-secrets/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/guides/tutorials/kubernetes-deployments/index.html
+++ b/docs/static/v0.8/guides/tutorials/kubernetes-deployments/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/guides/tutorials/kubernetes-pods/index.html
+++ b/docs/static/v0.8/guides/tutorials/kubernetes-pods/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/guides/tutorials/kubernetes-request-flow/index.html
+++ b/docs/static/v0.8/guides/tutorials/kubernetes-request-flow/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/guides/tutorials/kubernetes-services/index.html
+++ b/docs/static/v0.8/guides/tutorials/kubernetes-services/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/guides/tutorials/publish-to-artifacthub/index.html
+++ b/docs/static/v0.8/guides/tutorials/publish-to-artifacthub/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/guides/tutorials/wordpress-mysql-persistentvolume/index.html
+++ b/docs/static/v0.8/guides/tutorials/wordpress-mysql-persistentvolume/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/installation/accessing-meshery-ui/index.html
+++ b/docs/static/v0.8/installation/accessing-meshery-ui/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/installation/codespaces/index.html
+++ b/docs/static/v0.8/installation/codespaces/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/installation/compatibility-matrix/index.html
+++ b/docs/static/v0.8/installation/compatibility-matrix/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/installation/compatibility-matrix/meshery-cilium-past-results/index.html
+++ b/docs/static/v0.8/installation/compatibility-matrix/meshery-cilium-past-results/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/installation/compatibility-matrix/meshery-consul-past-results/index.html
+++ b/docs/static/v0.8/installation/compatibility-matrix/meshery-consul-past-results/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/installation/compatibility-matrix/meshery-istio-past-results/index.html
+++ b/docs/static/v0.8/installation/compatibility-matrix/meshery-istio-past-results/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/installation/compatibility-matrix/meshery-kuma-past-results/index.html
+++ b/docs/static/v0.8/installation/compatibility-matrix/meshery-kuma-past-results/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/installation/compatibility-matrix/meshery-linkerd-past-results/index.html
+++ b/docs/static/v0.8/installation/compatibility-matrix/meshery-linkerd-past-results/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/installation/compatibility-matrix/meshery-nginx-sm-past-results/index.html
+++ b/docs/static/v0.8/installation/compatibility-matrix/meshery-nginx-sm-past-results/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/installation/compatibility-matrix/meshery-osm-past-results/index.html
+++ b/docs/static/v0.8/installation/compatibility-matrix/meshery-osm-past-results/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/installation/compatibility-matrix/meshery-traefik-mesh-past-results/index.html
+++ b/docs/static/v0.8/installation/compatibility-matrix/meshery-traefik-mesh-past-results/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/installation/docker/docker-extension/index.html
+++ b/docs/static/v0.8/installation/docker/docker-extension/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/installation/docker/index.html
+++ b/docs/static/v0.8/installation/docker/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/installation/index.html
+++ b/docs/static/v0.8/installation/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/installation/kubernetes/aks/index.html
+++ b/docs/static/v0.8/installation/kubernetes/aks/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/installation/kubernetes/eks/index.html
+++ b/docs/static/v0.8/installation/kubernetes/eks/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/installation/kubernetes/gke/index.html
+++ b/docs/static/v0.8/installation/kubernetes/gke/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/installation/kubernetes/helm/index.html
+++ b/docs/static/v0.8/installation/kubernetes/helm/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/installation/kubernetes/index.html
+++ b/docs/static/v0.8/installation/kubernetes/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/installation/kubernetes/kind/index.html
+++ b/docs/static/v0.8/installation/kubernetes/kind/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/installation/kubernetes/kubesphere/index.html
+++ b/docs/static/v0.8/installation/kubernetes/kubesphere/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/installation/kubernetes/minikube/index.html
+++ b/docs/static/v0.8/installation/kubernetes/minikube/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/installation/linux-mac/bash/index.html
+++ b/docs/static/v0.8/installation/linux-mac/bash/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/installation/linux-mac/brew/index.html
+++ b/docs/static/v0.8/installation/linux-mac/brew/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/installation/linux-mac/index.html
+++ b/docs/static/v0.8/installation/linux-mac/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/installation/mesheryctl/index.html
+++ b/docs/static/v0.8/installation/mesheryctl/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/installation/multiple-adapters/index.html
+++ b/docs/static/v0.8/installation/multiple-adapters/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/installation/playground/index.html
+++ b/docs/static/v0.8/installation/playground/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/installation/quick-start/index.html
+++ b/docs/static/v0.8/installation/quick-start/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/installation/upgrades/index.html
+++ b/docs/static/v0.8/installation/upgrades/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/installation/windows/index.html
+++ b/docs/static/v0.8/installation/windows/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/installation/windows/scoop/index.html
+++ b/docs/static/v0.8/installation/windows/scoop/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/news/index.html
+++ b/docs/static/v0.8/news/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/pages/extensibility/integrations/index.html
+++ b/docs/static/v0.8/pages/extensibility/integrations/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/pages/installation/compatibility-matrix/index.html
+++ b/docs/static/v0.8/pages/installation/compatibility-matrix/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/pages/installation/platforms/index.html
+++ b/docs/static/v0.8/pages/installation/platforms/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/pages/project/mesheryctl/installation-bash/index.html
+++ b/docs/static/v0.8/pages/project/mesheryctl/installation-bash/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/pages/project/mesheryctl/installation-brew/index.html
+++ b/docs/static/v0.8/pages/project/mesheryctl/installation-brew/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/pages/project/mesheryctl/installation-scoop/index.html
+++ b/docs/static/v0.8/pages/project/mesheryctl/installation-scoop/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/project/community/index.html
+++ b/docs/static/v0.8/project/community/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/project/contributing/build-and-release/index.html
+++ b/docs/static/v0.8/project/contributing/build-and-release/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/project/contributing/contributing-adapters/index.html
+++ b/docs/static/v0.8/project/contributing/contributing-adapters/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/project/contributing/contributing-cli-guide/index.html
+++ b/docs/static/v0.8/project/contributing/contributing-cli-guide/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/project/contributing/contributing-cli-tests/index.html
+++ b/docs/static/v0.8/project/contributing/contributing-cli-tests/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/project/contributing/contributing-cli/index.html
+++ b/docs/static/v0.8/project/contributing/contributing-cli/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/project/contributing/contributing-components/index.html
+++ b/docs/static/v0.8/project/contributing/contributing-components/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/project/contributing/contributing-docker-extension/index.html
+++ b/docs/static/v0.8/project/contributing/contributing-docker-extension/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/project/contributing/contributing-docs-structure/index.html
+++ b/docs/static/v0.8/project/contributing/contributing-docs-structure/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/project/contributing/contributing-docs/index.html
+++ b/docs/static/v0.8/project/contributing/contributing-docs/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/project/contributing/contributing-error/index.html
+++ b/docs/static/v0.8/project/contributing/contributing-error/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/project/contributing/contributing-gitflow/index.html
+++ b/docs/static/v0.8/project/contributing/contributing-gitflow/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/project/contributing/contributing-models-quick-start/index.html
+++ b/docs/static/v0.8/project/contributing/contributing-models-quick-start/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/project/contributing/contributing-models/index.html
+++ b/docs/static/v0.8/project/contributing/contributing-models/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/project/contributing/contributing-policies/index.html
+++ b/docs/static/v0.8/project/contributing/contributing-policies/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/project/contributing/contributing-relationships/index.html
+++ b/docs/static/v0.8/project/contributing/contributing-relationships/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/project/contributing/contributing-schemas/index.html
+++ b/docs/static/v0.8/project/contributing/contributing-schemas/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/project/contributing/contributing-server-events/index.html
+++ b/docs/static/v0.8/project/contributing/contributing-server-events/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/project/contributing/contributing-server/index.html
+++ b/docs/static/v0.8/project/contributing/contributing-server/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/project/contributing/contributing-ui-notification-center/index.html
+++ b/docs/static/v0.8/project/contributing/contributing-ui-notification-center/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/project/contributing/contributing-ui-schemas/index.html
+++ b/docs/static/v0.8/project/contributing/contributing-ui-schemas/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/project/contributing/contributing-ui-sistent/index.html
+++ b/docs/static/v0.8/project/contributing/contributing-ui-sistent/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/project/contributing/contributing-ui-tests/index.html
+++ b/docs/static/v0.8/project/contributing/contributing-ui-tests/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/project/contributing/contributing-ui-widgets/index.html
+++ b/docs/static/v0.8/project/contributing/contributing-ui-widgets/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/project/contributing/contributing-ui/index.html
+++ b/docs/static/v0.8/project/contributing/contributing-ui/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/project/contributing/index.html
+++ b/docs/static/v0.8/project/contributing/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/project/contributing/meshery-windows/index.html
+++ b/docs/static/v0.8/project/contributing/meshery-windows/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/project/contributing/test-status/index.html
+++ b/docs/static/v0.8/project/contributing/test-status/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/project/faq/index.html
+++ b/docs/static/v0.8/project/faq/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/project/index.html
+++ b/docs/static/v0.8/project/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/project/overview/index.html
+++ b/docs/static/v0.8/project/overview/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/project/releases/index.html
+++ b/docs/static/v0.8/project/releases/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/project/releases/v0.0.1/index.html
+++ b/docs/static/v0.8/project/releases/v0.0.1/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/project/releases/v0.0.2/index.html
+++ b/docs/static/v0.8/project/releases/v0.0.2/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/project/releases/v0.0.3/index.html
+++ b/docs/static/v0.8/project/releases/v0.0.3/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/project/releases/v0.0.4/index.html
+++ b/docs/static/v0.8/project/releases/v0.0.4/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/project/releases/v0.0.5/index.html
+++ b/docs/static/v0.8/project/releases/v0.0.5/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/project/releases/v0.0.6/index.html
+++ b/docs/static/v0.8/project/releases/v0.0.6/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/project/releases/v0.0.7/index.html
+++ b/docs/static/v0.8/project/releases/v0.0.7/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/project/releases/v0.0.8/index.html
+++ b/docs/static/v0.8/project/releases/v0.0.8/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/project/releases/v0.0.9/index.html
+++ b/docs/static/v0.8/project/releases/v0.0.9/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/project/releases/v0.1.0/index.html
+++ b/docs/static/v0.8/project/releases/v0.1.0/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/project/releases/v0.1.1/index.html
+++ b/docs/static/v0.8/project/releases/v0.1.1/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/project/releases/v0.1.2/index.html
+++ b/docs/static/v0.8/project/releases/v0.1.2/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/project/releases/v0.1.3/index.html
+++ b/docs/static/v0.8/project/releases/v0.1.3/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/project/releases/v0.1.4/index.html
+++ b/docs/static/v0.8/project/releases/v0.1.4/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/project/releases/v0.1.5/index.html
+++ b/docs/static/v0.8/project/releases/v0.1.5/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/project/releases/v0.1.6/index.html
+++ b/docs/static/v0.8/project/releases/v0.1.6/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/project/releases/v0.2.0/index.html
+++ b/docs/static/v0.8/project/releases/v0.2.0/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/project/releases/v0.2.1/index.html
+++ b/docs/static/v0.8/project/releases/v0.2.1/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/project/releases/v0.2.2/index.html
+++ b/docs/static/v0.8/project/releases/v0.2.2/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/project/releases/v0.2.3/index.html
+++ b/docs/static/v0.8/project/releases/v0.2.3/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/project/releases/v0.2.4/index.html
+++ b/docs/static/v0.8/project/releases/v0.2.4/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/project/releases/v0.3.1/index.html
+++ b/docs/static/v0.8/project/releases/v0.3.1/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/project/releases/v0.3.10/index.html
+++ b/docs/static/v0.8/project/releases/v0.3.10/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/project/releases/v0.3.11/index.html
+++ b/docs/static/v0.8/project/releases/v0.3.11/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/project/releases/v0.3.12/index.html
+++ b/docs/static/v0.8/project/releases/v0.3.12/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/project/releases/v0.3.13/index.html
+++ b/docs/static/v0.8/project/releases/v0.3.13/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/project/releases/v0.3.14/index.html
+++ b/docs/static/v0.8/project/releases/v0.3.14/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/project/releases/v0.3.15/index.html
+++ b/docs/static/v0.8/project/releases/v0.3.15/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/project/releases/v0.3.16/index.html
+++ b/docs/static/v0.8/project/releases/v0.3.16/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/project/releases/v0.3.17/index.html
+++ b/docs/static/v0.8/project/releases/v0.3.17/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/project/releases/v0.3.18/index.html
+++ b/docs/static/v0.8/project/releases/v0.3.18/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/project/releases/v0.3.19/index.html
+++ b/docs/static/v0.8/project/releases/v0.3.19/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/project/releases/v0.3.2/index.html
+++ b/docs/static/v0.8/project/releases/v0.3.2/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/project/releases/v0.3.3/index.html
+++ b/docs/static/v0.8/project/releases/v0.3.3/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/project/releases/v0.3.4/index.html
+++ b/docs/static/v0.8/project/releases/v0.3.4/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/project/releases/v0.3.5/index.html
+++ b/docs/static/v0.8/project/releases/v0.3.5/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/project/releases/v0.3.6/index.html
+++ b/docs/static/v0.8/project/releases/v0.3.6/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/project/releases/v0.3.7/index.html
+++ b/docs/static/v0.8/project/releases/v0.3.7/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/project/releases/v0.3.8/index.html
+++ b/docs/static/v0.8/project/releases/v0.3.8/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/project/releases/v0.3.9/index.html
+++ b/docs/static/v0.8/project/releases/v0.3.9/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/project/releases/v0.4.0-beta.1/index.html
+++ b/docs/static/v0.8/project/releases/v0.4.0-beta.1/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/project/releases/v0.4.0-beta.2/index.html
+++ b/docs/static/v0.8/project/releases/v0.4.0-beta.2/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/project/releases/v0.4.0-beta.3/index.html
+++ b/docs/static/v0.8/project/releases/v0.4.0-beta.3/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/project/releases/v0.4.0-beta.4/index.html
+++ b/docs/static/v0.8/project/releases/v0.4.0-beta.4/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/project/releases/v0.4.1/index.html
+++ b/docs/static/v0.8/project/releases/v0.4.1/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/project/releases/v0.4.10/index.html
+++ b/docs/static/v0.8/project/releases/v0.4.10/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/project/releases/v0.4.11/index.html
+++ b/docs/static/v0.8/project/releases/v0.4.11/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/project/releases/v0.4.12/index.html
+++ b/docs/static/v0.8/project/releases/v0.4.12/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/project/releases/v0.4.13/index.html
+++ b/docs/static/v0.8/project/releases/v0.4.13/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/project/releases/v0.4.14/index.html
+++ b/docs/static/v0.8/project/releases/v0.4.14/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/project/releases/v0.4.15/index.html
+++ b/docs/static/v0.8/project/releases/v0.4.15/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/project/releases/v0.4.16/index.html
+++ b/docs/static/v0.8/project/releases/v0.4.16/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/project/releases/v0.4.17/index.html
+++ b/docs/static/v0.8/project/releases/v0.4.17/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/project/releases/v0.4.18/index.html
+++ b/docs/static/v0.8/project/releases/v0.4.18/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/project/releases/v0.4.19/index.html
+++ b/docs/static/v0.8/project/releases/v0.4.19/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/project/releases/v0.4.2/index.html
+++ b/docs/static/v0.8/project/releases/v0.4.2/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/project/releases/v0.4.20/index.html
+++ b/docs/static/v0.8/project/releases/v0.4.20/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/project/releases/v0.4.21/index.html
+++ b/docs/static/v0.8/project/releases/v0.4.21/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/project/releases/v0.4.22/index.html
+++ b/docs/static/v0.8/project/releases/v0.4.22/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/project/releases/v0.4.23/index.html
+++ b/docs/static/v0.8/project/releases/v0.4.23/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/project/releases/v0.4.24/index.html
+++ b/docs/static/v0.8/project/releases/v0.4.24/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/project/releases/v0.4.25/index.html
+++ b/docs/static/v0.8/project/releases/v0.4.25/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/project/releases/v0.4.26/index.html
+++ b/docs/static/v0.8/project/releases/v0.4.26/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/project/releases/v0.4.27/index.html
+++ b/docs/static/v0.8/project/releases/v0.4.27/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/project/releases/v0.4.3/index.html
+++ b/docs/static/v0.8/project/releases/v0.4.3/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/project/releases/v0.4.4/index.html
+++ b/docs/static/v0.8/project/releases/v0.4.4/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/project/releases/v0.4.5/index.html
+++ b/docs/static/v0.8/project/releases/v0.4.5/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/project/releases/v0.4.6/index.html
+++ b/docs/static/v0.8/project/releases/v0.4.6/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/project/releases/v0.4.7/index.html
+++ b/docs/static/v0.8/project/releases/v0.4.7/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/project/releases/v0.4.8/index.html
+++ b/docs/static/v0.8/project/releases/v0.4.8/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/project/releases/v0.4.9/index.html
+++ b/docs/static/v0.8/project/releases/v0.4.9/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/project/releases/v0.5.0-beta-1/index.html
+++ b/docs/static/v0.8/project/releases/v0.5.0-beta-1/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/project/releases/v0.5.0-beta-2/index.html
+++ b/docs/static/v0.8/project/releases/v0.5.0-beta-2/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/project/releases/v0.5.0-beta-3/index.html
+++ b/docs/static/v0.8/project/releases/v0.5.0-beta-3/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/project/releases/v0.5.0-beta-4/index.html
+++ b/docs/static/v0.8/project/releases/v0.5.0-beta-4/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/project/releases/v0.5.0-rc-1/index.html
+++ b/docs/static/v0.8/project/releases/v0.5.0-rc-1/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/project/releases/v0.5.0-rc-2/index.html
+++ b/docs/static/v0.8/project/releases/v0.5.0-rc-2/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/project/releases/v0.5.0-rc-3/index.html
+++ b/docs/static/v0.8/project/releases/v0.5.0-rc-3/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/project/releases/v0.5.0-rc-4/index.html
+++ b/docs/static/v0.8/project/releases/v0.5.0-rc-4/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/project/releases/v0.5.0-rc-5/index.html
+++ b/docs/static/v0.8/project/releases/v0.5.0-rc-5/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/project/releases/v0.5.0-rc-6/index.html
+++ b/docs/static/v0.8/project/releases/v0.5.0-rc-6/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/project/releases/v0.5.0/index.html
+++ b/docs/static/v0.8/project/releases/v0.5.0/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/project/releases/v0.5.1/index.html
+++ b/docs/static/v0.8/project/releases/v0.5.1/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/project/releases/v0.5.10/index.html
+++ b/docs/static/v0.8/project/releases/v0.5.10/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/project/releases/v0.5.11/index.html
+++ b/docs/static/v0.8/project/releases/v0.5.11/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/project/releases/v0.5.12/index.html
+++ b/docs/static/v0.8/project/releases/v0.5.12/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/project/releases/v0.5.13/index.html
+++ b/docs/static/v0.8/project/releases/v0.5.13/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/project/releases/v0.5.14/index.html
+++ b/docs/static/v0.8/project/releases/v0.5.14/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/project/releases/v0.5.15/index.html
+++ b/docs/static/v0.8/project/releases/v0.5.15/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/project/releases/v0.5.16/index.html
+++ b/docs/static/v0.8/project/releases/v0.5.16/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/project/releases/v0.5.17/index.html
+++ b/docs/static/v0.8/project/releases/v0.5.17/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/project/releases/v0.5.18/index.html
+++ b/docs/static/v0.8/project/releases/v0.5.18/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/project/releases/v0.5.19/index.html
+++ b/docs/static/v0.8/project/releases/v0.5.19/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/project/releases/v0.5.2/index.html
+++ b/docs/static/v0.8/project/releases/v0.5.2/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/project/releases/v0.5.20/index.html
+++ b/docs/static/v0.8/project/releases/v0.5.20/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/project/releases/v0.5.21/index.html
+++ b/docs/static/v0.8/project/releases/v0.5.21/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/project/releases/v0.5.22/index.html
+++ b/docs/static/v0.8/project/releases/v0.5.22/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/project/releases/v0.5.23/index.html
+++ b/docs/static/v0.8/project/releases/v0.5.23/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/project/releases/v0.5.24/index.html
+++ b/docs/static/v0.8/project/releases/v0.5.24/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/project/releases/v0.5.25/index.html
+++ b/docs/static/v0.8/project/releases/v0.5.25/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/project/releases/v0.5.26/index.html
+++ b/docs/static/v0.8/project/releases/v0.5.26/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/project/releases/v0.5.27/index.html
+++ b/docs/static/v0.8/project/releases/v0.5.27/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/project/releases/v0.5.28/index.html
+++ b/docs/static/v0.8/project/releases/v0.5.28/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/project/releases/v0.5.29/index.html
+++ b/docs/static/v0.8/project/releases/v0.5.29/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/project/releases/v0.5.3/index.html
+++ b/docs/static/v0.8/project/releases/v0.5.3/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/project/releases/v0.5.30/index.html
+++ b/docs/static/v0.8/project/releases/v0.5.30/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/project/releases/v0.5.31/index.html
+++ b/docs/static/v0.8/project/releases/v0.5.31/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/project/releases/v0.5.32/index.html
+++ b/docs/static/v0.8/project/releases/v0.5.32/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/project/releases/v0.5.33/index.html
+++ b/docs/static/v0.8/project/releases/v0.5.33/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/project/releases/v0.5.34/index.html
+++ b/docs/static/v0.8/project/releases/v0.5.34/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/project/releases/v0.5.35/index.html
+++ b/docs/static/v0.8/project/releases/v0.5.35/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/project/releases/v0.5.36/index.html
+++ b/docs/static/v0.8/project/releases/v0.5.36/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/project/releases/v0.5.37/index.html
+++ b/docs/static/v0.8/project/releases/v0.5.37/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/project/releases/v0.5.38/index.html
+++ b/docs/static/v0.8/project/releases/v0.5.38/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/project/releases/v0.5.39/index.html
+++ b/docs/static/v0.8/project/releases/v0.5.39/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/project/releases/v0.5.4/index.html
+++ b/docs/static/v0.8/project/releases/v0.5.4/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/project/releases/v0.5.40/index.html
+++ b/docs/static/v0.8/project/releases/v0.5.40/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/project/releases/v0.5.41/index.html
+++ b/docs/static/v0.8/project/releases/v0.5.41/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/project/releases/v0.5.42/index.html
+++ b/docs/static/v0.8/project/releases/v0.5.42/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/project/releases/v0.5.43/index.html
+++ b/docs/static/v0.8/project/releases/v0.5.43/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/project/releases/v0.5.44/index.html
+++ b/docs/static/v0.8/project/releases/v0.5.44/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/project/releases/v0.5.45/index.html
+++ b/docs/static/v0.8/project/releases/v0.5.45/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/project/releases/v0.5.46/index.html
+++ b/docs/static/v0.8/project/releases/v0.5.46/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/project/releases/v0.5.47/index.html
+++ b/docs/static/v0.8/project/releases/v0.5.47/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/project/releases/v0.5.48/index.html
+++ b/docs/static/v0.8/project/releases/v0.5.48/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/project/releases/v0.5.49/index.html
+++ b/docs/static/v0.8/project/releases/v0.5.49/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/project/releases/v0.5.5/index.html
+++ b/docs/static/v0.8/project/releases/v0.5.5/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/project/releases/v0.5.50/index.html
+++ b/docs/static/v0.8/project/releases/v0.5.50/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/project/releases/v0.5.51/index.html
+++ b/docs/static/v0.8/project/releases/v0.5.51/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/project/releases/v0.5.52/index.html
+++ b/docs/static/v0.8/project/releases/v0.5.52/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/project/releases/v0.5.53/index.html
+++ b/docs/static/v0.8/project/releases/v0.5.53/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/project/releases/v0.5.54/index.html
+++ b/docs/static/v0.8/project/releases/v0.5.54/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/project/releases/v0.5.55/index.html
+++ b/docs/static/v0.8/project/releases/v0.5.55/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/project/releases/v0.5.56/index.html
+++ b/docs/static/v0.8/project/releases/v0.5.56/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/project/releases/v0.5.57/index.html
+++ b/docs/static/v0.8/project/releases/v0.5.57/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/project/releases/v0.5.58/index.html
+++ b/docs/static/v0.8/project/releases/v0.5.58/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/project/releases/v0.5.59/index.html
+++ b/docs/static/v0.8/project/releases/v0.5.59/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/project/releases/v0.5.6/index.html
+++ b/docs/static/v0.8/project/releases/v0.5.6/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/project/releases/v0.5.60/index.html
+++ b/docs/static/v0.8/project/releases/v0.5.60/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/project/releases/v0.5.61/index.html
+++ b/docs/static/v0.8/project/releases/v0.5.61/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/project/releases/v0.5.62/index.html
+++ b/docs/static/v0.8/project/releases/v0.5.62/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/project/releases/v0.5.63-rc-1/index.html
+++ b/docs/static/v0.8/project/releases/v0.5.63-rc-1/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/project/releases/v0.5.64-rc-2/index.html
+++ b/docs/static/v0.8/project/releases/v0.5.64-rc-2/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/project/releases/v0.5.64/index.html
+++ b/docs/static/v0.8/project/releases/v0.5.64/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/project/releases/v0.5.65/index.html
+++ b/docs/static/v0.8/project/releases/v0.5.65/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/project/releases/v0.5.66/index.html
+++ b/docs/static/v0.8/project/releases/v0.5.66/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/project/releases/v0.5.67/index.html
+++ b/docs/static/v0.8/project/releases/v0.5.67/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/project/releases/v0.5.68/index.html
+++ b/docs/static/v0.8/project/releases/v0.5.68/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/project/releases/v0.5.69/index.html
+++ b/docs/static/v0.8/project/releases/v0.5.69/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/project/releases/v0.5.7/index.html
+++ b/docs/static/v0.8/project/releases/v0.5.7/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/project/releases/v0.5.70/index.html
+++ b/docs/static/v0.8/project/releases/v0.5.70/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/project/releases/v0.5.71/index.html
+++ b/docs/static/v0.8/project/releases/v0.5.71/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/project/releases/v0.5.72/index.html
+++ b/docs/static/v0.8/project/releases/v0.5.72/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/project/releases/v0.5.8/index.html
+++ b/docs/static/v0.8/project/releases/v0.5.8/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/project/releases/v0.5.9/index.html
+++ b/docs/static/v0.8/project/releases/v0.5.9/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/project/releases/v0.6.0-rc-1/index.html
+++ b/docs/static/v0.8/project/releases/v0.6.0-rc-1/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/project/releases/v0.6.0-rc-2/index.html
+++ b/docs/static/v0.8/project/releases/v0.6.0-rc-2/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/project/releases/v0.6.0-rc-3/index.html
+++ b/docs/static/v0.8/project/releases/v0.6.0-rc-3/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/project/releases/v0.6.0-rc-4/index.html
+++ b/docs/static/v0.8/project/releases/v0.6.0-rc-4/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/project/releases/v0.6.0-rc-5/index.html
+++ b/docs/static/v0.8/project/releases/v0.6.0-rc-5/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/project/releases/v0.6.0-rc-5a/index.html
+++ b/docs/static/v0.8/project/releases/v0.6.0-rc-5a/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/project/releases/v0.6.0-rc-5b/index.html
+++ b/docs/static/v0.8/project/releases/v0.6.0-rc-5b/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/project/releases/v0.6.0-rc-5c/index.html
+++ b/docs/static/v0.8/project/releases/v0.6.0-rc-5c/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/project/releases/v0.6.0-rc-5d/index.html
+++ b/docs/static/v0.8/project/releases/v0.6.0-rc-5d/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/project/releases/v0.6.0-rc-5f/index.html
+++ b/docs/static/v0.8/project/releases/v0.6.0-rc-5f/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/project/releases/v0.6.0-rc-5g/index.html
+++ b/docs/static/v0.8/project/releases/v0.6.0-rc-5g/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/project/releases/v0.6.0-rc-5h/index.html
+++ b/docs/static/v0.8/project/releases/v0.6.0-rc-5h/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/project/releases/v0.6.0-rc-5i/index.html
+++ b/docs/static/v0.8/project/releases/v0.6.0-rc-5i/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/project/releases/v0.6.0-rc-5j/index.html
+++ b/docs/static/v0.8/project/releases/v0.6.0-rc-5j/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/project/releases/v0.6.0-rc-5t/index.html
+++ b/docs/static/v0.8/project/releases/v0.6.0-rc-5t/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/project/releases/v0.6.0-rc.5aa/index.html
+++ b/docs/static/v0.8/project/releases/v0.6.0-rc.5aa/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/project/releases/v0.6.0-rc.5k/index.html
+++ b/docs/static/v0.8/project/releases/v0.6.0-rc.5k/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/project/releases/v0.6.0-rc.5l/index.html
+++ b/docs/static/v0.8/project/releases/v0.6.0-rc.5l/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/project/releases/v0.6.0-rc.5m/index.html
+++ b/docs/static/v0.8/project/releases/v0.6.0-rc.5m/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/project/releases/v0.6.0-rc.5n/index.html
+++ b/docs/static/v0.8/project/releases/v0.6.0-rc.5n/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/project/releases/v0.6.0-rc.5o/index.html
+++ b/docs/static/v0.8/project/releases/v0.6.0-rc.5o/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/project/releases/v0.6.0-rc.5p/index.html
+++ b/docs/static/v0.8/project/releases/v0.6.0-rc.5p/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/project/releases/v0.6.0-rc.5q/index.html
+++ b/docs/static/v0.8/project/releases/v0.6.0-rc.5q/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/project/releases/v0.6.0-rc.5r/index.html
+++ b/docs/static/v0.8/project/releases/v0.6.0-rc.5r/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/project/releases/v0.6.0-rc.5s/index.html
+++ b/docs/static/v0.8/project/releases/v0.6.0-rc.5s/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/project/releases/v0.6.0-rc.5u/index.html
+++ b/docs/static/v0.8/project/releases/v0.6.0-rc.5u/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/project/releases/v0.6.0-rc.5v/index.html
+++ b/docs/static/v0.8/project/releases/v0.6.0-rc.5v/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/project/releases/v0.6.0-rc.5w/index.html
+++ b/docs/static/v0.8/project/releases/v0.6.0-rc.5w/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/project/releases/v0.6.0-rc.5x/index.html
+++ b/docs/static/v0.8/project/releases/v0.6.0-rc.5x/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/project/releases/v0.6.0-rc.5y/index.html
+++ b/docs/static/v0.8/project/releases/v0.6.0-rc.5y/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/project/releases/v0.6.0-rc.5z/index.html
+++ b/docs/static/v0.8/project/releases/v0.6.0-rc.5z/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/project/releases/v0.6.0-rc.6/index.html
+++ b/docs/static/v0.8/project/releases/v0.6.0-rc.6/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/project/releases/v0.6.0-rc.6a/index.html
+++ b/docs/static/v0.8/project/releases/v0.6.0-rc.6a/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/project/releases/v0.6.0-rc.6b/index.html
+++ b/docs/static/v0.8/project/releases/v0.6.0-rc.6b/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/project/releases/v0.6.0-rc.6c/index.html
+++ b/docs/static/v0.8/project/releases/v0.6.0-rc.6c/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/project/releases/v0.6.0-rc.6d/index.html
+++ b/docs/static/v0.8/project/releases/v0.6.0-rc.6d/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/project/releases/v0.6.0-rc.6e/index.html
+++ b/docs/static/v0.8/project/releases/v0.6.0-rc.6e/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/project/releases/v0.6.0-rc.6f/index.html
+++ b/docs/static/v0.8/project/releases/v0.6.0-rc.6f/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/project/releases/v0.6.0-rc.6fa/index.html
+++ b/docs/static/v0.8/project/releases/v0.6.0-rc.6fa/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/project/releases/v0.6.0-rc.6fb/index.html
+++ b/docs/static/v0.8/project/releases/v0.6.0-rc.6fb/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/project/releases/v0.6.0-rc.6fc/index.html
+++ b/docs/static/v0.8/project/releases/v0.6.0-rc.6fc/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/project/releases/v0.6.0-rc.6fd/index.html
+++ b/docs/static/v0.8/project/releases/v0.6.0-rc.6fd/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/project/releases/v0.6.0-rc.6fe/index.html
+++ b/docs/static/v0.8/project/releases/v0.6.0-rc.6fe/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/project/releases/v0.6.0-rc.6ff/index.html
+++ b/docs/static/v0.8/project/releases/v0.6.0-rc.6ff/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/project/releases/v0.6.0/index.html
+++ b/docs/static/v0.8/project/releases/v0.6.0/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/project/releases/v0.6.10/index.html
+++ b/docs/static/v0.8/project/releases/v0.6.10/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/project/releases/v0.6.100/index.html
+++ b/docs/static/v0.8/project/releases/v0.6.100/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/project/releases/v0.6.102/index.html
+++ b/docs/static/v0.8/project/releases/v0.6.102/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/project/releases/v0.6.103/index.html
+++ b/docs/static/v0.8/project/releases/v0.6.103/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/project/releases/v0.6.104/index.html
+++ b/docs/static/v0.8/project/releases/v0.6.104/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/project/releases/v0.6.105/index.html
+++ b/docs/static/v0.8/project/releases/v0.6.105/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/project/releases/v0.6.107/index.html
+++ b/docs/static/v0.8/project/releases/v0.6.107/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/project/releases/v0.6.108/index.html
+++ b/docs/static/v0.8/project/releases/v0.6.108/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/project/releases/v0.6.109/index.html
+++ b/docs/static/v0.8/project/releases/v0.6.109/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/project/releases/v0.6.110/index.html
+++ b/docs/static/v0.8/project/releases/v0.6.110/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/project/releases/v0.6.111/index.html
+++ b/docs/static/v0.8/project/releases/v0.6.111/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/project/releases/v0.6.112/index.html
+++ b/docs/static/v0.8/project/releases/v0.6.112/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/project/releases/v0.6.113/index.html
+++ b/docs/static/v0.8/project/releases/v0.6.113/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/project/releases/v0.6.114/index.html
+++ b/docs/static/v0.8/project/releases/v0.6.114/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/project/releases/v0.6.115/index.html
+++ b/docs/static/v0.8/project/releases/v0.6.115/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/project/releases/v0.6.116/index.html
+++ b/docs/static/v0.8/project/releases/v0.6.116/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/project/releases/v0.6.117/index.html
+++ b/docs/static/v0.8/project/releases/v0.6.117/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/project/releases/v0.6.118/index.html
+++ b/docs/static/v0.8/project/releases/v0.6.118/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/project/releases/v0.6.119/index.html
+++ b/docs/static/v0.8/project/releases/v0.6.119/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/project/releases/v0.6.12/index.html
+++ b/docs/static/v0.8/project/releases/v0.6.12/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/project/releases/v0.6.120/index.html
+++ b/docs/static/v0.8/project/releases/v0.6.120/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/project/releases/v0.6.121/index.html
+++ b/docs/static/v0.8/project/releases/v0.6.121/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/project/releases/v0.6.122/index.html
+++ b/docs/static/v0.8/project/releases/v0.6.122/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/project/releases/v0.6.123/index.html
+++ b/docs/static/v0.8/project/releases/v0.6.123/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/project/releases/v0.6.124/index.html
+++ b/docs/static/v0.8/project/releases/v0.6.124/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/project/releases/v0.6.125/index.html
+++ b/docs/static/v0.8/project/releases/v0.6.125/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/project/releases/v0.6.126/index.html
+++ b/docs/static/v0.8/project/releases/v0.6.126/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/project/releases/v0.6.127/index.html
+++ b/docs/static/v0.8/project/releases/v0.6.127/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/project/releases/v0.6.128/index.html
+++ b/docs/static/v0.8/project/releases/v0.6.128/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/project/releases/v0.6.129/index.html
+++ b/docs/static/v0.8/project/releases/v0.6.129/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/project/releases/v0.6.13/index.html
+++ b/docs/static/v0.8/project/releases/v0.6.13/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/project/releases/v0.6.130/index.html
+++ b/docs/static/v0.8/project/releases/v0.6.130/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/project/releases/v0.6.131/index.html
+++ b/docs/static/v0.8/project/releases/v0.6.131/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/project/releases/v0.6.132/index.html
+++ b/docs/static/v0.8/project/releases/v0.6.132/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/project/releases/v0.6.133/index.html
+++ b/docs/static/v0.8/project/releases/v0.6.133/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/project/releases/v0.6.134/index.html
+++ b/docs/static/v0.8/project/releases/v0.6.134/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/project/releases/v0.6.135/index.html
+++ b/docs/static/v0.8/project/releases/v0.6.135/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/project/releases/v0.6.136/index.html
+++ b/docs/static/v0.8/project/releases/v0.6.136/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/project/releases/v0.6.137/index.html
+++ b/docs/static/v0.8/project/releases/v0.6.137/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/project/releases/v0.6.138/index.html
+++ b/docs/static/v0.8/project/releases/v0.6.138/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/project/releases/v0.6.139/index.html
+++ b/docs/static/v0.8/project/releases/v0.6.139/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/project/releases/v0.6.14/index.html
+++ b/docs/static/v0.8/project/releases/v0.6.14/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/project/releases/v0.6.140/index.html
+++ b/docs/static/v0.8/project/releases/v0.6.140/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/project/releases/v0.6.141/index.html
+++ b/docs/static/v0.8/project/releases/v0.6.141/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/project/releases/v0.6.142/index.html
+++ b/docs/static/v0.8/project/releases/v0.6.142/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/project/releases/v0.6.143/index.html
+++ b/docs/static/v0.8/project/releases/v0.6.143/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/project/releases/v0.6.144/index.html
+++ b/docs/static/v0.8/project/releases/v0.6.144/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/project/releases/v0.6.145/index.html
+++ b/docs/static/v0.8/project/releases/v0.6.145/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/project/releases/v0.6.146/index.html
+++ b/docs/static/v0.8/project/releases/v0.6.146/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/project/releases/v0.6.147/index.html
+++ b/docs/static/v0.8/project/releases/v0.6.147/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/project/releases/v0.6.148/index.html
+++ b/docs/static/v0.8/project/releases/v0.6.148/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/project/releases/v0.6.149/index.html
+++ b/docs/static/v0.8/project/releases/v0.6.149/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/project/releases/v0.6.15/index.html
+++ b/docs/static/v0.8/project/releases/v0.6.15/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/project/releases/v0.6.150/index.html
+++ b/docs/static/v0.8/project/releases/v0.6.150/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/project/releases/v0.6.151/index.html
+++ b/docs/static/v0.8/project/releases/v0.6.151/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/project/releases/v0.6.152/index.html
+++ b/docs/static/v0.8/project/releases/v0.6.152/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/project/releases/v0.6.153/index.html
+++ b/docs/static/v0.8/project/releases/v0.6.153/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/project/releases/v0.6.154/index.html
+++ b/docs/static/v0.8/project/releases/v0.6.154/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/project/releases/v0.6.155/index.html
+++ b/docs/static/v0.8/project/releases/v0.6.155/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/project/releases/v0.6.156/index.html
+++ b/docs/static/v0.8/project/releases/v0.6.156/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/project/releases/v0.6.157/index.html
+++ b/docs/static/v0.8/project/releases/v0.6.157/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/project/releases/v0.6.158/index.html
+++ b/docs/static/v0.8/project/releases/v0.6.158/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/project/releases/v0.6.159/index.html
+++ b/docs/static/v0.8/project/releases/v0.6.159/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/project/releases/v0.6.16/index.html
+++ b/docs/static/v0.8/project/releases/v0.6.16/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/project/releases/v0.6.160/index.html
+++ b/docs/static/v0.8/project/releases/v0.6.160/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/project/releases/v0.6.161/index.html
+++ b/docs/static/v0.8/project/releases/v0.6.161/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/project/releases/v0.6.162/index.html
+++ b/docs/static/v0.8/project/releases/v0.6.162/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/project/releases/v0.6.163/index.html
+++ b/docs/static/v0.8/project/releases/v0.6.163/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/project/releases/v0.6.164/index.html
+++ b/docs/static/v0.8/project/releases/v0.6.164/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/project/releases/v0.6.165/index.html
+++ b/docs/static/v0.8/project/releases/v0.6.165/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/project/releases/v0.6.166/index.html
+++ b/docs/static/v0.8/project/releases/v0.6.166/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/project/releases/v0.6.167/index.html
+++ b/docs/static/v0.8/project/releases/v0.6.167/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/project/releases/v0.6.168/index.html
+++ b/docs/static/v0.8/project/releases/v0.6.168/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/project/releases/v0.6.169/index.html
+++ b/docs/static/v0.8/project/releases/v0.6.169/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/project/releases/v0.6.17/index.html
+++ b/docs/static/v0.8/project/releases/v0.6.17/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/project/releases/v0.6.171/index.html
+++ b/docs/static/v0.8/project/releases/v0.6.171/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/project/releases/v0.6.172/index.html
+++ b/docs/static/v0.8/project/releases/v0.6.172/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/project/releases/v0.6.173/index.html
+++ b/docs/static/v0.8/project/releases/v0.6.173/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/project/releases/v0.6.174/index.html
+++ b/docs/static/v0.8/project/releases/v0.6.174/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/project/releases/v0.6.175/index.html
+++ b/docs/static/v0.8/project/releases/v0.6.175/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/project/releases/v0.6.176/index.html
+++ b/docs/static/v0.8/project/releases/v0.6.176/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/project/releases/v0.6.177/index.html
+++ b/docs/static/v0.8/project/releases/v0.6.177/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/project/releases/v0.6.178/index.html
+++ b/docs/static/v0.8/project/releases/v0.6.178/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/project/releases/v0.6.179/index.html
+++ b/docs/static/v0.8/project/releases/v0.6.179/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/project/releases/v0.6.18/index.html
+++ b/docs/static/v0.8/project/releases/v0.6.18/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/project/releases/v0.6.180/index.html
+++ b/docs/static/v0.8/project/releases/v0.6.180/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/project/releases/v0.6.181/index.html
+++ b/docs/static/v0.8/project/releases/v0.6.181/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/project/releases/v0.6.182/index.html
+++ b/docs/static/v0.8/project/releases/v0.6.182/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/project/releases/v0.6.183/index.html
+++ b/docs/static/v0.8/project/releases/v0.6.183/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/project/releases/v0.6.184/index.html
+++ b/docs/static/v0.8/project/releases/v0.6.184/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/project/releases/v0.6.185/index.html
+++ b/docs/static/v0.8/project/releases/v0.6.185/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/project/releases/v0.6.19/index.html
+++ b/docs/static/v0.8/project/releases/v0.6.19/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/project/releases/v0.6.2/index.html
+++ b/docs/static/v0.8/project/releases/v0.6.2/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/project/releases/v0.6.20/index.html
+++ b/docs/static/v0.8/project/releases/v0.6.20/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/project/releases/v0.6.21/index.html
+++ b/docs/static/v0.8/project/releases/v0.6.21/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/project/releases/v0.6.22/index.html
+++ b/docs/static/v0.8/project/releases/v0.6.22/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/project/releases/v0.6.23/index.html
+++ b/docs/static/v0.8/project/releases/v0.6.23/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/project/releases/v0.6.24/index.html
+++ b/docs/static/v0.8/project/releases/v0.6.24/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/project/releases/v0.6.25/index.html
+++ b/docs/static/v0.8/project/releases/v0.6.25/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/project/releases/v0.6.26/index.html
+++ b/docs/static/v0.8/project/releases/v0.6.26/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/project/releases/v0.6.27/index.html
+++ b/docs/static/v0.8/project/releases/v0.6.27/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/project/releases/v0.6.28/index.html
+++ b/docs/static/v0.8/project/releases/v0.6.28/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/project/releases/v0.6.29/index.html
+++ b/docs/static/v0.8/project/releases/v0.6.29/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/project/releases/v0.6.3/index.html
+++ b/docs/static/v0.8/project/releases/v0.6.3/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/project/releases/v0.6.30/index.html
+++ b/docs/static/v0.8/project/releases/v0.6.30/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/project/releases/v0.6.31/index.html
+++ b/docs/static/v0.8/project/releases/v0.6.31/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/project/releases/v0.6.32/index.html
+++ b/docs/static/v0.8/project/releases/v0.6.32/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/project/releases/v0.6.33/index.html
+++ b/docs/static/v0.8/project/releases/v0.6.33/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/project/releases/v0.6.34/index.html
+++ b/docs/static/v0.8/project/releases/v0.6.34/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/project/releases/v0.6.35/index.html
+++ b/docs/static/v0.8/project/releases/v0.6.35/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/project/releases/v0.6.36/index.html
+++ b/docs/static/v0.8/project/releases/v0.6.36/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/project/releases/v0.6.37/index.html
+++ b/docs/static/v0.8/project/releases/v0.6.37/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/project/releases/v0.6.38/index.html
+++ b/docs/static/v0.8/project/releases/v0.6.38/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/project/releases/v0.6.39/index.html
+++ b/docs/static/v0.8/project/releases/v0.6.39/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/project/releases/v0.6.4/index.html
+++ b/docs/static/v0.8/project/releases/v0.6.4/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/project/releases/v0.6.40/index.html
+++ b/docs/static/v0.8/project/releases/v0.6.40/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/project/releases/v0.6.41/index.html
+++ b/docs/static/v0.8/project/releases/v0.6.41/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/project/releases/v0.6.42/index.html
+++ b/docs/static/v0.8/project/releases/v0.6.42/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/project/releases/v0.6.43/index.html
+++ b/docs/static/v0.8/project/releases/v0.6.43/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/project/releases/v0.6.44/index.html
+++ b/docs/static/v0.8/project/releases/v0.6.44/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/project/releases/v0.6.45/index.html
+++ b/docs/static/v0.8/project/releases/v0.6.45/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/project/releases/v0.6.46/index.html
+++ b/docs/static/v0.8/project/releases/v0.6.46/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/project/releases/v0.6.47/index.html
+++ b/docs/static/v0.8/project/releases/v0.6.47/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/project/releases/v0.6.48/index.html
+++ b/docs/static/v0.8/project/releases/v0.6.48/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/project/releases/v0.6.49/index.html
+++ b/docs/static/v0.8/project/releases/v0.6.49/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/project/releases/v0.6.5/index.html
+++ b/docs/static/v0.8/project/releases/v0.6.5/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/project/releases/v0.6.50/index.html
+++ b/docs/static/v0.8/project/releases/v0.6.50/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/project/releases/v0.6.51/index.html
+++ b/docs/static/v0.8/project/releases/v0.6.51/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/project/releases/v0.6.52/index.html
+++ b/docs/static/v0.8/project/releases/v0.6.52/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/project/releases/v0.6.53/index.html
+++ b/docs/static/v0.8/project/releases/v0.6.53/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/project/releases/v0.6.54/index.html
+++ b/docs/static/v0.8/project/releases/v0.6.54/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/project/releases/v0.6.55/index.html
+++ b/docs/static/v0.8/project/releases/v0.6.55/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/project/releases/v0.6.56/index.html
+++ b/docs/static/v0.8/project/releases/v0.6.56/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/project/releases/v0.6.57/index.html
+++ b/docs/static/v0.8/project/releases/v0.6.57/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/project/releases/v0.6.58/index.html
+++ b/docs/static/v0.8/project/releases/v0.6.58/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/project/releases/v0.6.59/index.html
+++ b/docs/static/v0.8/project/releases/v0.6.59/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/project/releases/v0.6.6/index.html
+++ b/docs/static/v0.8/project/releases/v0.6.6/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/project/releases/v0.6.61/index.html
+++ b/docs/static/v0.8/project/releases/v0.6.61/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/project/releases/v0.6.62/index.html
+++ b/docs/static/v0.8/project/releases/v0.6.62/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/project/releases/v0.6.63/index.html
+++ b/docs/static/v0.8/project/releases/v0.6.63/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/project/releases/v0.6.64/index.html
+++ b/docs/static/v0.8/project/releases/v0.6.64/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/project/releases/v0.6.65/index.html
+++ b/docs/static/v0.8/project/releases/v0.6.65/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/project/releases/v0.6.66/index.html
+++ b/docs/static/v0.8/project/releases/v0.6.66/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/project/releases/v0.6.67/index.html
+++ b/docs/static/v0.8/project/releases/v0.6.67/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/project/releases/v0.6.68/index.html
+++ b/docs/static/v0.8/project/releases/v0.6.68/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/project/releases/v0.6.69/index.html
+++ b/docs/static/v0.8/project/releases/v0.6.69/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/project/releases/v0.6.7/index.html
+++ b/docs/static/v0.8/project/releases/v0.6.7/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/project/releases/v0.6.70/index.html
+++ b/docs/static/v0.8/project/releases/v0.6.70/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/project/releases/v0.6.71/index.html
+++ b/docs/static/v0.8/project/releases/v0.6.71/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/project/releases/v0.6.72/index.html
+++ b/docs/static/v0.8/project/releases/v0.6.72/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/project/releases/v0.6.73/index.html
+++ b/docs/static/v0.8/project/releases/v0.6.73/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/project/releases/v0.6.74/index.html
+++ b/docs/static/v0.8/project/releases/v0.6.74/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/project/releases/v0.6.75/index.html
+++ b/docs/static/v0.8/project/releases/v0.6.75/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/project/releases/v0.6.76/index.html
+++ b/docs/static/v0.8/project/releases/v0.6.76/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/project/releases/v0.6.77/index.html
+++ b/docs/static/v0.8/project/releases/v0.6.77/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/project/releases/v0.6.78/index.html
+++ b/docs/static/v0.8/project/releases/v0.6.78/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/project/releases/v0.6.79/index.html
+++ b/docs/static/v0.8/project/releases/v0.6.79/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/project/releases/v0.6.8/index.html
+++ b/docs/static/v0.8/project/releases/v0.6.8/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/project/releases/v0.6.80/index.html
+++ b/docs/static/v0.8/project/releases/v0.6.80/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/project/releases/v0.6.81/index.html
+++ b/docs/static/v0.8/project/releases/v0.6.81/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/project/releases/v0.6.82/index.html
+++ b/docs/static/v0.8/project/releases/v0.6.82/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/project/releases/v0.6.83/index.html
+++ b/docs/static/v0.8/project/releases/v0.6.83/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/project/releases/v0.6.84/index.html
+++ b/docs/static/v0.8/project/releases/v0.6.84/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/project/releases/v0.6.85/index.html
+++ b/docs/static/v0.8/project/releases/v0.6.85/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/project/releases/v0.6.86/index.html
+++ b/docs/static/v0.8/project/releases/v0.6.86/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/project/releases/v0.6.87/index.html
+++ b/docs/static/v0.8/project/releases/v0.6.87/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/project/releases/v0.6.88/index.html
+++ b/docs/static/v0.8/project/releases/v0.6.88/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/project/releases/v0.6.89/index.html
+++ b/docs/static/v0.8/project/releases/v0.6.89/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/project/releases/v0.6.9/index.html
+++ b/docs/static/v0.8/project/releases/v0.6.9/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/project/releases/v0.6.90/index.html
+++ b/docs/static/v0.8/project/releases/v0.6.90/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/project/releases/v0.6.91/index.html
+++ b/docs/static/v0.8/project/releases/v0.6.91/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/project/releases/v0.6.92/index.html
+++ b/docs/static/v0.8/project/releases/v0.6.92/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/project/releases/v0.6.93/index.html
+++ b/docs/static/v0.8/project/releases/v0.6.93/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/project/releases/v0.6.94/index.html
+++ b/docs/static/v0.8/project/releases/v0.6.94/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/project/releases/v0.6.95/index.html
+++ b/docs/static/v0.8/project/releases/v0.6.95/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/project/releases/v0.6.96/index.html
+++ b/docs/static/v0.8/project/releases/v0.6.96/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/project/releases/v0.6.97/index.html
+++ b/docs/static/v0.8/project/releases/v0.6.97/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/project/releases/v0.6.98/index.html
+++ b/docs/static/v0.8/project/releases/v0.6.98/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/project/releases/v0.6.99/index.html
+++ b/docs/static/v0.8/project/releases/v0.6.99/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/project/releases/v0.7.0-beta-1/index.html
+++ b/docs/static/v0.8/project/releases/v0.7.0-beta-1/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/project/releases/v0.7.0-beta-2/index.html
+++ b/docs/static/v0.8/project/releases/v0.7.0-beta-2/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/project/releases/v0.7.0-beta-3/index.html
+++ b/docs/static/v0.8/project/releases/v0.7.0-beta-3/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/project/releases/v0.7.0-beta-4/index.html
+++ b/docs/static/v0.8/project/releases/v0.7.0-beta-4/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/project/releases/v0.7.0/index.html
+++ b/docs/static/v0.8/project/releases/v0.7.0/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/project/releases/v0.7.1/index.html
+++ b/docs/static/v0.8/project/releases/v0.7.1/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/project/releases/v0.7.10/index.html
+++ b/docs/static/v0.8/project/releases/v0.7.10/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/project/releases/v0.7.101/index.html
+++ b/docs/static/v0.8/project/releases/v0.7.101/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/project/releases/v0.7.102/index.html
+++ b/docs/static/v0.8/project/releases/v0.7.102/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/project/releases/v0.7.103/index.html
+++ b/docs/static/v0.8/project/releases/v0.7.103/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/project/releases/v0.7.104/index.html
+++ b/docs/static/v0.8/project/releases/v0.7.104/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/project/releases/v0.7.105/index.html
+++ b/docs/static/v0.8/project/releases/v0.7.105/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/project/releases/v0.7.106/index.html
+++ b/docs/static/v0.8/project/releases/v0.7.106/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/project/releases/v0.7.107/index.html
+++ b/docs/static/v0.8/project/releases/v0.7.107/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/project/releases/v0.7.108/index.html
+++ b/docs/static/v0.8/project/releases/v0.7.108/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/project/releases/v0.7.109/index.html
+++ b/docs/static/v0.8/project/releases/v0.7.109/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/project/releases/v0.7.11-patch.1/index.html
+++ b/docs/static/v0.8/project/releases/v0.7.11-patch.1/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/project/releases/v0.7.11-patch.2/index.html
+++ b/docs/static/v0.8/project/releases/v0.7.11-patch.2/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/project/releases/v0.7.11-patch.3/index.html
+++ b/docs/static/v0.8/project/releases/v0.7.11-patch.3/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/project/releases/v0.7.11/index.html
+++ b/docs/static/v0.8/project/releases/v0.7.11/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/project/releases/v0.7.110/index.html
+++ b/docs/static/v0.8/project/releases/v0.7.110/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/project/releases/v0.7.111/index.html
+++ b/docs/static/v0.8/project/releases/v0.7.111/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/project/releases/v0.7.112/index.html
+++ b/docs/static/v0.8/project/releases/v0.7.112/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/project/releases/v0.7.113/index.html
+++ b/docs/static/v0.8/project/releases/v0.7.113/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/project/releases/v0.7.114/index.html
+++ b/docs/static/v0.8/project/releases/v0.7.114/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/project/releases/v0.7.115/index.html
+++ b/docs/static/v0.8/project/releases/v0.7.115/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/project/releases/v0.7.116/index.html
+++ b/docs/static/v0.8/project/releases/v0.7.116/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/project/releases/v0.7.117/index.html
+++ b/docs/static/v0.8/project/releases/v0.7.117/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/project/releases/v0.7.118/index.html
+++ b/docs/static/v0.8/project/releases/v0.7.118/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/project/releases/v0.7.119/index.html
+++ b/docs/static/v0.8/project/releases/v0.7.119/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/project/releases/v0.7.12/index.html
+++ b/docs/static/v0.8/project/releases/v0.7.12/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/project/releases/v0.7.120/index.html
+++ b/docs/static/v0.8/project/releases/v0.7.120/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/project/releases/v0.7.121/index.html
+++ b/docs/static/v0.8/project/releases/v0.7.121/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/project/releases/v0.7.122/index.html
+++ b/docs/static/v0.8/project/releases/v0.7.122/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/project/releases/v0.7.123/index.html
+++ b/docs/static/v0.8/project/releases/v0.7.123/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/project/releases/v0.7.124/index.html
+++ b/docs/static/v0.8/project/releases/v0.7.124/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/project/releases/v0.7.125/index.html
+++ b/docs/static/v0.8/project/releases/v0.7.125/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/project/releases/v0.7.126/index.html
+++ b/docs/static/v0.8/project/releases/v0.7.126/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/project/releases/v0.7.127/index.html
+++ b/docs/static/v0.8/project/releases/v0.7.127/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/project/releases/v0.7.128/index.html
+++ b/docs/static/v0.8/project/releases/v0.7.128/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/project/releases/v0.7.129/index.html
+++ b/docs/static/v0.8/project/releases/v0.7.129/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/project/releases/v0.7.13/index.html
+++ b/docs/static/v0.8/project/releases/v0.7.13/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/project/releases/v0.7.130/index.html
+++ b/docs/static/v0.8/project/releases/v0.7.130/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/project/releases/v0.7.131/index.html
+++ b/docs/static/v0.8/project/releases/v0.7.131/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/project/releases/v0.7.132/index.html
+++ b/docs/static/v0.8/project/releases/v0.7.132/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/project/releases/v0.7.133/index.html
+++ b/docs/static/v0.8/project/releases/v0.7.133/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/project/releases/v0.7.134/index.html
+++ b/docs/static/v0.8/project/releases/v0.7.134/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/project/releases/v0.7.135/index.html
+++ b/docs/static/v0.8/project/releases/v0.7.135/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/project/releases/v0.7.136/index.html
+++ b/docs/static/v0.8/project/releases/v0.7.136/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/project/releases/v0.7.137/index.html
+++ b/docs/static/v0.8/project/releases/v0.7.137/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/project/releases/v0.7.138/index.html
+++ b/docs/static/v0.8/project/releases/v0.7.138/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/project/releases/v0.7.139/index.html
+++ b/docs/static/v0.8/project/releases/v0.7.139/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/project/releases/v0.7.14/index.html
+++ b/docs/static/v0.8/project/releases/v0.7.14/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/project/releases/v0.7.140/index.html
+++ b/docs/static/v0.8/project/releases/v0.7.140/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/project/releases/v0.7.141/index.html
+++ b/docs/static/v0.8/project/releases/v0.7.141/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/project/releases/v0.7.142/index.html
+++ b/docs/static/v0.8/project/releases/v0.7.142/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/project/releases/v0.7.143/index.html
+++ b/docs/static/v0.8/project/releases/v0.7.143/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/project/releases/v0.7.144/index.html
+++ b/docs/static/v0.8/project/releases/v0.7.144/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/project/releases/v0.7.145/index.html
+++ b/docs/static/v0.8/project/releases/v0.7.145/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/project/releases/v0.7.146/index.html
+++ b/docs/static/v0.8/project/releases/v0.7.146/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/project/releases/v0.7.147/index.html
+++ b/docs/static/v0.8/project/releases/v0.7.147/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/project/releases/v0.7.148/index.html
+++ b/docs/static/v0.8/project/releases/v0.7.148/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/project/releases/v0.7.149/index.html
+++ b/docs/static/v0.8/project/releases/v0.7.149/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/project/releases/v0.7.15/index.html
+++ b/docs/static/v0.8/project/releases/v0.7.15/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/project/releases/v0.7.150/index.html
+++ b/docs/static/v0.8/project/releases/v0.7.150/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/project/releases/v0.7.151/index.html
+++ b/docs/static/v0.8/project/releases/v0.7.151/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/project/releases/v0.7.152/index.html
+++ b/docs/static/v0.8/project/releases/v0.7.152/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/project/releases/v0.7.153/index.html
+++ b/docs/static/v0.8/project/releases/v0.7.153/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/project/releases/v0.7.154/index.html
+++ b/docs/static/v0.8/project/releases/v0.7.154/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/project/releases/v0.7.155/index.html
+++ b/docs/static/v0.8/project/releases/v0.7.155/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/project/releases/v0.7.156/index.html
+++ b/docs/static/v0.8/project/releases/v0.7.156/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/project/releases/v0.7.157/index.html
+++ b/docs/static/v0.8/project/releases/v0.7.157/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/project/releases/v0.7.158/index.html
+++ b/docs/static/v0.8/project/releases/v0.7.158/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/project/releases/v0.7.159/index.html
+++ b/docs/static/v0.8/project/releases/v0.7.159/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/project/releases/v0.7.16/index.html
+++ b/docs/static/v0.8/project/releases/v0.7.16/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/project/releases/v0.7.160/index.html
+++ b/docs/static/v0.8/project/releases/v0.7.160/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/project/releases/v0.7.161/index.html
+++ b/docs/static/v0.8/project/releases/v0.7.161/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/project/releases/v0.7.162/index.html
+++ b/docs/static/v0.8/project/releases/v0.7.162/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/project/releases/v0.7.163/index.html
+++ b/docs/static/v0.8/project/releases/v0.7.163/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/project/releases/v0.7.164/index.html
+++ b/docs/static/v0.8/project/releases/v0.7.164/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/project/releases/v0.7.165/index.html
+++ b/docs/static/v0.8/project/releases/v0.7.165/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/project/releases/v0.7.166/index.html
+++ b/docs/static/v0.8/project/releases/v0.7.166/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/project/releases/v0.7.167/index.html
+++ b/docs/static/v0.8/project/releases/v0.7.167/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/project/releases/v0.7.168/index.html
+++ b/docs/static/v0.8/project/releases/v0.7.168/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/project/releases/v0.7.169/index.html
+++ b/docs/static/v0.8/project/releases/v0.7.169/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/project/releases/v0.7.17/index.html
+++ b/docs/static/v0.8/project/releases/v0.7.17/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/project/releases/v0.7.170/index.html
+++ b/docs/static/v0.8/project/releases/v0.7.170/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/project/releases/v0.7.171/index.html
+++ b/docs/static/v0.8/project/releases/v0.7.171/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/project/releases/v0.7.172/index.html
+++ b/docs/static/v0.8/project/releases/v0.7.172/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/project/releases/v0.7.18/index.html
+++ b/docs/static/v0.8/project/releases/v0.7.18/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/project/releases/v0.7.19/index.html
+++ b/docs/static/v0.8/project/releases/v0.7.19/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/project/releases/v0.7.2-rc-1/index.html
+++ b/docs/static/v0.8/project/releases/v0.7.2-rc-1/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/project/releases/v0.7.2-rc-2/index.html
+++ b/docs/static/v0.8/project/releases/v0.7.2-rc-2/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/project/releases/v0.7.2.4/index.html
+++ b/docs/static/v0.8/project/releases/v0.7.2.4/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/project/releases/v0.7.2/index.html
+++ b/docs/static/v0.8/project/releases/v0.7.2/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/project/releases/v0.7.20/index.html
+++ b/docs/static/v0.8/project/releases/v0.7.20/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/project/releases/v0.7.21/index.html
+++ b/docs/static/v0.8/project/releases/v0.7.21/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/project/releases/v0.7.22/index.html
+++ b/docs/static/v0.8/project/releases/v0.7.22/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/project/releases/v0.7.24/index.html
+++ b/docs/static/v0.8/project/releases/v0.7.24/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/project/releases/v0.7.25/index.html
+++ b/docs/static/v0.8/project/releases/v0.7.25/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/project/releases/v0.7.26/index.html
+++ b/docs/static/v0.8/project/releases/v0.7.26/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/project/releases/v0.7.27/index.html
+++ b/docs/static/v0.8/project/releases/v0.7.27/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/project/releases/v0.7.28/index.html
+++ b/docs/static/v0.8/project/releases/v0.7.28/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/project/releases/v0.7.29/index.html
+++ b/docs/static/v0.8/project/releases/v0.7.29/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/project/releases/v0.7.3-patch.1/index.html
+++ b/docs/static/v0.8/project/releases/v0.7.3-patch.1/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/project/releases/v0.7.3-patch.2/index.html
+++ b/docs/static/v0.8/project/releases/v0.7.3-patch.2/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/project/releases/v0.7.3-patch.3/index.html
+++ b/docs/static/v0.8/project/releases/v0.7.3-patch.3/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/project/releases/v0.7.3-patch.4/index.html
+++ b/docs/static/v0.8/project/releases/v0.7.3-patch.4/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/project/releases/v0.7.3/index.html
+++ b/docs/static/v0.8/project/releases/v0.7.3/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/project/releases/v0.7.30/index.html
+++ b/docs/static/v0.8/project/releases/v0.7.30/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/project/releases/v0.7.31/index.html
+++ b/docs/static/v0.8/project/releases/v0.7.31/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/project/releases/v0.7.32/index.html
+++ b/docs/static/v0.8/project/releases/v0.7.32/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/project/releases/v0.7.33/index.html
+++ b/docs/static/v0.8/project/releases/v0.7.33/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/project/releases/v0.7.34/index.html
+++ b/docs/static/v0.8/project/releases/v0.7.34/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/project/releases/v0.7.35/index.html
+++ b/docs/static/v0.8/project/releases/v0.7.35/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/project/releases/v0.7.36/index.html
+++ b/docs/static/v0.8/project/releases/v0.7.36/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/project/releases/v0.7.37/index.html
+++ b/docs/static/v0.8/project/releases/v0.7.37/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/project/releases/v0.7.38/index.html
+++ b/docs/static/v0.8/project/releases/v0.7.38/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/project/releases/v0.7.39/index.html
+++ b/docs/static/v0.8/project/releases/v0.7.39/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/project/releases/v0.7.4-patch.1/index.html
+++ b/docs/static/v0.8/project/releases/v0.7.4-patch.1/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/project/releases/v0.7.4/index.html
+++ b/docs/static/v0.8/project/releases/v0.7.4/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/project/releases/v0.7.40/index.html
+++ b/docs/static/v0.8/project/releases/v0.7.40/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/project/releases/v0.7.41/index.html
+++ b/docs/static/v0.8/project/releases/v0.7.41/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/project/releases/v0.7.42/index.html
+++ b/docs/static/v0.8/project/releases/v0.7.42/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/project/releases/v0.7.43/index.html
+++ b/docs/static/v0.8/project/releases/v0.7.43/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/project/releases/v0.7.44/index.html
+++ b/docs/static/v0.8/project/releases/v0.7.44/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/project/releases/v0.7.45/index.html
+++ b/docs/static/v0.8/project/releases/v0.7.45/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/project/releases/v0.7.46/index.html
+++ b/docs/static/v0.8/project/releases/v0.7.46/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/project/releases/v0.7.47/index.html
+++ b/docs/static/v0.8/project/releases/v0.7.47/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/project/releases/v0.7.48/index.html
+++ b/docs/static/v0.8/project/releases/v0.7.48/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/project/releases/v0.7.49/index.html
+++ b/docs/static/v0.8/project/releases/v0.7.49/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/project/releases/v0.7.5/index.html
+++ b/docs/static/v0.8/project/releases/v0.7.5/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/project/releases/v0.7.50/index.html
+++ b/docs/static/v0.8/project/releases/v0.7.50/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/project/releases/v0.7.51/index.html
+++ b/docs/static/v0.8/project/releases/v0.7.51/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/project/releases/v0.7.52/index.html
+++ b/docs/static/v0.8/project/releases/v0.7.52/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/project/releases/v0.7.53/index.html
+++ b/docs/static/v0.8/project/releases/v0.7.53/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/project/releases/v0.7.54/index.html
+++ b/docs/static/v0.8/project/releases/v0.7.54/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/project/releases/v0.7.55/index.html
+++ b/docs/static/v0.8/project/releases/v0.7.55/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/project/releases/v0.7.56/index.html
+++ b/docs/static/v0.8/project/releases/v0.7.56/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/project/releases/v0.7.57/index.html
+++ b/docs/static/v0.8/project/releases/v0.7.57/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/project/releases/v0.7.58/index.html
+++ b/docs/static/v0.8/project/releases/v0.7.58/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/project/releases/v0.7.59/index.html
+++ b/docs/static/v0.8/project/releases/v0.7.59/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/project/releases/v0.7.6/index.html
+++ b/docs/static/v0.8/project/releases/v0.7.6/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/project/releases/v0.7.60/index.html
+++ b/docs/static/v0.8/project/releases/v0.7.60/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/project/releases/v0.7.61/index.html
+++ b/docs/static/v0.8/project/releases/v0.7.61/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/project/releases/v0.7.62/index.html
+++ b/docs/static/v0.8/project/releases/v0.7.62/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/project/releases/v0.7.63/index.html
+++ b/docs/static/v0.8/project/releases/v0.7.63/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/project/releases/v0.7.64/index.html
+++ b/docs/static/v0.8/project/releases/v0.7.64/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/project/releases/v0.7.65/index.html
+++ b/docs/static/v0.8/project/releases/v0.7.65/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/project/releases/v0.7.66/index.html
+++ b/docs/static/v0.8/project/releases/v0.7.66/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/project/releases/v0.7.67/index.html
+++ b/docs/static/v0.8/project/releases/v0.7.67/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/project/releases/v0.7.68/index.html
+++ b/docs/static/v0.8/project/releases/v0.7.68/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/project/releases/v0.7.69/index.html
+++ b/docs/static/v0.8/project/releases/v0.7.69/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/project/releases/v0.7.7/index.html
+++ b/docs/static/v0.8/project/releases/v0.7.7/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/project/releases/v0.7.70/index.html
+++ b/docs/static/v0.8/project/releases/v0.7.70/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/project/releases/v0.7.71/index.html
+++ b/docs/static/v0.8/project/releases/v0.7.71/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/project/releases/v0.7.72/index.html
+++ b/docs/static/v0.8/project/releases/v0.7.72/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/project/releases/v0.7.73/index.html
+++ b/docs/static/v0.8/project/releases/v0.7.73/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/project/releases/v0.7.74/index.html
+++ b/docs/static/v0.8/project/releases/v0.7.74/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/project/releases/v0.7.75/index.html
+++ b/docs/static/v0.8/project/releases/v0.7.75/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/project/releases/v0.7.76/index.html
+++ b/docs/static/v0.8/project/releases/v0.7.76/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/project/releases/v0.7.77/index.html
+++ b/docs/static/v0.8/project/releases/v0.7.77/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/project/releases/v0.7.78/index.html
+++ b/docs/static/v0.8/project/releases/v0.7.78/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/project/releases/v0.7.79/index.html
+++ b/docs/static/v0.8/project/releases/v0.7.79/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/project/releases/v0.7.8/index.html
+++ b/docs/static/v0.8/project/releases/v0.7.8/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/project/releases/v0.7.80/index.html
+++ b/docs/static/v0.8/project/releases/v0.7.80/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/project/releases/v0.7.81/index.html
+++ b/docs/static/v0.8/project/releases/v0.7.81/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/project/releases/v0.7.82/index.html
+++ b/docs/static/v0.8/project/releases/v0.7.82/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/project/releases/v0.7.83/index.html
+++ b/docs/static/v0.8/project/releases/v0.7.83/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/project/releases/v0.7.84/index.html
+++ b/docs/static/v0.8/project/releases/v0.7.84/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/project/releases/v0.7.85/index.html
+++ b/docs/static/v0.8/project/releases/v0.7.85/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/project/releases/v0.7.86/index.html
+++ b/docs/static/v0.8/project/releases/v0.7.86/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/project/releases/v0.7.87/index.html
+++ b/docs/static/v0.8/project/releases/v0.7.87/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/project/releases/v0.7.88/index.html
+++ b/docs/static/v0.8/project/releases/v0.7.88/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/project/releases/v0.7.89/index.html
+++ b/docs/static/v0.8/project/releases/v0.7.89/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/project/releases/v0.7.9/index.html
+++ b/docs/static/v0.8/project/releases/v0.7.9/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/project/releases/v0.7.90/index.html
+++ b/docs/static/v0.8/project/releases/v0.7.90/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/project/releases/v0.7.91/index.html
+++ b/docs/static/v0.8/project/releases/v0.7.91/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/project/releases/v0.7.92/index.html
+++ b/docs/static/v0.8/project/releases/v0.7.92/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/project/releases/v0.7.93/index.html
+++ b/docs/static/v0.8/project/releases/v0.7.93/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/project/releases/v0.7.94/index.html
+++ b/docs/static/v0.8/project/releases/v0.7.94/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/project/releases/v0.7.95/index.html
+++ b/docs/static/v0.8/project/releases/v0.7.95/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/project/releases/v0.7.99/index.html
+++ b/docs/static/v0.8/project/releases/v0.7.99/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/project/releases/v0.8.0/index.html
+++ b/docs/static/v0.8/project/releases/v0.8.0/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/project/releases/v0.8.1/index.html
+++ b/docs/static/v0.8/project/releases/v0.8.1/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/project/releases/v0.8.10/index.html
+++ b/docs/static/v0.8/project/releases/v0.8.10/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/project/releases/v0.8.100/index.html
+++ b/docs/static/v0.8/project/releases/v0.8.100/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/project/releases/v0.8.101/index.html
+++ b/docs/static/v0.8/project/releases/v0.8.101/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/project/releases/v0.8.102/index.html
+++ b/docs/static/v0.8/project/releases/v0.8.102/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/project/releases/v0.8.103/index.html
+++ b/docs/static/v0.8/project/releases/v0.8.103/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/project/releases/v0.8.104/index.html
+++ b/docs/static/v0.8/project/releases/v0.8.104/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/project/releases/v0.8.105/index.html
+++ b/docs/static/v0.8/project/releases/v0.8.105/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/project/releases/v0.8.106/index.html
+++ b/docs/static/v0.8/project/releases/v0.8.106/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/project/releases/v0.8.107/index.html
+++ b/docs/static/v0.8/project/releases/v0.8.107/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/project/releases/v0.8.108/index.html
+++ b/docs/static/v0.8/project/releases/v0.8.108/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/project/releases/v0.8.109/index.html
+++ b/docs/static/v0.8/project/releases/v0.8.109/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/project/releases/v0.8.11/index.html
+++ b/docs/static/v0.8/project/releases/v0.8.11/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/project/releases/v0.8.110/index.html
+++ b/docs/static/v0.8/project/releases/v0.8.110/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/project/releases/v0.8.111/index.html
+++ b/docs/static/v0.8/project/releases/v0.8.111/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/project/releases/v0.8.112/index.html
+++ b/docs/static/v0.8/project/releases/v0.8.112/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/project/releases/v0.8.113/index.html
+++ b/docs/static/v0.8/project/releases/v0.8.113/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/project/releases/v0.8.114/index.html
+++ b/docs/static/v0.8/project/releases/v0.8.114/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/project/releases/v0.8.115/index.html
+++ b/docs/static/v0.8/project/releases/v0.8.115/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/project/releases/v0.8.116/index.html
+++ b/docs/static/v0.8/project/releases/v0.8.116/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/project/releases/v0.8.117/index.html
+++ b/docs/static/v0.8/project/releases/v0.8.117/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/project/releases/v0.8.118/index.html
+++ b/docs/static/v0.8/project/releases/v0.8.118/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/project/releases/v0.8.119/index.html
+++ b/docs/static/v0.8/project/releases/v0.8.119/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/project/releases/v0.8.12/index.html
+++ b/docs/static/v0.8/project/releases/v0.8.12/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/project/releases/v0.8.120/index.html
+++ b/docs/static/v0.8/project/releases/v0.8.120/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/project/releases/v0.8.122/index.html
+++ b/docs/static/v0.8/project/releases/v0.8.122/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/project/releases/v0.8.123/index.html
+++ b/docs/static/v0.8/project/releases/v0.8.123/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/project/releases/v0.8.124/index.html
+++ b/docs/static/v0.8/project/releases/v0.8.124/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/project/releases/v0.8.125/index.html
+++ b/docs/static/v0.8/project/releases/v0.8.125/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/project/releases/v0.8.126/index.html
+++ b/docs/static/v0.8/project/releases/v0.8.126/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/project/releases/v0.8.127/index.html
+++ b/docs/static/v0.8/project/releases/v0.8.127/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/project/releases/v0.8.128/index.html
+++ b/docs/static/v0.8/project/releases/v0.8.128/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/project/releases/v0.8.129/index.html
+++ b/docs/static/v0.8/project/releases/v0.8.129/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/project/releases/v0.8.13/index.html
+++ b/docs/static/v0.8/project/releases/v0.8.13/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/project/releases/v0.8.130/index.html
+++ b/docs/static/v0.8/project/releases/v0.8.130/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/project/releases/v0.8.131/index.html
+++ b/docs/static/v0.8/project/releases/v0.8.131/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/project/releases/v0.8.132/index.html
+++ b/docs/static/v0.8/project/releases/v0.8.132/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/project/releases/v0.8.133/index.html
+++ b/docs/static/v0.8/project/releases/v0.8.133/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/project/releases/v0.8.134/index.html
+++ b/docs/static/v0.8/project/releases/v0.8.134/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/project/releases/v0.8.136/index.html
+++ b/docs/static/v0.8/project/releases/v0.8.136/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/project/releases/v0.8.137/index.html
+++ b/docs/static/v0.8/project/releases/v0.8.137/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/project/releases/v0.8.138/index.html
+++ b/docs/static/v0.8/project/releases/v0.8.138/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/project/releases/v0.8.139/index.html
+++ b/docs/static/v0.8/project/releases/v0.8.139/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/project/releases/v0.8.14/index.html
+++ b/docs/static/v0.8/project/releases/v0.8.14/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/project/releases/v0.8.140/index.html
+++ b/docs/static/v0.8/project/releases/v0.8.140/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/project/releases/v0.8.141/index.html
+++ b/docs/static/v0.8/project/releases/v0.8.141/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/project/releases/v0.8.142/index.html
+++ b/docs/static/v0.8/project/releases/v0.8.142/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/project/releases/v0.8.143/index.html
+++ b/docs/static/v0.8/project/releases/v0.8.143/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/project/releases/v0.8.144/index.html
+++ b/docs/static/v0.8/project/releases/v0.8.144/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/project/releases/v0.8.145/index.html
+++ b/docs/static/v0.8/project/releases/v0.8.145/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/project/releases/v0.8.146/index.html
+++ b/docs/static/v0.8/project/releases/v0.8.146/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/project/releases/v0.8.147/index.html
+++ b/docs/static/v0.8/project/releases/v0.8.147/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/project/releases/v0.8.148/index.html
+++ b/docs/static/v0.8/project/releases/v0.8.148/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/project/releases/v0.8.149/index.html
+++ b/docs/static/v0.8/project/releases/v0.8.149/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/project/releases/v0.8.15/index.html
+++ b/docs/static/v0.8/project/releases/v0.8.15/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/project/releases/v0.8.150/index.html
+++ b/docs/static/v0.8/project/releases/v0.8.150/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/project/releases/v0.8.151/index.html
+++ b/docs/static/v0.8/project/releases/v0.8.151/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/project/releases/v0.8.152/index.html
+++ b/docs/static/v0.8/project/releases/v0.8.152/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/project/releases/v0.8.153/index.html
+++ b/docs/static/v0.8/project/releases/v0.8.153/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/project/releases/v0.8.154/index.html
+++ b/docs/static/v0.8/project/releases/v0.8.154/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/project/releases/v0.8.155/index.html
+++ b/docs/static/v0.8/project/releases/v0.8.155/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/project/releases/v0.8.156/index.html
+++ b/docs/static/v0.8/project/releases/v0.8.156/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/project/releases/v0.8.157/index.html
+++ b/docs/static/v0.8/project/releases/v0.8.157/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/project/releases/v0.8.158/index.html
+++ b/docs/static/v0.8/project/releases/v0.8.158/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/project/releases/v0.8.159/index.html
+++ b/docs/static/v0.8/project/releases/v0.8.159/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/project/releases/v0.8.16/index.html
+++ b/docs/static/v0.8/project/releases/v0.8.16/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/project/releases/v0.8.160/index.html
+++ b/docs/static/v0.8/project/releases/v0.8.160/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/project/releases/v0.8.168/index.html
+++ b/docs/static/v0.8/project/releases/v0.8.168/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/project/releases/v0.8.169/index.html
+++ b/docs/static/v0.8/project/releases/v0.8.169/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/project/releases/v0.8.17/index.html
+++ b/docs/static/v0.8/project/releases/v0.8.17/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/project/releases/v0.8.170/index.html
+++ b/docs/static/v0.8/project/releases/v0.8.170/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/project/releases/v0.8.171/index.html
+++ b/docs/static/v0.8/project/releases/v0.8.171/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/project/releases/v0.8.172/index.html
+++ b/docs/static/v0.8/project/releases/v0.8.172/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/project/releases/v0.8.173/index.html
+++ b/docs/static/v0.8/project/releases/v0.8.173/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/project/releases/v0.8.174/index.html
+++ b/docs/static/v0.8/project/releases/v0.8.174/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/project/releases/v0.8.175/index.html
+++ b/docs/static/v0.8/project/releases/v0.8.175/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/project/releases/v0.8.176/index.html
+++ b/docs/static/v0.8/project/releases/v0.8.176/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/project/releases/v0.8.177/index.html
+++ b/docs/static/v0.8/project/releases/v0.8.177/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/project/releases/v0.8.178/index.html
+++ b/docs/static/v0.8/project/releases/v0.8.178/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/project/releases/v0.8.179/index.html
+++ b/docs/static/v0.8/project/releases/v0.8.179/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/project/releases/v0.8.180/index.html
+++ b/docs/static/v0.8/project/releases/v0.8.180/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/project/releases/v0.8.181/index.html
+++ b/docs/static/v0.8/project/releases/v0.8.181/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/project/releases/v0.8.183/index.html
+++ b/docs/static/v0.8/project/releases/v0.8.183/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/project/releases/v0.8.184/index.html
+++ b/docs/static/v0.8/project/releases/v0.8.184/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/project/releases/v0.8.185/index.html
+++ b/docs/static/v0.8/project/releases/v0.8.185/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/project/releases/v0.8.186/index.html
+++ b/docs/static/v0.8/project/releases/v0.8.186/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/project/releases/v0.8.187/index.html
+++ b/docs/static/v0.8/project/releases/v0.8.187/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/project/releases/v0.8.188/index.html
+++ b/docs/static/v0.8/project/releases/v0.8.188/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/project/releases/v0.8.189/index.html
+++ b/docs/static/v0.8/project/releases/v0.8.189/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/project/releases/v0.8.19/index.html
+++ b/docs/static/v0.8/project/releases/v0.8.19/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/project/releases/v0.8.190/index.html
+++ b/docs/static/v0.8/project/releases/v0.8.190/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/project/releases/v0.8.192/index.html
+++ b/docs/static/v0.8/project/releases/v0.8.192/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/project/releases/v0.8.193/index.html
+++ b/docs/static/v0.8/project/releases/v0.8.193/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/project/releases/v0.8.195/index.html
+++ b/docs/static/v0.8/project/releases/v0.8.195/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/project/releases/v0.8.196/index.html
+++ b/docs/static/v0.8/project/releases/v0.8.196/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/project/releases/v0.8.197/index.html
+++ b/docs/static/v0.8/project/releases/v0.8.197/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/project/releases/v0.8.198/index.html
+++ b/docs/static/v0.8/project/releases/v0.8.198/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/project/releases/v0.8.199/index.html
+++ b/docs/static/v0.8/project/releases/v0.8.199/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/project/releases/v0.8.2/index.html
+++ b/docs/static/v0.8/project/releases/v0.8.2/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/project/releases/v0.8.20/index.html
+++ b/docs/static/v0.8/project/releases/v0.8.20/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/project/releases/v0.8.200/index.html
+++ b/docs/static/v0.8/project/releases/v0.8.200/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/project/releases/v0.8.201/index.html
+++ b/docs/static/v0.8/project/releases/v0.8.201/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/project/releases/v0.8.202/index.html
+++ b/docs/static/v0.8/project/releases/v0.8.202/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/project/releases/v0.8.203/index.html
+++ b/docs/static/v0.8/project/releases/v0.8.203/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/project/releases/v0.8.204/index.html
+++ b/docs/static/v0.8/project/releases/v0.8.204/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/project/releases/v0.8.205/index.html
+++ b/docs/static/v0.8/project/releases/v0.8.205/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/project/releases/v0.8.206/index.html
+++ b/docs/static/v0.8/project/releases/v0.8.206/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/project/releases/v0.8.21/index.html
+++ b/docs/static/v0.8/project/releases/v0.8.21/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/project/releases/v0.8.22/index.html
+++ b/docs/static/v0.8/project/releases/v0.8.22/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/project/releases/v0.8.23/index.html
+++ b/docs/static/v0.8/project/releases/v0.8.23/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/project/releases/v0.8.24/index.html
+++ b/docs/static/v0.8/project/releases/v0.8.24/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/project/releases/v0.8.26/index.html
+++ b/docs/static/v0.8/project/releases/v0.8.26/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/project/releases/v0.8.27/index.html
+++ b/docs/static/v0.8/project/releases/v0.8.27/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/project/releases/v0.8.28/index.html
+++ b/docs/static/v0.8/project/releases/v0.8.28/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/project/releases/v0.8.29/index.html
+++ b/docs/static/v0.8/project/releases/v0.8.29/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/project/releases/v0.8.3/index.html
+++ b/docs/static/v0.8/project/releases/v0.8.3/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/project/releases/v0.8.30/index.html
+++ b/docs/static/v0.8/project/releases/v0.8.30/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/project/releases/v0.8.31/index.html
+++ b/docs/static/v0.8/project/releases/v0.8.31/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/project/releases/v0.8.32/index.html
+++ b/docs/static/v0.8/project/releases/v0.8.32/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/project/releases/v0.8.36/index.html
+++ b/docs/static/v0.8/project/releases/v0.8.36/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/project/releases/v0.8.37/index.html
+++ b/docs/static/v0.8/project/releases/v0.8.37/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/project/releases/v0.8.38/index.html
+++ b/docs/static/v0.8/project/releases/v0.8.38/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/project/releases/v0.8.39/index.html
+++ b/docs/static/v0.8/project/releases/v0.8.39/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/project/releases/v0.8.40/index.html
+++ b/docs/static/v0.8/project/releases/v0.8.40/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/project/releases/v0.8.41/index.html
+++ b/docs/static/v0.8/project/releases/v0.8.41/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/project/releases/v0.8.42/index.html
+++ b/docs/static/v0.8/project/releases/v0.8.42/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/project/releases/v0.8.43/index.html
+++ b/docs/static/v0.8/project/releases/v0.8.43/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/project/releases/v0.8.44/index.html
+++ b/docs/static/v0.8/project/releases/v0.8.44/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/project/releases/v0.8.46/index.html
+++ b/docs/static/v0.8/project/releases/v0.8.46/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/project/releases/v0.8.47/index.html
+++ b/docs/static/v0.8/project/releases/v0.8.47/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/project/releases/v0.8.48/index.html
+++ b/docs/static/v0.8/project/releases/v0.8.48/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/project/releases/v0.8.49/index.html
+++ b/docs/static/v0.8/project/releases/v0.8.49/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/project/releases/v0.8.5/index.html
+++ b/docs/static/v0.8/project/releases/v0.8.5/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/project/releases/v0.8.50/index.html
+++ b/docs/static/v0.8/project/releases/v0.8.50/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/project/releases/v0.8.52/index.html
+++ b/docs/static/v0.8/project/releases/v0.8.52/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/project/releases/v0.8.54/index.html
+++ b/docs/static/v0.8/project/releases/v0.8.54/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/project/releases/v0.8.55/index.html
+++ b/docs/static/v0.8/project/releases/v0.8.55/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/project/releases/v0.8.56/index.html
+++ b/docs/static/v0.8/project/releases/v0.8.56/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/project/releases/v0.8.57/index.html
+++ b/docs/static/v0.8/project/releases/v0.8.57/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/project/releases/v0.8.59/index.html
+++ b/docs/static/v0.8/project/releases/v0.8.59/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/project/releases/v0.8.6/index.html
+++ b/docs/static/v0.8/project/releases/v0.8.6/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/project/releases/v0.8.61/index.html
+++ b/docs/static/v0.8/project/releases/v0.8.61/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/project/releases/v0.8.62/index.html
+++ b/docs/static/v0.8/project/releases/v0.8.62/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/project/releases/v0.8.63/index.html
+++ b/docs/static/v0.8/project/releases/v0.8.63/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/project/releases/v0.8.64/index.html
+++ b/docs/static/v0.8/project/releases/v0.8.64/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/project/releases/v0.8.65/index.html
+++ b/docs/static/v0.8/project/releases/v0.8.65/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/project/releases/v0.8.66/index.html
+++ b/docs/static/v0.8/project/releases/v0.8.66/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/project/releases/v0.8.67/index.html
+++ b/docs/static/v0.8/project/releases/v0.8.67/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/project/releases/v0.8.68/index.html
+++ b/docs/static/v0.8/project/releases/v0.8.68/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/project/releases/v0.8.69/index.html
+++ b/docs/static/v0.8/project/releases/v0.8.69/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/project/releases/v0.8.7/index.html
+++ b/docs/static/v0.8/project/releases/v0.8.7/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/project/releases/v0.8.70/index.html
+++ b/docs/static/v0.8/project/releases/v0.8.70/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/project/releases/v0.8.71/index.html
+++ b/docs/static/v0.8/project/releases/v0.8.71/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/project/releases/v0.8.72/index.html
+++ b/docs/static/v0.8/project/releases/v0.8.72/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/project/releases/v0.8.73/index.html
+++ b/docs/static/v0.8/project/releases/v0.8.73/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/project/releases/v0.8.74/index.html
+++ b/docs/static/v0.8/project/releases/v0.8.74/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/project/releases/v0.8.75/index.html
+++ b/docs/static/v0.8/project/releases/v0.8.75/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/project/releases/v0.8.76/index.html
+++ b/docs/static/v0.8/project/releases/v0.8.76/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/project/releases/v0.8.78/index.html
+++ b/docs/static/v0.8/project/releases/v0.8.78/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/project/releases/v0.8.79/index.html
+++ b/docs/static/v0.8/project/releases/v0.8.79/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/project/releases/v0.8.8/index.html
+++ b/docs/static/v0.8/project/releases/v0.8.8/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/project/releases/v0.8.80/index.html
+++ b/docs/static/v0.8/project/releases/v0.8.80/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/project/releases/v0.8.81/index.html
+++ b/docs/static/v0.8/project/releases/v0.8.81/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/project/releases/v0.8.82/index.html
+++ b/docs/static/v0.8/project/releases/v0.8.82/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/project/releases/v0.8.83/index.html
+++ b/docs/static/v0.8/project/releases/v0.8.83/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/project/releases/v0.8.84/index.html
+++ b/docs/static/v0.8/project/releases/v0.8.84/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/project/releases/v0.8.85/index.html
+++ b/docs/static/v0.8/project/releases/v0.8.85/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/project/releases/v0.8.86/index.html
+++ b/docs/static/v0.8/project/releases/v0.8.86/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/project/releases/v0.8.87/index.html
+++ b/docs/static/v0.8/project/releases/v0.8.87/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/project/releases/v0.8.88/index.html
+++ b/docs/static/v0.8/project/releases/v0.8.88/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/project/releases/v0.8.89/index.html
+++ b/docs/static/v0.8/project/releases/v0.8.89/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/project/releases/v0.8.9/index.html
+++ b/docs/static/v0.8/project/releases/v0.8.9/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/project/releases/v0.8.90/index.html
+++ b/docs/static/v0.8/project/releases/v0.8.90/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/project/releases/v0.8.91/index.html
+++ b/docs/static/v0.8/project/releases/v0.8.91/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/project/releases/v0.8.92/index.html
+++ b/docs/static/v0.8/project/releases/v0.8.92/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/project/releases/v0.8.93/index.html
+++ b/docs/static/v0.8/project/releases/v0.8.93/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/project/releases/v0.8.94/index.html
+++ b/docs/static/v0.8/project/releases/v0.8.94/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/project/releases/v0.8.95/index.html
+++ b/docs/static/v0.8/project/releases/v0.8.95/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/project/releases/v0.8.96/index.html
+++ b/docs/static/v0.8/project/releases/v0.8.96/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/project/releases/v0.8.97/index.html
+++ b/docs/static/v0.8/project/releases/v0.8.97/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/project/releases/v0.8.98/index.html
+++ b/docs/static/v0.8/project/releases/v0.8.98/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/project/releases/v0.8.99/index.html
+++ b/docs/static/v0.8/project/releases/v0.8.99/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/project/security-vulnerabilities/index.html
+++ b/docs/static/v0.8/project/security-vulnerabilities/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/reference/error-codes/index.html
+++ b/docs/static/v0.8/reference/error-codes/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/reference/graphql-apis/index.html
+++ b/docs/static/v0.8/reference/graphql-apis/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/reference/index.html
+++ b/docs/static/v0.8/reference/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/reference/meshery-operator-crds/index.html
+++ b/docs/static/v0.8/reference/meshery-operator-crds/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/reference/mesheryctl/adapter/deploy/index.html
+++ b/docs/static/v0.8/reference/mesheryctl/adapter/deploy/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/reference/mesheryctl/adapter/index.html
+++ b/docs/static/v0.8/reference/mesheryctl/adapter/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/reference/mesheryctl/adapter/remove/index.html
+++ b/docs/static/v0.8/reference/mesheryctl/adapter/remove/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/reference/mesheryctl/adapter/validate/index.html
+++ b/docs/static/v0.8/reference/mesheryctl/adapter/validate/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/reference/mesheryctl/completion/index.html
+++ b/docs/static/v0.8/reference/mesheryctl/completion/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/reference/mesheryctl/component/index.html
+++ b/docs/static/v0.8/reference/mesheryctl/component/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/reference/mesheryctl/component/list/index.html
+++ b/docs/static/v0.8/reference/mesheryctl/component/list/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/reference/mesheryctl/component/search/index.html
+++ b/docs/static/v0.8/reference/mesheryctl/component/search/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/reference/mesheryctl/component/view/index.html
+++ b/docs/static/v0.8/reference/mesheryctl/component/view/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/reference/mesheryctl/connection/create/index.html
+++ b/docs/static/v0.8/reference/mesheryctl/connection/create/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/reference/mesheryctl/connection/delete/index.html
+++ b/docs/static/v0.8/reference/mesheryctl/connection/delete/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/reference/mesheryctl/connection/index.html
+++ b/docs/static/v0.8/reference/mesheryctl/connection/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/reference/mesheryctl/connection/list/index.html
+++ b/docs/static/v0.8/reference/mesheryctl/connection/list/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/reference/mesheryctl/connection/view/index.html
+++ b/docs/static/v0.8/reference/mesheryctl/connection/view/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/reference/mesheryctl/design/apply/index.html
+++ b/docs/static/v0.8/reference/mesheryctl/design/apply/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/reference/mesheryctl/design/delete/index.html
+++ b/docs/static/v0.8/reference/mesheryctl/design/delete/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/reference/mesheryctl/design/export/index.html
+++ b/docs/static/v0.8/reference/mesheryctl/design/export/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/reference/mesheryctl/design/import/index.html
+++ b/docs/static/v0.8/reference/mesheryctl/design/import/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/reference/mesheryctl/design/index.html
+++ b/docs/static/v0.8/reference/mesheryctl/design/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/reference/mesheryctl/design/list/index.html
+++ b/docs/static/v0.8/reference/mesheryctl/design/list/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/reference/mesheryctl/design/offboard/index.html
+++ b/docs/static/v0.8/reference/mesheryctl/design/offboard/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/reference/mesheryctl/design/onboard/index.html
+++ b/docs/static/v0.8/reference/mesheryctl/design/onboard/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/reference/mesheryctl/design/view/index.html
+++ b/docs/static/v0.8/reference/mesheryctl/design/view/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/reference/mesheryctl/environment/create/index.html
+++ b/docs/static/v0.8/reference/mesheryctl/environment/create/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/reference/mesheryctl/environment/delete/index.html
+++ b/docs/static/v0.8/reference/mesheryctl/environment/delete/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/reference/mesheryctl/environment/index.html
+++ b/docs/static/v0.8/reference/mesheryctl/environment/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/reference/mesheryctl/environment/list/index.html
+++ b/docs/static/v0.8/reference/mesheryctl/environment/list/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/reference/mesheryctl/environment/view/index.html
+++ b/docs/static/v0.8/reference/mesheryctl/environment/view/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/reference/mesheryctl/exp/index.html
+++ b/docs/static/v0.8/reference/mesheryctl/exp/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/reference/mesheryctl/exp/relationship/generate/index.html
+++ b/docs/static/v0.8/reference/mesheryctl/exp/relationship/generate/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/reference/mesheryctl/exp/relationship/index.html
+++ b/docs/static/v0.8/reference/mesheryctl/exp/relationship/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/reference/mesheryctl/exp/relationship/list/index.html
+++ b/docs/static/v0.8/reference/mesheryctl/exp/relationship/list/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/reference/mesheryctl/exp/relationship/search/index.html
+++ b/docs/static/v0.8/reference/mesheryctl/exp/relationship/search/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/reference/mesheryctl/exp/relationship/view/index.html
+++ b/docs/static/v0.8/reference/mesheryctl/exp/relationship/view/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/reference/mesheryctl/exp/workspace/create/index.html
+++ b/docs/static/v0.8/reference/mesheryctl/exp/workspace/create/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/reference/mesheryctl/exp/workspace/index.html
+++ b/docs/static/v0.8/reference/mesheryctl/exp/workspace/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/reference/mesheryctl/exp/workspace/list/index.html
+++ b/docs/static/v0.8/reference/mesheryctl/exp/workspace/list/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/reference/mesheryctl/filter/delete/index.html
+++ b/docs/static/v0.8/reference/mesheryctl/filter/delete/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/reference/mesheryctl/filter/import/index.html
+++ b/docs/static/v0.8/reference/mesheryctl/filter/import/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/reference/mesheryctl/filter/index.html
+++ b/docs/static/v0.8/reference/mesheryctl/filter/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/reference/mesheryctl/filter/list/index.html
+++ b/docs/static/v0.8/reference/mesheryctl/filter/list/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/reference/mesheryctl/filter/view/index.html
+++ b/docs/static/v0.8/reference/mesheryctl/filter/view/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/reference/mesheryctl/index.html
+++ b/docs/static/v0.8/reference/mesheryctl/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/reference/mesheryctl/model/build/index.html
+++ b/docs/static/v0.8/reference/mesheryctl/model/build/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/reference/mesheryctl/model/delete/index.html
+++ b/docs/static/v0.8/reference/mesheryctl/model/delete/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/reference/mesheryctl/model/export/index.html
+++ b/docs/static/v0.8/reference/mesheryctl/model/export/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/reference/mesheryctl/model/generate/index.html
+++ b/docs/static/v0.8/reference/mesheryctl/model/generate/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/reference/mesheryctl/model/import/index.html
+++ b/docs/static/v0.8/reference/mesheryctl/model/import/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/reference/mesheryctl/model/index.html
+++ b/docs/static/v0.8/reference/mesheryctl/model/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/reference/mesheryctl/model/init/index.html
+++ b/docs/static/v0.8/reference/mesheryctl/model/init/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/reference/mesheryctl/model/list/index.html
+++ b/docs/static/v0.8/reference/mesheryctl/model/list/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/reference/mesheryctl/model/search/index.html
+++ b/docs/static/v0.8/reference/mesheryctl/model/search/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/reference/mesheryctl/model/view/index.html
+++ b/docs/static/v0.8/reference/mesheryctl/model/view/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/reference/mesheryctl/organization/index.html
+++ b/docs/static/v0.8/reference/mesheryctl/organization/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/reference/mesheryctl/organization/list/index.html
+++ b/docs/static/v0.8/reference/mesheryctl/organization/list/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/reference/mesheryctl/perf/apply/index.html
+++ b/docs/static/v0.8/reference/mesheryctl/perf/apply/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/reference/mesheryctl/perf/index.html
+++ b/docs/static/v0.8/reference/mesheryctl/perf/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/reference/mesheryctl/perf/profile/index.html
+++ b/docs/static/v0.8/reference/mesheryctl/perf/profile/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/reference/mesheryctl/perf/result/index.html
+++ b/docs/static/v0.8/reference/mesheryctl/perf/result/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/reference/mesheryctl/registry/generate/index.html
+++ b/docs/static/v0.8/reference/mesheryctl/registry/generate/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/reference/mesheryctl/registry/index.html
+++ b/docs/static/v0.8/reference/mesheryctl/registry/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/reference/mesheryctl/registry/publish/index.html
+++ b/docs/static/v0.8/reference/mesheryctl/registry/publish/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/reference/mesheryctl/registry/update/index.html
+++ b/docs/static/v0.8/reference/mesheryctl/registry/update/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/reference/mesheryctl/system/channel/index.html
+++ b/docs/static/v0.8/reference/mesheryctl/system/channel/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/reference/mesheryctl/system/channel/set/index.html
+++ b/docs/static/v0.8/reference/mesheryctl/system/channel/set/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/reference/mesheryctl/system/channel/switch/index.html
+++ b/docs/static/v0.8/reference/mesheryctl/system/channel/switch/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/reference/mesheryctl/system/channel/view/index.html
+++ b/docs/static/v0.8/reference/mesheryctl/system/channel/view/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/reference/mesheryctl/system/check/index.html
+++ b/docs/static/v0.8/reference/mesheryctl/system/check/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/reference/mesheryctl/system/context/create/index.html
+++ b/docs/static/v0.8/reference/mesheryctl/system/context/create/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/reference/mesheryctl/system/context/delete/index.html
+++ b/docs/static/v0.8/reference/mesheryctl/system/context/delete/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/reference/mesheryctl/system/context/index.html
+++ b/docs/static/v0.8/reference/mesheryctl/system/context/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/reference/mesheryctl/system/context/list/index.html
+++ b/docs/static/v0.8/reference/mesheryctl/system/context/list/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/reference/mesheryctl/system/context/switch/index.html
+++ b/docs/static/v0.8/reference/mesheryctl/system/context/switch/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/reference/mesheryctl/system/context/view/index.html
+++ b/docs/static/v0.8/reference/mesheryctl/system/context/view/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/reference/mesheryctl/system/dashboard/index.html
+++ b/docs/static/v0.8/reference/mesheryctl/system/dashboard/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/reference/mesheryctl/system/delete/index.html
+++ b/docs/static/v0.8/reference/mesheryctl/system/delete/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/reference/mesheryctl/system/index.html
+++ b/docs/static/v0.8/reference/mesheryctl/system/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/reference/mesheryctl/system/login/index.html
+++ b/docs/static/v0.8/reference/mesheryctl/system/login/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/reference/mesheryctl/system/logout/index.html
+++ b/docs/static/v0.8/reference/mesheryctl/system/logout/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/reference/mesheryctl/system/logs/index.html
+++ b/docs/static/v0.8/reference/mesheryctl/system/logs/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/reference/mesheryctl/system/provider/index.html
+++ b/docs/static/v0.8/reference/mesheryctl/system/provider/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/reference/mesheryctl/system/provider/list/index.html
+++ b/docs/static/v0.8/reference/mesheryctl/system/provider/list/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/reference/mesheryctl/system/provider/reset/index.html
+++ b/docs/static/v0.8/reference/mesheryctl/system/provider/reset/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/reference/mesheryctl/system/provider/set/index.html
+++ b/docs/static/v0.8/reference/mesheryctl/system/provider/set/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/reference/mesheryctl/system/provider/switch/index.html
+++ b/docs/static/v0.8/reference/mesheryctl/system/provider/switch/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/reference/mesheryctl/system/provider/view/index.html
+++ b/docs/static/v0.8/reference/mesheryctl/system/provider/view/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/reference/mesheryctl/system/reset/index.html
+++ b/docs/static/v0.8/reference/mesheryctl/system/reset/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/reference/mesheryctl/system/restart/index.html
+++ b/docs/static/v0.8/reference/mesheryctl/system/restart/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/reference/mesheryctl/system/start/index.html
+++ b/docs/static/v0.8/reference/mesheryctl/system/start/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/reference/mesheryctl/system/status/index.html
+++ b/docs/static/v0.8/reference/mesheryctl/system/status/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/reference/mesheryctl/system/stop/index.html
+++ b/docs/static/v0.8/reference/mesheryctl/system/stop/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/reference/mesheryctl/system/token/create/index.html
+++ b/docs/static/v0.8/reference/mesheryctl/system/token/create/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/reference/mesheryctl/system/token/delete/index.html
+++ b/docs/static/v0.8/reference/mesheryctl/system/token/delete/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/reference/mesheryctl/system/token/index.html
+++ b/docs/static/v0.8/reference/mesheryctl/system/token/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/reference/mesheryctl/system/token/list/index.html
+++ b/docs/static/v0.8/reference/mesheryctl/system/token/list/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/reference/mesheryctl/system/token/set/index.html
+++ b/docs/static/v0.8/reference/mesheryctl/system/token/set/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/reference/mesheryctl/system/token/view/index.html
+++ b/docs/static/v0.8/reference/mesheryctl/system/token/view/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/reference/mesheryctl/system/update/index.html
+++ b/docs/static/v0.8/reference/mesheryctl/system/update/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/reference/mesheryctl/version/index.html
+++ b/docs/static/v0.8/reference/mesheryctl/version/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/reference/permissions/index.html
+++ b/docs/static/v0.8/reference/permissions/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/reference/rest-apis/index.html
+++ b/docs/static/v0.8/reference/rest-apis/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/search/index.html
+++ b/docs/static/v0.8/search/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.8/tags/index.html
+++ b/docs/static/v0.8/tags/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="generator" content="Hugo 0.55.6" />
 
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link rel="alternate" type="application/rss&#43;xml" href="/index.xml" />
 

--- a/docs/static/v0.9/404.html
+++ b/docs/static/v0.9/404.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/architecture/adapters/index.html
+++ b/docs/static/v0.9/architecture/adapters/index.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
   <head>
+  <meta name="robots" content="noindex, follow" />
     <title>/v0.9/concepts/architecture/adapters/</title>
     <link rel="canonical" href="/v0.9/concepts/architecture/adapters/">
     <meta charset="utf-8">

--- a/docs/static/v0.9/architecture/broker/index.html
+++ b/docs/static/v0.9/architecture/broker/index.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
   <head>
+  <meta name="robots" content="noindex, follow" />
     <title>/v0.9/concepts/architecture/broker/</title>
     <link rel="canonical" href="/v0.9/concepts/architecture/broker/">
     <meta charset="utf-8">

--- a/docs/static/v0.9/architecture/database/index.html
+++ b/docs/static/v0.9/architecture/database/index.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
   <head>
+  <meta name="robots" content="noindex, follow" />
     <title>/v0.9/concepts/architecture/database/</title>
     <link rel="canonical" href="/v0.9/concepts/architecture/database/">
     <meta charset="utf-8">

--- a/docs/static/v0.9/architecture/index.html
+++ b/docs/static/v0.9/architecture/index.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
   <head>
+  <meta name="robots" content="noindex, follow" />
     <title>/v0.9/concepts/architecture/</title>
     <link rel="canonical" href="/v0.9/concepts/architecture/">
     <meta charset="utf-8">

--- a/docs/static/v0.9/architecture/meshsync/index.html
+++ b/docs/static/v0.9/architecture/meshsync/index.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
   <head>
+  <meta name="robots" content="noindex, follow" />
     <title>/v0.9/concepts/architecture/meshsync/</title>
     <link rel="canonical" href="/v0.9/concepts/architecture/meshsync/">
     <meta charset="utf-8">

--- a/docs/static/v0.9/architecture/operator/index.html
+++ b/docs/static/v0.9/architecture/operator/index.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
   <head>
+  <meta name="robots" content="noindex, follow" />
     <title>/v0.9/concepts/architecture/operator/</title>
     <link rel="canonical" href="/v0.9/concepts/architecture/operator/">
     <meta charset="utf-8">

--- a/docs/static/v0.9/catalog/index.html
+++ b/docs/static/v0.9/catalog/index.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
   <head>
+  <meta name="robots" content="noindex, follow" />
     <title>/v0.9/concepts/architecture/catalog/</title>
     <link rel="canonical" href="/v0.9/concepts/architecture/catalog/">
     <meta charset="utf-8">

--- a/docs/static/v0.9/categories/community/index.html
+++ b/docs/static/v0.9/categories/community/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/categories/configuration/index.html
+++ b/docs/static/v0.9/categories/configuration/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/categories/contributing/index.html
+++ b/docs/static/v0.9/categories/contributing/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/categories/docker/index.html
+++ b/docs/static/v0.9/categories/docker/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/categories/index.html
+++ b/docs/static/v0.9/categories/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/categories/infrastructure/index.html
+++ b/docs/static/v0.9/categories/infrastructure/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/categories/installation/index.html
+++ b/docs/static/v0.9/categories/installation/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/categories/integrations/index.html
+++ b/docs/static/v0.9/categories/integrations/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/categories/kanvas/index.html
+++ b/docs/static/v0.9/categories/kanvas/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/categories/kubernetes/index.html
+++ b/docs/static/v0.9/categories/kubernetes/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/categories/mesheryctl/index.html
+++ b/docs/static/v0.9/categories/mesheryctl/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/categories/none/index.html
+++ b/docs/static/v0.9/categories/none/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/categories/performance/index.html
+++ b/docs/static/v0.9/categories/performance/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/categories/project/index.html
+++ b/docs/static/v0.9/categories/project/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/categories/troubleshooting/index.html
+++ b/docs/static/v0.9/categories/troubleshooting/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/categories/tutorials/index.html
+++ b/docs/static/v0.9/categories/tutorials/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/concepts/architecture/adapters/index.html
+++ b/docs/static/v0.9/concepts/architecture/adapters/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/concepts/architecture/broker/index.html
+++ b/docs/static/v0.9/concepts/architecture/broker/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/concepts/architecture/catalog/index.html
+++ b/docs/static/v0.9/concepts/architecture/catalog/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/concepts/architecture/database/index.html
+++ b/docs/static/v0.9/concepts/architecture/database/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/concepts/architecture/index.html
+++ b/docs/static/v0.9/concepts/architecture/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/concepts/architecture/meshsync/index.html
+++ b/docs/static/v0.9/concepts/architecture/meshsync/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/concepts/architecture/operator/index.html
+++ b/docs/static/v0.9/concepts/architecture/operator/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/concepts/catalog/index.html
+++ b/docs/static/v0.9/concepts/catalog/index.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
   <head>
+  <meta name="robots" content="noindex, follow" />
     <title>/v0.9/concepts/architecture/catalog/</title>
     <link rel="canonical" href="/v0.9/concepts/architecture/catalog/">
     <meta charset="utf-8">

--- a/docs/static/v0.9/concepts/components/index.html
+++ b/docs/static/v0.9/concepts/components/index.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
   <head>
+  <meta name="robots" content="noindex, follow" />
     <title>/v0.9/concepts/logical/components/</title>
     <link rel="canonical" href="/v0.9/concepts/logical/components/">
     <meta charset="utf-8">

--- a/docs/static/v0.9/concepts/connections/index.html
+++ b/docs/static/v0.9/concepts/connections/index.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
   <head>
+  <meta name="robots" content="noindex, follow" />
     <title>/v0.9/concepts/logical/connections/</title>
     <link rel="canonical" href="/v0.9/concepts/logical/connections/">
     <meta charset="utf-8">

--- a/docs/static/v0.9/concepts/credentials/index.html
+++ b/docs/static/v0.9/concepts/credentials/index.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
   <head>
+  <meta name="robots" content="noindex, follow" />
     <title>/v0.9/concepts/logical/credentials/</title>
     <link rel="canonical" href="/v0.9/concepts/logical/credentials/">
     <meta charset="utf-8">

--- a/docs/static/v0.9/concepts/designs/index.html
+++ b/docs/static/v0.9/concepts/designs/index.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
   <head>
+  <meta name="robots" content="noindex, follow" />
     <title>/v0.9/concepts/logical/designs/</title>
     <link rel="canonical" href="/v0.9/concepts/logical/designs/">
     <meta charset="utf-8">

--- a/docs/static/v0.9/concepts/environments/index.html
+++ b/docs/static/v0.9/concepts/environments/index.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
   <head>
+  <meta name="robots" content="noindex, follow" />
     <title>/v0.9/concepts/logical/environments/</title>
     <link rel="canonical" href="/v0.9/concepts/logical/environments/">
     <meta charset="utf-8">

--- a/docs/static/v0.9/concepts/index.html
+++ b/docs/static/v0.9/concepts/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/concepts/logical/components/index.html
+++ b/docs/static/v0.9/concepts/logical/components/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/concepts/logical/connections/index.html
+++ b/docs/static/v0.9/concepts/logical/connections/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/concepts/logical/credentials/index.html
+++ b/docs/static/v0.9/concepts/logical/credentials/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/concepts/logical/designs/index.html
+++ b/docs/static/v0.9/concepts/logical/designs/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/concepts/logical/environments/index.html
+++ b/docs/static/v0.9/concepts/logical/environments/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/concepts/logical/index.html
+++ b/docs/static/v0.9/concepts/logical/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/concepts/logical/models/index.html
+++ b/docs/static/v0.9/concepts/logical/models/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/concepts/logical/patterns/index.html
+++ b/docs/static/v0.9/concepts/logical/patterns/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/concepts/logical/policies/index.html
+++ b/docs/static/v0.9/concepts/logical/policies/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/concepts/logical/registry/index.html
+++ b/docs/static/v0.9/concepts/logical/registry/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/concepts/logical/relationships/index.html
+++ b/docs/static/v0.9/concepts/logical/relationships/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/concepts/logical/workspaces/index.html
+++ b/docs/static/v0.9/concepts/logical/workspaces/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/concepts/models/index.html
+++ b/docs/static/v0.9/concepts/models/index.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
   <head>
+  <meta name="robots" content="noindex, follow" />
     <title>/v0.9/concepts/logical/models/</title>
     <link rel="canonical" href="/v0.9/concepts/logical/models/">
     <meta charset="utf-8">

--- a/docs/static/v0.9/concepts/patterns/index.html
+++ b/docs/static/v0.9/concepts/patterns/index.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
   <head>
+  <meta name="robots" content="noindex, follow" />
     <title>/v0.9/concepts/logical/patterns/</title>
     <link rel="canonical" href="/v0.9/concepts/logical/patterns/">
     <meta charset="utf-8">

--- a/docs/static/v0.9/concepts/relationships/index.html
+++ b/docs/static/v0.9/concepts/relationships/index.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
   <head>
+  <meta name="robots" content="noindex, follow" />
     <title>/v0.9/concepts/logical/relationships/</title>
     <link rel="canonical" href="/v0.9/concepts/logical/relationships/">
     <meta charset="utf-8">

--- a/docs/static/v0.9/concepts/workspaces/index.html
+++ b/docs/static/v0.9/concepts/workspaces/index.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
   <head>
+  <meta name="robots" content="noindex, follow" />
     <title>/v0.9/concepts/logical/workspaces/</title>
     <link rel="canonical" href="/v0.9/concepts/logical/workspaces/">
     <meta charset="utf-8">

--- a/docs/static/v0.9/configuration-management/filter-management/index.html
+++ b/docs/static/v0.9/configuration-management/filter-management/index.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
   <head>
+  <meta name="robots" content="noindex, follow" />
     <title>/v0.9/guides/infrastructure-management/filter-management/</title>
     <link rel="canonical" href="/v0.9/guides/infrastructure-management/filter-management/">
     <meta charset="utf-8">

--- a/docs/static/v0.9/extensibility/adapters/app-mesh/index.html
+++ b/docs/static/v0.9/extensibility/adapters/app-mesh/index.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
   <head>
+  <meta name="robots" content="noindex, follow" />
     <title>/v0.9/extensions/adapters/app-mesh/</title>
     <link rel="canonical" href="/v0.9/extensions/adapters/app-mesh/">
     <meta charset="utf-8">

--- a/docs/static/v0.9/extensibility/adapters/cilium/index.html
+++ b/docs/static/v0.9/extensibility/adapters/cilium/index.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
   <head>
+  <meta name="robots" content="noindex, follow" />
     <title>/v0.9/extensions/adapters/cilium/</title>
     <link rel="canonical" href="/v0.9/extensions/adapters/cilium/">
     <meta charset="utf-8">

--- a/docs/static/v0.9/extensibility/adapters/consul/index.html
+++ b/docs/static/v0.9/extensibility/adapters/consul/index.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
   <head>
+  <meta name="robots" content="noindex, follow" />
     <title>/v0.9/extensions/adapters/consul/</title>
     <link rel="canonical" href="/v0.9/extensions/adapters/consul/">
     <meta charset="utf-8">

--- a/docs/static/v0.9/extensibility/adapters/index.html
+++ b/docs/static/v0.9/extensibility/adapters/index.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
   <head>
+  <meta name="robots" content="noindex, follow" />
     <title>/v0.9/extensions/adapters/</title>
     <link rel="canonical" href="/v0.9/extensions/adapters/">
     <meta charset="utf-8">

--- a/docs/static/v0.9/extensibility/adapters/istio/index.html
+++ b/docs/static/v0.9/extensibility/adapters/istio/index.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
   <head>
+  <meta name="robots" content="noindex, follow" />
     <title>/v0.9/extensions/adapters/istio/</title>
     <link rel="canonical" href="/v0.9/extensions/adapters/istio/">
     <meta charset="utf-8">

--- a/docs/static/v0.9/extensibility/adapters/kuma/index.html
+++ b/docs/static/v0.9/extensibility/adapters/kuma/index.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
   <head>
+  <meta name="robots" content="noindex, follow" />
     <title>/v0.9/extensions/adapters/kuma/</title>
     <link rel="canonical" href="/v0.9/extensions/adapters/kuma/">
     <meta charset="utf-8">

--- a/docs/static/v0.9/extensibility/adapters/linkerd/index.html
+++ b/docs/static/v0.9/extensibility/adapters/linkerd/index.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
   <head>
+  <meta name="robots" content="noindex, follow" />
     <title>/v0.9/extensions/adapters/linkerd/</title>
     <link rel="canonical" href="/v0.9/extensions/adapters/linkerd/">
     <meta charset="utf-8">

--- a/docs/static/v0.9/extensibility/adapters/nginx-sm/index.html
+++ b/docs/static/v0.9/extensibility/adapters/nginx-sm/index.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
   <head>
+  <meta name="robots" content="noindex, follow" />
     <title>/v0.9/extensions/adapters/nginx-sm/</title>
     <link rel="canonical" href="/v0.9/extensions/adapters/nginx-sm/">
     <meta charset="utf-8">

--- a/docs/static/v0.9/extensibility/adapters/nighthawk/index.html
+++ b/docs/static/v0.9/extensibility/adapters/nighthawk/index.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
   <head>
+  <meta name="robots" content="noindex, follow" />
     <title>/v0.9/extensions/adapters/nighthawk/</title>
     <link rel="canonical" href="/v0.9/extensions/adapters/nighthawk/">
     <meta charset="utf-8">

--- a/docs/static/v0.9/extensibility/adapters/nsm/index.html
+++ b/docs/static/v0.9/extensibility/adapters/nsm/index.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
   <head>
+  <meta name="robots" content="noindex, follow" />
     <title>/v0.9/extensions/adapters/nsm/</title>
     <link rel="canonical" href="/v0.9/extensions/adapters/nsm/">
     <meta charset="utf-8">

--- a/docs/static/v0.9/extensibility/adapters/tanzu-sm/index.html
+++ b/docs/static/v0.9/extensibility/adapters/tanzu-sm/index.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
   <head>
+  <meta name="robots" content="noindex, follow" />
     <title>/v0.9/extensions/adapters/tanzu-sm/</title>
     <link rel="canonical" href="/v0.9/extensions/adapters/tanzu-sm/">
     <meta charset="utf-8">

--- a/docs/static/v0.9/extensibility/adapters/traefik-mesh/index.html
+++ b/docs/static/v0.9/extensibility/adapters/traefik-mesh/index.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
   <head>
+  <meta name="robots" content="noindex, follow" />
     <title>/v0.9/extensions/adapters/traefik-mesh/</title>
     <link rel="canonical" href="/v0.9/extensions/adapters/traefik-mesh/">
     <meta charset="utf-8">

--- a/docs/static/v0.9/extensibility/api/index.html
+++ b/docs/static/v0.9/extensibility/api/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/extensibility/authorization/index.html
+++ b/docs/static/v0.9/extensibility/authorization/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/extensibility/build-time/index.html
+++ b/docs/static/v0.9/extensibility/build-time/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/extensibility/extensions/index.html
+++ b/docs/static/v0.9/extensibility/extensions/index.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
   <head>
+  <meta name="robots" content="noindex, follow" />
     <title>/v0.9/extensions/</title>
     <link rel="canonical" href="/v0.9/extensions/">
     <meta charset="utf-8">

--- a/docs/static/v0.9/extensibility/index.html
+++ b/docs/static/v0.9/extensibility/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/extensibility/integrations/aad-pod-identity/index.html
+++ b/docs/static/v0.9/extensibility/integrations/aad-pod-identity/index.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
   <head>
+  <meta name="robots" content="noindex, follow" />
     <title>/v0.9/extensions/models/aad-pod-identity/</title>
     <link rel="canonical" href="/v0.9/extensions/models/aad-pod-identity/">
     <meta charset="utf-8">

--- a/docs/static/v0.9/extensibility/integrations/accurate/index.html
+++ b/docs/static/v0.9/extensibility/integrations/accurate/index.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
   <head>
+  <meta name="robots" content="noindex, follow" />
     <title>/v0.9/extensions/models/accurate/</title>
     <link rel="canonical" href="/v0.9/extensions/models/accurate/">
     <meta charset="utf-8">

--- a/docs/static/v0.9/extensibility/integrations/ace/index.html
+++ b/docs/static/v0.9/extensibility/integrations/ace/index.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
   <head>
+  <meta name="robots" content="noindex, follow" />
     <title>/v0.9/extensions/models/ace/</title>
     <link rel="canonical" href="/v0.9/extensions/models/ace/">
     <meta charset="utf-8">

--- a/docs/static/v0.9/extensibility/integrations/actions-runner-controller/index.html
+++ b/docs/static/v0.9/extensibility/integrations/actions-runner-controller/index.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
   <head>
+  <meta name="robots" content="noindex, follow" />
     <title>/v0.9/extensions/models/actions-runner-controller/</title>
     <link rel="canonical" href="/v0.9/extensions/models/actions-runner-controller/">
     <meta charset="utf-8">

--- a/docs/static/v0.9/extensibility/integrations/admin-console-operator/index.html
+++ b/docs/static/v0.9/extensibility/integrations/admin-console-operator/index.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
   <head>
+  <meta name="robots" content="noindex, follow" />
     <title>/v0.9/extensions/models/admin-console-operator/</title>
     <link rel="canonical" href="/v0.9/extensions/models/admin-console-operator/">
     <meta charset="utf-8">

--- a/docs/static/v0.9/extensibility/integrations/aerokube/index.html
+++ b/docs/static/v0.9/extensibility/integrations/aerokube/index.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
   <head>
+  <meta name="robots" content="noindex, follow" />
     <title>/v0.9/extensions/models/aerokube/</title>
     <link rel="canonical" href="/v0.9/extensions/models/aerokube/">
     <meta charset="utf-8">

--- a/docs/static/v0.9/extensibility/integrations/aerospike-kubernetes-operator/index.html
+++ b/docs/static/v0.9/extensibility/integrations/aerospike-kubernetes-operator/index.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
   <head>
+  <meta name="robots" content="noindex, follow" />
     <title>/v0.9/extensions/models/aerospike-kubernetes-operator/</title>
     <link rel="canonical" href="/v0.9/extensions/models/aerospike-kubernetes-operator/">
     <meta charset="utf-8">

--- a/docs/static/v0.9/extensibility/integrations/aigisuk/index.html
+++ b/docs/static/v0.9/extensibility/integrations/aigisuk/index.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
   <head>
+  <meta name="robots" content="noindex, follow" />
     <title>/v0.9/extensions/models/aigisuk/</title>
     <link rel="canonical" href="/v0.9/extensions/models/aigisuk/">
     <meta charset="utf-8">

--- a/docs/static/v0.9/extensibility/integrations/akri/index.html
+++ b/docs/static/v0.9/extensibility/integrations/akri/index.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
   <head>
+  <meta name="robots" content="noindex, follow" />
     <title>/v0.9/extensions/models/akri/</title>
     <link rel="canonical" href="/v0.9/extensions/models/akri/">
     <meta charset="utf-8">

--- a/docs/static/v0.9/extensibility/integrations/aks-appgw-fe/index.html
+++ b/docs/static/v0.9/extensibility/integrations/aks-appgw-fe/index.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
   <head>
+  <meta name="robots" content="noindex, follow" />
     <title>/v0.9/extensions/models/aks-appgw-fe/</title>
     <link rel="canonical" href="/v0.9/extensions/models/aks-appgw-fe/">
     <meta charset="utf-8">

--- a/docs/static/v0.9/extensibility/integrations/altinity-clickhouse-operator/index.html
+++ b/docs/static/v0.9/extensibility/integrations/altinity-clickhouse-operator/index.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
   <head>
+  <meta name="robots" content="noindex, follow" />
     <title>/v0.9/extensions/models/altinity-clickhouse-operator/</title>
     <link rel="canonical" href="/v0.9/extensions/models/altinity-clickhouse-operator/">
     <meta charset="utf-8">

--- a/docs/static/v0.9/extensibility/integrations/ambassador/index.html
+++ b/docs/static/v0.9/extensibility/integrations/ambassador/index.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
   <head>
+  <meta name="robots" content="noindex, follow" />
     <title>/v0.9/extensions/models/ambassador/</title>
     <link rel="canonical" href="/v0.9/extensions/models/ambassador/">
     <meta charset="utf-8">

--- a/docs/static/v0.9/extensibility/integrations/amd-gpu/index.html
+++ b/docs/static/v0.9/extensibility/integrations/amd-gpu/index.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
   <head>
+  <meta name="robots" content="noindex, follow" />
     <title>/v0.9/extensions/models/amd-gpu/</title>
     <link rel="canonical" href="/v0.9/extensions/models/amd-gpu/">
     <meta charset="utf-8">

--- a/docs/static/v0.9/extensibility/integrations/antrea/index.html
+++ b/docs/static/v0.9/extensibility/integrations/antrea/index.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
   <head>
+  <meta name="robots" content="noindex, follow" />
     <title>/v0.9/extensions/models/antrea/</title>
     <link rel="canonical" href="/v0.9/extensions/models/antrea/">
     <meta charset="utf-8">

--- a/docs/static/v0.9/extensibility/integrations/apache-shardingsphere-operator-charts/index.html
+++ b/docs/static/v0.9/extensibility/integrations/apache-shardingsphere-operator-charts/index.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
   <head>
+  <meta name="robots" content="noindex, follow" />
     <title>/v0.9/extensions/models/apache-shardingsphere-operator-charts/</title>
     <link rel="canonical" href="/v0.9/extensions/models/apache-shardingsphere-operator-charts/">
     <meta charset="utf-8">

--- a/docs/static/v0.9/extensibility/integrations/aperture-agent/index.html
+++ b/docs/static/v0.9/extensibility/integrations/aperture-agent/index.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
   <head>
+  <meta name="robots" content="noindex, follow" />
     <title>/v0.9/extensions/models/aperture-agent/</title>
     <link rel="canonical" href="/v0.9/extensions/models/aperture-agent/">
     <meta charset="utf-8">

--- a/docs/static/v0.9/extensibility/integrations/aperture-controller/index.html
+++ b/docs/static/v0.9/extensibility/integrations/aperture-controller/index.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
   <head>
+  <meta name="robots" content="noindex, follow" />
     <title>/v0.9/extensions/models/aperture-controller/</title>
     <link rel="canonical" href="/v0.9/extensions/models/aperture-controller/">
     <meta charset="utf-8">

--- a/docs/static/v0.9/extensibility/integrations/apisix-ingress-controller/index.html
+++ b/docs/static/v0.9/extensibility/integrations/apisix-ingress-controller/index.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
   <head>
+  <meta name="robots" content="noindex, follow" />
     <title>/v0.9/extensions/models/apisix-ingress-controller/</title>
     <link rel="canonical" href="/v0.9/extensions/models/apisix-ingress-controller/">
     <meta charset="utf-8">

--- a/docs/static/v0.9/extensibility/integrations/apisix/index.html
+++ b/docs/static/v0.9/extensibility/integrations/apisix/index.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
   <head>
+  <meta name="robots" content="noindex, follow" />
     <title>/v0.9/extensions/models/apisix/</title>
     <link rel="canonical" href="/v0.9/extensions/models/apisix/">
     <meta charset="utf-8">

--- a/docs/static/v0.9/extensibility/integrations/application-crds/index.html
+++ b/docs/static/v0.9/extensibility/integrations/application-crds/index.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
   <head>
+  <meta name="robots" content="noindex, follow" />
     <title>/v0.9/extensions/models/application-crds/</title>
     <link rel="canonical" href="/v0.9/extensions/models/application-crds/">
     <meta charset="utf-8">

--- a/docs/static/v0.9/extensibility/integrations/appmesh-controller/index.html
+++ b/docs/static/v0.9/extensibility/integrations/appmesh-controller/index.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
   <head>
+  <meta name="robots" content="noindex, follow" />
     <title>/v0.9/extensions/models/appmesh-controller/</title>
     <link rel="canonical" href="/v0.9/extensions/models/appmesh-controller/">
     <meta charset="utf-8">

--- a/docs/static/v0.9/extensibility/integrations/argo-cd/index.html
+++ b/docs/static/v0.9/extensibility/integrations/argo-cd/index.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
   <head>
+  <meta name="robots" content="noindex, follow" />
     <title>/v0.9/extensions/models/argo-cd/</title>
     <link rel="canonical" href="/v0.9/extensions/models/argo-cd/">
     <meta charset="utf-8">

--- a/docs/static/v0.9/extensibility/integrations/argo-workflows/index.html
+++ b/docs/static/v0.9/extensibility/integrations/argo-workflows/index.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
   <head>
+  <meta name="robots" content="noindex, follow" />
     <title>/v0.9/extensions/models/argo-workflows/</title>
     <link rel="canonical" href="/v0.9/extensions/models/argo-workflows/">
     <meta charset="utf-8">

--- a/docs/static/v0.9/extensibility/integrations/argocd-operator/index.html
+++ b/docs/static/v0.9/extensibility/integrations/argocd-operator/index.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
   <head>
+  <meta name="robots" content="noindex, follow" />
     <title>/v0.9/extensions/models/argocd-operator/</title>
     <link rel="canonical" href="/v0.9/extensions/models/argocd-operator/">
     <meta charset="utf-8">

--- a/docs/static/v0.9/extensibility/integrations/armory-spinnaker-operator/index.html
+++ b/docs/static/v0.9/extensibility/integrations/armory-spinnaker-operator/index.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
   <head>
+  <meta name="robots" content="noindex, follow" />
     <title>/v0.9/extensions/models/armory-spinnaker-operator/</title>
     <link rel="canonical" href="/v0.9/extensions/models/armory-spinnaker-operator/">
     <meta charset="utf-8">

--- a/docs/static/v0.9/extensibility/integrations/artifact-hub/index.html
+++ b/docs/static/v0.9/extensibility/integrations/artifact-hub/index.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
   <head>
+  <meta name="robots" content="noindex, follow" />
     <title>/v0.9/extensions/models/artifact-hub/</title>
     <link rel="canonical" href="/v0.9/extensions/models/artifact-hub/">
     <meta charset="utf-8">

--- a/docs/static/v0.9/extensibility/integrations/athenz/index.html
+++ b/docs/static/v0.9/extensibility/integrations/athenz/index.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
   <head>
+  <meta name="robots" content="noindex, follow" />
     <title>/v0.9/extensions/models/athenz/</title>
     <link rel="canonical" href="/v0.9/extensions/models/athenz/">
     <meta charset="utf-8">

--- a/docs/static/v0.9/extensibility/integrations/aws-api-gateway-operator/index.html
+++ b/docs/static/v0.9/extensibility/integrations/aws-api-gateway-operator/index.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
   <head>
+  <meta name="robots" content="noindex, follow" />
     <title>/v0.9/extensions/models/aws-api-gateway-operator/</title>
     <link rel="canonical" href="/v0.9/extensions/models/aws-api-gateway-operator/">
     <meta charset="utf-8">

--- a/docs/static/v0.9/extensibility/integrations/aws-apigatewayv2-controller/index.html
+++ b/docs/static/v0.9/extensibility/integrations/aws-apigatewayv2-controller/index.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
   <head>
+  <meta name="robots" content="noindex, follow" />
     <title>/v0.9/extensions/models/aws-apigatewayv2-controller/</title>
     <link rel="canonical" href="/v0.9/extensions/models/aws-apigatewayv2-controller/">
     <meta charset="utf-8">

--- a/docs/static/v0.9/extensibility/integrations/aws-applicationautoscaling-controller/index.html
+++ b/docs/static/v0.9/extensibility/integrations/aws-applicationautoscaling-controller/index.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
   <head>
+  <meta name="robots" content="noindex, follow" />
     <title>/v0.9/extensions/models/aws-applicationautoscaling-controller/</title>
     <link rel="canonical" href="/v0.9/extensions/models/aws-applicationautoscaling-controller/">
     <meta charset="utf-8">

--- a/docs/static/v0.9/extensibility/integrations/aws-cloudfront-controller/index.html
+++ b/docs/static/v0.9/extensibility/integrations/aws-cloudfront-controller/index.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
   <head>
+  <meta name="robots" content="noindex, follow" />
     <title>/v0.9/extensions/models/aws-cloudfront-controller/</title>
     <link rel="canonical" href="/v0.9/extensions/models/aws-cloudfront-controller/">
     <meta charset="utf-8">

--- a/docs/static/v0.9/extensibility/integrations/aws-cloudtrail-controller/index.html
+++ b/docs/static/v0.9/extensibility/integrations/aws-cloudtrail-controller/index.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
   <head>
+  <meta name="robots" content="noindex, follow" />
     <title>/v0.9/extensions/models/aws-cloudtrail-controller/</title>
     <link rel="canonical" href="/v0.9/extensions/models/aws-cloudtrail-controller/">
     <meta charset="utf-8">

--- a/docs/static/v0.9/extensibility/integrations/aws-cloudwatch-controller/index.html
+++ b/docs/static/v0.9/extensibility/integrations/aws-cloudwatch-controller/index.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
   <head>
+  <meta name="robots" content="noindex, follow" />
     <title>/v0.9/extensions/models/aws-cloudwatch-controller/</title>
     <link rel="canonical" href="/v0.9/extensions/models/aws-cloudwatch-controller/">
     <meta charset="utf-8">

--- a/docs/static/v0.9/extensibility/integrations/aws-cloudwatchlogs-controller/index.html
+++ b/docs/static/v0.9/extensibility/integrations/aws-cloudwatchlogs-controller/index.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
   <head>
+  <meta name="robots" content="noindex, follow" />
     <title>/v0.9/extensions/models/aws-cloudwatchlogs-controller/</title>
     <link rel="canonical" href="/v0.9/extensions/models/aws-cloudwatchlogs-controller/">
     <meta charset="utf-8">

--- a/docs/static/v0.9/extensibility/integrations/aws-documentdb-controller/index.html
+++ b/docs/static/v0.9/extensibility/integrations/aws-documentdb-controller/index.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
   <head>
+  <meta name="robots" content="noindex, follow" />
     <title>/v0.9/extensions/models/aws-documentdb-controller/</title>
     <link rel="canonical" href="/v0.9/extensions/models/aws-documentdb-controller/">
     <meta charset="utf-8">

--- a/docs/static/v0.9/extensibility/integrations/aws-dynamodb-controller/index.html
+++ b/docs/static/v0.9/extensibility/integrations/aws-dynamodb-controller/index.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
   <head>
+  <meta name="robots" content="noindex, follow" />
     <title>/v0.9/extensions/models/aws-dynamodb-controller/</title>
     <link rel="canonical" href="/v0.9/extensions/models/aws-dynamodb-controller/">
     <meta charset="utf-8">

--- a/docs/static/v0.9/extensibility/integrations/aws-ec2-controller/index.html
+++ b/docs/static/v0.9/extensibility/integrations/aws-ec2-controller/index.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
   <head>
+  <meta name="robots" content="noindex, follow" />
     <title>/v0.9/extensions/models/aws-ec2-controller/</title>
     <link rel="canonical" href="/v0.9/extensions/models/aws-ec2-controller/">
     <meta charset="utf-8">

--- a/docs/static/v0.9/extensibility/integrations/aws-ecr-controller/index.html
+++ b/docs/static/v0.9/extensibility/integrations/aws-ecr-controller/index.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
   <head>
+  <meta name="robots" content="noindex, follow" />
     <title>/v0.9/extensions/models/aws-ecr-controller/</title>
     <link rel="canonical" href="/v0.9/extensions/models/aws-ecr-controller/">
     <meta charset="utf-8">

--- a/docs/static/v0.9/extensibility/integrations/aws-ecs-controller/index.html
+++ b/docs/static/v0.9/extensibility/integrations/aws-ecs-controller/index.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
   <head>
+  <meta name="robots" content="noindex, follow" />
     <title>/v0.9/extensions/models/aws-ecs-controller/</title>
     <link rel="canonical" href="/v0.9/extensions/models/aws-ecs-controller/">
     <meta charset="utf-8">

--- a/docs/static/v0.9/extensibility/integrations/aws-efs-controller/index.html
+++ b/docs/static/v0.9/extensibility/integrations/aws-efs-controller/index.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
   <head>
+  <meta name="robots" content="noindex, follow" />
     <title>/v0.9/extensions/models/aws-efs-controller/</title>
     <link rel="canonical" href="/v0.9/extensions/models/aws-efs-controller/">
     <meta charset="utf-8">

--- a/docs/static/v0.9/extensibility/integrations/aws-eks-controller/index.html
+++ b/docs/static/v0.9/extensibility/integrations/aws-eks-controller/index.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
   <head>
+  <meta name="robots" content="noindex, follow" />
     <title>/v0.9/extensions/models/aws-eks-controller/</title>
     <link rel="canonical" href="/v0.9/extensions/models/aws-eks-controller/">
     <meta charset="utf-8">

--- a/docs/static/v0.9/extensibility/integrations/aws-elasticache-controller/index.html
+++ b/docs/static/v0.9/extensibility/integrations/aws-elasticache-controller/index.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
   <head>
+  <meta name="robots" content="noindex, follow" />
     <title>/v0.9/extensions/models/aws-elasticache-controller/</title>
     <link rel="canonical" href="/v0.9/extensions/models/aws-elasticache-controller/">
     <meta charset="utf-8">

--- a/docs/static/v0.9/extensibility/integrations/aws-elasticsearchservice-controller/index.html
+++ b/docs/static/v0.9/extensibility/integrations/aws-elasticsearchservice-controller/index.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
   <head>
+  <meta name="robots" content="noindex, follow" />
     <title>/v0.9/extensions/models/aws-elasticsearchservice-controller/</title>
     <link rel="canonical" href="/v0.9/extensions/models/aws-elasticsearchservice-controller/">
     <meta charset="utf-8">

--- a/docs/static/v0.9/extensibility/integrations/aws-emrcontainers-controller/index.html
+++ b/docs/static/v0.9/extensibility/integrations/aws-emrcontainers-controller/index.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
   <head>
+  <meta name="robots" content="noindex, follow" />
     <title>/v0.9/extensions/models/aws-emrcontainers-controller/</title>
     <link rel="canonical" href="/v0.9/extensions/models/aws-emrcontainers-controller/">
     <meta charset="utf-8">

--- a/docs/static/v0.9/extensibility/integrations/aws-eventbridge-controller/index.html
+++ b/docs/static/v0.9/extensibility/integrations/aws-eventbridge-controller/index.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
   <head>
+  <meta name="robots" content="noindex, follow" />
     <title>/v0.9/extensions/models/aws-eventbridge-controller/</title>
     <link rel="canonical" href="/v0.9/extensions/models/aws-eventbridge-controller/">
     <meta charset="utf-8">

--- a/docs/static/v0.9/extensibility/integrations/aws-iam-controller/index.html
+++ b/docs/static/v0.9/extensibility/integrations/aws-iam-controller/index.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
   <head>
+  <meta name="robots" content="noindex, follow" />
     <title>/v0.9/extensions/models/aws-iam-controller/</title>
     <link rel="canonical" href="/v0.9/extensions/models/aws-iam-controller/">
     <meta charset="utf-8">

--- a/docs/static/v0.9/extensibility/integrations/aws-kinesis-controller/index.html
+++ b/docs/static/v0.9/extensibility/integrations/aws-kinesis-controller/index.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
   <head>
+  <meta name="robots" content="noindex, follow" />
     <title>/v0.9/extensions/models/aws-kinesis-controller/</title>
     <link rel="canonical" href="/v0.9/extensions/models/aws-kinesis-controller/">
     <meta charset="utf-8">

--- a/docs/static/v0.9/extensibility/integrations/aws-kms-controller/index.html
+++ b/docs/static/v0.9/extensibility/integrations/aws-kms-controller/index.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
   <head>
+  <meta name="robots" content="noindex, follow" />
     <title>/v0.9/extensions/models/aws-kms-controller/</title>
     <link rel="canonical" href="/v0.9/extensions/models/aws-kms-controller/">
     <meta charset="utf-8">

--- a/docs/static/v0.9/extensibility/integrations/aws-lambda-controller/index.html
+++ b/docs/static/v0.9/extensibility/integrations/aws-lambda-controller/index.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
   <head>
+  <meta name="robots" content="noindex, follow" />
     <title>/v0.9/extensions/models/aws-lambda-controller/</title>
     <link rel="canonical" href="/v0.9/extensions/models/aws-lambda-controller/">
     <meta charset="utf-8">

--- a/docs/static/v0.9/extensibility/integrations/aws-load-balancer-controller/index.html
+++ b/docs/static/v0.9/extensibility/integrations/aws-load-balancer-controller/index.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
   <head>
+  <meta name="robots" content="noindex, follow" />
     <title>/v0.9/extensions/models/aws-load-balancer-controller/</title>
     <link rel="canonical" href="/v0.9/extensions/models/aws-load-balancer-controller/">
     <meta charset="utf-8">

--- a/docs/static/v0.9/extensibility/integrations/aws-memorydb-controller/index.html
+++ b/docs/static/v0.9/extensibility/integrations/aws-memorydb-controller/index.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
   <head>
+  <meta name="robots" content="noindex, follow" />
     <title>/v0.9/extensions/models/aws-memorydb-controller/</title>
     <link rel="canonical" href="/v0.9/extensions/models/aws-memorydb-controller/">
     <meta charset="utf-8">

--- a/docs/static/v0.9/extensibility/integrations/aws-mq-controller/index.html
+++ b/docs/static/v0.9/extensibility/integrations/aws-mq-controller/index.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
   <head>
+  <meta name="robots" content="noindex, follow" />
     <title>/v0.9/extensions/models/aws-mq-controller/</title>
     <link rel="canonical" href="/v0.9/extensions/models/aws-mq-controller/">
     <meta charset="utf-8">

--- a/docs/static/v0.9/extensibility/integrations/aws-node-termination-handler-2/index.html
+++ b/docs/static/v0.9/extensibility/integrations/aws-node-termination-handler-2/index.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
   <head>
+  <meta name="robots" content="noindex, follow" />
     <title>/v0.9/extensions/models/aws-node-termination-handler-2/</title>
     <link rel="canonical" href="/v0.9/extensions/models/aws-node-termination-handler-2/">
     <meta charset="utf-8">

--- a/docs/static/v0.9/extensibility/integrations/aws-opensearchservice-controller/index.html
+++ b/docs/static/v0.9/extensibility/integrations/aws-opensearchservice-controller/index.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
   <head>
+  <meta name="robots" content="noindex, follow" />
     <title>/v0.9/extensions/models/aws-opensearchservice-controller/</title>
     <link rel="canonical" href="/v0.9/extensions/models/aws-opensearchservice-controller/">
     <meta charset="utf-8">

--- a/docs/static/v0.9/extensibility/integrations/aws-prometheusservice-controller/index.html
+++ b/docs/static/v0.9/extensibility/integrations/aws-prometheusservice-controller/index.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
   <head>
+  <meta name="robots" content="noindex, follow" />
     <title>/v0.9/extensions/models/aws-prometheusservice-controller/</title>
     <link rel="canonical" href="/v0.9/extensions/models/aws-prometheusservice-controller/">
     <meta charset="utf-8">

--- a/docs/static/v0.9/extensibility/integrations/aws-rds-controller/index.html
+++ b/docs/static/v0.9/extensibility/integrations/aws-rds-controller/index.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
   <head>
+  <meta name="robots" content="noindex, follow" />
     <title>/v0.9/extensions/models/aws-rds-controller/</title>
     <link rel="canonical" href="/v0.9/extensions/models/aws-rds-controller/">
     <meta charset="utf-8">

--- a/docs/static/v0.9/extensibility/integrations/aws-route53-controller/index.html
+++ b/docs/static/v0.9/extensibility/integrations/aws-route53-controller/index.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
   <head>
+  <meta name="robots" content="noindex, follow" />
     <title>/v0.9/extensions/models/aws-route53-controller/</title>
     <link rel="canonical" href="/v0.9/extensions/models/aws-route53-controller/">
     <meta charset="utf-8">

--- a/docs/static/v0.9/extensibility/integrations/aws-route53resolver-controller/index.html
+++ b/docs/static/v0.9/extensibility/integrations/aws-route53resolver-controller/index.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
   <head>
+  <meta name="robots" content="noindex, follow" />
     <title>/v0.9/extensions/models/aws-route53resolver-controller/</title>
     <link rel="canonical" href="/v0.9/extensions/models/aws-route53resolver-controller/">
     <meta charset="utf-8">

--- a/docs/static/v0.9/extensibility/integrations/aws-s3-controller/index.html
+++ b/docs/static/v0.9/extensibility/integrations/aws-s3-controller/index.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
   <head>
+  <meta name="robots" content="noindex, follow" />
     <title>/v0.9/extensions/models/aws-s3-controller/</title>
     <link rel="canonical" href="/v0.9/extensions/models/aws-s3-controller/">
     <meta charset="utf-8">

--- a/docs/static/v0.9/extensibility/integrations/aws-sagemaker-controller/index.html
+++ b/docs/static/v0.9/extensibility/integrations/aws-sagemaker-controller/index.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
   <head>
+  <meta name="robots" content="noindex, follow" />
     <title>/v0.9/extensions/models/aws-sagemaker-controller/</title>
     <link rel="canonical" href="/v0.9/extensions/models/aws-sagemaker-controller/">
     <meta charset="utf-8">

--- a/docs/static/v0.9/extensibility/integrations/aws-secretsmanager-controller/index.html
+++ b/docs/static/v0.9/extensibility/integrations/aws-secretsmanager-controller/index.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
   <head>
+  <meta name="robots" content="noindex, follow" />
     <title>/v0.9/extensions/models/aws-secretsmanager-controller/</title>
     <link rel="canonical" href="/v0.9/extensions/models/aws-secretsmanager-controller/">
     <meta charset="utf-8">

--- a/docs/static/v0.9/extensibility/integrations/aws-sfn-controller/index.html
+++ b/docs/static/v0.9/extensibility/integrations/aws-sfn-controller/index.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
   <head>
+  <meta name="robots" content="noindex, follow" />
     <title>/v0.9/extensions/models/aws-sfn-controller/</title>
     <link rel="canonical" href="/v0.9/extensions/models/aws-sfn-controller/">
     <meta charset="utf-8">

--- a/docs/static/v0.9/extensibility/integrations/aws-sns-controller/index.html
+++ b/docs/static/v0.9/extensibility/integrations/aws-sns-controller/index.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
   <head>
+  <meta name="robots" content="noindex, follow" />
     <title>/v0.9/extensions/models/aws-sns-controller/</title>
     <link rel="canonical" href="/v0.9/extensions/models/aws-sns-controller/">
     <meta charset="utf-8">

--- a/docs/static/v0.9/extensibility/integrations/aws-sqs-controller/index.html
+++ b/docs/static/v0.9/extensibility/integrations/aws-sqs-controller/index.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
   <head>
+  <meta name="robots" content="noindex, follow" />
     <title>/v0.9/extensions/models/aws-sqs-controller/</title>
     <link rel="canonical" href="/v0.9/extensions/models/aws-sqs-controller/">
     <meta charset="utf-8">

--- a/docs/static/v0.9/extensibility/integrations/aws-ssm-controller/index.html
+++ b/docs/static/v0.9/extensibility/integrations/aws-ssm-controller/index.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
   <head>
+  <meta name="robots" content="noindex, follow" />
     <title>/v0.9/extensions/models/aws-ssm-controller/</title>
     <link rel="canonical" href="/v0.9/extensions/models/aws-ssm-controller/">
     <meta charset="utf-8">

--- a/docs/static/v0.9/extensibility/integrations/aws-target-group-binding/index.html
+++ b/docs/static/v0.9/extensibility/integrations/aws-target-group-binding/index.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
   <head>
+  <meta name="robots" content="noindex, follow" />
     <title>/v0.9/extensions/models/aws-target-group-binding/</title>
     <link rel="canonical" href="/v0.9/extensions/models/aws-target-group-binding/">
     <meta charset="utf-8">

--- a/docs/static/v0.9/extensibility/integrations/aws-vpc-cni/index.html
+++ b/docs/static/v0.9/extensibility/integrations/aws-vpc-cni/index.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
   <head>
+  <meta name="robots" content="noindex, follow" />
     <title>/v0.9/extensions/models/aws-vpc-cni/</title>
     <link rel="canonical" href="/v0.9/extensions/models/aws-vpc-cni/">
     <meta charset="utf-8">

--- a/docs/static/v0.9/extensibility/integrations/aws/index.html
+++ b/docs/static/v0.9/extensibility/integrations/aws/index.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
   <head>
+  <meta name="robots" content="noindex, follow" />
     <title>/v0.9/extensions/models/aws/</title>
     <link rel="canonical" href="/v0.9/extensions/models/aws/">
     <meta charset="utf-8">

--- a/docs/static/v0.9/extensibility/integrations/awx-operator/index.html
+++ b/docs/static/v0.9/extensibility/integrations/awx-operator/index.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
   <head>
+  <meta name="robots" content="noindex, follow" />
     <title>/v0.9/extensions/models/awx-operator/</title>
     <link rel="canonical" href="/v0.9/extensions/models/awx-operator/">
     <meta charset="utf-8">

--- a/docs/static/v0.9/extensibility/integrations/azure-alerts-management/index.html
+++ b/docs/static/v0.9/extensibility/integrations/azure-alerts-management/index.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
   <head>
+  <meta name="robots" content="noindex, follow" />
     <title>/v0.9/extensions/models/azure-alerts-management/</title>
     <link rel="canonical" href="/v0.9/extensions/models/azure-alerts-management/">
     <meta charset="utf-8">

--- a/docs/static/v0.9/extensibility/integrations/azure-api-management/index.html
+++ b/docs/static/v0.9/extensibility/integrations/azure-api-management/index.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
   <head>
+  <meta name="robots" content="noindex, follow" />
     <title>/v0.9/extensions/models/azure-api-management/</title>
     <link rel="canonical" href="/v0.9/extensions/models/azure-api-management/">
     <meta charset="utf-8">

--- a/docs/static/v0.9/extensibility/integrations/azure-app-configuration/index.html
+++ b/docs/static/v0.9/extensibility/integrations/azure-app-configuration/index.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
   <head>
+  <meta name="robots" content="noindex, follow" />
     <title>/v0.9/extensions/models/azure-app-configuration/</title>
     <link rel="canonical" href="/v0.9/extensions/models/azure-app-configuration/">
     <meta charset="utf-8">

--- a/docs/static/v0.9/extensibility/integrations/azure-app-service/index.html
+++ b/docs/static/v0.9/extensibility/integrations/azure-app-service/index.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
   <head>
+  <meta name="robots" content="noindex, follow" />
     <title>/v0.9/extensions/models/azure-app-service/</title>
     <link rel="canonical" href="/v0.9/extensions/models/azure-app-service/">
     <meta charset="utf-8">

--- a/docs/static/v0.9/extensibility/integrations/azure-architecture/index.html
+++ b/docs/static/v0.9/extensibility/integrations/azure-architecture/index.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
   <head>
+  <meta name="robots" content="noindex, follow" />
     <title>/v0.9/extensions/models/azure-architecture/</title>
     <link rel="canonical" href="/v0.9/extensions/models/azure-architecture/">
     <meta charset="utf-8">

--- a/docs/static/v0.9/extensibility/integrations/azure-authorization/index.html
+++ b/docs/static/v0.9/extensibility/integrations/azure-authorization/index.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
   <head>
+  <meta name="robots" content="noindex, follow" />
     <title>/v0.9/extensions/models/azure-authorization/</title>
     <link rel="canonical" href="/v0.9/extensions/models/azure-authorization/">
     <meta charset="utf-8">

--- a/docs/static/v0.9/extensibility/integrations/azure-batch/index.html
+++ b/docs/static/v0.9/extensibility/integrations/azure-batch/index.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
   <head>
+  <meta name="robots" content="noindex, follow" />
     <title>/v0.9/extensions/models/azure-batch/</title>
     <link rel="canonical" href="/v0.9/extensions/models/azure-batch/">
     <meta charset="utf-8">

--- a/docs/static/v0.9/extensibility/integrations/azure-cache/index.html
+++ b/docs/static/v0.9/extensibility/integrations/azure-cache/index.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
   <head>
+  <meta name="robots" content="noindex, follow" />
     <title>/v0.9/extensions/models/azure-cache/</title>
     <link rel="canonical" href="/v0.9/extensions/models/azure-cache/">
     <meta charset="utf-8">

--- a/docs/static/v0.9/extensibility/integrations/azure-cdn/index.html
+++ b/docs/static/v0.9/extensibility/integrations/azure-cdn/index.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
   <head>
+  <meta name="robots" content="noindex, follow" />
     <title>/v0.9/extensions/models/azure-cdn/</title>
     <link rel="canonical" href="/v0.9/extensions/models/azure-cdn/">
     <meta charset="utf-8">

--- a/docs/static/v0.9/extensibility/integrations/azure-compute/index.html
+++ b/docs/static/v0.9/extensibility/integrations/azure-compute/index.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
   <head>
+  <meta name="robots" content="noindex, follow" />
     <title>/v0.9/extensions/models/azure-compute/</title>
     <link rel="canonical" href="/v0.9/extensions/models/azure-compute/">
     <meta charset="utf-8">

--- a/docs/static/v0.9/extensibility/integrations/azure-container-instance/index.html
+++ b/docs/static/v0.9/extensibility/integrations/azure-container-instance/index.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
   <head>
+  <meta name="robots" content="noindex, follow" />
     <title>/v0.9/extensions/models/azure-container-instance/</title>
     <link rel="canonical" href="/v0.9/extensions/models/azure-container-instance/">
     <meta charset="utf-8">

--- a/docs/static/v0.9/extensibility/integrations/azure-container-registry/index.html
+++ b/docs/static/v0.9/extensibility/integrations/azure-container-registry/index.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
   <head>
+  <meta name="robots" content="noindex, follow" />
     <title>/v0.9/extensions/models/azure-container-registry/</title>
     <link rel="canonical" href="/v0.9/extensions/models/azure-container-registry/">
     <meta charset="utf-8">

--- a/docs/static/v0.9/extensibility/integrations/azure-container-service/index.html
+++ b/docs/static/v0.9/extensibility/integrations/azure-container-service/index.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
   <head>
+  <meta name="robots" content="noindex, follow" />
     <title>/v0.9/extensions/models/azure-container-service/</title>
     <link rel="canonical" href="/v0.9/extensions/models/azure-container-service/">
     <meta charset="utf-8">

--- a/docs/static/v0.9/extensibility/integrations/azure-data-factory/index.html
+++ b/docs/static/v0.9/extensibility/integrations/azure-data-factory/index.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
   <head>
+  <meta name="robots" content="noindex, follow" />
     <title>/v0.9/extensions/models/azure-data-factory/</title>
     <link rel="canonical" href="/v0.9/extensions/models/azure-data-factory/">
     <meta charset="utf-8">

--- a/docs/static/v0.9/extensibility/integrations/azure-data-protection/index.html
+++ b/docs/static/v0.9/extensibility/integrations/azure-data-protection/index.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
   <head>
+  <meta name="robots" content="noindex, follow" />
     <title>/v0.9/extensions/models/azure-data-protection/</title>
     <link rel="canonical" href="/v0.9/extensions/models/azure-data-protection/">
     <meta charset="utf-8">

--- a/docs/static/v0.9/extensibility/integrations/azure-db-for-mariadb/index.html
+++ b/docs/static/v0.9/extensibility/integrations/azure-db-for-mariadb/index.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
   <head>
+  <meta name="robots" content="noindex, follow" />
     <title>/v0.9/extensions/models/azure-db-for-mariadb/</title>
     <link rel="canonical" href="/v0.9/extensions/models/azure-db-for-mariadb/">
     <meta charset="utf-8">

--- a/docs/static/v0.9/extensibility/integrations/azure-db-for-mysql/index.html
+++ b/docs/static/v0.9/extensibility/integrations/azure-db-for-mysql/index.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
   <head>
+  <meta name="robots" content="noindex, follow" />
     <title>/v0.9/extensions/models/azure-db-for-mysql/</title>
     <link rel="canonical" href="/v0.9/extensions/models/azure-db-for-mysql/">
     <meta charset="utf-8">

--- a/docs/static/v0.9/extensibility/integrations/azure-db-for-postgresql/index.html
+++ b/docs/static/v0.9/extensibility/integrations/azure-db-for-postgresql/index.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
   <head>
+  <meta name="robots" content="noindex, follow" />
     <title>/v0.9/extensions/models/azure-db-for-postgresql/</title>
     <link rel="canonical" href="/v0.9/extensions/models/azure-db-for-postgresql/">
     <meta charset="utf-8">

--- a/docs/static/v0.9/extensibility/integrations/azure-devices/index.html
+++ b/docs/static/v0.9/extensibility/integrations/azure-devices/index.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
   <head>
+  <meta name="robots" content="noindex, follow" />
     <title>/v0.9/extensions/models/azure-devices/</title>
     <link rel="canonical" href="/v0.9/extensions/models/azure-devices/">
     <meta charset="utf-8">

--- a/docs/static/v0.9/extensibility/integrations/azure-documentdb/index.html
+++ b/docs/static/v0.9/extensibility/integrations/azure-documentdb/index.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
   <head>
+  <meta name="robots" content="noindex, follow" />
     <title>/v0.9/extensions/models/azure-documentdb/</title>
     <link rel="canonical" href="/v0.9/extensions/models/azure-documentdb/">
     <meta charset="utf-8">

--- a/docs/static/v0.9/extensibility/integrations/azure-entra/index.html
+++ b/docs/static/v0.9/extensibility/integrations/azure-entra/index.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
   <head>
+  <meta name="robots" content="noindex, follow" />
     <title>/v0.9/extensions/models/azure-entra/</title>
     <link rel="canonical" href="/v0.9/extensions/models/azure-entra/">
     <meta charset="utf-8">

--- a/docs/static/v0.9/extensibility/integrations/azure-event-grid/index.html
+++ b/docs/static/v0.9/extensibility/integrations/azure-event-grid/index.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
   <head>
+  <meta name="robots" content="noindex, follow" />
     <title>/v0.9/extensions/models/azure-event-grid/</title>
     <link rel="canonical" href="/v0.9/extensions/models/azure-event-grid/">
     <meta charset="utf-8">

--- a/docs/static/v0.9/extensibility/integrations/azure-event-hub/index.html
+++ b/docs/static/v0.9/extensibility/integrations/azure-event-hub/index.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
   <head>
+  <meta name="robots" content="noindex, follow" />
     <title>/v0.9/extensions/models/azure-event-hub/</title>
     <link rel="canonical" href="/v0.9/extensions/models/azure-event-hub/">
     <meta charset="utf-8">

--- a/docs/static/v0.9/extensibility/integrations/azure-insights/index.html
+++ b/docs/static/v0.9/extensibility/integrations/azure-insights/index.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
   <head>
+  <meta name="robots" content="noindex, follow" />
     <title>/v0.9/extensions/models/azure-insights/</title>
     <link rel="canonical" href="/v0.9/extensions/models/azure-insights/">
     <meta charset="utf-8">

--- a/docs/static/v0.9/extensibility/integrations/azure-key-vault/index.html
+++ b/docs/static/v0.9/extensibility/integrations/azure-key-vault/index.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
   <head>
+  <meta name="robots" content="noindex, follow" />
     <title>/v0.9/extensions/models/azure-key-vault/</title>
     <link rel="canonical" href="/v0.9/extensions/models/azure-key-vault/">
     <meta charset="utf-8">

--- a/docs/static/v0.9/extensibility/integrations/azure-kubernetes-configuration/index.html
+++ b/docs/static/v0.9/extensibility/integrations/azure-kubernetes-configuration/index.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
   <head>
+  <meta name="robots" content="noindex, follow" />
     <title>/v0.9/extensions/models/azure-kubernetes-configuration/</title>
     <link rel="canonical" href="/v0.9/extensions/models/azure-kubernetes-configuration/">
     <meta charset="utf-8">

--- a/docs/static/v0.9/extensibility/integrations/azure-kubernetes-service/index.html
+++ b/docs/static/v0.9/extensibility/integrations/azure-kubernetes-service/index.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
   <head>
+  <meta name="robots" content="noindex, follow" />
     <title>/v0.9/extensions/models/azure-kubernetes-service/</title>
     <link rel="canonical" href="/v0.9/extensions/models/azure-kubernetes-service/">
     <meta charset="utf-8">

--- a/docs/static/v0.9/extensibility/integrations/azure-kusto/index.html
+++ b/docs/static/v0.9/extensibility/integrations/azure-kusto/index.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
   <head>
+  <meta name="robots" content="noindex, follow" />
     <title>/v0.9/extensions/models/azure-kusto/</title>
     <link rel="canonical" href="/v0.9/extensions/models/azure-kusto/">
     <meta charset="utf-8">

--- a/docs/static/v0.9/extensibility/integrations/azure-machine-learning-services/index.html
+++ b/docs/static/v0.9/extensibility/integrations/azure-machine-learning-services/index.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
   <head>
+  <meta name="robots" content="noindex, follow" />
     <title>/v0.9/extensions/models/azure-machine-learning-services/</title>
     <link rel="canonical" href="/v0.9/extensions/models/azure-machine-learning-services/">
     <meta charset="utf-8">

--- a/docs/static/v0.9/extensibility/integrations/azure-managed-identity/index.html
+++ b/docs/static/v0.9/extensibility/integrations/azure-managed-identity/index.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
   <head>
+  <meta name="robots" content="noindex, follow" />
     <title>/v0.9/extensions/models/azure-managed-identity/</title>
     <link rel="canonical" href="/v0.9/extensions/models/azure-managed-identity/">
     <meta charset="utf-8">

--- a/docs/static/v0.9/extensibility/integrations/azure-monitor/index.html
+++ b/docs/static/v0.9/extensibility/integrations/azure-monitor/index.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
   <head>
+  <meta name="robots" content="noindex, follow" />
     <title>/v0.9/extensions/models/azure-monitor/</title>
     <link rel="canonical" href="/v0.9/extensions/models/azure-monitor/">
     <meta charset="utf-8">

--- a/docs/static/v0.9/extensibility/integrations/azure-network-frontdoor/index.html
+++ b/docs/static/v0.9/extensibility/integrations/azure-network-frontdoor/index.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
   <head>
+  <meta name="robots" content="noindex, follow" />
     <title>/v0.9/extensions/models/azure-network-frontdoor/</title>
     <link rel="canonical" href="/v0.9/extensions/models/azure-network-frontdoor/">
     <meta charset="utf-8">

--- a/docs/static/v0.9/extensibility/integrations/azure-network/index.html
+++ b/docs/static/v0.9/extensibility/integrations/azure-network/index.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
   <head>
+  <meta name="robots" content="noindex, follow" />
     <title>/v0.9/extensions/models/azure-network/</title>
     <link rel="canonical" href="/v0.9/extensions/models/azure-network/">
     <meta charset="utf-8">

--- a/docs/static/v0.9/extensibility/integrations/azure-notification-hubs/index.html
+++ b/docs/static/v0.9/extensibility/integrations/azure-notification-hubs/index.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
   <head>
+  <meta name="robots" content="noindex, follow" />
     <title>/v0.9/extensions/models/azure-notification-hubs/</title>
     <link rel="canonical" href="/v0.9/extensions/models/azure-notification-hubs/">
     <meta charset="utf-8">

--- a/docs/static/v0.9/extensibility/integrations/azure-operational-insights/index.html
+++ b/docs/static/v0.9/extensibility/integrations/azure-operational-insights/index.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
   <head>
+  <meta name="robots" content="noindex, follow" />
     <title>/v0.9/extensions/models/azure-operational-insights/</title>
     <link rel="canonical" href="/v0.9/extensions/models/azure-operational-insights/">
     <meta charset="utf-8">

--- a/docs/static/v0.9/extensibility/integrations/azure-operator/index.html
+++ b/docs/static/v0.9/extensibility/integrations/azure-operator/index.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
   <head>
+  <meta name="robots" content="noindex, follow" />
     <title>/v0.9/extensions/models/azure-operator/</title>
     <link rel="canonical" href="/v0.9/extensions/models/azure-operator/">
     <meta charset="utf-8">

--- a/docs/static/v0.9/extensibility/integrations/azure-red-hat-openshift/index.html
+++ b/docs/static/v0.9/extensibility/integrations/azure-red-hat-openshift/index.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
   <head>
+  <meta name="robots" content="noindex, follow" />
     <title>/v0.9/extensions/models/azure-red-hat-openshift/</title>
     <link rel="canonical" href="/v0.9/extensions/models/azure-red-hat-openshift/">
     <meta charset="utf-8">

--- a/docs/static/v0.9/extensibility/integrations/azure-resources/index.html
+++ b/docs/static/v0.9/extensibility/integrations/azure-resources/index.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
   <head>
+  <meta name="robots" content="noindex, follow" />
     <title>/v0.9/extensions/models/azure-resources/</title>
     <link rel="canonical" href="/v0.9/extensions/models/azure-resources/">
     <meta charset="utf-8">

--- a/docs/static/v0.9/extensibility/integrations/azure-search/index.html
+++ b/docs/static/v0.9/extensibility/integrations/azure-search/index.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
   <head>
+  <meta name="robots" content="noindex, follow" />
     <title>/v0.9/extensions/models/azure-search/</title>
     <link rel="canonical" href="/v0.9/extensions/models/azure-search/">
     <meta charset="utf-8">

--- a/docs/static/v0.9/extensibility/integrations/azure-service-bus/index.html
+++ b/docs/static/v0.9/extensibility/integrations/azure-service-bus/index.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
   <head>
+  <meta name="robots" content="noindex, follow" />
     <title>/v0.9/extensions/models/azure-service-bus/</title>
     <link rel="canonical" href="/v0.9/extensions/models/azure-service-bus/">
     <meta charset="utf-8">

--- a/docs/static/v0.9/extensibility/integrations/azure-signalr-service/index.html
+++ b/docs/static/v0.9/extensibility/integrations/azure-signalr-service/index.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
   <head>
+  <meta name="robots" content="noindex, follow" />
     <title>/v0.9/extensions/models/azure-signalr-service/</title>
     <link rel="canonical" href="/v0.9/extensions/models/azure-signalr-service/">
     <meta charset="utf-8">

--- a/docs/static/v0.9/extensibility/integrations/azure-sql/index.html
+++ b/docs/static/v0.9/extensibility/integrations/azure-sql/index.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
   <head>
+  <meta name="robots" content="noindex, follow" />
     <title>/v0.9/extensions/models/azure-sql/</title>
     <link rel="canonical" href="/v0.9/extensions/models/azure-sql/">
     <meta charset="utf-8">

--- a/docs/static/v0.9/extensibility/integrations/azure-storage/index.html
+++ b/docs/static/v0.9/extensibility/integrations/azure-storage/index.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
   <head>
+  <meta name="robots" content="noindex, follow" />
     <title>/v0.9/extensions/models/azure-storage/</title>
     <link rel="canonical" href="/v0.9/extensions/models/azure-storage/">
     <meta charset="utf-8">

--- a/docs/static/v0.9/extensibility/integrations/azure-subscription/index.html
+++ b/docs/static/v0.9/extensibility/integrations/azure-subscription/index.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
   <head>
+  <meta name="robots" content="noindex, follow" />
     <title>/v0.9/extensions/models/azure-subscription/</title>
     <link rel="canonical" href="/v0.9/extensions/models/azure-subscription/">
     <meta charset="utf-8">

--- a/docs/static/v0.9/extensibility/integrations/azure-synapse/index.html
+++ b/docs/static/v0.9/extensibility/integrations/azure-synapse/index.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
   <head>
+  <meta name="robots" content="noindex, follow" />
     <title>/v0.9/extensions/models/azure-synapse/</title>
     <link rel="canonical" href="/v0.9/extensions/models/azure-synapse/">
     <meta charset="utf-8">

--- a/docs/static/v0.9/extensibility/integrations/azure-web/index.html
+++ b/docs/static/v0.9/extensibility/integrations/azure-web/index.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
   <head>
+  <meta name="robots" content="noindex, follow" />
     <title>/v0.9/extensions/models/azure-web/</title>
     <link rel="canonical" href="/v0.9/extensions/models/azure-web/">
     <meta charset="utf-8">

--- a/docs/static/v0.9/extensibility/integrations/azureorkestra/index.html
+++ b/docs/static/v0.9/extensibility/integrations/azureorkestra/index.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
   <head>
+  <meta name="robots" content="noindex, follow" />
     <title>/v0.9/extensions/models/azureorkestra/</title>
     <link rel="canonical" href="/v0.9/extensions/models/azureorkestra/">
     <meta charset="utf-8">

--- a/docs/static/v0.9/extensibility/integrations/backend/index.html
+++ b/docs/static/v0.9/extensibility/integrations/backend/index.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
   <head>
+  <meta name="robots" content="noindex, follow" />
     <title>/v0.9/extensions/models/backend/</title>
     <link rel="canonical" href="/v0.9/extensions/models/backend/">
     <meta charset="utf-8">

--- a/docs/static/v0.9/extensibility/integrations/backstage/index.html
+++ b/docs/static/v0.9/extensibility/integrations/backstage/index.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
   <head>
+  <meta name="robots" content="noindex, follow" />
     <title>/v0.9/extensions/models/backstage/</title>
     <link rel="canonical" href="/v0.9/extensions/models/backstage/">
     <meta charset="utf-8">

--- a/docs/static/v0.9/extensibility/integrations/bfe/index.html
+++ b/docs/static/v0.9/extensibility/integrations/bfe/index.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
   <head>
+  <meta name="robots" content="noindex, follow" />
     <title>/v0.9/extensions/models/bfe/</title>
     <link rel="canonical" href="/v0.9/extensions/models/bfe/">
     <meta charset="utf-8">

--- a/docs/static/v0.9/extensibility/integrations/bitwarden-crd-operator/index.html
+++ b/docs/static/v0.9/extensibility/integrations/bitwarden-crd-operator/index.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
   <head>
+  <meta name="robots" content="noindex, follow" />
     <title>/v0.9/extensions/models/bitwarden-crd-operator/</title>
     <link rel="canonical" href="/v0.9/extensions/models/bitwarden-crd-operator/">
     <meta charset="utf-8">

--- a/docs/static/v0.9/extensibility/integrations/brigade/index.html
+++ b/docs/static/v0.9/extensibility/integrations/brigade/index.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
   <head>
+  <meta name="robots" content="noindex, follow" />
     <title>/v0.9/extensions/models/brigade/</title>
     <link rel="canonical" href="/v0.9/extensions/models/brigade/">
     <meta charset="utf-8">

--- a/docs/static/v0.9/extensibility/integrations/buildpacks/index.html
+++ b/docs/static/v0.9/extensibility/integrations/buildpacks/index.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
   <head>
+  <meta name="robots" content="noindex, follow" />
     <title>/v0.9/extensions/models/buildpacks/</title>
     <link rel="canonical" href="/v0.9/extensions/models/buildpacks/">
     <meta charset="utf-8">

--- a/docs/static/v0.9/extensibility/integrations/camel-k/index.html
+++ b/docs/static/v0.9/extensibility/integrations/camel-k/index.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
   <head>
+  <meta name="robots" content="noindex, follow" />
     <title>/v0.9/extensions/models/camel-k/</title>
     <link rel="canonical" href="/v0.9/extensions/models/camel-k/">
     <meta charset="utf-8">

--- a/docs/static/v0.9/extensibility/integrations/capsule-proxy/index.html
+++ b/docs/static/v0.9/extensibility/integrations/capsule-proxy/index.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
   <head>
+  <meta name="robots" content="noindex, follow" />
     <title>/v0.9/extensions/models/capsule-proxy/</title>
     <link rel="canonical" href="/v0.9/extensions/models/capsule-proxy/">
     <meta charset="utf-8">

--- a/docs/static/v0.9/extensibility/integrations/cass-operator/index.html
+++ b/docs/static/v0.9/extensibility/integrations/cass-operator/index.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
   <head>
+  <meta name="robots" content="noindex, follow" />
     <title>/v0.9/extensions/models/cass-operator/</title>
     <link rel="canonical" href="/v0.9/extensions/models/cass-operator/">
     <meta charset="utf-8">

--- a/docs/static/v0.9/extensibility/integrations/cd-pipeline-operator/index.html
+++ b/docs/static/v0.9/extensibility/integrations/cd-pipeline-operator/index.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
   <head>
+  <meta name="robots" content="noindex, follow" />
     <title>/v0.9/extensions/models/cd-pipeline-operator/</title>
     <link rel="canonical" href="/v0.9/extensions/models/cd-pipeline-operator/">
     <meta charset="utf-8">

--- a/docs/static/v0.9/extensibility/integrations/cdk8s/index.html
+++ b/docs/static/v0.9/extensibility/integrations/cdk8s/index.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
   <head>
+  <meta name="robots" content="noindex, follow" />
     <title>/v0.9/extensions/models/cdk8s/</title>
     <link rel="canonical" href="/v0.9/extensions/models/cdk8s/">
     <meta charset="utf-8">

--- a/docs/static/v0.9/extensibility/integrations/cert-manager-crds/index.html
+++ b/docs/static/v0.9/extensibility/integrations/cert-manager-crds/index.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
   <head>
+  <meta name="robots" content="noindex, follow" />
     <title>/v0.9/extensions/models/cert-manager-crds/</title>
     <link rel="canonical" href="/v0.9/extensions/models/cert-manager-crds/">
     <meta charset="utf-8">

--- a/docs/static/v0.9/extensibility/integrations/cert-manager-csi-driver-cacerts/index.html
+++ b/docs/static/v0.9/extensibility/integrations/cert-manager-csi-driver-cacerts/index.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
   <head>
+  <meta name="robots" content="noindex, follow" />
     <title>/v0.9/extensions/models/cert-manager-csi-driver-cacerts/</title>
     <link rel="canonical" href="/v0.9/extensions/models/cert-manager-csi-driver-cacerts/">
     <meta charset="utf-8">

--- a/docs/static/v0.9/extensibility/integrations/cert-manager/index.html
+++ b/docs/static/v0.9/extensibility/integrations/cert-manager/index.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
   <head>
+  <meta name="robots" content="noindex, follow" />
     <title>/v0.9/extensions/models/cert-manager/</title>
     <link rel="canonical" href="/v0.9/extensions/models/cert-manager/">
     <meta charset="utf-8">

--- a/docs/static/v0.9/extensibility/integrations/chaos-mesh/index.html
+++ b/docs/static/v0.9/extensibility/integrations/chaos-mesh/index.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
   <head>
+  <meta name="robots" content="noindex, follow" />
     <title>/v0.9/extensions/models/chaos-mesh/</title>
     <link rel="canonical" href="/v0.9/extensions/models/chaos-mesh/">
     <meta charset="utf-8">

--- a/docs/static/v0.9/extensibility/integrations/chaos/index.html
+++ b/docs/static/v0.9/extensibility/integrations/chaos/index.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
   <head>
+  <meta name="robots" content="noindex, follow" />
     <title>/v0.9/extensions/models/chaos/</title>
     <link rel="canonical" href="/v0.9/extensions/models/chaos/">
     <meta charset="utf-8">

--- a/docs/static/v0.9/extensibility/integrations/chaosblade-operator/index.html
+++ b/docs/static/v0.9/extensibility/integrations/chaosblade-operator/index.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
   <head>
+  <meta name="robots" content="noindex, follow" />
     <title>/v0.9/extensions/models/chaosblade-operator/</title>
     <link rel="canonical" href="/v0.9/extensions/models/chaosblade-operator/">
     <meta charset="utf-8">

--- a/docs/static/v0.9/extensibility/integrations/cilium/index.html
+++ b/docs/static/v0.9/extensibility/integrations/cilium/index.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
   <head>
+  <meta name="robots" content="noindex, follow" />
     <title>/v0.9/extensions/models/cilium/</title>
     <link rel="canonical" href="/v0.9/extensions/models/cilium/">
     <meta charset="utf-8">

--- a/docs/static/v0.9/extensibility/integrations/clickhouse/index.html
+++ b/docs/static/v0.9/extensibility/integrations/clickhouse/index.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
   <head>
+  <meta name="robots" content="noindex, follow" />
     <title>/v0.9/extensions/models/clickhouse/</title>
     <link rel="canonical" href="/v0.9/extensions/models/clickhouse/">
     <meta charset="utf-8">

--- a/docs/static/v0.9/extensibility/integrations/cloud-custodian/index.html
+++ b/docs/static/v0.9/extensibility/integrations/cloud-custodian/index.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
   <head>
+  <meta name="robots" content="noindex, follow" />
     <title>/v0.9/extensions/models/cloud-custodian/</title>
     <link rel="canonical" href="/v0.9/extensions/models/cloud-custodian/">
     <meta charset="utf-8">

--- a/docs/static/v0.9/extensibility/integrations/cloudbees-previews/index.html
+++ b/docs/static/v0.9/extensibility/integrations/cloudbees-previews/index.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
   <head>
+  <meta name="robots" content="noindex, follow" />
     <title>/v0.9/extensions/models/cloudbees-previews/</title>
     <link rel="canonical" href="/v0.9/extensions/models/cloudbees-previews/">
     <meta charset="utf-8">

--- a/docs/static/v0.9/extensibility/integrations/cloudcore/index.html
+++ b/docs/static/v0.9/extensibility/integrations/cloudcore/index.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
   <head>
+  <meta name="robots" content="noindex, follow" />
     <title>/v0.9/extensions/models/cloudcore/</title>
     <link rel="canonical" href="/v0.9/extensions/models/cloudcore/">
     <meta charset="utf-8">

--- a/docs/static/v0.9/extensibility/integrations/cloudevents/index.html
+++ b/docs/static/v0.9/extensibility/integrations/cloudevents/index.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
   <head>
+  <meta name="robots" content="noindex, follow" />
     <title>/v0.9/extensions/models/cloudevents/</title>
     <link rel="canonical" href="/v0.9/extensions/models/cloudevents/">
     <meta charset="utf-8">

--- a/docs/static/v0.9/extensibility/integrations/cloudnative-pg/index.html
+++ b/docs/static/v0.9/extensibility/integrations/cloudnative-pg/index.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
   <head>
+  <meta name="robots" content="noindex, follow" />
     <title>/v0.9/extensions/models/cloudnative-pg/</title>
     <link rel="canonical" href="/v0.9/extensions/models/cloudnative-pg/">
     <meta charset="utf-8">

--- a/docs/static/v0.9/extensibility/integrations/cluster-api-provider-openstack/index.html
+++ b/docs/static/v0.9/extensibility/integrations/cluster-api-provider-openstack/index.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
   <head>
+  <meta name="robots" content="noindex, follow" />
     <title>/v0.9/extensions/models/cluster-api-provider-openstack/</title>
     <link rel="canonical" href="/v0.9/extensions/models/cluster-api-provider-openstack/">
     <meta charset="utf-8">

--- a/docs/static/v0.9/extensibility/integrations/clusterpedia/index.html
+++ b/docs/static/v0.9/extensibility/integrations/clusterpedia/index.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
   <head>
+  <meta name="robots" content="noindex, follow" />
     <title>/v0.9/extensions/models/clusterpedia/</title>
     <link rel="canonical" href="/v0.9/extensions/models/clusterpedia/">
     <meta charset="utf-8">

--- a/docs/static/v0.9/extensibility/integrations/cni-hostnic/index.html
+++ b/docs/static/v0.9/extensibility/integrations/cni-hostnic/index.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
   <head>
+  <meta name="robots" content="noindex, follow" />
     <title>/v0.9/extensions/models/cni-hostnic/</title>
     <link rel="canonical" href="/v0.9/extensions/models/cni-hostnic/">
     <meta charset="utf-8">

--- a/docs/static/v0.9/extensibility/integrations/cockroachdb-operator/index.html
+++ b/docs/static/v0.9/extensibility/integrations/cockroachdb-operator/index.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
   <head>
+  <meta name="robots" content="noindex, follow" />
     <title>/v0.9/extensions/models/cockroachdb-operator/</title>
     <link rel="canonical" href="/v0.9/extensions/models/cockroachdb-operator/">
     <meta charset="utf-8">

--- a/docs/static/v0.9/extensibility/integrations/confidential-containers/index.html
+++ b/docs/static/v0.9/extensibility/integrations/confidential-containers/index.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
   <head>
+  <meta name="robots" content="noindex, follow" />
     <title>/v0.9/extensions/models/confidential-containers/</title>
     <link rel="canonical" href="/v0.9/extensions/models/confidential-containers/">
     <meta charset="utf-8">

--- a/docs/static/v0.9/extensibility/integrations/consul/index.html
+++ b/docs/static/v0.9/extensibility/integrations/consul/index.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
   <head>
+  <meta name="robots" content="noindex, follow" />
     <title>/v0.9/extensions/models/consul/</title>
     <link rel="canonical" href="/v0.9/extensions/models/consul/">
     <meta charset="utf-8">

--- a/docs/static/v0.9/extensibility/integrations/containerd/index.html
+++ b/docs/static/v0.9/extensibility/integrations/containerd/index.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
   <head>
+  <meta name="robots" content="noindex, follow" />
     <title>/v0.9/extensions/models/containerd/</title>
     <link rel="canonical" href="/v0.9/extensions/models/containerd/">
     <meta charset="utf-8">

--- a/docs/static/v0.9/extensibility/integrations/containerssh/index.html
+++ b/docs/static/v0.9/extensibility/integrations/containerssh/index.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
   <head>
+  <meta name="robots" content="noindex, follow" />
     <title>/v0.9/extensions/models/containerssh/</title>
     <link rel="canonical" href="/v0.9/extensions/models/containerssh/">
     <meta charset="utf-8">

--- a/docs/static/v0.9/extensibility/integrations/contour-operator/index.html
+++ b/docs/static/v0.9/extensibility/integrations/contour-operator/index.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
   <head>
+  <meta name="robots" content="noindex, follow" />
     <title>/v0.9/extensions/models/contour-operator/</title>
     <link rel="canonical" href="/v0.9/extensions/models/contour-operator/">
     <meta charset="utf-8">

--- a/docs/static/v0.9/extensibility/integrations/contrail-analytics/index.html
+++ b/docs/static/v0.9/extensibility/integrations/contrail-analytics/index.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
   <head>
+  <meta name="robots" content="noindex, follow" />
     <title>/v0.9/extensions/models/contrail-analytics/</title>
     <link rel="canonical" href="/v0.9/extensions/models/contrail-analytics/">
     <meta charset="utf-8">

--- a/docs/static/v0.9/extensibility/integrations/coredns/index.html
+++ b/docs/static/v0.9/extensibility/integrations/coredns/index.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
   <head>
+  <meta name="robots" content="noindex, follow" />
     <title>/v0.9/extensions/models/coredns/</title>
     <link rel="canonical" href="/v0.9/extensions/models/coredns/">
     <meta charset="utf-8">

--- a/docs/static/v0.9/extensibility/integrations/cortex/index.html
+++ b/docs/static/v0.9/extensibility/integrations/cortex/index.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
   <head>
+  <meta name="robots" content="noindex, follow" />
     <title>/v0.9/extensions/models/cortex/</title>
     <link rel="canonical" href="/v0.9/extensions/models/cortex/">
     <meta charset="utf-8">

--- a/docs/static/v0.9/extensibility/integrations/couchbase-monitor-stack/index.html
+++ b/docs/static/v0.9/extensibility/integrations/couchbase-monitor-stack/index.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
   <head>
+  <meta name="robots" content="noindex, follow" />
     <title>/v0.9/extensions/models/couchbase-monitor-stack/</title>
     <link rel="canonical" href="/v0.9/extensions/models/couchbase-monitor-stack/">
     <meta charset="utf-8">

--- a/docs/static/v0.9/extensibility/integrations/couchbase-operator/index.html
+++ b/docs/static/v0.9/extensibility/integrations/couchbase-operator/index.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
   <head>
+  <meta name="robots" content="noindex, follow" />
     <title>/v0.9/extensions/models/couchbase-operator/</title>
     <link rel="canonical" href="/v0.9/extensions/models/couchbase-operator/">
     <meta charset="utf-8">

--- a/docs/static/v0.9/extensibility/integrations/cpx/index.html
+++ b/docs/static/v0.9/extensibility/integrations/cpx/index.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
   <head>
+  <meta name="robots" content="noindex, follow" />
     <title>/v0.9/extensions/models/cpx/</title>
     <link rel="canonical" href="/v0.9/extensions/models/cpx/">
     <meta charset="utf-8">

--- a/docs/static/v0.9/extensibility/integrations/cri-o/index.html
+++ b/docs/static/v0.9/extensibility/integrations/cri-o/index.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
   <head>
+  <meta name="robots" content="noindex, follow" />
     <title>/v0.9/extensions/models/cri-o/</title>
     <link rel="canonical" href="/v0.9/extensions/models/cri-o/">
     <meta charset="utf-8">

--- a/docs/static/v0.9/extensibility/integrations/crossplane-provider-exoscale/index.html
+++ b/docs/static/v0.9/extensibility/integrations/crossplane-provider-exoscale/index.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
   <head>
+  <meta name="robots" content="noindex, follow" />
     <title>/v0.9/extensions/models/crossplane-provider-exoscale/</title>
     <link rel="canonical" href="/v0.9/extensions/models/crossplane-provider-exoscale/">
     <meta charset="utf-8">

--- a/docs/static/v0.9/extensibility/integrations/crossplane-provider-openstack/index.html
+++ b/docs/static/v0.9/extensibility/integrations/crossplane-provider-openstack/index.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
   <head>
+  <meta name="robots" content="noindex, follow" />
     <title>/v0.9/extensions/models/crossplane-provider-openstack/</title>
     <link rel="canonical" href="/v0.9/extensions/models/crossplane-provider-openstack/">
     <meta charset="utf-8">

--- a/docs/static/v0.9/extensibility/integrations/crossplane/index.html
+++ b/docs/static/v0.9/extensibility/integrations/crossplane/index.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
   <head>
+  <meta name="robots" content="noindex, follow" />
     <title>/v0.9/extensions/models/crossplane/</title>
     <link rel="canonical" href="/v0.9/extensions/models/crossplane/">
     <meta charset="utf-8">

--- a/docs/static/v0.9/extensibility/integrations/cubefs/index.html
+++ b/docs/static/v0.9/extensibility/integrations/cubefs/index.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
   <head>
+  <meta name="robots" content="noindex, follow" />
     <title>/v0.9/extensions/models/cubefs/</title>
     <link rel="canonical" href="/v0.9/extensions/models/cubefs/">
     <meta charset="utf-8">

--- a/docs/static/v0.9/extensibility/integrations/curiefense/index.html
+++ b/docs/static/v0.9/extensibility/integrations/curiefense/index.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
   <head>
+  <meta name="robots" content="noindex, follow" />
     <title>/v0.9/extensions/models/curiefense/</title>
     <link rel="canonical" href="/v0.9/extensions/models/curiefense/">
     <meta charset="utf-8">

--- a/docs/static/v0.9/extensibility/integrations/dapr/index.html
+++ b/docs/static/v0.9/extensibility/integrations/dapr/index.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
   <head>
+  <meta name="robots" content="noindex, follow" />
     <title>/v0.9/extensions/models/dapr/</title>
     <link rel="canonical" href="/v0.9/extensions/models/dapr/">
     <meta charset="utf-8">

--- a/docs/static/v0.9/extensibility/integrations/datadog-operator/index.html
+++ b/docs/static/v0.9/extensibility/integrations/datadog-operator/index.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
   <head>
+  <meta name="robots" content="noindex, follow" />
     <title>/v0.9/extensions/models/datadog-operator/</title>
     <link rel="canonical" href="/v0.9/extensions/models/datadog-operator/">
     <meta charset="utf-8">

--- a/docs/static/v0.9/extensibility/integrations/devfile/index.html
+++ b/docs/static/v0.9/extensibility/integrations/devfile/index.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
   <head>
+  <meta name="robots" content="noindex, follow" />
     <title>/v0.9/extensions/models/devfile/</title>
     <link rel="canonical" href="/v0.9/extensions/models/devfile/">
     <meta charset="utf-8">

--- a/docs/static/v0.9/extensibility/integrations/devstream/index.html
+++ b/docs/static/v0.9/extensibility/integrations/devstream/index.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
   <head>
+  <meta name="robots" content="noindex, follow" />
     <title>/v0.9/extensions/models/devstream/</title>
     <link rel="canonical" href="/v0.9/extensions/models/devstream/">
     <meta charset="utf-8">

--- a/docs/static/v0.9/extensibility/integrations/dex/index.html
+++ b/docs/static/v0.9/extensibility/integrations/dex/index.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
   <head>
+  <meta name="robots" content="noindex, follow" />
     <title>/v0.9/extensions/models/dex/</title>
     <link rel="canonical" href="/v0.9/extensions/models/dex/">
     <meta charset="utf-8">

--- a/docs/static/v0.9/extensibility/integrations/distribution/index.html
+++ b/docs/static/v0.9/extensibility/integrations/distribution/index.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
   <head>
+  <meta name="robots" content="noindex, follow" />
     <title>/v0.9/extensions/models/distribution/</title>
     <link rel="canonical" href="/v0.9/extensions/models/distribution/">
     <meta charset="utf-8">

--- a/docs/static/v0.9/extensibility/integrations/docker/index.html
+++ b/docs/static/v0.9/extensibility/integrations/docker/index.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
   <head>
+  <meta name="robots" content="noindex, follow" />
     <title>/v0.9/extensions/models/docker/</title>
     <link rel="canonical" href="/v0.9/extensions/models/docker/">
     <meta charset="utf-8">

--- a/docs/static/v0.9/extensibility/integrations/dragonfly/index.html
+++ b/docs/static/v0.9/extensibility/integrations/dragonfly/index.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
   <head>
+  <meta name="robots" content="noindex, follow" />
     <title>/v0.9/extensions/models/dragonfly/</title>
     <link rel="canonical" href="/v0.9/extensions/models/dragonfly/">
     <meta charset="utf-8">

--- a/docs/static/v0.9/extensibility/integrations/edp-argocd-operator/index.html
+++ b/docs/static/v0.9/extensibility/integrations/edp-argocd-operator/index.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
   <head>
+  <meta name="robots" content="noindex, follow" />
     <title>/v0.9/extensions/models/edp-argocd-operator/</title>
     <link rel="canonical" href="/v0.9/extensions/models/edp-argocd-operator/">
     <meta charset="utf-8">

--- a/docs/static/v0.9/extensibility/integrations/edp-component-operator/index.html
+++ b/docs/static/v0.9/extensibility/integrations/edp-component-operator/index.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
   <head>
+  <meta name="robots" content="noindex, follow" />
     <title>/v0.9/extensions/models/edp-component-operator/</title>
     <link rel="canonical" href="/v0.9/extensions/models/edp-component-operator/">
     <meta charset="utf-8">

--- a/docs/static/v0.9/extensibility/integrations/edp-install/index.html
+++ b/docs/static/v0.9/extensibility/integrations/edp-install/index.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
   <head>
+  <meta name="robots" content="noindex, follow" />
     <title>/v0.9/extensions/models/edp-install/</title>
     <link rel="canonical" href="/v0.9/extensions/models/edp-install/">
     <meta charset="utf-8">

--- a/docs/static/v0.9/extensibility/integrations/eks/index.html
+++ b/docs/static/v0.9/extensibility/integrations/eks/index.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
   <head>
+  <meta name="robots" content="noindex, follow" />
     <title>/v0.9/extensions/models/eks/</title>
     <link rel="canonical" href="/v0.9/extensions/models/eks/">
     <meta charset="utf-8">

--- a/docs/static/v0.9/extensibility/integrations/elasticsearch-operator/index.html
+++ b/docs/static/v0.9/extensibility/integrations/elasticsearch-operator/index.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
   <head>
+  <meta name="robots" content="noindex, follow" />
     <title>/v0.9/extensions/models/elasticsearch-operator/</title>
     <link rel="canonical" href="/v0.9/extensions/models/elasticsearch-operator/">
     <meta charset="utf-8">

--- a/docs/static/v0.9/extensibility/integrations/emissary-ingress/index.html
+++ b/docs/static/v0.9/extensibility/integrations/emissary-ingress/index.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
   <head>
+  <meta name="robots" content="noindex, follow" />
     <title>/v0.9/extensions/models/emissary-ingress/</title>
     <link rel="canonical" href="/v0.9/extensions/models/emissary-ingress/">
     <meta charset="utf-8">

--- a/docs/static/v0.9/extensibility/integrations/envoy/index.html
+++ b/docs/static/v0.9/extensibility/integrations/envoy/index.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
   <head>
+  <meta name="robots" content="noindex, follow" />
     <title>/v0.9/extensions/models/envoy/</title>
     <link rel="canonical" href="/v0.9/extensions/models/envoy/">
     <meta charset="utf-8">

--- a/docs/static/v0.9/extensibility/integrations/etcd-cluster-operator/index.html
+++ b/docs/static/v0.9/extensibility/integrations/etcd-cluster-operator/index.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
   <head>
+  <meta name="robots" content="noindex, follow" />
     <title>/v0.9/extensions/models/etcd-cluster-operator/</title>
     <link rel="canonical" href="/v0.9/extensions/models/etcd-cluster-operator/">
     <meta charset="utf-8">

--- a/docs/static/v0.9/extensibility/integrations/external-secrets-operator/index.html
+++ b/docs/static/v0.9/extensibility/integrations/external-secrets-operator/index.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
   <head>
+  <meta name="robots" content="noindex, follow" />
     <title>/v0.9/extensions/models/external-secrets-operator/</title>
     <link rel="canonical" href="/v0.9/extensions/models/external-secrets-operator/">
     <meta charset="utf-8">

--- a/docs/static/v0.9/extensibility/integrations/fabedge/index.html
+++ b/docs/static/v0.9/extensibility/integrations/fabedge/index.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
   <head>
+  <meta name="robots" content="noindex, follow" />
     <title>/v0.9/extensions/models/fabedge/</title>
     <link rel="canonical" href="/v0.9/extensions/models/fabedge/">
     <meta charset="utf-8">

--- a/docs/static/v0.9/extensibility/integrations/falco/index.html
+++ b/docs/static/v0.9/extensibility/integrations/falco/index.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
   <head>
+  <meta name="robots" content="noindex, follow" />
     <title>/v0.9/extensions/models/falco/</title>
     <link rel="canonical" href="/v0.9/extensions/models/falco/">
     <meta charset="utf-8">

--- a/docs/static/v0.9/extensibility/integrations/flagger/index.html
+++ b/docs/static/v0.9/extensibility/integrations/flagger/index.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
   <head>
+  <meta name="robots" content="noindex, follow" />
     <title>/v0.9/extensions/models/flagger/</title>
     <link rel="canonical" href="/v0.9/extensions/models/flagger/">
     <meta charset="utf-8">

--- a/docs/static/v0.9/extensibility/integrations/fluent-operator/index.html
+++ b/docs/static/v0.9/extensibility/integrations/fluent-operator/index.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
   <head>
+  <meta name="robots" content="noindex, follow" />
     <title>/v0.9/extensions/models/fluent-operator/</title>
     <link rel="canonical" href="/v0.9/extensions/models/fluent-operator/">
     <meta charset="utf-8">

--- a/docs/static/v0.9/extensibility/integrations/fluentbit-operator/index.html
+++ b/docs/static/v0.9/extensibility/integrations/fluentbit-operator/index.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
   <head>
+  <meta name="robots" content="noindex, follow" />
     <title>/v0.9/extensions/models/fluentbit-operator/</title>
     <link rel="canonical" href="/v0.9/extensions/models/fluentbit-operator/">
     <meta charset="utf-8">

--- a/docs/static/v0.9/extensibility/integrations/fluentbit-skt/index.html
+++ b/docs/static/v0.9/extensibility/integrations/fluentbit-skt/index.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
   <head>
+  <meta name="robots" content="noindex, follow" />
     <title>/v0.9/extensions/models/fluentbit-skt/</title>
     <link rel="canonical" href="/v0.9/extensions/models/fluentbit-skt/">
     <meta charset="utf-8">

--- a/docs/static/v0.9/extensibility/integrations/fluentd-operator/index.html
+++ b/docs/static/v0.9/extensibility/integrations/fluentd-operator/index.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
   <head>
+  <meta name="robots" content="noindex, follow" />
     <title>/v0.9/extensions/models/fluentd-operator/</title>
     <link rel="canonical" href="/v0.9/extensions/models/fluentd-operator/">
     <meta charset="utf-8">

--- a/docs/static/v0.9/extensibility/integrations/fluentd/index.html
+++ b/docs/static/v0.9/extensibility/integrations/fluentd/index.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
   <head>
+  <meta name="robots" content="noindex, follow" />
     <title>/v0.9/extensions/models/fluentd/</title>
     <link rel="canonical" href="/v0.9/extensions/models/fluentd/">
     <meta charset="utf-8">

--- a/docs/static/v0.9/extensibility/integrations/fluid/index.html
+++ b/docs/static/v0.9/extensibility/integrations/fluid/index.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
   <head>
+  <meta name="robots" content="noindex, follow" />
     <title>/v0.9/extensions/models/fluid/</title>
     <link rel="canonical" href="/v0.9/extensions/models/fluid/">
     <meta charset="utf-8">

--- a/docs/static/v0.9/extensibility/integrations/flux/index.html
+++ b/docs/static/v0.9/extensibility/integrations/flux/index.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
   <head>
+  <meta name="robots" content="noindex, follow" />
     <title>/v0.9/extensions/models/flux/</title>
     <link rel="canonical" href="/v0.9/extensions/models/flux/">
     <meta charset="utf-8">

--- a/docs/static/v0.9/extensibility/integrations/flyte-sandbox/index.html
+++ b/docs/static/v0.9/extensibility/integrations/flyte-sandbox/index.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
   <head>
+  <meta name="robots" content="noindex, follow" />
     <title>/v0.9/extensions/models/flyte-sandbox/</title>
     <link rel="canonical" href="/v0.9/extensions/models/flyte-sandbox/">
     <meta charset="utf-8">

--- a/docs/static/v0.9/extensibility/integrations/fonio/index.html
+++ b/docs/static/v0.9/extensibility/integrations/fonio/index.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
   <head>
+  <meta name="robots" content="noindex, follow" />
     <title>/v0.9/extensions/models/fonio/</title>
     <link rel="canonical" href="/v0.9/extensions/models/fonio/">
     <meta charset="utf-8">

--- a/docs/static/v0.9/extensibility/integrations/gatekeeper/index.html
+++ b/docs/static/v0.9/extensibility/integrations/gatekeeper/index.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
   <head>
+  <meta name="robots" content="noindex, follow" />
     <title>/v0.9/extensions/models/gatekeeper/</title>
     <link rel="canonical" href="/v0.9/extensions/models/gatekeeper/">
     <meta charset="utf-8">

--- a/docs/static/v0.9/extensibility/integrations/gcp/index.html
+++ b/docs/static/v0.9/extensibility/integrations/gcp/index.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
   <head>
+  <meta name="robots" content="noindex, follow" />
     <title>/v0.9/extensions/models/gcp/</title>
     <link rel="canonical" href="/v0.9/extensions/models/gcp/">
     <meta charset="utf-8">

--- a/docs/static/v0.9/extensibility/integrations/gerrit-operator/index.html
+++ b/docs/static/v0.9/extensibility/integrations/gerrit-operator/index.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
   <head>
+  <meta name="robots" content="noindex, follow" />
     <title>/v0.9/extensions/models/gerrit-operator/</title>
     <link rel="canonical" href="/v0.9/extensions/models/gerrit-operator/">
     <meta charset="utf-8">

--- a/docs/static/v0.9/extensibility/integrations/github-actions-runner-operator/index.html
+++ b/docs/static/v0.9/extensibility/integrations/github-actions-runner-operator/index.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
   <head>
+  <meta name="robots" content="noindex, follow" />
     <title>/v0.9/extensions/models/github-actions-runner-operator/</title>
     <link rel="canonical" href="/v0.9/extensions/models/github-actions-runner-operator/">
     <meta charset="utf-8">

--- a/docs/static/v0.9/extensibility/integrations/github-actions-runners/index.html
+++ b/docs/static/v0.9/extensibility/integrations/github-actions-runners/index.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
   <head>
+  <meta name="robots" content="noindex, follow" />
     <title>/v0.9/extensions/models/github-actions-runners/</title>
     <link rel="canonical" href="/v0.9/extensions/models/github-actions-runners/">
     <meta charset="utf-8">

--- a/docs/static/v0.9/extensibility/integrations/gitlab-controller/index.html
+++ b/docs/static/v0.9/extensibility/integrations/gitlab-controller/index.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
   <head>
+  <meta name="robots" content="noindex, follow" />
     <title>/v0.9/extensions/models/gitlab-controller/</title>
     <link rel="canonical" href="/v0.9/extensions/models/gitlab-controller/">
     <meta charset="utf-8">

--- a/docs/static/v0.9/extensibility/integrations/gitlab-runner-operator/index.html
+++ b/docs/static/v0.9/extensibility/integrations/gitlab-runner-operator/index.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
   <head>
+  <meta name="robots" content="noindex, follow" />
     <title>/v0.9/extensions/models/gitlab-runner-operator/</title>
     <link rel="canonical" href="/v0.9/extensions/models/gitlab-runner-operator/">
     <meta charset="utf-8">

--- a/docs/static/v0.9/extensibility/integrations/gitlab/index.html
+++ b/docs/static/v0.9/extensibility/integrations/gitlab/index.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
   <head>
+  <meta name="robots" content="noindex, follow" />
     <title>/v0.9/extensions/models/gitlab/</title>
     <link rel="canonical" href="/v0.9/extensions/models/gitlab/">
     <meta charset="utf-8">

--- a/docs/static/v0.9/extensibility/integrations/grafana-agent-operator/index.html
+++ b/docs/static/v0.9/extensibility/integrations/grafana-agent-operator/index.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
   <head>
+  <meta name="robots" content="noindex, follow" />
     <title>/v0.9/extensions/models/grafana-agent-operator/</title>
     <link rel="canonical" href="/v0.9/extensions/models/grafana-agent-operator/">
     <meta charset="utf-8">

--- a/docs/static/v0.9/extensibility/integrations/grafana-agent/index.html
+++ b/docs/static/v0.9/extensibility/integrations/grafana-agent/index.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
   <head>
+  <meta name="robots" content="noindex, follow" />
     <title>/v0.9/extensions/models/grafana-agent/</title>
     <link rel="canonical" href="/v0.9/extensions/models/grafana-agent/">
     <meta charset="utf-8">

--- a/docs/static/v0.9/extensibility/integrations/grafana-operator/index.html
+++ b/docs/static/v0.9/extensibility/integrations/grafana-operator/index.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
   <head>
+  <meta name="robots" content="noindex, follow" />
     <title>/v0.9/extensions/models/grafana-operator/</title>
     <link rel="canonical" href="/v0.9/extensions/models/grafana-operator/">
     <meta charset="utf-8">

--- a/docs/static/v0.9/extensibility/integrations/grafana-ui-server/index.html
+++ b/docs/static/v0.9/extensibility/integrations/grafana-ui-server/index.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
   <head>
+  <meta name="robots" content="noindex, follow" />
     <title>/v0.9/extensions/models/grafana-ui-server/</title>
     <link rel="canonical" href="/v0.9/extensions/models/grafana-ui-server/">
     <meta charset="utf-8">

--- a/docs/static/v0.9/extensibility/integrations/harbor-operator/index.html
+++ b/docs/static/v0.9/extensibility/integrations/harbor-operator/index.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
   <head>
+  <meta name="robots" content="noindex, follow" />
     <title>/v0.9/extensions/models/harbor-operator/</title>
     <link rel="canonical" href="/v0.9/extensions/models/harbor-operator/">
     <meta charset="utf-8">

--- a/docs/static/v0.9/extensibility/integrations/helm-controller/index.html
+++ b/docs/static/v0.9/extensibility/integrations/helm-controller/index.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
   <head>
+  <meta name="robots" content="noindex, follow" />
     <title>/v0.9/extensions/models/helm-controller/</title>
     <link rel="canonical" href="/v0.9/extensions/models/helm-controller/">
     <meta charset="utf-8">

--- a/docs/static/v0.9/extensibility/integrations/hexa/index.html
+++ b/docs/static/v0.9/extensibility/integrations/hexa/index.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
   <head>
+  <meta name="robots" content="noindex, follow" />
     <title>/v0.9/extensions/models/hexa/</title>
     <link rel="canonical" href="/v0.9/extensions/models/hexa/">
     <meta charset="utf-8">

--- a/docs/static/v0.9/extensibility/integrations/hybridnet/index.html
+++ b/docs/static/v0.9/extensibility/integrations/hybridnet/index.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
   <head>
+  <meta name="robots" content="noindex, follow" />
     <title>/v0.9/extensions/models/hybridnet/</title>
     <link rel="canonical" href="/v0.9/extensions/models/hybridnet/">
     <meta charset="utf-8">

--- a/docs/static/v0.9/extensibility/integrations/identity-manager/index.html
+++ b/docs/static/v0.9/extensibility/integrations/identity-manager/index.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
   <head>
+  <meta name="robots" content="noindex, follow" />
     <title>/v0.9/extensions/models/identity-manager/</title>
     <link rel="canonical" href="/v0.9/extensions/models/identity-manager/">
     <meta charset="utf-8">

--- a/docs/static/v0.9/extensibility/integrations/in-toto/index.html
+++ b/docs/static/v0.9/extensibility/integrations/in-toto/index.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
   <head>
+  <meta name="robots" content="noindex, follow" />
     <title>/v0.9/extensions/models/in-toto/</title>
     <link rel="canonical" href="/v0.9/extensions/models/in-toto/">
     <meta charset="utf-8">

--- a/docs/static/v0.9/extensibility/integrations/inclavare-containers/index.html
+++ b/docs/static/v0.9/extensibility/integrations/inclavare-containers/index.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
   <head>
+  <meta name="robots" content="noindex, follow" />
     <title>/v0.9/extensions/models/inclavare-containers/</title>
     <link rel="canonical" href="/v0.9/extensions/models/inclavare-containers/">
     <meta charset="utf-8">

--- a/docs/static/v0.9/extensibility/integrations/index.html
+++ b/docs/static/v0.9/extensibility/integrations/index.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
   <head>
+  <meta name="robots" content="noindex, follow" />
     <title>/v0.9/extensions/models/</title>
     <link rel="canonical" href="/v0.9/extensions/models/">
     <meta charset="utf-8">

--- a/docs/static/v0.9/extensibility/integrations/ingress-azure/index.html
+++ b/docs/static/v0.9/extensibility/integrations/ingress-azure/index.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
   <head>
+  <meta name="robots" content="noindex, follow" />
     <title>/v0.9/extensions/models/ingress-azure/</title>
     <link rel="canonical" href="/v0.9/extensions/models/ingress-azure/">
     <meta charset="utf-8">

--- a/docs/static/v0.9/extensibility/integrations/inlets-operator/index.html
+++ b/docs/static/v0.9/extensibility/integrations/inlets-operator/index.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
   <head>
+  <meta name="robots" content="noindex, follow" />
     <title>/v0.9/extensions/models/inlets-operator/</title>
     <link rel="canonical" href="/v0.9/extensions/models/inlets-operator/">
     <meta charset="utf-8">

--- a/docs/static/v0.9/extensibility/integrations/intel-device-plugins-operator/index.html
+++ b/docs/static/v0.9/extensibility/integrations/intel-device-plugins-operator/index.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
   <head>
+  <meta name="robots" content="noindex, follow" />
     <title>/v0.9/extensions/models/intel-device-plugins-operator/</title>
     <link rel="canonical" href="/v0.9/extensions/models/intel-device-plugins-operator/">
     <meta charset="utf-8">

--- a/docs/static/v0.9/extensibility/integrations/istio-base/index.html
+++ b/docs/static/v0.9/extensibility/integrations/istio-base/index.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
   <head>
+  <meta name="robots" content="noindex, follow" />
     <title>/v0.9/extensions/models/istio-base/</title>
     <link rel="canonical" href="/v0.9/extensions/models/istio-base/">
     <meta charset="utf-8">

--- a/docs/static/v0.9/extensibility/integrations/istio-operator/index.html
+++ b/docs/static/v0.9/extensibility/integrations/istio-operator/index.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
   <head>
+  <meta name="robots" content="noindex, follow" />
     <title>/v0.9/extensions/models/istio-operator/</title>
     <link rel="canonical" href="/v0.9/extensions/models/istio-operator/">
     <meta charset="utf-8">

--- a/docs/static/v0.9/extensibility/integrations/istio-ratelimit-operator/index.html
+++ b/docs/static/v0.9/extensibility/integrations/istio-ratelimit-operator/index.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
   <head>
+  <meta name="robots" content="noindex, follow" />
     <title>/v0.9/extensions/models/istio-ratelimit-operator/</title>
     <link rel="canonical" href="/v0.9/extensions/models/istio-ratelimit-operator/">
     <meta charset="utf-8">

--- a/docs/static/v0.9/extensibility/integrations/jaeger-operator/index.html
+++ b/docs/static/v0.9/extensibility/integrations/jaeger-operator/index.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
   <head>
+  <meta name="robots" content="noindex, follow" />
     <title>/v0.9/extensions/models/jaeger-operator/</title>
     <link rel="canonical" href="/v0.9/extensions/models/jaeger-operator/">
     <meta charset="utf-8">

--- a/docs/static/v0.9/extensibility/integrations/jaeger/index.html
+++ b/docs/static/v0.9/extensibility/integrations/jaeger/index.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
   <head>
+  <meta name="robots" content="noindex, follow" />
     <title>/v0.9/extensions/models/jaeger/</title>
     <link rel="canonical" href="/v0.9/extensions/models/jaeger/">
     <meta charset="utf-8">

--- a/docs/static/v0.9/extensibility/integrations/jenkins-operator/index.html
+++ b/docs/static/v0.9/extensibility/integrations/jenkins-operator/index.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
   <head>
+  <meta name="robots" content="noindex, follow" />
     <title>/v0.9/extensions/models/jenkins-operator/</title>
     <link rel="canonical" href="/v0.9/extensions/models/jenkins-operator/">
     <meta charset="utf-8">

--- a/docs/static/v0.9/extensibility/integrations/jira-service-desk-operator/index.html
+++ b/docs/static/v0.9/extensibility/integrations/jira-service-desk-operator/index.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
   <head>
+  <meta name="robots" content="noindex, follow" />
     <title>/v0.9/extensions/models/jira-service-desk-operator/</title>
     <link rel="canonical" href="/v0.9/extensions/models/jira-service-desk-operator/">
     <meta charset="utf-8">

--- a/docs/static/v0.9/extensibility/integrations/jitsi/index.html
+++ b/docs/static/v0.9/extensibility/integrations/jitsi/index.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
   <head>
+  <meta name="robots" content="noindex, follow" />
     <title>/v0.9/extensions/models/jitsi/</title>
     <link rel="canonical" href="/v0.9/extensions/models/jitsi/">
     <meta charset="utf-8">

--- a/docs/static/v0.9/extensibility/integrations/k3s/index.html
+++ b/docs/static/v0.9/extensibility/integrations/k3s/index.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
   <head>
+  <meta name="robots" content="noindex, follow" />
     <title>/v0.9/extensions/models/k3s/</title>
     <link rel="canonical" href="/v0.9/extensions/models/k3s/">
     <meta charset="utf-8">

--- a/docs/static/v0.9/extensibility/integrations/k6-operator/index.html
+++ b/docs/static/v0.9/extensibility/integrations/k6-operator/index.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
   <head>
+  <meta name="robots" content="noindex, follow" />
     <title>/v0.9/extensions/models/k6-operator/</title>
     <link rel="canonical" href="/v0.9/extensions/models/k6-operator/">
     <meta charset="utf-8">

--- a/docs/static/v0.9/extensibility/integrations/k8gb/index.html
+++ b/docs/static/v0.9/extensibility/integrations/k8gb/index.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
   <head>
+  <meta name="robots" content="noindex, follow" />
     <title>/v0.9/extensions/models/k8gb/</title>
     <link rel="canonical" href="/v0.9/extensions/models/k8gb/">
     <meta charset="utf-8">

--- a/docs/static/v0.9/extensibility/integrations/k8s-config-connector/index.html
+++ b/docs/static/v0.9/extensibility/integrations/k8s-config-connector/index.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
   <head>
+  <meta name="robots" content="noindex, follow" />
     <title>/v0.9/extensions/models/k8s-config-connector/</title>
     <link rel="canonical" href="/v0.9/extensions/models/k8s-config-connector/">
     <meta charset="utf-8">

--- a/docs/static/v0.9/extensibility/integrations/k8svault-controller/index.html
+++ b/docs/static/v0.9/extensibility/integrations/k8svault-controller/index.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
   <head>
+  <meta name="robots" content="noindex, follow" />
     <title>/v0.9/extensions/models/k8svault-controller/</title>
     <link rel="canonical" href="/v0.9/extensions/models/k8svault-controller/">
     <meta charset="utf-8">

--- a/docs/static/v0.9/extensibility/integrations/kanister-operator/index.html
+++ b/docs/static/v0.9/extensibility/integrations/kanister-operator/index.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
   <head>
+  <meta name="robots" content="noindex, follow" />
     <title>/v0.9/extensions/models/kanister-operator/</title>
     <link rel="canonical" href="/v0.9/extensions/models/kanister-operator/">
     <meta charset="utf-8">

--- a/docs/static/v0.9/extensibility/integrations/karmada/index.html
+++ b/docs/static/v0.9/extensibility/integrations/karmada/index.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
   <head>
+  <meta name="robots" content="noindex, follow" />
     <title>/v0.9/extensions/models/karmada/</title>
     <link rel="canonical" href="/v0.9/extensions/models/karmada/">
     <meta charset="utf-8">

--- a/docs/static/v0.9/extensibility/integrations/karpenter/index.html
+++ b/docs/static/v0.9/extensibility/integrations/karpenter/index.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
   <head>
+  <meta name="robots" content="noindex, follow" />
     <title>/v0.9/extensions/models/karpenter/</title>
     <link rel="canonical" href="/v0.9/extensions/models/karpenter/">
     <meta charset="utf-8">

--- a/docs/static/v0.9/extensibility/integrations/katib/index.html
+++ b/docs/static/v0.9/extensibility/integrations/katib/index.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
   <head>
+  <meta name="robots" content="noindex, follow" />
     <title>/v0.9/extensions/models/katib/</title>
     <link rel="canonical" href="/v0.9/extensions/models/katib/">
     <meta charset="utf-8">

--- a/docs/static/v0.9/extensibility/integrations/keda-http-scaler/index.html
+++ b/docs/static/v0.9/extensibility/integrations/keda-http-scaler/index.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
   <head>
+  <meta name="robots" content="noindex, follow" />
     <title>/v0.9/extensions/models/keda-http-scaler/</title>
     <link rel="canonical" href="/v0.9/extensions/models/keda-http-scaler/">
     <meta charset="utf-8">

--- a/docs/static/v0.9/extensibility/integrations/keda/index.html
+++ b/docs/static/v0.9/extensibility/integrations/keda/index.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
   <head>
+  <meta name="robots" content="noindex, follow" />
     <title>/v0.9/extensions/models/keda/</title>
     <link rel="canonical" href="/v0.9/extensions/models/keda/">
     <meta charset="utf-8">

--- a/docs/static/v0.9/extensibility/integrations/keycloak-operator/index.html
+++ b/docs/static/v0.9/extensibility/integrations/keycloak-operator/index.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
   <head>
+  <meta name="robots" content="noindex, follow" />
     <title>/v0.9/extensions/models/keycloak-operator/</title>
     <link rel="canonical" href="/v0.9/extensions/models/keycloak-operator/">
     <meta charset="utf-8">

--- a/docs/static/v0.9/extensibility/integrations/keylime/index.html
+++ b/docs/static/v0.9/extensibility/integrations/keylime/index.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
   <head>
+  <meta name="robots" content="noindex, follow" />
     <title>/v0.9/extensions/models/keylime/</title>
     <link rel="canonical" href="/v0.9/extensions/models/keylime/">
     <meta charset="utf-8">

--- a/docs/static/v0.9/extensibility/integrations/kiali-operator/index.html
+++ b/docs/static/v0.9/extensibility/integrations/kiali-operator/index.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
   <head>
+  <meta name="robots" content="noindex, follow" />
     <title>/v0.9/extensions/models/kiali-operator/</title>
     <link rel="canonical" href="/v0.9/extensions/models/kiali-operator/">
     <meta charset="utf-8">

--- a/docs/static/v0.9/extensibility/integrations/knative-eventing/index.html
+++ b/docs/static/v0.9/extensibility/integrations/knative-eventing/index.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
   <head>
+  <meta name="robots" content="noindex, follow" />
     <title>/v0.9/extensions/models/knative-eventing/</title>
     <link rel="canonical" href="/v0.9/extensions/models/knative-eventing/">
     <meta charset="utf-8">

--- a/docs/static/v0.9/extensibility/integrations/knative-serving/index.html
+++ b/docs/static/v0.9/extensibility/integrations/knative-serving/index.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
   <head>
+  <meta name="robots" content="noindex, follow" />
     <title>/v0.9/extensions/models/knative-serving/</title>
     <link rel="canonical" href="/v0.9/extensions/models/knative-serving/">
     <meta charset="utf-8">

--- a/docs/static/v0.9/extensibility/integrations/knative/index.html
+++ b/docs/static/v0.9/extensibility/integrations/knative/index.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
   <head>
+  <meta name="robots" content="noindex, follow" />
     <title>/v0.9/extensions/models/knative/</title>
     <link rel="canonical" href="/v0.9/extensions/models/knative/">
     <meta charset="utf-8">

--- a/docs/static/v0.9/extensibility/integrations/kommander/index.html
+++ b/docs/static/v0.9/extensibility/integrations/kommander/index.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
   <head>
+  <meta name="robots" content="noindex, follow" />
     <title>/v0.9/extensions/models/kommander/</title>
     <link rel="canonical" href="/v0.9/extensions/models/kommander/">
     <meta charset="utf-8">

--- a/docs/static/v0.9/extensibility/integrations/kong-mesh/index.html
+++ b/docs/static/v0.9/extensibility/integrations/kong-mesh/index.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
   <head>
+  <meta name="robots" content="noindex, follow" />
     <title>/v0.9/extensions/models/kong-mesh/</title>
     <link rel="canonical" href="/v0.9/extensions/models/kong-mesh/">
     <meta charset="utf-8">

--- a/docs/static/v0.9/extensibility/integrations/kong/index.html
+++ b/docs/static/v0.9/extensibility/integrations/kong/index.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
   <head>
+  <meta name="robots" content="noindex, follow" />
     <title>/v0.9/extensions/models/kong/</title>
     <link rel="canonical" href="/v0.9/extensions/models/kong/">
     <meta charset="utf-8">

--- a/docs/static/v0.9/extensibility/integrations/kube-arangodb/index.html
+++ b/docs/static/v0.9/extensibility/integrations/kube-arangodb/index.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
   <head>
+  <meta name="robots" content="noindex, follow" />
     <title>/v0.9/extensions/models/kube-arangodb/</title>
     <link rel="canonical" href="/v0.9/extensions/models/kube-arangodb/">
     <meta charset="utf-8">

--- a/docs/static/v0.9/extensibility/integrations/kube-prometheus-stack/index.html
+++ b/docs/static/v0.9/extensibility/integrations/kube-prometheus-stack/index.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
   <head>
+  <meta name="robots" content="noindex, follow" />
     <title>/v0.9/extensions/models/kube-prometheus-stack/</title>
     <link rel="canonical" href="/v0.9/extensions/models/kube-prometheus-stack/">
     <meta charset="utf-8">

--- a/docs/static/v0.9/extensibility/integrations/kube-prometheus/index.html
+++ b/docs/static/v0.9/extensibility/integrations/kube-prometheus/index.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
   <head>
+  <meta name="robots" content="noindex, follow" />
     <title>/v0.9/extensions/models/kube-prometheus/</title>
     <link rel="canonical" href="/v0.9/extensions/models/kube-prometheus/">
     <meta charset="utf-8">

--- a/docs/static/v0.9/extensibility/integrations/kube-rs/index.html
+++ b/docs/static/v0.9/extensibility/integrations/kube-rs/index.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
   <head>
+  <meta name="robots" content="noindex, follow" />
     <title>/v0.9/extensions/models/kube-rs/</title>
     <link rel="canonical" href="/v0.9/extensions/models/kube-rs/">
     <meta charset="utf-8">

--- a/docs/static/v0.9/extensibility/integrations/kube-ui-server/index.html
+++ b/docs/static/v0.9/extensibility/integrations/kube-ui-server/index.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
   <head>
+  <meta name="robots" content="noindex, follow" />
     <title>/v0.9/extensions/models/kube-ui-server/</title>
     <link rel="canonical" href="/v0.9/extensions/models/kube-ui-server/">
     <meta charset="utf-8">

--- a/docs/static/v0.9/extensibility/integrations/kubedb-catalog/index.html
+++ b/docs/static/v0.9/extensibility/integrations/kubedb-catalog/index.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
   <head>
+  <meta name="robots" content="noindex, follow" />
     <title>/v0.9/extensions/models/kubedb-catalog/</title>
     <link rel="canonical" href="/v0.9/extensions/models/kubedb-catalog/">
     <meta charset="utf-8">

--- a/docs/static/v0.9/extensibility/integrations/kubedb-crds/index.html
+++ b/docs/static/v0.9/extensibility/integrations/kubedb-crds/index.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
   <head>
+  <meta name="robots" content="noindex, follow" />
     <title>/v0.9/extensions/models/kubedb-crds/</title>
     <link rel="canonical" href="/v0.9/extensions/models/kubedb-crds/">
     <meta charset="utf-8">

--- a/docs/static/v0.9/extensibility/integrations/kubedb-grafana-dashboards/index.html
+++ b/docs/static/v0.9/extensibility/integrations/kubedb-grafana-dashboards/index.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
   <head>
+  <meta name="robots" content="noindex, follow" />
     <title>/v0.9/extensions/models/kubedb-grafana-dashboards/</title>
     <link rel="canonical" href="/v0.9/extensions/models/kubedb-grafana-dashboards/">
     <meta charset="utf-8">

--- a/docs/static/v0.9/extensibility/integrations/kubedb-metrics/index.html
+++ b/docs/static/v0.9/extensibility/integrations/kubedb-metrics/index.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
   <head>
+  <meta name="robots" content="noindex, follow" />
     <title>/v0.9/extensions/models/kubedb-metrics/</title>
     <link rel="canonical" href="/v0.9/extensions/models/kubedb-metrics/">
     <meta charset="utf-8">

--- a/docs/static/v0.9/extensibility/integrations/kubedb-ops-manager/index.html
+++ b/docs/static/v0.9/extensibility/integrations/kubedb-ops-manager/index.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
   <head>
+  <meta name="robots" content="noindex, follow" />
     <title>/v0.9/extensions/models/kubedb-ops-manager/</title>
     <link rel="canonical" href="/v0.9/extensions/models/kubedb-ops-manager/">
     <meta charset="utf-8">

--- a/docs/static/v0.9/extensibility/integrations/kubedb-opscenter/index.html
+++ b/docs/static/v0.9/extensibility/integrations/kubedb-opscenter/index.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
   <head>
+  <meta name="robots" content="noindex, follow" />
     <title>/v0.9/extensions/models/kubedb-opscenter/</title>
     <link rel="canonical" href="/v0.9/extensions/models/kubedb-opscenter/">
     <meta charset="utf-8">

--- a/docs/static/v0.9/extensibility/integrations/kubedb-ui-server/index.html
+++ b/docs/static/v0.9/extensibility/integrations/kubedb-ui-server/index.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
   <head>
+  <meta name="robots" content="noindex, follow" />
     <title>/v0.9/extensions/models/kubedb-ui-server/</title>
     <link rel="canonical" href="/v0.9/extensions/models/kubedb-ui-server/">
     <meta charset="utf-8">

--- a/docs/static/v0.9/extensibility/integrations/kubedb/index.html
+++ b/docs/static/v0.9/extensibility/integrations/kubedb/index.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
   <head>
+  <meta name="robots" content="noindex, follow" />
     <title>/v0.9/extensions/models/kubedb/</title>
     <link rel="canonical" href="/v0.9/extensions/models/kubedb/">
     <meta charset="utf-8">

--- a/docs/static/v0.9/extensibility/integrations/kubedl/index.html
+++ b/docs/static/v0.9/extensibility/integrations/kubedl/index.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
   <head>
+  <meta name="robots" content="noindex, follow" />
     <title>/v0.9/extensions/models/kubedl/</title>
     <link rel="canonical" href="/v0.9/extensions/models/kubedl/">
     <meta charset="utf-8">

--- a/docs/static/v0.9/extensibility/integrations/kubeflow/index.html
+++ b/docs/static/v0.9/extensibility/integrations/kubeflow/index.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
   <head>
+  <meta name="robots" content="noindex, follow" />
     <title>/v0.9/extensions/models/kubeflow/</title>
     <link rel="canonical" href="/v0.9/extensions/models/kubeflow/">
     <meta charset="utf-8">

--- a/docs/static/v0.9/extensibility/integrations/kubeform-provider-aws/index.html
+++ b/docs/static/v0.9/extensibility/integrations/kubeform-provider-aws/index.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
   <head>
+  <meta name="robots" content="noindex, follow" />
     <title>/v0.9/extensions/models/kubeform-provider-aws/</title>
     <link rel="canonical" href="/v0.9/extensions/models/kubeform-provider-aws/">
     <meta charset="utf-8">

--- a/docs/static/v0.9/extensibility/integrations/kubegems-edge/index.html
+++ b/docs/static/v0.9/extensibility/integrations/kubegems-edge/index.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
   <head>
+  <meta name="robots" content="noindex, follow" />
     <title>/v0.9/extensions/models/kubegems-edge/</title>
     <link rel="canonical" href="/v0.9/extensions/models/kubegems-edge/">
     <meta charset="utf-8">

--- a/docs/static/v0.9/extensibility/integrations/kubegems-installer/index.html
+++ b/docs/static/v0.9/extensibility/integrations/kubegems-installer/index.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
   <head>
+  <meta name="robots" content="noindex, follow" />
     <title>/v0.9/extensions/models/kubegems-installer/</title>
     <link rel="canonical" href="/v0.9/extensions/models/kubegems-installer/">
     <meta charset="utf-8">

--- a/docs/static/v0.9/extensibility/integrations/kubegems-local/index.html
+++ b/docs/static/v0.9/extensibility/integrations/kubegems-local/index.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
   <head>
+  <meta name="robots" content="noindex, follow" />
     <title>/v0.9/extensions/models/kubegems-local/</title>
     <link rel="canonical" href="/v0.9/extensions/models/kubegems-local/">
     <meta charset="utf-8">

--- a/docs/static/v0.9/extensibility/integrations/kubegems-models/index.html
+++ b/docs/static/v0.9/extensibility/integrations/kubegems-models/index.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
   <head>
+  <meta name="robots" content="noindex, follow" />
     <title>/v0.9/extensions/models/kubegems-models/</title>
     <link rel="canonical" href="/v0.9/extensions/models/kubegems-models/">
     <meta charset="utf-8">

--- a/docs/static/v0.9/extensibility/integrations/kubegems/index.html
+++ b/docs/static/v0.9/extensibility/integrations/kubegems/index.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
   <head>
+  <meta name="robots" content="noindex, follow" />
     <title>/v0.9/extensions/models/kubegems/</title>
     <link rel="canonical" href="/v0.9/extensions/models/kubegems/">
     <meta charset="utf-8">

--- a/docs/static/v0.9/extensibility/integrations/kuberhealthy/index.html
+++ b/docs/static/v0.9/extensibility/integrations/kuberhealthy/index.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
   <head>
+  <meta name="robots" content="noindex, follow" />
     <title>/v0.9/extensions/models/kuberhealthy/</title>
     <link rel="canonical" href="/v0.9/extensions/models/kuberhealthy/">
     <meta charset="utf-8">

--- a/docs/static/v0.9/extensibility/integrations/kubernetes-ingress/index.html
+++ b/docs/static/v0.9/extensibility/integrations/kubernetes-ingress/index.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
   <head>
+  <meta name="robots" content="noindex, follow" />
     <title>/v0.9/extensions/models/kubernetes-ingress/</title>
     <link rel="canonical" href="/v0.9/extensions/models/kubernetes-ingress/">
     <meta charset="utf-8">

--- a/docs/static/v0.9/extensibility/integrations/kubernetes-secret-generator/index.html
+++ b/docs/static/v0.9/extensibility/integrations/kubernetes-secret-generator/index.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
   <head>
+  <meta name="robots" content="noindex, follow" />
     <title>/v0.9/extensions/models/kubernetes-secret-generator/</title>
     <link rel="canonical" href="/v0.9/extensions/models/kubernetes-secret-generator/">
     <meta charset="utf-8">

--- a/docs/static/v0.9/extensibility/integrations/kubernetes/index.html
+++ b/docs/static/v0.9/extensibility/integrations/kubernetes/index.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
   <head>
+  <meta name="robots" content="noindex, follow" />
     <title>/v0.9/extensions/models/kubernetes/</title>
     <link rel="canonical" href="/v0.9/extensions/models/kubernetes/">
     <meta charset="utf-8">

--- a/docs/static/v0.9/extensibility/integrations/kubeslice-worker/index.html
+++ b/docs/static/v0.9/extensibility/integrations/kubeslice-worker/index.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
   <head>
+  <meta name="robots" content="noindex, follow" />
     <title>/v0.9/extensions/models/kubeslice-worker/</title>
     <link rel="canonical" href="/v0.9/extensions/models/kubeslice-worker/">
     <meta charset="utf-8">

--- a/docs/static/v0.9/extensibility/integrations/kubesphere/index.html
+++ b/docs/static/v0.9/extensibility/integrations/kubesphere/index.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
   <head>
+  <meta name="robots" content="noindex, follow" />
     <title>/v0.9/extensions/models/kubesphere/</title>
     <link rel="canonical" href="/v0.9/extensions/models/kubesphere/">
     <meta charset="utf-8">

--- a/docs/static/v0.9/extensibility/integrations/kubevault-catalog/index.html
+++ b/docs/static/v0.9/extensibility/integrations/kubevault-catalog/index.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
   <head>
+  <meta name="robots" content="noindex, follow" />
     <title>/v0.9/extensions/models/kubevault-catalog/</title>
     <link rel="canonical" href="/v0.9/extensions/models/kubevault-catalog/">
     <meta charset="utf-8">

--- a/docs/static/v0.9/extensibility/integrations/kubevault-crds/index.html
+++ b/docs/static/v0.9/extensibility/integrations/kubevault-crds/index.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
   <head>
+  <meta name="robots" content="noindex, follow" />
     <title>/v0.9/extensions/models/kubevault-crds/</title>
     <link rel="canonical" href="/v0.9/extensions/models/kubevault-crds/">
     <meta charset="utf-8">

--- a/docs/static/v0.9/extensibility/integrations/kubevault-metrics/index.html
+++ b/docs/static/v0.9/extensibility/integrations/kubevault-metrics/index.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
   <head>
+  <meta name="robots" content="noindex, follow" />
     <title>/v0.9/extensions/models/kubevault-metrics/</title>
     <link rel="canonical" href="/v0.9/extensions/models/kubevault-metrics/">
     <meta charset="utf-8">

--- a/docs/static/v0.9/extensibility/integrations/kubevault-operator/index.html
+++ b/docs/static/v0.9/extensibility/integrations/kubevault-operator/index.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
   <head>
+  <meta name="robots" content="noindex, follow" />
     <title>/v0.9/extensions/models/kubevault-operator/</title>
     <link rel="canonical" href="/v0.9/extensions/models/kubevault-operator/">
     <meta charset="utf-8">

--- a/docs/static/v0.9/extensibility/integrations/kubevault/index.html
+++ b/docs/static/v0.9/extensibility/integrations/kubevault/index.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
   <head>
+  <meta name="robots" content="noindex, follow" />
     <title>/v0.9/extensions/models/kubevault/</title>
     <link rel="canonical" href="/v0.9/extensions/models/kubevault/">
     <meta charset="utf-8">

--- a/docs/static/v0.9/extensibility/integrations/kubevela/index.html
+++ b/docs/static/v0.9/extensibility/integrations/kubevela/index.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
   <head>
+  <meta name="robots" content="noindex, follow" />
     <title>/v0.9/extensions/models/kubevela/</title>
     <link rel="canonical" href="/v0.9/extensions/models/kubevela/">
     <meta charset="utf-8">

--- a/docs/static/v0.9/extensibility/integrations/kubevirt/index.html
+++ b/docs/static/v0.9/extensibility/integrations/kubevirt/index.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
   <head>
+  <meta name="robots" content="noindex, follow" />
     <title>/v0.9/extensions/models/kubevirt/</title>
     <link rel="canonical" href="/v0.9/extensions/models/kubevirt/">
     <meta charset="utf-8">

--- a/docs/static/v0.9/extensibility/integrations/kuma/index.html
+++ b/docs/static/v0.9/extensibility/integrations/kuma/index.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
   <head>
+  <meta name="robots" content="noindex, follow" />
     <title>/v0.9/extensions/models/kuma/</title>
     <link rel="canonical" href="/v0.9/extensions/models/kuma/">
     <meta charset="utf-8">

--- a/docs/static/v0.9/extensibility/integrations/kured/index.html
+++ b/docs/static/v0.9/extensibility/integrations/kured/index.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
   <head>
+  <meta name="robots" content="noindex, follow" />
     <title>/v0.9/extensions/models/kured/</title>
     <link rel="canonical" href="/v0.9/extensions/models/kured/">
     <meta charset="utf-8">

--- a/docs/static/v0.9/extensibility/integrations/kusk-gateway/index.html
+++ b/docs/static/v0.9/extensibility/integrations/kusk-gateway/index.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
   <head>
+  <meta name="robots" content="noindex, follow" />
     <title>/v0.9/extensions/models/kusk-gateway/</title>
     <link rel="canonical" href="/v0.9/extensions/models/kusk-gateway/">
     <meta charset="utf-8">

--- a/docs/static/v0.9/extensibility/integrations/kyverno-monitor/index.html
+++ b/docs/static/v0.9/extensibility/integrations/kyverno-monitor/index.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
   <head>
+  <meta name="robots" content="noindex, follow" />
     <title>/v0.9/extensions/models/kyverno-monitor/</title>
     <link rel="canonical" href="/v0.9/extensions/models/kyverno-monitor/">
     <meta charset="utf-8">

--- a/docs/static/v0.9/extensibility/integrations/kyverno-operator/index.html
+++ b/docs/static/v0.9/extensibility/integrations/kyverno-operator/index.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
   <head>
+  <meta name="robots" content="noindex, follow" />
     <title>/v0.9/extensions/models/kyverno-operator/</title>
     <link rel="canonical" href="/v0.9/extensions/models/kyverno-operator/">
     <meta charset="utf-8">

--- a/docs/static/v0.9/extensibility/integrations/kyverno/index.html
+++ b/docs/static/v0.9/extensibility/integrations/kyverno/index.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
   <head>
+  <meta name="robots" content="noindex, follow" />
     <title>/v0.9/extensions/models/kyverno/</title>
     <link rel="canonical" href="/v0.9/extensions/models/kyverno/">
     <meta charset="utf-8">

--- a/docs/static/v0.9/extensibility/integrations/linkerd/index.html
+++ b/docs/static/v0.9/extensibility/integrations/linkerd/index.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
   <head>
+  <meta name="robots" content="noindex, follow" />
     <title>/v0.9/extensions/models/linkerd/</title>
     <link rel="canonical" href="/v0.9/extensions/models/linkerd/">
     <meta charset="utf-8">

--- a/docs/static/v0.9/extensibility/integrations/linux/index.html
+++ b/docs/static/v0.9/extensibility/integrations/linux/index.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
   <head>
+  <meta name="robots" content="noindex, follow" />
     <title>/v0.9/extensions/models/linux/</title>
     <link rel="canonical" href="/v0.9/extensions/models/linux/">
     <meta charset="utf-8">

--- a/docs/static/v0.9/extensibility/integrations/litmus-core/index.html
+++ b/docs/static/v0.9/extensibility/integrations/litmus-core/index.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
   <head>
+  <meta name="robots" content="noindex, follow" />
     <title>/v0.9/extensions/models/litmus-core/</title>
     <link rel="canonical" href="/v0.9/extensions/models/litmus-core/">
     <meta charset="utf-8">

--- a/docs/static/v0.9/extensibility/integrations/loki-simple-scalable/index.html
+++ b/docs/static/v0.9/extensibility/integrations/loki-simple-scalable/index.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
   <head>
+  <meta name="robots" content="noindex, follow" />
     <title>/v0.9/extensions/models/loki-simple-scalable/</title>
     <link rel="canonical" href="/v0.9/extensions/models/loki-simple-scalable/">
     <meta charset="utf-8">

--- a/docs/static/v0.9/extensibility/integrations/loki/index.html
+++ b/docs/static/v0.9/extensibility/integrations/loki/index.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
   <head>
+  <meta name="robots" content="noindex, follow" />
     <title>/v0.9/extensions/models/loki/</title>
     <link rel="canonical" href="/v0.9/extensions/models/loki/">
     <meta charset="utf-8">

--- a/docs/static/v0.9/extensibility/integrations/longhorn/index.html
+++ b/docs/static/v0.9/extensibility/integrations/longhorn/index.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
   <head>
+  <meta name="robots" content="noindex, follow" />
     <title>/v0.9/extensions/models/longhorn/</title>
     <link rel="canonical" href="/v0.9/extensions/models/longhorn/">
     <meta charset="utf-8">

--- a/docs/static/v0.9/extensibility/integrations/loxilb/index.html
+++ b/docs/static/v0.9/extensibility/integrations/loxilb/index.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
   <head>
+  <meta name="robots" content="noindex, follow" />
     <title>/v0.9/extensions/models/loxilb/</title>
     <link rel="canonical" href="/v0.9/extensions/models/loxilb/">
     <meta charset="utf-8">

--- a/docs/static/v0.9/extensibility/integrations/mattermost-operator/index.html
+++ b/docs/static/v0.9/extensibility/integrations/mattermost-operator/index.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
   <head>
+  <meta name="robots" content="noindex, follow" />
     <title>/v0.9/extensions/models/mattermost-operator/</title>
     <link rel="canonical" href="/v0.9/extensions/models/mattermost-operator/">
     <meta charset="utf-8">

--- a/docs/static/v0.9/extensibility/integrations/meshery-core/index.html
+++ b/docs/static/v0.9/extensibility/integrations/meshery-core/index.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
   <head>
+  <meta name="robots" content="noindex, follow" />
     <title>/v0.9/extensions/models/meshery-core/</title>
     <link rel="canonical" href="/v0.9/extensions/models/meshery-core/">
     <meta charset="utf-8">

--- a/docs/static/v0.9/extensibility/integrations/metallb/index.html
+++ b/docs/static/v0.9/extensibility/integrations/metallb/index.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
   <head>
+  <meta name="robots" content="noindex, follow" />
     <title>/v0.9/extensions/models/metallb/</title>
     <link rel="canonical" href="/v0.9/extensions/models/metallb/">
     <meta charset="utf-8">

--- a/docs/static/v0.9/extensibility/integrations/metrics-server/index.html
+++ b/docs/static/v0.9/extensibility/integrations/metrics-server/index.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
   <head>
+  <meta name="robots" content="noindex, follow" />
     <title>/v0.9/extensions/models/metrics-server/</title>
     <link rel="canonical" href="/v0.9/extensions/models/metrics-server/">
     <meta charset="utf-8">

--- a/docs/static/v0.9/extensibility/integrations/mimir-distributed/index.html
+++ b/docs/static/v0.9/extensibility/integrations/mimir-distributed/index.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
   <head>
+  <meta name="robots" content="noindex, follow" />
     <title>/v0.9/extensions/models/mimir-distributed/</title>
     <link rel="canonical" href="/v0.9/extensions/models/mimir-distributed/">
     <meta charset="utf-8">

--- a/docs/static/v0.9/extensibility/integrations/minio-operator/index.html
+++ b/docs/static/v0.9/extensibility/integrations/minio-operator/index.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
   <head>
+  <meta name="robots" content="noindex, follow" />
     <title>/v0.9/extensions/models/minio-operator/</title>
     <link rel="canonical" href="/v0.9/extensions/models/minio-operator/">
     <meta charset="utf-8">

--- a/docs/static/v0.9/extensibility/integrations/mpi-operator/index.html
+++ b/docs/static/v0.9/extensibility/integrations/mpi-operator/index.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
   <head>
+  <meta name="robots" content="noindex, follow" />
     <title>/v0.9/extensions/models/mpi-operator/</title>
     <link rel="canonical" href="/v0.9/extensions/models/mpi-operator/">
     <meta charset="utf-8">

--- a/docs/static/v0.9/extensibility/integrations/mysql-operator/index.html
+++ b/docs/static/v0.9/extensibility/integrations/mysql-operator/index.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
   <head>
+  <meta name="robots" content="noindex, follow" />
     <title>/v0.9/extensions/models/mysql-operator/</title>
     <link rel="canonical" href="/v0.9/extensions/models/mysql-operator/">
     <meta charset="utf-8">

--- a/docs/static/v0.9/extensibility/integrations/nats-operator/index.html
+++ b/docs/static/v0.9/extensibility/integrations/nats-operator/index.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
   <head>
+  <meta name="robots" content="noindex, follow" />
     <title>/v0.9/extensions/models/nats-operator/</title>
     <link rel="canonical" href="/v0.9/extensions/models/nats-operator/">
     <meta charset="utf-8">

--- a/docs/static/v0.9/extensibility/integrations/newrelic-operator/index.html
+++ b/docs/static/v0.9/extensibility/integrations/newrelic-operator/index.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
   <head>
+  <meta name="robots" content="noindex, follow" />
     <title>/v0.9/extensions/models/newrelic-operator/</title>
     <link rel="canonical" href="/v0.9/extensions/models/newrelic-operator/">
     <meta charset="utf-8">

--- a/docs/static/v0.9/extensibility/integrations/nginx-ingress/index.html
+++ b/docs/static/v0.9/extensibility/integrations/nginx-ingress/index.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
   <head>
+  <meta name="robots" content="noindex, follow" />
     <title>/v0.9/extensions/models/nginx-ingress/</title>
     <link rel="canonical" href="/v0.9/extensions/models/nginx-ingress/">
     <meta charset="utf-8">

--- a/docs/static/v0.9/extensibility/integrations/nginx-service-mesh/index.html
+++ b/docs/static/v0.9/extensibility/integrations/nginx-service-mesh/index.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
   <head>
+  <meta name="robots" content="noindex, follow" />
     <title>/v0.9/extensions/models/nginx-service-mesh/</title>
     <link rel="canonical" href="/v0.9/extensions/models/nginx-service-mesh/">
     <meta charset="utf-8">

--- a/docs/static/v0.9/extensibility/integrations/nginx/index.html
+++ b/docs/static/v0.9/extensibility/integrations/nginx/index.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
   <head>
+  <meta name="robots" content="noindex, follow" />
     <title>/v0.9/extensions/models/nginx/</title>
     <link rel="canonical" href="/v0.9/extensions/models/nginx/">
     <meta charset="utf-8">

--- a/docs/static/v0.9/extensibility/integrations/ngrok-operator/index.html
+++ b/docs/static/v0.9/extensibility/integrations/ngrok-operator/index.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
   <head>
+  <meta name="robots" content="noindex, follow" />
     <title>/v0.9/extensions/models/ngrok-operator/</title>
     <link rel="canonical" href="/v0.9/extensions/models/ngrok-operator/">
     <meta charset="utf-8">

--- a/docs/static/v0.9/extensibility/integrations/nirmata-aws-adapter/index.html
+++ b/docs/static/v0.9/extensibility/integrations/nirmata-aws-adapter/index.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
   <head>
+  <meta name="robots" content="noindex, follow" />
     <title>/v0.9/extensions/models/nirmata-aws-adapter/</title>
     <link rel="canonical" href="/v0.9/extensions/models/nirmata-aws-adapter/">
     <meta charset="utf-8">

--- a/docs/static/v0.9/extensibility/integrations/nirmata-venafi-adapter/index.html
+++ b/docs/static/v0.9/extensibility/integrations/nirmata-venafi-adapter/index.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
   <head>
+  <meta name="robots" content="noindex, follow" />
     <title>/v0.9/extensions/models/nirmata-venafi-adapter/</title>
     <link rel="canonical" href="/v0.9/extensions/models/nirmata-venafi-adapter/">
     <meta charset="utf-8">

--- a/docs/static/v0.9/extensibility/integrations/nocalhost/index.html
+++ b/docs/static/v0.9/extensibility/integrations/nocalhost/index.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
   <head>
+  <meta name="robots" content="noindex, follow" />
     <title>/v0.9/extensions/models/nocalhost/</title>
     <link rel="canonical" href="/v0.9/extensions/models/nocalhost/">
     <meta charset="utf-8">

--- a/docs/static/v0.9/extensibility/integrations/notary/index.html
+++ b/docs/static/v0.9/extensibility/integrations/notary/index.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
   <head>
+  <meta name="robots" content="noindex, follow" />
     <title>/v0.9/extensions/models/notary/</title>
     <link rel="canonical" href="/v0.9/extensions/models/notary/">
     <meta charset="utf-8">

--- a/docs/static/v0.9/extensibility/integrations/ondat-operator/index.html
+++ b/docs/static/v0.9/extensibility/integrations/ondat-operator/index.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
   <head>
+  <meta name="robots" content="noindex, follow" />
     <title>/v0.9/extensions/models/ondat-operator/</title>
     <link rel="canonical" href="/v0.9/extensions/models/ondat-operator/">
     <meta charset="utf-8">

--- a/docs/static/v0.9/extensibility/integrations/open-cluster-management/index.html
+++ b/docs/static/v0.9/extensibility/integrations/open-cluster-management/index.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
   <head>
+  <meta name="robots" content="noindex, follow" />
     <title>/v0.9/extensions/models/open-cluster-management/</title>
     <link rel="canonical" href="/v0.9/extensions/models/open-cluster-management/">
     <meta charset="utf-8">

--- a/docs/static/v0.9/extensibility/integrations/open-policy-agent-(opa)/index.html
+++ b/docs/static/v0.9/extensibility/integrations/open-policy-agent-(opa)/index.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
   <head>
+  <meta name="robots" content="noindex, follow" />
     <title>/v0.9/extensions/models/open-policy-agent-opa/</title>
     <link rel="canonical" href="/v0.9/extensions/models/open-policy-agent-opa/">
     <meta charset="utf-8">

--- a/docs/static/v0.9/extensibility/integrations/open-service-mesh/index.html
+++ b/docs/static/v0.9/extensibility/integrations/open-service-mesh/index.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
   <head>
+  <meta name="robots" content="noindex, follow" />
     <title>/v0.9/extensions/models/open-service-mesh/</title>
     <link rel="canonical" href="/v0.9/extensions/models/open-service-mesh/">
     <meta charset="utf-8">

--- a/docs/static/v0.9/extensibility/integrations/openebs/index.html
+++ b/docs/static/v0.9/extensibility/integrations/openebs/index.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
   <head>
+  <meta name="robots" content="noindex, follow" />
     <title>/v0.9/extensions/models/openebs/</title>
     <link rel="canonical" href="/v0.9/extensions/models/openebs/">
     <meta charset="utf-8">

--- a/docs/static/v0.9/extensibility/integrations/openelb/index.html
+++ b/docs/static/v0.9/extensibility/integrations/openelb/index.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
   <head>
+  <meta name="robots" content="noindex, follow" />
     <title>/v0.9/extensions/models/openelb/</title>
     <link rel="canonical" href="/v0.9/extensions/models/openelb/">
     <meta charset="utf-8">

--- a/docs/static/v0.9/extensibility/integrations/openfeature/index.html
+++ b/docs/static/v0.9/extensibility/integrations/openfeature/index.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
   <head>
+  <meta name="robots" content="noindex, follow" />
     <title>/v0.9/extensions/models/openfeature/</title>
     <link rel="canonical" href="/v0.9/extensions/models/openfeature/">
     <meta charset="utf-8">

--- a/docs/static/v0.9/extensibility/integrations/opengitops/index.html
+++ b/docs/static/v0.9/extensibility/integrations/opengitops/index.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
   <head>
+  <meta name="robots" content="noindex, follow" />
     <title>/v0.9/extensions/models/opengitops/</title>
     <link rel="canonical" href="/v0.9/extensions/models/opengitops/">
     <meta charset="utf-8">

--- a/docs/static/v0.9/extensibility/integrations/openkruise/index.html
+++ b/docs/static/v0.9/extensibility/integrations/openkruise/index.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
   <head>
+  <meta name="robots" content="noindex, follow" />
     <title>/v0.9/extensions/models/openkruise/</title>
     <link rel="canonical" href="/v0.9/extensions/models/openkruise/">
     <meta charset="utf-8">

--- a/docs/static/v0.9/extensibility/integrations/openmetrics/index.html
+++ b/docs/static/v0.9/extensibility/integrations/openmetrics/index.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
   <head>
+  <meta name="robots" content="noindex, follow" />
     <title>/v0.9/extensions/models/openmetrics/</title>
     <link rel="canonical" href="/v0.9/extensions/models/openmetrics/">
     <meta charset="utf-8">

--- a/docs/static/v0.9/extensibility/integrations/opentelemetry-operator/index.html
+++ b/docs/static/v0.9/extensibility/integrations/opentelemetry-operator/index.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
   <head>
+  <meta name="robots" content="noindex, follow" />
     <title>/v0.9/extensions/models/opentelemetry-operator/</title>
     <link rel="canonical" href="/v0.9/extensions/models/opentelemetry-operator/">
     <meta charset="utf-8">

--- a/docs/static/v0.9/extensibility/integrations/operator-framework/index.html
+++ b/docs/static/v0.9/extensibility/integrations/operator-framework/index.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
   <head>
+  <meta name="robots" content="noindex, follow" />
     <title>/v0.9/extensions/models/operator-framework/</title>
     <link rel="canonical" href="/v0.9/extensions/models/operator-framework/">
     <meta charset="utf-8">

--- a/docs/static/v0.9/extensibility/integrations/oras/index.html
+++ b/docs/static/v0.9/extensibility/integrations/oras/index.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
   <head>
+  <meta name="robots" content="noindex, follow" />
     <title>/v0.9/extensions/models/oras/</title>
     <link rel="canonical" href="/v0.9/extensions/models/oras/">
     <meta charset="utf-8">

--- a/docs/static/v0.9/extensibility/integrations/parsec/index.html
+++ b/docs/static/v0.9/extensibility/integrations/parsec/index.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
   <head>
+  <meta name="robots" content="noindex, follow" />
     <title>/v0.9/extensions/models/parsec/</title>
     <link rel="canonical" href="/v0.9/extensions/models/parsec/">
     <meta charset="utf-8">

--- a/docs/static/v0.9/extensibility/integrations/pg-db/index.html
+++ b/docs/static/v0.9/extensibility/integrations/pg-db/index.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
   <head>
+  <meta name="robots" content="noindex, follow" />
     <title>/v0.9/extensions/models/pg-db/</title>
     <link rel="canonical" href="/v0.9/extensions/models/pg-db/">
     <meta charset="utf-8">

--- a/docs/static/v0.9/extensibility/integrations/pg-operator/index.html
+++ b/docs/static/v0.9/extensibility/integrations/pg-operator/index.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
   <head>
+  <meta name="robots" content="noindex, follow" />
     <title>/v0.9/extensions/models/pg-operator/</title>
     <link rel="canonical" href="/v0.9/extensions/models/pg-operator/">
     <meta charset="utf-8">

--- a/docs/static/v0.9/extensibility/integrations/pgo/index.html
+++ b/docs/static/v0.9/extensibility/integrations/pgo/index.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
   <head>
+  <meta name="robots" content="noindex, follow" />
     <title>/v0.9/extensions/models/pgo/</title>
     <link rel="canonical" href="/v0.9/extensions/models/pgo/">
     <meta charset="utf-8">

--- a/docs/static/v0.9/extensibility/integrations/piraeus-datastore/index.html
+++ b/docs/static/v0.9/extensibility/integrations/piraeus-datastore/index.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
   <head>
+  <meta name="robots" content="noindex, follow" />
     <title>/v0.9/extensions/models/piraeus-datastore/</title>
     <link rel="canonical" href="/v0.9/extensions/models/piraeus-datastore/">
     <meta charset="utf-8">

--- a/docs/static/v0.9/extensibility/integrations/pixie/index.html
+++ b/docs/static/v0.9/extensibility/integrations/pixie/index.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
   <head>
+  <meta name="robots" content="noindex, follow" />
     <title>/v0.9/extensions/models/pixie/</title>
     <link rel="canonical" href="/v0.9/extensions/models/pixie/">
     <meta charset="utf-8">

--- a/docs/static/v0.9/extensibility/integrations/porter/index.html
+++ b/docs/static/v0.9/extensibility/integrations/porter/index.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
   <head>
+  <meta name="robots" content="noindex, follow" />
     <title>/v0.9/extensions/models/porter/</title>
     <link rel="canonical" href="/v0.9/extensions/models/porter/">
     <meta charset="utf-8">

--- a/docs/static/v0.9/extensibility/integrations/postgres-controller/index.html
+++ b/docs/static/v0.9/extensibility/integrations/postgres-controller/index.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
   <head>
+  <meta name="robots" content="noindex, follow" />
     <title>/v0.9/extensions/models/postgres-controller/</title>
     <link rel="canonical" href="/v0.9/extensions/models/postgres-controller/">
     <meta charset="utf-8">

--- a/docs/static/v0.9/extensibility/integrations/postgres-operator/index.html
+++ b/docs/static/v0.9/extensibility/integrations/postgres-operator/index.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
   <head>
+  <meta name="robots" content="noindex, follow" />
     <title>/v0.9/extensions/models/postgres-operator/</title>
     <link rel="canonical" href="/v0.9/extensions/models/postgres-operator/">
     <meta charset="utf-8">

--- a/docs/static/v0.9/extensibility/integrations/postgres-with-operator/index.html
+++ b/docs/static/v0.9/extensibility/integrations/postgres-with-operator/index.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
   <head>
+  <meta name="robots" content="noindex, follow" />
     <title>/v0.9/extensions/models/postgres-with-operator/</title>
     <link rel="canonical" href="/v0.9/extensions/models/postgres-with-operator/">
     <meta charset="utf-8">

--- a/docs/static/v0.9/extensibility/integrations/posthog/index.html
+++ b/docs/static/v0.9/extensibility/integrations/posthog/index.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
   <head>
+  <meta name="robots" content="noindex, follow" />
     <title>/v0.9/extensions/models/posthog/</title>
     <link rel="canonical" href="/v0.9/extensions/models/posthog/">
     <meta charset="utf-8">

--- a/docs/static/v0.9/extensibility/integrations/pravega/index.html
+++ b/docs/static/v0.9/extensibility/integrations/pravega/index.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
   <head>
+  <meta name="robots" content="noindex, follow" />
     <title>/v0.9/extensions/models/pravega/</title>
     <link rel="canonical" href="/v0.9/extensions/models/pravega/">
     <meta charset="utf-8">

--- a/docs/static/v0.9/extensibility/integrations/prometheus-operator-crds/index.html
+++ b/docs/static/v0.9/extensibility/integrations/prometheus-operator-crds/index.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
   <head>
+  <meta name="robots" content="noindex, follow" />
     <title>/v0.9/extensions/models/prometheus-operator-crds/</title>
     <link rel="canonical" href="/v0.9/extensions/models/prometheus-operator-crds/">
     <meta charset="utf-8">

--- a/docs/static/v0.9/extensibility/integrations/prometheus/index.html
+++ b/docs/static/v0.9/extensibility/integrations/prometheus/index.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
   <head>
+  <meta name="robots" content="noindex, follow" />
     <title>/v0.9/extensions/models/prometheus/</title>
     <link rel="canonical" href="/v0.9/extensions/models/prometheus/">
     <meta charset="utf-8">

--- a/docs/static/v0.9/extensibility/integrations/ps-db/index.html
+++ b/docs/static/v0.9/extensibility/integrations/ps-db/index.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
   <head>
+  <meta name="robots" content="noindex, follow" />
     <title>/v0.9/extensions/models/ps-db/</title>
     <link rel="canonical" href="/v0.9/extensions/models/ps-db/">
     <meta charset="utf-8">

--- a/docs/static/v0.9/extensibility/integrations/ps-operator/index.html
+++ b/docs/static/v0.9/extensibility/integrations/ps-operator/index.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
   <head>
+  <meta name="robots" content="noindex, follow" />
     <title>/v0.9/extensions/models/ps-operator/</title>
     <link rel="canonical" href="/v0.9/extensions/models/ps-operator/">
     <meta charset="utf-8">

--- a/docs/static/v0.9/extensibility/integrations/psmdb-db/index.html
+++ b/docs/static/v0.9/extensibility/integrations/psmdb-db/index.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
   <head>
+  <meta name="robots" content="noindex, follow" />
     <title>/v0.9/extensions/models/psmdb-db/</title>
     <link rel="canonical" href="/v0.9/extensions/models/psmdb-db/">
     <meta charset="utf-8">

--- a/docs/static/v0.9/extensibility/integrations/psmdb-operator/index.html
+++ b/docs/static/v0.9/extensibility/integrations/psmdb-operator/index.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
   <head>
+  <meta name="robots" content="noindex, follow" />
     <title>/v0.9/extensions/models/psmdb-operator/</title>
     <link rel="canonical" href="/v0.9/extensions/models/psmdb-operator/">
     <meta charset="utf-8">

--- a/docs/static/v0.9/extensibility/integrations/pulsar-operator/index.html
+++ b/docs/static/v0.9/extensibility/integrations/pulsar-operator/index.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
   <head>
+  <meta name="robots" content="noindex, follow" />
     <title>/v0.9/extensions/models/pulsar-operator/</title>
     <link rel="canonical" href="/v0.9/extensions/models/pulsar-operator/">
     <meta charset="utf-8">

--- a/docs/static/v0.9/extensibility/integrations/pulsar-resources-operator/index.html
+++ b/docs/static/v0.9/extensibility/integrations/pulsar-resources-operator/index.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
   <head>
+  <meta name="robots" content="noindex, follow" />
     <title>/v0.9/extensions/models/pulsar-resources-operator/</title>
     <link rel="canonical" href="/v0.9/extensions/models/pulsar-resources-operator/">
     <meta charset="utf-8">

--- a/docs/static/v0.9/extensibility/integrations/rabbitmq-cluster-operator/index.html
+++ b/docs/static/v0.9/extensibility/integrations/rabbitmq-cluster-operator/index.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
   <head>
+  <meta name="robots" content="noindex, follow" />
     <title>/v0.9/extensions/models/rabbitmq-cluster-operator/</title>
     <link rel="canonical" href="/v0.9/extensions/models/rabbitmq-cluster-operator/">
     <meta charset="utf-8">

--- a/docs/static/v0.9/extensibility/integrations/rabbitmq-operator/index.html
+++ b/docs/static/v0.9/extensibility/integrations/rabbitmq-operator/index.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
   <head>
+  <meta name="robots" content="noindex, follow" />
     <title>/v0.9/extensions/models/rabbitmq-operator/</title>
     <link rel="canonical" href="/v0.9/extensions/models/rabbitmq-operator/">
     <meta charset="utf-8">

--- a/docs/static/v0.9/extensibility/integrations/redis-operator/index.html
+++ b/docs/static/v0.9/extensibility/integrations/redis-operator/index.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
   <head>
+  <meta name="robots" content="noindex, follow" />
     <title>/v0.9/extensions/models/redis-operator/</title>
     <link rel="canonical" href="/v0.9/extensions/models/redis-operator/">
     <meta charset="utf-8">

--- a/docs/static/v0.9/extensibility/integrations/rook-ceph-cluster/index.html
+++ b/docs/static/v0.9/extensibility/integrations/rook-ceph-cluster/index.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
   <head>
+  <meta name="robots" content="noindex, follow" />
     <title>/v0.9/extensions/models/rook-ceph-cluster/</title>
     <link rel="canonical" href="/v0.9/extensions/models/rook-ceph-cluster/">
     <meta charset="utf-8">

--- a/docs/static/v0.9/extensibility/integrations/rook/index.html
+++ b/docs/static/v0.9/extensibility/integrations/rook/index.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
   <head>
+  <meta name="robots" content="noindex, follow" />
     <title>/v0.9/extensions/models/rook/</title>
     <link rel="canonical" href="/v0.9/extensions/models/rook/">
     <meta charset="utf-8">

--- a/docs/static/v0.9/extensibility/integrations/rustrial-aws-eks-iam-auth-controller/index.html
+++ b/docs/static/v0.9/extensibility/integrations/rustrial-aws-eks-iam-auth-controller/index.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
   <head>
+  <meta name="robots" content="noindex, follow" />
     <title>/v0.9/extensions/models/rustrial-aws-eks-iam-auth-controller/</title>
     <link rel="canonical" href="/v0.9/extensions/models/rustrial-aws-eks-iam-auth-controller/">
     <meta charset="utf-8">

--- a/docs/static/v0.9/extensibility/integrations/saferwall/index.html
+++ b/docs/static/v0.9/extensibility/integrations/saferwall/index.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
   <head>
+  <meta name="robots" content="noindex, follow" />
     <title>/v0.9/extensions/models/saferwall/</title>
     <link rel="canonical" href="/v0.9/extensions/models/saferwall/">
     <meta charset="utf-8">

--- a/docs/static/v0.9/extensibility/integrations/scheduler-plugins/index.html
+++ b/docs/static/v0.9/extensibility/integrations/scheduler-plugins/index.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
   <head>
+  <meta name="robots" content="noindex, follow" />
     <title>/v0.9/extensions/models/scheduler-plugins/</title>
     <link rel="canonical" href="/v0.9/extensions/models/scheduler-plugins/">
     <meta charset="utf-8">

--- a/docs/static/v0.9/extensibility/integrations/schemahero/index.html
+++ b/docs/static/v0.9/extensibility/integrations/schemahero/index.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
   <head>
+  <meta name="robots" content="noindex, follow" />
     <title>/v0.9/extensions/models/schemahero/</title>
     <link rel="canonical" href="/v0.9/extensions/models/schemahero/">
     <meta charset="utf-8">

--- a/docs/static/v0.9/extensibility/integrations/security-role-perm-operator-svc/index.html
+++ b/docs/static/v0.9/extensibility/integrations/security-role-perm-operator-svc/index.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
   <head>
+  <meta name="robots" content="noindex, follow" />
     <title>/v0.9/extensions/models/security-role-perm-operator-svc/</title>
     <link rel="canonical" href="/v0.9/extensions/models/security-role-perm-operator-svc/">
     <meta charset="utf-8">

--- a/docs/static/v0.9/extensibility/integrations/serverless-workflow/index.html
+++ b/docs/static/v0.9/extensibility/integrations/serverless-workflow/index.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
   <head>
+  <meta name="robots" content="noindex, follow" />
     <title>/v0.9/extensions/models/serverless-workflow/</title>
     <link rel="canonical" href="/v0.9/extensions/models/serverless-workflow/">
     <meta charset="utf-8">

--- a/docs/static/v0.9/extensibility/integrations/sidekick/index.html
+++ b/docs/static/v0.9/extensibility/integrations/sidekick/index.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
   <head>
+  <meta name="robots" content="noindex, follow" />
     <title>/v0.9/extensions/models/sidekick/</title>
     <link rel="canonical" href="/v0.9/extensions/models/sidekick/">
     <meta charset="utf-8">

--- a/docs/static/v0.9/extensibility/integrations/skooner/index.html
+++ b/docs/static/v0.9/extensibility/integrations/skooner/index.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
   <head>
+  <meta name="robots" content="noindex, follow" />
     <title>/v0.9/extensions/models/skooner/</title>
     <link rel="canonical" href="/v0.9/extensions/models/skooner/">
     <meta charset="utf-8">

--- a/docs/static/v0.9/extensibility/integrations/slack-operator/index.html
+++ b/docs/static/v0.9/extensibility/integrations/slack-operator/index.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
   <head>
+  <meta name="robots" content="noindex, follow" />
     <title>/v0.9/extensions/models/slack-operator/</title>
     <link rel="canonical" href="/v0.9/extensions/models/slack-operator/">
     <meta charset="utf-8">

--- a/docs/static/v0.9/extensibility/integrations/sm-kubernetes/index.html
+++ b/docs/static/v0.9/extensibility/integrations/sm-kubernetes/index.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
   <head>
+  <meta name="robots" content="noindex, follow" />
     <title>/v0.9/extensions/models/sm-kubernetes/</title>
     <link rel="canonical" href="/v0.9/extensions/models/sm-kubernetes/">
     <meta charset="utf-8">

--- a/docs/static/v0.9/extensibility/integrations/solr-operator/index.html
+++ b/docs/static/v0.9/extensibility/integrations/solr-operator/index.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
   <head>
+  <meta name="robots" content="noindex, follow" />
     <title>/v0.9/extensions/models/solr-operator/</title>
     <link rel="canonical" href="/v0.9/extensions/models/solr-operator/">
     <meta charset="utf-8">

--- a/docs/static/v0.9/extensibility/integrations/spiffe/index.html
+++ b/docs/static/v0.9/extensibility/integrations/spiffe/index.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
   <head>
+  <meta name="robots" content="noindex, follow" />
     <title>/v0.9/extensions/models/spiffe/</title>
     <link rel="canonical" href="/v0.9/extensions/models/spiffe/">
     <meta charset="utf-8">

--- a/docs/static/v0.9/extensibility/integrations/spire/index.html
+++ b/docs/static/v0.9/extensibility/integrations/spire/index.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
   <head>
+  <meta name="robots" content="noindex, follow" />
     <title>/v0.9/extensions/models/spire/</title>
     <link rel="canonical" href="/v0.9/extensions/models/spire/">
     <meta charset="utf-8">

--- a/docs/static/v0.9/extensibility/integrations/stackgres-operator/index.html
+++ b/docs/static/v0.9/extensibility/integrations/stackgres-operator/index.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
   <head>
+  <meta name="robots" content="noindex, follow" />
     <title>/v0.9/extensions/models/stackgres-operator/</title>
     <link rel="canonical" href="/v0.9/extensions/models/stackgres-operator/">
     <meta charset="utf-8">

--- a/docs/static/v0.9/extensibility/integrations/strimzi-kafka-operator/index.html
+++ b/docs/static/v0.9/extensibility/integrations/strimzi-kafka-operator/index.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
   <head>
+  <meta name="robots" content="noindex, follow" />
     <title>/v0.9/extensions/models/strimzi-kafka-operator/</title>
     <link rel="canonical" href="/v0.9/extensions/models/strimzi-kafka-operator/">
     <meta charset="utf-8">

--- a/docs/static/v0.9/extensibility/integrations/strimzi-registry-operator/index.html
+++ b/docs/static/v0.9/extensibility/integrations/strimzi-registry-operator/index.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
   <head>
+  <meta name="robots" content="noindex, follow" />
     <title>/v0.9/extensions/models/strimzi-registry-operator/</title>
     <link rel="canonical" href="/v0.9/extensions/models/strimzi-registry-operator/">
     <meta charset="utf-8">

--- a/docs/static/v0.9/extensibility/integrations/submariner/index.html
+++ b/docs/static/v0.9/extensibility/integrations/submariner/index.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
   <head>
+  <meta name="robots" content="noindex, follow" />
     <title>/v0.9/extensions/models/submariner/</title>
     <link rel="canonical" href="/v0.9/extensions/models/submariner/">
     <meta charset="utf-8">

--- a/docs/static/v0.9/extensibility/integrations/supabase/index.html
+++ b/docs/static/v0.9/extensibility/integrations/supabase/index.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
   <head>
+  <meta name="robots" content="noindex, follow" />
     <title>/v0.9/extensions/models/supabase/</title>
     <link rel="canonical" href="/v0.9/extensions/models/supabase/">
     <meta charset="utf-8">

--- a/docs/static/v0.9/extensibility/integrations/superedge/index.html
+++ b/docs/static/v0.9/extensibility/integrations/superedge/index.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
   <head>
+  <meta name="robots" content="noindex, follow" />
     <title>/v0.9/extensions/models/superedge/</title>
     <link rel="canonical" href="/v0.9/extensions/models/superedge/">
     <meta charset="utf-8">

--- a/docs/static/v0.9/extensibility/integrations/telepresence/index.html
+++ b/docs/static/v0.9/extensibility/integrations/telepresence/index.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
   <head>
+  <meta name="robots" content="noindex, follow" />
     <title>/v0.9/extensions/models/telepresence/</title>
     <link rel="canonical" href="/v0.9/extensions/models/telepresence/">
     <meta charset="utf-8">

--- a/docs/static/v0.9/extensibility/integrations/teller/index.html
+++ b/docs/static/v0.9/extensibility/integrations/teller/index.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
   <head>
+  <meta name="robots" content="noindex, follow" />
     <title>/v0.9/extensions/models/teller/</title>
     <link rel="canonical" href="/v0.9/extensions/models/teller/">
     <meta charset="utf-8">

--- a/docs/static/v0.9/extensibility/integrations/tenant-operator/index.html
+++ b/docs/static/v0.9/extensibility/integrations/tenant-operator/index.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
   <head>
+  <meta name="robots" content="noindex, follow" />
     <title>/v0.9/extensions/models/tenant-operator/</title>
     <link rel="canonical" href="/v0.9/extensions/models/tenant-operator/">
     <meta charset="utf-8">

--- a/docs/static/v0.9/extensibility/integrations/terraform/index.html
+++ b/docs/static/v0.9/extensibility/integrations/terraform/index.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
   <head>
+  <meta name="robots" content="noindex, follow" />
     <title>/v0.9/extensions/models/terraform/</title>
     <link rel="canonical" href="/v0.9/extensions/models/terraform/">
     <meta charset="utf-8">

--- a/docs/static/v0.9/extensibility/integrations/thanos-operator/index.html
+++ b/docs/static/v0.9/extensibility/integrations/thanos-operator/index.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
   <head>
+  <meta name="robots" content="noindex, follow" />
     <title>/v0.9/extensions/models/thanos-operator/</title>
     <link rel="canonical" href="/v0.9/extensions/models/thanos-operator/">
     <meta charset="utf-8">

--- a/docs/static/v0.9/extensibility/integrations/thanos/index.html
+++ b/docs/static/v0.9/extensibility/integrations/thanos/index.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
   <head>
+  <meta name="robots" content="noindex, follow" />
     <title>/v0.9/extensions/models/thanos/</title>
     <link rel="canonical" href="/v0.9/extensions/models/thanos/">
     <meta charset="utf-8">

--- a/docs/static/v0.9/extensibility/integrations/tikv-operator/index.html
+++ b/docs/static/v0.9/extensibility/integrations/tikv-operator/index.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
   <head>
+  <meta name="robots" content="noindex, follow" />
     <title>/v0.9/extensions/models/tikv-operator/</title>
     <link rel="canonical" href="/v0.9/extensions/models/tikv-operator/">
     <meta charset="utf-8">

--- a/docs/static/v0.9/extensibility/integrations/tinkerbell/index.html
+++ b/docs/static/v0.9/extensibility/integrations/tinkerbell/index.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
   <head>
+  <meta name="robots" content="noindex, follow" />
     <title>/v0.9/extensions/models/tinkerbell/</title>
     <link rel="canonical" href="/v0.9/extensions/models/tinkerbell/">
     <meta charset="utf-8">

--- a/docs/static/v0.9/extensibility/integrations/tremor/index.html
+++ b/docs/static/v0.9/extensibility/integrations/tremor/index.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
   <head>
+  <meta name="robots" content="noindex, follow" />
     <title>/v0.9/extensions/models/tremor/</title>
     <link rel="canonical" href="/v0.9/extensions/models/tremor/">
     <meta charset="utf-8">

--- a/docs/static/v0.9/extensibility/integrations/trickster/index.html
+++ b/docs/static/v0.9/extensibility/integrations/trickster/index.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
   <head>
+  <meta name="robots" content="noindex, follow" />
     <title>/v0.9/extensions/models/trickster/</title>
     <link rel="canonical" href="/v0.9/extensions/models/trickster/">
     <meta charset="utf-8">

--- a/docs/static/v0.9/extensibility/integrations/tuf/index.html
+++ b/docs/static/v0.9/extensibility/integrations/tuf/index.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
   <head>
+  <meta name="robots" content="noindex, follow" />
     <title>/v0.9/extensions/models/tuf/</title>
     <link rel="canonical" href="/v0.9/extensions/models/tuf/">
     <meta charset="utf-8">

--- a/docs/static/v0.9/extensibility/integrations/vald-helm-operator/index.html
+++ b/docs/static/v0.9/extensibility/integrations/vald-helm-operator/index.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
   <head>
+  <meta name="robots" content="noindex, follow" />
     <title>/v0.9/extensions/models/vald-helm-operator/</title>
     <link rel="canonical" href="/v0.9/extensions/models/vald-helm-operator/">
     <meta charset="utf-8">

--- a/docs/static/v0.9/extensibility/integrations/vald/index.html
+++ b/docs/static/v0.9/extensibility/integrations/vald/index.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
   <head>
+  <meta name="robots" content="noindex, follow" />
     <title>/v0.9/extensions/models/vald/</title>
     <link rel="canonical" href="/v0.9/extensions/models/vald/">
     <meta charset="utf-8">

--- a/docs/static/v0.9/extensibility/integrations/vault-config-operator/index.html
+++ b/docs/static/v0.9/extensibility/integrations/vault-config-operator/index.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
   <head>
+  <meta name="robots" content="noindex, follow" />
     <title>/v0.9/extensions/models/vault-config-operator/</title>
     <link rel="canonical" href="/v0.9/extensions/models/vault-config-operator/">
     <meta charset="utf-8">

--- a/docs/static/v0.9/extensibility/integrations/vault-operator/index.html
+++ b/docs/static/v0.9/extensibility/integrations/vault-operator/index.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
   <head>
+  <meta name="robots" content="noindex, follow" />
     <title>/v0.9/extensions/models/vault-operator/</title>
     <link rel="canonical" href="/v0.9/extensions/models/vault-operator/">
     <meta charset="utf-8">

--- a/docs/static/v0.9/extensibility/integrations/vault-secrets/index.html
+++ b/docs/static/v0.9/extensibility/integrations/vault-secrets/index.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
   <head>
+  <meta name="robots" content="noindex, follow" />
     <title>/v0.9/extensions/models/vault-secrets/</title>
     <link rel="canonical" href="/v0.9/extensions/models/vault-secrets/">
     <meta charset="utf-8">

--- a/docs/static/v0.9/extensibility/integrations/vela-workflow/index.html
+++ b/docs/static/v0.9/extensibility/integrations/vela-workflow/index.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
   <head>
+  <meta name="robots" content="noindex, follow" />
     <title>/v0.9/extensions/models/vela-workflow/</title>
     <link rel="canonical" href="/v0.9/extensions/models/vela-workflow/">
     <meta charset="utf-8">

--- a/docs/static/v0.9/extensibility/integrations/velero-s3-deployment/index.html
+++ b/docs/static/v0.9/extensibility/integrations/velero-s3-deployment/index.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
   <head>
+  <meta name="robots" content="noindex, follow" />
     <title>/v0.9/extensions/models/velero-s3-deployment/</title>
     <link rel="canonical" href="/v0.9/extensions/models/velero-s3-deployment/">
     <meta charset="utf-8">

--- a/docs/static/v0.9/extensibility/integrations/velero/index.html
+++ b/docs/static/v0.9/extensibility/integrations/velero/index.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
   <head>
+  <meta name="robots" content="noindex, follow" />
     <title>/v0.9/extensions/models/velero/</title>
     <link rel="canonical" href="/v0.9/extensions/models/velero/">
     <meta charset="utf-8">

--- a/docs/static/v0.9/extensibility/integrations/victoria-metrics-k8s-stack/index.html
+++ b/docs/static/v0.9/extensibility/integrations/victoria-metrics-k8s-stack/index.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
   <head>
+  <meta name="robots" content="noindex, follow" />
     <title>/v0.9/extensions/models/victoria-metrics-k8s-stack/</title>
     <link rel="canonical" href="/v0.9/extensions/models/victoria-metrics-k8s-stack/">
     <meta charset="utf-8">

--- a/docs/static/v0.9/extensibility/integrations/vineyard/index.html
+++ b/docs/static/v0.9/extensibility/integrations/vineyard/index.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
   <head>
+  <meta name="robots" content="noindex, follow" />
     <title>/v0.9/extensions/models/vineyard/</title>
     <link rel="canonical" href="/v0.9/extensions/models/vineyard/">
     <meta charset="utf-8">

--- a/docs/static/v0.9/extensibility/integrations/virtual-kubelet/index.html
+++ b/docs/static/v0.9/extensibility/integrations/virtual-kubelet/index.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
   <head>
+  <meta name="robots" content="noindex, follow" />
     <title>/v0.9/extensions/models/virtual-kubelet/</title>
     <link rel="canonical" href="/v0.9/extensions/models/virtual-kubelet/">
     <meta charset="utf-8">

--- a/docs/static/v0.9/extensibility/integrations/vitess/index.html
+++ b/docs/static/v0.9/extensibility/integrations/vitess/index.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
   <head>
+  <meta name="robots" content="noindex, follow" />
     <title>/v0.9/extensions/models/vitess/</title>
     <link rel="canonical" href="/v0.9/extensions/models/vitess/">
     <meta charset="utf-8">

--- a/docs/static/v0.9/extensibility/integrations/volcano/index.html
+++ b/docs/static/v0.9/extensibility/integrations/volcano/index.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
   <head>
+  <meta name="robots" content="noindex, follow" />
     <title>/v0.9/extensions/models/volcano/</title>
     <link rel="canonical" href="/v0.9/extensions/models/volcano/">
     <meta charset="utf-8">

--- a/docs/static/v0.9/extensibility/integrations/wasmcloud/index.html
+++ b/docs/static/v0.9/extensibility/integrations/wasmcloud/index.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
   <head>
+  <meta name="robots" content="noindex, follow" />
     <title>/v0.9/extensions/models/wasmcloud/</title>
     <link rel="canonical" href="/v0.9/extensions/models/wasmcloud/">
     <meta charset="utf-8">

--- a/docs/static/v0.9/extensibility/integrations/wasmedgeruntime/index.html
+++ b/docs/static/v0.9/extensibility/integrations/wasmedgeruntime/index.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
   <head>
+  <meta name="robots" content="noindex, follow" />
     <title>/v0.9/extensions/models/wasmedgeruntime/</title>
     <link rel="canonical" href="/v0.9/extensions/models/wasmedgeruntime/">
     <meta charset="utf-8">

--- a/docs/static/v0.9/extensibility/integrations/whereabouts/index.html
+++ b/docs/static/v0.9/extensibility/integrations/whereabouts/index.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
   <head>
+  <meta name="robots" content="noindex, follow" />
     <title>/v0.9/extensions/models/whereabouts/</title>
     <link rel="canonical" href="/v0.9/extensions/models/whereabouts/">
     <meta charset="utf-8">

--- a/docs/static/v0.9/extensibility/integrations/windows/index.html
+++ b/docs/static/v0.9/extensibility/integrations/windows/index.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
   <head>
+  <meta name="robots" content="noindex, follow" />
     <title>/v0.9/extensions/models/windows/</title>
     <link rel="canonical" href="/v0.9/extensions/models/windows/">
     <meta charset="utf-8">

--- a/docs/static/v0.9/extensibility/integrations/wordpress-operator/index.html
+++ b/docs/static/v0.9/extensibility/integrations/wordpress-operator/index.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
   <head>
+  <meta name="robots" content="noindex, follow" />
     <title>/v0.9/extensions/models/wordpress-operator/</title>
     <link rel="canonical" href="/v0.9/extensions/models/wordpress-operator/">
     <meta charset="utf-8">

--- a/docs/static/v0.9/extensibility/load-generators/index.html
+++ b/docs/static/v0.9/extensibility/load-generators/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/extensibility/providers/index.html
+++ b/docs/static/v0.9/extensibility/providers/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/extensibility/ui/index.html
+++ b/docs/static/v0.9/extensibility/ui/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/extensibility/verify-compatibility/index.html
+++ b/docs/static/v0.9/extensibility/verify-compatibility/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/extensions/adapters/app-mesh/index.html
+++ b/docs/static/v0.9/extensions/adapters/app-mesh/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/extensions/adapters/cilium/index.html
+++ b/docs/static/v0.9/extensions/adapters/cilium/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/extensions/adapters/consul/index.html
+++ b/docs/static/v0.9/extensions/adapters/consul/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/extensions/adapters/index.html
+++ b/docs/static/v0.9/extensions/adapters/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/extensions/adapters/istio/index.html
+++ b/docs/static/v0.9/extensions/adapters/istio/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/extensions/adapters/kuma/index.html
+++ b/docs/static/v0.9/extensions/adapters/kuma/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/extensions/adapters/linkerd/index.html
+++ b/docs/static/v0.9/extensions/adapters/linkerd/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/extensions/adapters/nginx-sm/index.html
+++ b/docs/static/v0.9/extensions/adapters/nginx-sm/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/extensions/adapters/nighthawk/index.html
+++ b/docs/static/v0.9/extensions/adapters/nighthawk/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/extensions/adapters/nsm/index.html
+++ b/docs/static/v0.9/extensions/adapters/nsm/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/extensions/adapters/tanzu-sm/index.html
+++ b/docs/static/v0.9/extensions/adapters/tanzu-sm/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/extensions/adapters/traefik-mesh/index.html
+++ b/docs/static/v0.9/extensions/adapters/traefik-mesh/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/extensions/component-shape-guide/index.html
+++ b/docs/static/v0.9/extensions/component-shape-guide/index.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
   <head>
+  <meta name="robots" content="noindex, follow" />
     <title>/v0.9/guides/configuration-management/identifying-components/</title>
     <link rel="canonical" href="/v0.9/guides/configuration-management/identifying-components/">
     <meta charset="utf-8">

--- a/docs/static/v0.9/extensions/edges-shape-guide/index.html
+++ b/docs/static/v0.9/extensions/edges-shape-guide/index.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
   <head>
+  <meta name="robots" content="noindex, follow" />
     <title>/v0.9/guides/configuration-management/edges-guide/</title>
     <link rel="canonical" href="/v0.9/guides/configuration-management/edges-guide/">
     <meta charset="utf-8">

--- a/docs/static/v0.9/extensions/helm-kanvas-snapshot/index.html
+++ b/docs/static/v0.9/extensions/helm-kanvas-snapshot/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/extensions/import-export-designs/index.html
+++ b/docs/static/v0.9/extensions/import-export-designs/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/extensions/importing-a-design/index.html
+++ b/docs/static/v0.9/extensions/importing-a-design/index.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
   <head>
+  <meta name="robots" content="noindex, follow" />
     <title>/v0.9/extensions/import-export-designs/</title>
     <link rel="canonical" href="/v0.9/extensions/import-export-designs/">
     <meta charset="utf-8">

--- a/docs/static/v0.9/extensions/importing-an-application/index.html
+++ b/docs/static/v0.9/extensions/importing-an-application/index.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
   <head>
+  <meta name="robots" content="noindex, follow" />
     <title>/v0.9/extensions/import-export-designs/</title>
     <link rel="canonical" href="/v0.9/extensions/import-export-designs/">
     <meta charset="utf-8">

--- a/docs/static/v0.9/extensions/index.html
+++ b/docs/static/v0.9/extensions/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/extensions/integrations/index.html
+++ b/docs/static/v0.9/extensions/integrations/index.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
   <head>
+  <meta name="robots" content="noindex, follow" />
     <title>/v0.9/extensions/models/</title>
     <link rel="canonical" href="/v0.9/extensions/models/">
     <meta charset="utf-8">

--- a/docs/static/v0.9/extensions/kanvas-snapshot/index.html
+++ b/docs/static/v0.9/extensions/kanvas-snapshot/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/extensions/kanvas/index.html
+++ b/docs/static/v0.9/extensions/kanvas/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/extensions/kubectl-kanvas-snapshot/index.html
+++ b/docs/static/v0.9/extensions/kubectl-kanvas-snapshot/index.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
   <head>
+  <meta name="robots" content="noindex, follow" />
     <title>/v0.9/extensions/kubectl-meshsync-snapshot/</title>
     <link rel="canonical" href="/v0.9/extensions/kubectl-meshsync-snapshot/">
     <meta charset="utf-8">

--- a/docs/static/v0.9/extensions/kubectl-meshsync-snapshot/index.html
+++ b/docs/static/v0.9/extensions/kubectl-meshsync-snapshot/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/extensions/meshmap/index.html
+++ b/docs/static/v0.9/extensions/meshmap/index.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
   <head>
+  <meta name="robots" content="noindex, follow" />
     <title>/v0.9/extensions/kanvas/</title>
     <link rel="canonical" href="/v0.9/extensions/kanvas/">
     <meta charset="utf-8">

--- a/docs/static/v0.9/extensions/models/aad-pod-identity/index.html
+++ b/docs/static/v0.9/extensions/models/aad-pod-identity/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/extensions/models/accurate/index.html
+++ b/docs/static/v0.9/extensions/models/accurate/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/extensions/models/ace/index.html
+++ b/docs/static/v0.9/extensions/models/ace/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/extensions/models/actions-runner-controller/index.html
+++ b/docs/static/v0.9/extensions/models/actions-runner-controller/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/extensions/models/admin-console-operator/index.html
+++ b/docs/static/v0.9/extensions/models/admin-console-operator/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/extensions/models/aerokube/index.html
+++ b/docs/static/v0.9/extensions/models/aerokube/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/extensions/models/aerospike-kubernetes-operator/index.html
+++ b/docs/static/v0.9/extensions/models/aerospike-kubernetes-operator/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/extensions/models/aigisuk/index.html
+++ b/docs/static/v0.9/extensions/models/aigisuk/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/extensions/models/akri/index.html
+++ b/docs/static/v0.9/extensions/models/akri/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/extensions/models/aks-appgw-fe/index.html
+++ b/docs/static/v0.9/extensions/models/aks-appgw-fe/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/extensions/models/altinity-clickhouse-operator/index.html
+++ b/docs/static/v0.9/extensions/models/altinity-clickhouse-operator/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/extensions/models/ambassador/index.html
+++ b/docs/static/v0.9/extensions/models/ambassador/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/extensions/models/amd-gpu/index.html
+++ b/docs/static/v0.9/extensions/models/amd-gpu/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/extensions/models/antrea/index.html
+++ b/docs/static/v0.9/extensions/models/antrea/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/extensions/models/apache-shardingsphere-operator-charts/index.html
+++ b/docs/static/v0.9/extensions/models/apache-shardingsphere-operator-charts/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/extensions/models/aperture-agent/index.html
+++ b/docs/static/v0.9/extensions/models/aperture-agent/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/extensions/models/aperture-controller/index.html
+++ b/docs/static/v0.9/extensions/models/aperture-controller/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/extensions/models/apisix-ingress-controller/index.html
+++ b/docs/static/v0.9/extensions/models/apisix-ingress-controller/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/extensions/models/apisix/index.html
+++ b/docs/static/v0.9/extensions/models/apisix/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/extensions/models/application-crds/index.html
+++ b/docs/static/v0.9/extensions/models/application-crds/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/extensions/models/appmesh-controller/index.html
+++ b/docs/static/v0.9/extensions/models/appmesh-controller/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/extensions/models/argo-cd/index.html
+++ b/docs/static/v0.9/extensions/models/argo-cd/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/extensions/models/argo-workflows/index.html
+++ b/docs/static/v0.9/extensions/models/argo-workflows/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/extensions/models/argocd-operator/index.html
+++ b/docs/static/v0.9/extensions/models/argocd-operator/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/extensions/models/armory-spinnaker-operator/index.html
+++ b/docs/static/v0.9/extensions/models/armory-spinnaker-operator/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/extensions/models/artifact-hub/index.html
+++ b/docs/static/v0.9/extensions/models/artifact-hub/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/extensions/models/athenz/index.html
+++ b/docs/static/v0.9/extensions/models/athenz/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/extensions/models/aws-api-gateway-operator/index.html
+++ b/docs/static/v0.9/extensions/models/aws-api-gateway-operator/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/extensions/models/aws-apigatewayv2-controller/index.html
+++ b/docs/static/v0.9/extensions/models/aws-apigatewayv2-controller/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/extensions/models/aws-applicationautoscaling-controller/index.html
+++ b/docs/static/v0.9/extensions/models/aws-applicationautoscaling-controller/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/extensions/models/aws-cloudfront-controller/index.html
+++ b/docs/static/v0.9/extensions/models/aws-cloudfront-controller/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/extensions/models/aws-cloudtrail-controller/index.html
+++ b/docs/static/v0.9/extensions/models/aws-cloudtrail-controller/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/extensions/models/aws-cloudwatch-controller/index.html
+++ b/docs/static/v0.9/extensions/models/aws-cloudwatch-controller/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/extensions/models/aws-cloudwatchlogs-controller/index.html
+++ b/docs/static/v0.9/extensions/models/aws-cloudwatchlogs-controller/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/extensions/models/aws-documentdb-controller/index.html
+++ b/docs/static/v0.9/extensions/models/aws-documentdb-controller/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/extensions/models/aws-dynamodb-controller/index.html
+++ b/docs/static/v0.9/extensions/models/aws-dynamodb-controller/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/extensions/models/aws-ec2-controller/index.html
+++ b/docs/static/v0.9/extensions/models/aws-ec2-controller/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/extensions/models/aws-ecr-controller/index.html
+++ b/docs/static/v0.9/extensions/models/aws-ecr-controller/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/extensions/models/aws-ecs-controller/index.html
+++ b/docs/static/v0.9/extensions/models/aws-ecs-controller/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/extensions/models/aws-efs-controller/index.html
+++ b/docs/static/v0.9/extensions/models/aws-efs-controller/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/extensions/models/aws-eks-controller/index.html
+++ b/docs/static/v0.9/extensions/models/aws-eks-controller/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/extensions/models/aws-elasticache-controller/index.html
+++ b/docs/static/v0.9/extensions/models/aws-elasticache-controller/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/extensions/models/aws-elasticsearchservice-controller/index.html
+++ b/docs/static/v0.9/extensions/models/aws-elasticsearchservice-controller/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/extensions/models/aws-emrcontainers-controller/index.html
+++ b/docs/static/v0.9/extensions/models/aws-emrcontainers-controller/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/extensions/models/aws-eventbridge-controller/index.html
+++ b/docs/static/v0.9/extensions/models/aws-eventbridge-controller/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/extensions/models/aws-iam-controller/index.html
+++ b/docs/static/v0.9/extensions/models/aws-iam-controller/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/extensions/models/aws-kinesis-controller/index.html
+++ b/docs/static/v0.9/extensions/models/aws-kinesis-controller/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/extensions/models/aws-kms-controller/index.html
+++ b/docs/static/v0.9/extensions/models/aws-kms-controller/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/extensions/models/aws-lambda-controller/index.html
+++ b/docs/static/v0.9/extensions/models/aws-lambda-controller/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/extensions/models/aws-load-balancer-controller/index.html
+++ b/docs/static/v0.9/extensions/models/aws-load-balancer-controller/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/extensions/models/aws-memorydb-controller/index.html
+++ b/docs/static/v0.9/extensions/models/aws-memorydb-controller/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/extensions/models/aws-mq-controller/index.html
+++ b/docs/static/v0.9/extensions/models/aws-mq-controller/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/extensions/models/aws-node-termination-handler-2/index.html
+++ b/docs/static/v0.9/extensions/models/aws-node-termination-handler-2/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/extensions/models/aws-opensearchservice-controller/index.html
+++ b/docs/static/v0.9/extensions/models/aws-opensearchservice-controller/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/extensions/models/aws-prometheusservice-controller/index.html
+++ b/docs/static/v0.9/extensions/models/aws-prometheusservice-controller/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/extensions/models/aws-rds-controller/index.html
+++ b/docs/static/v0.9/extensions/models/aws-rds-controller/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/extensions/models/aws-route53-controller/index.html
+++ b/docs/static/v0.9/extensions/models/aws-route53-controller/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/extensions/models/aws-route53resolver-controller/index.html
+++ b/docs/static/v0.9/extensions/models/aws-route53resolver-controller/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/extensions/models/aws-s3-controller/index.html
+++ b/docs/static/v0.9/extensions/models/aws-s3-controller/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/extensions/models/aws-sagemaker-controller/index.html
+++ b/docs/static/v0.9/extensions/models/aws-sagemaker-controller/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/extensions/models/aws-secretsmanager-controller/index.html
+++ b/docs/static/v0.9/extensions/models/aws-secretsmanager-controller/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/extensions/models/aws-sfn-controller/index.html
+++ b/docs/static/v0.9/extensions/models/aws-sfn-controller/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/extensions/models/aws-sns-controller/index.html
+++ b/docs/static/v0.9/extensions/models/aws-sns-controller/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/extensions/models/aws-sqs-controller/index.html
+++ b/docs/static/v0.9/extensions/models/aws-sqs-controller/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/extensions/models/aws-ssm-controller/index.html
+++ b/docs/static/v0.9/extensions/models/aws-ssm-controller/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/extensions/models/aws-target-group-binding/index.html
+++ b/docs/static/v0.9/extensions/models/aws-target-group-binding/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/extensions/models/aws-vpc-cni/index.html
+++ b/docs/static/v0.9/extensions/models/aws-vpc-cni/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/extensions/models/aws/index.html
+++ b/docs/static/v0.9/extensions/models/aws/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/extensions/models/awx-operator/index.html
+++ b/docs/static/v0.9/extensions/models/awx-operator/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/extensions/models/azure-alerts-management/index.html
+++ b/docs/static/v0.9/extensions/models/azure-alerts-management/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/extensions/models/azure-api-management/index.html
+++ b/docs/static/v0.9/extensions/models/azure-api-management/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/extensions/models/azure-app-configuration/index.html
+++ b/docs/static/v0.9/extensions/models/azure-app-configuration/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/extensions/models/azure-app-service/index.html
+++ b/docs/static/v0.9/extensions/models/azure-app-service/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/extensions/models/azure-architecture/index.html
+++ b/docs/static/v0.9/extensions/models/azure-architecture/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/extensions/models/azure-authorization/index.html
+++ b/docs/static/v0.9/extensions/models/azure-authorization/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/extensions/models/azure-batch/index.html
+++ b/docs/static/v0.9/extensions/models/azure-batch/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/extensions/models/azure-cache/index.html
+++ b/docs/static/v0.9/extensions/models/azure-cache/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/extensions/models/azure-cdn/index.html
+++ b/docs/static/v0.9/extensions/models/azure-cdn/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/extensions/models/azure-compute/index.html
+++ b/docs/static/v0.9/extensions/models/azure-compute/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/extensions/models/azure-container-instance/index.html
+++ b/docs/static/v0.9/extensions/models/azure-container-instance/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/extensions/models/azure-container-registry/index.html
+++ b/docs/static/v0.9/extensions/models/azure-container-registry/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/extensions/models/azure-container-service/index.html
+++ b/docs/static/v0.9/extensions/models/azure-container-service/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/extensions/models/azure-data-factory/index.html
+++ b/docs/static/v0.9/extensions/models/azure-data-factory/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/extensions/models/azure-data-protection/index.html
+++ b/docs/static/v0.9/extensions/models/azure-data-protection/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/extensions/models/azure-db-for-mariadb/index.html
+++ b/docs/static/v0.9/extensions/models/azure-db-for-mariadb/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/extensions/models/azure-db-for-mysql/index.html
+++ b/docs/static/v0.9/extensions/models/azure-db-for-mysql/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/extensions/models/azure-db-for-postgresql/index.html
+++ b/docs/static/v0.9/extensions/models/azure-db-for-postgresql/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/extensions/models/azure-devices/index.html
+++ b/docs/static/v0.9/extensions/models/azure-devices/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/extensions/models/azure-documentdb/index.html
+++ b/docs/static/v0.9/extensions/models/azure-documentdb/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/extensions/models/azure-entra/index.html
+++ b/docs/static/v0.9/extensions/models/azure-entra/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/extensions/models/azure-event-grid/index.html
+++ b/docs/static/v0.9/extensions/models/azure-event-grid/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/extensions/models/azure-event-hub/index.html
+++ b/docs/static/v0.9/extensions/models/azure-event-hub/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/extensions/models/azure-insights/index.html
+++ b/docs/static/v0.9/extensions/models/azure-insights/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/extensions/models/azure-key-vault/index.html
+++ b/docs/static/v0.9/extensions/models/azure-key-vault/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/extensions/models/azure-kubernetes-configuration/index.html
+++ b/docs/static/v0.9/extensions/models/azure-kubernetes-configuration/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/extensions/models/azure-kubernetes-service/index.html
+++ b/docs/static/v0.9/extensions/models/azure-kubernetes-service/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/extensions/models/azure-kusto/index.html
+++ b/docs/static/v0.9/extensions/models/azure-kusto/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/extensions/models/azure-machine-learning-services/index.html
+++ b/docs/static/v0.9/extensions/models/azure-machine-learning-services/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/extensions/models/azure-managed-identity/index.html
+++ b/docs/static/v0.9/extensions/models/azure-managed-identity/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/extensions/models/azure-monitor/index.html
+++ b/docs/static/v0.9/extensions/models/azure-monitor/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/extensions/models/azure-network-frontdoor/index.html
+++ b/docs/static/v0.9/extensions/models/azure-network-frontdoor/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/extensions/models/azure-network/index.html
+++ b/docs/static/v0.9/extensions/models/azure-network/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/extensions/models/azure-notification-hubs/index.html
+++ b/docs/static/v0.9/extensions/models/azure-notification-hubs/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/extensions/models/azure-operational-insights/index.html
+++ b/docs/static/v0.9/extensions/models/azure-operational-insights/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/extensions/models/azure-operator/index.html
+++ b/docs/static/v0.9/extensions/models/azure-operator/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/extensions/models/azure-red-hat-openshift/index.html
+++ b/docs/static/v0.9/extensions/models/azure-red-hat-openshift/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/extensions/models/azure-resources/index.html
+++ b/docs/static/v0.9/extensions/models/azure-resources/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/extensions/models/azure-search/index.html
+++ b/docs/static/v0.9/extensions/models/azure-search/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/extensions/models/azure-service-bus/index.html
+++ b/docs/static/v0.9/extensions/models/azure-service-bus/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/extensions/models/azure-signalr-service/index.html
+++ b/docs/static/v0.9/extensions/models/azure-signalr-service/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/extensions/models/azure-sql/index.html
+++ b/docs/static/v0.9/extensions/models/azure-sql/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/extensions/models/azure-storage/index.html
+++ b/docs/static/v0.9/extensions/models/azure-storage/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/extensions/models/azure-subscription/index.html
+++ b/docs/static/v0.9/extensions/models/azure-subscription/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/extensions/models/azure-synapse/index.html
+++ b/docs/static/v0.9/extensions/models/azure-synapse/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/extensions/models/azure-web/index.html
+++ b/docs/static/v0.9/extensions/models/azure-web/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/extensions/models/azureorkestra/index.html
+++ b/docs/static/v0.9/extensions/models/azureorkestra/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/extensions/models/backend/index.html
+++ b/docs/static/v0.9/extensions/models/backend/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/extensions/models/backstage/index.html
+++ b/docs/static/v0.9/extensions/models/backstage/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/extensions/models/bfe/index.html
+++ b/docs/static/v0.9/extensions/models/bfe/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/extensions/models/bitwarden-crd-operator/index.html
+++ b/docs/static/v0.9/extensions/models/bitwarden-crd-operator/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/extensions/models/brigade/index.html
+++ b/docs/static/v0.9/extensions/models/brigade/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/extensions/models/buildpacks/index.html
+++ b/docs/static/v0.9/extensions/models/buildpacks/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/extensions/models/camel-k/index.html
+++ b/docs/static/v0.9/extensions/models/camel-k/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/extensions/models/capsule-proxy/index.html
+++ b/docs/static/v0.9/extensions/models/capsule-proxy/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/extensions/models/cass-operator/index.html
+++ b/docs/static/v0.9/extensions/models/cass-operator/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/extensions/models/cd-pipeline-operator/index.html
+++ b/docs/static/v0.9/extensions/models/cd-pipeline-operator/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/extensions/models/cdk8s/index.html
+++ b/docs/static/v0.9/extensions/models/cdk8s/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/extensions/models/cert-manager-crds/index.html
+++ b/docs/static/v0.9/extensions/models/cert-manager-crds/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/extensions/models/cert-manager-csi-driver-cacerts/index.html
+++ b/docs/static/v0.9/extensions/models/cert-manager-csi-driver-cacerts/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/extensions/models/cert-manager/index.html
+++ b/docs/static/v0.9/extensions/models/cert-manager/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/extensions/models/chaos-mesh/index.html
+++ b/docs/static/v0.9/extensions/models/chaos-mesh/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/extensions/models/chaos/index.html
+++ b/docs/static/v0.9/extensions/models/chaos/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/extensions/models/chaosblade-operator/index.html
+++ b/docs/static/v0.9/extensions/models/chaosblade-operator/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/extensions/models/cilium/index.html
+++ b/docs/static/v0.9/extensions/models/cilium/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/extensions/models/clickhouse/index.html
+++ b/docs/static/v0.9/extensions/models/clickhouse/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/extensions/models/cloud-custodian/index.html
+++ b/docs/static/v0.9/extensions/models/cloud-custodian/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/extensions/models/cloudbees-previews/index.html
+++ b/docs/static/v0.9/extensions/models/cloudbees-previews/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/extensions/models/cloudcore/index.html
+++ b/docs/static/v0.9/extensions/models/cloudcore/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/extensions/models/cloudevents/index.html
+++ b/docs/static/v0.9/extensions/models/cloudevents/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/extensions/models/cloudnative-pg/index.html
+++ b/docs/static/v0.9/extensions/models/cloudnative-pg/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/extensions/models/cluster-api-provider-openstack/index.html
+++ b/docs/static/v0.9/extensions/models/cluster-api-provider-openstack/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/extensions/models/clusterpedia/index.html
+++ b/docs/static/v0.9/extensions/models/clusterpedia/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/extensions/models/cni-hostnic/index.html
+++ b/docs/static/v0.9/extensions/models/cni-hostnic/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/extensions/models/cockroachdb-operator/index.html
+++ b/docs/static/v0.9/extensions/models/cockroachdb-operator/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/extensions/models/confidential-containers/index.html
+++ b/docs/static/v0.9/extensions/models/confidential-containers/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/extensions/models/consul/index.html
+++ b/docs/static/v0.9/extensions/models/consul/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/extensions/models/containerd/index.html
+++ b/docs/static/v0.9/extensions/models/containerd/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/extensions/models/containerssh/index.html
+++ b/docs/static/v0.9/extensions/models/containerssh/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/extensions/models/contour-operator/index.html
+++ b/docs/static/v0.9/extensions/models/contour-operator/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/extensions/models/contrail-analytics/index.html
+++ b/docs/static/v0.9/extensions/models/contrail-analytics/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/extensions/models/coredns/index.html
+++ b/docs/static/v0.9/extensions/models/coredns/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/extensions/models/cortex/index.html
+++ b/docs/static/v0.9/extensions/models/cortex/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/extensions/models/couchbase-monitor-stack/index.html
+++ b/docs/static/v0.9/extensions/models/couchbase-monitor-stack/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/extensions/models/couchbase-operator/index.html
+++ b/docs/static/v0.9/extensions/models/couchbase-operator/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/extensions/models/cpx/index.html
+++ b/docs/static/v0.9/extensions/models/cpx/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/extensions/models/cri-o/index.html
+++ b/docs/static/v0.9/extensions/models/cri-o/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/extensions/models/crossplane-provider-exoscale/index.html
+++ b/docs/static/v0.9/extensions/models/crossplane-provider-exoscale/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/extensions/models/crossplane-provider-openstack/index.html
+++ b/docs/static/v0.9/extensions/models/crossplane-provider-openstack/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/extensions/models/crossplane/index.html
+++ b/docs/static/v0.9/extensions/models/crossplane/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/extensions/models/cubefs/index.html
+++ b/docs/static/v0.9/extensions/models/cubefs/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/extensions/models/curiefense/index.html
+++ b/docs/static/v0.9/extensions/models/curiefense/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/extensions/models/dapr/index.html
+++ b/docs/static/v0.9/extensions/models/dapr/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/extensions/models/datadog-operator/index.html
+++ b/docs/static/v0.9/extensions/models/datadog-operator/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/extensions/models/devfile/index.html
+++ b/docs/static/v0.9/extensions/models/devfile/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/extensions/models/devstream/index.html
+++ b/docs/static/v0.9/extensions/models/devstream/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/extensions/models/dex/index.html
+++ b/docs/static/v0.9/extensions/models/dex/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/extensions/models/distribution/index.html
+++ b/docs/static/v0.9/extensions/models/distribution/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/extensions/models/docker/index.html
+++ b/docs/static/v0.9/extensions/models/docker/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/extensions/models/dragonfly/index.html
+++ b/docs/static/v0.9/extensions/models/dragonfly/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/extensions/models/edp-argocd-operator/index.html
+++ b/docs/static/v0.9/extensions/models/edp-argocd-operator/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/extensions/models/edp-component-operator/index.html
+++ b/docs/static/v0.9/extensions/models/edp-component-operator/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/extensions/models/edp-install/index.html
+++ b/docs/static/v0.9/extensions/models/edp-install/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/extensions/models/eks/index.html
+++ b/docs/static/v0.9/extensions/models/eks/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/extensions/models/elasticsearch-operator/index.html
+++ b/docs/static/v0.9/extensions/models/elasticsearch-operator/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/extensions/models/emissary-ingress/index.html
+++ b/docs/static/v0.9/extensions/models/emissary-ingress/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/extensions/models/envoy/index.html
+++ b/docs/static/v0.9/extensions/models/envoy/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/extensions/models/etcd-cluster-operator/index.html
+++ b/docs/static/v0.9/extensions/models/etcd-cluster-operator/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/extensions/models/external-secrets-operator/index.html
+++ b/docs/static/v0.9/extensions/models/external-secrets-operator/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/extensions/models/fabedge/index.html
+++ b/docs/static/v0.9/extensions/models/fabedge/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/extensions/models/falco/index.html
+++ b/docs/static/v0.9/extensions/models/falco/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/extensions/models/flagger/index.html
+++ b/docs/static/v0.9/extensions/models/flagger/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/extensions/models/fluent-operator/index.html
+++ b/docs/static/v0.9/extensions/models/fluent-operator/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/extensions/models/fluentbit-operator/index.html
+++ b/docs/static/v0.9/extensions/models/fluentbit-operator/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/extensions/models/fluentbit-skt/index.html
+++ b/docs/static/v0.9/extensions/models/fluentbit-skt/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/extensions/models/fluentd-operator/index.html
+++ b/docs/static/v0.9/extensions/models/fluentd-operator/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/extensions/models/fluentd/index.html
+++ b/docs/static/v0.9/extensions/models/fluentd/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/extensions/models/fluid/index.html
+++ b/docs/static/v0.9/extensions/models/fluid/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/extensions/models/flux/index.html
+++ b/docs/static/v0.9/extensions/models/flux/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/extensions/models/flyte-sandbox/index.html
+++ b/docs/static/v0.9/extensions/models/flyte-sandbox/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/extensions/models/fonio/index.html
+++ b/docs/static/v0.9/extensions/models/fonio/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/extensions/models/gatekeeper/index.html
+++ b/docs/static/v0.9/extensions/models/gatekeeper/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/extensions/models/gcp/index.html
+++ b/docs/static/v0.9/extensions/models/gcp/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/extensions/models/gerrit-operator/index.html
+++ b/docs/static/v0.9/extensions/models/gerrit-operator/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/extensions/models/github-actions-runner-operator/index.html
+++ b/docs/static/v0.9/extensions/models/github-actions-runner-operator/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/extensions/models/github-actions-runners/index.html
+++ b/docs/static/v0.9/extensions/models/github-actions-runners/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/extensions/models/gitlab-controller/index.html
+++ b/docs/static/v0.9/extensions/models/gitlab-controller/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/extensions/models/gitlab-runner-operator/index.html
+++ b/docs/static/v0.9/extensions/models/gitlab-runner-operator/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/extensions/models/gitlab/index.html
+++ b/docs/static/v0.9/extensions/models/gitlab/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/extensions/models/grafana-agent-operator/index.html
+++ b/docs/static/v0.9/extensions/models/grafana-agent-operator/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/extensions/models/grafana-agent/index.html
+++ b/docs/static/v0.9/extensions/models/grafana-agent/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/extensions/models/grafana-operator/index.html
+++ b/docs/static/v0.9/extensions/models/grafana-operator/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/extensions/models/grafana-ui-server/index.html
+++ b/docs/static/v0.9/extensions/models/grafana-ui-server/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/extensions/models/harbor-operator/index.html
+++ b/docs/static/v0.9/extensions/models/harbor-operator/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/extensions/models/helm-controller/index.html
+++ b/docs/static/v0.9/extensions/models/helm-controller/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/extensions/models/hexa/index.html
+++ b/docs/static/v0.9/extensions/models/hexa/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/extensions/models/hybridnet/index.html
+++ b/docs/static/v0.9/extensions/models/hybridnet/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/extensions/models/identity-manager/index.html
+++ b/docs/static/v0.9/extensions/models/identity-manager/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/extensions/models/in-toto/index.html
+++ b/docs/static/v0.9/extensions/models/in-toto/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/extensions/models/inclavare-containers/index.html
+++ b/docs/static/v0.9/extensions/models/inclavare-containers/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/extensions/models/index.html
+++ b/docs/static/v0.9/extensions/models/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/extensions/models/ingress-azure/index.html
+++ b/docs/static/v0.9/extensions/models/ingress-azure/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/extensions/models/inlets-operator/index.html
+++ b/docs/static/v0.9/extensions/models/inlets-operator/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/extensions/models/intel-device-plugins-operator/index.html
+++ b/docs/static/v0.9/extensions/models/intel-device-plugins-operator/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/extensions/models/istio-base/index.html
+++ b/docs/static/v0.9/extensions/models/istio-base/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/extensions/models/istio-operator/index.html
+++ b/docs/static/v0.9/extensions/models/istio-operator/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/extensions/models/istio-ratelimit-operator/index.html
+++ b/docs/static/v0.9/extensions/models/istio-ratelimit-operator/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/extensions/models/jaeger-operator/index.html
+++ b/docs/static/v0.9/extensions/models/jaeger-operator/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/extensions/models/jaeger/index.html
+++ b/docs/static/v0.9/extensions/models/jaeger/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/extensions/models/jenkins-operator/index.html
+++ b/docs/static/v0.9/extensions/models/jenkins-operator/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/extensions/models/jira-service-desk-operator/index.html
+++ b/docs/static/v0.9/extensions/models/jira-service-desk-operator/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/extensions/models/jitsi/index.html
+++ b/docs/static/v0.9/extensions/models/jitsi/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/extensions/models/k3s/index.html
+++ b/docs/static/v0.9/extensions/models/k3s/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/extensions/models/k6-operator/index.html
+++ b/docs/static/v0.9/extensions/models/k6-operator/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/extensions/models/k8gb/index.html
+++ b/docs/static/v0.9/extensions/models/k8gb/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/extensions/models/k8s-config-connector/index.html
+++ b/docs/static/v0.9/extensions/models/k8s-config-connector/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/extensions/models/k8svault-controller/index.html
+++ b/docs/static/v0.9/extensions/models/k8svault-controller/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/extensions/models/kanister-operator/index.html
+++ b/docs/static/v0.9/extensions/models/kanister-operator/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/extensions/models/karmada/index.html
+++ b/docs/static/v0.9/extensions/models/karmada/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/extensions/models/karpenter/index.html
+++ b/docs/static/v0.9/extensions/models/karpenter/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/extensions/models/katib/index.html
+++ b/docs/static/v0.9/extensions/models/katib/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/extensions/models/keda-http-scaler/index.html
+++ b/docs/static/v0.9/extensions/models/keda-http-scaler/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/extensions/models/keda/index.html
+++ b/docs/static/v0.9/extensions/models/keda/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/extensions/models/keycloak-operator/index.html
+++ b/docs/static/v0.9/extensions/models/keycloak-operator/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/extensions/models/keylime/index.html
+++ b/docs/static/v0.9/extensions/models/keylime/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/extensions/models/kiali-operator/index.html
+++ b/docs/static/v0.9/extensions/models/kiali-operator/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/extensions/models/knative-eventing/index.html
+++ b/docs/static/v0.9/extensions/models/knative-eventing/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/extensions/models/knative-serving/index.html
+++ b/docs/static/v0.9/extensions/models/knative-serving/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/extensions/models/knative/index.html
+++ b/docs/static/v0.9/extensions/models/knative/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/extensions/models/kommander/index.html
+++ b/docs/static/v0.9/extensions/models/kommander/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/extensions/models/kong-mesh/index.html
+++ b/docs/static/v0.9/extensions/models/kong-mesh/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/extensions/models/kong/index.html
+++ b/docs/static/v0.9/extensions/models/kong/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/extensions/models/kube-arangodb/index.html
+++ b/docs/static/v0.9/extensions/models/kube-arangodb/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/extensions/models/kube-prometheus-stack/index.html
+++ b/docs/static/v0.9/extensions/models/kube-prometheus-stack/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/extensions/models/kube-prometheus/index.html
+++ b/docs/static/v0.9/extensions/models/kube-prometheus/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/extensions/models/kube-rs/index.html
+++ b/docs/static/v0.9/extensions/models/kube-rs/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/extensions/models/kube-ui-server/index.html
+++ b/docs/static/v0.9/extensions/models/kube-ui-server/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/extensions/models/kubedb-catalog/index.html
+++ b/docs/static/v0.9/extensions/models/kubedb-catalog/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/extensions/models/kubedb-crds/index.html
+++ b/docs/static/v0.9/extensions/models/kubedb-crds/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/extensions/models/kubedb-grafana-dashboards/index.html
+++ b/docs/static/v0.9/extensions/models/kubedb-grafana-dashboards/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/extensions/models/kubedb-metrics/index.html
+++ b/docs/static/v0.9/extensions/models/kubedb-metrics/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/extensions/models/kubedb-ops-manager/index.html
+++ b/docs/static/v0.9/extensions/models/kubedb-ops-manager/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/extensions/models/kubedb-opscenter/index.html
+++ b/docs/static/v0.9/extensions/models/kubedb-opscenter/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/extensions/models/kubedb-ui-server/index.html
+++ b/docs/static/v0.9/extensions/models/kubedb-ui-server/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/extensions/models/kubedb/index.html
+++ b/docs/static/v0.9/extensions/models/kubedb/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/extensions/models/kubedl/index.html
+++ b/docs/static/v0.9/extensions/models/kubedl/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/extensions/models/kubeflow/index.html
+++ b/docs/static/v0.9/extensions/models/kubeflow/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/extensions/models/kubeform-provider-aws/index.html
+++ b/docs/static/v0.9/extensions/models/kubeform-provider-aws/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/extensions/models/kubegems-edge/index.html
+++ b/docs/static/v0.9/extensions/models/kubegems-edge/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/extensions/models/kubegems-installer/index.html
+++ b/docs/static/v0.9/extensions/models/kubegems-installer/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/extensions/models/kubegems-local/index.html
+++ b/docs/static/v0.9/extensions/models/kubegems-local/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/extensions/models/kubegems-models/index.html
+++ b/docs/static/v0.9/extensions/models/kubegems-models/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/extensions/models/kubegems/index.html
+++ b/docs/static/v0.9/extensions/models/kubegems/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/extensions/models/kuberhealthy/index.html
+++ b/docs/static/v0.9/extensions/models/kuberhealthy/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/extensions/models/kubernetes-ingress/index.html
+++ b/docs/static/v0.9/extensions/models/kubernetes-ingress/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/extensions/models/kubernetes-secret-generator/index.html
+++ b/docs/static/v0.9/extensions/models/kubernetes-secret-generator/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/extensions/models/kubernetes/index.html
+++ b/docs/static/v0.9/extensions/models/kubernetes/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/extensions/models/kubeslice-worker/index.html
+++ b/docs/static/v0.9/extensions/models/kubeslice-worker/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/extensions/models/kubesphere/index.html
+++ b/docs/static/v0.9/extensions/models/kubesphere/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/extensions/models/kubevault-catalog/index.html
+++ b/docs/static/v0.9/extensions/models/kubevault-catalog/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/extensions/models/kubevault-crds/index.html
+++ b/docs/static/v0.9/extensions/models/kubevault-crds/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/extensions/models/kubevault-metrics/index.html
+++ b/docs/static/v0.9/extensions/models/kubevault-metrics/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/extensions/models/kubevault-operator/index.html
+++ b/docs/static/v0.9/extensions/models/kubevault-operator/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/extensions/models/kubevault/index.html
+++ b/docs/static/v0.9/extensions/models/kubevault/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/extensions/models/kubevela/index.html
+++ b/docs/static/v0.9/extensions/models/kubevela/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/extensions/models/kubevirt/index.html
+++ b/docs/static/v0.9/extensions/models/kubevirt/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/extensions/models/kuma/index.html
+++ b/docs/static/v0.9/extensions/models/kuma/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/extensions/models/kured/index.html
+++ b/docs/static/v0.9/extensions/models/kured/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/extensions/models/kusk-gateway/index.html
+++ b/docs/static/v0.9/extensions/models/kusk-gateway/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/extensions/models/kyverno-monitor/index.html
+++ b/docs/static/v0.9/extensions/models/kyverno-monitor/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/extensions/models/kyverno-operator/index.html
+++ b/docs/static/v0.9/extensions/models/kyverno-operator/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/extensions/models/kyverno/index.html
+++ b/docs/static/v0.9/extensions/models/kyverno/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/extensions/models/linkerd/index.html
+++ b/docs/static/v0.9/extensions/models/linkerd/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/extensions/models/linux/index.html
+++ b/docs/static/v0.9/extensions/models/linux/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/extensions/models/litmus-core/index.html
+++ b/docs/static/v0.9/extensions/models/litmus-core/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/extensions/models/loki-simple-scalable/index.html
+++ b/docs/static/v0.9/extensions/models/loki-simple-scalable/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/extensions/models/loki/index.html
+++ b/docs/static/v0.9/extensions/models/loki/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/extensions/models/longhorn/index.html
+++ b/docs/static/v0.9/extensions/models/longhorn/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/extensions/models/loxilb/index.html
+++ b/docs/static/v0.9/extensions/models/loxilb/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/extensions/models/mattermost-operator/index.html
+++ b/docs/static/v0.9/extensions/models/mattermost-operator/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/extensions/models/meshery-core/index.html
+++ b/docs/static/v0.9/extensions/models/meshery-core/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/extensions/models/metallb/index.html
+++ b/docs/static/v0.9/extensions/models/metallb/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/extensions/models/metrics-server/index.html
+++ b/docs/static/v0.9/extensions/models/metrics-server/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/extensions/models/mimir-distributed/index.html
+++ b/docs/static/v0.9/extensions/models/mimir-distributed/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/extensions/models/minio-operator/index.html
+++ b/docs/static/v0.9/extensions/models/minio-operator/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/extensions/models/mpi-operator/index.html
+++ b/docs/static/v0.9/extensions/models/mpi-operator/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/extensions/models/mysql-operator/index.html
+++ b/docs/static/v0.9/extensions/models/mysql-operator/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/extensions/models/nats-operator/index.html
+++ b/docs/static/v0.9/extensions/models/nats-operator/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/extensions/models/newrelic-operator/index.html
+++ b/docs/static/v0.9/extensions/models/newrelic-operator/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/extensions/models/nginx-ingress/index.html
+++ b/docs/static/v0.9/extensions/models/nginx-ingress/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/extensions/models/nginx-service-mesh/index.html
+++ b/docs/static/v0.9/extensions/models/nginx-service-mesh/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/extensions/models/nginx/index.html
+++ b/docs/static/v0.9/extensions/models/nginx/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/extensions/models/ngrok-operator/index.html
+++ b/docs/static/v0.9/extensions/models/ngrok-operator/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/extensions/models/nirmata-aws-adapter/index.html
+++ b/docs/static/v0.9/extensions/models/nirmata-aws-adapter/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/extensions/models/nirmata-venafi-adapter/index.html
+++ b/docs/static/v0.9/extensions/models/nirmata-venafi-adapter/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/extensions/models/nocalhost/index.html
+++ b/docs/static/v0.9/extensions/models/nocalhost/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/extensions/models/notary/index.html
+++ b/docs/static/v0.9/extensions/models/notary/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/extensions/models/ondat-operator/index.html
+++ b/docs/static/v0.9/extensions/models/ondat-operator/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/extensions/models/open-cluster-management/index.html
+++ b/docs/static/v0.9/extensions/models/open-cluster-management/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/extensions/models/open-policy-agent-opa/index.html
+++ b/docs/static/v0.9/extensions/models/open-policy-agent-opa/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/extensions/models/open-service-mesh/index.html
+++ b/docs/static/v0.9/extensions/models/open-service-mesh/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/extensions/models/openebs/index.html
+++ b/docs/static/v0.9/extensions/models/openebs/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/extensions/models/openelb/index.html
+++ b/docs/static/v0.9/extensions/models/openelb/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/extensions/models/openfeature/index.html
+++ b/docs/static/v0.9/extensions/models/openfeature/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/extensions/models/opengitops/index.html
+++ b/docs/static/v0.9/extensions/models/opengitops/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/extensions/models/openkruise/index.html
+++ b/docs/static/v0.9/extensions/models/openkruise/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/extensions/models/openmetrics/index.html
+++ b/docs/static/v0.9/extensions/models/openmetrics/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/extensions/models/opentelemetry-operator/index.html
+++ b/docs/static/v0.9/extensions/models/opentelemetry-operator/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/extensions/models/operator-framework/index.html
+++ b/docs/static/v0.9/extensions/models/operator-framework/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/extensions/models/oras/index.html
+++ b/docs/static/v0.9/extensions/models/oras/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/extensions/models/parsec/index.html
+++ b/docs/static/v0.9/extensions/models/parsec/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/extensions/models/pg-db/index.html
+++ b/docs/static/v0.9/extensions/models/pg-db/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/extensions/models/pg-operator/index.html
+++ b/docs/static/v0.9/extensions/models/pg-operator/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/extensions/models/pgo/index.html
+++ b/docs/static/v0.9/extensions/models/pgo/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/extensions/models/piraeus-datastore/index.html
+++ b/docs/static/v0.9/extensions/models/piraeus-datastore/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/extensions/models/pixie/index.html
+++ b/docs/static/v0.9/extensions/models/pixie/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/extensions/models/porter/index.html
+++ b/docs/static/v0.9/extensions/models/porter/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/extensions/models/postgres-controller/index.html
+++ b/docs/static/v0.9/extensions/models/postgres-controller/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/extensions/models/postgres-operator/index.html
+++ b/docs/static/v0.9/extensions/models/postgres-operator/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/extensions/models/postgres-with-operator/index.html
+++ b/docs/static/v0.9/extensions/models/postgres-with-operator/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/extensions/models/posthog/index.html
+++ b/docs/static/v0.9/extensions/models/posthog/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/extensions/models/pravega/index.html
+++ b/docs/static/v0.9/extensions/models/pravega/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/extensions/models/prometheus-operator-crds/index.html
+++ b/docs/static/v0.9/extensions/models/prometheus-operator-crds/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/extensions/models/prometheus/index.html
+++ b/docs/static/v0.9/extensions/models/prometheus/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/extensions/models/ps-db/index.html
+++ b/docs/static/v0.9/extensions/models/ps-db/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/extensions/models/ps-operator/index.html
+++ b/docs/static/v0.9/extensions/models/ps-operator/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/extensions/models/psmdb-db/index.html
+++ b/docs/static/v0.9/extensions/models/psmdb-db/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/extensions/models/psmdb-operator/index.html
+++ b/docs/static/v0.9/extensions/models/psmdb-operator/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/extensions/models/pulsar-operator/index.html
+++ b/docs/static/v0.9/extensions/models/pulsar-operator/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/extensions/models/pulsar-resources-operator/index.html
+++ b/docs/static/v0.9/extensions/models/pulsar-resources-operator/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/extensions/models/rabbitmq-cluster-operator/index.html
+++ b/docs/static/v0.9/extensions/models/rabbitmq-cluster-operator/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/extensions/models/rabbitmq-operator/index.html
+++ b/docs/static/v0.9/extensions/models/rabbitmq-operator/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/extensions/models/redis-operator/index.html
+++ b/docs/static/v0.9/extensions/models/redis-operator/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/extensions/models/rook-ceph-cluster/index.html
+++ b/docs/static/v0.9/extensions/models/rook-ceph-cluster/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/extensions/models/rook/index.html
+++ b/docs/static/v0.9/extensions/models/rook/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/extensions/models/rustrial-aws-eks-iam-auth-controller/index.html
+++ b/docs/static/v0.9/extensions/models/rustrial-aws-eks-iam-auth-controller/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/extensions/models/saferwall/index.html
+++ b/docs/static/v0.9/extensions/models/saferwall/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/extensions/models/scheduler-plugins/index.html
+++ b/docs/static/v0.9/extensions/models/scheduler-plugins/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/extensions/models/schemahero/index.html
+++ b/docs/static/v0.9/extensions/models/schemahero/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/extensions/models/security-role-perm-operator-svc/index.html
+++ b/docs/static/v0.9/extensions/models/security-role-perm-operator-svc/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/extensions/models/serverless-workflow/index.html
+++ b/docs/static/v0.9/extensions/models/serverless-workflow/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/extensions/models/sidekick/index.html
+++ b/docs/static/v0.9/extensions/models/sidekick/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/extensions/models/skooner/index.html
+++ b/docs/static/v0.9/extensions/models/skooner/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/extensions/models/slack-operator/index.html
+++ b/docs/static/v0.9/extensions/models/slack-operator/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/extensions/models/sm-kubernetes/index.html
+++ b/docs/static/v0.9/extensions/models/sm-kubernetes/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/extensions/models/solr-operator/index.html
+++ b/docs/static/v0.9/extensions/models/solr-operator/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/extensions/models/spiffe/index.html
+++ b/docs/static/v0.9/extensions/models/spiffe/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/extensions/models/spire/index.html
+++ b/docs/static/v0.9/extensions/models/spire/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/extensions/models/stackgres-operator/index.html
+++ b/docs/static/v0.9/extensions/models/stackgres-operator/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/extensions/models/strimzi-kafka-operator/index.html
+++ b/docs/static/v0.9/extensions/models/strimzi-kafka-operator/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/extensions/models/strimzi-registry-operator/index.html
+++ b/docs/static/v0.9/extensions/models/strimzi-registry-operator/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/extensions/models/submariner/index.html
+++ b/docs/static/v0.9/extensions/models/submariner/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/extensions/models/supabase/index.html
+++ b/docs/static/v0.9/extensions/models/supabase/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/extensions/models/superedge/index.html
+++ b/docs/static/v0.9/extensions/models/superedge/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/extensions/models/telepresence/index.html
+++ b/docs/static/v0.9/extensions/models/telepresence/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/extensions/models/teller/index.html
+++ b/docs/static/v0.9/extensions/models/teller/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/extensions/models/tenant-operator/index.html
+++ b/docs/static/v0.9/extensions/models/tenant-operator/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/extensions/models/terraform/index.html
+++ b/docs/static/v0.9/extensions/models/terraform/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/extensions/models/thanos-operator/index.html
+++ b/docs/static/v0.9/extensions/models/thanos-operator/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/extensions/models/thanos/index.html
+++ b/docs/static/v0.9/extensions/models/thanos/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/extensions/models/tikv-operator/index.html
+++ b/docs/static/v0.9/extensions/models/tikv-operator/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/extensions/models/tinkerbell/index.html
+++ b/docs/static/v0.9/extensions/models/tinkerbell/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/extensions/models/tremor/index.html
+++ b/docs/static/v0.9/extensions/models/tremor/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/extensions/models/trickster/index.html
+++ b/docs/static/v0.9/extensions/models/trickster/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/extensions/models/tuf/index.html
+++ b/docs/static/v0.9/extensions/models/tuf/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/extensions/models/vald-helm-operator/index.html
+++ b/docs/static/v0.9/extensions/models/vald-helm-operator/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/extensions/models/vald/index.html
+++ b/docs/static/v0.9/extensions/models/vald/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/extensions/models/vault-config-operator/index.html
+++ b/docs/static/v0.9/extensions/models/vault-config-operator/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/extensions/models/vault-operator/index.html
+++ b/docs/static/v0.9/extensions/models/vault-operator/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/extensions/models/vault-secrets/index.html
+++ b/docs/static/v0.9/extensions/models/vault-secrets/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/extensions/models/vela-workflow/index.html
+++ b/docs/static/v0.9/extensions/models/vela-workflow/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/extensions/models/velero-s3-deployment/index.html
+++ b/docs/static/v0.9/extensions/models/velero-s3-deployment/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/extensions/models/velero/index.html
+++ b/docs/static/v0.9/extensions/models/velero/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/extensions/models/victoria-metrics-k8s-stack/index.html
+++ b/docs/static/v0.9/extensions/models/victoria-metrics-k8s-stack/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/extensions/models/vineyard/index.html
+++ b/docs/static/v0.9/extensions/models/vineyard/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/extensions/models/virtual-kubelet/index.html
+++ b/docs/static/v0.9/extensions/models/virtual-kubelet/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/extensions/models/vitess/index.html
+++ b/docs/static/v0.9/extensions/models/vitess/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/extensions/models/volcano/index.html
+++ b/docs/static/v0.9/extensions/models/volcano/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/extensions/models/wasmcloud/index.html
+++ b/docs/static/v0.9/extensions/models/wasmcloud/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/extensions/models/wasmedgeruntime/index.html
+++ b/docs/static/v0.9/extensions/models/wasmedgeruntime/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/extensions/models/whereabouts/index.html
+++ b/docs/static/v0.9/extensions/models/whereabouts/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/extensions/models/windows/index.html
+++ b/docs/static/v0.9/extensions/models/windows/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/extensions/models/wordpress-operator/index.html
+++ b/docs/static/v0.9/extensions/models/wordpress-operator/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/extensions/snapshot/index.html
+++ b/docs/static/v0.9/extensions/snapshot/index.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
   <head>
+  <meta name="robots" content="noindex, follow" />
     <title>/v0.9/extensions/kanvas-snapshot/</title>
     <link rel="canonical" href="/v0.9/extensions/kanvas-snapshot/">
     <meta charset="utf-8">

--- a/docs/static/v0.9/functionality/performance-management/index.html
+++ b/docs/static/v0.9/functionality/performance-management/index.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
   <head>
+  <meta name="robots" content="noindex, follow" />
     <title>/v0.9/guides/performance-management/performance-management/</title>
     <link rel="canonical" href="/v0.9/guides/performance-management/performance-management/">
     <meta charset="utf-8">

--- a/docs/static/v0.9/getting-started/overview/index.html
+++ b/docs/static/v0.9/getting-started/overview/index.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
   <head>
+  <meta name="robots" content="noindex, follow" />
     <title>/v0.9/project/overview/</title>
     <link rel="canonical" href="/v0.9/project/overview/">
     <meta charset="utf-8">

--- a/docs/static/v0.9/guides/configuration-management/creating-a-meshery-design/index.html
+++ b/docs/static/v0.9/guides/configuration-management/creating-a-meshery-design/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/guides/configuration-management/creating-models/index.html
+++ b/docs/static/v0.9/guides/configuration-management/creating-models/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/guides/configuration-management/edges-guide/index.html
+++ b/docs/static/v0.9/guides/configuration-management/edges-guide/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/guides/configuration-management/exporting-models/index.html
+++ b/docs/static/v0.9/guides/configuration-management/exporting-models/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/guides/configuration-management/generating-models/index.html
+++ b/docs/static/v0.9/guides/configuration-management/generating-models/index.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
   <head>
+  <meta name="robots" content="noindex, follow" />
     <title>/v0.9/guides/configuration-management/creating-models/</title>
     <link rel="canonical" href="/v0.9/guides/configuration-management/creating-models/">
     <meta charset="utf-8">

--- a/docs/static/v0.9/guides/configuration-management/identifying-components/index.html
+++ b/docs/static/v0.9/guides/configuration-management/identifying-components/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/guides/configuration-management/importing-designs/index.html
+++ b/docs/static/v0.9/guides/configuration-management/importing-designs/index.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
   <head>
+  <meta name="robots" content="noindex, follow" />
     <title>/v0.9/extensions/import-export-designs/</title>
     <link rel="canonical" href="/v0.9/extensions/import-export-designs/">
     <meta charset="utf-8">

--- a/docs/static/v0.9/guides/configuration-management/importing-models/index.html
+++ b/docs/static/v0.9/guides/configuration-management/importing-models/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/guides/configuration-management/index.html
+++ b/docs/static/v0.9/guides/configuration-management/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/guides/configuration-management/pattern-management/index.html
+++ b/docs/static/v0.9/guides/configuration-management/pattern-management/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/guides/configuration-management/push-pull-model-image/index.html
+++ b/docs/static/v0.9/guides/configuration-management/push-pull-model-image/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/guides/configuration-management/working-with-designs/index.html
+++ b/docs/static/v0.9/guides/configuration-management/working-with-designs/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/guides/creating-a-meshery-design/index.html
+++ b/docs/static/v0.9/guides/creating-a-meshery-design/index.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
   <head>
+  <meta name="robots" content="noindex, follow" />
     <title>/v0.9/guides/configuration-management/creating-a-meshery-design/</title>
     <link rel="canonical" href="/v0.9/guides/configuration-management/creating-a-meshery-design/">
     <meta charset="utf-8">

--- a/docs/static/v0.9/guides/events-management/index.html
+++ b/docs/static/v0.9/guides/events-management/index.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
   <head>
+  <meta name="robots" content="noindex, follow" />
     <title>/v0.9/guides/infrastructure-management/notification-management/</title>
     <link rel="canonical" href="/v0.9/guides/infrastructure-management/notification-management/">
     <meta charset="utf-8">

--- a/docs/static/v0.9/guides/index.html
+++ b/docs/static/v0.9/guides/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/guides/infrastructure-management/filter-management/index.html
+++ b/docs/static/v0.9/guides/infrastructure-management/filter-management/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/guides/infrastructure-management/gitops-with-meshery/index.html
+++ b/docs/static/v0.9/guides/infrastructure-management/gitops-with-meshery/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/guides/infrastructure-management/index.html
+++ b/docs/static/v0.9/guides/infrastructure-management/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/guides/infrastructure-management/lifecycle-management/index.html
+++ b/docs/static/v0.9/guides/infrastructure-management/lifecycle-management/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/guides/infrastructure-management/managing-connections/index.html
+++ b/docs/static/v0.9/guides/infrastructure-management/managing-connections/index.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
   <head>
+  <meta name="robots" content="noindex, follow" />
     <title>/v0.9/guides/infrastructure-management/lifecycle-management/</title>
     <link rel="canonical" href="/v0.9/guides/infrastructure-management/lifecycle-management/">
     <meta charset="utf-8">

--- a/docs/static/v0.9/guides/infrastructure-management/notification-management/index.html
+++ b/docs/static/v0.9/guides/infrastructure-management/notification-management/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/guides/infrastructure-management/overview/index.html
+++ b/docs/static/v0.9/guides/infrastructure-management/overview/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/guides/infrastructure-management/registering-a-connection/index.html
+++ b/docs/static/v0.9/guides/infrastructure-management/registering-a-connection/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/guides/infrastructure-management/sample-apps/index.html
+++ b/docs/static/v0.9/guides/infrastructure-management/sample-apps/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/guides/mesheryctl/authenticate-with-meshery-via-cli/index.html
+++ b/docs/static/v0.9/guides/mesheryctl/authenticate-with-meshery-via-cli/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/guides/mesheryctl/configuring-autocompletion-for-mesheryctl/index.html
+++ b/docs/static/v0.9/guides/mesheryctl/configuring-autocompletion-for-mesheryctl/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/guides/mesheryctl/index.html
+++ b/docs/static/v0.9/guides/mesheryctl/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/guides/mesheryctl/running-system-checks-using-mesheryctl/index.html
+++ b/docs/static/v0.9/guides/mesheryctl/running-system-checks-using-mesheryctl/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/guides/mesheryctl/system-commands/index.html
+++ b/docs/static/v0.9/guides/mesheryctl/system-commands/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/guides/mesheryctl/working-with-mesheryctl/index.html
+++ b/docs/static/v0.9/guides/mesheryctl/working-with-mesheryctl/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/guides/multiple-adapters/index.html
+++ b/docs/static/v0.9/guides/multiple-adapters/index.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
   <head>
+  <meta name="robots" content="noindex, follow" />
     <title>/v0.9/installation/multiple-adapters/</title>
     <link rel="canonical" href="/v0.9/installation/multiple-adapters/">
     <meta charset="utf-8">

--- a/docs/static/v0.9/guides/performance-management/index.html
+++ b/docs/static/v0.9/guides/performance-management/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/guides/performance-management/interpreting-performance-test-results/index.html
+++ b/docs/static/v0.9/guides/performance-management/interpreting-performance-test-results/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/guides/performance-management/managing-performance/index.html
+++ b/docs/static/v0.9/guides/performance-management/managing-performance/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/guides/performance-management/meshery-metrics/index.html
+++ b/docs/static/v0.9/guides/performance-management/meshery-metrics/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/guides/performance-management/performance-management/index.html
+++ b/docs/static/v0.9/guides/performance-management/performance-management/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/guides/troubleshooting/enabling-extensions-locally/index.html
+++ b/docs/static/v0.9/guides/troubleshooting/enabling-extensions-locally/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/guides/troubleshooting/index.html
+++ b/docs/static/v0.9/guides/troubleshooting/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/guides/troubleshooting/installation/index.html
+++ b/docs/static/v0.9/guides/troubleshooting/installation/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/guides/troubleshooting/meshery-operator-meshsync/index.html
+++ b/docs/static/v0.9/guides/troubleshooting/meshery-operator-meshsync/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/guides/troubleshooting/meshery-server/index.html
+++ b/docs/static/v0.9/guides/troubleshooting/meshery-server/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/guides/troubleshooting/running/index.html
+++ b/docs/static/v0.9/guides/troubleshooting/running/index.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
   <head>
+  <meta name="robots" content="noindex, follow" />
     <title>/v0.9/guides/troubleshooting/meshery-server/</title>
     <link rel="canonical" href="/v0.9/guides/troubleshooting/meshery-server/">
     <meta charset="utf-8">

--- a/docs/static/v0.9/guides/tutorials/artifacthub/index.html
+++ b/docs/static/v0.9/guides/tutorials/artifacthub/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/guides/tutorials/artifacthub/publish-to-artifacthub/index.html
+++ b/docs/static/v0.9/guides/tutorials/artifacthub/publish-to-artifacthub/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/guides/tutorials/aws/deploy-aws-ec2-instances-with-meshery/index.html
+++ b/docs/static/v0.9/guides/tutorials/aws/deploy-aws-ec2-instances-with-meshery/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/guides/tutorials/aws/index.html
+++ b/docs/static/v0.9/guides/tutorials/aws/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/guides/tutorials/azure/deploy-azure-resources-with-meshery/index.html
+++ b/docs/static/v0.9/guides/tutorials/azure/deploy-azure-resources-with-meshery/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/guides/tutorials/azure/deploy-azure-storage-account-with-meshery/index.html
+++ b/docs/static/v0.9/guides/tutorials/azure/deploy-azure-storage-account-with-meshery/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/guides/tutorials/azure/index.html
+++ b/docs/static/v0.9/guides/tutorials/azure/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/guides/tutorials/deploy-apache-cassandra-with-statefulset/index.html
+++ b/docs/static/v0.9/guides/tutorials/deploy-apache-cassandra-with-statefulset/index.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
   <head>
+  <meta name="robots" content="noindex, follow" />
     <title>/v0.9/guides/tutorials/kubernetes/deploy-apache-cassandra-with-statefulset/</title>
     <link rel="canonical" href="/v0.9/guides/tutorials/kubernetes/deploy-apache-cassandra-with-statefulset/">
     <meta charset="utf-8">

--- a/docs/static/v0.9/guides/tutorials/deploy-aws-ec2-instances-with-meshery/index.html
+++ b/docs/static/v0.9/guides/tutorials/deploy-aws-ec2-instances-with-meshery/index.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
   <head>
+  <meta name="robots" content="noindex, follow" />
     <title>/v0.9/guides/tutorials/aws/deploy-aws-ec2-instances-with-meshery/</title>
     <link rel="canonical" href="/v0.9/guides/tutorials/aws/deploy-aws-ec2-instances-with-meshery/">
     <meta charset="utf-8">

--- a/docs/static/v0.9/guides/tutorials/deploy-azure-resources-with-meshery/index.html
+++ b/docs/static/v0.9/guides/tutorials/deploy-azure-resources-with-meshery/index.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
   <head>
+  <meta name="robots" content="noindex, follow" />
     <title>/v0.9/guides/tutorials/azure/deploy-azure-resources-with-meshery/</title>
     <link rel="canonical" href="/v0.9/guides/tutorials/azure/deploy-azure-resources-with-meshery/">
     <meta charset="utf-8">

--- a/docs/static/v0.9/guides/tutorials/deploy-azure-storage-account-with-meshery/index.html
+++ b/docs/static/v0.9/guides/tutorials/deploy-azure-storage-account-with-meshery/index.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
   <head>
+  <meta name="robots" content="noindex, follow" />
     <title>/v0.9/guides/tutorials/azure/deploy-azure-storage-account-with-meshery/</title>
     <link rel="canonical" href="/v0.9/guides/tutorials/azure/deploy-azure-storage-account-with-meshery/">
     <meta charset="utf-8">

--- a/docs/static/v0.9/guides/tutorials/deploy-php-redis/index.html
+++ b/docs/static/v0.9/guides/tutorials/deploy-php-redis/index.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
   <head>
+  <meta name="robots" content="noindex, follow" />
     <title>/v0.9/guides/tutorials/kubernetes/deploy-php-redis/</title>
     <link rel="canonical" href="/v0.9/guides/tutorials/kubernetes/deploy-php-redis/">
     <meta charset="utf-8">

--- a/docs/static/v0.9/guides/tutorials/embedding-meshery-design-in-wordpress/index.html
+++ b/docs/static/v0.9/guides/tutorials/embedding-meshery-design-in-wordpress/index.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
   <head>
+  <meta name="robots" content="noindex, follow" />
     <title>/v0.9/guides/tutorials/wordpress/embedding-meshery-design-in-wordpress/</title>
     <link rel="canonical" href="/v0.9/guides/tutorials/wordpress/embedding-meshery-design-in-wordpress/">
     <meta charset="utf-8">

--- a/docs/static/v0.9/guides/tutorials/exploring-kubernetes-cronjobs/index.html
+++ b/docs/static/v0.9/guides/tutorials/exploring-kubernetes-cronjobs/index.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
   <head>
+  <meta name="robots" content="noindex, follow" />
     <title>/v0.9/guides/tutorials/kubernetes/exploring-kubernetes-cronjobs/</title>
     <link rel="canonical" href="/v0.9/guides/tutorials/kubernetes/exploring-kubernetes-cronjobs/">
     <meta charset="utf-8">

--- a/docs/static/v0.9/guides/tutorials/index.html
+++ b/docs/static/v0.9/guides/tutorials/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/guides/tutorials/kubernetes-configmaps-secrets/index.html
+++ b/docs/static/v0.9/guides/tutorials/kubernetes-configmaps-secrets/index.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
   <head>
+  <meta name="robots" content="noindex, follow" />
     <title>/v0.9/guides/tutorials/kubernetes/kubernetes-configmaps-secrets/</title>
     <link rel="canonical" href="/v0.9/guides/tutorials/kubernetes/kubernetes-configmaps-secrets/">
     <meta charset="utf-8">

--- a/docs/static/v0.9/guides/tutorials/kubernetes-deployments/index.html
+++ b/docs/static/v0.9/guides/tutorials/kubernetes-deployments/index.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
   <head>
+  <meta name="robots" content="noindex, follow" />
     <title>/v0.9/guides/tutorials/kubernetes/kubernetes-deployments/</title>
     <link rel="canonical" href="/v0.9/guides/tutorials/kubernetes/kubernetes-deployments/">
     <meta charset="utf-8">

--- a/docs/static/v0.9/guides/tutorials/kubernetes-pods/index.html
+++ b/docs/static/v0.9/guides/tutorials/kubernetes-pods/index.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
   <head>
+  <meta name="robots" content="noindex, follow" />
     <title>/v0.9/guides/tutorials/kubernetes/kubernetes-pods/</title>
     <link rel="canonical" href="/v0.9/guides/tutorials/kubernetes/kubernetes-pods/">
     <meta charset="utf-8">

--- a/docs/static/v0.9/guides/tutorials/kubernetes-request-flow/index.html
+++ b/docs/static/v0.9/guides/tutorials/kubernetes-request-flow/index.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
   <head>
+  <meta name="robots" content="noindex, follow" />
     <title>/v0.9/guides/tutorials/kubernetes/kubernetes-request-flow/</title>
     <link rel="canonical" href="/v0.9/guides/tutorials/kubernetes/kubernetes-request-flow/">
     <meta charset="utf-8">

--- a/docs/static/v0.9/guides/tutorials/kubernetes-services/index.html
+++ b/docs/static/v0.9/guides/tutorials/kubernetes-services/index.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
   <head>
+  <meta name="robots" content="noindex, follow" />
     <title>/v0.9/guides/tutorials/kubernetes/kubernetes-services/</title>
     <link rel="canonical" href="/v0.9/guides/tutorials/kubernetes/kubernetes-services/">
     <meta charset="utf-8">

--- a/docs/static/v0.9/guides/tutorials/kubernetes/deploy-apache-cassandra-with-statefulset/index.html
+++ b/docs/static/v0.9/guides/tutorials/kubernetes/deploy-apache-cassandra-with-statefulset/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/guides/tutorials/kubernetes/deploy-php-redis/index.html
+++ b/docs/static/v0.9/guides/tutorials/kubernetes/deploy-php-redis/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/guides/tutorials/kubernetes/exploring-kubernetes-cronjobs/index.html
+++ b/docs/static/v0.9/guides/tutorials/kubernetes/exploring-kubernetes-cronjobs/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/guides/tutorials/kubernetes/index.html
+++ b/docs/static/v0.9/guides/tutorials/kubernetes/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/guides/tutorials/kubernetes/kubernetes-configmaps-secrets/index.html
+++ b/docs/static/v0.9/guides/tutorials/kubernetes/kubernetes-configmaps-secrets/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/guides/tutorials/kubernetes/kubernetes-deployments/index.html
+++ b/docs/static/v0.9/guides/tutorials/kubernetes/kubernetes-deployments/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/guides/tutorials/kubernetes/kubernetes-pods/index.html
+++ b/docs/static/v0.9/guides/tutorials/kubernetes/kubernetes-pods/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/guides/tutorials/kubernetes/kubernetes-request-flow/index.html
+++ b/docs/static/v0.9/guides/tutorials/kubernetes/kubernetes-request-flow/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/guides/tutorials/kubernetes/kubernetes-services/index.html
+++ b/docs/static/v0.9/guides/tutorials/kubernetes/kubernetes-services/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/guides/tutorials/kubernetes/wordpress-mysql-persistentvolume/index.html
+++ b/docs/static/v0.9/guides/tutorials/kubernetes/wordpress-mysql-persistentvolume/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/guides/tutorials/publish-to-artifacthub/index.html
+++ b/docs/static/v0.9/guides/tutorials/publish-to-artifacthub/index.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
   <head>
+  <meta name="robots" content="noindex, follow" />
     <title>/v0.9/guides/tutorials/artifacthub/publish-to-artifacthub/</title>
     <link rel="canonical" href="/v0.9/guides/tutorials/artifacthub/publish-to-artifacthub/">
     <meta charset="utf-8">

--- a/docs/static/v0.9/guides/tutorials/wordpress-mysql-persistentvolume/index.html
+++ b/docs/static/v0.9/guides/tutorials/wordpress-mysql-persistentvolume/index.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
   <head>
+  <meta name="robots" content="noindex, follow" />
     <title>/v0.9/guides/tutorials/kubernetes/wordpress-mysql-persistentvolume/</title>
     <link rel="canonical" href="/v0.9/guides/tutorials/kubernetes/wordpress-mysql-persistentvolume/">
     <meta charset="utf-8">

--- a/docs/static/v0.9/guides/tutorials/wordpress/embedding-meshery-design-in-wordpress/index.html
+++ b/docs/static/v0.9/guides/tutorials/wordpress/embedding-meshery-design-in-wordpress/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/guides/tutorials/wordpress/index.html
+++ b/docs/static/v0.9/guides/tutorials/wordpress/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/installation/accessing-meshery-ui/index.html
+++ b/docs/static/v0.9/installation/accessing-meshery-ui/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/installation/bash/index.html
+++ b/docs/static/v0.9/installation/bash/index.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
   <head>
+  <meta name="robots" content="noindex, follow" />
     <title>/v0.9/installation/linux-mac/bash/</title>
     <link rel="canonical" href="/v0.9/installation/linux-mac/bash/">
     <meta charset="utf-8">

--- a/docs/static/v0.9/installation/codespaces/index.html
+++ b/docs/static/v0.9/installation/codespaces/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/installation/compatibility-matrix/index.html
+++ b/docs/static/v0.9/installation/compatibility-matrix/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/installation/compatibility-matrix/meshery-cilium-past-results/index.html
+++ b/docs/static/v0.9/installation/compatibility-matrix/meshery-cilium-past-results/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/installation/compatibility-matrix/meshery-consul-past-results/index.html
+++ b/docs/static/v0.9/installation/compatibility-matrix/meshery-consul-past-results/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/installation/compatibility-matrix/meshery-istio-past-results/index.html
+++ b/docs/static/v0.9/installation/compatibility-matrix/meshery-istio-past-results/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/installation/compatibility-matrix/meshery-kuma-past-results/index.html
+++ b/docs/static/v0.9/installation/compatibility-matrix/meshery-kuma-past-results/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/installation/compatibility-matrix/meshery-linkerd-past-results/index.html
+++ b/docs/static/v0.9/installation/compatibility-matrix/meshery-linkerd-past-results/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/installation/compatibility-matrix/meshery-nginx-past-results/index.html
+++ b/docs/static/v0.9/installation/compatibility-matrix/meshery-nginx-past-results/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/installation/compatibility-matrix/meshery-osm-past-results/index.html
+++ b/docs/static/v0.9/installation/compatibility-matrix/meshery-osm-past-results/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/installation/compatibility-matrix/meshery-traefik-mesh-past-results/index.html
+++ b/docs/static/v0.9/installation/compatibility-matrix/meshery-traefik-mesh-past-results/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/installation/docker/docker-extension/index.html
+++ b/docs/static/v0.9/installation/docker/docker-extension/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/installation/docker/index.html
+++ b/docs/static/v0.9/installation/docker/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/installation/index.html
+++ b/docs/static/v0.9/installation/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/installation/kubernetes/aks/index.html
+++ b/docs/static/v0.9/installation/kubernetes/aks/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/installation/kubernetes/eks/index.html
+++ b/docs/static/v0.9/installation/kubernetes/eks/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/installation/kubernetes/gke/index.html
+++ b/docs/static/v0.9/installation/kubernetes/gke/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/installation/kubernetes/helm/index.html
+++ b/docs/static/v0.9/installation/kubernetes/helm/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/installation/kubernetes/index.html
+++ b/docs/static/v0.9/installation/kubernetes/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/installation/kubernetes/kind/index.html
+++ b/docs/static/v0.9/installation/kubernetes/kind/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/installation/kubernetes/kubesphere/index.html
+++ b/docs/static/v0.9/installation/kubernetes/kubesphere/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/installation/kubernetes/minikube/index.html
+++ b/docs/static/v0.9/installation/kubernetes/minikube/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/installation/linux-mac/bash/index.html
+++ b/docs/static/v0.9/installation/linux-mac/bash/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/installation/linux-mac/brew/index.html
+++ b/docs/static/v0.9/installation/linux-mac/brew/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/installation/linux-mac/index.html
+++ b/docs/static/v0.9/installation/linux-mac/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/installation/mesheryctl/index.html
+++ b/docs/static/v0.9/installation/mesheryctl/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/installation/multiple-adapters/index.html
+++ b/docs/static/v0.9/installation/multiple-adapters/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/installation/platforms/aks/index.html
+++ b/docs/static/v0.9/installation/platforms/aks/index.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
   <head>
+  <meta name="robots" content="noindex, follow" />
     <title>/v0.9/installation/kubernetes/aks/</title>
     <link rel="canonical" href="/v0.9/installation/kubernetes/aks/">
     <meta charset="utf-8">

--- a/docs/static/v0.9/installation/platforms/bash/index.html
+++ b/docs/static/v0.9/installation/platforms/bash/index.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
   <head>
+  <meta name="robots" content="noindex, follow" />
     <title>/v0.9/installation/linux-mac/bash/</title>
     <link rel="canonical" href="/v0.9/installation/linux-mac/bash/">
     <meta charset="utf-8">

--- a/docs/static/v0.9/installation/platforms/brew/index.html
+++ b/docs/static/v0.9/installation/platforms/brew/index.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
   <head>
+  <meta name="robots" content="noindex, follow" />
     <title>/v0.9/installation/linux-mac/brew/</title>
     <link rel="canonical" href="/v0.9/installation/linux-mac/brew/">
     <meta charset="utf-8">

--- a/docs/static/v0.9/installation/platforms/codespaces/index.html
+++ b/docs/static/v0.9/installation/platforms/codespaces/index.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
   <head>
+  <meta name="robots" content="noindex, follow" />
     <title>/v0.9/installation/codespaces/</title>
     <link rel="canonical" href="/v0.9/installation/codespaces/">
     <meta charset="utf-8">

--- a/docs/static/v0.9/installation/platforms/docker-extension/index.html
+++ b/docs/static/v0.9/installation/platforms/docker-extension/index.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
   <head>
+  <meta name="robots" content="noindex, follow" />
     <title>/v0.9/installation/docker/docker-extension/</title>
     <link rel="canonical" href="/v0.9/installation/docker/docker-extension/">
     <meta charset="utf-8">

--- a/docs/static/v0.9/installation/platforms/docker/index.html
+++ b/docs/static/v0.9/installation/platforms/docker/index.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
   <head>
+  <meta name="robots" content="noindex, follow" />
     <title>/v0.9/installation/docker/</title>
     <link rel="canonical" href="/v0.9/installation/docker/">
     <meta charset="utf-8">

--- a/docs/static/v0.9/installation/platforms/eks/index.html
+++ b/docs/static/v0.9/installation/platforms/eks/index.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
   <head>
+  <meta name="robots" content="noindex, follow" />
     <title>/v0.9/installation/kubernetes/eks/</title>
     <link rel="canonical" href="/v0.9/installation/kubernetes/eks/">
     <meta charset="utf-8">

--- a/docs/static/v0.9/installation/platforms/gke/index.html
+++ b/docs/static/v0.9/installation/platforms/gke/index.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
   <head>
+  <meta name="robots" content="noindex, follow" />
     <title>/v0.9/installation/kubernetes/gke/</title>
     <link rel="canonical" href="/v0.9/installation/kubernetes/gke/">
     <meta charset="utf-8">

--- a/docs/static/v0.9/installation/platforms/helm/index.html
+++ b/docs/static/v0.9/installation/platforms/helm/index.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
   <head>
+  <meta name="robots" content="noindex, follow" />
     <title>/v0.9/installation/kubernetes/helm/</title>
     <link rel="canonical" href="/v0.9/installation/kubernetes/helm/">
     <meta charset="utf-8">

--- a/docs/static/v0.9/installation/platforms/index.html
+++ b/docs/static/v0.9/installation/platforms/index.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
   <head>
+  <meta name="robots" content="noindex, follow" />
     <title>/v0.9/installation/</title>
     <link rel="canonical" href="/v0.9/installation/">
     <meta charset="utf-8">

--- a/docs/static/v0.9/installation/platforms/kind/index.html
+++ b/docs/static/v0.9/installation/platforms/kind/index.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
   <head>
+  <meta name="robots" content="noindex, follow" />
     <title>/v0.9/installation/kubernetes/kind/</title>
     <link rel="canonical" href="/v0.9/installation/kubernetes/kind/">
     <meta charset="utf-8">

--- a/docs/static/v0.9/installation/platforms/kubernetes/index.html
+++ b/docs/static/v0.9/installation/platforms/kubernetes/index.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
   <head>
+  <meta name="robots" content="noindex, follow" />
     <title>/v0.9/installation/kubernetes/</title>
     <link rel="canonical" href="/v0.9/installation/kubernetes/">
     <meta charset="utf-8">

--- a/docs/static/v0.9/installation/platforms/kubesphere/index.html
+++ b/docs/static/v0.9/installation/platforms/kubesphere/index.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
   <head>
+  <meta name="robots" content="noindex, follow" />
     <title>/v0.9/installation/kubernetes/kubesphere/</title>
     <link rel="canonical" href="/v0.9/installation/kubernetes/kubesphere/">
     <meta charset="utf-8">

--- a/docs/static/v0.9/installation/platforms/linux-mac/index.html
+++ b/docs/static/v0.9/installation/platforms/linux-mac/index.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
   <head>
+  <meta name="robots" content="noindex, follow" />
     <title>/v0.9/installation/linux-mac/</title>
     <link rel="canonical" href="/v0.9/installation/linux-mac/">
     <meta charset="utf-8">

--- a/docs/static/v0.9/installation/platforms/mesheryctl/index.html
+++ b/docs/static/v0.9/installation/platforms/mesheryctl/index.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
   <head>
+  <meta name="robots" content="noindex, follow" />
     <title>/v0.9/installation/mesheryctl/</title>
     <link rel="canonical" href="/v0.9/installation/mesheryctl/">
     <meta charset="utf-8">

--- a/docs/static/v0.9/installation/platforms/minikube/index.html
+++ b/docs/static/v0.9/installation/platforms/minikube/index.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
   <head>
+  <meta name="robots" content="noindex, follow" />
     <title>/v0.9/installation/kubernetes/minikube/</title>
     <link rel="canonical" href="/v0.9/installation/kubernetes/minikube/">
     <meta charset="utf-8">

--- a/docs/static/v0.9/installation/platforms/scoop/index.html
+++ b/docs/static/v0.9/installation/platforms/scoop/index.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
   <head>
+  <meta name="robots" content="noindex, follow" />
     <title>/v0.9/installation/windows/scoop/</title>
     <link rel="canonical" href="/v0.9/installation/windows/scoop/">
     <meta charset="utf-8">

--- a/docs/static/v0.9/installation/platforms/windows/index.html
+++ b/docs/static/v0.9/installation/platforms/windows/index.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
   <head>
+  <meta name="robots" content="noindex, follow" />
     <title>/v0.9/installation/windows/</title>
     <link rel="canonical" href="/v0.9/installation/windows/">
     <meta charset="utf-8">

--- a/docs/static/v0.9/installation/playground/index.html
+++ b/docs/static/v0.9/installation/playground/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/installation/quick-start/index.html
+++ b/docs/static/v0.9/installation/quick-start/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/installation/upgrades/index.html
+++ b/docs/static/v0.9/installation/upgrades/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/installation/windows/index.html
+++ b/docs/static/v0.9/installation/windows/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/installation/windows/scoop/index.html
+++ b/docs/static/v0.9/installation/windows/scoop/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/platforms/index.html
+++ b/docs/static/v0.9/platforms/index.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
   <head>
+  <meta name="robots" content="noindex, follow" />
     <title>/v0.9/installation/</title>
     <link rel="canonical" href="/v0.9/installation/">
     <meta charset="utf-8">

--- a/docs/static/v0.9/project/community/index.html
+++ b/docs/static/v0.9/project/community/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility-matrix/index.html
+++ b/docs/static/v0.9/project/compatibility-matrix/index.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
   <head>
+  <meta name="robots" content="noindex, follow" />
     <title>/v0.9/installation/compatibility-matrix/</title>
     <link rel="canonical" href="/v0.9/installation/compatibility-matrix/">
     <meta charset="utf-8">

--- a/docs/static/v0.9/project/compatibility/index.html
+++ b/docs/static/v0.9/project/compatibility/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-cilium/01-02-2023-16-47-01_/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-cilium/01-02-2023-16-47-01_/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-cilium/01-14-2023-04-39-01_/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-cilium/01-14-2023-04-39-01_/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-cilium/01-25-2023-21-10-01_/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-cilium/01-25-2023-21-10-01_/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-cilium/01-26-2023-13-24-01_/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-cilium/01-26-2023-13-24-01_/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-cilium/01-26-2023-15-47-01_/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-cilium/01-26-2023-15-47-01_/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-cilium/03-23-2023-19-58-03_/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-cilium/03-23-2023-19-58-03_/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-cilium/05-10-2022-12-32-05_/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-cilium/05-10-2022-12-32-05_/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-cilium/05-30-2022-19-50-05_/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-cilium/05-30-2022-19-50-05_/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-cilium/06-11-2022-00-25-06_/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-cilium/06-11-2022-00-25-06_/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-cilium/06-11-2022-13-12-06_/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-cilium/06-11-2022-13-12-06_/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-cilium/06-25-2022-04-00-06_/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-cilium/06-25-2022-04-00-06_/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-cilium/07-14-2023-17-55-07_/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-cilium/07-14-2023-17-55-07_/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-cilium/08-05-2022-19-36-08_/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-cilium/08-05-2022-19-36-08_/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-cilium/10-21-2022-13-33-10_/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-cilium/10-21-2022-13-33-10_/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-cilium/11-10-2023-06-53-11_/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-cilium/11-10-2023-06-53-11_/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-consul/02-07-2023-21-56-02_15bfb367/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-consul/02-07-2023-21-56-02_15bfb367/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-consul/02-07-2023-22-04-02_2efcfcac/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-consul/02-07-2023-22-04-02_2efcfcac/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-consul/02-13-2023-19-19-02_75fc4b02/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-consul/02-13-2023-19-19-02_75fc4b02/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-consul/02-14-2023-13-47-02_75fc4b02/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-consul/02-14-2023-13-47-02_75fc4b02/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-consul/02-14-2023-13-48-02_75fc4b02/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-consul/02-14-2023-13-48-02_75fc4b02/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-consul/02-17-2023-07-45-02_1d2a9534/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-consul/02-17-2023-07-45-02_1d2a9534/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-consul/02-17-2023-07-51-02_b48319c7/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-consul/02-17-2023-07-51-02_b48319c7/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-consul/02-17-2023-07-59-02_9e5cb650/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-consul/02-17-2023-07-59-02_9e5cb650/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-consul/02-17-2023-08-02-02_9e5cb650/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-consul/02-17-2023-08-02-02_9e5cb650/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-consul/02-17-2023-08-03-02_9e5cb650/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-consul/02-17-2023-08-03-02_9e5cb650/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-consul/03-06-2023-17-02-03_31da6cbd/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-consul/03-06-2023-17-02-03_31da6cbd/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-consul/03-06-2023-17-47-03_72dfb671/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-consul/03-06-2023-17-47-03_72dfb671/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-consul/03-23-2023-20-18-03_fad55ff1/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-consul/03-23-2023-20-18-03_fad55ff1/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-consul/03-23-2023-20-19-03_fad55ff1/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-consul/03-23-2023-20-19-03_fad55ff1/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-consul/04-01-2023-01-47-04_a5b46e51/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-consul/04-01-2023-01-47-04_a5b46e51/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-consul/05-21-2023-14-25-05_f6f29ec3/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-consul/05-21-2023-14-25-05_f6f29ec3/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-consul/05-21-2023-14-34-05_28f3389e/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-consul/05-21-2023-14-34-05_28f3389e/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-consul/06-06-2023-02-11-06_c65d7a72/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-consul/06-06-2023-02-11-06_c65d7a72/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-consul/06-15-2023-18-53-06_2dce4e09/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-consul/06-15-2023-18-53-06_2dce4e09/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-consul/06-15-2023-18-54-06_46a7a527/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-consul/06-15-2023-18-54-06_46a7a527/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-consul/07-19-2023-21-58-07_65e89db0/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-consul/07-19-2023-21-58-07_65e89db0/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-consul/07-19-2023-22-19-07_5a8933f5/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-consul/07-19-2023-22-19-07_5a8933f5/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-consul/08-12-2023-01-25-08_7cd0dda9/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-consul/08-12-2023-01-25-08_7cd0dda9/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-consul/08-19-2023-19-13-08_c6c709b7/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-consul/08-19-2023-19-13-08_c6c709b7/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-consul/09-22-2023-01-32-09_17c4c4f2/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-consul/09-22-2023-01-32-09_17c4c4f2/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-consul/09-27-2022-21-04-09_6cf960c6/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-consul/09-27-2022-21-04-09_6cf960c6/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-consul/09-29-2022-15-59-09_062fe7ca/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-consul/09-29-2022-15-59-09_062fe7ca/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-consul/09-29-2022-16-01-09_55299d76/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-consul/09-29-2022-16-01-09_55299d76/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-consul/09-29-2022-16-04-09_8c17f987/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-consul/09-29-2022-16-04-09_8c17f987/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-consul/09-29-2022-17-41-09_8c17f987/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-consul/09-29-2022-17-41-09_8c17f987/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-consul/09-29-2022-17-42-09_8c17f987/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-consul/09-29-2022-17-42-09_8c17f987/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-consul/10-01-2022-03-13-10_6f9b5f55/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-consul/10-01-2022-03-13-10_6f9b5f55/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-consul/10-03-2022-04-20-10_a3374f2f/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-consul/10-03-2022-04-20-10_a3374f2f/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-consul/10-04-2022-11-47-10_3c92d085/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-consul/10-04-2022-11-47-10_3c92d085/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-consul/10-04-2022-19-47-10_6221f429/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-consul/10-04-2022-19-47-10_6221f429/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-consul/10-04-2022-19-51-10_6221f429/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-consul/10-04-2022-19-51-10_6221f429/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-consul/10-04-2022-19-56-10_fc5847eb/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-consul/10-04-2022-19-56-10_fc5847eb/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-consul/10-05-2022-02-42-10_103cc75f/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-consul/10-05-2022-02-42-10_103cc75f/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-consul/10-05-2022-11-45-10_adc5b5b7/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-consul/10-05-2022-11-45-10_adc5b5b7/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-consul/10-11-2022-22-23-10_79781888/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-consul/10-11-2022-22-23-10_79781888/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-consul/10-11-2022-22-24-10_79781888/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-consul/10-11-2022-22-24-10_79781888/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-consul/10-11-2023-01-32-10_a31ecf14/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-consul/10-11-2023-01-32-10_a31ecf14/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-consul/10-12-2022-01-53-10_56b762eb/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-consul/10-12-2022-01-53-10_56b762eb/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-consul/10-12-2022-02-03-10_9078178a/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-consul/10-12-2022-02-03-10_9078178a/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-consul/10-12-2023-02-03-10_cb01bc62/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-consul/10-12-2023-02-03-10_cb01bc62/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-consul/10-12-2023-02-20-10_90f0d049/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-consul/10-12-2023-02-20-10_90f0d049/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-consul/10-12-2023-02-26-10_69667807/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-consul/10-12-2023-02-26-10_69667807/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-consul/10-12-2023-02-32-10_2302b19a/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-consul/10-12-2023-02-32-10_2302b19a/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-consul/10-12-2023-02-34-10_fd072f64/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-consul/10-12-2023-02-34-10_fd072f64/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-consul/10-12-2023-03-17-10_81317eb2/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-consul/10-12-2023-03-17-10_81317eb2/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-consul/10-12-2023-03-20-10_81317eb2/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-consul/10-12-2023-03-20-10_81317eb2/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-consul/10-13-2022-17-10-10_50caf82f/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-consul/10-13-2022-17-10-10_50caf82f/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-consul/10-20-2022-16-21-10_44de40e9/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-consul/10-20-2022-16-21-10_44de40e9/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-consul/10-21-2022-14-12-10_9b68b9bf/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-consul/10-21-2022-14-12-10_9b68b9bf/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-consul/10-21-2022-14-17-10_9b68b9bf/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-consul/10-21-2022-14-17-10_9b68b9bf/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-consul/10-21-2022-14-23-10_9b68b9bf/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-consul/10-21-2022-14-23-10_9b68b9bf/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-consul/10-24-2022-13-48-10_af9800e4/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-consul/10-24-2022-13-48-10_af9800e4/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-consul/10-27-2023-00-09-10_0ba626af/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-consul/10-27-2023-00-09-10_0ba626af/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-consul/10-31-2023-03-55-10_d2f1b165/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-consul/10-31-2023-03-55-10_d2f1b165/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-consul/10-31-2023-04-00-10_d2f1b165/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-consul/10-31-2023-04-00-10_d2f1b165/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-consul/10-31-2023-04-09-10_d2f1b165/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-consul/10-31-2023-04-09-10_d2f1b165/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-consul/11-01-2023-23-58-11_26aea5c6/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-consul/11-01-2023-23-58-11_26aea5c6/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-consul/11-02-2023-23-48-11_2a9823d3/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-consul/11-02-2023-23-48-11_2a9823d3/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-consul/11-10-2022-01-47-11_2e965872/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-consul/11-10-2022-01-47-11_2e965872/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-consul/11-22-2022-02-21-11_f8b091e8/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-consul/11-22-2022-02-21-11_f8b091e8/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-consul/12-02-2022-02-01-12_a1fc8347/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-consul/12-02-2022-02-01-12_a1fc8347/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-consul/12-02-2022-16-05-12_ed953646/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-consul/12-02-2022-16-05-12_ed953646/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-consul/12-15-2022-13-36-12_3cd776e5/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-consul/12-15-2022-13-36-12_3cd776e5/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-consul/12-15-2022-16-47-12_0a331ecc/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-consul/12-15-2022-16-47-12_0a331ecc/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-consul/12-19-2022-17-29-12_c7259f54/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-consul/12-19-2022-17-29-12_c7259f54/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-consul/12-22-2022-14-59-12_fd9e2068/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-consul/12-22-2022-14-59-12_fd9e2068/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-consul/12-26-2022-14-15-12_36fce1c7/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-consul/12-26-2022-14-15-12_36fce1c7/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-consul/12-26-2022-15-02-12_35d1027c/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-consul/12-26-2022-15-02-12_35d1027c/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-consul/12-26-2022-15-15-12_db1321ef/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-consul/12-26-2022-15-15-12_db1321ef/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-consul/12-26-2022-15-17-12_db1321ef/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-consul/12-26-2022-15-17-12_db1321ef/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-istio/01-04-2022-03-02-01_fa8672c0/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-istio/01-04-2022-03-02-01_fa8672c0/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-istio/01-04-2022-03-04-01_fa8672c0/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-istio/01-04-2022-03-04-01_fa8672c0/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-istio/01-04-2022-03-05-01_f0fa5dc8/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-istio/01-04-2022-03-05-01_f0fa5dc8/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-istio/01-04-2023-08-13-01_6db2ab99/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-istio/01-04-2023-08-13-01_6db2ab99/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-istio/01-04-2023-08-14-01_6db2ab99/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-istio/01-04-2023-08-14-01_6db2ab99/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-istio/01-05-2022-18-00-01_27f183cb/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-istio/01-05-2022-18-00-01_27f183cb/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-istio/01-05-2022-18-01-01_fb0a56c8/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-istio/01-05-2022-18-01-01_fb0a56c8/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-istio/01-05-2023-19-00-01_403c2307/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-istio/01-05-2023-19-00-01_403c2307/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-istio/01-05-2023-19-03-01_403c2307/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-istio/01-05-2023-19-03-01_403c2307/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-istio/01-05-2023-19-05-01_403c2307/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-istio/01-05-2023-19-05-01_403c2307/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-istio/01-06-2022-19-34-01_d050eb4c/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-istio/01-06-2022-19-34-01_d050eb4c/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-istio/01-06-2022-19-35-01_d050eb4c/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-istio/01-06-2022-19-35-01_d050eb4c/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-istio/01-06-2023-14-27-01_559bdfb8/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-istio/01-06-2023-14-27-01_559bdfb8/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-istio/01-06-2023-14-27-01_b0a0cf6f/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-istio/01-06-2023-14-27-01_b0a0cf6f/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-istio/01-06-2023-14-28-01_559bdfb8/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-istio/01-06-2023-14-28-01_559bdfb8/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-istio/01-06-2023-14-30-01_559bdfb8/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-istio/01-06-2023-14-30-01_559bdfb8/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-istio/01-06-2023-14-30-01_b0a0cf6f/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-istio/01-06-2023-14-30-01_b0a0cf6f/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-istio/01-11-2024-01-17-01_40f04b7b/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-istio/01-11-2024-01-17-01_40f04b7b/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-istio/01-11-2024-01-21-01_40f04b7b/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-istio/01-11-2024-01-21-01_40f04b7b/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-istio/01-11-2024-01-23-01_40f04b7b/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-istio/01-11-2024-01-23-01_40f04b7b/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-istio/01-12-2023-05-08-01_59a394a6/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-istio/01-12-2023-05-08-01_59a394a6/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-istio/01-12-2023-05-09-01_59a394a6/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-istio/01-12-2023-05-09-01_59a394a6/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-istio/01-13-2023-05-18-01_ba0c9d60/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-istio/01-13-2023-05-18-01_ba0c9d60/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-istio/01-13-2023-05-19-01_ba0c9d60/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-istio/01-13-2023-05-19-01_ba0c9d60/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-istio/01-15-2024-00-27-01_d8314a2f/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-istio/01-15-2024-00-27-01_d8314a2f/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-istio/01-15-2024-17-59-01_bc57a5d9/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-istio/01-15-2024-17-59-01_bc57a5d9/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-istio/01-15-2024-18-00-01_bc57a5d9/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-istio/01-15-2024-18-00-01_bc57a5d9/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-istio/01-16-2022-14-33-01_bd6c2b35/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-istio/01-16-2022-14-33-01_bd6c2b35/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-istio/01-16-2023-10-19-01_db0ededd/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-istio/01-16-2023-10-19-01_db0ededd/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-istio/01-16-2023-10-22-01_db0ededd/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-istio/01-16-2023-10-22-01_db0ededd/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-istio/01-16-2023-10-23-01_6e4fb208/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-istio/01-16-2023-10-23-01_6e4fb208/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-istio/01-16-2023-10-25-01_6e4fb208/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-istio/01-16-2023-10-25-01_6e4fb208/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-istio/01-16-2023-10-28-01_6e4fb208/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-istio/01-16-2023-10-28-01_6e4fb208/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-istio/01-16-2023-13-19-01_6e4fb208/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-istio/01-16-2023-13-19-01_6e4fb208/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-istio/01-16-2023-13-22-01_6e4fb208/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-istio/01-16-2023-13-22-01_6e4fb208/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-istio/01-16-2023-13-23-01_6e4fb208/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-istio/01-16-2023-13-23-01_6e4fb208/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-istio/01-16-2023-13-25-01_6e4fb208/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-istio/01-16-2023-13-25-01_6e4fb208/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-istio/01-16-2025-01-07-01_26f5522b/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-istio/01-16-2025-01-07-01_26f5522b/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-istio/01-17-2022-21-12-01_48edcf00/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-istio/01-17-2022-21-12-01_48edcf00/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-istio/01-18-2022-14-48-01_287e130a/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-istio/01-18-2022-14-48-01_287e130a/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-istio/01-18-2022-14-50-01_287e130a/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-istio/01-18-2022-14-50-01_287e130a/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-istio/01-18-2022-14-52-01_532877cb/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-istio/01-18-2022-14-52-01_532877cb/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-istio/01-18-2022-14-53-01_532877cb/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-istio/01-18-2022-14-53-01_532877cb/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-istio/01-19-2022-00-32-01_7dd50c6b/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-istio/01-19-2022-00-32-01_7dd50c6b/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-istio/01-21-2023-01-29-01_dc6adc92/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-istio/01-21-2023-01-29-01_dc6adc92/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-istio/01-21-2023-01-30-01_dc6adc92/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-istio/01-21-2023-01-30-01_dc6adc92/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-istio/01-23-2023-15-46-01_435b6630/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-istio/01-23-2023-15-46-01_435b6630/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-istio/01-23-2023-15-58-01_1f6f7736/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-istio/01-23-2023-15-58-01_1f6f7736/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-istio/01-23-2023-16-01-01_1f6f7736/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-istio/01-23-2023-16-01-01_1f6f7736/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-istio/01-24-2022-21-44-01_b5c19631/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-istio/01-24-2022-21-44-01_b5c19631/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-istio/01-24-2022-21-45-01_b5c19631/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-istio/01-24-2022-21-45-01_b5c19631/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-istio/01-24-2022-21-46-01_b5c19631/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-istio/01-24-2022-21-46-01_b5c19631/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-istio/01-25-2022-13-49-01_0bec867e/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-istio/01-25-2022-13-49-01_0bec867e/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-istio/01-25-2022-14-20-01_d9b13cfe/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-istio/01-25-2022-14-20-01_d9b13cfe/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-istio/01-26-2023-16-42-01_1e606ecb/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-istio/01-26-2023-16-42-01_1e606ecb/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-istio/01-26-2023-16-45-01_1e606ecb/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-istio/01-26-2023-16-45-01_1e606ecb/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-istio/01-27-2024-01-14-01_566c4f87/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-istio/01-27-2024-01-14-01_566c4f87/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-istio/01-27-2024-01-15-01_566c4f87/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-istio/01-27-2024-01-15-01_566c4f87/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-istio/01-27-2024-01-17-01_566c4f87/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-istio/01-27-2024-01-17-01_566c4f87/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-istio/01-29-2022-16-46-01_ee0dbf84/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-istio/01-29-2022-16-46-01_ee0dbf84/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-istio/01-29-2022-16-52-01_33929ed3/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-istio/01-29-2022-16-52-01_33929ed3/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-istio/01-29-2022-16-54-01_33929ed3/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-istio/01-29-2022-16-54-01_33929ed3/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-istio/01-29-2022-17-42-01_33929ed3/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-istio/01-29-2022-17-42-01_33929ed3/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-istio/01-29-2022-17-43-01_33929ed3/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-istio/01-29-2022-17-43-01_33929ed3/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-istio/01-31-2023-20-57-01_5584cf20/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-istio/01-31-2023-20-57-01_5584cf20/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-istio/01-31-2023-20-58-01_5584cf20/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-istio/01-31-2023-20-58-01_5584cf20/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-istio/01-31-2023-21-00-01_70cca7a7/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-istio/01-31-2023-21-00-01_70cca7a7/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-istio/01-31-2023-21-06-01_70cca7a7/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-istio/01-31-2023-21-06-01_70cca7a7/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-istio/02-01-2022-21-45-02_2cbb0225/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-istio/02-01-2022-21-45-02_2cbb0225/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-istio/02-01-2022-21-46-02_2cbb0225/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-istio/02-01-2022-21-46-02_2cbb0225/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-istio/02-02-2022-05-55-02_27fece60/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-istio/02-02-2022-05-55-02_27fece60/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-istio/02-03-2024-01-21-02_afa536c8/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-istio/02-03-2024-01-21-02_afa536c8/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-istio/02-03-2024-01-32-02_afa536c8/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-istio/02-03-2024-01-32-02_afa536c8/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-istio/02-05-2022-00-30-02_085644ef/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-istio/02-05-2022-00-30-02_085644ef/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-istio/02-05-2022-00-31-02_085644ef/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-istio/02-05-2022-00-31-02_085644ef/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-istio/02-07-2023-01-33-02_c563fb89/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-istio/02-07-2023-01-33-02_c563fb89/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-istio/02-07-2023-19-51-02_c563fb89/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-istio/02-07-2023-19-51-02_c563fb89/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-istio/02-07-2023-19-52-02_c563fb89/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-istio/02-07-2023-19-52-02_c563fb89/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-istio/02-07-2023-22-00-02_bdea5432/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-istio/02-07-2023-22-00-02_bdea5432/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-istio/02-07-2023-22-01-02_bdea5432/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-istio/02-07-2023-22-01-02_bdea5432/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-istio/02-07-2023-22-05-02_4a4eb03c/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-istio/02-07-2023-22-05-02_4a4eb03c/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-istio/02-07-2023-22-11-02_4a4eb03c/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-istio/02-07-2023-22-11-02_4a4eb03c/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-istio/02-07-2023-22-15-02_4a4eb03c/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-istio/02-07-2023-22-15-02_4a4eb03c/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-istio/02-08-2023-13-14-02_a771230a/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-istio/02-08-2023-13-14-02_a771230a/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-istio/02-08-2023-13-16-02_a771230a/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-istio/02-08-2023-13-16-02_a771230a/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-istio/02-08-2023-13-20-02_a771230a/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-istio/02-08-2023-13-20-02_a771230a/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-istio/02-11-2022-15-39-02_8deb7179/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-istio/02-11-2022-15-39-02_8deb7179/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-istio/02-11-2022-15-40-02_8deb7179/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-istio/02-11-2022-15-40-02_8deb7179/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-istio/02-11-2023-01-20-02_a4dbd3b4/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-istio/02-11-2023-01-20-02_a4dbd3b4/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-istio/02-11-2023-01-21-02_a4dbd3b4/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-istio/02-11-2023-01-21-02_a4dbd3b4/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-istio/02-11-2023-01-24-02_a4dbd3b4/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-istio/02-11-2023-01-24-02_a4dbd3b4/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-istio/02-12-2022-00-35-02_54019554/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-istio/02-12-2022-00-35-02_54019554/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-istio/02-13-2023-18-09-02_bd449bc5/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-istio/02-13-2023-18-09-02_bd449bc5/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-istio/02-13-2023-18-12-02_bd449bc5/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-istio/02-13-2023-18-12-02_bd449bc5/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-istio/02-13-2023-18-15-02_bd449bc5/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-istio/02-13-2023-18-15-02_bd449bc5/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-istio/02-14-2023-13-30-02_bd449bc5/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-istio/02-14-2023-13-30-02_bd449bc5/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-istio/02-14-2023-13-31-02_bd449bc5/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-istio/02-14-2023-13-31-02_bd449bc5/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-istio/02-14-2023-13-39-02_bd449bc5/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-istio/02-14-2023-13-39-02_bd449bc5/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-istio/02-15-2023-01-29-02_0980477c/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-istio/02-15-2023-01-29-02_0980477c/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-istio/02-15-2023-01-30-02_0980477c/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-istio/02-15-2023-01-30-02_0980477c/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-istio/02-16-2024-06-31-02_8677a7c8/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-istio/02-16-2024-06-31-02_8677a7c8/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-istio/02-16-2024-07-25-02_8677a7c8/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-istio/02-16-2024-07-25-02_8677a7c8/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-istio/02-16-2024-09-58-02_26ed9e85/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-istio/02-16-2024-09-58-02_26ed9e85/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-istio/02-16-2024-10-04-02_27ed6a4b/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-istio/02-16-2024-10-04-02_27ed6a4b/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-istio/02-16-2024-10-10-02_27ed6a4b/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-istio/02-16-2024-10-10-02_27ed6a4b/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-istio/02-21-2024-01-40-02_b75b3949/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-istio/02-21-2024-01-40-02_b75b3949/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-istio/02-21-2024-01-43-02_b75b3949/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-istio/02-21-2024-01-43-02_b75b3949/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-istio/02-21-2024-01-51-02_b75b3949/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-istio/02-21-2024-01-51-02_b75b3949/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-istio/02-22-2022-19-30-02_54019554/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-istio/02-22-2022-19-30-02_54019554/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-istio/02-22-2022-19-31-02_54019554/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-istio/02-22-2022-19-31-02_54019554/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-istio/02-22-2022-19-33-02_54019554/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-istio/02-22-2022-19-33-02_54019554/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-istio/02-23-2022-00-40-02_e2e2bde9/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-istio/02-23-2022-00-40-02_e2e2bde9/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-istio/02-23-2022-00-41-02_e2e2bde9/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-istio/02-23-2022-00-41-02_e2e2bde9/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-istio/02-23-2023-13-13-02_48061c7a/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-istio/02-23-2023-13-13-02_48061c7a/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-istio/02-23-2023-13-16-02_48061c7a/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-istio/02-23-2023-13-16-02_48061c7a/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-istio/02-23-2023-17-51-02_afd430e6/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-istio/02-23-2023-17-51-02_afd430e6/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-istio/02-23-2023-17-52-02_afd430e6/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-istio/02-23-2023-17-52-02_afd430e6/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-istio/02-23-2023-17-53-02_afd430e6/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-istio/02-23-2023-17-53-02_afd430e6/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-istio/02-25-2022-22-38-02_8c61d09b/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-istio/02-25-2022-22-38-02_8c61d09b/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-istio/02-25-2022-22-39-02_8c61d09b/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-istio/02-25-2022-22-39-02_8c61d09b/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-istio/02-26-2024-21-38-02_b75b3949/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-istio/02-26-2024-21-38-02_b75b3949/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-istio/02-26-2024-21-40-02_b75b3949/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-istio/02-26-2024-21-40-02_b75b3949/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-istio/02-26-2024-21-41-02_b75b3949/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-istio/02-26-2024-21-41-02_b75b3949/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-istio/03-01-2022-02-06-03_7bedaba5/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-istio/03-01-2022-02-06-03_7bedaba5/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-istio/03-01-2022-02-07-03_7bedaba5/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-istio/03-01-2022-02-07-03_7bedaba5/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-istio/03-06-2023-16-04-03_b0b000bf/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-istio/03-06-2023-16-04-03_b0b000bf/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-istio/03-06-2023-17-14-03_b0b000bf/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-istio/03-06-2023-17-14-03_b0b000bf/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-istio/03-06-2023-17-15-03_6dd38ec4/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-istio/03-06-2023-17-15-03_6dd38ec4/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-istio/03-06-2023-17-25-03_6dd38ec4/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-istio/03-06-2023-17-25-03_6dd38ec4/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-istio/03-06-2023-17-27-03_6dd38ec4/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-istio/03-06-2023-17-27-03_6dd38ec4/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-istio/03-07-2022-16-10-03_2eeeac5b/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-istio/03-07-2022-16-10-03_2eeeac5b/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-istio/03-07-2022-16-11-03_2eeeac5b/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-istio/03-07-2022-16-11-03_2eeeac5b/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-istio/03-08-2024-00-32-03_9d894558/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-istio/03-08-2024-00-32-03_9d894558/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-istio/03-08-2024-00-33-03_9d894558/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-istio/03-08-2024-00-33-03_9d894558/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-istio/03-10-2022-00-38-03_9ba4e8ec/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-istio/03-10-2022-00-38-03_9ba4e8ec/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-istio/03-10-2022-03-51-03_919260d8/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-istio/03-10-2022-03-51-03_919260d8/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-istio/03-12-2022-04-08-03_29477dce/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-istio/03-12-2022-04-08-03_29477dce/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-istio/03-14-2022-17-05-03_00609d25/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-istio/03-14-2022-17-05-03_00609d25/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-istio/03-16-2022-15-53-03_a8a4769c/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-istio/03-16-2022-15-53-03_a8a4769c/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-istio/03-16-2022-15-54-03_a8a4769c/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-istio/03-16-2022-15-54-03_a8a4769c/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-istio/03-17-2022-00-13-03_70ba4123/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-istio/03-17-2022-00-13-03_70ba4123/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-istio/03-17-2022-00-14-03_70ba4123/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-istio/03-17-2022-00-14-03_70ba4123/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-istio/03-17-2022-00-27-03_df77d1c2/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-istio/03-17-2022-00-27-03_df77d1c2/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-istio/03-17-2022-00-31-03_a6fd1c61/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-istio/03-17-2022-00-31-03_a6fd1c61/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-istio/03-17-2022-00-31-03_c5a94e14/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-istio/03-17-2022-00-31-03_c5a94e14/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-istio/03-17-2022-00-32-03_1fbfb32f/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-istio/03-17-2022-00-32-03_1fbfb32f/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-istio/03-17-2022-00-35-03_a6fd1c61/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-istio/03-17-2022-00-35-03_a6fd1c61/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-istio/03-17-2022-00-35-03_c5a94e14/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-istio/03-17-2022-00-35-03_c5a94e14/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-istio/03-17-2022-00-35-03_df77d1c2/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-istio/03-17-2022-00-35-03_df77d1c2/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-istio/03-17-2022-00-36-03_1fbfb32f/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-istio/03-17-2022-00-36-03_1fbfb32f/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-istio/03-17-2022-00-37-03_0f64fd51/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-istio/03-17-2022-00-37-03_0f64fd51/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-istio/03-17-2022-00-39-03_0f64fd51/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-istio/03-17-2022-00-39-03_0f64fd51/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-istio/03-17-2022-00-42-03_21a7ae54/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-istio/03-17-2022-00-42-03_21a7ae54/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-istio/03-17-2022-00-43-03_21a7ae54/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-istio/03-17-2022-00-43-03_21a7ae54/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-istio/03-22-2022-07-48-03_21a7ae54/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-istio/03-22-2022-07-48-03_21a7ae54/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-istio/03-22-2022-14-03-03_1f49c36a/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-istio/03-22-2022-14-03-03_1f49c36a/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-istio/03-22-2022-20-22-03_1f49c36a/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-istio/03-22-2022-20-22-03_1f49c36a/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-istio/03-22-2022-20-23-03_1f49c36a/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-istio/03-22-2022-20-23-03_1f49c36a/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-istio/03-22-2022-20-24-03_1f49c36a/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-istio/03-22-2022-20-24-03_1f49c36a/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-istio/03-23-2023-15-44-03_5ccf28e5/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-istio/03-23-2023-15-44-03_5ccf28e5/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-istio/03-23-2023-16-27-03_5ccf28e5/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-istio/03-23-2023-16-27-03_5ccf28e5/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-istio/03-23-2023-16-40-03_0fa2b69d/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-istio/03-23-2023-16-40-03_0fa2b69d/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-istio/03-23-2023-17-58-03_0fa2b69d/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-istio/03-23-2023-17-58-03_0fa2b69d/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-istio/03-30-2022-21-42-03_297f9d33/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-istio/03-30-2022-21-42-03_297f9d33/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-istio/03-30-2022-21-43-03_297f9d33/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-istio/03-30-2022-21-43-03_297f9d33/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-istio/03-31-2023-20-53-03_ae5fa286/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-istio/03-31-2023-20-53-03_ae5fa286/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-istio/03-31-2023-20-53-03_b2ba7482/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-istio/03-31-2023-20-53-03_b2ba7482/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-istio/03-31-2023-20-56-03_ae5fa286/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-istio/03-31-2023-20-56-03_ae5fa286/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-istio/03-31-2023-20-57-03_ae5fa286/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-istio/03-31-2023-20-57-03_ae5fa286/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-istio/03-31-2023-21-09-03_7a505446/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-istio/03-31-2023-21-09-03_7a505446/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-istio/03-31-2023-21-11-03_7a505446/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-istio/03-31-2023-21-11-03_7a505446/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-istio/03-31-2023-21-12-03_7a505446/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-istio/03-31-2023-21-12-03_7a505446/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-istio/04-07-2022-13-26-04_f3af2031/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-istio/04-07-2022-13-26-04_f3af2031/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-istio/04-07-2022-13-27-04_f3af2031/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-istio/04-07-2022-13-27-04_f3af2031/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-istio/04-07-2022-13-29-04_f3af2031/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-istio/04-07-2022-13-29-04_f3af2031/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-istio/04-07-2022-13-30-04_f3af2031/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-istio/04-07-2022-13-30-04_f3af2031/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-istio/04-11-2022-02-10-04_8964c6c2/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-istio/04-11-2022-02-10-04_8964c6c2/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-istio/04-11-2022-02-12-04_8964c6c2/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-istio/04-11-2022-02-12-04_8964c6c2/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-istio/04-11-2022-14-41-04_7ee1ef67/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-istio/04-11-2022-14-41-04_7ee1ef67/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-istio/04-12-2022-18-42-04_6e315d7f/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-istio/04-12-2022-18-42-04_6e315d7f/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-istio/04-12-2022-18-43-04_6e315d7f/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-istio/04-12-2022-18-43-04_6e315d7f/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-istio/04-15-2022-16-05-04_3b17696a/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-istio/04-15-2022-16-05-04_3b17696a/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-istio/04-15-2022-16-06-04_3b17696a/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-istio/04-15-2022-16-06-04_3b17696a/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-istio/04-15-2022-16-08-04_3b17696a/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-istio/04-15-2022-16-08-04_3b17696a/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-istio/04-15-2022-22-24-04_37c6b2f8/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-istio/04-15-2022-22-24-04_37c6b2f8/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-istio/04-15-2022-22-25-04_37c6b2f8/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-istio/04-15-2022-22-25-04_37c6b2f8/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-istio/04-15-2022-22-26-04_37c6b2f8/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-istio/04-15-2022-22-26-04_37c6b2f8/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-istio/04-15-2022-22-28-04_37c6b2f8/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-istio/04-15-2022-22-28-04_37c6b2f8/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-istio/04-15-2022-22-29-04_37c6b2f8/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-istio/04-15-2022-22-29-04_37c6b2f8/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-istio/04-20-2022-01-39-04_be1113f5/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-istio/04-20-2022-01-39-04_be1113f5/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-istio/04-20-2022-01-41-04_be1113f5/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-istio/04-20-2022-01-41-04_be1113f5/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-istio/04-26-2022-13-11-04_41f8d381/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-istio/04-26-2022-13-11-04_41f8d381/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-istio/04-26-2022-13-12-04_41f8d381/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-istio/04-26-2022-13-12-04_41f8d381/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-istio/04-26-2022-13-15-04_41f8d381/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-istio/04-26-2022-13-15-04_41f8d381/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-istio/04-26-2023-08-45-04_ff712d3c/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-istio/04-26-2023-08-45-04_ff712d3c/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-istio/05-03-2022-14-47-05_c858426f/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-istio/05-03-2022-14-47-05_c858426f/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-istio/05-03-2022-14-48-05_c858426f/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-istio/05-03-2022-14-48-05_c858426f/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-istio/05-04-2022-18-56-05_6bd30897/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-istio/05-04-2022-18-56-05_6bd30897/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-istio/05-04-2022-18-58-05_6bd30897/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-istio/05-04-2022-18-58-05_6bd30897/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-istio/05-04-2022-18-59-05_6bd30897/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-istio/05-04-2022-18-59-05_6bd30897/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-istio/05-04-2022-19-00-05_6bd30897/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-istio/05-04-2022-19-00-05_6bd30897/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-istio/05-04-2022-19-02-05_6bd30897/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-istio/05-04-2022-19-02-05_6bd30897/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-istio/05-04-2022-19-04-05_6bd30897/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-istio/05-04-2022-19-04-05_6bd30897/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-istio/05-04-2023-01-24-05_013e3f85/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-istio/05-04-2023-01-24-05_013e3f85/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-istio/05-04-2023-01-25-05_013e3f85/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-istio/05-04-2023-01-25-05_013e3f85/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-istio/05-05-2022-16-26-05_d0c2ea74/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-istio/05-05-2022-16-26-05_d0c2ea74/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-istio/05-06-2022-15-13-05_ff200319/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-istio/05-06-2022-15-13-05_ff200319/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-istio/05-06-2022-15-14-05_ff200319/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-istio/05-06-2022-15-14-05_ff200319/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-istio/05-10-2022-01-22-05_af657ee3/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-istio/05-10-2022-01-22-05_af657ee3/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-istio/05-10-2022-01-24-05_af657ee3/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-istio/05-10-2022-01-24-05_af657ee3/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-istio/05-12-2023-01-25-05_06982fff/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-istio/05-12-2023-01-25-05_06982fff/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-istio/05-12-2023-01-26-05_06982fff/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-istio/05-12-2023-01-26-05_06982fff/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-istio/05-16-2022-01-30-05_75ddd299/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-istio/05-16-2022-01-30-05_75ddd299/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-istio/05-16-2022-01-31-05_75ddd299/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-istio/05-16-2022-01-31-05_75ddd299/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-istio/05-16-2022-01-35-05_75ddd299/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-istio/05-16-2022-01-35-05_75ddd299/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-istio/05-16-2022-16-34-05_08085932/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-istio/05-16-2022-16-34-05_08085932/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-istio/05-16-2022-16-38-05_08085932/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-istio/05-16-2022-16-38-05_08085932/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-istio/05-21-2022-01-20-05_8810b890/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-istio/05-21-2022-01-20-05_8810b890/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-istio/05-21-2022-01-21-05_8810b890/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-istio/05-21-2022-01-21-05_8810b890/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-istio/05-21-2022-01-22-05_8810b890/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-istio/05-21-2022-01-22-05_8810b890/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-istio/05-21-2023-23-37-05_cfa4c1d9/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-istio/05-21-2023-23-37-05_cfa4c1d9/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-istio/05-24-2022-18-28-05_6570f148/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-istio/05-24-2022-18-28-05_6570f148/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-istio/05-24-2022-18-29-05_6570f148/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-istio/05-24-2022-18-29-05_6570f148/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-istio/05-24-2022-18-32-05_6570f148/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-istio/05-24-2022-18-32-05_6570f148/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-istio/05-25-2023-18-12-05_6c8371ff/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-istio/05-25-2023-18-12-05_6c8371ff/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-istio/05-26-2023-01-25-05_cd67ee8c/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-istio/05-26-2023-01-25-05_cd67ee8c/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-istio/05-26-2023-01-26-05_cd67ee8c/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-istio/05-26-2023-01-26-05_cd67ee8c/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-istio/05-26-2023-01-27-05_cd67ee8c/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-istio/05-26-2023-01-27-05_cd67ee8c/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-istio/05-30-2022-17-07-05_ca475b11/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-istio/05-30-2022-17-07-05_ca475b11/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-istio/05-30-2022-17-08-05_ca475b11/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-istio/05-30-2022-17-08-05_ca475b11/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-istio/05-31-2022-13-13-05_ca475b11/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-istio/05-31-2022-13-13-05_ca475b11/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-istio/05-31-2022-13-15-05_ca475b11/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-istio/05-31-2022-13-15-05_ca475b11/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-istio/05-31-2022-13-16-05_ca475b11/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-istio/05-31-2022-13-16-05_ca475b11/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-istio/06-02-2022-01-39-06_7d2aa3f8/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-istio/06-02-2022-01-39-06_7d2aa3f8/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-istio/06-02-2022-01-40-06_7d2aa3f8/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-istio/06-02-2022-01-40-06_7d2aa3f8/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-istio/06-08-2022-07-42-06_93cd4b9d/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-istio/06-08-2022-07-42-06_93cd4b9d/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-istio/06-08-2022-07-46-06_93cd4b9d/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-istio/06-08-2022-07-46-06_93cd4b9d/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-istio/06-08-2023-01-35-06_28f9d4a8/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-istio/06-08-2023-01-35-06_28f9d4a8/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-istio/06-08-2023-01-36-06_28f9d4a8/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-istio/06-08-2023-01-36-06_28f9d4a8/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-istio/06-08-2023-01-37-06_28f9d4a8/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-istio/06-08-2023-01-37-06_28f9d4a8/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-istio/06-09-2023-11-04-06_e6ab6777/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-istio/06-09-2023-11-04-06_e6ab6777/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-istio/06-09-2023-11-05-06_e6ab6777/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-istio/06-09-2023-11-05-06_e6ab6777/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-istio/06-09-2023-11-21-06_c854864c/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-istio/06-09-2023-11-21-06_c854864c/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-istio/06-09-2023-11-22-06_c854864c/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-istio/06-09-2023-11-22-06_c854864c/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-istio/06-09-2023-11-24-06_c854864c/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-istio/06-09-2023-11-24-06_c854864c/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-istio/06-09-2023-11-49-06_c854864c/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-istio/06-09-2023-11-49-06_c854864c/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-istio/06-09-2023-15-23-06_c854864c/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-istio/06-09-2023-15-23-06_c854864c/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-istio/06-09-2023-15-24-06_c854864c/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-istio/06-09-2023-15-24-06_c854864c/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-istio/06-09-2023-15-29-06_c854864c/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-istio/06-09-2023-15-29-06_c854864c/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-istio/06-09-2023-15-33-06_c854864c/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-istio/06-09-2023-15-33-06_c854864c/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-istio/06-09-2023-15-34-06_c854864c/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-istio/06-09-2023-15-34-06_c854864c/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-istio/06-09-2023-15-35-06_c854864c/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-istio/06-09-2023-15-35-06_c854864c/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-istio/06-10-2022-16-37-06_93cd4b9d/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-istio/06-10-2022-16-37-06_93cd4b9d/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-istio/06-10-2022-16-38-06_93cd4b9d/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-istio/06-10-2022-16-38-06_93cd4b9d/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-istio/06-10-2022-16-39-06_93cd4b9d/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-istio/06-10-2022-16-39-06_93cd4b9d/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-istio/06-10-2022-16-45-06_93cd4b9d/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-istio/06-10-2022-16-45-06_93cd4b9d/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-istio/06-10-2022-16-46-06_93cd4b9d/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-istio/06-10-2022-16-46-06_93cd4b9d/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-istio/06-11-2022-01-32-06_e6160e51/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-istio/06-11-2022-01-32-06_e6160e51/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-istio/06-11-2022-01-33-06_e6160e51/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-istio/06-11-2022-01-33-06_e6160e51/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-istio/06-11-2022-07-22-06_42fa4e7c/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-istio/06-11-2022-07-22-06_42fa4e7c/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-istio/06-11-2022-07-23-06_42fa4e7c/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-istio/06-11-2022-07-23-06_42fa4e7c/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-istio/06-11-2022-11-21-06_c6ff2dfb/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-istio/06-11-2022-11-21-06_c6ff2dfb/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-istio/06-11-2022-11-36-06_c6ff2dfb/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-istio/06-11-2022-11-36-06_c6ff2dfb/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-istio/06-11-2022-11-39-06_c6ff2dfb/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-istio/06-11-2022-11-39-06_c6ff2dfb/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-istio/06-11-2022-11-42-06_c6ff2dfb/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-istio/06-11-2022-11-42-06_c6ff2dfb/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-istio/06-11-2022-11-44-06_c6ff2dfb/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-istio/06-11-2022-11-44-06_c6ff2dfb/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-istio/06-13-2023-20-58-06_aba01180/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-istio/06-13-2023-20-58-06_aba01180/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-istio/06-13-2023-20-59-06_aba01180/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-istio/06-13-2023-20-59-06_aba01180/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-istio/06-13-2023-21-01-06_aba01180/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-istio/06-13-2023-21-01-06_aba01180/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-istio/06-13-2023-21-02-06_aba01180/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-istio/06-13-2023-21-02-06_aba01180/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-istio/06-13-2023-21-09-06_aba01180/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-istio/06-13-2023-21-09-06_aba01180/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-istio/06-15-2023-18-00-06_6cb20387/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-istio/06-15-2023-18-00-06_6cb20387/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-istio/06-15-2023-18-01-06_6cb20387/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-istio/06-15-2023-18-01-06_6cb20387/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-istio/06-15-2023-18-37-06_6cb20387/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-istio/06-15-2023-18-37-06_6cb20387/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-istio/06-15-2023-18-43-06_a5fb03d9/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-istio/06-15-2023-18-43-06_a5fb03d9/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-istio/06-15-2023-18-47-06_a5fb03d9/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-istio/06-15-2023-18-47-06_a5fb03d9/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-istio/06-15-2023-18-48-06_a5fb03d9/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-istio/06-15-2023-18-48-06_a5fb03d9/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-istio/06-16-2022-18-06-06_7e77c9bc/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-istio/06-16-2022-18-06-06_7e77c9bc/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-istio/06-16-2022-18-07-06_7e77c9bc/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-istio/06-16-2022-18-07-06_7e77c9bc/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-istio/06-16-2022-18-08-06_7e77c9bc/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-istio/06-16-2022-18-08-06_7e77c9bc/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-istio/06-17-2022-13-19-06_a53a72bc/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-istio/06-17-2022-13-19-06_a53a72bc/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-istio/06-17-2022-13-20-06_a53a72bc/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-istio/06-17-2022-13-20-06_a53a72bc/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-istio/06-17-2022-15-06-06_27d5ba8d/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-istio/06-17-2022-15-06-06_27d5ba8d/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-istio/06-17-2022-15-07-06_27d5ba8d/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-istio/06-17-2022-15-07-06_27d5ba8d/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-istio/06-17-2022-15-08-06_27d5ba8d/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-istio/06-17-2022-15-08-06_27d5ba8d/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-istio/06-20-2022-21-10-06_27d5ba8d/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-istio/06-20-2022-21-10-06_27d5ba8d/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-istio/06-20-2022-21-11-06_27d5ba8d/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-istio/06-20-2022-21-11-06_27d5ba8d/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-istio/06-20-2022-21-12-06_27d5ba8d/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-istio/06-20-2022-21-12-06_27d5ba8d/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-istio/06-20-2022-21-15-06_27d5ba8d/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-istio/06-20-2022-21-15-06_27d5ba8d/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-istio/06-20-2022-21-16-06_27d5ba8d/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-istio/06-20-2022-21-16-06_27d5ba8d/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-istio/06-20-2022-21-22-06_27d5ba8d/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-istio/06-20-2022-21-22-06_27d5ba8d/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-istio/06-22-2023-17-45-06_aba01180/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-istio/06-22-2023-17-45-06_aba01180/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-istio/06-25-2022-04-22-06_27033060/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-istio/06-25-2022-04-22-06_27033060/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-istio/06-25-2022-04-23-06_27033060/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-istio/06-25-2022-04-23-06_27033060/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-istio/06-25-2022-04-24-06_27033060/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-istio/06-25-2022-04-24-06_27033060/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-istio/06-26-2022-19-59-06_d63cbbea/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-istio/06-26-2022-19-59-06_d63cbbea/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-istio/06-26-2022-20-00-06_d63cbbea/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-istio/06-26-2022-20-00-06_d63cbbea/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-istio/06-26-2022-20-03-06_d63cbbea/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-istio/06-26-2022-20-03-06_d63cbbea/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-istio/06-29-2023-01-35-06_0745077b/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-istio/06-29-2023-01-35-06_0745077b/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-istio/06-29-2023-01-36-06_0745077b/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-istio/06-29-2023-01-36-06_0745077b/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-istio/06-29-2023-01-38-06_0745077b/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-istio/06-29-2023-01-38-06_0745077b/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-istio/06-29-2023-14-06-06_ea379008/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-istio/06-29-2023-14-06-06_ea379008/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-istio/06-29-2023-14-16-06_ea379008/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-istio/06-29-2023-14-16-06_ea379008/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-istio/07-04-2022-17-53-07_d80711f7/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-istio/07-04-2022-17-53-07_d80711f7/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-istio/07-04-2022-17-55-07_d80711f7/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-istio/07-04-2022-17-55-07_d80711f7/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-istio/07-04-2022-17-57-07_d80711f7/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-istio/07-04-2022-17-57-07_d80711f7/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-istio/07-04-2023-10-46-07_84305f8d/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-istio/07-04-2023-10-46-07_84305f8d/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-istio/07-04-2023-10-49-07_84305f8d/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-istio/07-04-2023-10-49-07_84305f8d/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-istio/07-08-2022-21-44-07_e50713f4/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-istio/07-08-2022-21-44-07_e50713f4/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-istio/07-08-2022-21-45-07_e50713f4/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-istio/07-08-2022-21-45-07_e50713f4/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-istio/07-08-2022-21-48-07_e50713f4/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-istio/07-08-2022-21-48-07_e50713f4/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-istio/07-08-2022-21-49-07_e50713f4/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-istio/07-08-2022-21-49-07_e50713f4/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-istio/07-08-2022-21-55-07_e50713f4/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-istio/07-08-2022-21-55-07_e50713f4/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-istio/07-08-2022-23-27-07_c779f0fb/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-istio/07-08-2022-23-27-07_c779f0fb/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-istio/07-15-2022-11-44-07_92c852fe/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-istio/07-15-2022-11-44-07_92c852fe/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-istio/07-15-2022-11-45-07_92c852fe/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-istio/07-15-2022-11-45-07_92c852fe/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-istio/07-15-2022-11-46-07_92c852fe/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-istio/07-15-2022-11-46-07_92c852fe/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-istio/07-18-2022-18-07-07_2e591607/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-istio/07-18-2022-18-07-07_2e591607/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-istio/07-18-2022-18-41-07_2e591607/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-istio/07-18-2022-18-41-07_2e591607/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-istio/07-18-2022-18-42-07_2e591607/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-istio/07-18-2022-18-42-07_2e591607/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-istio/07-18-2022-19-31-07_e85d648a/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-istio/07-18-2022-19-31-07_e85d648a/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-istio/07-18-2022-19-32-07_e85d648a/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-istio/07-18-2022-19-32-07_e85d648a/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-istio/07-18-2022-19-33-07_e85d648a/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-istio/07-18-2022-19-33-07_e85d648a/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-istio/07-18-2022-19-34-07_e85d648a/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-istio/07-18-2022-19-34-07_e85d648a/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-istio/07-18-2022-19-36-07_e85d648a/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-istio/07-18-2022-19-36-07_e85d648a/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-istio/07-18-2022-19-39-07_e85d648a/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-istio/07-18-2022-19-39-07_e85d648a/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-istio/07-18-2022-22-14-07_c0607bc3/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-istio/07-18-2022-22-14-07_c0607bc3/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-istio/07-18-2022-22-15-07_c0607bc3/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-istio/07-18-2022-22-15-07_c0607bc3/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-istio/07-18-2022-22-17-07_c0607bc3/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-istio/07-18-2022-22-17-07_c0607bc3/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-istio/07-19-2023-16-01-07_3ee053d6/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-istio/07-19-2023-16-01-07_3ee053d6/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-istio/07-19-2023-16-02-07_3ee053d6/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-istio/07-19-2023-16-02-07_3ee053d6/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-istio/07-19-2023-16-09-07_531a945d/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-istio/07-19-2023-16-09-07_531a945d/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-istio/07-19-2023-16-12-07_531a945d/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-istio/07-19-2023-16-12-07_531a945d/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-istio/07-19-2023-16-13-07_531a945d/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-istio/07-19-2023-16-13-07_531a945d/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-istio/07-19-2023-17-38-07_531a945d/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-istio/07-19-2023-17-38-07_531a945d/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-istio/07-19-2023-17-39-07_531a945d/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-istio/07-19-2023-17-39-07_531a945d/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-istio/07-19-2023-17-43-07_531a945d/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-istio/07-19-2023-17-43-07_531a945d/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-istio/07-19-2023-17-47-07_531a945d/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-istio/07-19-2023-17-47-07_531a945d/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-istio/07-19-2023-17-48-07_531a945d/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-istio/07-19-2023-17-48-07_531a945d/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-istio/07-19-2023-22-46-07_4f4a3148/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-istio/07-19-2023-22-46-07_4f4a3148/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-istio/07-20-2022-00-09-07_da76f55f/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-istio/07-20-2022-00-09-07_da76f55f/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-istio/07-20-2022-00-10-07_da76f55f/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-istio/07-20-2022-00-10-07_da76f55f/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-istio/07-20-2022-00-11-07_da76f55f/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-istio/07-20-2022-00-11-07_da76f55f/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-istio/07-20-2022-00-17-07_2019c8b2/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-istio/07-20-2022-00-17-07_2019c8b2/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-istio/07-20-2022-00-18-07_2019c8b2/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-istio/07-20-2022-00-18-07_2019c8b2/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-istio/07-22-2023-02-55-07_42d37c3b/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-istio/07-22-2023-02-55-07_42d37c3b/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-istio/07-22-2023-03-00-07_42d37c3b/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-istio/07-22-2023-03-00-07_42d37c3b/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-istio/07-22-2023-03-04-07_42d37c3b/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-istio/07-22-2023-03-04-07_42d37c3b/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-istio/07-26-2022-01-59-07_eb360351/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-istio/07-26-2022-01-59-07_eb360351/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-istio/07-26-2022-02-01-07_eb360351/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-istio/07-26-2022-02-01-07_eb360351/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-istio/07-26-2022-02-05-07_eb360351/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-istio/07-26-2022-02-05-07_eb360351/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-istio/07-28-2022-16-05-07_a7904b71/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-istio/07-28-2022-16-05-07_a7904b71/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-istio/07-28-2022-16-06-07_a7904b71/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-istio/07-28-2022-16-06-07_a7904b71/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-istio/07-28-2022-16-08-07_a7904b71/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-istio/07-28-2022-16-08-07_a7904b71/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-istio/07-28-2023-16-25-07_546c1a5c/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-istio/07-28-2023-16-25-07_546c1a5c/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-istio/07-28-2023-16-26-07_546c1a5c/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-istio/07-28-2023-16-26-07_546c1a5c/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-istio/07-30-2022-10-23-07_a07d4b8b/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-istio/07-30-2022-10-23-07_a07d4b8b/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-istio/07-30-2022-10-24-07_a07d4b8b/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-istio/07-30-2022-10-24-07_a07d4b8b/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-istio/07-31-2022-19-25-07_a07d4b8b/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-istio/07-31-2022-19-25-07_a07d4b8b/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-istio/07-31-2022-19-27-07_a07d4b8b/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-istio/07-31-2022-19-27-07_a07d4b8b/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-istio/07-31-2022-19-28-07_a07d4b8b/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-istio/07-31-2022-19-28-07_a07d4b8b/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-istio/08-01-2022-10-53-08_393d24c6/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-istio/08-01-2022-10-53-08_393d24c6/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-istio/08-01-2022-10-53-08_82652c32/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-istio/08-01-2022-10-53-08_82652c32/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-istio/08-01-2022-10-54-08_393d24c6/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-istio/08-01-2022-10-54-08_393d24c6/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-istio/08-01-2022-10-55-08_82652c32/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-istio/08-01-2022-10-55-08_82652c32/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-istio/08-01-2022-18-48-08_830d6a26/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-istio/08-01-2022-18-48-08_830d6a26/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-istio/08-01-2022-18-49-08_830d6a26/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-istio/08-01-2022-18-49-08_830d6a26/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-istio/08-01-2023-17-51-08_546c1a5c/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-istio/08-01-2023-17-51-08_546c1a5c/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-istio/08-01-2023-17-57-08_546c1a5c/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-istio/08-01-2023-17-57-08_546c1a5c/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-istio/08-01-2023-18-00-08_546c1a5c/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-istio/08-01-2023-18-00-08_546c1a5c/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-istio/08-01-2023-18-02-08_546c1a5c/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-istio/08-01-2023-18-02-08_546c1a5c/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-istio/08-03-2022-15-28-08_8e8c7ab3/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-istio/08-03-2022-15-28-08_8e8c7ab3/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-istio/08-03-2022-15-31-08_8e8c7ab3/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-istio/08-03-2022-15-31-08_8e8c7ab3/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-istio/08-03-2022-15-36-08_8e8c7ab3/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-istio/08-03-2022-15-36-08_8e8c7ab3/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-istio/08-03-2022-17-04-08_8e8c7ab3/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-istio/08-03-2022-17-04-08_8e8c7ab3/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-istio/08-03-2022-17-05-08_8e8c7ab3/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-istio/08-03-2022-17-05-08_8e8c7ab3/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-istio/08-03-2022-17-08-08_8e8c7ab3/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-istio/08-03-2022-17-08-08_8e8c7ab3/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-istio/08-04-2022-14-33-08_72883170/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-istio/08-04-2022-14-33-08_72883170/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-istio/08-04-2022-14-34-08_72883170/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-istio/08-04-2022-14-34-08_72883170/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-istio/08-04-2022-14-35-08_72883170/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-istio/08-04-2022-14-35-08_72883170/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-istio/08-05-2022-13-38-08_3e378945/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-istio/08-05-2022-13-38-08_3e378945/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-istio/08-05-2022-15-38-08_8030707a/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-istio/08-05-2022-15-38-08_8030707a/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-istio/08-05-2022-15-39-08_8030707a/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-istio/08-05-2022-15-39-08_8030707a/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-istio/08-05-2022-15-40-08_8030707a/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-istio/08-05-2022-15-40-08_8030707a/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-istio/08-05-2022-18-02-08_8030707a/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-istio/08-05-2022-18-02-08_8030707a/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-istio/08-05-2022-18-03-08_8030707a/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-istio/08-05-2022-18-03-08_8030707a/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-istio/08-05-2022-18-10-08_8030707a/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-istio/08-05-2022-18-10-08_8030707a/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-istio/08-05-2022-18-11-08_8030707a/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-istio/08-05-2022-18-11-08_8030707a/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-istio/08-09-2022-22-56-08_f7073811/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-istio/08-09-2022-22-56-08_f7073811/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-istio/08-09-2022-23-12-08_f7073811/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-istio/08-09-2022-23-12-08_f7073811/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-istio/08-11-2022-01-34-08_18c95fe2/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-istio/08-11-2022-01-34-08_18c95fe2/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-istio/08-11-2022-01-35-08_18c95fe2/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-istio/08-11-2022-01-35-08_18c95fe2/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-istio/08-11-2022-01-42-08_18c95fe2/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-istio/08-11-2022-01-42-08_18c95fe2/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-istio/08-19-2022-01-55-08_c1c7321d/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-istio/08-19-2022-01-55-08_c1c7321d/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-istio/08-19-2022-01-57-08_c1c7321d/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-istio/08-19-2022-01-57-08_c1c7321d/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-istio/08-19-2022-01-59-08_c1c7321d/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-istio/08-19-2022-01-59-08_c1c7321d/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-istio/08-26-2022-13-27-08_96a818bc/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-istio/08-26-2022-13-27-08_96a818bc/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-istio/08-26-2022-13-28-08_96a818bc/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-istio/08-26-2022-13-28-08_96a818bc/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-istio/08-31-2022-02-17-08_1cf67020/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-istio/08-31-2022-02-17-08_1cf67020/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-istio/08-31-2022-02-18-08_1cf67020/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-istio/08-31-2022-02-18-08_1cf67020/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-istio/08-31-2022-02-22-08_1cf67020/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-istio/08-31-2022-02-22-08_1cf67020/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-istio/08-31-2022-17-24-08_cd1b93c4/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-istio/08-31-2022-17-24-08_cd1b93c4/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-istio/08-31-2022-17-43-08_cd1b93c4/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-istio/08-31-2022-17-43-08_cd1b93c4/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-istio/09-01-2022-01-42-09_8edde4d7/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-istio/09-01-2022-01-42-09_8edde4d7/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-istio/09-01-2022-01-43-09_8edde4d7/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-istio/09-01-2022-01-43-09_8edde4d7/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-istio/09-01-2022-01-47-09_8edde4d7/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-istio/09-01-2022-01-47-09_8edde4d7/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-istio/09-02-2022-14-57-09_8edde4d7/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-istio/09-02-2022-14-57-09_8edde4d7/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-istio/09-02-2022-14-58-09_8edde4d7/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-istio/09-02-2022-14-58-09_8edde4d7/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-istio/09-02-2022-15-00-09_8edde4d7/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-istio/09-02-2022-15-00-09_8edde4d7/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-istio/09-02-2022-15-01-09_8edde4d7/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-istio/09-02-2022-15-01-09_8edde4d7/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-istio/09-02-2022-15-05-09_8edde4d7/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-istio/09-02-2022-15-05-09_8edde4d7/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-istio/09-02-2022-15-09-09_8edde4d7/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-istio/09-02-2022-15-09-09_8edde4d7/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-istio/09-05-2022-18-01-09_e20fdb95/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-istio/09-05-2022-18-01-09_e20fdb95/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-istio/09-05-2022-18-02-09_e20fdb95/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-istio/09-05-2022-18-02-09_e20fdb95/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-istio/09-05-2022-18-05-09_e20fdb95/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-istio/09-05-2022-18-05-09_e20fdb95/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-istio/09-20-2022-04-21-09_cb7bf6bb/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-istio/09-20-2022-04-21-09_cb7bf6bb/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-istio/09-20-2022-04-26-09_cb7bf6bb/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-istio/09-20-2022-04-26-09_cb7bf6bb/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-istio/09-20-2022-04-27-09_cb7bf6bb/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-istio/09-20-2022-04-27-09_cb7bf6bb/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-istio/09-21-2022-14-01-09_cb7bf6bb/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-istio/09-21-2022-14-01-09_cb7bf6bb/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-istio/09-21-2022-14-02-09_cb7bf6bb/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-istio/09-21-2022-14-02-09_cb7bf6bb/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-istio/09-21-2022-14-05-09_cb7bf6bb/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-istio/09-21-2022-14-05-09_cb7bf6bb/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-istio/09-25-2022-09-32-09_cb7bf6bb/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-istio/09-25-2022-09-32-09_cb7bf6bb/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-istio/09-25-2022-09-33-09_cb7bf6bb/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-istio/09-25-2022-09-33-09_cb7bf6bb/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-istio/09-25-2022-09-35-09_cb7bf6bb/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-istio/09-25-2022-09-35-09_cb7bf6bb/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-istio/09-27-2022-02-05-09_09e78247/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-istio/09-27-2022-02-05-09_09e78247/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-istio/09-27-2022-02-09-09_09e78247/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-istio/09-27-2022-02-09-09_09e78247/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-istio/09-27-2022-11-25-09_e30c33c4/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-istio/09-27-2022-11-25-09_e30c33c4/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-istio/09-27-2022-16-05-09_e30c33c4/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-istio/09-27-2022-16-05-09_e30c33c4/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-istio/09-29-2022-05-49-09_7ecbb21b/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-istio/09-29-2022-05-49-09_7ecbb21b/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-istio/09-29-2022-05-50-09_7ecbb21b/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-istio/09-29-2022-05-50-09_7ecbb21b/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-istio/09-29-2022-05-51-09_7ecbb21b/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-istio/09-29-2022-05-51-09_7ecbb21b/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-istio/09-29-2022-05-58-09_7ecbb21b/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-istio/09-29-2022-05-58-09_7ecbb21b/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-istio/10-03-2022-04-18-10_410618a8/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-istio/10-03-2022-04-18-10_410618a8/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-istio/10-03-2022-04-26-10_410618a8/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-istio/10-03-2022-04-26-10_410618a8/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-istio/10-03-2022-04-27-10_410618a8/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-istio/10-03-2022-04-27-10_410618a8/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-istio/10-03-2022-04-29-10_410618a8/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-istio/10-03-2022-04-29-10_410618a8/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-istio/10-03-2022-04-30-10_410618a8/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-istio/10-03-2022-04-30-10_410618a8/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-istio/10-03-2022-17-39-10_bf728308/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-istio/10-03-2022-17-39-10_bf728308/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-istio/10-04-2023-01-16-10_fe5258b4/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-istio/10-04-2023-01-16-10_fe5258b4/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-istio/10-04-2023-01-18-10_fe5258b4/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-istio/10-04-2023-01-18-10_fe5258b4/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-istio/10-09-2023-08-03-10_7acc1837/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-istio/10-09-2023-08-03-10_7acc1837/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-istio/10-09-2023-08-04-10_7acc1837/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-istio/10-09-2023-08-04-10_7acc1837/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-istio/10-11-2022-14-18-10_1cf8677d/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-istio/10-11-2022-14-18-10_1cf8677d/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-istio/10-11-2022-14-27-10_1cf8677d/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-istio/10-11-2022-14-27-10_1cf8677d/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-istio/10-11-2022-14-29-10_1cf8677d/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-istio/10-11-2022-14-29-10_1cf8677d/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-istio/10-11-2022-17-03-10_74beabb5/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-istio/10-11-2022-17-03-10_74beabb5/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-istio/10-11-2022-20-05-10_eff4bb15/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-istio/10-11-2022-20-05-10_eff4bb15/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-istio/10-11-2022-20-27-10_a0974514/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-istio/10-11-2022-20-27-10_a0974514/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-istio/10-11-2022-20-27-10_eff4bb15/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-istio/10-11-2022-20-27-10_eff4bb15/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-istio/10-11-2022-20-28-10_a0974514/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-istio/10-11-2022-20-28-10_a0974514/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-istio/10-11-2022-20-29-10_a0974514/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-istio/10-11-2022-20-29-10_a0974514/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-istio/10-11-2022-20-34-10_c4b58fa3/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-istio/10-11-2022-20-34-10_c4b58fa3/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-istio/10-11-2022-20-35-10_c4b58fa3/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-istio/10-11-2022-20-35-10_c4b58fa3/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-istio/10-11-2022-20-37-10_c4b58fa3/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-istio/10-11-2022-20-37-10_c4b58fa3/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-istio/10-12-2023-01-14-10_2f3996bb/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-istio/10-12-2023-01-14-10_2f3996bb/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-istio/10-12-2023-01-17-10_2f3996bb/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-istio/10-12-2023-01-17-10_2f3996bb/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-istio/10-12-2023-01-42-10_0967f5c5/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-istio/10-12-2023-01-42-10_0967f5c5/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-istio/10-12-2023-01-43-10_0967f5c5/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-istio/10-12-2023-01-43-10_0967f5c5/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-istio/10-12-2023-16-38-10_7f550784/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-istio/10-12-2023-16-38-10_7f550784/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-istio/10-12-2023-17-10-10_6313fb5c/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-istio/10-12-2023-17-10-10_6313fb5c/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-istio/10-12-2023-17-11-10_6313fb5c/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-istio/10-12-2023-17-11-10_6313fb5c/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-istio/10-20-2022-07-21-10_f521704c/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-istio/10-20-2022-07-21-10_f521704c/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-istio/10-20-2022-07-44-10_f521704c/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-istio/10-20-2022-07-44-10_f521704c/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-istio/10-20-2022-07-46-10_f521704c/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-istio/10-20-2022-07-46-10_f521704c/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-istio/10-20-2022-16-08-10_80953d09/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-istio/10-20-2022-16-08-10_80953d09/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-istio/10-20-2022-16-08-10_b4c3dbbc/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-istio/10-20-2022-16-08-10_b4c3dbbc/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-istio/10-20-2022-16-09-10_80953d09/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-istio/10-20-2022-16-09-10_80953d09/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-istio/10-20-2022-16-11-10_b4c3dbbc/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-istio/10-20-2022-16-11-10_b4c3dbbc/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-istio/10-20-2022-16-18-10_b4c3dbbc/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-istio/10-20-2022-16-18-10_b4c3dbbc/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-istio/10-21-2022-14-11-10_b4c3dbbc/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-istio/10-21-2022-14-11-10_b4c3dbbc/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-istio/10-21-2022-14-12-10_b4c3dbbc/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-istio/10-21-2022-14-12-10_b4c3dbbc/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-istio/10-21-2022-14-18-10_b4c3dbbc/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-istio/10-21-2022-14-18-10_b4c3dbbc/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-istio/10-21-2022-14-19-10_b4c3dbbc/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-istio/10-21-2022-14-19-10_b4c3dbbc/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-istio/10-21-2022-17-57-10_d1e846fa/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-istio/10-21-2022-17-57-10_d1e846fa/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-istio/10-21-2022-17-58-10_b9406b6d/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-istio/10-21-2022-17-58-10_b9406b6d/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-istio/10-21-2022-18-10-10_b9406b6d/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-istio/10-21-2022-18-10-10_b9406b6d/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-istio/10-21-2022-18-15-10_0c549044/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-istio/10-21-2022-18-15-10_0c549044/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-istio/10-21-2022-18-39-10_0c549044/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-istio/10-21-2022-18-39-10_0c549044/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-istio/10-21-2022-18-39-10_a89b7e7e/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-istio/10-21-2022-18-39-10_a89b7e7e/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-istio/10-21-2022-18-43-10_a89b7e7e/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-istio/10-21-2022-18-43-10_a89b7e7e/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-istio/10-21-2022-18-50-10_a89b7e7e/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-istio/10-21-2022-18-50-10_a89b7e7e/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-istio/10-22-2022-02-02-10_6ad2c85c/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-istio/10-22-2022-02-02-10_6ad2c85c/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-istio/10-24-2022-16-59-10_34e524e7/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-istio/10-24-2022-16-59-10_34e524e7/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-istio/10-24-2022-17-00-10_34e524e7/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-istio/10-24-2022-17-00-10_34e524e7/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-istio/10-24-2022-17-02-10_34e524e7/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-istio/10-24-2022-17-02-10_34e524e7/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-istio/10-25-2023-01-15-10_060ab0e7/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-istio/10-25-2023-01-15-10_060ab0e7/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-istio/10-25-2023-01-17-10_060ab0e7/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-istio/10-25-2023-01-17-10_060ab0e7/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-istio/10-27-2023-00-07-10_accb1f23/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-istio/10-27-2023-00-07-10_accb1f23/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-istio/10-28-2022-02-02-10_0cce60d4/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-istio/10-28-2022-02-02-10_0cce60d4/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-istio/10-28-2022-02-05-10_0cce60d4/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-istio/10-28-2022-02-05-10_0cce60d4/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-istio/11-03-2023-01-15-11_d78d99bf/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-istio/11-03-2023-01-15-11_d78d99bf/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-istio/11-03-2023-01-16-11_d78d99bf/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-istio/11-03-2023-01-16-11_d78d99bf/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-istio/11-08-2022-16-54-11_fb09f750/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-istio/11-08-2022-16-54-11_fb09f750/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-istio/11-09-2022-01-42-11_00eba6af/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-istio/11-09-2022-01-42-11_00eba6af/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-istio/11-09-2022-01-43-11_00eba6af/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-istio/11-09-2022-01-43-11_00eba6af/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-istio/11-09-2022-01-44-11_00eba6af/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-istio/11-09-2022-01-44-11_00eba6af/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-istio/11-09-2022-15-32-11_18649a56/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-istio/11-09-2022-15-32-11_18649a56/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-istio/11-09-2022-15-33-11_18649a56/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-istio/11-09-2022-15-33-11_18649a56/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-istio/11-14-2022-13-31-11_c4b928ac/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-istio/11-14-2022-13-31-11_c4b928ac/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-istio/11-16-2022-01-38-11_4a8164e7/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-istio/11-16-2022-01-38-11_4a8164e7/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-istio/11-16-2022-01-39-11_4a8164e7/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-istio/11-16-2022-01-39-11_4a8164e7/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-istio/11-21-2022-17-14-11_d8a266b2/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-istio/11-21-2022-17-14-11_d8a266b2/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-istio/11-21-2022-18-27-11_4e1cc0ac/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-istio/11-21-2022-18-27-11_4e1cc0ac/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-istio/11-21-2022-18-28-11_4e1cc0ac/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-istio/11-21-2022-18-28-11_4e1cc0ac/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-istio/11-21-2022-18-32-11_4c470a0f/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-istio/11-21-2022-18-32-11_4c470a0f/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-istio/11-21-2022-18-34-11_4c470a0f/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-istio/11-21-2022-18-34-11_4c470a0f/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-istio/11-21-2022-18-36-11_4c470a0f/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-istio/11-21-2022-18-36-11_4c470a0f/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-istio/11-22-2022-12-05-11_10d9c79d/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-istio/11-22-2022-12-05-11_10d9c79d/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-istio/11-22-2022-12-08-11_10d9c79d/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-istio/11-22-2022-12-08-11_10d9c79d/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-istio/11-29-2022-20-16-11_3d825298/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-istio/11-29-2022-20-16-11_3d825298/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-istio/11-29-2022-20-17-11_3d825298/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-istio/11-29-2022-20-17-11_3d825298/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-istio/12-01-2022-20-48-12_c14a63f8/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-istio/12-01-2022-20-48-12_c14a63f8/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-istio/12-01-2022-20-49-12_c14a63f8/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-istio/12-01-2022-20-49-12_c14a63f8/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-istio/12-01-2022-20-52-12_c14a63f8/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-istio/12-01-2022-20-52-12_c14a63f8/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-istio/12-13-2022-01-30-12_5be793ac/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-istio/12-13-2022-01-30-12_5be793ac/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-istio/12-13-2022-01-31-12_5be793ac/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-istio/12-13-2022-01-31-12_5be793ac/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-istio/12-13-2022-01-33-12_5be793ac/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-istio/12-13-2022-01-33-12_5be793ac/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-istio/12-13-2023-01-17-12_4b46f1c7/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-istio/12-13-2023-01-17-12_4b46f1c7/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-istio/12-13-2023-01-24-12_4b46f1c7/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-istio/12-13-2023-01-24-12_4b46f1c7/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-istio/12-15-2022-09-49-12_86291f18/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-istio/12-15-2022-09-49-12_86291f18/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-istio/12-15-2022-09-54-12_86291f18/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-istio/12-15-2022-09-54-12_86291f18/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-istio/12-15-2022-10-01-12_86291f18/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-istio/12-15-2022-10-01-12_86291f18/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-istio/12-15-2022-10-02-12_5ed8818a/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-istio/12-15-2022-10-02-12_5ed8818a/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-istio/12-15-2022-10-03-12_5ed8818a/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-istio/12-15-2022-10-03-12_5ed8818a/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-istio/12-15-2022-10-06-12_5af79bfa/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-istio/12-15-2022-10-06-12_5af79bfa/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-istio/12-15-2022-10-07-12_5ed8818a/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-istio/12-15-2022-10-07-12_5ed8818a/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-istio/12-15-2022-10-09-12_5af79bfa/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-istio/12-15-2022-10-09-12_5af79bfa/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-istio/12-15-2022-10-10-12_5af79bfa/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-istio/12-15-2022-10-10-12_5af79bfa/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-istio/12-22-2022-15-14-12_a76ab168/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-istio/12-22-2022-15-14-12_a76ab168/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-istio/12-27-2022-15-54-12_9c7d3517/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-istio/12-27-2022-15-54-12_9c7d3517/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-istio/12-27-2022-15-55-12_9c7d3517/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-istio/12-27-2022-15-55-12_9c7d3517/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-istio/12-27-2024-20-38-12_7ca6afeb/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-istio/12-27-2024-20-38-12_7ca6afeb/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-istio/12-29-2021-17-50-12_4d961b9d/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-istio/12-29-2021-17-50-12_4d961b9d/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-istio/12-30-2021-02-54-12_d89889fb/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-istio/12-30-2021-02-54-12_d89889fb/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-istio/12-30-2021-21-10-12_3a0c27cb/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-istio/12-30-2021-21-10-12_3a0c27cb/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-istio/12-30-2021-23-01-12_1be9ab76/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-istio/12-30-2021-23-01-12_1be9ab76/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-istio/12-30-2024-22-59-12_fb9e7ff6/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-istio/12-30-2024-22-59-12_fb9e7ff6/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-istio/12-31-2021-22-47-12_1be9ab76/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-istio/12-31-2021-22-47-12_1be9ab76/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-istio/12-31-2021-22-48-12_1be9ab76/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-istio/12-31-2021-22-48-12_1be9ab76/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-istio/12-31-2021-22-49-12_1be9ab76/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-istio/12-31-2021-22-49-12_1be9ab76/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-istio/12-31-2021-22-52-12_1be9ab76/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-istio/12-31-2021-22-52-12_1be9ab76/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-istio/2021-12-20_18-51-22/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-istio/2021-12-20_18-51-22/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-istio/2021-12-20_18-52-48/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-istio/2021-12-20_18-52-48/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-istio/2021-12-20_18-53-17/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-istio/2021-12-20_18-53-17/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-kuma/01-02-2022-00-44-01_/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-kuma/01-02-2022-00-44-01_/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-kuma/01-02-2022-12-19-01_/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-kuma/01-02-2022-12-19-01_/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-kuma/01-07-2022-01-24-01_/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-kuma/01-07-2022-01-24-01_/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-kuma/01-07-2022-08-42-01_/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-kuma/01-07-2022-08-42-01_/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-kuma/01-09-2022-12-17-01_117c89fb/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-kuma/01-09-2022-12-17-01_117c89fb/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-kuma/01-16-2022-20-40-01_27fca1e6/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-kuma/01-16-2022-20-40-01_27fca1e6/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-kuma/01-22-2025-00-30-01_a6c7012e/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-kuma/01-22-2025-00-30-01_a6c7012e/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-kuma/01-24-2022-20-14-01_c9eb48e1/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-kuma/01-24-2022-20-14-01_c9eb48e1/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-kuma/01-24-2022-20-21-01_28b5898e/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-kuma/01-24-2022-20-21-01_28b5898e/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-kuma/01-24-2022-21-49-01_28b5898e/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-kuma/01-24-2022-21-49-01_28b5898e/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-kuma/01-24-2022-21-51-01_28b5898e/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-kuma/01-24-2022-21-51-01_28b5898e/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-kuma/02-02-2022-05-44-02_b1bf75e9/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-kuma/02-02-2022-05-44-02_b1bf75e9/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-kuma/02-02-2022-08-12-02_ea44220a/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-kuma/02-02-2022-08-12-02_ea44220a/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-kuma/02-02-2024-00-56-02_e1a9ea6b/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-kuma/02-02-2024-00-56-02_e1a9ea6b/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-kuma/02-06-2025-19-33-02_392ca363/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-kuma/02-06-2025-19-33-02_392ca363/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-kuma/02-11-2022-18-46-02_1aad6dad/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-kuma/02-11-2022-18-46-02_1aad6dad/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-kuma/02-20-2022-17-27-02_08e9cf2b/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-kuma/02-20-2022-17-27-02_08e9cf2b/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-kuma/02-20-2024-00-57-02_5e24aed1/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-kuma/02-20-2024-00-57-02_5e24aed1/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-kuma/02-25-2022-00-55-02_9335e16e/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-kuma/02-25-2022-00-55-02_9335e16e/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-kuma/02-27-2025-00-31-02_21c17f20/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-kuma/02-27-2025-00-31-02_21c17f20/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-kuma/03-07-2022-16-09-03_c96c9181/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-kuma/03-07-2022-16-09-03_c96c9181/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-kuma/03-14-2022-04-34-03_84d5f49a/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-kuma/03-14-2022-04-34-03_84d5f49a/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-kuma/03-17-2022-00-12-03_8e1f7676/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-kuma/03-17-2022-00-12-03_8e1f7676/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-kuma/03-17-2022-00-13-03_a624426f/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-kuma/03-17-2022-00-13-03_a624426f/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-kuma/03-21-2025-00-31-03_0ca55af0/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-kuma/03-21-2025-00-31-03_0ca55af0/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-kuma/03-22-2022-20-27-03_780972a4/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-kuma/03-22-2022-20-27-03_780972a4/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-kuma/03-22-2022-21-02-03_eea6d9ff/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-kuma/03-22-2022-21-02-03_eea6d9ff/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-kuma/03-22-2022-21-03-03_eea6d9ff/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-kuma/03-22-2022-21-03-03_eea6d9ff/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-kuma/03-29-2022-17-01-03_775a03d4/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-kuma/03-29-2022-17-01-03_775a03d4/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-kuma/04-01-2025-00-34-04_d781fe6d/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-kuma/04-01-2025-00-34-04_d781fe6d/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-kuma/04-07-2022-10-07-04_fe196f2d/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-kuma/04-07-2022-10-07-04_fe196f2d/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-kuma/04-07-2022-13-36-04_426627ad/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-kuma/04-07-2022-13-36-04_426627ad/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-kuma/04-07-2022-16-12-04_1fb32c2f/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-kuma/04-07-2022-16-12-04_1fb32c2f/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-kuma/04-11-2022-02-10-04_f403cfc8/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-kuma/04-11-2022-02-10-04_f403cfc8/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-kuma/04-11-2022-17-16-04_e5d39c4a/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-kuma/04-11-2022-17-16-04_e5d39c4a/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-kuma/04-11-2022-17-22-04_f37cd137/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-kuma/04-11-2022-17-22-04_f37cd137/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-kuma/04-13-2022-01-01-04_3d37eca9/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-kuma/04-13-2022-01-01-04_3d37eca9/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-kuma/04-13-2022-12-35-04_3d37eca9/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-kuma/04-13-2022-12-35-04_3d37eca9/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-kuma/04-13-2022-12-36-04_3d37eca9/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-kuma/04-13-2022-12-36-04_3d37eca9/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-kuma/04-15-2022-22-58-04_e1bf05f7/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-kuma/04-15-2022-22-58-04_e1bf05f7/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-kuma/04-15-2022-22-59-04_e1bf05f7/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-kuma/04-15-2022-22-59-04_e1bf05f7/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-kuma/04-18-2022-17-36-04_182f75d8/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-kuma/04-18-2022-17-36-04_182f75d8/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-kuma/04-26-2022-19-46-04_9f18e253/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-kuma/04-26-2022-19-46-04_9f18e253/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-kuma/05-03-2022-14-23-05_a04c014a/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-kuma/05-03-2022-14-23-05_a04c014a/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-kuma/05-10-2022-12-59-05_a04c014a/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-kuma/05-10-2022-12-59-05_a04c014a/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-kuma/05-10-2022-13-00-05_a04c014a/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-kuma/05-10-2022-13-00-05_a04c014a/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-kuma/05-12-2022-15-17-05_b21b3835/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-kuma/05-12-2022-15-17-05_b21b3835/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-kuma/05-21-2023-14-26-05_9e86e739/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-kuma/05-21-2023-14-26-05_9e86e739/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-kuma/05-22-2023-19-35-05_4e078717/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-kuma/05-22-2023-19-35-05_4e078717/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-kuma/05-30-2022-17-01-05_9f728bd5/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-kuma/05-30-2022-17-01-05_9f728bd5/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-kuma/06-02-2025-20-24-06_a491659a/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-kuma/06-02-2025-20-24-06_a491659a/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-kuma/06-02-2025-20-48-06_a491659a/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-kuma/06-02-2025-20-48-06_a491659a/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-kuma/06-10-2022-23-53-06_0628edfc/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-kuma/06-10-2022-23-53-06_0628edfc/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-kuma/06-10-2022-23-53-06_79bd6f8b/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-kuma/06-10-2022-23-53-06_79bd6f8b/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-kuma/06-11-2022-00-36-06_0628edfc/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-kuma/06-11-2022-00-36-06_0628edfc/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-kuma/06-11-2022-11-58-06_01c27510/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-kuma/06-11-2022-11-58-06_01c27510/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-kuma/06-11-2022-12-03-06_01c27510/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-kuma/06-11-2022-12-03-06_01c27510/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-kuma/06-11-2022-12-04-06_01c27510/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-kuma/06-11-2022-12-04-06_01c27510/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-kuma/06-11-2025-00-34-06_f64685b7/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-kuma/06-11-2025-00-34-06_f64685b7/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-kuma/06-14-2022-16-09-06_d7e8f4e6/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-kuma/06-14-2022-16-09-06_d7e8f4e6/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-kuma/06-17-2022-13-30-06_d892c5f5/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-kuma/06-17-2022-13-30-06_d892c5f5/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-kuma/06-17-2022-15-29-06_5b5dd770/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-kuma/06-17-2022-15-29-06_5b5dd770/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-kuma/06-18-2025-18-46-06_42974b7d/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-kuma/06-18-2025-18-46-06_42974b7d/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-kuma/06-18-2025-18-49-06_e5f2a4f5/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-kuma/06-18-2025-18-49-06_e5f2a4f5/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-kuma/06-20-2022-17-31-06_119b0bb1/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-kuma/06-20-2022-17-31-06_119b0bb1/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-kuma/06-20-2022-17-40-06_0da95c52/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-kuma/06-20-2022-17-40-06_0da95c52/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-kuma/06-20-2022-20-53-06_0da95c52/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-kuma/06-20-2022-20-53-06_0da95c52/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-kuma/06-20-2022-20-54-06_0da95c52/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-kuma/06-20-2022-20-54-06_0da95c52/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-kuma/06-22-2023-01-08-06_e7c9839f/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-kuma/06-22-2023-01-08-06_e7c9839f/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-kuma/06-24-2023-01-15-06_33fbd36d/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-kuma/06-24-2023-01-15-06_33fbd36d/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-kuma/06-26-2025-00-32-06_18b6dfc5/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-kuma/06-26-2025-00-32-06_18b6dfc5/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-kuma/07-02-2025-21-07-07_2702f8a5/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-kuma/07-02-2025-21-07-07_2702f8a5/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-kuma/07-04-2022-15-20-07_369128c3/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-kuma/07-04-2022-15-20-07_369128c3/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-kuma/07-11-2025-00-32-07_8d867045/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-kuma/07-11-2025-00-32-07_8d867045/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-kuma/07-12-2023-21-13-07_a240f646/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-kuma/07-12-2023-21-13-07_a240f646/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-kuma/07-18-2022-18-12-07_d9885611/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-kuma/07-18-2022-18-12-07_d9885611/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-kuma/07-18-2022-18-57-07_b1630875/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-kuma/07-18-2022-18-57-07_b1630875/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-kuma/07-18-2022-19-03-07_b1630875/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-kuma/07-18-2022-19-03-07_b1630875/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-kuma/07-18-2023-16-59-07_d823c891/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-kuma/07-18-2023-16-59-07_d823c891/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-kuma/07-19-2023-21-56-07_803e9c1e/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-kuma/07-19-2023-21-56-07_803e9c1e/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-kuma/07-21-2022-19-33-07_eb095dda/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-kuma/07-21-2022-19-33-07_eb095dda/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-kuma/07-26-2025-00-32-07_1918d265/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-kuma/07-26-2025-00-32-07_1918d265/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-kuma/07-29-2022-17-22-07_21d17cd4/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-kuma/07-29-2022-17-22-07_21d17cd4/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-kuma/08-04-2022-15-01-08_90f8d4e8/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-kuma/08-04-2022-15-01-08_90f8d4e8/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-kuma/08-04-2022-15-19-08_6f84667c/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-kuma/08-04-2022-15-19-08_6f84667c/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-kuma/08-05-2022-13-52-08_ef18c59f/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-kuma/08-05-2022-13-52-08_ef18c59f/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-kuma/08-05-2022-19-50-08_e8b34f87/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-kuma/08-05-2022-19-50-08_e8b34f87/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-kuma/08-05-2022-19-51-08_e8b34f87/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-kuma/08-05-2022-19-51-08_e8b34f87/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-kuma/08-05-2022-19-53-08_e8b34f87/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-kuma/08-05-2022-19-53-08_e8b34f87/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-kuma/08-05-2022-19-57-08_809ad93c/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-kuma/08-05-2022-19-57-08_809ad93c/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-kuma/08-07-2025-00-33-08_b798eeb4/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-kuma/08-07-2025-00-33-08_b798eeb4/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-kuma/08-22-2022-17-52-08_7b6cef6a/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-kuma/08-22-2022-17-52-08_7b6cef6a/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-kuma/08-25-2022-01-16-08_89c7dee7/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-kuma/08-25-2022-01-16-08_89c7dee7/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-kuma/08-27-2025-00-33-08_898d9dd6/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-kuma/08-27-2025-00-33-08_898d9dd6/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-kuma/08-27-2025-16-47-08_e0c05f2a/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-kuma/08-27-2025-16-47-08_e0c05f2a/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-kuma/08-30-2022-09-16-08_be7c0796/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-kuma/08-30-2022-09-16-08_be7c0796/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-kuma/08-30-2022-13-08-08_23c3ed82/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-kuma/08-30-2022-13-08-08_23c3ed82/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-kuma/08-30-2022-13-14-08_3ca44ec5/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-kuma/08-30-2022-13-14-08_3ca44ec5/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-kuma/08-30-2022-14-20-08_e81b1050/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-kuma/08-30-2022-14-20-08_e81b1050/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-kuma/08-31-2022-17-16-08_f3db0c0f/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-kuma/08-31-2022-17-16-08_f3db0c0f/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-kuma/09-02-2022-16-32-09_f3db0c0f/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-kuma/09-02-2022-16-32-09_f3db0c0f/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-kuma/09-10-2025-00-26-09_8047465c/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-kuma/09-10-2025-00-26-09_8047465c/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-kuma/09-10-2025-11-46-09_02fdbf2e/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-kuma/09-10-2025-11-46-09_02fdbf2e/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-kuma/09-10-2025-11-52-09_0357d6f9/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-kuma/09-10-2025-11-52-09_0357d6f9/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-kuma/09-20-2022-04-36-09_59154617/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-kuma/09-20-2022-04-36-09_59154617/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-kuma/09-23-2025-20-15-09_ff9006ac/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-kuma/09-23-2025-20-15-09_ff9006ac/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-kuma/09-27-2022-09-16-09_59154617/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-kuma/09-27-2022-09-16-09_59154617/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-kuma/09-29-2022-18-52-09_494ea6ee/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-kuma/09-29-2022-18-52-09_494ea6ee/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-kuma/09-30-2025-04-30-09_2bc561b8/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-kuma/09-30-2025-04-30-09_2bc561b8/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-kuma/10-03-2023-00-59-10_818a7f0c/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-kuma/10-03-2023-00-59-10_818a7f0c/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-kuma/10-06-2022-08-39-10_7c29ed5a/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-kuma/10-06-2022-08-39-10_7c29ed5a/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-kuma/10-06-2023-08-24-10_e9c5b1d3/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-kuma/10-06-2023-08-24-10_e9c5b1d3/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-kuma/10-06-2023-08-25-10_88db98e9/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-kuma/10-06-2023-08-25-10_88db98e9/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-kuma/10-11-2022-01-19-10_4c2b94f9/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-kuma/10-11-2022-01-19-10_4c2b94f9/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-kuma/10-11-2022-14-04-10_fc8fc8d3/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-kuma/10-11-2022-14-04-10_fc8fc8d3/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-kuma/10-11-2022-14-06-10_3f225c98/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-kuma/10-11-2022-14-06-10_3f225c98/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-kuma/10-12-2023-01-44-10_ce6f4483/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-kuma/10-12-2023-01-44-10_ce6f4483/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-kuma/10-12-2023-03-31-10_ce6f4483/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-kuma/10-12-2023-03-31-10_ce6f4483/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-kuma/10-12-2023-03-32-10_ce6f4483/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-kuma/10-12-2023-03-32-10_ce6f4483/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-kuma/10-13-2023-00-59-10_26c932e0/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-kuma/10-13-2023-00-59-10_26c932e0/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-kuma/10-18-2025-00-26-10_739aa666/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-kuma/10-18-2025-00-26-10_739aa666/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-kuma/10-20-2022-07-53-10_9647141f/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-kuma/10-20-2022-07-53-10_9647141f/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-kuma/10-21-2022-14-10-10_a552b27e/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-kuma/10-21-2022-14-10-10_a552b27e/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-kuma/10-26-2023-23-44-10_0a4dbede/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-kuma/10-26-2023-23-44-10_0a4dbede/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-kuma/10-31-2023-12-58-10_aa697ab2/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-kuma/10-31-2023-12-58-10_aa697ab2/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-kuma/10-31-2025-00-27-10_e4b550f6/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-kuma/10-31-2025-00-27-10_e4b550f6/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-kuma/11-07-2023-00-57-11_8d44031e/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-kuma/11-07-2023-00-57-11_8d44031e/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-kuma/11-16-2023-00-57-11_4d8c8381/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-kuma/11-16-2023-00-57-11_4d8c8381/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-kuma/12-13-2023-00-57-12_938699f8/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-kuma/12-13-2023-00-57-12_938699f8/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-kuma/12-27-2024-20-42-12_097bdff3/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-kuma/12-27-2024-20-42-12_097bdff3/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-kuma/12-30-2021-22-43-12_/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-kuma/12-30-2021-22-43-12_/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-kuma/12-31-2021-22-37-12_/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-kuma/12-31-2021-22-37-12_/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-linkerd/01-04-2022-07-08-01_/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-linkerd/01-04-2022-07-08-01_/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-linkerd/01-06-2022-20-38-01_/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-linkerd/01-06-2022-20-38-01_/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-linkerd/01-06-2023-14-38-01_/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-linkerd/01-06-2023-14-38-01_/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-linkerd/01-10-2022-22-31-01_/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-linkerd/01-10-2022-22-31-01_/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-linkerd/01-11-2022-07-13-01_/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-linkerd/01-11-2022-07-13-01_/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-linkerd/01-14-2022-01-22-01_/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-linkerd/01-14-2022-01-22-01_/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-linkerd/01-15-2024-18-23-01_/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-linkerd/01-15-2024-18-23-01_/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-linkerd/01-15-2024-18-30-01_/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-linkerd/01-15-2024-18-30-01_/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-linkerd/01-15-2024-18-38-01_/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-linkerd/01-15-2024-18-38-01_/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-linkerd/01-17-2025-00-28-01_/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-linkerd/01-17-2025-00-28-01_/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-linkerd/01-18-2022-00-54-01_/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-linkerd/01-18-2022-00-54-01_/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-linkerd/01-20-2022-02-31-01_/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-linkerd/01-20-2022-02-31-01_/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-linkerd/01-24-2025-00-29-01_/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-linkerd/01-24-2025-00-29-01_/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-linkerd/01-25-2024-00-54-01_/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-linkerd/01-25-2024-00-54-01_/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-linkerd/01-26-2022-21-31-01_/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-linkerd/01-26-2022-21-31-01_/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-linkerd/01-26-2022-21-32-01_/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-linkerd/01-26-2022-21-32-01_/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-linkerd/01-27-2024-00-52-01_/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-linkerd/01-27-2024-00-52-01_/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-linkerd/01-27-2025-03-00-01_/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-linkerd/01-27-2025-03-00-01_/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-linkerd/01-29-2022-16-37-01_/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-linkerd/01-29-2022-16-37-01_/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-linkerd/02-02-2022-05-46-02_/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-linkerd/02-02-2022-05-46-02_/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-linkerd/02-03-2024-00-58-02_/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-linkerd/02-03-2024-00-58-02_/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-linkerd/02-06-2025-16-36-02_/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-linkerd/02-06-2025-16-36-02_/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-linkerd/02-06-2025-16-59-02_/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-linkerd/02-06-2025-16-59-02_/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-linkerd/02-06-2025-20-58-02_/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-linkerd/02-06-2025-20-58-02_/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-linkerd/02-07-2023-19-36-02_/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-linkerd/02-07-2023-19-36-02_/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-linkerd/02-07-2023-19-39-02_/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-linkerd/02-07-2023-19-39-02_/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-linkerd/02-07-2023-19-40-02_/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-linkerd/02-07-2023-19-40-02_/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-linkerd/02-07-2023-21-10-02_/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-linkerd/02-07-2023-21-10-02_/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-linkerd/02-07-2023-21-11-02_/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-linkerd/02-07-2023-21-11-02_/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-linkerd/02-07-2023-21-12-02_/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-linkerd/02-07-2023-21-12-02_/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-linkerd/02-07-2023-21-29-02_/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-linkerd/02-07-2023-21-29-02_/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-linkerd/02-10-2024-00-53-02_/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-linkerd/02-10-2024-00-53-02_/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-linkerd/02-11-2023-00-53-02_/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-linkerd/02-11-2023-00-53-02_/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-linkerd/02-13-2025-00-29-02_/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-linkerd/02-13-2025-00-29-02_/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-linkerd/02-17-2024-01-08-02_/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-linkerd/02-17-2024-01-08-02_/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-linkerd/02-21-2024-01-06-02_/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-linkerd/02-21-2024-01-06-02_/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-linkerd/02-21-2025-00-28-02_/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-linkerd/02-21-2025-00-28-02_/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-linkerd/02-23-2022-15-11-02_/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-linkerd/02-23-2022-15-11-02_/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-linkerd/02-23-2023-13-26-02_/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-linkerd/02-23-2023-13-26-02_/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-linkerd/02-23-2024-01-01-02_/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-linkerd/02-23-2024-01-01-02_/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-linkerd/02-24-2022-17-27-02_/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-linkerd/02-24-2022-17-27-02_/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-linkerd/02-25-2022-21-48-02_/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-linkerd/02-25-2022-21-48-02_/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-linkerd/02-25-2022-21-56-02_/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-linkerd/02-25-2022-21-56-02_/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-linkerd/02-28-2025-00-28-02_/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-linkerd/02-28-2025-00-28-02_/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-linkerd/03-01-2022-02-17-03_/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-linkerd/03-01-2022-02-17-03_/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-linkerd/03-02-2024-00-22-03_/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-linkerd/03-02-2024-00-22-03_/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-linkerd/03-02-2024-03-40-03_/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-linkerd/03-02-2024-03-40-03_/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-linkerd/03-05-2025-17-41-03_/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-linkerd/03-05-2025-17-41-03_/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-linkerd/03-06-2023-13-56-03_/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-linkerd/03-06-2023-13-56-03_/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-linkerd/03-06-2023-15-52-03_/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-linkerd/03-06-2023-15-52-03_/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-linkerd/03-07-2025-00-30-03_/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-linkerd/03-07-2025-00-30-03_/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-linkerd/03-08-2024-00-30-03_/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-linkerd/03-08-2024-00-30-03_/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-linkerd/03-14-2025-00-29-03_/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-linkerd/03-14-2025-00-29-03_/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-linkerd/03-17-2022-00-17-03_/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-linkerd/03-17-2022-00-17-03_/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-linkerd/03-17-2022-00-18-03_/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-linkerd/03-17-2022-00-18-03_/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-linkerd/03-17-2022-00-51-03_/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-linkerd/03-17-2022-00-51-03_/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-linkerd/03-17-2022-00-52-03_/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-linkerd/03-17-2022-00-52-03_/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-linkerd/03-21-2025-00-29-03_/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-linkerd/03-21-2025-00-29-03_/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-linkerd/03-22-2022-20-27-03_/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-linkerd/03-22-2022-20-27-03_/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-linkerd/03-22-2022-20-28-03_/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-linkerd/03-22-2022-20-28-03_/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-linkerd/03-23-2023-20-03-03_/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-linkerd/03-23-2023-20-03-03_/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-linkerd/03-25-2022-23-17-03_/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-linkerd/03-25-2022-23-17-03_/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-linkerd/03-28-2025-00-29-03_/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-linkerd/03-28-2025-00-29-03_/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-linkerd/03-29-2022-16-54-03_/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-linkerd/03-29-2022-16-54-03_/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-linkerd/03-30-2022-21-37-03_/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-linkerd/03-30-2022-21-37-03_/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-linkerd/03-31-2023-21-28-03_/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-linkerd/03-31-2023-21-28-03_/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-linkerd/03-31-2023-21-29-03_/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-linkerd/03-31-2023-21-29-03_/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-linkerd/04-03-2025-00-29-04_/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-linkerd/04-03-2025-00-29-04_/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-linkerd/04-07-2022-13-29-04_/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-linkerd/04-07-2022-13-29-04_/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-linkerd/04-15-2022-22-28-04_/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-linkerd/04-15-2022-22-28-04_/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-linkerd/04-20-2025-01-19-04_/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-linkerd/04-20-2025-01-19-04_/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-linkerd/04-22-2025-01-16-04_/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-linkerd/04-22-2025-01-16-04_/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-linkerd/05-01-2024-02-57-05_/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-linkerd/05-01-2024-02-57-05_/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-linkerd/05-03-2024-00-23-05_/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-linkerd/05-03-2024-00-23-05_/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-linkerd/05-04-2022-18-22-05_/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-linkerd/05-04-2022-18-22-05_/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-linkerd/05-09-2025-00-30-05_/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-linkerd/05-09-2025-00-30-05_/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-linkerd/05-14-2024-00-23-05_/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-linkerd/05-14-2024-00-23-05_/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-linkerd/05-16-2024-00-22-05_/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-linkerd/05-16-2024-00-22-05_/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-linkerd/05-17-2025-00-29-05_/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-linkerd/05-17-2025-00-29-05_/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-linkerd/05-17-2025-00-34-05_/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-linkerd/05-17-2025-00-34-05_/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-linkerd/05-23-2025-00-29-05_/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-linkerd/05-23-2025-00-29-05_/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-linkerd/05-26-2023-12-33-05_/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-linkerd/05-26-2023-12-33-05_/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-linkerd/05-30-2025-00-29-05_/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-linkerd/05-30-2025-00-29-05_/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-linkerd/06-02-2025-20-16-06_/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-linkerd/06-02-2025-20-16-06_/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-linkerd/06-03-2025-10-19-06_/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-linkerd/06-03-2025-10-19-06_/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-linkerd/06-11-2022-12-17-06_/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-linkerd/06-11-2022-12-17-06_/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-linkerd/06-14-2022-10-59-06_/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-linkerd/06-14-2022-10-59-06_/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-linkerd/06-15-2023-17-53-06_/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-linkerd/06-15-2023-17-53-06_/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-linkerd/06-15-2023-18-42-06_/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-linkerd/06-15-2023-18-42-06_/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-linkerd/06-15-2023-18-58-06_/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-linkerd/06-15-2023-18-58-06_/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-linkerd/06-18-2025-07-31-06_/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-linkerd/06-18-2025-07-31-06_/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-linkerd/06-18-2025-07-45-06_/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-linkerd/06-18-2025-07-45-06_/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-linkerd/06-18-2025-09-24-06_/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-linkerd/06-18-2025-09-24-06_/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-linkerd/06-18-2025-09-29-06_/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-linkerd/06-18-2025-09-29-06_/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-linkerd/06-19-2025-00-29-06_/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-linkerd/06-19-2025-00-29-06_/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-linkerd/06-20-2022-20-47-06_/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-linkerd/06-20-2022-20-47-06_/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-linkerd/06-22-2023-01-30-06_/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-linkerd/06-22-2023-01-30-06_/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-linkerd/06-22-2023-01-32-06_/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-linkerd/06-22-2023-01-32-06_/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-linkerd/06-22-2023-01-43-06_/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-linkerd/06-22-2023-01-43-06_/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-linkerd/06-22-2023-01-44-06_/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-linkerd/06-22-2023-01-44-06_/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-linkerd/06-22-2023-01-45-06_/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-linkerd/06-22-2023-01-45-06_/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-linkerd/06-22-2023-01-53-06_/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-linkerd/06-22-2023-01-53-06_/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-linkerd/06-22-2023-09-37-06_/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-linkerd/06-22-2023-09-37-06_/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-linkerd/06-22-2023-09-38-06_/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-linkerd/06-22-2023-09-38-06_/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-linkerd/06-22-2023-10-33-06_/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-linkerd/06-22-2023-10-33-06_/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-linkerd/06-22-2023-11-26-06_/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-linkerd/06-22-2023-11-26-06_/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-linkerd/06-22-2023-11-27-06_/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-linkerd/06-22-2023-11-27-06_/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-linkerd/06-22-2023-13-44-06_/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-linkerd/06-22-2023-13-44-06_/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-linkerd/06-22-2023-13-52-06_/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-linkerd/06-22-2023-13-52-06_/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-linkerd/06-22-2023-17-04-06_/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-linkerd/06-22-2023-17-04-06_/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-linkerd/06-22-2023-17-07-06_/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-linkerd/06-22-2023-17-07-06_/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-linkerd/06-23-2023-19-51-06_/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-linkerd/06-23-2023-19-51-06_/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-linkerd/06-25-2022-04-40-06_/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-linkerd/06-25-2022-04-40-06_/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-linkerd/06-26-2023-17-58-06_/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-linkerd/06-26-2023-17-58-06_/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-linkerd/06-27-2025-00-30-06_/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-linkerd/06-27-2025-00-30-06_/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-linkerd/07-04-2025-00-29-07_/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-linkerd/07-04-2025-00-29-07_/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-linkerd/07-11-2023-05-01-07_/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-linkerd/07-11-2023-05-01-07_/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-linkerd/07-11-2025-00-29-07_/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-linkerd/07-11-2025-00-29-07_/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-linkerd/07-12-2022-20-54-07_/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-linkerd/07-12-2022-20-54-07_/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-linkerd/07-13-2023-21-59-07_/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-linkerd/07-13-2023-21-59-07_/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-linkerd/07-14-2023-01-07-07_/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-linkerd/07-14-2023-01-07-07_/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-linkerd/07-17-2023-04-16-07_/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-linkerd/07-17-2023-04-16-07_/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-linkerd/07-18-2022-17-57-07_/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-linkerd/07-18-2022-17-57-07_/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-linkerd/07-18-2023-03-29-07_/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-linkerd/07-18-2023-03-29-07_/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-linkerd/07-19-2023-17-13-07_/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-linkerd/07-19-2023-17-13-07_/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-linkerd/07-19-2023-17-18-07_/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-linkerd/07-19-2023-17-18-07_/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-linkerd/07-19-2023-17-23-07_/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-linkerd/07-19-2023-17-23-07_/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-linkerd/07-19-2023-17-24-07_/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-linkerd/07-19-2023-17-24-07_/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-linkerd/07-19-2025-00-29-07_/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-linkerd/07-19-2025-00-29-07_/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-linkerd/07-24-2025-00-30-07_/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-linkerd/07-24-2025-00-30-07_/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-linkerd/07-29-2023-00-55-07_/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-linkerd/07-29-2023-00-55-07_/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-linkerd/08-01-2025-00-31-08_/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-linkerd/08-01-2025-00-31-08_/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-linkerd/08-02-2025-00-29-08_/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-linkerd/08-02-2025-00-29-08_/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-linkerd/08-03-2022-20-44-08_/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-linkerd/08-03-2022-20-44-08_/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-linkerd/08-04-2023-00-57-08_/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-linkerd/08-04-2023-00-57-08_/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-linkerd/08-05-2022-19-55-08_/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-linkerd/08-05-2022-19-55-08_/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-linkerd/08-08-2025-00-30-08_/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-linkerd/08-08-2025-00-30-08_/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-linkerd/08-12-2023-00-46-08_/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-linkerd/08-12-2023-00-46-08_/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-linkerd/08-15-2025-00-30-08_/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-linkerd/08-15-2025-00-30-08_/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-linkerd/08-17-2023-00-46-08_/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-linkerd/08-17-2023-00-46-08_/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-linkerd/08-18-2023-16-56-08_/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-linkerd/08-18-2023-16-56-08_/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-linkerd/08-22-2023-02-41-08_/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-linkerd/08-22-2023-02-41-08_/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-linkerd/08-22-2023-02-50-08_/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-linkerd/08-22-2023-02-50-08_/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-linkerd/08-22-2023-03-04-08_/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-linkerd/08-22-2023-03-04-08_/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-linkerd/08-22-2023-03-18-08_/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-linkerd/08-22-2023-03-18-08_/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-linkerd/08-23-2025-00-28-08_/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-linkerd/08-23-2025-00-28-08_/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-linkerd/08-27-2025-16-42-08_/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-linkerd/08-27-2025-16-42-08_/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-linkerd/08-28-2025-00-29-08_/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-linkerd/08-28-2025-00-29-08_/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-linkerd/09-02-2022-16-25-09_/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-linkerd/09-02-2022-16-25-09_/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-linkerd/09-05-2025-00-24-09_/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-linkerd/09-05-2025-00-24-09_/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-linkerd/09-10-2025-16-00-09_/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-linkerd/09-10-2025-16-00-09_/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-linkerd/09-13-2025-00-24-09_/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-linkerd/09-13-2025-00-24-09_/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-linkerd/09-19-2025-00-24-09_/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-linkerd/09-19-2025-00-24-09_/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-linkerd/09-23-2023-00-48-09_/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-linkerd/09-23-2023-00-48-09_/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-linkerd/09-23-2025-20-09-09_/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-linkerd/09-23-2025-20-09-09_/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-linkerd/09-26-2025-00-24-09_/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-linkerd/09-26-2025-00-24-09_/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-linkerd/09-30-2023-00-49-09_/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-linkerd/09-30-2023-00-49-09_/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-linkerd/09-30-2023-05-37-09_/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-linkerd/09-30-2023-05-37-09_/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-linkerd/10-01-2023-06-33-10_/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-linkerd/10-01-2023-06-33-10_/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-linkerd/10-03-2025-00-24-10_/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-linkerd/10-03-2025-00-24-10_/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-linkerd/10-05-2023-00-51-10_/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-linkerd/10-05-2023-00-51-10_/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-linkerd/10-06-2022-03-18-10_/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-linkerd/10-06-2022-03-18-10_/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-linkerd/10-09-2023-08-09-10_/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-linkerd/10-09-2023-08-09-10_/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-linkerd/10-10-2023-10-49-10_/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-linkerd/10-10-2023-10-49-10_/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-linkerd/10-10-2023-10-53-10_/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-linkerd/10-10-2023-10-53-10_/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-linkerd/10-10-2023-11-14-10_/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-linkerd/10-10-2023-11-14-10_/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-linkerd/10-10-2025-00-25-10_/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-linkerd/10-10-2025-00-25-10_/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-linkerd/10-13-2023-00-49-10_/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-linkerd/10-13-2023-00-49-10_/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-linkerd/10-14-2025-00-24-10_/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-linkerd/10-14-2025-00-24-10_/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-linkerd/10-17-2022-21-39-10_/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-linkerd/10-17-2022-21-39-10_/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-linkerd/10-17-2025-00-24-10_/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-linkerd/10-17-2025-00-24-10_/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-linkerd/10-18-2022-21-35-10_/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-linkerd/10-18-2022-21-35-10_/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-linkerd/10-18-2022-21-37-10_/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-linkerd/10-18-2022-21-37-10_/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-linkerd/10-20-2022-01-18-10_/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-linkerd/10-20-2022-01-18-10_/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-linkerd/10-20-2022-08-08-10_/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-linkerd/10-20-2022-08-08-10_/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-linkerd/10-20-2022-08-21-10_/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-linkerd/10-20-2022-08-21-10_/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-linkerd/10-20-2022-16-25-10_/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-linkerd/10-20-2022-16-25-10_/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-linkerd/10-20-2022-16-26-10_/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-linkerd/10-20-2022-16-26-10_/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-linkerd/10-20-2023-00-49-10_/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-linkerd/10-20-2023-00-49-10_/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-linkerd/10-21-2022-13-19-10_/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-linkerd/10-21-2022-13-19-10_/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-linkerd/10-21-2022-13-31-10_/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-linkerd/10-21-2022-13-31-10_/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-linkerd/10-21-2023-00-48-10_/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-linkerd/10-21-2023-00-48-10_/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-linkerd/10-21-2025-00-26-10_/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-linkerd/10-21-2025-00-26-10_/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-linkerd/10-24-2025-00-23-10_/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-linkerd/10-24-2025-00-23-10_/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-linkerd/10-28-2023-00-48-10_/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-linkerd/10-28-2023-00-48-10_/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-linkerd/10-30-2025-00-25-10_/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-linkerd/10-30-2025-00-25-10_/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-linkerd/11-03-2023-00-49-11_/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-linkerd/11-03-2023-00-49-11_/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-linkerd/11-07-2022-21-13-11_/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-linkerd/11-07-2022-21-13-11_/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-linkerd/11-07-2025-00-24-11_/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-linkerd/11-07-2025-00-24-11_/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-linkerd/11-14-2025-00-24-11_/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-linkerd/11-14-2025-00-24-11_/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-linkerd/11-30-2022-07-11-11_/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-linkerd/11-30-2022-07-11-11_/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-linkerd/12-02-2022-11-15-12_/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-linkerd/12-02-2022-11-15-12_/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-linkerd/12-02-2022-16-07-12_/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-linkerd/12-02-2022-16-07-12_/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-linkerd/12-06-2022-15-02-12_/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-linkerd/12-06-2022-15-02-12_/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-linkerd/12-08-2022-20-14-12_/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-linkerd/12-08-2022-20-14-12_/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-linkerd/12-10-2022-00-59-12_/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-linkerd/12-10-2022-00-59-12_/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-linkerd/12-13-2022-11-52-12_/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-linkerd/12-13-2022-11-52-12_/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-linkerd/12-13-2022-12-24-12_/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-linkerd/12-13-2022-12-24-12_/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-linkerd/12-13-2022-13-10-12_/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-linkerd/12-13-2022-13-10-12_/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-linkerd/12-13-2022-13-44-12_/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-linkerd/12-13-2022-13-44-12_/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-linkerd/12-15-2022-10-59-12_/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-linkerd/12-15-2022-10-59-12_/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-linkerd/12-15-2022-11-00-12_/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-linkerd/12-15-2022-11-00-12_/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-linkerd/12-15-21_302eb8e/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-linkerd/12-15-21_302eb8e/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-linkerd/12-16-21_721b787/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-linkerd/12-16-21_721b787/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-linkerd/12-26-2022-14-50-12_/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-linkerd/12-26-2022-14-50-12_/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-linkerd/12-26-2022-14-52-12_/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-linkerd/12-26-2022-14-52-12_/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-linkerd/12-26-2022-14-54-12_/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-linkerd/12-26-2022-14-54-12_/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-linkerd/12-26-2022-14-59-12_/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-linkerd/12-26-2022-14-59-12_/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-linkerd/12-26-2024-12-32-12_/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-linkerd/12-26-2024-12-32-12_/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-linkerd/12-30-2021-23-49-12_/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-linkerd/12-30-2021-23-49-12_/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-linkerd/12-30-2021-23-58-12_/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-linkerd/12-30-2021-23-58-12_/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-linkerd/12-30-2021-23-59-12_/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-linkerd/12-30-2021-23-59-12_/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-linkerd/12-30-2022-20-56-12_/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-linkerd/12-30-2022-20-56-12_/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-linkerd/12-31-2021-00-55-12_/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-linkerd/12-31-2021-00-55-12_/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-linkerd/12-31-2021-16-41-12_/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-linkerd/12-31-2021-16-41-12_/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-linkerd/12-31-2021-16-42-12_/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-linkerd/12-31-2021-16-42-12_/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-linkerd/2021-12-23_07-19-23/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-linkerd/2021-12-23_07-19-23/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-linkerd/2021-12-28_06-23-17/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-linkerd/2021-12-28_06-23-17/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-nginx-sm/01-05-2022-14-39-01_e4f75bd8/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-nginx-sm/01-05-2022-14-39-01_e4f75bd8/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-nginx-sm/01-08-2022-18-04-01_d3e4e5c0/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-nginx-sm/01-08-2022-18-04-01_d3e4e5c0/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-nginx-sm/01-08-2022-18-06-01_e55775b4/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-nginx-sm/01-08-2022-18-06-01_e55775b4/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-nginx-sm/01-12-2022-04-18-01_5fea123c/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-nginx-sm/01-12-2022-04-18-01_5fea123c/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-nginx-sm/01-13-2022-00-49-01_f6f8116a/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-nginx-sm/01-13-2022-00-49-01_f6f8116a/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-nginx-sm/01-16-2023-13-37-01_cdaf99c0/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-nginx-sm/01-16-2023-13-37-01_cdaf99c0/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-nginx-sm/01-16-2023-13-40-01_cdaf99c0/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-nginx-sm/01-16-2023-13-40-01_cdaf99c0/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-nginx-sm/01-17-2022-15-36-01_295100f9/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-nginx-sm/01-17-2022-15-36-01_295100f9/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-nginx-sm/01-25-2024-07-24-01_23e7dc3b/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-nginx-sm/01-25-2024-07-24-01_23e7dc3b/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-nginx-sm/02-02-2022-05-54-02_78b68bcb/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-nginx-sm/02-02-2022-05-54-02_78b68bcb/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-nginx-sm/02-07-2023-21-03-02_5893b6a8/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-nginx-sm/02-07-2023-21-03-02_5893b6a8/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-nginx-sm/03-05-2022-08-46-03_55377906/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-nginx-sm/03-05-2022-08-46-03_55377906/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-nginx-sm/03-05-2022-08-47-03_aa5b23dd/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-nginx-sm/03-05-2022-08-47-03_aa5b23dd/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-nginx-sm/03-06-2023-13-54-03_306f529a/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-nginx-sm/03-06-2023-13-54-03_306f529a/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-nginx-sm/03-06-2023-14-08-03_9105ee27/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-nginx-sm/03-06-2023-14-08-03_9105ee27/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-nginx-sm/03-17-2022-00-09-03_60e7ac5f/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-nginx-sm/03-17-2022-00-09-03_60e7ac5f/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-nginx-sm/03-17-2022-00-40-03_aa141f08/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-nginx-sm/03-17-2022-00-40-03_aa141f08/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-nginx-sm/03-25-2022-16-14-03_2b924809/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-nginx-sm/03-25-2022-16-14-03_2b924809/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-nginx-sm/03-30-2022-22-31-03_8fb2290e/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-nginx-sm/03-30-2022-22-31-03_8fb2290e/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-nginx-sm/03-30-2022-22-51-03_b47eaef2/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-nginx-sm/03-30-2022-22-51-03_b47eaef2/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-nginx-sm/04-11-2022-21-21-04_9cb6e81e/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-nginx-sm/04-11-2022-21-21-04_9cb6e81e/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-nginx-sm/04-12-2022-11-31-04_8d07087c/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-nginx-sm/04-12-2022-11-31-04_8d07087c/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-nginx-sm/04-12-2022-18-57-04_98778a3d/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-nginx-sm/04-12-2022-18-57-04_98778a3d/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-nginx-sm/04-15-2022-22-56-04_b483a67d/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-nginx-sm/04-15-2022-22-56-04_b483a67d/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-nginx-sm/04-22-2022-02-35-04_4b142694/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-nginx-sm/04-22-2022-02-35-04_4b142694/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-nginx-sm/04-22-2022-02-41-04_4b142694/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-nginx-sm/04-22-2022-02-41-04_4b142694/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-nginx-sm/04-26-2022-09-59-04_b609a492/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-nginx-sm/04-26-2022-09-59-04_b609a492/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-nginx-sm/05-03-2022-14-20-05_84393be2/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-nginx-sm/05-03-2022-14-20-05_84393be2/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-nginx-sm/05-16-2022-18-11-05_e627f31c/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-nginx-sm/05-16-2022-18-11-05_e627f31c/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-nginx-sm/05-21-2023-13-54-05_121a2264/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-nginx-sm/05-21-2023-13-54-05_121a2264/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-nginx-sm/05-27-2022-00-52-05_16614294/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-nginx-sm/05-27-2022-00-52-05_16614294/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-nginx-sm/05-30-2022-17-24-05_751cf120/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-nginx-sm/05-30-2022-17-24-05_751cf120/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-nginx-sm/05-30-2022-17-50-05_64d9b62c/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-nginx-sm/05-30-2022-17-50-05_64d9b62c/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-nginx-sm/05-30-2022-19-47-05_64d9b62c/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-nginx-sm/05-30-2022-19-47-05_64d9b62c/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-nginx-sm/06-11-2022-00-11-06_4a98ea7c/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-nginx-sm/06-11-2022-00-11-06_4a98ea7c/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-nginx-sm/06-12-2022-13-10-06_ec61aab1/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-nginx-sm/06-12-2022-13-10-06_ec61aab1/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-nginx-sm/06-12-2022-13-18-06_ec61aab1/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-nginx-sm/06-12-2022-13-18-06_ec61aab1/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-nginx-sm/06-12-2022-13-20-06_ec61aab1/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-nginx-sm/06-12-2022-13-20-06_ec61aab1/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-nginx-sm/06-15-2023-18-39-06_d80b7ccf/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-nginx-sm/06-15-2023-18-39-06_d80b7ccf/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-nginx-sm/06-16-2022-16-52-06_166380cf/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-nginx-sm/06-16-2022-16-52-06_166380cf/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-nginx-sm/06-25-2022-04-41-06_4c31f045/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-nginx-sm/06-25-2022-04-41-06_4c31f045/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-nginx-sm/06-29-2023-14-26-06_9cb19737/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-nginx-sm/06-29-2023-14-26-06_9cb19737/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-nginx-sm/07-04-2022-11-04-07_31a15f90/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-nginx-sm/07-04-2022-11-04-07_31a15f90/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-nginx-sm/07-08-2022-12-25-07_2e8e3f2a/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-nginx-sm/07-08-2022-12-25-07_2e8e3f2a/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-nginx-sm/07-08-2022-12-30-07_2e8e3f2a/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-nginx-sm/07-08-2022-12-30-07_2e8e3f2a/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-nginx-sm/07-08-2022-12-32-07_2e8e3f2a/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-nginx-sm/07-08-2022-12-32-07_2e8e3f2a/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-nginx-sm/07-09-2023-16-58-07_fba9b9b7/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-nginx-sm/07-09-2023-16-58-07_fba9b9b7/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-nginx-sm/07-09-2023-17-05-07_541bca80/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-nginx-sm/07-09-2023-17-05-07_541bca80/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-nginx-sm/07-19-2022-01-16-07_c402ea86/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-nginx-sm/07-19-2022-01-16-07_c402ea86/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-nginx-sm/07-19-2023-21-03-07_defd2af2/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-nginx-sm/07-19-2023-21-03-07_defd2af2/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-nginx-sm/07-19-2023-22-01-07_b3970bd5/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-nginx-sm/07-19-2023-22-01-07_b3970bd5/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-nginx-sm/07-19-2023-22-02-07_094c8edb/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-nginx-sm/07-19-2023-22-02-07_094c8edb/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-nginx-sm/07-19-2023-22-03-07_094c8edb/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-nginx-sm/07-19-2023-22-03-07_094c8edb/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-nginx-sm/07-19-2023-22-16-07_ee826514/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-nginx-sm/07-19-2023-22-16-07_ee826514/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-nginx-sm/07-26-2022-10-07-07_c54a3e7d/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-nginx-sm/07-26-2022-10-07-07_c54a3e7d/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-nginx-sm/07-28-2022-00-53-07_92733c25/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-nginx-sm/07-28-2022-00-53-07_92733c25/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-nginx-sm/07-28-2022-12-46-07_0c0757fe/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-nginx-sm/07-28-2022-12-46-07_0c0757fe/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-nginx-sm/08-01-2022-09-47-08_6d7d3351/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-nginx-sm/08-01-2022-09-47-08_6d7d3351/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-nginx-sm/08-04-2022-15-30-08_57926806/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-nginx-sm/08-04-2022-15-30-08_57926806/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-nginx-sm/08-04-2022-15-36-08_7fbbb032/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-nginx-sm/08-04-2022-15-36-08_7fbbb032/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-nginx-sm/08-05-2022-20-27-08_5b965717/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-nginx-sm/08-05-2022-20-27-08_5b965717/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-nginx-sm/08-05-2022-20-28-08_52881f26/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-nginx-sm/08-05-2022-20-28-08_52881f26/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-nginx-sm/08-05-2022-20-34-08_52881f26/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-nginx-sm/08-05-2022-20-34-08_52881f26/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-nginx-sm/08-05-2022-20-36-08_52881f26/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-nginx-sm/08-05-2022-20-36-08_52881f26/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-nginx-sm/08-26-2022-14-58-08_26168d1b/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-nginx-sm/08-26-2022-14-58-08_26168d1b/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-nginx-sm/09-04-2022-10-06-09_035696d1/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-nginx-sm/09-04-2022-10-06-09_035696d1/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-nginx-sm/09-04-2022-10-19-09_035696d1/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-nginx-sm/09-04-2022-10-19-09_035696d1/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-nginx-sm/09-04-2022-10-24-09_035696d1/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-nginx-sm/09-04-2022-10-24-09_035696d1/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-nginx-sm/09-16-2022-10-59-09_035696d1/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-nginx-sm/09-16-2022-10-59-09_035696d1/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-nginx-sm/09-19-2022-23-21-09_9fd0c8be/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-nginx-sm/09-19-2022-23-21-09_9fd0c8be/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-nginx-sm/09-19-2022-23-26-09_9fd0c8be/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-nginx-sm/09-19-2022-23-26-09_9fd0c8be/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-nginx-sm/09-19-2022-23-30-09_9fd0c8be/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-nginx-sm/09-19-2022-23-30-09_9fd0c8be/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-nginx-sm/09-23-2023-13-38-09_d219c66b/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-nginx-sm/09-23-2023-13-38-09_d219c66b/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-nginx-sm/10-04-2022-03-43-10_99d2df78/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-nginx-sm/10-04-2022-03-43-10_99d2df78/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-nginx-sm/10-04-2022-03-44-10_99d2df78/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-nginx-sm/10-04-2022-03-44-10_99d2df78/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-nginx-sm/10-04-2022-03-47-10_99d2df78/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-nginx-sm/10-04-2022-03-47-10_99d2df78/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-nginx-sm/10-05-2022-10-53-10_6f83b9f2/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-nginx-sm/10-05-2022-10-53-10_6f83b9f2/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-nginx-sm/10-09-2022-05-12-10_adaa184b/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-nginx-sm/10-09-2022-05-12-10_adaa184b/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-nginx-sm/10-10-2022-17-22-10_c6048fad/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-nginx-sm/10-10-2022-17-22-10_c6048fad/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-nginx-sm/10-20-2022-16-38-10_5c426ec6/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-nginx-sm/10-20-2022-16-38-10_5c426ec6/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-nginx-sm/10-21-2022-13-42-10_a6d37ecc/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-nginx-sm/10-21-2022-13-42-10_a6d37ecc/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-nginx-sm/10-21-2022-13-56-10_beaf3fbd/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-nginx-sm/10-21-2022-13-56-10_beaf3fbd/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-nginx-sm/10-21-2022-14-07-10_beaf3fbd/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-nginx-sm/10-21-2022-14-07-10_beaf3fbd/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-nginx-sm/10-21-2022-14-09-10_beaf3fbd/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-nginx-sm/10-21-2022-14-09-10_beaf3fbd/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-nginx-sm/10-21-2022-20-30-10_467d9dbe/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-nginx-sm/10-21-2022-20-30-10_467d9dbe/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-nginx-sm/12-04-2023-00-06-12_1166099d/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-nginx-sm/12-04-2023-00-06-12_1166099d/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-nginx-sm/12-11-2023-08-04-12_e6f852fe/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-nginx-sm/12-11-2023-08-04-12_e6f852fe/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-osm/01-06-2022-20-14-01_/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-osm/01-06-2022-20-14-01_/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-osm/01-12-2023-17-18-01_49d5aaf3/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-osm/01-12-2023-17-18-01_49d5aaf3/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-osm/01-24-2022-20-12-01_bd30cad0/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-osm/01-24-2022-20-12-01_bd30cad0/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-osm/01-24-2022-21-50-01_5b1fa6b5/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-osm/01-24-2022-21-50-01_5b1fa6b5/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-osm/01-26-2023-16-25-01_49d5aaf3/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-osm/01-26-2023-16-25-01_49d5aaf3/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-osm/01-29-2022-19-43-01_001dad8f/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-osm/01-29-2022-19-43-01_001dad8f/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-osm/02-05-2022-00-43-02_44ea063f/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-osm/02-05-2022-00-43-02_44ea063f/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-osm/02-17-2022-00-45-02_3a64bca2/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-osm/02-17-2022-00-45-02_3a64bca2/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-osm/02-20-2022-17-25-02_c4860b88/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-osm/02-20-2022-17-25-02_c4860b88/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-osm/03-14-2022-04-29-03_2e299d8c/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-osm/03-14-2022-04-29-03_2e299d8c/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-osm/03-17-2022-00-06-03_4c2ad381/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-osm/03-17-2022-00-06-03_4c2ad381/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-osm/03-20-2023-19-31-03_6503414b/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-osm/03-20-2023-19-31-03_6503414b/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-osm/03-20-2023-19-40-03_427b09d7/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-osm/03-20-2023-19-40-03_427b09d7/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-osm/03-23-2023-18-33-03_3673afa8/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-osm/03-23-2023-18-33-03_3673afa8/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-osm/03-23-2023-20-03-03_eb69d924/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-osm/03-23-2023-20-03-03_eb69d924/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-osm/04-04-2022-12-52-04_f3135a6d/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-osm/04-04-2022-12-52-04_f3135a6d/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-osm/04-05-2022-00-57-04_87c47082/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-osm/04-05-2022-00-57-04_87c47082/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-osm/04-07-2022-10-03-04_8730ba08/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-osm/04-07-2022-10-03-04_8730ba08/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-osm/04-07-2022-13-38-04_8730ba08/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-osm/04-07-2022-13-38-04_8730ba08/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-osm/04-11-2022-02-26-04_926ee652/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-osm/04-11-2022-02-26-04_926ee652/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-osm/04-11-2022-17-05-04_99a3329d/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-osm/04-11-2022-17-05-04_99a3329d/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-osm/04-11-2022-20-34-04_a4ad2ff7/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-osm/04-11-2022-20-34-04_a4ad2ff7/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-osm/04-12-2022-18-52-04_4883909f/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-osm/04-12-2022-18-52-04_4883909f/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-osm/04-15-2022-01-03-04_30084945/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-osm/04-15-2022-01-03-04_30084945/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-osm/04-15-2022-21-10-04_7004e769/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-osm/04-15-2022-21-10-04_7004e769/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-osm/04-26-2022-13-08-04_9e5d01af/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-osm/04-26-2022-13-08-04_9e5d01af/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-osm/05-04-2022-18-09-05_8ce11cba/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-osm/05-04-2022-18-09-05_8ce11cba/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-osm/05-05-2022-01-08-05_e103d92d/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-osm/05-05-2022-01-08-05_e103d92d/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-osm/05-10-2022-13-01-05_c10853fd/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-osm/05-10-2022-13-01-05_c10853fd/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-osm/05-10-2022-13-03-05_c10853fd/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-osm/05-10-2022-13-03-05_c10853fd/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-osm/05-11-2022-01-12-05_98394088/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-osm/05-11-2022-01-12-05_98394088/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-osm/05-30-2022-17-24-05_9eeffe0c/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-osm/05-30-2022-17-24-05_9eeffe0c/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-osm/05-30-2022-19-51-05_bccaa433/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-osm/05-30-2022-19-51-05_bccaa433/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-osm/05-30-2022-19-56-05_bccaa433/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-osm/05-30-2022-19-56-05_bccaa433/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-osm/06-11-2022-12-50-06_ec8cb8d0/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-osm/06-11-2022-12-50-06_ec8cb8d0/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-osm/06-11-2022-12-56-06_ec8cb8d0/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-osm/06-11-2022-12-56-06_ec8cb8d0/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-osm/06-11-2022-12-57-06_ec8cb8d0/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-osm/06-11-2022-12-57-06_ec8cb8d0/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-osm/06-15-2023-18-46-06_faa16e0c/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-osm/06-15-2023-18-46-06_faa16e0c/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-osm/06-15-2023-19-00-06_58dbaa4c/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-osm/06-15-2023-19-00-06_58dbaa4c/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-osm/06-17-2022-15-33-06_5a70c114/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-osm/06-17-2022-15-33-06_5a70c114/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-osm/06-29-2023-14-24-06_28e558dd/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-osm/06-29-2023-14-24-06_28e558dd/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-osm/07-13-2022-01-13-07_4f7b322e/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-osm/07-13-2022-01-13-07_4f7b322e/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-osm/07-18-2022-21-04-07_3ce92c94/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-osm/07-18-2022-21-04-07_3ce92c94/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-osm/07-19-2023-22-48-07_294c5b56/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-osm/07-19-2023-22-48-07_294c5b56/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-osm/07-19-2023-23-02-07_8d29c3d0/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-osm/07-19-2023-23-02-07_8d29c3d0/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-osm/07-21-2022-01-20-07_f89948c5/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-osm/07-21-2022-01-20-07_f89948c5/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-osm/08-01-2022-08-19-08_16aff27c/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-osm/08-01-2022-08-19-08_16aff27c/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-osm/08-03-2022-08-05-08_c451657f/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-osm/08-03-2022-08-05-08_c451657f/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-osm/08-04-2022-15-19-08_e6bd376b/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-osm/08-04-2022-15-19-08_e6bd376b/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-osm/08-04-2022-15-45-08_eaa20539/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-osm/08-04-2022-15-45-08_eaa20539/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-osm/08-04-2022-22-47-08_d02e0ca7/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-osm/08-04-2022-22-47-08_d02e0ca7/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-osm/08-04-2022-22-49-08_d02e0ca7/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-osm/08-04-2022-22-49-08_d02e0ca7/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-osm/08-04-2022-22-52-08_d02e0ca7/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-osm/08-04-2022-22-52-08_d02e0ca7/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-osm/08-05-2022-19-10-08_2144a66e/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-osm/08-05-2022-19-10-08_2144a66e/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-osm/08-05-2022-19-38-08_2144a66e/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-osm/08-05-2022-19-38-08_2144a66e/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-osm/08-05-2022-19-45-08_2144a66e/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-osm/08-05-2022-19-45-08_2144a66e/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-osm/08-26-2022-14-27-08_15d60959/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-osm/08-26-2022-14-27-08_15d60959/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-osm/08-30-2022-13-37-08_12a6719f/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-osm/08-30-2022-13-37-08_12a6719f/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-osm/08-31-2022-18-02-08_7400cbe2/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-osm/08-31-2022-18-02-08_7400cbe2/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-osm/09-02-2022-16-42-09_7400cbe2/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-osm/09-02-2022-16-42-09_7400cbe2/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-osm/09-02-2022-16-50-09_7400cbe2/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-osm/09-02-2022-16-50-09_7400cbe2/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-osm/09-03-2022-01-19-09_4908eb7d/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-osm/09-03-2022-01-19-09_4908eb7d/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-osm/09-06-2022-12-04-09_38b110be/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-osm/09-06-2022-12-04-09_38b110be/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-osm/09-07-2022-01-29-09_60d320bf/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-osm/09-07-2022-01-29-09_60d320bf/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-osm/09-21-2022-09-27-09_fcde3ac3/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-osm/09-21-2022-09-27-09_fcde3ac3/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-osm/10-04-2022-01-39-10_37859987/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-osm/10-04-2022-01-39-10_37859987/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-osm/10-05-2022-18-55-10_53ea8224/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-osm/10-05-2022-18-55-10_53ea8224/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-osm/10-05-2022-18-59-10_53ea8224/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-osm/10-05-2022-18-59-10_53ea8224/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-osm/10-05-2022-19-05-10_53ea8224/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-osm/10-05-2022-19-05-10_53ea8224/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-osm/10-06-2022-01-29-10_5800e074/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-osm/10-06-2022-01-29-10_5800e074/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-osm/10-06-2022-02-59-10_e0944d86/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-osm/10-06-2022-02-59-10_e0944d86/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-osm/10-18-2022-09-48-10_a3a28ddf/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-osm/10-18-2022-09-48-10_a3a28ddf/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-osm/10-19-2022-19-29-10_0dcbea14/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-osm/10-19-2022-19-29-10_0dcbea14/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-osm/10-20-2022-16-54-10_a82c177d/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-osm/10-20-2022-16-54-10_a82c177d/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-osm/10-21-2022-13-40-10_a82c177d/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-osm/10-21-2022-13-40-10_a82c177d/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-osm/10-21-2022-13-48-10_a82c177d/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-osm/10-21-2022-13-48-10_a82c177d/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-osm/10-22-2022-01-31-10_d1570e41/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-osm/10-22-2022-01-31-10_d1570e41/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-osm/10-25-2022-02-59-10_5174eedd/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-osm/10-25-2022-02-59-10_5174eedd/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-osm/11-07-2022-22-22-11_afa57955/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-osm/11-07-2022-22-22-11_afa57955/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-osm/11-07-2022-22-24-11_0228acb1/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-osm/11-07-2022-22-24-11_0228acb1/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-osm/11-28-2022-22-56-11_2205b4b2/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-osm/11-28-2022-22-56-11_2205b4b2/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-osm/12-15-2022-01-09-12_95a5e9e7/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-osm/12-15-2022-01-09-12_95a5e9e7/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-osm/12-15-2022-17-07-12_aefe7711/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-osm/12-15-2022-17-07-12_aefe7711/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-osm/12-16-2022-11-33-12_40e79057/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-osm/12-16-2022-11-33-12_40e79057/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-osm/12-26-2022-14-50-12_1bd3de65/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-osm/12-26-2022-14-50-12_1bd3de65/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-osm/12-26-2022-15-50-12_edc2f0c3/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-osm/12-26-2022-15-50-12_edc2f0c3/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-osm/12-26-2022-15-54-12_f314e65a/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-osm/12-26-2022-15-54-12_f314e65a/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-osm/12-26-2022-16-05-12_49d5aaf3/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-osm/12-26-2022-16-05-12_49d5aaf3/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-osm/12-30-2021-22-45-12_/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-osm/12-30-2021-22-45-12_/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-osm/12-30-2022-21-13-12_49d5aaf3/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-osm/12-30-2022-21-13-12_49d5aaf3/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-osm/12-30-2022-21-19-12_49d5aaf3/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-osm/12-30-2022-21-19-12_49d5aaf3/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-osm/12-31-2021-18-25-12_/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-osm/12-31-2021-18-25-12_/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-osm/12-31-2021-18-33-12_/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-osm/12-31-2021-18-33-12_/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-osm/2021-12-22_20-38-21/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-osm/2021-12-22_20-38-21/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-osm/2021-12-28_06-18-19/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-osm/2021-12-28_06-18-19/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-traefik-mesh/01-03-2023-13-54-01_9301cf60/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-traefik-mesh/01-03-2023-13-54-01_9301cf60/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-traefik-mesh/01-09-2022-08-04-01_/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-traefik-mesh/01-09-2022-08-04-01_/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-traefik-mesh/01-09-2022-08-45-01_/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-traefik-mesh/01-09-2022-08-45-01_/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-traefik-mesh/01-09-2022-12-19-01_9281b545/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-traefik-mesh/01-09-2022-12-19-01_9281b545/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-traefik-mesh/01-10-2022-22-33-01_9e21c00a/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-traefik-mesh/01-10-2022-22-33-01_9e21c00a/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-traefik-mesh/01-16-2023-13-34-01_9301cf60/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-traefik-mesh/01-16-2023-13-34-01_9301cf60/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-traefik-mesh/01-24-2022-20-22-01_06abb625/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-traefik-mesh/01-24-2022-20-22-01_06abb625/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-traefik-mesh/01-24-2022-20-25-01_82d6c1d6/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-traefik-mesh/01-24-2022-20-25-01_82d6c1d6/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-traefik-mesh/01-24-2022-21-50-01_4ea6b148/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-traefik-mesh/01-24-2022-21-50-01_4ea6b148/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-traefik-mesh/01-25-2022-13-48-01_d3418c60/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-traefik-mesh/01-25-2022-13-48-01_d3418c60/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-traefik-mesh/01-26-2023-16-39-01_9301cf60/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-traefik-mesh/01-26-2023-16-39-01_9301cf60/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-traefik-mesh/01-26-2023-16-39-01_acf015f7/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-traefik-mesh/01-26-2023-16-39-01_acf015f7/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-traefik-mesh/02-09-2023-15-45-02_4b8a069d/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-traefik-mesh/02-09-2023-15-45-02_4b8a069d/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-traefik-mesh/02-09-2023-15-47-02_f77dbe92/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-traefik-mesh/02-09-2023-15-47-02_f77dbe92/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-traefik-mesh/02-09-2023-15-48-02_821abc5d/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-traefik-mesh/02-09-2023-15-48-02_821abc5d/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-traefik-mesh/02-09-2023-15-53-02_736d798e/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-traefik-mesh/02-09-2023-15-53-02_736d798e/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-traefik-mesh/02-11-2022-19-15-02_f45b7ab3/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-traefik-mesh/02-11-2022-19-15-02_f45b7ab3/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-traefik-mesh/02-11-2022-19-36-02_e8cb1819/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-traefik-mesh/02-11-2022-19-36-02_e8cb1819/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-traefik-mesh/02-24-2022-17-26-02_e8cb1819/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-traefik-mesh/02-24-2022-17-26-02_e8cb1819/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-traefik-mesh/03-01-2022-10-44-03_478bc342/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-traefik-mesh/03-01-2022-10-44-03_478bc342/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-traefik-mesh/03-06-2022-08-50-03_a553a92a/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-traefik-mesh/03-06-2022-08-50-03_a553a92a/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-traefik-mesh/03-12-2022-19-05-03_54ff16f2/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-traefik-mesh/03-12-2022-19-05-03_54ff16f2/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-traefik-mesh/03-17-2022-13-39-03_67b497d0/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-traefik-mesh/03-17-2022-13-39-03_67b497d0/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-traefik-mesh/03-20-2023-19-23-03_a49acfd8/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-traefik-mesh/03-20-2023-19-23-03_a49acfd8/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-traefik-mesh/03-20-2023-19-31-03_acadac92/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-traefik-mesh/03-20-2023-19-31-03_acadac92/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-traefik-mesh/03-22-2022-07-58-03_26d264be/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-traefik-mesh/03-22-2022-07-58-03_26d264be/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-traefik-mesh/03-23-2023-20-29-03_2dddac5b/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-traefik-mesh/03-23-2023-20-29-03_2dddac5b/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-traefik-mesh/03-23-2023-20-53-03_12910009/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-traefik-mesh/03-23-2023-20-53-03_12910009/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-traefik-mesh/04-07-2022-13-34-04_26d264be/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-traefik-mesh/04-07-2022-13-34-04_26d264be/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-traefik-mesh/04-26-2023-08-59-04_7eb9e074/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-traefik-mesh/04-26-2023-08-59-04_7eb9e074/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-traefik-mesh/04-26-2023-09-02-04_9ddf92f8/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-traefik-mesh/04-26-2023-09-02-04_9ddf92f8/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-traefik-mesh/04-26-2023-09-15-04_70d8bf5c/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-traefik-mesh/04-26-2023-09-15-04_70d8bf5c/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-traefik-mesh/04-26-2023-09-18-04_b7a200c2/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-traefik-mesh/04-26-2023-09-18-04_b7a200c2/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-traefik-mesh/04-26-2023-09-30-04_2608eaf6/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-traefik-mesh/04-26-2023-09-30-04_2608eaf6/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-traefik-mesh/04-26-2023-10-06-04_e0ee0705/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-traefik-mesh/04-26-2023-10-06-04_e0ee0705/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-traefik-mesh/05-03-2022-14-40-05_ecc57e1f/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-traefik-mesh/05-03-2022-14-40-05_ecc57e1f/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-traefik-mesh/05-03-2022-14-59-05_1977c442/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-traefik-mesh/05-03-2022-14-59-05_1977c442/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-traefik-mesh/05-04-2022-09-43-05_1977c442/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-traefik-mesh/05-04-2022-09-43-05_1977c442/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-traefik-mesh/05-06-2022-15-50-05_2eb85f9b/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-traefik-mesh/05-06-2022-15-50-05_2eb85f9b/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-traefik-mesh/05-12-2022-15-21-05_26ebbe7d/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-traefik-mesh/05-12-2022-15-21-05_26ebbe7d/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-traefik-mesh/05-17-2022-14-18-05_82af4ba7/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-traefik-mesh/05-17-2022-14-18-05_82af4ba7/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-traefik-mesh/05-22-2023-19-38-05_4a7c31fb/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-traefik-mesh/05-22-2023-19-38-05_4a7c31fb/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-traefik-mesh/05-24-2022-07-02-05_bb2034d5/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-traefik-mesh/05-24-2022-07-02-05_bb2034d5/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-traefik-mesh/05-30-2022-17-24-05_cd8f3257/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-traefik-mesh/05-30-2022-17-24-05_cd8f3257/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-traefik-mesh/05-30-2022-19-50-05_cd8f3257/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-traefik-mesh/05-30-2022-19-50-05_cd8f3257/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-traefik-mesh/06-11-2022-00-23-06_e285b449/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-traefik-mesh/06-11-2022-00-23-06_e285b449/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-traefik-mesh/06-11-2022-00-33-06_e285b449/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-traefik-mesh/06-11-2022-00-33-06_e285b449/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-traefik-mesh/06-11-2022-12-38-06_c7589d2a/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-traefik-mesh/06-11-2022-12-38-06_c7589d2a/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-traefik-mesh/06-11-2022-12-39-06_c7589d2a/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-traefik-mesh/06-11-2022-12-39-06_c7589d2a/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-traefik-mesh/06-17-2022-15-50-06_694801ae/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-traefik-mesh/06-17-2022-15-50-06_694801ae/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-traefik-mesh/06-25-2022-04-33-06_75a8acf2/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-traefik-mesh/06-25-2022-04-33-06_75a8acf2/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-traefik-mesh/06-26-2023-13-57-06_43181414/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-traefik-mesh/06-26-2023-13-57-06_43181414/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-traefik-mesh/07-04-2022-10-54-07_00a73aca/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-traefik-mesh/07-04-2022-10-54-07_00a73aca/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-traefik-mesh/07-04-2022-10-57-07_00a73aca/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-traefik-mesh/07-04-2022-10-57-07_00a73aca/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-traefik-mesh/07-13-2022-10-52-07_ed79e153/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-traefik-mesh/07-13-2022-10-52-07_ed79e153/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-traefik-mesh/07-13-2023-22-00-07_593eb0c0/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-traefik-mesh/07-13-2023-22-00-07_593eb0c0/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-traefik-mesh/07-15-2023-01-03-07_4dec3639/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-traefik-mesh/07-15-2023-01-03-07_4dec3639/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-traefik-mesh/07-15-2023-01-04-07_0197683b/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-traefik-mesh/07-15-2023-01-04-07_0197683b/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-traefik-mesh/07-15-2023-01-10-07_491290d0/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-traefik-mesh/07-15-2023-01-10-07_491290d0/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-traefik-mesh/07-15-2023-01-22-07_491290d0/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-traefik-mesh/07-15-2023-01-22-07_491290d0/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-traefik-mesh/07-15-2023-01-23-07_491290d0/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-traefik-mesh/07-15-2023-01-23-07_491290d0/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-traefik-mesh/07-18-2022-18-02-07_ef120d19/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-traefik-mesh/07-18-2022-18-02-07_ef120d19/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-traefik-mesh/07-18-2022-18-07-07_ef120d19/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-traefik-mesh/07-18-2022-18-07-07_ef120d19/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-traefik-mesh/07-19-2022-01-17-07_0f6acc32/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-traefik-mesh/07-19-2022-01-17-07_0f6acc32/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-traefik-mesh/07-19-2023-22-17-07_c828e465/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-traefik-mesh/07-19-2023-22-17-07_c828e465/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-traefik-mesh/07-22-2023-03-05-07_d61d4265/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-traefik-mesh/07-22-2023-03-05-07_d61d4265/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-traefik-mesh/07-22-2023-05-48-07_85e431e6/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-traefik-mesh/07-22-2023-05-48-07_85e431e6/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-traefik-mesh/07-22-2023-05-52-07_85e431e6/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-traefik-mesh/07-22-2023-05-52-07_85e431e6/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-traefik-mesh/07-22-2023-05-55-07_85e431e6/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-traefik-mesh/07-22-2023-05-55-07_85e431e6/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-traefik-mesh/07-26-2022-12-33-07_abff75bc/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-traefik-mesh/07-26-2022-12-33-07_abff75bc/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-traefik-mesh/07-27-2022-11-36-07_84eaa8f0/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-traefik-mesh/07-27-2022-11-36-07_84eaa8f0/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-traefik-mesh/07-28-2022-19-04-07_c36b0c61/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-traefik-mesh/07-28-2022-19-04-07_c36b0c61/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-traefik-mesh/08-01-2022-08-16-08_44381401/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-traefik-mesh/08-01-2022-08-16-08_44381401/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-traefik-mesh/08-03-2022-08-03-08_0b03d868/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-traefik-mesh/08-03-2022-08-03-08_0b03d868/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-traefik-mesh/08-04-2022-01-54-08_40f265c3/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-traefik-mesh/08-04-2022-01-54-08_40f265c3/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-traefik-mesh/08-04-2022-08-39-08_40f265c3/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-traefik-mesh/08-04-2022-08-39-08_40f265c3/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-traefik-mesh/08-04-2022-14-36-08_23bcec4e/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-traefik-mesh/08-04-2022-14-36-08_23bcec4e/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-traefik-mesh/08-04-2022-15-38-08_9cfa64f7/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-traefik-mesh/08-04-2022-15-38-08_9cfa64f7/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-traefik-mesh/08-05-2022-15-04-08_87661371/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-traefik-mesh/08-05-2022-15-04-08_87661371/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-traefik-mesh/08-05-2022-15-16-08_1dd6b0be/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-traefik-mesh/08-05-2022-15-16-08_1dd6b0be/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-traefik-mesh/08-05-2022-15-23-08_a60778b1/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-traefik-mesh/08-05-2022-15-23-08_a60778b1/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-traefik-mesh/08-05-2022-15-30-08_a60778b1/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-traefik-mesh/08-05-2022-15-30-08_a60778b1/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-traefik-mesh/08-05-2022-15-41-08_bed6087a/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-traefik-mesh/08-05-2022-15-41-08_bed6087a/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-traefik-mesh/08-05-2022-18-27-08_cff4cd39/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-traefik-mesh/08-05-2022-18-27-08_cff4cd39/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-traefik-mesh/08-05-2022-18-33-08_cff4cd39/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-traefik-mesh/08-05-2022-18-33-08_cff4cd39/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-traefik-mesh/08-19-2022-11-15-08_87af9f3b/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-traefik-mesh/08-19-2022-11-15-08_87af9f3b/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-traefik-mesh/08-19-2022-11-19-08_6d13a102/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-traefik-mesh/08-19-2022-11-19-08_6d13a102/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-traefik-mesh/08-26-2022-14-47-08_27fa59dc/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-traefik-mesh/08-26-2022-14-47-08_27fa59dc/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-traefik-mesh/08-30-2022-21-08-08_9860d035/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-traefik-mesh/08-30-2022-21-08-08_9860d035/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-traefik-mesh/08-30-2022-21-11-08_319e7eef/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-traefik-mesh/08-30-2022-21-11-08_319e7eef/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-traefik-mesh/09-01-2022-18-32-09_de199eac/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-traefik-mesh/09-01-2022-18-32-09_de199eac/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-traefik-mesh/09-01-2022-21-40-09_23a6cd08/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-traefik-mesh/09-01-2022-21-40-09_23a6cd08/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-traefik-mesh/09-01-2022-21-41-09_5fa8d28e/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-traefik-mesh/09-01-2022-21-41-09_5fa8d28e/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-traefik-mesh/09-02-2022-16-43-09_5fa8d28e/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-traefik-mesh/09-02-2022-16-43-09_5fa8d28e/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-traefik-mesh/09-02-2022-16-51-09_5fa8d28e/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-traefik-mesh/09-02-2022-16-51-09_5fa8d28e/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-traefik-mesh/09-24-2022-03-29-09_147d1a8a/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-traefik-mesh/09-24-2022-03-29-09_147d1a8a/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-traefik-mesh/09-26-2022-10-36-09_147d1a8a/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-traefik-mesh/09-26-2022-10-36-09_147d1a8a/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-traefik-mesh/09-26-2022-10-37-09_147d1a8a/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-traefik-mesh/09-26-2022-10-37-09_147d1a8a/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-traefik-mesh/09-29-2022-18-44-09_ed4277e0/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-traefik-mesh/09-29-2022-18-44-09_ed4277e0/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-traefik-mesh/10-05-2022-18-09-10_4ae3cb63/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-traefik-mesh/10-05-2022-18-09-10_4ae3cb63/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-traefik-mesh/10-05-2022-18-13-10_9993c178/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-traefik-mesh/10-05-2022-18-13-10_9993c178/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-traefik-mesh/10-05-2022-18-23-10_9993c178/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-traefik-mesh/10-05-2022-18-23-10_9993c178/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-traefik-mesh/10-05-2022-18-25-10_9993c178/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-traefik-mesh/10-05-2022-18-25-10_9993c178/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-traefik-mesh/10-06-2023-08-26-10_a7a2cdd7/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-traefik-mesh/10-06-2023-08-26-10_a7a2cdd7/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-traefik-mesh/10-11-2022-14-34-10_2dde9e0d/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-traefik-mesh/10-11-2022-14-34-10_2dde9e0d/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-traefik-mesh/10-11-2022-14-37-10_7fc9f164/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-traefik-mesh/10-11-2022-14-37-10_7fc9f164/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-traefik-mesh/10-12-2023-01-57-10_161565d3/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-traefik-mesh/10-12-2023-01-57-10_161565d3/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-traefik-mesh/10-20-2022-07-40-10_19e38740/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-traefik-mesh/10-20-2022-07-40-10_19e38740/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-traefik-mesh/10-21-2022-14-20-10_8abab5c1/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-traefik-mesh/10-21-2022-14-20-10_8abab5c1/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-traefik-mesh/10-21-2022-17-14-10_8abab5c1/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-traefik-mesh/10-21-2022-17-14-10_8abab5c1/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-traefik-mesh/10-24-2022-11-42-10_a0102d39/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-traefik-mesh/10-24-2022-11-42-10_a0102d39/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-traefik-mesh/10-26-2023-23-45-10_170b306b/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-traefik-mesh/10-26-2023-23-45-10_170b306b/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-traefik-mesh/10-31-2022-15-45-10_175ec23d/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-traefik-mesh/10-31-2022-15-45-10_175ec23d/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-traefik-mesh/11-09-2022-19-57-11_c3d3b4e8/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-traefik-mesh/11-09-2022-19-57-11_c3d3b4e8/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-traefik-mesh/12-06-2022-04-01-12_98c77c56/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-traefik-mesh/12-06-2022-04-01-12_98c77c56/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-traefik-mesh/12-22-2022-15-08-12_4f5a1036/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-traefik-mesh/12-22-2022-15-08-12_4f5a1036/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-traefik-mesh/12-26-2022-16-03-12_6e5e5002/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-traefik-mesh/12-26-2022-16-03-12_6e5e5002/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-traefik-mesh/12-26-2022-16-06-12_6e5e5002/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-traefik-mesh/12-26-2022-16-06-12_6e5e5002/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-traefik-mesh/12-26-2022-16-11-12_6e5e5002/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-traefik-mesh/12-26-2022-16-11-12_6e5e5002/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/compatibility/meshery-traefik-mesh/12-30-2022-21-01-12_b38898ab/index.html
+++ b/docs/static/v0.9/project/compatibility/meshery-traefik-mesh/12-30-2022-21-01-12_b38898ab/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/contributing/build-and-release/index.html
+++ b/docs/static/v0.9/project/contributing/build-and-release/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/contributing/contributing-adapters/index.html
+++ b/docs/static/v0.9/project/contributing/contributing-adapters/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/contributing/contributing-cli-guide/index.html
+++ b/docs/static/v0.9/project/contributing/contributing-cli-guide/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/contributing/contributing-cli-tests/index.html
+++ b/docs/static/v0.9/project/contributing/contributing-cli-tests/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/contributing/contributing-cli/index.html
+++ b/docs/static/v0.9/project/contributing/contributing-cli/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/contributing/contributing-components/index.html
+++ b/docs/static/v0.9/project/contributing/contributing-components/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/contributing/contributing-docker-extension/index.html
+++ b/docs/static/v0.9/project/contributing/contributing-docker-extension/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/contributing/contributing-docs-structure/index.html
+++ b/docs/static/v0.9/project/contributing/contributing-docs-structure/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/contributing/contributing-docs/index.html
+++ b/docs/static/v0.9/project/contributing/contributing-docs/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/contributing/contributing-error/index.html
+++ b/docs/static/v0.9/project/contributing/contributing-error/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/contributing/contributing-gitflow/index.html
+++ b/docs/static/v0.9/project/contributing/contributing-gitflow/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/contributing/contributing-models-quick-start/index.html
+++ b/docs/static/v0.9/project/contributing/contributing-models-quick-start/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/contributing/contributing-models/index.html
+++ b/docs/static/v0.9/project/contributing/contributing-models/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/contributing/contributing-policies/index.html
+++ b/docs/static/v0.9/project/contributing/contributing-policies/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/contributing/contributing-relationships/index.html
+++ b/docs/static/v0.9/project/contributing/contributing-relationships/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/contributing/contributing-schemas/index.html
+++ b/docs/static/v0.9/project/contributing/contributing-schemas/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/contributing/contributing-server-events/index.html
+++ b/docs/static/v0.9/project/contributing/contributing-server-events/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/contributing/contributing-server/index.html
+++ b/docs/static/v0.9/project/contributing/contributing-server/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/contributing/contributing-ui-notification-center/index.html
+++ b/docs/static/v0.9/project/contributing/contributing-ui-notification-center/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/contributing/contributing-ui-schemas/index.html
+++ b/docs/static/v0.9/project/contributing/contributing-ui-schemas/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/contributing/contributing-ui-sistent/index.html
+++ b/docs/static/v0.9/project/contributing/contributing-ui-sistent/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/contributing/contributing-ui-tests/index.html
+++ b/docs/static/v0.9/project/contributing/contributing-ui-tests/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/contributing/contributing-ui-widgets/index.html
+++ b/docs/static/v0.9/project/contributing/contributing-ui-widgets/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/contributing/contributing-ui/index.html
+++ b/docs/static/v0.9/project/contributing/contributing-ui/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/contributing/index.html
+++ b/docs/static/v0.9/project/contributing/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/contributing/meshery-windows/index.html
+++ b/docs/static/v0.9/project/contributing/meshery-windows/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/contributing/test-status/index.html
+++ b/docs/static/v0.9/project/contributing/test-status/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/faq/index.html
+++ b/docs/static/v0.9/project/faq/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/index.html
+++ b/docs/static/v0.9/project/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/overview/index.html
+++ b/docs/static/v0.9/project/overview/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/releases/index.html
+++ b/docs/static/v0.9/project/releases/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/releases/roadmap-v0.7/index.html
+++ b/docs/static/v0.9/project/releases/roadmap-v0.7/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/releases/roadmap-v0.8/index.html
+++ b/docs/static/v0.9/project/releases/roadmap-v0.8/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/releases/roadmap-v0.9/index.html
+++ b/docs/static/v0.9/project/releases/roadmap-v0.9/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/releases/v0.0.1/index.html
+++ b/docs/static/v0.9/project/releases/v0.0.1/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/releases/v0.0.2/index.html
+++ b/docs/static/v0.9/project/releases/v0.0.2/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/releases/v0.0.3/index.html
+++ b/docs/static/v0.9/project/releases/v0.0.3/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/releases/v0.0.4/index.html
+++ b/docs/static/v0.9/project/releases/v0.0.4/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/releases/v0.0.5/index.html
+++ b/docs/static/v0.9/project/releases/v0.0.5/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/releases/v0.0.6/index.html
+++ b/docs/static/v0.9/project/releases/v0.0.6/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/releases/v0.0.7/index.html
+++ b/docs/static/v0.9/project/releases/v0.0.7/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/releases/v0.0.8/index.html
+++ b/docs/static/v0.9/project/releases/v0.0.8/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/releases/v0.0.9/index.html
+++ b/docs/static/v0.9/project/releases/v0.0.9/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/releases/v0.1.0/index.html
+++ b/docs/static/v0.9/project/releases/v0.1.0/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/releases/v0.1.1/index.html
+++ b/docs/static/v0.9/project/releases/v0.1.1/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/releases/v0.1.2/index.html
+++ b/docs/static/v0.9/project/releases/v0.1.2/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/releases/v0.1.3/index.html
+++ b/docs/static/v0.9/project/releases/v0.1.3/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/releases/v0.1.4/index.html
+++ b/docs/static/v0.9/project/releases/v0.1.4/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/releases/v0.1.5/index.html
+++ b/docs/static/v0.9/project/releases/v0.1.5/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/releases/v0.1.6/index.html
+++ b/docs/static/v0.9/project/releases/v0.1.6/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/releases/v0.2.0/index.html
+++ b/docs/static/v0.9/project/releases/v0.2.0/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/releases/v0.2.1/index.html
+++ b/docs/static/v0.9/project/releases/v0.2.1/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/releases/v0.2.2/index.html
+++ b/docs/static/v0.9/project/releases/v0.2.2/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/releases/v0.2.3/index.html
+++ b/docs/static/v0.9/project/releases/v0.2.3/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/releases/v0.2.4/index.html
+++ b/docs/static/v0.9/project/releases/v0.2.4/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/releases/v0.3.1/index.html
+++ b/docs/static/v0.9/project/releases/v0.3.1/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/releases/v0.3.10/index.html
+++ b/docs/static/v0.9/project/releases/v0.3.10/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/releases/v0.3.11/index.html
+++ b/docs/static/v0.9/project/releases/v0.3.11/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/releases/v0.3.12/index.html
+++ b/docs/static/v0.9/project/releases/v0.3.12/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/releases/v0.3.13/index.html
+++ b/docs/static/v0.9/project/releases/v0.3.13/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/releases/v0.3.14/index.html
+++ b/docs/static/v0.9/project/releases/v0.3.14/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/releases/v0.3.15/index.html
+++ b/docs/static/v0.9/project/releases/v0.3.15/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/releases/v0.3.16/index.html
+++ b/docs/static/v0.9/project/releases/v0.3.16/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/releases/v0.3.17/index.html
+++ b/docs/static/v0.9/project/releases/v0.3.17/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/releases/v0.3.18/index.html
+++ b/docs/static/v0.9/project/releases/v0.3.18/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/releases/v0.3.19/index.html
+++ b/docs/static/v0.9/project/releases/v0.3.19/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/releases/v0.3.2/index.html
+++ b/docs/static/v0.9/project/releases/v0.3.2/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/releases/v0.3.3/index.html
+++ b/docs/static/v0.9/project/releases/v0.3.3/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/releases/v0.3.4/index.html
+++ b/docs/static/v0.9/project/releases/v0.3.4/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/releases/v0.3.5/index.html
+++ b/docs/static/v0.9/project/releases/v0.3.5/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/releases/v0.3.6/index.html
+++ b/docs/static/v0.9/project/releases/v0.3.6/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/releases/v0.3.7/index.html
+++ b/docs/static/v0.9/project/releases/v0.3.7/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/releases/v0.3.8/index.html
+++ b/docs/static/v0.9/project/releases/v0.3.8/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/releases/v0.3.9/index.html
+++ b/docs/static/v0.9/project/releases/v0.3.9/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/releases/v0.4.0-beta.1/index.html
+++ b/docs/static/v0.9/project/releases/v0.4.0-beta.1/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/releases/v0.4.0-beta.2/index.html
+++ b/docs/static/v0.9/project/releases/v0.4.0-beta.2/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/releases/v0.4.0-beta.3/index.html
+++ b/docs/static/v0.9/project/releases/v0.4.0-beta.3/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/releases/v0.4.0-beta.4/index.html
+++ b/docs/static/v0.9/project/releases/v0.4.0-beta.4/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/releases/v0.4.1/index.html
+++ b/docs/static/v0.9/project/releases/v0.4.1/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/releases/v0.4.10/index.html
+++ b/docs/static/v0.9/project/releases/v0.4.10/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/releases/v0.4.11/index.html
+++ b/docs/static/v0.9/project/releases/v0.4.11/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/releases/v0.4.12/index.html
+++ b/docs/static/v0.9/project/releases/v0.4.12/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/releases/v0.4.13/index.html
+++ b/docs/static/v0.9/project/releases/v0.4.13/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/releases/v0.4.14/index.html
+++ b/docs/static/v0.9/project/releases/v0.4.14/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/releases/v0.4.15/index.html
+++ b/docs/static/v0.9/project/releases/v0.4.15/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/releases/v0.4.16/index.html
+++ b/docs/static/v0.9/project/releases/v0.4.16/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/releases/v0.4.17/index.html
+++ b/docs/static/v0.9/project/releases/v0.4.17/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/releases/v0.4.18/index.html
+++ b/docs/static/v0.9/project/releases/v0.4.18/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/releases/v0.4.19/index.html
+++ b/docs/static/v0.9/project/releases/v0.4.19/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/releases/v0.4.2/index.html
+++ b/docs/static/v0.9/project/releases/v0.4.2/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/releases/v0.4.20/index.html
+++ b/docs/static/v0.9/project/releases/v0.4.20/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/releases/v0.4.21/index.html
+++ b/docs/static/v0.9/project/releases/v0.4.21/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/releases/v0.4.22/index.html
+++ b/docs/static/v0.9/project/releases/v0.4.22/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/releases/v0.4.23/index.html
+++ b/docs/static/v0.9/project/releases/v0.4.23/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/releases/v0.4.24/index.html
+++ b/docs/static/v0.9/project/releases/v0.4.24/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/releases/v0.4.25/index.html
+++ b/docs/static/v0.9/project/releases/v0.4.25/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/releases/v0.4.26/index.html
+++ b/docs/static/v0.9/project/releases/v0.4.26/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/releases/v0.4.27/index.html
+++ b/docs/static/v0.9/project/releases/v0.4.27/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/releases/v0.4.3/index.html
+++ b/docs/static/v0.9/project/releases/v0.4.3/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/releases/v0.4.4/index.html
+++ b/docs/static/v0.9/project/releases/v0.4.4/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/releases/v0.4.5/index.html
+++ b/docs/static/v0.9/project/releases/v0.4.5/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/releases/v0.4.6/index.html
+++ b/docs/static/v0.9/project/releases/v0.4.6/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/releases/v0.4.7/index.html
+++ b/docs/static/v0.9/project/releases/v0.4.7/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/releases/v0.4.8/index.html
+++ b/docs/static/v0.9/project/releases/v0.4.8/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/releases/v0.4.9/index.html
+++ b/docs/static/v0.9/project/releases/v0.4.9/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/releases/v0.5.0-beta-1/index.html
+++ b/docs/static/v0.9/project/releases/v0.5.0-beta-1/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/releases/v0.5.0-beta-2/index.html
+++ b/docs/static/v0.9/project/releases/v0.5.0-beta-2/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/releases/v0.5.0-beta-3/index.html
+++ b/docs/static/v0.9/project/releases/v0.5.0-beta-3/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/releases/v0.5.0-beta-4/index.html
+++ b/docs/static/v0.9/project/releases/v0.5.0-beta-4/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/releases/v0.5.0-rc-1/index.html
+++ b/docs/static/v0.9/project/releases/v0.5.0-rc-1/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/releases/v0.5.0-rc-2/index.html
+++ b/docs/static/v0.9/project/releases/v0.5.0-rc-2/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/releases/v0.5.0-rc-3/index.html
+++ b/docs/static/v0.9/project/releases/v0.5.0-rc-3/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/releases/v0.5.0-rc-4/index.html
+++ b/docs/static/v0.9/project/releases/v0.5.0-rc-4/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/releases/v0.5.0-rc-5/index.html
+++ b/docs/static/v0.9/project/releases/v0.5.0-rc-5/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/releases/v0.5.0-rc-6/index.html
+++ b/docs/static/v0.9/project/releases/v0.5.0-rc-6/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/releases/v0.5.0/index.html
+++ b/docs/static/v0.9/project/releases/v0.5.0/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/releases/v0.5.1/index.html
+++ b/docs/static/v0.9/project/releases/v0.5.1/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/releases/v0.5.10/index.html
+++ b/docs/static/v0.9/project/releases/v0.5.10/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/releases/v0.5.11/index.html
+++ b/docs/static/v0.9/project/releases/v0.5.11/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/releases/v0.5.12/index.html
+++ b/docs/static/v0.9/project/releases/v0.5.12/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/releases/v0.5.13/index.html
+++ b/docs/static/v0.9/project/releases/v0.5.13/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/releases/v0.5.14/index.html
+++ b/docs/static/v0.9/project/releases/v0.5.14/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/releases/v0.5.15/index.html
+++ b/docs/static/v0.9/project/releases/v0.5.15/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/releases/v0.5.16/index.html
+++ b/docs/static/v0.9/project/releases/v0.5.16/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/releases/v0.5.17/index.html
+++ b/docs/static/v0.9/project/releases/v0.5.17/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/releases/v0.5.18/index.html
+++ b/docs/static/v0.9/project/releases/v0.5.18/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/releases/v0.5.19/index.html
+++ b/docs/static/v0.9/project/releases/v0.5.19/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/releases/v0.5.2/index.html
+++ b/docs/static/v0.9/project/releases/v0.5.2/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/releases/v0.5.20/index.html
+++ b/docs/static/v0.9/project/releases/v0.5.20/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/releases/v0.5.21/index.html
+++ b/docs/static/v0.9/project/releases/v0.5.21/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/releases/v0.5.22/index.html
+++ b/docs/static/v0.9/project/releases/v0.5.22/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/releases/v0.5.23/index.html
+++ b/docs/static/v0.9/project/releases/v0.5.23/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/releases/v0.5.24/index.html
+++ b/docs/static/v0.9/project/releases/v0.5.24/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/releases/v0.5.25/index.html
+++ b/docs/static/v0.9/project/releases/v0.5.25/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/releases/v0.5.26/index.html
+++ b/docs/static/v0.9/project/releases/v0.5.26/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/releases/v0.5.27/index.html
+++ b/docs/static/v0.9/project/releases/v0.5.27/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/releases/v0.5.28/index.html
+++ b/docs/static/v0.9/project/releases/v0.5.28/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/releases/v0.5.29/index.html
+++ b/docs/static/v0.9/project/releases/v0.5.29/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/releases/v0.5.3/index.html
+++ b/docs/static/v0.9/project/releases/v0.5.3/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/releases/v0.5.30/index.html
+++ b/docs/static/v0.9/project/releases/v0.5.30/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/releases/v0.5.31/index.html
+++ b/docs/static/v0.9/project/releases/v0.5.31/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/releases/v0.5.32/index.html
+++ b/docs/static/v0.9/project/releases/v0.5.32/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/releases/v0.5.33/index.html
+++ b/docs/static/v0.9/project/releases/v0.5.33/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/releases/v0.5.34/index.html
+++ b/docs/static/v0.9/project/releases/v0.5.34/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/releases/v0.5.35/index.html
+++ b/docs/static/v0.9/project/releases/v0.5.35/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/releases/v0.5.36/index.html
+++ b/docs/static/v0.9/project/releases/v0.5.36/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/releases/v0.5.37/index.html
+++ b/docs/static/v0.9/project/releases/v0.5.37/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/releases/v0.5.38/index.html
+++ b/docs/static/v0.9/project/releases/v0.5.38/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/releases/v0.5.39/index.html
+++ b/docs/static/v0.9/project/releases/v0.5.39/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/releases/v0.5.4/index.html
+++ b/docs/static/v0.9/project/releases/v0.5.4/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/releases/v0.5.40/index.html
+++ b/docs/static/v0.9/project/releases/v0.5.40/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/releases/v0.5.41/index.html
+++ b/docs/static/v0.9/project/releases/v0.5.41/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/releases/v0.5.42/index.html
+++ b/docs/static/v0.9/project/releases/v0.5.42/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/releases/v0.5.43/index.html
+++ b/docs/static/v0.9/project/releases/v0.5.43/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/releases/v0.5.44/index.html
+++ b/docs/static/v0.9/project/releases/v0.5.44/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/releases/v0.5.45/index.html
+++ b/docs/static/v0.9/project/releases/v0.5.45/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/releases/v0.5.46/index.html
+++ b/docs/static/v0.9/project/releases/v0.5.46/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/releases/v0.5.47/index.html
+++ b/docs/static/v0.9/project/releases/v0.5.47/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/releases/v0.5.48/index.html
+++ b/docs/static/v0.9/project/releases/v0.5.48/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/releases/v0.5.49/index.html
+++ b/docs/static/v0.9/project/releases/v0.5.49/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/releases/v0.5.5/index.html
+++ b/docs/static/v0.9/project/releases/v0.5.5/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/releases/v0.5.50/index.html
+++ b/docs/static/v0.9/project/releases/v0.5.50/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/releases/v0.5.51/index.html
+++ b/docs/static/v0.9/project/releases/v0.5.51/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/releases/v0.5.52/index.html
+++ b/docs/static/v0.9/project/releases/v0.5.52/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/releases/v0.5.53/index.html
+++ b/docs/static/v0.9/project/releases/v0.5.53/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/releases/v0.5.54/index.html
+++ b/docs/static/v0.9/project/releases/v0.5.54/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/releases/v0.5.55/index.html
+++ b/docs/static/v0.9/project/releases/v0.5.55/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/releases/v0.5.56/index.html
+++ b/docs/static/v0.9/project/releases/v0.5.56/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/releases/v0.5.57/index.html
+++ b/docs/static/v0.9/project/releases/v0.5.57/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/releases/v0.5.58/index.html
+++ b/docs/static/v0.9/project/releases/v0.5.58/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/releases/v0.5.59/index.html
+++ b/docs/static/v0.9/project/releases/v0.5.59/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/releases/v0.5.6/index.html
+++ b/docs/static/v0.9/project/releases/v0.5.6/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/releases/v0.5.60/index.html
+++ b/docs/static/v0.9/project/releases/v0.5.60/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/releases/v0.5.61/index.html
+++ b/docs/static/v0.9/project/releases/v0.5.61/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/releases/v0.5.62/index.html
+++ b/docs/static/v0.9/project/releases/v0.5.62/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/releases/v0.5.63-rc-1/index.html
+++ b/docs/static/v0.9/project/releases/v0.5.63-rc-1/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/releases/v0.5.64-rc-2/index.html
+++ b/docs/static/v0.9/project/releases/v0.5.64-rc-2/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/releases/v0.5.64/index.html
+++ b/docs/static/v0.9/project/releases/v0.5.64/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/releases/v0.5.65/index.html
+++ b/docs/static/v0.9/project/releases/v0.5.65/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/releases/v0.5.66/index.html
+++ b/docs/static/v0.9/project/releases/v0.5.66/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/releases/v0.5.67/index.html
+++ b/docs/static/v0.9/project/releases/v0.5.67/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/releases/v0.5.68/index.html
+++ b/docs/static/v0.9/project/releases/v0.5.68/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/releases/v0.5.69/index.html
+++ b/docs/static/v0.9/project/releases/v0.5.69/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/releases/v0.5.7/index.html
+++ b/docs/static/v0.9/project/releases/v0.5.7/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/releases/v0.5.70/index.html
+++ b/docs/static/v0.9/project/releases/v0.5.70/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/releases/v0.5.71/index.html
+++ b/docs/static/v0.9/project/releases/v0.5.71/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/releases/v0.5.72/index.html
+++ b/docs/static/v0.9/project/releases/v0.5.72/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/releases/v0.5.8/index.html
+++ b/docs/static/v0.9/project/releases/v0.5.8/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/releases/v0.5.9/index.html
+++ b/docs/static/v0.9/project/releases/v0.5.9/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/releases/v0.6.0-rc-1/index.html
+++ b/docs/static/v0.9/project/releases/v0.6.0-rc-1/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/releases/v0.6.0-rc-2/index.html
+++ b/docs/static/v0.9/project/releases/v0.6.0-rc-2/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/releases/v0.6.0-rc-3/index.html
+++ b/docs/static/v0.9/project/releases/v0.6.0-rc-3/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/releases/v0.6.0-rc-4/index.html
+++ b/docs/static/v0.9/project/releases/v0.6.0-rc-4/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/releases/v0.6.0-rc-5/index.html
+++ b/docs/static/v0.9/project/releases/v0.6.0-rc-5/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/releases/v0.6.0-rc-5a/index.html
+++ b/docs/static/v0.9/project/releases/v0.6.0-rc-5a/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/releases/v0.6.0-rc-5b/index.html
+++ b/docs/static/v0.9/project/releases/v0.6.0-rc-5b/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/releases/v0.6.0-rc-5c/index.html
+++ b/docs/static/v0.9/project/releases/v0.6.0-rc-5c/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/releases/v0.6.0-rc-5d/index.html
+++ b/docs/static/v0.9/project/releases/v0.6.0-rc-5d/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/releases/v0.6.0-rc-5f/index.html
+++ b/docs/static/v0.9/project/releases/v0.6.0-rc-5f/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/releases/v0.6.0-rc-5g/index.html
+++ b/docs/static/v0.9/project/releases/v0.6.0-rc-5g/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/releases/v0.6.0-rc-5h/index.html
+++ b/docs/static/v0.9/project/releases/v0.6.0-rc-5h/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/releases/v0.6.0-rc-5i/index.html
+++ b/docs/static/v0.9/project/releases/v0.6.0-rc-5i/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/releases/v0.6.0-rc-5j/index.html
+++ b/docs/static/v0.9/project/releases/v0.6.0-rc-5j/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/releases/v0.6.0-rc-5t/index.html
+++ b/docs/static/v0.9/project/releases/v0.6.0-rc-5t/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/releases/v0.6.0-rc.5aa/index.html
+++ b/docs/static/v0.9/project/releases/v0.6.0-rc.5aa/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/releases/v0.6.0-rc.5k/index.html
+++ b/docs/static/v0.9/project/releases/v0.6.0-rc.5k/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/releases/v0.6.0-rc.5l/index.html
+++ b/docs/static/v0.9/project/releases/v0.6.0-rc.5l/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/releases/v0.6.0-rc.5m/index.html
+++ b/docs/static/v0.9/project/releases/v0.6.0-rc.5m/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/releases/v0.6.0-rc.5n/index.html
+++ b/docs/static/v0.9/project/releases/v0.6.0-rc.5n/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/releases/v0.6.0-rc.5o/index.html
+++ b/docs/static/v0.9/project/releases/v0.6.0-rc.5o/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/releases/v0.6.0-rc.5p/index.html
+++ b/docs/static/v0.9/project/releases/v0.6.0-rc.5p/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/releases/v0.6.0-rc.5q/index.html
+++ b/docs/static/v0.9/project/releases/v0.6.0-rc.5q/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/releases/v0.6.0-rc.5r/index.html
+++ b/docs/static/v0.9/project/releases/v0.6.0-rc.5r/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/releases/v0.6.0-rc.5s/index.html
+++ b/docs/static/v0.9/project/releases/v0.6.0-rc.5s/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/releases/v0.6.0-rc.5u/index.html
+++ b/docs/static/v0.9/project/releases/v0.6.0-rc.5u/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/releases/v0.6.0-rc.5v/index.html
+++ b/docs/static/v0.9/project/releases/v0.6.0-rc.5v/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/releases/v0.6.0-rc.5w/index.html
+++ b/docs/static/v0.9/project/releases/v0.6.0-rc.5w/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/releases/v0.6.0-rc.5x/index.html
+++ b/docs/static/v0.9/project/releases/v0.6.0-rc.5x/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/releases/v0.6.0-rc.5y/index.html
+++ b/docs/static/v0.9/project/releases/v0.6.0-rc.5y/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/releases/v0.6.0-rc.5z/index.html
+++ b/docs/static/v0.9/project/releases/v0.6.0-rc.5z/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/releases/v0.6.0-rc.6/index.html
+++ b/docs/static/v0.9/project/releases/v0.6.0-rc.6/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/releases/v0.6.0-rc.6a/index.html
+++ b/docs/static/v0.9/project/releases/v0.6.0-rc.6a/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/releases/v0.6.0-rc.6b/index.html
+++ b/docs/static/v0.9/project/releases/v0.6.0-rc.6b/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/releases/v0.6.0-rc.6c/index.html
+++ b/docs/static/v0.9/project/releases/v0.6.0-rc.6c/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/releases/v0.6.0-rc.6d/index.html
+++ b/docs/static/v0.9/project/releases/v0.6.0-rc.6d/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/releases/v0.6.0-rc.6e/index.html
+++ b/docs/static/v0.9/project/releases/v0.6.0-rc.6e/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/releases/v0.6.0-rc.6f/index.html
+++ b/docs/static/v0.9/project/releases/v0.6.0-rc.6f/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/releases/v0.6.0-rc.6fa/index.html
+++ b/docs/static/v0.9/project/releases/v0.6.0-rc.6fa/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/releases/v0.6.0-rc.6fb/index.html
+++ b/docs/static/v0.9/project/releases/v0.6.0-rc.6fb/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/releases/v0.6.0-rc.6fc/index.html
+++ b/docs/static/v0.9/project/releases/v0.6.0-rc.6fc/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/releases/v0.6.0-rc.6fd/index.html
+++ b/docs/static/v0.9/project/releases/v0.6.0-rc.6fd/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/releases/v0.6.0-rc.6fe/index.html
+++ b/docs/static/v0.9/project/releases/v0.6.0-rc.6fe/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/releases/v0.6.0-rc.6ff/index.html
+++ b/docs/static/v0.9/project/releases/v0.6.0-rc.6ff/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/releases/v0.6.0/index.html
+++ b/docs/static/v0.9/project/releases/v0.6.0/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/releases/v0.6.10/index.html
+++ b/docs/static/v0.9/project/releases/v0.6.10/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/releases/v0.6.100/index.html
+++ b/docs/static/v0.9/project/releases/v0.6.100/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/releases/v0.6.102/index.html
+++ b/docs/static/v0.9/project/releases/v0.6.102/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/releases/v0.6.103/index.html
+++ b/docs/static/v0.9/project/releases/v0.6.103/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/releases/v0.6.104/index.html
+++ b/docs/static/v0.9/project/releases/v0.6.104/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/releases/v0.6.105/index.html
+++ b/docs/static/v0.9/project/releases/v0.6.105/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/releases/v0.6.107/index.html
+++ b/docs/static/v0.9/project/releases/v0.6.107/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/releases/v0.6.108/index.html
+++ b/docs/static/v0.9/project/releases/v0.6.108/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/releases/v0.6.109/index.html
+++ b/docs/static/v0.9/project/releases/v0.6.109/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/releases/v0.6.110/index.html
+++ b/docs/static/v0.9/project/releases/v0.6.110/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/releases/v0.6.111/index.html
+++ b/docs/static/v0.9/project/releases/v0.6.111/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/releases/v0.6.112/index.html
+++ b/docs/static/v0.9/project/releases/v0.6.112/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/releases/v0.6.113/index.html
+++ b/docs/static/v0.9/project/releases/v0.6.113/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/releases/v0.6.114/index.html
+++ b/docs/static/v0.9/project/releases/v0.6.114/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/releases/v0.6.115/index.html
+++ b/docs/static/v0.9/project/releases/v0.6.115/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/releases/v0.6.116/index.html
+++ b/docs/static/v0.9/project/releases/v0.6.116/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/releases/v0.6.117/index.html
+++ b/docs/static/v0.9/project/releases/v0.6.117/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/releases/v0.6.118/index.html
+++ b/docs/static/v0.9/project/releases/v0.6.118/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/releases/v0.6.119/index.html
+++ b/docs/static/v0.9/project/releases/v0.6.119/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/releases/v0.6.12/index.html
+++ b/docs/static/v0.9/project/releases/v0.6.12/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/releases/v0.6.120/index.html
+++ b/docs/static/v0.9/project/releases/v0.6.120/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/releases/v0.6.121/index.html
+++ b/docs/static/v0.9/project/releases/v0.6.121/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/releases/v0.6.122/index.html
+++ b/docs/static/v0.9/project/releases/v0.6.122/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/releases/v0.6.123/index.html
+++ b/docs/static/v0.9/project/releases/v0.6.123/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/releases/v0.6.124/index.html
+++ b/docs/static/v0.9/project/releases/v0.6.124/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/releases/v0.6.125/index.html
+++ b/docs/static/v0.9/project/releases/v0.6.125/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/releases/v0.6.126/index.html
+++ b/docs/static/v0.9/project/releases/v0.6.126/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/releases/v0.6.127/index.html
+++ b/docs/static/v0.9/project/releases/v0.6.127/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/releases/v0.6.128/index.html
+++ b/docs/static/v0.9/project/releases/v0.6.128/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/releases/v0.6.129/index.html
+++ b/docs/static/v0.9/project/releases/v0.6.129/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/releases/v0.6.13/index.html
+++ b/docs/static/v0.9/project/releases/v0.6.13/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/releases/v0.6.130/index.html
+++ b/docs/static/v0.9/project/releases/v0.6.130/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/releases/v0.6.131/index.html
+++ b/docs/static/v0.9/project/releases/v0.6.131/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/releases/v0.6.132/index.html
+++ b/docs/static/v0.9/project/releases/v0.6.132/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/releases/v0.6.133/index.html
+++ b/docs/static/v0.9/project/releases/v0.6.133/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/releases/v0.6.134/index.html
+++ b/docs/static/v0.9/project/releases/v0.6.134/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/releases/v0.6.135/index.html
+++ b/docs/static/v0.9/project/releases/v0.6.135/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/releases/v0.6.136/index.html
+++ b/docs/static/v0.9/project/releases/v0.6.136/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/releases/v0.6.137/index.html
+++ b/docs/static/v0.9/project/releases/v0.6.137/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/releases/v0.6.138/index.html
+++ b/docs/static/v0.9/project/releases/v0.6.138/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/releases/v0.6.139/index.html
+++ b/docs/static/v0.9/project/releases/v0.6.139/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/releases/v0.6.14/index.html
+++ b/docs/static/v0.9/project/releases/v0.6.14/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/releases/v0.6.140/index.html
+++ b/docs/static/v0.9/project/releases/v0.6.140/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/releases/v0.6.141/index.html
+++ b/docs/static/v0.9/project/releases/v0.6.141/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/releases/v0.6.142/index.html
+++ b/docs/static/v0.9/project/releases/v0.6.142/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/releases/v0.6.143/index.html
+++ b/docs/static/v0.9/project/releases/v0.6.143/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/releases/v0.6.144/index.html
+++ b/docs/static/v0.9/project/releases/v0.6.144/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/releases/v0.6.145/index.html
+++ b/docs/static/v0.9/project/releases/v0.6.145/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/releases/v0.6.146/index.html
+++ b/docs/static/v0.9/project/releases/v0.6.146/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/releases/v0.6.147/index.html
+++ b/docs/static/v0.9/project/releases/v0.6.147/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/releases/v0.6.148/index.html
+++ b/docs/static/v0.9/project/releases/v0.6.148/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/releases/v0.6.149/index.html
+++ b/docs/static/v0.9/project/releases/v0.6.149/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/releases/v0.6.15/index.html
+++ b/docs/static/v0.9/project/releases/v0.6.15/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/releases/v0.6.150/index.html
+++ b/docs/static/v0.9/project/releases/v0.6.150/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/releases/v0.6.151/index.html
+++ b/docs/static/v0.9/project/releases/v0.6.151/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/releases/v0.6.152/index.html
+++ b/docs/static/v0.9/project/releases/v0.6.152/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/releases/v0.6.153/index.html
+++ b/docs/static/v0.9/project/releases/v0.6.153/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/releases/v0.6.154/index.html
+++ b/docs/static/v0.9/project/releases/v0.6.154/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/releases/v0.6.155/index.html
+++ b/docs/static/v0.9/project/releases/v0.6.155/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/releases/v0.6.156/index.html
+++ b/docs/static/v0.9/project/releases/v0.6.156/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/releases/v0.6.157/index.html
+++ b/docs/static/v0.9/project/releases/v0.6.157/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/releases/v0.6.158/index.html
+++ b/docs/static/v0.9/project/releases/v0.6.158/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/releases/v0.6.159/index.html
+++ b/docs/static/v0.9/project/releases/v0.6.159/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/releases/v0.6.16/index.html
+++ b/docs/static/v0.9/project/releases/v0.6.16/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/releases/v0.6.160/index.html
+++ b/docs/static/v0.9/project/releases/v0.6.160/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/releases/v0.6.161/index.html
+++ b/docs/static/v0.9/project/releases/v0.6.161/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/releases/v0.6.162/index.html
+++ b/docs/static/v0.9/project/releases/v0.6.162/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/releases/v0.6.163/index.html
+++ b/docs/static/v0.9/project/releases/v0.6.163/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/releases/v0.6.164/index.html
+++ b/docs/static/v0.9/project/releases/v0.6.164/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/releases/v0.6.165/index.html
+++ b/docs/static/v0.9/project/releases/v0.6.165/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/releases/v0.6.166/index.html
+++ b/docs/static/v0.9/project/releases/v0.6.166/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/releases/v0.6.167/index.html
+++ b/docs/static/v0.9/project/releases/v0.6.167/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/releases/v0.6.168/index.html
+++ b/docs/static/v0.9/project/releases/v0.6.168/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/releases/v0.6.169/index.html
+++ b/docs/static/v0.9/project/releases/v0.6.169/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/releases/v0.6.17/index.html
+++ b/docs/static/v0.9/project/releases/v0.6.17/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/releases/v0.6.171/index.html
+++ b/docs/static/v0.9/project/releases/v0.6.171/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/releases/v0.6.172/index.html
+++ b/docs/static/v0.9/project/releases/v0.6.172/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/releases/v0.6.173/index.html
+++ b/docs/static/v0.9/project/releases/v0.6.173/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/releases/v0.6.174/index.html
+++ b/docs/static/v0.9/project/releases/v0.6.174/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/releases/v0.6.175/index.html
+++ b/docs/static/v0.9/project/releases/v0.6.175/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/releases/v0.6.176/index.html
+++ b/docs/static/v0.9/project/releases/v0.6.176/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/releases/v0.6.177/index.html
+++ b/docs/static/v0.9/project/releases/v0.6.177/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/releases/v0.6.178/index.html
+++ b/docs/static/v0.9/project/releases/v0.6.178/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/releases/v0.6.179/index.html
+++ b/docs/static/v0.9/project/releases/v0.6.179/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/releases/v0.6.18/index.html
+++ b/docs/static/v0.9/project/releases/v0.6.18/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/releases/v0.6.180/index.html
+++ b/docs/static/v0.9/project/releases/v0.6.180/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/releases/v0.6.181/index.html
+++ b/docs/static/v0.9/project/releases/v0.6.181/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/releases/v0.6.182/index.html
+++ b/docs/static/v0.9/project/releases/v0.6.182/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/releases/v0.6.183/index.html
+++ b/docs/static/v0.9/project/releases/v0.6.183/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/releases/v0.6.184/index.html
+++ b/docs/static/v0.9/project/releases/v0.6.184/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/releases/v0.6.185/index.html
+++ b/docs/static/v0.9/project/releases/v0.6.185/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/releases/v0.6.19/index.html
+++ b/docs/static/v0.9/project/releases/v0.6.19/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/releases/v0.6.2/index.html
+++ b/docs/static/v0.9/project/releases/v0.6.2/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/releases/v0.6.20/index.html
+++ b/docs/static/v0.9/project/releases/v0.6.20/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/releases/v0.6.21/index.html
+++ b/docs/static/v0.9/project/releases/v0.6.21/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/releases/v0.6.22/index.html
+++ b/docs/static/v0.9/project/releases/v0.6.22/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/releases/v0.6.23/index.html
+++ b/docs/static/v0.9/project/releases/v0.6.23/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/releases/v0.6.24/index.html
+++ b/docs/static/v0.9/project/releases/v0.6.24/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/releases/v0.6.25/index.html
+++ b/docs/static/v0.9/project/releases/v0.6.25/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/releases/v0.6.26/index.html
+++ b/docs/static/v0.9/project/releases/v0.6.26/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/releases/v0.6.27/index.html
+++ b/docs/static/v0.9/project/releases/v0.6.27/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/releases/v0.6.28/index.html
+++ b/docs/static/v0.9/project/releases/v0.6.28/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/releases/v0.6.29/index.html
+++ b/docs/static/v0.9/project/releases/v0.6.29/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/releases/v0.6.3/index.html
+++ b/docs/static/v0.9/project/releases/v0.6.3/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/releases/v0.6.30/index.html
+++ b/docs/static/v0.9/project/releases/v0.6.30/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/releases/v0.6.31/index.html
+++ b/docs/static/v0.9/project/releases/v0.6.31/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/releases/v0.6.32/index.html
+++ b/docs/static/v0.9/project/releases/v0.6.32/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/releases/v0.6.33/index.html
+++ b/docs/static/v0.9/project/releases/v0.6.33/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/releases/v0.6.34/index.html
+++ b/docs/static/v0.9/project/releases/v0.6.34/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/releases/v0.6.35/index.html
+++ b/docs/static/v0.9/project/releases/v0.6.35/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/releases/v0.6.36/index.html
+++ b/docs/static/v0.9/project/releases/v0.6.36/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/releases/v0.6.37/index.html
+++ b/docs/static/v0.9/project/releases/v0.6.37/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/releases/v0.6.38/index.html
+++ b/docs/static/v0.9/project/releases/v0.6.38/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/releases/v0.6.39/index.html
+++ b/docs/static/v0.9/project/releases/v0.6.39/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/releases/v0.6.4/index.html
+++ b/docs/static/v0.9/project/releases/v0.6.4/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/releases/v0.6.40/index.html
+++ b/docs/static/v0.9/project/releases/v0.6.40/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/releases/v0.6.41/index.html
+++ b/docs/static/v0.9/project/releases/v0.6.41/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/releases/v0.6.42/index.html
+++ b/docs/static/v0.9/project/releases/v0.6.42/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/releases/v0.6.43/index.html
+++ b/docs/static/v0.9/project/releases/v0.6.43/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/releases/v0.6.44/index.html
+++ b/docs/static/v0.9/project/releases/v0.6.44/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/releases/v0.6.45/index.html
+++ b/docs/static/v0.9/project/releases/v0.6.45/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/releases/v0.6.46/index.html
+++ b/docs/static/v0.9/project/releases/v0.6.46/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/releases/v0.6.47/index.html
+++ b/docs/static/v0.9/project/releases/v0.6.47/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/releases/v0.6.48/index.html
+++ b/docs/static/v0.9/project/releases/v0.6.48/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/releases/v0.6.49/index.html
+++ b/docs/static/v0.9/project/releases/v0.6.49/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/releases/v0.6.5/index.html
+++ b/docs/static/v0.9/project/releases/v0.6.5/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/releases/v0.6.50/index.html
+++ b/docs/static/v0.9/project/releases/v0.6.50/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/releases/v0.6.51/index.html
+++ b/docs/static/v0.9/project/releases/v0.6.51/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/releases/v0.6.52/index.html
+++ b/docs/static/v0.9/project/releases/v0.6.52/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/releases/v0.6.53/index.html
+++ b/docs/static/v0.9/project/releases/v0.6.53/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/releases/v0.6.54/index.html
+++ b/docs/static/v0.9/project/releases/v0.6.54/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/releases/v0.6.55/index.html
+++ b/docs/static/v0.9/project/releases/v0.6.55/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/releases/v0.6.56/index.html
+++ b/docs/static/v0.9/project/releases/v0.6.56/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/releases/v0.6.57/index.html
+++ b/docs/static/v0.9/project/releases/v0.6.57/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/releases/v0.6.58/index.html
+++ b/docs/static/v0.9/project/releases/v0.6.58/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/releases/v0.6.59/index.html
+++ b/docs/static/v0.9/project/releases/v0.6.59/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/releases/v0.6.6/index.html
+++ b/docs/static/v0.9/project/releases/v0.6.6/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/releases/v0.6.61/index.html
+++ b/docs/static/v0.9/project/releases/v0.6.61/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/releases/v0.6.62/index.html
+++ b/docs/static/v0.9/project/releases/v0.6.62/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/releases/v0.6.63/index.html
+++ b/docs/static/v0.9/project/releases/v0.6.63/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/releases/v0.6.64/index.html
+++ b/docs/static/v0.9/project/releases/v0.6.64/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/releases/v0.6.65/index.html
+++ b/docs/static/v0.9/project/releases/v0.6.65/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/releases/v0.6.66/index.html
+++ b/docs/static/v0.9/project/releases/v0.6.66/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/releases/v0.6.67/index.html
+++ b/docs/static/v0.9/project/releases/v0.6.67/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/releases/v0.6.68/index.html
+++ b/docs/static/v0.9/project/releases/v0.6.68/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/releases/v0.6.69/index.html
+++ b/docs/static/v0.9/project/releases/v0.6.69/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/releases/v0.6.7/index.html
+++ b/docs/static/v0.9/project/releases/v0.6.7/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/releases/v0.6.70/index.html
+++ b/docs/static/v0.9/project/releases/v0.6.70/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/releases/v0.6.71/index.html
+++ b/docs/static/v0.9/project/releases/v0.6.71/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/releases/v0.6.72/index.html
+++ b/docs/static/v0.9/project/releases/v0.6.72/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/releases/v0.6.73/index.html
+++ b/docs/static/v0.9/project/releases/v0.6.73/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/releases/v0.6.74/index.html
+++ b/docs/static/v0.9/project/releases/v0.6.74/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/releases/v0.6.75/index.html
+++ b/docs/static/v0.9/project/releases/v0.6.75/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/releases/v0.6.76/index.html
+++ b/docs/static/v0.9/project/releases/v0.6.76/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/releases/v0.6.77/index.html
+++ b/docs/static/v0.9/project/releases/v0.6.77/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/releases/v0.6.78/index.html
+++ b/docs/static/v0.9/project/releases/v0.6.78/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/releases/v0.6.79/index.html
+++ b/docs/static/v0.9/project/releases/v0.6.79/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/releases/v0.6.8/index.html
+++ b/docs/static/v0.9/project/releases/v0.6.8/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/releases/v0.6.80/index.html
+++ b/docs/static/v0.9/project/releases/v0.6.80/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/releases/v0.6.81/index.html
+++ b/docs/static/v0.9/project/releases/v0.6.81/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/releases/v0.6.82/index.html
+++ b/docs/static/v0.9/project/releases/v0.6.82/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/releases/v0.6.83/index.html
+++ b/docs/static/v0.9/project/releases/v0.6.83/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/releases/v0.6.84/index.html
+++ b/docs/static/v0.9/project/releases/v0.6.84/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/releases/v0.6.85/index.html
+++ b/docs/static/v0.9/project/releases/v0.6.85/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/releases/v0.6.86/index.html
+++ b/docs/static/v0.9/project/releases/v0.6.86/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/releases/v0.6.87/index.html
+++ b/docs/static/v0.9/project/releases/v0.6.87/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/releases/v0.6.88/index.html
+++ b/docs/static/v0.9/project/releases/v0.6.88/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/releases/v0.6.89/index.html
+++ b/docs/static/v0.9/project/releases/v0.6.89/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/releases/v0.6.9/index.html
+++ b/docs/static/v0.9/project/releases/v0.6.9/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/releases/v0.6.90/index.html
+++ b/docs/static/v0.9/project/releases/v0.6.90/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/releases/v0.6.91/index.html
+++ b/docs/static/v0.9/project/releases/v0.6.91/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/releases/v0.6.92/index.html
+++ b/docs/static/v0.9/project/releases/v0.6.92/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/releases/v0.6.93/index.html
+++ b/docs/static/v0.9/project/releases/v0.6.93/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/releases/v0.6.94/index.html
+++ b/docs/static/v0.9/project/releases/v0.6.94/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/releases/v0.6.95/index.html
+++ b/docs/static/v0.9/project/releases/v0.6.95/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/releases/v0.6.96/index.html
+++ b/docs/static/v0.9/project/releases/v0.6.96/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/releases/v0.6.97/index.html
+++ b/docs/static/v0.9/project/releases/v0.6.97/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/releases/v0.6.98/index.html
+++ b/docs/static/v0.9/project/releases/v0.6.98/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/releases/v0.6.99/index.html
+++ b/docs/static/v0.9/project/releases/v0.6.99/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/releases/v0.7.0-beta-1/index.html
+++ b/docs/static/v0.9/project/releases/v0.7.0-beta-1/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/releases/v0.7.0-beta-2/index.html
+++ b/docs/static/v0.9/project/releases/v0.7.0-beta-2/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/releases/v0.7.0-beta-3/index.html
+++ b/docs/static/v0.9/project/releases/v0.7.0-beta-3/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/releases/v0.7.0-beta-4/index.html
+++ b/docs/static/v0.9/project/releases/v0.7.0-beta-4/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/releases/v0.7.0/index.html
+++ b/docs/static/v0.9/project/releases/v0.7.0/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/releases/v0.7.1/index.html
+++ b/docs/static/v0.9/project/releases/v0.7.1/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/releases/v0.7.10/index.html
+++ b/docs/static/v0.9/project/releases/v0.7.10/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/releases/v0.7.101/index.html
+++ b/docs/static/v0.9/project/releases/v0.7.101/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/releases/v0.7.102/index.html
+++ b/docs/static/v0.9/project/releases/v0.7.102/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/releases/v0.7.103/index.html
+++ b/docs/static/v0.9/project/releases/v0.7.103/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/releases/v0.7.104/index.html
+++ b/docs/static/v0.9/project/releases/v0.7.104/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/releases/v0.7.105/index.html
+++ b/docs/static/v0.9/project/releases/v0.7.105/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/releases/v0.7.106/index.html
+++ b/docs/static/v0.9/project/releases/v0.7.106/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/releases/v0.7.107/index.html
+++ b/docs/static/v0.9/project/releases/v0.7.107/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/releases/v0.7.108/index.html
+++ b/docs/static/v0.9/project/releases/v0.7.108/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/releases/v0.7.109/index.html
+++ b/docs/static/v0.9/project/releases/v0.7.109/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/releases/v0.7.11-patch.1/index.html
+++ b/docs/static/v0.9/project/releases/v0.7.11-patch.1/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/releases/v0.7.11-patch.2/index.html
+++ b/docs/static/v0.9/project/releases/v0.7.11-patch.2/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/releases/v0.7.11-patch.3/index.html
+++ b/docs/static/v0.9/project/releases/v0.7.11-patch.3/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/releases/v0.7.11/index.html
+++ b/docs/static/v0.9/project/releases/v0.7.11/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/releases/v0.7.110/index.html
+++ b/docs/static/v0.9/project/releases/v0.7.110/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/releases/v0.7.111/index.html
+++ b/docs/static/v0.9/project/releases/v0.7.111/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/releases/v0.7.112/index.html
+++ b/docs/static/v0.9/project/releases/v0.7.112/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/releases/v0.7.113/index.html
+++ b/docs/static/v0.9/project/releases/v0.7.113/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/releases/v0.7.114/index.html
+++ b/docs/static/v0.9/project/releases/v0.7.114/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/releases/v0.7.115/index.html
+++ b/docs/static/v0.9/project/releases/v0.7.115/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/releases/v0.7.116/index.html
+++ b/docs/static/v0.9/project/releases/v0.7.116/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/releases/v0.7.117/index.html
+++ b/docs/static/v0.9/project/releases/v0.7.117/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/releases/v0.7.118/index.html
+++ b/docs/static/v0.9/project/releases/v0.7.118/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/releases/v0.7.119/index.html
+++ b/docs/static/v0.9/project/releases/v0.7.119/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/releases/v0.7.12/index.html
+++ b/docs/static/v0.9/project/releases/v0.7.12/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/releases/v0.7.120/index.html
+++ b/docs/static/v0.9/project/releases/v0.7.120/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/releases/v0.7.121/index.html
+++ b/docs/static/v0.9/project/releases/v0.7.121/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/releases/v0.7.122/index.html
+++ b/docs/static/v0.9/project/releases/v0.7.122/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/releases/v0.7.123/index.html
+++ b/docs/static/v0.9/project/releases/v0.7.123/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/releases/v0.7.124/index.html
+++ b/docs/static/v0.9/project/releases/v0.7.124/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/releases/v0.7.125/index.html
+++ b/docs/static/v0.9/project/releases/v0.7.125/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/releases/v0.7.126/index.html
+++ b/docs/static/v0.9/project/releases/v0.7.126/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/releases/v0.7.127/index.html
+++ b/docs/static/v0.9/project/releases/v0.7.127/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/releases/v0.7.128/index.html
+++ b/docs/static/v0.9/project/releases/v0.7.128/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/releases/v0.7.129/index.html
+++ b/docs/static/v0.9/project/releases/v0.7.129/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/releases/v0.7.13/index.html
+++ b/docs/static/v0.9/project/releases/v0.7.13/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/releases/v0.7.130/index.html
+++ b/docs/static/v0.9/project/releases/v0.7.130/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/releases/v0.7.131/index.html
+++ b/docs/static/v0.9/project/releases/v0.7.131/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/releases/v0.7.132/index.html
+++ b/docs/static/v0.9/project/releases/v0.7.132/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/releases/v0.7.133/index.html
+++ b/docs/static/v0.9/project/releases/v0.7.133/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/releases/v0.7.134/index.html
+++ b/docs/static/v0.9/project/releases/v0.7.134/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/releases/v0.7.135/index.html
+++ b/docs/static/v0.9/project/releases/v0.7.135/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/releases/v0.7.136/index.html
+++ b/docs/static/v0.9/project/releases/v0.7.136/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/releases/v0.7.137/index.html
+++ b/docs/static/v0.9/project/releases/v0.7.137/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/releases/v0.7.138/index.html
+++ b/docs/static/v0.9/project/releases/v0.7.138/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/releases/v0.7.139/index.html
+++ b/docs/static/v0.9/project/releases/v0.7.139/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/releases/v0.7.14/index.html
+++ b/docs/static/v0.9/project/releases/v0.7.14/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/releases/v0.7.140/index.html
+++ b/docs/static/v0.9/project/releases/v0.7.140/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/releases/v0.7.141/index.html
+++ b/docs/static/v0.9/project/releases/v0.7.141/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/releases/v0.7.142/index.html
+++ b/docs/static/v0.9/project/releases/v0.7.142/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/releases/v0.7.143/index.html
+++ b/docs/static/v0.9/project/releases/v0.7.143/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/releases/v0.7.144/index.html
+++ b/docs/static/v0.9/project/releases/v0.7.144/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/releases/v0.7.145/index.html
+++ b/docs/static/v0.9/project/releases/v0.7.145/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/releases/v0.7.146/index.html
+++ b/docs/static/v0.9/project/releases/v0.7.146/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/releases/v0.7.147/index.html
+++ b/docs/static/v0.9/project/releases/v0.7.147/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/releases/v0.7.148/index.html
+++ b/docs/static/v0.9/project/releases/v0.7.148/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/releases/v0.7.149/index.html
+++ b/docs/static/v0.9/project/releases/v0.7.149/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/releases/v0.7.15/index.html
+++ b/docs/static/v0.9/project/releases/v0.7.15/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/releases/v0.7.150/index.html
+++ b/docs/static/v0.9/project/releases/v0.7.150/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/releases/v0.7.151/index.html
+++ b/docs/static/v0.9/project/releases/v0.7.151/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/releases/v0.7.152/index.html
+++ b/docs/static/v0.9/project/releases/v0.7.152/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/releases/v0.7.153/index.html
+++ b/docs/static/v0.9/project/releases/v0.7.153/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/releases/v0.7.154/index.html
+++ b/docs/static/v0.9/project/releases/v0.7.154/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/releases/v0.7.155/index.html
+++ b/docs/static/v0.9/project/releases/v0.7.155/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/releases/v0.7.156/index.html
+++ b/docs/static/v0.9/project/releases/v0.7.156/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/releases/v0.7.157/index.html
+++ b/docs/static/v0.9/project/releases/v0.7.157/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/releases/v0.7.158/index.html
+++ b/docs/static/v0.9/project/releases/v0.7.158/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/releases/v0.7.159/index.html
+++ b/docs/static/v0.9/project/releases/v0.7.159/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/releases/v0.7.16/index.html
+++ b/docs/static/v0.9/project/releases/v0.7.16/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/releases/v0.7.160/index.html
+++ b/docs/static/v0.9/project/releases/v0.7.160/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/releases/v0.7.161/index.html
+++ b/docs/static/v0.9/project/releases/v0.7.161/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/releases/v0.7.162/index.html
+++ b/docs/static/v0.9/project/releases/v0.7.162/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/releases/v0.7.163/index.html
+++ b/docs/static/v0.9/project/releases/v0.7.163/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/releases/v0.7.164/index.html
+++ b/docs/static/v0.9/project/releases/v0.7.164/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/releases/v0.7.165/index.html
+++ b/docs/static/v0.9/project/releases/v0.7.165/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/releases/v0.7.166/index.html
+++ b/docs/static/v0.9/project/releases/v0.7.166/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/releases/v0.7.167/index.html
+++ b/docs/static/v0.9/project/releases/v0.7.167/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/releases/v0.7.168/index.html
+++ b/docs/static/v0.9/project/releases/v0.7.168/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/releases/v0.7.169/index.html
+++ b/docs/static/v0.9/project/releases/v0.7.169/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/releases/v0.7.17/index.html
+++ b/docs/static/v0.9/project/releases/v0.7.17/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/releases/v0.7.170/index.html
+++ b/docs/static/v0.9/project/releases/v0.7.170/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/releases/v0.7.171/index.html
+++ b/docs/static/v0.9/project/releases/v0.7.171/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/releases/v0.7.172/index.html
+++ b/docs/static/v0.9/project/releases/v0.7.172/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/releases/v0.7.18/index.html
+++ b/docs/static/v0.9/project/releases/v0.7.18/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/releases/v0.7.19/index.html
+++ b/docs/static/v0.9/project/releases/v0.7.19/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/releases/v0.7.2-rc-1/index.html
+++ b/docs/static/v0.9/project/releases/v0.7.2-rc-1/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/releases/v0.7.2-rc-2/index.html
+++ b/docs/static/v0.9/project/releases/v0.7.2-rc-2/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/releases/v0.7.2.4/index.html
+++ b/docs/static/v0.9/project/releases/v0.7.2.4/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/releases/v0.7.2/index.html
+++ b/docs/static/v0.9/project/releases/v0.7.2/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/releases/v0.7.20/index.html
+++ b/docs/static/v0.9/project/releases/v0.7.20/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/releases/v0.7.21/index.html
+++ b/docs/static/v0.9/project/releases/v0.7.21/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/releases/v0.7.22/index.html
+++ b/docs/static/v0.9/project/releases/v0.7.22/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/releases/v0.7.24/index.html
+++ b/docs/static/v0.9/project/releases/v0.7.24/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/releases/v0.7.25/index.html
+++ b/docs/static/v0.9/project/releases/v0.7.25/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/releases/v0.7.26/index.html
+++ b/docs/static/v0.9/project/releases/v0.7.26/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/releases/v0.7.27/index.html
+++ b/docs/static/v0.9/project/releases/v0.7.27/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/releases/v0.7.28/index.html
+++ b/docs/static/v0.9/project/releases/v0.7.28/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/releases/v0.7.29/index.html
+++ b/docs/static/v0.9/project/releases/v0.7.29/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/releases/v0.7.3-patch.1/index.html
+++ b/docs/static/v0.9/project/releases/v0.7.3-patch.1/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/releases/v0.7.3-patch.2/index.html
+++ b/docs/static/v0.9/project/releases/v0.7.3-patch.2/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/releases/v0.7.3-patch.3/index.html
+++ b/docs/static/v0.9/project/releases/v0.7.3-patch.3/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/releases/v0.7.3-patch.4/index.html
+++ b/docs/static/v0.9/project/releases/v0.7.3-patch.4/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/releases/v0.7.3/index.html
+++ b/docs/static/v0.9/project/releases/v0.7.3/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/releases/v0.7.30/index.html
+++ b/docs/static/v0.9/project/releases/v0.7.30/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/releases/v0.7.31/index.html
+++ b/docs/static/v0.9/project/releases/v0.7.31/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/releases/v0.7.32/index.html
+++ b/docs/static/v0.9/project/releases/v0.7.32/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/releases/v0.7.33/index.html
+++ b/docs/static/v0.9/project/releases/v0.7.33/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/releases/v0.7.34/index.html
+++ b/docs/static/v0.9/project/releases/v0.7.34/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/releases/v0.7.35/index.html
+++ b/docs/static/v0.9/project/releases/v0.7.35/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/releases/v0.7.36/index.html
+++ b/docs/static/v0.9/project/releases/v0.7.36/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/releases/v0.7.37/index.html
+++ b/docs/static/v0.9/project/releases/v0.7.37/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/releases/v0.7.38/index.html
+++ b/docs/static/v0.9/project/releases/v0.7.38/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/releases/v0.7.39/index.html
+++ b/docs/static/v0.9/project/releases/v0.7.39/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/releases/v0.7.4-patch.1/index.html
+++ b/docs/static/v0.9/project/releases/v0.7.4-patch.1/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/releases/v0.7.4/index.html
+++ b/docs/static/v0.9/project/releases/v0.7.4/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/releases/v0.7.40/index.html
+++ b/docs/static/v0.9/project/releases/v0.7.40/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/releases/v0.7.41/index.html
+++ b/docs/static/v0.9/project/releases/v0.7.41/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/releases/v0.7.42/index.html
+++ b/docs/static/v0.9/project/releases/v0.7.42/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/releases/v0.7.43/index.html
+++ b/docs/static/v0.9/project/releases/v0.7.43/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/releases/v0.7.44/index.html
+++ b/docs/static/v0.9/project/releases/v0.7.44/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/releases/v0.7.45/index.html
+++ b/docs/static/v0.9/project/releases/v0.7.45/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/releases/v0.7.46/index.html
+++ b/docs/static/v0.9/project/releases/v0.7.46/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/releases/v0.7.47/index.html
+++ b/docs/static/v0.9/project/releases/v0.7.47/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/releases/v0.7.48/index.html
+++ b/docs/static/v0.9/project/releases/v0.7.48/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/releases/v0.7.49/index.html
+++ b/docs/static/v0.9/project/releases/v0.7.49/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/releases/v0.7.5/index.html
+++ b/docs/static/v0.9/project/releases/v0.7.5/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/releases/v0.7.50/index.html
+++ b/docs/static/v0.9/project/releases/v0.7.50/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/releases/v0.7.51/index.html
+++ b/docs/static/v0.9/project/releases/v0.7.51/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/releases/v0.7.52/index.html
+++ b/docs/static/v0.9/project/releases/v0.7.52/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/releases/v0.7.53/index.html
+++ b/docs/static/v0.9/project/releases/v0.7.53/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/releases/v0.7.54/index.html
+++ b/docs/static/v0.9/project/releases/v0.7.54/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/releases/v0.7.55/index.html
+++ b/docs/static/v0.9/project/releases/v0.7.55/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/releases/v0.7.56/index.html
+++ b/docs/static/v0.9/project/releases/v0.7.56/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/releases/v0.7.57/index.html
+++ b/docs/static/v0.9/project/releases/v0.7.57/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/releases/v0.7.58/index.html
+++ b/docs/static/v0.9/project/releases/v0.7.58/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/releases/v0.7.59/index.html
+++ b/docs/static/v0.9/project/releases/v0.7.59/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/releases/v0.7.6/index.html
+++ b/docs/static/v0.9/project/releases/v0.7.6/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/releases/v0.7.60/index.html
+++ b/docs/static/v0.9/project/releases/v0.7.60/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/releases/v0.7.61/index.html
+++ b/docs/static/v0.9/project/releases/v0.7.61/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/releases/v0.7.62/index.html
+++ b/docs/static/v0.9/project/releases/v0.7.62/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/releases/v0.7.63/index.html
+++ b/docs/static/v0.9/project/releases/v0.7.63/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/releases/v0.7.64/index.html
+++ b/docs/static/v0.9/project/releases/v0.7.64/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/releases/v0.7.65/index.html
+++ b/docs/static/v0.9/project/releases/v0.7.65/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/releases/v0.7.66/index.html
+++ b/docs/static/v0.9/project/releases/v0.7.66/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/releases/v0.7.67/index.html
+++ b/docs/static/v0.9/project/releases/v0.7.67/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/releases/v0.7.68/index.html
+++ b/docs/static/v0.9/project/releases/v0.7.68/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/releases/v0.7.69/index.html
+++ b/docs/static/v0.9/project/releases/v0.7.69/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/releases/v0.7.7/index.html
+++ b/docs/static/v0.9/project/releases/v0.7.7/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/releases/v0.7.70/index.html
+++ b/docs/static/v0.9/project/releases/v0.7.70/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/releases/v0.7.71/index.html
+++ b/docs/static/v0.9/project/releases/v0.7.71/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/releases/v0.7.72/index.html
+++ b/docs/static/v0.9/project/releases/v0.7.72/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/releases/v0.7.73/index.html
+++ b/docs/static/v0.9/project/releases/v0.7.73/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/releases/v0.7.74/index.html
+++ b/docs/static/v0.9/project/releases/v0.7.74/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/releases/v0.7.75/index.html
+++ b/docs/static/v0.9/project/releases/v0.7.75/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/releases/v0.7.76/index.html
+++ b/docs/static/v0.9/project/releases/v0.7.76/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/releases/v0.7.77/index.html
+++ b/docs/static/v0.9/project/releases/v0.7.77/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/releases/v0.7.78/index.html
+++ b/docs/static/v0.9/project/releases/v0.7.78/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/releases/v0.7.79/index.html
+++ b/docs/static/v0.9/project/releases/v0.7.79/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/releases/v0.7.8/index.html
+++ b/docs/static/v0.9/project/releases/v0.7.8/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/releases/v0.7.80/index.html
+++ b/docs/static/v0.9/project/releases/v0.7.80/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/releases/v0.7.81/index.html
+++ b/docs/static/v0.9/project/releases/v0.7.81/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/releases/v0.7.82/index.html
+++ b/docs/static/v0.9/project/releases/v0.7.82/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/releases/v0.7.83/index.html
+++ b/docs/static/v0.9/project/releases/v0.7.83/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/releases/v0.7.84/index.html
+++ b/docs/static/v0.9/project/releases/v0.7.84/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/releases/v0.7.85/index.html
+++ b/docs/static/v0.9/project/releases/v0.7.85/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/releases/v0.7.86/index.html
+++ b/docs/static/v0.9/project/releases/v0.7.86/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/releases/v0.7.87/index.html
+++ b/docs/static/v0.9/project/releases/v0.7.87/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/releases/v0.7.88/index.html
+++ b/docs/static/v0.9/project/releases/v0.7.88/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/releases/v0.7.89/index.html
+++ b/docs/static/v0.9/project/releases/v0.7.89/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/releases/v0.7.9/index.html
+++ b/docs/static/v0.9/project/releases/v0.7.9/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/releases/v0.7.90/index.html
+++ b/docs/static/v0.9/project/releases/v0.7.90/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/releases/v0.7.91/index.html
+++ b/docs/static/v0.9/project/releases/v0.7.91/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/releases/v0.7.92/index.html
+++ b/docs/static/v0.9/project/releases/v0.7.92/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/releases/v0.7.93/index.html
+++ b/docs/static/v0.9/project/releases/v0.7.93/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/releases/v0.7.94/index.html
+++ b/docs/static/v0.9/project/releases/v0.7.94/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/releases/v0.7.95/index.html
+++ b/docs/static/v0.9/project/releases/v0.7.95/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/releases/v0.7.99/index.html
+++ b/docs/static/v0.9/project/releases/v0.7.99/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/releases/v0.8.0/index.html
+++ b/docs/static/v0.9/project/releases/v0.8.0/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/releases/v0.8.1/index.html
+++ b/docs/static/v0.9/project/releases/v0.8.1/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/releases/v0.8.10/index.html
+++ b/docs/static/v0.9/project/releases/v0.8.10/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/releases/v0.8.100/index.html
+++ b/docs/static/v0.9/project/releases/v0.8.100/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/releases/v0.8.101/index.html
+++ b/docs/static/v0.9/project/releases/v0.8.101/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/releases/v0.8.102/index.html
+++ b/docs/static/v0.9/project/releases/v0.8.102/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/releases/v0.8.103/index.html
+++ b/docs/static/v0.9/project/releases/v0.8.103/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/releases/v0.8.104/index.html
+++ b/docs/static/v0.9/project/releases/v0.8.104/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/releases/v0.8.105/index.html
+++ b/docs/static/v0.9/project/releases/v0.8.105/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/releases/v0.8.106/index.html
+++ b/docs/static/v0.9/project/releases/v0.8.106/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/releases/v0.8.107/index.html
+++ b/docs/static/v0.9/project/releases/v0.8.107/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/releases/v0.8.108/index.html
+++ b/docs/static/v0.9/project/releases/v0.8.108/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/releases/v0.8.109/index.html
+++ b/docs/static/v0.9/project/releases/v0.8.109/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/releases/v0.8.11/index.html
+++ b/docs/static/v0.9/project/releases/v0.8.11/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/releases/v0.8.110/index.html
+++ b/docs/static/v0.9/project/releases/v0.8.110/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/releases/v0.8.111/index.html
+++ b/docs/static/v0.9/project/releases/v0.8.111/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/releases/v0.8.112/index.html
+++ b/docs/static/v0.9/project/releases/v0.8.112/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/releases/v0.8.113/index.html
+++ b/docs/static/v0.9/project/releases/v0.8.113/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/releases/v0.8.114/index.html
+++ b/docs/static/v0.9/project/releases/v0.8.114/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/releases/v0.8.115/index.html
+++ b/docs/static/v0.9/project/releases/v0.8.115/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/releases/v0.8.116/index.html
+++ b/docs/static/v0.9/project/releases/v0.8.116/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/releases/v0.8.117/index.html
+++ b/docs/static/v0.9/project/releases/v0.8.117/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/releases/v0.8.118/index.html
+++ b/docs/static/v0.9/project/releases/v0.8.118/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/releases/v0.8.119/index.html
+++ b/docs/static/v0.9/project/releases/v0.8.119/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/releases/v0.8.12/index.html
+++ b/docs/static/v0.9/project/releases/v0.8.12/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/releases/v0.8.120/index.html
+++ b/docs/static/v0.9/project/releases/v0.8.120/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/releases/v0.8.122/index.html
+++ b/docs/static/v0.9/project/releases/v0.8.122/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/releases/v0.8.123/index.html
+++ b/docs/static/v0.9/project/releases/v0.8.123/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/releases/v0.8.124/index.html
+++ b/docs/static/v0.9/project/releases/v0.8.124/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/releases/v0.8.125/index.html
+++ b/docs/static/v0.9/project/releases/v0.8.125/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/releases/v0.8.126/index.html
+++ b/docs/static/v0.9/project/releases/v0.8.126/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/releases/v0.8.127/index.html
+++ b/docs/static/v0.9/project/releases/v0.8.127/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/releases/v0.8.128/index.html
+++ b/docs/static/v0.9/project/releases/v0.8.128/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/releases/v0.8.129/index.html
+++ b/docs/static/v0.9/project/releases/v0.8.129/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/releases/v0.8.13/index.html
+++ b/docs/static/v0.9/project/releases/v0.8.13/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/releases/v0.8.130/index.html
+++ b/docs/static/v0.9/project/releases/v0.8.130/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/releases/v0.8.131/index.html
+++ b/docs/static/v0.9/project/releases/v0.8.131/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/releases/v0.8.132/index.html
+++ b/docs/static/v0.9/project/releases/v0.8.132/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/releases/v0.8.133/index.html
+++ b/docs/static/v0.9/project/releases/v0.8.133/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/releases/v0.8.134/index.html
+++ b/docs/static/v0.9/project/releases/v0.8.134/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/releases/v0.8.136/index.html
+++ b/docs/static/v0.9/project/releases/v0.8.136/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/releases/v0.8.137/index.html
+++ b/docs/static/v0.9/project/releases/v0.8.137/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/releases/v0.8.138/index.html
+++ b/docs/static/v0.9/project/releases/v0.8.138/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/releases/v0.8.139/index.html
+++ b/docs/static/v0.9/project/releases/v0.8.139/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/releases/v0.8.14/index.html
+++ b/docs/static/v0.9/project/releases/v0.8.14/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/releases/v0.8.140/index.html
+++ b/docs/static/v0.9/project/releases/v0.8.140/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/releases/v0.8.141/index.html
+++ b/docs/static/v0.9/project/releases/v0.8.141/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/releases/v0.8.142/index.html
+++ b/docs/static/v0.9/project/releases/v0.8.142/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/releases/v0.8.143/index.html
+++ b/docs/static/v0.9/project/releases/v0.8.143/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/releases/v0.8.144/index.html
+++ b/docs/static/v0.9/project/releases/v0.8.144/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/releases/v0.8.145/index.html
+++ b/docs/static/v0.9/project/releases/v0.8.145/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/releases/v0.8.146/index.html
+++ b/docs/static/v0.9/project/releases/v0.8.146/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/releases/v0.8.147/index.html
+++ b/docs/static/v0.9/project/releases/v0.8.147/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/releases/v0.8.148/index.html
+++ b/docs/static/v0.9/project/releases/v0.8.148/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/releases/v0.8.149/index.html
+++ b/docs/static/v0.9/project/releases/v0.8.149/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/releases/v0.8.15/index.html
+++ b/docs/static/v0.9/project/releases/v0.8.15/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/releases/v0.8.150/index.html
+++ b/docs/static/v0.9/project/releases/v0.8.150/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/releases/v0.8.151/index.html
+++ b/docs/static/v0.9/project/releases/v0.8.151/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/releases/v0.8.152/index.html
+++ b/docs/static/v0.9/project/releases/v0.8.152/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/releases/v0.8.153/index.html
+++ b/docs/static/v0.9/project/releases/v0.8.153/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/releases/v0.8.154/index.html
+++ b/docs/static/v0.9/project/releases/v0.8.154/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/releases/v0.8.155/index.html
+++ b/docs/static/v0.9/project/releases/v0.8.155/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/releases/v0.8.156/index.html
+++ b/docs/static/v0.9/project/releases/v0.8.156/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/releases/v0.8.157/index.html
+++ b/docs/static/v0.9/project/releases/v0.8.157/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/releases/v0.8.158/index.html
+++ b/docs/static/v0.9/project/releases/v0.8.158/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/releases/v0.8.159/index.html
+++ b/docs/static/v0.9/project/releases/v0.8.159/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/releases/v0.8.16/index.html
+++ b/docs/static/v0.9/project/releases/v0.8.16/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/releases/v0.8.160/index.html
+++ b/docs/static/v0.9/project/releases/v0.8.160/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/releases/v0.8.168/index.html
+++ b/docs/static/v0.9/project/releases/v0.8.168/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/releases/v0.8.169/index.html
+++ b/docs/static/v0.9/project/releases/v0.8.169/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/releases/v0.8.17/index.html
+++ b/docs/static/v0.9/project/releases/v0.8.17/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/releases/v0.8.170/index.html
+++ b/docs/static/v0.9/project/releases/v0.8.170/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/releases/v0.8.171/index.html
+++ b/docs/static/v0.9/project/releases/v0.8.171/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/releases/v0.8.172/index.html
+++ b/docs/static/v0.9/project/releases/v0.8.172/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/releases/v0.8.173/index.html
+++ b/docs/static/v0.9/project/releases/v0.8.173/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/releases/v0.8.174/index.html
+++ b/docs/static/v0.9/project/releases/v0.8.174/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/releases/v0.8.175/index.html
+++ b/docs/static/v0.9/project/releases/v0.8.175/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/releases/v0.8.176/index.html
+++ b/docs/static/v0.9/project/releases/v0.8.176/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/releases/v0.8.177/index.html
+++ b/docs/static/v0.9/project/releases/v0.8.177/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/releases/v0.8.178/index.html
+++ b/docs/static/v0.9/project/releases/v0.8.178/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/releases/v0.8.179/index.html
+++ b/docs/static/v0.9/project/releases/v0.8.179/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/releases/v0.8.180/index.html
+++ b/docs/static/v0.9/project/releases/v0.8.180/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/releases/v0.8.181/index.html
+++ b/docs/static/v0.9/project/releases/v0.8.181/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/releases/v0.8.183/index.html
+++ b/docs/static/v0.9/project/releases/v0.8.183/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/releases/v0.8.184/index.html
+++ b/docs/static/v0.9/project/releases/v0.8.184/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/releases/v0.8.185/index.html
+++ b/docs/static/v0.9/project/releases/v0.8.185/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/releases/v0.8.186/index.html
+++ b/docs/static/v0.9/project/releases/v0.8.186/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/releases/v0.8.187/index.html
+++ b/docs/static/v0.9/project/releases/v0.8.187/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/releases/v0.8.188/index.html
+++ b/docs/static/v0.9/project/releases/v0.8.188/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/releases/v0.8.189/index.html
+++ b/docs/static/v0.9/project/releases/v0.8.189/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/releases/v0.8.19/index.html
+++ b/docs/static/v0.9/project/releases/v0.8.19/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/releases/v0.8.190/index.html
+++ b/docs/static/v0.9/project/releases/v0.8.190/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/releases/v0.8.192/index.html
+++ b/docs/static/v0.9/project/releases/v0.8.192/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/releases/v0.8.193/index.html
+++ b/docs/static/v0.9/project/releases/v0.8.193/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/releases/v0.8.195/index.html
+++ b/docs/static/v0.9/project/releases/v0.8.195/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/releases/v0.8.196/index.html
+++ b/docs/static/v0.9/project/releases/v0.8.196/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/releases/v0.8.197/index.html
+++ b/docs/static/v0.9/project/releases/v0.8.197/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/releases/v0.8.198/index.html
+++ b/docs/static/v0.9/project/releases/v0.8.198/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/releases/v0.8.199/index.html
+++ b/docs/static/v0.9/project/releases/v0.8.199/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/releases/v0.8.2/index.html
+++ b/docs/static/v0.9/project/releases/v0.8.2/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/releases/v0.8.20/index.html
+++ b/docs/static/v0.9/project/releases/v0.8.20/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/releases/v0.8.200/index.html
+++ b/docs/static/v0.9/project/releases/v0.8.200/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/releases/v0.8.201/index.html
+++ b/docs/static/v0.9/project/releases/v0.8.201/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/releases/v0.8.202/index.html
+++ b/docs/static/v0.9/project/releases/v0.8.202/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/releases/v0.8.203/index.html
+++ b/docs/static/v0.9/project/releases/v0.8.203/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/releases/v0.8.204/index.html
+++ b/docs/static/v0.9/project/releases/v0.8.204/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/releases/v0.8.205/index.html
+++ b/docs/static/v0.9/project/releases/v0.8.205/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/releases/v0.8.206/index.html
+++ b/docs/static/v0.9/project/releases/v0.8.206/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/releases/v0.8.207/index.html
+++ b/docs/static/v0.9/project/releases/v0.8.207/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/releases/v0.8.208/index.html
+++ b/docs/static/v0.9/project/releases/v0.8.208/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/releases/v0.8.209/index.html
+++ b/docs/static/v0.9/project/releases/v0.8.209/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/releases/v0.8.21/index.html
+++ b/docs/static/v0.9/project/releases/v0.8.21/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/releases/v0.8.210/index.html
+++ b/docs/static/v0.9/project/releases/v0.8.210/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/releases/v0.8.211/index.html
+++ b/docs/static/v0.9/project/releases/v0.8.211/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/releases/v0.8.212/index.html
+++ b/docs/static/v0.9/project/releases/v0.8.212/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/releases/v0.8.213/index.html
+++ b/docs/static/v0.9/project/releases/v0.8.213/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/releases/v0.8.214/index.html
+++ b/docs/static/v0.9/project/releases/v0.8.214/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/releases/v0.8.22/index.html
+++ b/docs/static/v0.9/project/releases/v0.8.22/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/releases/v0.8.23/index.html
+++ b/docs/static/v0.9/project/releases/v0.8.23/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/releases/v0.8.24/index.html
+++ b/docs/static/v0.9/project/releases/v0.8.24/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/releases/v0.8.26/index.html
+++ b/docs/static/v0.9/project/releases/v0.8.26/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/releases/v0.8.27/index.html
+++ b/docs/static/v0.9/project/releases/v0.8.27/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/releases/v0.8.28/index.html
+++ b/docs/static/v0.9/project/releases/v0.8.28/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/releases/v0.8.29/index.html
+++ b/docs/static/v0.9/project/releases/v0.8.29/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/releases/v0.8.3/index.html
+++ b/docs/static/v0.9/project/releases/v0.8.3/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/releases/v0.8.30/index.html
+++ b/docs/static/v0.9/project/releases/v0.8.30/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/releases/v0.8.31/index.html
+++ b/docs/static/v0.9/project/releases/v0.8.31/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/releases/v0.8.32/index.html
+++ b/docs/static/v0.9/project/releases/v0.8.32/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/releases/v0.8.36/index.html
+++ b/docs/static/v0.9/project/releases/v0.8.36/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/releases/v0.8.37/index.html
+++ b/docs/static/v0.9/project/releases/v0.8.37/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/releases/v0.8.38/index.html
+++ b/docs/static/v0.9/project/releases/v0.8.38/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/releases/v0.8.39/index.html
+++ b/docs/static/v0.9/project/releases/v0.8.39/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/releases/v0.8.40/index.html
+++ b/docs/static/v0.9/project/releases/v0.8.40/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/releases/v0.8.41/index.html
+++ b/docs/static/v0.9/project/releases/v0.8.41/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/releases/v0.8.42/index.html
+++ b/docs/static/v0.9/project/releases/v0.8.42/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/releases/v0.8.43/index.html
+++ b/docs/static/v0.9/project/releases/v0.8.43/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/releases/v0.8.44/index.html
+++ b/docs/static/v0.9/project/releases/v0.8.44/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/releases/v0.8.46/index.html
+++ b/docs/static/v0.9/project/releases/v0.8.46/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/releases/v0.8.47/index.html
+++ b/docs/static/v0.9/project/releases/v0.8.47/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/releases/v0.8.48/index.html
+++ b/docs/static/v0.9/project/releases/v0.8.48/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/releases/v0.8.49/index.html
+++ b/docs/static/v0.9/project/releases/v0.8.49/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/releases/v0.8.5/index.html
+++ b/docs/static/v0.9/project/releases/v0.8.5/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/releases/v0.8.50/index.html
+++ b/docs/static/v0.9/project/releases/v0.8.50/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/releases/v0.8.52/index.html
+++ b/docs/static/v0.9/project/releases/v0.8.52/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/releases/v0.8.54/index.html
+++ b/docs/static/v0.9/project/releases/v0.8.54/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/releases/v0.8.55/index.html
+++ b/docs/static/v0.9/project/releases/v0.8.55/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/releases/v0.8.56/index.html
+++ b/docs/static/v0.9/project/releases/v0.8.56/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/releases/v0.8.57/index.html
+++ b/docs/static/v0.9/project/releases/v0.8.57/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/releases/v0.8.59/index.html
+++ b/docs/static/v0.9/project/releases/v0.8.59/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/releases/v0.8.6/index.html
+++ b/docs/static/v0.9/project/releases/v0.8.6/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/releases/v0.8.61/index.html
+++ b/docs/static/v0.9/project/releases/v0.8.61/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/releases/v0.8.62/index.html
+++ b/docs/static/v0.9/project/releases/v0.8.62/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/releases/v0.8.63/index.html
+++ b/docs/static/v0.9/project/releases/v0.8.63/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/releases/v0.8.64/index.html
+++ b/docs/static/v0.9/project/releases/v0.8.64/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/releases/v0.8.65/index.html
+++ b/docs/static/v0.9/project/releases/v0.8.65/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/releases/v0.8.66/index.html
+++ b/docs/static/v0.9/project/releases/v0.8.66/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/releases/v0.8.67/index.html
+++ b/docs/static/v0.9/project/releases/v0.8.67/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/releases/v0.8.68/index.html
+++ b/docs/static/v0.9/project/releases/v0.8.68/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/releases/v0.8.69/index.html
+++ b/docs/static/v0.9/project/releases/v0.8.69/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/releases/v0.8.7/index.html
+++ b/docs/static/v0.9/project/releases/v0.8.7/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/releases/v0.8.70/index.html
+++ b/docs/static/v0.9/project/releases/v0.8.70/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/releases/v0.8.71/index.html
+++ b/docs/static/v0.9/project/releases/v0.8.71/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/releases/v0.8.72/index.html
+++ b/docs/static/v0.9/project/releases/v0.8.72/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/releases/v0.8.73/index.html
+++ b/docs/static/v0.9/project/releases/v0.8.73/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/releases/v0.8.74/index.html
+++ b/docs/static/v0.9/project/releases/v0.8.74/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/releases/v0.8.75/index.html
+++ b/docs/static/v0.9/project/releases/v0.8.75/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/releases/v0.8.76/index.html
+++ b/docs/static/v0.9/project/releases/v0.8.76/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/releases/v0.8.78/index.html
+++ b/docs/static/v0.9/project/releases/v0.8.78/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/releases/v0.8.79/index.html
+++ b/docs/static/v0.9/project/releases/v0.8.79/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/releases/v0.8.8/index.html
+++ b/docs/static/v0.9/project/releases/v0.8.8/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/releases/v0.8.80/index.html
+++ b/docs/static/v0.9/project/releases/v0.8.80/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/releases/v0.8.81/index.html
+++ b/docs/static/v0.9/project/releases/v0.8.81/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/releases/v0.8.82/index.html
+++ b/docs/static/v0.9/project/releases/v0.8.82/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/releases/v0.8.83/index.html
+++ b/docs/static/v0.9/project/releases/v0.8.83/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/releases/v0.8.84/index.html
+++ b/docs/static/v0.9/project/releases/v0.8.84/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/releases/v0.8.85/index.html
+++ b/docs/static/v0.9/project/releases/v0.8.85/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/releases/v0.8.86/index.html
+++ b/docs/static/v0.9/project/releases/v0.8.86/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/releases/v0.8.87/index.html
+++ b/docs/static/v0.9/project/releases/v0.8.87/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/releases/v0.8.88/index.html
+++ b/docs/static/v0.9/project/releases/v0.8.88/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/releases/v0.8.89/index.html
+++ b/docs/static/v0.9/project/releases/v0.8.89/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/releases/v0.8.9/index.html
+++ b/docs/static/v0.9/project/releases/v0.8.9/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/releases/v0.8.90/index.html
+++ b/docs/static/v0.9/project/releases/v0.8.90/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/releases/v0.8.91/index.html
+++ b/docs/static/v0.9/project/releases/v0.8.91/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/releases/v0.8.92/index.html
+++ b/docs/static/v0.9/project/releases/v0.8.92/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/releases/v0.8.93/index.html
+++ b/docs/static/v0.9/project/releases/v0.8.93/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/releases/v0.8.94/index.html
+++ b/docs/static/v0.9/project/releases/v0.8.94/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/releases/v0.8.95/index.html
+++ b/docs/static/v0.9/project/releases/v0.8.95/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/releases/v0.8.96/index.html
+++ b/docs/static/v0.9/project/releases/v0.8.96/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/releases/v0.8.97/index.html
+++ b/docs/static/v0.9/project/releases/v0.8.97/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/releases/v0.8.98/index.html
+++ b/docs/static/v0.9/project/releases/v0.8.98/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/releases/v0.8.99/index.html
+++ b/docs/static/v0.9/project/releases/v0.8.99/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/releases/v0.9.0/index.html
+++ b/docs/static/v0.9/project/releases/v0.9.0/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/releases/v0.9.1/index.html
+++ b/docs/static/v0.9/project/releases/v0.9.1/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/releases/v0.9.2/index.html
+++ b/docs/static/v0.9/project/releases/v0.9.2/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/project/security-vulnerabilities/index.html
+++ b/docs/static/v0.9/project/security-vulnerabilities/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/reference/error-codes/index.html
+++ b/docs/static/v0.9/reference/error-codes/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/reference/graphql-apis/index.html
+++ b/docs/static/v0.9/reference/graphql-apis/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/reference/index.html
+++ b/docs/static/v0.9/reference/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/reference/meshery-operator-crds/index.html
+++ b/docs/static/v0.9/reference/meshery-operator-crds/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/reference/mesheryctl/adapter/deploy/index.html
+++ b/docs/static/v0.9/reference/mesheryctl/adapter/deploy/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/reference/mesheryctl/adapter/index.html
+++ b/docs/static/v0.9/reference/mesheryctl/adapter/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/reference/mesheryctl/adapter/remove/index.html
+++ b/docs/static/v0.9/reference/mesheryctl/adapter/remove/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/reference/mesheryctl/adapter/validate/index.html
+++ b/docs/static/v0.9/reference/mesheryctl/adapter/validate/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/reference/mesheryctl/commands/index.html
+++ b/docs/static/v0.9/reference/mesheryctl/commands/index.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
   <head>
+  <meta name="robots" content="noindex, follow" />
     <title>/v0.9/reference/mesheryctl/</title>
     <link rel="canonical" href="/v0.9/reference/mesheryctl/">
     <meta charset="utf-8">

--- a/docs/static/v0.9/reference/mesheryctl/completion/index.html
+++ b/docs/static/v0.9/reference/mesheryctl/completion/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/reference/mesheryctl/component/index.html
+++ b/docs/static/v0.9/reference/mesheryctl/component/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/reference/mesheryctl/component/list/index.html
+++ b/docs/static/v0.9/reference/mesheryctl/component/list/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/reference/mesheryctl/component/search/index.html
+++ b/docs/static/v0.9/reference/mesheryctl/component/search/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/reference/mesheryctl/component/view/index.html
+++ b/docs/static/v0.9/reference/mesheryctl/component/view/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/reference/mesheryctl/connection/create/index.html
+++ b/docs/static/v0.9/reference/mesheryctl/connection/create/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/reference/mesheryctl/connection/delete/index.html
+++ b/docs/static/v0.9/reference/mesheryctl/connection/delete/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/reference/mesheryctl/connection/index.html
+++ b/docs/static/v0.9/reference/mesheryctl/connection/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/reference/mesheryctl/connection/list/index.html
+++ b/docs/static/v0.9/reference/mesheryctl/connection/list/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/reference/mesheryctl/connection/view/index.html
+++ b/docs/static/v0.9/reference/mesheryctl/connection/view/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/reference/mesheryctl/design/apply/index.html
+++ b/docs/static/v0.9/reference/mesheryctl/design/apply/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/reference/mesheryctl/design/delete/index.html
+++ b/docs/static/v0.9/reference/mesheryctl/design/delete/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/reference/mesheryctl/design/deploy/index.html
+++ b/docs/static/v0.9/reference/mesheryctl/design/deploy/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/reference/mesheryctl/design/export/index.html
+++ b/docs/static/v0.9/reference/mesheryctl/design/export/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/reference/mesheryctl/design/import/index.html
+++ b/docs/static/v0.9/reference/mesheryctl/design/import/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/reference/mesheryctl/design/index.html
+++ b/docs/static/v0.9/reference/mesheryctl/design/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/reference/mesheryctl/design/list/index.html
+++ b/docs/static/v0.9/reference/mesheryctl/design/list/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/reference/mesheryctl/design/undeploy/index.html
+++ b/docs/static/v0.9/reference/mesheryctl/design/undeploy/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/reference/mesheryctl/design/view/index.html
+++ b/docs/static/v0.9/reference/mesheryctl/design/view/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/reference/mesheryctl/environment/create/index.html
+++ b/docs/static/v0.9/reference/mesheryctl/environment/create/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/reference/mesheryctl/environment/delete/index.html
+++ b/docs/static/v0.9/reference/mesheryctl/environment/delete/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/reference/mesheryctl/environment/index.html
+++ b/docs/static/v0.9/reference/mesheryctl/environment/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/reference/mesheryctl/environment/list/index.html
+++ b/docs/static/v0.9/reference/mesheryctl/environment/list/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/reference/mesheryctl/environment/view/index.html
+++ b/docs/static/v0.9/reference/mesheryctl/environment/view/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/reference/mesheryctl/exp/index.html
+++ b/docs/static/v0.9/reference/mesheryctl/exp/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/reference/mesheryctl/filter/delete/index.html
+++ b/docs/static/v0.9/reference/mesheryctl/filter/delete/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/reference/mesheryctl/filter/import/index.html
+++ b/docs/static/v0.9/reference/mesheryctl/filter/import/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/reference/mesheryctl/filter/index.html
+++ b/docs/static/v0.9/reference/mesheryctl/filter/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/reference/mesheryctl/filter/list/index.html
+++ b/docs/static/v0.9/reference/mesheryctl/filter/list/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/reference/mesheryctl/filter/view/index.html
+++ b/docs/static/v0.9/reference/mesheryctl/filter/view/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/reference/mesheryctl/index.html
+++ b/docs/static/v0.9/reference/mesheryctl/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/reference/mesheryctl/model/build/index.html
+++ b/docs/static/v0.9/reference/mesheryctl/model/build/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/reference/mesheryctl/model/delete/index.html
+++ b/docs/static/v0.9/reference/mesheryctl/model/delete/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/reference/mesheryctl/model/export/index.html
+++ b/docs/static/v0.9/reference/mesheryctl/model/export/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/reference/mesheryctl/model/generate/index.html
+++ b/docs/static/v0.9/reference/mesheryctl/model/generate/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/reference/mesheryctl/model/import/index.html
+++ b/docs/static/v0.9/reference/mesheryctl/model/import/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/reference/mesheryctl/model/index.html
+++ b/docs/static/v0.9/reference/mesheryctl/model/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/reference/mesheryctl/model/init/index.html
+++ b/docs/static/v0.9/reference/mesheryctl/model/init/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/reference/mesheryctl/model/list/index.html
+++ b/docs/static/v0.9/reference/mesheryctl/model/list/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/reference/mesheryctl/model/search/index.html
+++ b/docs/static/v0.9/reference/mesheryctl/model/search/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/reference/mesheryctl/model/view/index.html
+++ b/docs/static/v0.9/reference/mesheryctl/model/view/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/reference/mesheryctl/organization/index.html
+++ b/docs/static/v0.9/reference/mesheryctl/organization/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/reference/mesheryctl/organization/list/index.html
+++ b/docs/static/v0.9/reference/mesheryctl/organization/list/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/reference/mesheryctl/perf/apply/index.html
+++ b/docs/static/v0.9/reference/mesheryctl/perf/apply/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/reference/mesheryctl/perf/index.html
+++ b/docs/static/v0.9/reference/mesheryctl/perf/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/reference/mesheryctl/perf/profile/index.html
+++ b/docs/static/v0.9/reference/mesheryctl/perf/profile/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/reference/mesheryctl/perf/result/index.html
+++ b/docs/static/v0.9/reference/mesheryctl/perf/result/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/reference/mesheryctl/registry/generate/index.html
+++ b/docs/static/v0.9/reference/mesheryctl/registry/generate/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/reference/mesheryctl/registry/index.html
+++ b/docs/static/v0.9/reference/mesheryctl/registry/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/reference/mesheryctl/registry/publish/index.html
+++ b/docs/static/v0.9/reference/mesheryctl/registry/publish/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/reference/mesheryctl/registry/update/index.html
+++ b/docs/static/v0.9/reference/mesheryctl/registry/update/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/reference/mesheryctl/relationship/generate/index.html
+++ b/docs/static/v0.9/reference/mesheryctl/relationship/generate/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/reference/mesheryctl/relationship/index.html
+++ b/docs/static/v0.9/reference/mesheryctl/relationship/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/reference/mesheryctl/relationship/list/index.html
+++ b/docs/static/v0.9/reference/mesheryctl/relationship/list/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/reference/mesheryctl/relationship/search/index.html
+++ b/docs/static/v0.9/reference/mesheryctl/relationship/search/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/reference/mesheryctl/relationship/view/index.html
+++ b/docs/static/v0.9/reference/mesheryctl/relationship/view/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/reference/mesheryctl/system/channel/index.html
+++ b/docs/static/v0.9/reference/mesheryctl/system/channel/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/reference/mesheryctl/system/channel/set/index.html
+++ b/docs/static/v0.9/reference/mesheryctl/system/channel/set/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/reference/mesheryctl/system/channel/switch/index.html
+++ b/docs/static/v0.9/reference/mesheryctl/system/channel/switch/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/reference/mesheryctl/system/channel/view/index.html
+++ b/docs/static/v0.9/reference/mesheryctl/system/channel/view/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/reference/mesheryctl/system/check/index.html
+++ b/docs/static/v0.9/reference/mesheryctl/system/check/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/reference/mesheryctl/system/context/create/index.html
+++ b/docs/static/v0.9/reference/mesheryctl/system/context/create/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/reference/mesheryctl/system/context/delete/index.html
+++ b/docs/static/v0.9/reference/mesheryctl/system/context/delete/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/reference/mesheryctl/system/context/index.html
+++ b/docs/static/v0.9/reference/mesheryctl/system/context/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/reference/mesheryctl/system/context/list/index.html
+++ b/docs/static/v0.9/reference/mesheryctl/system/context/list/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/reference/mesheryctl/system/context/switch/index.html
+++ b/docs/static/v0.9/reference/mesheryctl/system/context/switch/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/reference/mesheryctl/system/context/view/index.html
+++ b/docs/static/v0.9/reference/mesheryctl/system/context/view/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/reference/mesheryctl/system/dashboard/index.html
+++ b/docs/static/v0.9/reference/mesheryctl/system/dashboard/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/reference/mesheryctl/system/delete/index.html
+++ b/docs/static/v0.9/reference/mesheryctl/system/delete/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/reference/mesheryctl/system/index.html
+++ b/docs/static/v0.9/reference/mesheryctl/system/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/reference/mesheryctl/system/login/index.html
+++ b/docs/static/v0.9/reference/mesheryctl/system/login/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/reference/mesheryctl/system/logout/index.html
+++ b/docs/static/v0.9/reference/mesheryctl/system/logout/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/reference/mesheryctl/system/logs/index.html
+++ b/docs/static/v0.9/reference/mesheryctl/system/logs/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/reference/mesheryctl/system/provider/index.html
+++ b/docs/static/v0.9/reference/mesheryctl/system/provider/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/reference/mesheryctl/system/provider/list/index.html
+++ b/docs/static/v0.9/reference/mesheryctl/system/provider/list/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/reference/mesheryctl/system/provider/reset/index.html
+++ b/docs/static/v0.9/reference/mesheryctl/system/provider/reset/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/reference/mesheryctl/system/provider/set/index.html
+++ b/docs/static/v0.9/reference/mesheryctl/system/provider/set/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/reference/mesheryctl/system/provider/switch/index.html
+++ b/docs/static/v0.9/reference/mesheryctl/system/provider/switch/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/reference/mesheryctl/system/provider/view/index.html
+++ b/docs/static/v0.9/reference/mesheryctl/system/provider/view/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/reference/mesheryctl/system/reset/index.html
+++ b/docs/static/v0.9/reference/mesheryctl/system/reset/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/reference/mesheryctl/system/restart/index.html
+++ b/docs/static/v0.9/reference/mesheryctl/system/restart/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/reference/mesheryctl/system/start/index.html
+++ b/docs/static/v0.9/reference/mesheryctl/system/start/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/reference/mesheryctl/system/status/index.html
+++ b/docs/static/v0.9/reference/mesheryctl/system/status/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/reference/mesheryctl/system/stop/index.html
+++ b/docs/static/v0.9/reference/mesheryctl/system/stop/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/reference/mesheryctl/system/token/create/index.html
+++ b/docs/static/v0.9/reference/mesheryctl/system/token/create/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/reference/mesheryctl/system/token/delete/index.html
+++ b/docs/static/v0.9/reference/mesheryctl/system/token/delete/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/reference/mesheryctl/system/token/index.html
+++ b/docs/static/v0.9/reference/mesheryctl/system/token/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/reference/mesheryctl/system/token/list/index.html
+++ b/docs/static/v0.9/reference/mesheryctl/system/token/list/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/reference/mesheryctl/system/token/set/index.html
+++ b/docs/static/v0.9/reference/mesheryctl/system/token/set/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/reference/mesheryctl/system/token/view/index.html
+++ b/docs/static/v0.9/reference/mesheryctl/system/token/view/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/reference/mesheryctl/system/update/index.html
+++ b/docs/static/v0.9/reference/mesheryctl/system/update/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/reference/mesheryctl/version/index.html
+++ b/docs/static/v0.9/reference/mesheryctl/version/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/reference/mesheryctl/workspace/create/index.html
+++ b/docs/static/v0.9/reference/mesheryctl/workspace/create/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/reference/mesheryctl/workspace/index.html
+++ b/docs/static/v0.9/reference/mesheryctl/workspace/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/reference/mesheryctl/workspace/list/index.html
+++ b/docs/static/v0.9/reference/mesheryctl/workspace/list/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/reference/mesheryctl/workspace/view/index.html
+++ b/docs/static/v0.9/reference/mesheryctl/workspace/view/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/reference/permissions/index.html
+++ b/docs/static/v0.9/reference/permissions/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/reference/rest-apis/index.html
+++ b/docs/static/v0.9/reference/rest-apis/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/reference/rest-apis/swagger/index.html
+++ b/docs/static/v0.9/reference/rest-apis/swagger/index.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
   <head>
+  <meta name="robots" content="noindex, follow" />
     <title>/v0.9/reference/rest-apis/</title>
     <link rel="canonical" href="/v0.9/reference/rest-apis/">
     <meta charset="utf-8">

--- a/docs/static/v0.9/search/index.html
+++ b/docs/static/v0.9/search/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/service-meshes/adapters/app-mesh/index.html
+++ b/docs/static/v0.9/service-meshes/adapters/app-mesh/index.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
   <head>
+  <meta name="robots" content="noindex, follow" />
     <title>/v0.9/extensions/adapters/app-mesh/</title>
     <link rel="canonical" href="/v0.9/extensions/adapters/app-mesh/">
     <meta charset="utf-8">

--- a/docs/static/v0.9/service-meshes/adapters/cilium/index.html
+++ b/docs/static/v0.9/service-meshes/adapters/cilium/index.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
   <head>
+  <meta name="robots" content="noindex, follow" />
     <title>/v0.9/extensions/adapters/cilium/</title>
     <link rel="canonical" href="/v0.9/extensions/adapters/cilium/">
     <meta charset="utf-8">

--- a/docs/static/v0.9/service-meshes/adapters/consul/index.html
+++ b/docs/static/v0.9/service-meshes/adapters/consul/index.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
   <head>
+  <meta name="robots" content="noindex, follow" />
     <title>/v0.9/extensions/adapters/consul/</title>
     <link rel="canonical" href="/v0.9/extensions/adapters/consul/">
     <meta charset="utf-8">

--- a/docs/static/v0.9/service-meshes/adapters/istio/index.html
+++ b/docs/static/v0.9/service-meshes/adapters/istio/index.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
   <head>
+  <meta name="robots" content="noindex, follow" />
     <title>/v0.9/extensions/adapters/istio/</title>
     <link rel="canonical" href="/v0.9/extensions/adapters/istio/">
     <meta charset="utf-8">

--- a/docs/static/v0.9/service-meshes/adapters/kuma/index.html
+++ b/docs/static/v0.9/service-meshes/adapters/kuma/index.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
   <head>
+  <meta name="robots" content="noindex, follow" />
     <title>/v0.9/extensions/adapters/kuma/</title>
     <link rel="canonical" href="/v0.9/extensions/adapters/kuma/">
     <meta charset="utf-8">

--- a/docs/static/v0.9/service-meshes/adapters/linkerd/index.html
+++ b/docs/static/v0.9/service-meshes/adapters/linkerd/index.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
   <head>
+  <meta name="robots" content="noindex, follow" />
     <title>/v0.9/extensions/adapters/linkerd/</title>
     <link rel="canonical" href="/v0.9/extensions/adapters/linkerd/">
     <meta charset="utf-8">

--- a/docs/static/v0.9/service-meshes/adapters/nginx-sm/index.html
+++ b/docs/static/v0.9/service-meshes/adapters/nginx-sm/index.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
   <head>
+  <meta name="robots" content="noindex, follow" />
     <title>/v0.9/extensions/adapters/nginx-sm/</title>
     <link rel="canonical" href="/v0.9/extensions/adapters/nginx-sm/">
     <meta charset="utf-8">

--- a/docs/static/v0.9/service-meshes/adapters/nsm/index.html
+++ b/docs/static/v0.9/service-meshes/adapters/nsm/index.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
   <head>
+  <meta name="robots" content="noindex, follow" />
     <title>/v0.9/extensions/adapters/nsm/</title>
     <link rel="canonical" href="/v0.9/extensions/adapters/nsm/">
     <meta charset="utf-8">

--- a/docs/static/v0.9/service-meshes/adapters/tanzu-sm/index.html
+++ b/docs/static/v0.9/service-meshes/adapters/tanzu-sm/index.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
   <head>
+  <meta name="robots" content="noindex, follow" />
     <title>/v0.9/extensions/adapters/tanzu-sm/</title>
     <link rel="canonical" href="/v0.9/extensions/adapters/tanzu-sm/">
     <meta charset="utf-8">

--- a/docs/static/v0.9/service-meshes/adapters/traefik-mesh/index.html
+++ b/docs/static/v0.9/service-meshes/adapters/traefik-mesh/index.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
   <head>
+  <meta name="robots" content="noindex, follow" />
     <title>/v0.9/extensions/adapters/traefik-mesh/</title>
     <link rel="canonical" href="/v0.9/extensions/adapters/traefik-mesh/">
     <meta charset="utf-8">

--- a/docs/static/v0.9/tags/index.html
+++ b/docs/static/v0.9/tags/index.html
@@ -8,7 +8,7 @@
     content="width=device-width, initial-scale=1, shrink-to-fit=no"
   />
   <meta name="generator" content="Hugo 0.154.5" />
-  <meta name="ROBOTS" content="INDEX, FOLLOW" />
+  <meta name="robots" content="noindex, follow" />
 
   <link
     rel="alternate"

--- a/docs/static/v0.9/tasks/application-management/index.html
+++ b/docs/static/v0.9/tasks/application-management/index.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
   <head>
+  <meta name="robots" content="noindex, follow" />
     <title>/v0.9/guides/infrastructure-management/overview/</title>
     <link rel="canonical" href="/v0.9/guides/infrastructure-management/overview/">
     <meta charset="utf-8">

--- a/docs/static/v0.9/tasks/filter-management/index.html
+++ b/docs/static/v0.9/tasks/filter-management/index.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
   <head>
+  <meta name="robots" content="noindex, follow" />
     <title>/v0.9/guides/infrastructure-management/filter-management/</title>
     <link rel="canonical" href="/v0.9/guides/infrastructure-management/filter-management/">
     <meta charset="utf-8">

--- a/docs/static/v0.9/tasks/index.html
+++ b/docs/static/v0.9/tasks/index.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
   <head>
+  <meta name="robots" content="noindex, follow" />
     <title>/v0.9/guides/</title>
     <link rel="canonical" href="/v0.9/guides/">
     <meta charset="utf-8">

--- a/docs/static/v0.9/tasks/infrastructure-management/index.html
+++ b/docs/static/v0.9/tasks/infrastructure-management/index.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
   <head>
+  <meta name="robots" content="noindex, follow" />
     <title>/v0.9/guides/infrastructure-management/overview/</title>
     <link rel="canonical" href="/v0.9/guides/infrastructure-management/overview/">
     <meta charset="utf-8">

--- a/docs/static/v0.9/tasks/lifecycle-management/index.html
+++ b/docs/static/v0.9/tasks/lifecycle-management/index.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
   <head>
+  <meta name="robots" content="noindex, follow" />
     <title>/v0.9/guides/infrastructure-management/lifecycle-management/</title>
     <link rel="canonical" href="/v0.9/guides/infrastructure-management/lifecycle-management/">
     <meta charset="utf-8">

--- a/docs/static/v0.9/tasks/pattern-management/index.html
+++ b/docs/static/v0.9/tasks/pattern-management/index.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
   <head>
+  <meta name="robots" content="noindex, follow" />
     <title>/v0.9/guides/configuration-management/pattern-management/</title>
     <link rel="canonical" href="/v0.9/guides/configuration-management/pattern-management/">
     <meta charset="utf-8">

--- a/docs/static/v0.9/tasks/patterns/index.html
+++ b/docs/static/v0.9/tasks/patterns/index.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
   <head>
+  <meta name="robots" content="noindex, follow" />
     <title>/v0.9/guides/configuration-management/working-with-designs/</title>
     <link rel="canonical" href="/v0.9/guides/configuration-management/working-with-designs/">
     <meta charset="utf-8">

--- a/docs/static/v0.9/tasks/performance/managing-performance/index.html
+++ b/docs/static/v0.9/tasks/performance/managing-performance/index.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
   <head>
+  <meta name="robots" content="noindex, follow" />
     <title>/v0.9/guides/performance-management/managing-performance/</title>
     <link rel="canonical" href="/v0.9/guides/performance-management/managing-performance/">
     <meta charset="utf-8">


### PR DESCRIPTION
Removes the broad Disallow rules for /v0.4/ through /v0.9/ from the robots.txt template so Googlebot can fetch those pages and read their noindex tag. Normalizes the per-page robots meta across all versioned HTML snapshots to <meta name="robots" content="noindex, follow" />:

  - 6086 pages had "INDEX, FOLLOW" -> replaced with "noindex, follow"
  - 495 pages had no robots meta -> inserted "noindex, follow"
  - 91 pages already declared noindex -> left untouched

Using "noindex, follow" rather than "noindex, nofollow" so link equity from outdated docs can still flow to current-version pages.

Fixes #19250

**Notes for Reviewers**

- This PR fixes #

**[Signed commits](https://github.com/meshery/meshery/blob/master/CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [ ] Yes, I signed my commits.

<!--
Thank you for contributing to Meshery! 

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. Sign your commits.
4. Include before and after screenshots/terminal output.

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.
-->
