### PR TITLE
[UI] Phase 2: Wrap @rjsf/mui behind shared RJSFProvider (#18727)

### DIFF
--- a/ui/components/MesheryMeshInterface/PatternService/RJSF.tsx
+++ b/ui/components/MesheryMeshInterface/PatternService/RJSF.tsx
@@ -1,5 +1,4 @@
-import { withTheme } from '@rjsf/core';
-import { Theme as MaterialUITheme } from '@rjsf/mui';
+import RJSFProvider from '../../shared/FormFields/RJSFProvider';
 import customValidator from '../../../utils/rjsfValidator';
 import React, { useEffect, useMemo, useState } from 'react';
 import { rjsfTheme } from '../../../themes';
@@ -23,9 +22,6 @@ import CustomRadioWidget from './RJSFCustomComponents/CustomRadioWidget';
 import { ErrorBoundary } from '@sistent/sistent';
 import CustomErrorFallback from '@/components/General/ErrorBoundary';
 import ProviderStoreWrapper from '@/store/ProviderStoreWrapper';
-
-const MuiRJSFForm = withTheme(MaterialUITheme);
-
 /**
  * The Custom RJSF Form that accepts custom fields from the extension
  * or seed it's own default
@@ -101,7 +97,7 @@ function RJSFForm_({
     <ErrorBoundary customFallback={CustomErrorFallback}>
       {/* Putting RJSF into error boundary, so that error can be catched.. */}{' '}
       <ThemeProvider theme={resolvedRjsfTheme}>
-        <MuiRJSFForm
+        <RJSFProvider
           schema={schema.rjsfSchema}
           idPrefix={jsonSchema?.title}
           ref={formRef}
@@ -141,7 +137,7 @@ function RJSFForm_({
         >
           {children}
           <div></div>
-        </MuiRJSFForm>
+        </RJSFProvider>
       </ThemeProvider>
     </ErrorBoundary>
   );

--- a/ui/components/shared/FormFields/RJSFProvider.tsx
+++ b/ui/components/shared/FormFields/RJSFProvider.tsx
@@ -1,0 +1,7 @@
+import { withTheme } from '@rjsf/core';
+// eslint-disable-next-line no-restricted-imports
+import { Theme as MaterialUITheme } from '@rjsf/mui';
+
+const RJSFProvider = withTheme(MaterialUITheme);
+
+export default RJSFProvider;


### PR DESCRIPTION
## Summary

Introduces `ui/components/shared/FormFields/RJSFProvider.tsx` as the single app-level boundary for the `@rjsf/mui` adapter, and migrates `ui/components/MesheryMeshInterface/PatternService/RJSF.tsx` to consume the shared provider instead of importing `@rjsf/mui` directly.

This is a Phase 2 sub-issue of the broader UI restructure (#18657) — centralizing the RJSF MUI adapter wiring so the future MUI elimination work has exactly one wrapper to swap, and so the Phase 1 `no-restricted-imports` ESLint guardrail can keep the boundary closed.

This PR is a **takeover** of #18818 by community contributor @rishiraj38 — their original commit is preserved (Author: Rishi Raj) and credited via a `Co-authored-by` trailer. Thank you @rishiraj38 for the foundation work.

## Changes

- **New:** `ui/components/shared/FormFields/RJSFProvider.tsx` — wraps `withTheme(MaterialUITheme)` from `@rjsf/core` + `@rjsf/mui`. The only file in app code that imports `@rjsf/mui` (with a single targeted `eslint-disable-next-line no-restricted-imports`).
- **Migrated:** `ui/components/MesheryMeshInterface/PatternService/RJSF.tsx` now imports the shared `RJSFProvider` and uses it in place of the locally-constructed `MuiRJSFForm`.
- No behavioral change — same `withTheme(MaterialUITheme)` composition, same props, same `ThemeProvider` wrapping.
- `@rjsf/mui` remains in `package.json` per the sub-issue scope ("Keep package dependencies in place until the final cleanup issue for this phase").
- RJSFCustomComponents under `ui/components/MesheryMeshInterface/PatternService/RJSFCustomComponents/` were intentionally not touched — that is the scope of #18729 — and none of them currently import `@rjsf/mui` directly.

## Verification

- Acceptance audit: `rg "@rjsf/mui" ui --glob '*.{ts,tsx}'` returns exactly one match: `ui/components/shared/FormFields/RJSFProvider.tsx`.
- `npm run lint` — clean (no new warnings or errors).
- `npm run audit:mui` — informational audit script (Phase 1 #19298) ran cleanly; the only rjsf/mui-importing file under `components/` is the shared wrapper.
- `npm run audit:hex` — informational audit script ran cleanly; this PR introduces no new hex/rgb literals.
- `npm run build` — production build succeeded (Next.js 16.2.5, all 18 pages compiled and exported).

Note: `ui/remote-component.config.js` (a JS runtime resolver for federated extension plugins) still exposes `@rjsf/mui` as a shared runtime module so loaded extensions continue to deduplicate against the host. This is not an app-level import and lives outside the `.{ts,tsx}` glob in the acceptance criteria; it is intentionally retained until the final cleanup issue.

## Test plan

- [ ] Pattern Service form flows still render correctly via the shared provider (smoke-test the pattern configurator, the form-driven service editor, and the design-import dialog).
- [ ] No console errors or theme regressions in the RJSF-driven forms.
- [ ] CI: `audit:mui`, `audit:hex`, ESLint, build, and unit tests all pass.

Fixes #18727
Refs #18657, #18654

Credit: @rishiraj38 — original PR #18818