### PR TITLE
[UI] Phase 2: Drop direct MUI imports from header/modal/notification surfaces (#18733)

### DIFF
--- a/ui/components/Header.tsx
+++ b/ui/components/Header.tsx
@@ -2,7 +2,6 @@ import React, { useState, useEffect, useContext, useMemo } from 'react';
 import PropTypes from 'prop-types';
 import { NotificationDrawerButton } from './NotificationCenter';
 import User from './User';
-import { Search } from '@mui/icons-material';
 import { successHandlerGenerator, errorHandlerGenerator } from '../utils/helpers/common';
 import { ConnectionChip } from './connections/ConnectionChip';
 import { useLazyGetSystemSyncQuery } from '../rtk-query/system';
@@ -15,7 +14,6 @@ import RemoteComponent from './RemoteComponent';
 import { useNotification } from '../utils/hooks/useNotification';
 import useKubernetesHook, { useControllerStatus } from './hooks/useKubernetesHook';
 import { formatToTitleCase } from '../utils/utils';
-import SettingsIcon from '@mui/icons-material/Settings';
 import RegistryModal from './Registry/RegistryModal';
 
 import {
@@ -34,6 +32,8 @@ import {
   NoSsr,
   useTheme,
   useMediaQuery,
+  SearchIcon,
+  SettingsIcon,
 } from '@sistent/sistent';
 import { CanShow } from '@/utils/can';
 import { keys } from '@/utils/permission_constants';
@@ -349,7 +349,7 @@ function K8sContextMenu({
                         margin: '1px 0px',
                       }}
                       InputProps={{
-                        endAdornment: <Search style={iconMedium} width={24} />,
+                        endAdornment: <SearchIcon style={iconMedium} width={24} />,
                       }}
                     />
                   </div>

--- a/ui/components/NotificationCenter/formatters/common.tsx
+++ b/ui/components/NotificationCenter/formatters/common.tsx
@@ -1,6 +1,5 @@
 import React from 'react';
-import { Typography } from '@sistent/sistent';
-import { Launch as LaunchIcon } from '@mui/icons-material';
+import { LaunchIcon, Typography } from '@sistent/sistent';
 import { TextWithLinks } from '../../DataFormatter';
 
 type TitleLinkProps = {

--- a/ui/components/NotificationCenter/index.tsx
+++ b/ui/components/NotificationCenter/index.tsx
@@ -1,6 +1,7 @@
 import React, { useContext, useEffect, useRef, useState } from 'react';
 import { CustomTooltip, NoSsr } from '@sistent/sistent';
 import {
+  alpha,
   Divider,
   ClickAwayListener,
   Typography,
@@ -64,7 +65,6 @@ import { operationsCenterActor } from 'machines/operationsCenter';
 import { useDispatch, useSelector } from 'react-redux';
 import { ErrorBoundary } from '@sistent/sistent';
 import CustomErrorFallback from '../General/ErrorBoundary';
-import { alpha } from '@mui/system';
 
 export const NotificationCenterContext = React.createContext({
   drawerAnchorEl: null,

--- a/ui/components/NotificationCenter/notificationCenter.style.tsx
+++ b/ui/components/NotificationCenter/notificationCenter.style.tsx
@@ -1,5 +1,14 @@
-import { Badge, Box, Button, Drawer, Grid, IconButton, Typography, styled } from '@sistent/sistent';
-import { alpha } from '@mui/system';
+import {
+  alpha,
+  Badge,
+  Box,
+  Button,
+  Drawer,
+  Grid,
+  IconButton,
+  Typography,
+  styled,
+} from '@sistent/sistent';
 import { STATUS } from './constants';
 
 export const DarkBackdrop = styled('div')(({ open }) => ({


### PR DESCRIPTION
## Summary

Phase 2 sub-issue [#18733](https://github.com/meshery/meshery/issues/18733) of the UI restructure (parent [#18657](https://github.com/meshery/meshery/issues/18657)). Removes the last direct `@mui/*` imports from header and notification surfaces in favor of `@sistent/sistent` re-exports.

No behavior changes — only import sources move from `@mui/*` to `@sistent/sistent`.

## Changes

- `ui/components/Header.tsx`: replace `Search` and `SettingsIcon` from `@mui/icons-material` with `SearchIcon` and `SettingsIcon` from `@sistent/sistent`; rename the `<Search />` JSX usage to `<SearchIcon />`.
- `ui/components/NotificationCenter/index.tsx` and `ui/components/NotificationCenter/notificationCenter.style.tsx`: source `alpha` from `@sistent/sistent` (already re-exported) instead of `@mui/system`.
- `ui/components/NotificationCenter/formatters/common.tsx`: source `LaunchIcon` from `@sistent/sistent` instead of `@mui/icons-material`.

`HeaderMenu.tsx`, `General/**`, and `TroubleshootingModalComponent.tsx` were already free of direct `@mui/*` imports — they remain untouched.

Package dependencies on `@mui/*` stay in place per parent issue guidance; final cleanup is tracked elsewhere in Phase 2.

## Verification

- `rg "@mui" ui/components/Header.tsx ui/components/HeaderMenu.tsx ui/components/General ui/components/NotificationCenter ui/components/TroubleshootingModalComponent.tsx` returns no matches.
- `npx eslint --ext .ts,.tsx components/Header.tsx components/NotificationCenter components/HeaderMenu.tsx components/General components/TroubleshootingModalComponent.tsx` is clean.
- `npx tsc --noEmit -p .` is clean.
- `node scripts/audit-mui.js` shows none of the scoped files in the offender list (overall count unchanged outside scope).
- All scoped files remain under the 600-line soft budget.

## Test plan

- [ ] Header renders with Kubernetes context menu, search input shows `SearchIcon`.
- [ ] Notifications drawer opens; severity chips and bulk actions behave normally.
- [ ] Launch icon renders in notification-format `TitleLink` (e.g., "Download Trace").
- [ ] Settings icon button in K8s context menu still opens the Connection modal.

## Coordination

- `Header.tsx` is also touched by [#19021](https://github.com/meshery/meshery/pull/19021) (app shell, [#18738](https://github.com/meshery/meshery/issues/18738)) — that PR adds different changes, so a rebase may be needed depending on merge order. The conflict surface here is the import block at the top of `Header.tsx`.

Fixes #18733
Refs #18657, #18654