### PR TITLE
[UI] Phase 2: Consolidate Registry tree views behind shared TreeView (#18731)

### DIFF
--- a/ui/components/Settings/Registry/ComponentTree.tsx
+++ b/ui/components/Settings/Registry/ComponentTree.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { SimpleTreeView } from '@mui/x-tree-view/SimpleTreeView';
+import { SimpleTreeView } from '../../shared/TreeView';
 import { CircularProgress } from '@sistent/sistent';
 import { COMPONENTS } from '../../../constants/navigator';
 import MinusSquare from '../../../assets/icons/MinusSquare';

--- a/ui/components/Settings/Registry/MeshModel.style.ts
+++ b/ui/components/Settings/Registry/MeshModel.style.ts
@@ -1,6 +1,6 @@
 import React from 'react';
 import { styled, Button, alpha } from '@sistent/sistent';
-import { TreeItem, treeItemClasses } from '@mui/x-tree-view/TreeItem';
+import { TreeItem, treeItemClasses } from '../../shared/TreeView';
 
 export const DisableButton = styled(Button)(({ theme }) => ({
   '&.MuiButtonBase-root:disabled': {

--- a/ui/components/Settings/Registry/MesheryTreeViewModel.tsx
+++ b/ui/components/Settings/Registry/MesheryTreeViewModel.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { SimpleTreeView } from '@mui/x-tree-view/SimpleTreeView';
+import { SimpleTreeView } from '../../shared/TreeView';
 import { CircularProgress, Box } from '@sistent/sistent';
 import MinusSquare from '../../../assets/icons/MinusSquare';
 import PlusSquare from '../../../assets/icons/PlusSquare';

--- a/ui/components/Settings/Registry/MesheryTreeViewRegistrants.tsx
+++ b/ui/components/Settings/Registry/MesheryTreeViewRegistrants.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { SimpleTreeView } from '@mui/x-tree-view/SimpleTreeView';
+import { SimpleTreeView } from '../../shared/TreeView';
 import { CircularProgress } from '@sistent/sistent';
 import { REGISTRANTS } from '@/constants/navigator';
 import MinusSquare from '../../../assets/icons/MinusSquare';

--- a/ui/components/Settings/Registry/RelationshipTree.tsx
+++ b/ui/components/Settings/Registry/RelationshipTree.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { SimpleTreeView } from '@mui/x-tree-view/SimpleTreeView';
+import { SimpleTreeView } from '../../shared/TreeView';
 import { CircularProgress } from '@sistent/sistent';
 import { RELATIONSHIPS } from '@/constants/navigator';
 import MinusSquare from '../../../assets/icons/MinusSquare';

--- a/ui/components/shared/TreeView/TreeView.tsx
+++ b/ui/components/shared/TreeView/TreeView.tsx
@@ -1,0 +1,21 @@
+/**
+ * Shared TreeView wrapper.
+ *
+ * This module is the single application-level boundary for `@mui/x-tree-view`.
+ * All app code MUST consume tree-view primitives from `ui/components/shared/TreeView`
+ * rather than importing `@mui/x-tree-view` directly. The ESLint rule
+ * `no-restricted-imports` enforces this boundary; the only intentional escape
+ * hatch is this file.
+ *
+ * Re-exports the primitives currently used by the Registry surfaces. Add more
+ * primitives here (e.g. `RichTreeView`, `TreeView`) on an as-needed basis;
+ * keep the surface intentionally small.
+ */
+/* eslint-disable no-restricted-imports */
+export { SimpleTreeView, TreeItem, treeItemClasses } from '@mui/x-tree-view';
+export type {
+  SimpleTreeViewProps,
+  SimpleTreeViewSlots,
+  SimpleTreeViewSlotProps,
+} from '@mui/x-tree-view/SimpleTreeView';
+export type { TreeItemProps } from '@mui/x-tree-view/TreeItem';

--- a/ui/components/shared/TreeView/index.tsx
+++ b/ui/components/shared/TreeView/index.tsx
@@ -1,0 +1,4 @@
+// eslint-disable-next-line no-restricted-imports
+export { SimpleTreeView } from '@mui/x-tree-view/SimpleTreeView';
+// eslint-disable-next-line no-restricted-imports
+export { TreeItem, treeItemClasses } from '@mui/x-tree-view/TreeItem';

--- a/ui/components/shared/TreeView/index.tsx
+++ b/ui/components/shared/TreeView/index.tsx
@@ -1,2 +1,4 @@
-/* eslint-disable no-restricted-imports */
-export { SimpleTreeView, TreeItem, treeItemClasses } from '@mui/x-tree-view';
+// Re-export the shared TreeView wrapper from its discoverable filename so
+// `import { SimpleTreeView } from '../../shared/TreeView'` continues to resolve.
+// The actual `@mui/x-tree-view` boundary lives in `./TreeView.tsx`.
+export * from './TreeView';

--- a/ui/components/shared/TreeView/index.tsx
+++ b/ui/components/shared/TreeView/index.tsx
@@ -1,4 +1,2 @@
-// eslint-disable-next-line no-restricted-imports
-export { SimpleTreeView } from '@mui/x-tree-view/SimpleTreeView';
-// eslint-disable-next-line no-restricted-imports
-export { TreeItem, treeItemClasses } from '@mui/x-tree-view/TreeItem';
+/* eslint-disable no-restricted-imports */
+export { SimpleTreeView, TreeItem, treeItemClasses } from '@mui/x-tree-view';


### PR DESCRIPTION
## Summary

Consolidates all `@mui/x-tree-view` usage in the Registry feature behind a single shared wrapper at `ui/components/shared/TreeView/`, satisfying the Phase 2 binding rule from #18657 that primitives are wrapped before app code consumes them. After this change, `rg \"@mui/x-tree-view\" ui --glob '*.{ts,tsx}'` only matches the wrapper itself.

Carries forward @rishiraj38's foundation work from #18819 via cherry-pick + `Co-authored-by`, then adds a small follow-up that splits the wrapper into a discoverable filename (`TreeView.tsx`) so the `index.tsx`-only constraint from the Phase 2 binding rules is honored.

Fixes #18731
Refs #18657, #18654

## Changes

**New: `ui/components/shared/TreeView/`** — the single app-level boundary for `@mui/x-tree-view`.
- `TreeView.tsx` — re-exports `SimpleTreeView`, `TreeItem`, `treeItemClasses` and surfaces the corresponding types. Uses `/* eslint-disable no-restricted-imports */` so it is the only file allowed to import `@mui/x-tree-view` directly.
- `index.tsx` — small barrel that re-exports from `./TreeView` so consumer paths like `import { SimpleTreeView } from '../../shared/TreeView'` keep working.

**Migrated Registry surfaces** (now import from `'../../shared/TreeView'`):
- `ui/components/Settings/Registry/ComponentTree.tsx`
- `ui/components/Settings/Registry/MesheryTreeViewModel.tsx`
- `ui/components/Settings/Registry/MesheryTreeViewRegistrants.tsx`
- `ui/components/Settings/Registry/RelationshipTree.tsx`
- `ui/components/Settings/Registry/MeshModel.style.ts`

## Verification

- `rg \"@mui/x-tree-view\" ui --glob '*.{ts,tsx}'` only matches `ui/components/shared/TreeView/TreeView.tsx` (the wrapper boundary itself) and the docstring inside `TreeView.tsx`/`index.tsx`. No Registry file imports `@mui/x-tree-view` directly anymore.
- `npm run lint` — clean.
- `npm run audit:mui` — clean (informational audit).
- `tsc --noEmit` — clean.

## Credit

Foundation work by @rishiraj38 in #18819 (commits `f6ee39f` and `8fc7936f`) is preserved via cherry-pick with sign-off and carried forward via `Co-authored-by` trailers. Once this PR merges, #18819 will be closed in favor of this one.

## Coordination

#18735 also migrates Registry files. Landing this PR first means #18735 can consume the shared wrapper without rewriting these same files.