### PR TITLE
[UI] Phase 1: CI audits for MUI usage, hex literals, and giant files (#18725)

### DIFF
--- a/.github/workflows/ui-audits.yml
+++ b/.github/workflows/ui-audits.yml
@@ -58,77 +58,29 @@ jobs:
             echo ""
           } >> "$GITHUB_STEP_SUMMARY"
 
-      - name: Run audit:mui
-        id: audit-mui
-        env:
-          AUDIT_KIND: mui
+      - name: Run audits (mui, hex, size)
+        id: audits
         run: |
-          output="$(npm run --silent audit:${AUDIT_KIND})"
-          trend="$(printf '%s\n' "$output" | grep -E "^AUDIT ${AUDIT_KIND} " | tail -1)"
-          : "${trend:=AUDIT ${AUDIT_KIND} (no summary line)}"
-          printf '%s\n' "$output"
-          printf 'trend=%s\n' "$trend" >> "$GITHUB_OUTPUT"
-          {
-            echo "<details><summary><strong>audit:${AUDIT_KIND}</strong> &mdash; <code>${trend}</code></summary>"
-            echo ""
-            echo '```'
-            echo "${trend}"
-            echo '```'
-            echo ""
-            echo '```text'
+          for kind in mui hex size; do
+            output="$(npm run --silent audit:${kind})"
+            trend="$(printf '%s\n' "$output" | grep -E "^AUDIT ${kind} " | tail -1)"
+            : "${trend:=AUDIT ${kind} (no summary line)}"
             printf '%s\n' "$output"
-            echo '```'
-            echo ""
-            echo "</details>"
-          } >> "$GITHUB_STEP_SUMMARY"
-
-      - name: Run audit:hex
-        id: audit-hex
-        env:
-          AUDIT_KIND: hex
-        run: |
-          output="$(npm run --silent audit:${AUDIT_KIND})"
-          trend="$(printf '%s\n' "$output" | grep -E "^AUDIT ${AUDIT_KIND} " | tail -1)"
-          : "${trend:=AUDIT ${AUDIT_KIND} (no summary line)}"
-          printf '%s\n' "$output"
-          printf 'trend=%s\n' "$trend" >> "$GITHUB_OUTPUT"
-          {
-            echo "<details><summary><strong>audit:${AUDIT_KIND}</strong> &mdash; <code>${trend}</code></summary>"
-            echo ""
-            echo '```'
-            echo "${trend}"
-            echo '```'
-            echo ""
-            echo '```text'
-            printf '%s\n' "$output"
-            echo '```'
-            echo ""
-            echo "</details>"
-          } >> "$GITHUB_STEP_SUMMARY"
-
-      - name: Run audit:size
-        id: audit-size
-        env:
-          AUDIT_KIND: size
-        run: |
-          output="$(npm run --silent audit:${AUDIT_KIND})"
-          trend="$(printf '%s\n' "$output" | grep -E "^AUDIT ${AUDIT_KIND} " | tail -1)"
-          : "${trend:=AUDIT ${AUDIT_KIND} (no summary line)}"
-          printf '%s\n' "$output"
-          printf 'trend=%s\n' "$trend" >> "$GITHUB_OUTPUT"
-          {
-            echo "<details><summary><strong>audit:${AUDIT_KIND}</strong> &mdash; <code>${trend}</code></summary>"
-            echo ""
-            echo '```'
-            echo "${trend}"
-            echo '```'
-            echo ""
-            echo '```text'
-            printf '%s\n' "$output"
-            echo '```'
-            echo ""
-            echo "</details>"
-          } >> "$GITHUB_STEP_SUMMARY"
+            printf '%s-trend=%s\n' "$kind" "$trend" >> "$GITHUB_OUTPUT"
+            {
+              echo "<details><summary><strong>audit:${kind}</strong> &mdash; <code>${trend}</code></summary>"
+              echo ""
+              echo '```'
+              echo "${trend}"
+              echo '```'
+              echo ""
+              echo '```text'
+              printf '%s\n' "$output"
+              echo '```'
+              echo ""
+              echo "</details>"
+            } >> "$GITHUB_STEP_SUMMARY"
+          done
 
       - name: Run lint:ui-kit
         id: lint-ui-kit
