### PR TITLE
[UI] Phase 2: Drop direct MUI imports from workspace/lifecycle surfaces (#18734)

### DIFF
--- a/ui/components/Lifecycle/Environments/environment-card.tsx
+++ b/ui/components/Lifecycle/Environments/environment-card.tsx
@@ -1,11 +1,9 @@
 import React from 'react';
-import SyncAltIcon from '@mui/icons-material/SyncAlt';
-import { Delete, Edit } from '@mui/icons-material';
 import { FlipCard } from '../General';
 import { useGetEnvironmentConnectionsQuery } from '../../../rtk-query/environments';
 import CAN from '@/utils/can';
 import { keys } from '@/utils/permission_constants';
-import { Grid2, useTheme } from '@sistent/sistent';
+import { DeleteIcon, EditIcon, Grid2, SyncAltIcon, useTheme } from '@sistent/sistent';
 
 import {
   Name,
@@ -38,12 +36,12 @@ export const TransferButton = ({ title, count, onAssign, disabled }) => {
         <TabCount>{count}</TabCount>
         <TabTitle>{title}</TabTitle>
         <SyncAltIcon
-          sx={{
+          style={{
             position: 'absolute',
             top: '10px',
             right: '10px',
-            color: theme.palette.background?.neutral?.default,
           }}
+          fill={theme.palette.background?.neutral?.default}
         />
       </Grid2>
     </PopupButton>
@@ -230,7 +228,7 @@ const EnvironmentCard = ({
                       : !CAN(keys.EDIT_ENVIRONMENT.action, keys.EDIT_ENVIRONMENT.subject)
                   }
                 >
-                  <Edit sx={{ color: 'white', margin: '0 2px' }} />
+                  <EditIcon fill="white" style={{ margin: '0 2px' }} />
                 </IconButton>
                 <IconButton
                   onClick={onDelete}
@@ -240,7 +238,7 @@ const EnvironmentCard = ({
                       : !CAN(keys.DELETE_ENVIRONMENT.action, keys.DELETE_ENVIRONMENT.subject)
                   }
                 >
-                  <Delete sx={{ color: 'white', margin: '0 2px' }} />
+                  <DeleteIcon fill="white" style={{ margin: '0 2px' }} />
                 </IconButton>
               </Grid2>
             </Grid2>

--- a/ui/components/Lifecycle/Environments/index.tsx
+++ b/ui/components/Lifecycle/Environments/index.tsx
@@ -1,11 +1,14 @@
 import { useEffect, useRef, useState } from 'react';
-import ChevronLeftIcon from '@mui/icons-material/ChevronLeft';
-import ChevronRightIcon from '@mui/icons-material/ChevronRight';
-import { Pagination, PaginationItem } from '@sistent/sistent';
+import {
+  ChevronLeft,
+  ChevronRight,
+  DeleteIcon,
+  NoSsr,
+  Pagination,
+  PaginationItem,
+} from '@sistent/sistent';
 import { withRouter } from 'next/router';
 import { debounce } from 'lodash';
-import { Delete } from '@mui/icons-material';
-import { NoSsr } from '@sistent/sistent';
 import { CreateButtonWrapper, BulkActionWrapper } from './styles';
 import { ToolWrapper } from '@/assets/styles/general/tool.styles';
 import AddIconCircleBorder from '../../../assets/icons/AddIconCircleBorder';
@@ -489,16 +492,15 @@ const Environments = () => {
                   ? `${selectedEnvironments.length} environments selected`
                   : `${selectedEnvironments.length} environment selected`}
               </Typography>
-              <Button>
-                <Delete
-                  sx={{ color: 'red', margin: '0 2px' }}
-                  onClick={handleBulkDeleteEnvironmentConfirm}
-                  disabled={
-                    selectedEnvironments.length > 0
-                      ? !CAN(keys.DELETE_ENVIRONMENT.action, keys.DELETE_ENVIRONMENT.subject)
-                      : true
-                  }
-                />
+              <Button
+                onClick={handleBulkDeleteEnvironmentConfirm}
+                disabled={
+                  selectedEnvironments.length > 0
+                    ? !CAN(keys.DELETE_ENVIRONMENT.action, keys.DELETE_ENVIRONMENT.subject)
+                    : true
+                }
+              >
+                <DeleteIcon fill="red" style={{ margin: '0 2px' }} />
               </Button>
             </BulkActionWrapper>
           )}
@@ -534,7 +536,7 @@ const Environments = () => {
                   boundaryCount={3}
                   renderItem={(item) => (
                     <PaginationItem
-                      slots={{ previous: ChevronLeftIcon, next: ChevronRightIcon }}
+                      slots={{ previous: ChevronLeft, next: ChevronRight }}
                       {...item}
                     />
                   )}

--- a/ui/components/Lifecycle/Workspaces/WorkspaceGridView.tsx
+++ b/ui/components/Lifecycle/Workspaces/WorkspaceGridView.tsx
@@ -1,5 +1,7 @@
 import React, { useState } from 'react';
 import {
+  ChevronLeft,
+  ChevronRight,
   Grid2,
   L5DeleteIcon,
   Modal,
@@ -12,8 +14,6 @@ import {
   useTheme,
   ErrorBoundary,
 } from '@sistent/sistent';
-import ChevronLeftIcon from '@mui/icons-material/ChevronLeft';
-import ChevronRightIcon from '@mui/icons-material/ChevronRight';
 import { useDeleteWorkspaceMutation } from '../../../rtk-query/workspace';
 import { keys } from '@/utils/permission_constants';
 import CAN from '@/utils/can';
@@ -128,10 +128,7 @@ const WorkspaceGridView = ({
           onChange={debounce((_, page) => setPage(page - 1), 150)}
           boundaryCount={3}
           renderItem={(item) => (
-            <PaginationItem
-              slots={{ previous: ChevronLeftIcon, next: ChevronRightIcon }}
-              {...item}
-            />
+            <PaginationItem slots={{ previous: ChevronLeft, next: ChevronRight }} {...item} />
           )}
         />
       </Grid2>

--- a/ui/components/SpacesSwitcher/MainDesignsContent.tsx
+++ b/ui/components/SpacesSwitcher/MainDesignsContent.tsx
@@ -1,20 +1,21 @@
 import { getDesign, useUpdatePatternFileMutation } from '@/rtk-query/design';
 import { getUserAccessToken, getUserProfile, useGetLoggedInUserQuery } from '@/rtk-query/user';
 import {
+  DeleteIcon,
+  Divider,
+  ExportIcon,
+  InfoIcon,
   ListItem,
   ListItemText,
-  Divider,
-  PromptComponent,
-  OutlinedPatternIcon,
-  useModal,
+  MergeOutlinedIcon,
   Modal,
+  OutlinedPatternIcon,
+  PromptComponent,
   ShareIcon,
-  useTheme,
-  useRoomActivity,
-  ExportIcon,
-  DeleteIcon,
-  InfoIcon,
   WorkspaceContentMoveModal,
+  useModal,
+  useRoomActivity,
+  useTheme,
 } from '@sistent/sistent';
 import React, { useCallback, useContext, useRef, useState } from 'react';
 import DesignViewListItem, { DesignViewListItemSkeleton } from './DesignViewListItem';
@@ -48,7 +49,6 @@ import {
   useGetWorkspacesQuery,
 } from '@/rtk-query/workspace';
 import { useNotification } from '@/utils/hooks/useNotification';
-import { MergeOutlined } from '@mui/icons-material';
 
 const MainDesignsContent = ({
   page,
@@ -173,7 +173,7 @@ const MainDesignsContent = ({
     MERGE_DESIGN: {
       id: 'merge_design',
       title: 'Merge Into Current Design',
-      icon: <MergeOutlined fill={theme.palette.icon.default} />,
+      icon: <MergeOutlinedIcon fill={theme.palette.icon.default} />,
       enabled: () =>
         isDesignOpenInKanvas() && CAN(keys.EDIT_DESIGN.action, keys.EDIT_DESIGN.subject),
     },

--- a/ui/components/SpacesSwitcher/WorkspaceModal.tsx
+++ b/ui/components/SpacesSwitcher/WorkspaceModal.tsx
@@ -1,27 +1,28 @@
 import React, { useContext, useState, useEffect } from 'react';
 import {
-  ModalBody,
-  useTheme,
-  WorkspaceIcon,
-  List,
+  AccessTimeFilledIcon,
+  Box,
+  ChevronLeft,
+  ChevronRight,
+  CustomTooltip,
+  DesignIcon,
+  Divider,
+  ErrorBoundary,
   IconButton,
+  List,
   ListItem,
   ListItemButton,
   ListItemIcon,
   ListItemText,
-  Box,
-  DesignIcon,
+  ModalBody,
+  PeopleIcon,
   ViewIcon,
+  WorkspaceIcon,
   useMediaQuery,
-  Divider,
-  ErrorBoundary,
-  CustomTooltip,
+  useTheme,
 } from '@sistent/sistent';
 import { WorkspacesComponent } from '../Lifecycle';
 import { iconMedium, iconSmall } from 'css/icons.styles';
-import ChevronLeftIcon from '@mui/icons-material/ChevronLeft';
-import ChevronRightIcon from '@mui/icons-material/ChevronRight';
-import AccessTimeFilledIcon from '@mui/icons-material/AccessTimeFilled';
 import MyViewsContent from './MyViewsContent';
 import MyDesignsContent from './MyDesignsContent';
 import RecentContent from './RecentContent';
@@ -29,7 +30,6 @@ import { useGetWorkspacesQuery } from '../../rtk-query/workspace';
 import { DrawerHeader, StyledDrawer, StyledMainContent, StyledModal } from './styles';
 import WorkspaceContent from './WorkspaceContent';
 import { useGetProviderCapabilitiesQuery, useGetSelectedOrganization } from '@/rtk-query/user';
-import PeopleIcon from '@mui/icons-material/People';
 import SharedContent from './SharedContent';
 import CAN from '@/utils/can';
 import { keys } from '@/utils/permission_constants';
@@ -348,7 +348,7 @@ const Navigation = ({ setHeaderInfo }) => {
 
           <DrawerHeader open={open}>
             <IconButton onClick={handleDrawerToggle}>
-              {open ? <ChevronLeftIcon /> : <ChevronRightIcon />}
+              {open ? <ChevronLeft /> : <ChevronRight />}
             </IconButton>
           </DrawerHeader>
         </StyledDrawer>

--- a/ui/components/SpacesSwitcher/components.tsx
+++ b/ui/components/SpacesSwitcher/components.tsx
@@ -5,35 +5,35 @@ import {
   Button,
   Checkbox,
   CircularProgress,
+  CloseIcon,
+  DeleteIcon,
+  ExportIcon,
+  FileUploadIcon,
   FormControl,
+  FormControlLabel,
+  FormGroup,
+  Grid2,
+  IconButton,
   InputLabel,
   ListItemText,
   MenuItem,
+  OutlinedInput,
+  PersonIcon,
   Select,
+  SettingsIcon,
+  ShareIcon,
   TextField,
   Typography,
-  Grid2,
   useTheme,
-  PersonIcon,
-  OutlinedInput,
-  FormControlLabel,
-  FormGroup,
-  DeleteIcon,
-  ShareIcon,
-  ExportIcon,
-  IconButton,
-  CloseIcon,
 } from '@sistent/sistent';
 import React, { useContext, useState } from 'react';
 import { capitalize } from 'lodash/fp';
 import { getAllUsers } from '@/rtk-query/user';
-import { FileUpload } from '@mui/icons-material';
 import { ImportDesignModal } from '../MesheryPatterns/MesheryPatterns';
 import { useNotification } from '@/utils/hooks/useNotification';
 import { getUnit8ArrayDecodedFile } from '@/utils/utils';
 import { EVENT_TYPES } from 'lib/event-types';
 import { useImportPatternMutation } from '@/rtk-query/design';
-import SettingsIcon from '@mui/icons-material/Settings';
 import { updateProgress } from '@/store/slices/mesheryUi';
 import { WorkspaceModalContext } from '@/utils/context/WorkspaceModalContextProvider';
 import { useAssignDesignToWorkspaceMutation } from '@/rtk-query/workspace';
@@ -395,7 +395,7 @@ export const ImportButton = ({ workspaceId, disabled = false, refetch }) => {
           padding: '0.85rem !important',
           width: '100%',
         }}
-        startIcon={<FileUpload color={theme.palette.common.white} />}
+        startIcon={<FileUploadIcon fill={theme.palette.common.white} />}
       >
         <Box sx={{ display: { xs: 'none', sm: 'block' } }}>Import</Box>
       </StyledResponsiveButton>

--- a/ui/components/UserPreferences/index.tsx
+++ b/ui/components/UserPreferences/index.tsx
@@ -13,6 +13,8 @@ import {
   CustomTooltip,
   NoSsr,
   TachometerIcon,
+  SettingsCellIcon,
+  SettingsRemoteIcon,
   useTheme,
   ErrorBoundary,
 } from '@sistent/sistent';
@@ -35,8 +37,6 @@ import {
   FormContainerWrapper,
   FormGroupWrapper,
 } from './style';
-import SettingsRemoteIcon from '@mui/icons-material/SettingsRemote';
-import SettingsCellIcon from '@mui/icons-material/SettingsCell';
 import ExtensionSandbox from '../ExtensionSandbox';
 import RemoteComponent from '../RemoteComponent';
 import ExtensionPointSchemaValidator from '../../utils/ExtensionPointSchemaValidator';


### PR DESCRIPTION
## Summary

Closes #18734. Removes direct `@mui/*` imports from the workspace switching, workspace management, environment management, and user-preference surfaces, replacing them with `@sistent/sistent` typed-SVG equivalents.

## Scope

Files touched:
- `ui/components/SpacesSwitcher/WorkspaceModal.tsx`
- `ui/components/SpacesSwitcher/MainDesignsContent.tsx`
- `ui/components/SpacesSwitcher/components.tsx`
- `ui/components/Lifecycle/Workspaces/WorkspaceGridView.tsx`
- `ui/components/Lifecycle/Environments/index.tsx`
- `ui/components/Lifecycle/Environments/environment-card.tsx`
- `ui/components/UserPreferences/index.tsx`

## Icon mappings (all from `@sistent/sistent`)

| Was | Now |
| --- | --- |
| `ChevronLeftIcon` (`@mui/icons-material/ChevronLeft`) | `ChevronLeft` |
| `ChevronRightIcon` (`@mui/icons-material/ChevronRight`) | `ChevronRight` |
| `AccessTimeFilledIcon` (`@mui/icons-material/AccessTimeFilled`) | `AccessTimeFilledIcon` |
| `PeopleIcon` (`@mui/icons-material/People`) | `PeopleIcon` |
| `SettingsIcon` (`@mui/icons-material/Settings`) | `SettingsIcon` |
| `SettingsRemoteIcon` (`@mui/icons-material/SettingsRemote`) | `SettingsRemoteIcon` |
| `SettingsCellIcon` (`@mui/icons-material/SettingsCell`) | `SettingsCellIcon` |
| `SyncAltIcon` (`@mui/icons-material/SyncAlt`) | `SyncAltIcon` |
| `FileUpload` (`@mui/icons-material`) | `FileUploadIcon` |
| `MergeOutlined` (`@mui/icons-material`) | `MergeOutlinedIcon` |
| `Delete` (`@mui/icons-material`) | `DeleteIcon` |
| `Edit` (`@mui/icons-material`) | `EditIcon` |

Sistent typed-SVG icons accept `width`, `height`, `fill`, and `style` (not `sx`). Where MUI icons previously used `sx={{ color }}`, this PR migrates those props to `fill` plus `style` for layout positioning. Behavior preserved; no UX redesign.

## Validation

- `node scripts/audit-mui.js` drops from **52 files / 137 matches** to **45 files / 121 matches**. None of the scoped files appear in the audit anymore.
- `npx eslint` clean on the touched files (0 errors / 0 warnings).
- `npx tsc --noEmit --skipLibCheck` clean.

## Phase 2 rules respected

- Sistent-only (no MUI imports in scoped files).
- No new color literals introduced; existing `fill="white"`/`fill="red"` are preserved from the original code (slated for token migration in later phases per parent #18657).
- No file size budget broken; no inline `style={{}}` introduced except where MUI's prior `sx` had to be downgraded to a typed-SVG-compatible prop.

Fixes #18734
Refs #18657, #18654