@@ -165,9 +117,16 @@ jobs:
             exit 1
           fi
 
+      # PR-comment steps are best-effort. Fork PRs receive a read-only
+      # GITHUB_TOKEN regardless of the workflow's `permissions:` block, so
+      # find-comment / create-or-update-comment return HTTP 403 from forks.
+      # continue-on-error keeps fork PRs green — contributors still get the
+      # full report via the job summary even when the sticky comment cannot
+      # be posted. Same-repo PRs continue to post normally.
       - name: Find existing audit comment
         if: github.event_name == 'pull_request'
         id: find-comment
+        continue-on-error: true
         uses: peter-evans/find-comment@v3
         with:
           issue-number: ${{ github.event.pull_request.number }}
@@ -176,6 +135,7 @@ jobs:
 
       - name: Post or update PR comment
         if: github.event_name == 'pull_request'
+        continue-on-error: true
         uses: peter-evans/create-or-update-comment@v4
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
@@ -189,9 +149,9 @@ jobs:
             Phase 1 baseline counters (informational; see [#18656](https://github.com/meshery/meshery/issues/18656)).
 
             ```
-            ${{ steps.audit-mui.outputs.trend }}
-            ${{ steps.audit-hex.outputs.trend }}
-            ${{ steps.audit-size.outputs.trend }}
+            ${{ steps.audits.outputs.mui-trend }}
+            ${{ steps.audits.outputs.hex-trend }}
+            ${{ steps.audits.outputs.size-trend }}
             ${{ steps.lint-ui-kit.outputs.trend }}
             ```
 

--- a/.github/workflows/ui-audits.yml
+++ b/.github/workflows/ui-audits.yml
@@ -1,0 +1,198 @@
+# meshery-ui restructure audits.
+#
+# This workflow is informational; it does not gate merges. It surfaces the
+# Phase 1 baseline counts (direct MUI usage, hex/rgb color literals, and
+# giant source files) that gate the Phase 1 exit criteria of issue #18656.
+#
+# See ui/restructure-plan.md §8.6. The audits trend toward zero across the
+# multi-phase UI restructure; this job tracks them on every UI PR and on
+# every push to master.
+name: ui-audits
+on:
+  pull_request:
+    paths:
+      - 'ui/**'
+  push:
+    branches:
+      - master
+    paths:
+      - 'ui/**'
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  audits:
+    name: runner / ui-audits
+    runs-on: ubuntu-24.04
+    defaults:
+      run:
+        working-directory: ui
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Setup Node.js v22
+        uses: actions/setup-node@v6
+        with:
+          node-version: '22'
+          cache: 'npm'
+          cache-dependency-path: ui/package-lock.json
+
+      - name: Cache ui/node_modules
+        uses: actions/cache@v4
+        with:
+          path: ui/node_modules
+          key: ui-node-modules-${{ runner.os }}-${{ hashFiles('ui/package-lock.json') }}
+
+      - name: Install dependencies in Meshery UI
+        run: npm ci
+
+      - name: Initialise audit summary
+        run: |
+          {
+            echo "# Meshery UI restructure audits"
+            echo ""
+            echo "Phase 1 baseline counters for issue [#18656](https://github.com/meshery/meshery/issues/18656)."
+            echo "These audits are informational; they do not gate merges."
+            echo ""
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Run audit:mui
+        id: audit-mui
+        env:
+          AUDIT_KIND: mui
+        run: |
+          output="$(npm run --silent audit:${AUDIT_KIND})"
+          trend="$(printf '%s\n' "$output" | grep -E "^AUDIT ${AUDIT_KIND} " | tail -1)"
+          : "${trend:=AUDIT ${AUDIT_KIND} (no summary line)}"
+          printf '%s\n' "$output"
+          printf 'trend=%s\n' "$trend" >> "$GITHUB_OUTPUT"
+          {
+            echo "<details><summary><strong>audit:${AUDIT_KIND}</strong> &mdash; <code>${trend}</code></summary>"
+            echo ""
+            echo '```'
+            echo "${trend}"
+            echo '```'
+            echo ""
+            echo '```text'
+            printf '%s\n' "$output"
+            echo '```'
+            echo ""
+            echo "</details>"
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Run audit:hex
+        id: audit-hex
+        env:
+          AUDIT_KIND: hex
+        run: |
+          output="$(npm run --silent audit:${AUDIT_KIND})"
+          trend="$(printf '%s\n' "$output" | grep -E "^AUDIT ${AUDIT_KIND} " | tail -1)"
+          : "${trend:=AUDIT ${AUDIT_KIND} (no summary line)}"
+          printf '%s\n' "$output"
+          printf 'trend=%s\n' "$trend" >> "$GITHUB_OUTPUT"
+          {
+            echo "<details><summary><strong>audit:${AUDIT_KIND}</strong> &mdash; <code>${trend}</code></summary>"
+            echo ""
+            echo '```'
+            echo "${trend}"
+            echo '```'
+            echo ""
+            echo '```text'
+            printf '%s\n' "$output"
+            echo '```'
+            echo ""
+            echo "</details>"
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Run audit:size
+        id: audit-size
+        env:
+          AUDIT_KIND: size
+        run: |
+          output="$(npm run --silent audit:${AUDIT_KIND})"
+          trend="$(printf '%s\n' "$output" | grep -E "^AUDIT ${AUDIT_KIND} " | tail -1)"
+          : "${trend:=AUDIT ${AUDIT_KIND} (no summary line)}"
+          printf '%s\n' "$output"
+          printf 'trend=%s\n' "$trend" >> "$GITHUB_OUTPUT"
+          {
+            echo "<details><summary><strong>audit:${AUDIT_KIND}</strong> &mdash; <code>${trend}</code></summary>"
+            echo ""
+            echo '```'
+            echo "${trend}"
+            echo '```'
+            echo ""
+            echo '```text'
+            printf '%s\n' "$output"
+            echo '```'
+            echo ""
+            echo "</details>"
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Run lint:ui-kit
+        id: lint-ui-kit
+        # Errors (real guardrail violations) fail this step; warnings do not,
+        # because `--quiet` filters lint output down to errors only.
+        run: |
+          set +e
+          lint_output="$(npm run --silent lint:ui-kit 2>&1)"
+          lint_exit=$?
+          set -e
+          if [ "$lint_exit" -eq 0 ]; then
+            lint_status="pass"
+          else
+            lint_status="fail"
+          fi
+          lint_trend="AUDIT lint-ui-kit status=${lint_status}"
+          printf '%s\n' "$lint_output"
+          printf 'trend=%s\n' "$lint_trend" >> "$GITHUB_OUTPUT"
+          {
+            echo "<details><summary><strong>lint:ui-kit</strong> &mdash; <code>${lint_trend}</code></summary>"
+            echo ""
+            echo '```'
+            echo "${lint_trend}"
+            echo '```'
+            echo ""
+            echo '```text'
+            printf '%s\n' "${lint_output:-(no lint output)}"
+            echo '```'
+            echo ""
+            echo "</details>"
+          } >> "$GITHUB_STEP_SUMMARY"
+          if [ "$lint_status" = "fail" ]; then
+            echo "lint:ui-kit reported errors; failing this step."
+            exit 1
+          fi
+
+      - name: Find existing audit comment
+        if: github.event_name == 'pull_request'
+        id: find-comment
+        uses: peter-evans/find-comment@v3
+        with:
+          issue-number: ${{ github.event.pull_request.number }}
+          comment-author: 'github-actions[bot]'
+          body-includes: '<!-- meshery-ui-audit-marker -->'
+
+      - name: Post or update PR comment
+        if: github.event_name == 'pull_request'
+        uses: peter-evans/create-or-update-comment@v4
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          comment-id: ${{ steps.find-comment.outputs.comment-id }}
+          issue-number: ${{ github.event.pull_request.number }}
+          edit-mode: replace
+          body: |
+            <!-- meshery-ui-audit-marker -->
+            ### Meshery UI restructure audits
+
+            Phase 1 baseline counters (informational; see [#18656](https://github.com/meshery/meshery/issues/18656)).
+
+            ```
+            ${{ steps.audit-mui.outputs.trend }}
+            ${{ steps.audit-hex.outputs.trend }}
+            ${{ steps.audit-size.outputs.trend }}
+            ${{ steps.lint-ui-kit.outputs.trend }}
+            ```
+
+            Full per-file breakdowns are in the workflow's [job summary](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}).

--- a/ui/package.json
+++ b/ui/package.json
@@ -6,6 +6,7 @@
   "scripts": {
     "dev": "npm run lint:fix && node ui_dev_server.js",
     "lint": "eslint --cache --ext .js,.jsx,.ts,.tsx .",
+    "lint:ui-kit": "eslint --cache --quiet --ext .js,.jsx,.ts,.tsx .",
     "lint:fix": "eslint --cache --fix --ext .js,.jsx,.ts,.tsx .",
     "format": "npx prettier --write \"**/*.{ts,tsx,js,jsx,md,json}\"",
     "build": "npm run clean && cross-env next build",


### PR DESCRIPTION
## Summary

Adds `.github/workflows/ui-audits.yml`, the missing CI surface for the
four Phase 1 trend trackers described in `ui/restructure-plan.md` §8.6.

- Runs on `pull_request` events touching `ui/**` and on every push to
  `master` that touches `ui/**`.
- Executes four checks as separate steps: `audit:mui`, `audit:hex`,
  `audit:size`, and a new `lint:ui-kit` npm script that wraps the
  existing ESLint config in `--quiet` mode (errors fail; warnings
  don't).
- Posts each audit's output into the GitHub Actions job summary as a
  collapsible block, with the trailing `AUDIT ...` trend line surfaced
  as a code block at the top of each block.
- Posts a sticky PR comment (marker: `<!-- meshery-ui-audit-marker -->`,
  via `peter-evans/find-comment` + `peter-evans/create-or-update-comment`)
  with the four trend lines, so reviewers see the baseline counts at a
  glance.
- Audits are informational only — they do not gate merges. The
  workflow exits 0 regardless of the counts. Only a real ESLint
  *error* from `lint:ui-kit` (i.e., a hard guardrail violation) fails
  the workflow.
- Caches `~/.npm` (via `setup-node`) and `ui/node_modules` for fast
  reruns.

Adds `lint:ui-kit` to `ui/package.json` as the fourth Phase 1 CI
surface called out in §8.6.

## Baseline counters

Captured locally at the same commit this PR branches from:

```
AUDIT mui files=56 matches=143
AUDIT hex files=92 matches=334 hex=278 rgb=56
AUDIT size over_warn=16 over_hard=7
AUDIT lint-ui-kit status=pass
```

Counts differ slightly from the round numbers cited in the parent epic
(100 MUI files, 457 hex literals, 8 giant files) because the baseline
in the parent was taken at an earlier commit; this PR's surfaces are
the live counters that will land on master.

## Closes / references

Closes #18725. Refs parent epic #18656.

## Test plan

- [x] `npm run audit:mui` emits `AUDIT mui ...` summary line.
- [x] `npm run audit:hex` emits `AUDIT hex ...` summary line.
- [x] `npm run audit:size` emits `AUDIT size ...` summary line.
- [x] `npm run lint:ui-kit` exits 0 (no errors at baseline).
- [x] `.github/workflows/ui-audits.yml` parses as valid YAML.
- [ ] On merge: workflow runs against master and writes baseline to the
      Actions job summary.
- [ ] On a follow-up PR touching `ui/**`: workflow runs and posts a
      sticky comment with the updated counters.