### PR TITLE
[UI] Phase 2: Typed SVG icon library for repeated MUI icons (#18730)

### DIFF
--- a/ui/assets/icons/ArrowDropDownIcon.tsx
+++ b/ui/assets/icons/ArrowDropDownIcon.tsx
@@ -1,0 +1,27 @@
+import React from 'react';
+import type { IconProps } from './types';
+
+/**
+ * ArrowDropDownIcon — typed SVG replacement for `@mui/icons-material/ArrowDropDown`.
+ *
+ * Material Icons triangular-caret glyph, viewBox 0 0 24 24.
+ */
+export const ArrowDropDownIcon: React.FC<IconProps> = ({
+  width = 24,
+  height = 24,
+  fill = 'currentColor',
+  ...props
+}) => (
+  <svg
+    xmlns="http://www.w3.org/2000/svg"
+    width={width}
+    height={height}
+    viewBox="0 0 24 24"
+    fill={fill}
+    {...props}
+  >
+    <path d="M7 10l5 5 5-5z" />
+  </svg>
+);
+
+export default ArrowDropDownIcon;

--- a/ui/assets/icons/ChevronLeftIcon.tsx
+++ b/ui/assets/icons/ChevronLeftIcon.tsx
@@ -1,0 +1,29 @@
+import React from 'react';
+import type { IconProps } from './types';
+
+/**
+ * ChevronLeftIcon — typed SVG replacement for `@mui/icons-material/ChevronLeft`.
+ *
+ * Material Icons single-stroke chevron pointing left, viewBox 0 0 24 24.
+ * Note: this is distinct from the existing `LeftArrowIcon` (thicker
+ * double-stroke style) and from the unrelated `chevron_right.tsx` glyph.
+ */
+export const ChevronLeftIcon: React.FC<IconProps> = ({
+  width = 24,
+  height = 24,
+  fill = 'currentColor',
+  ...props
+}) => (
+  <svg
+    xmlns="http://www.w3.org/2000/svg"
+    width={width}
+    height={height}
+    viewBox="0 0 24 24"
+    fill={fill}
+    {...props}
+  >
+    <path d="M15.41 7.41L14 6l-6 6 6 6 1.41-1.41L10.83 12z" />
+  </svg>
+);
+
+export default ChevronLeftIcon;

--- a/ui/assets/icons/ChevronRightIcon.tsx
+++ b/ui/assets/icons/ChevronRightIcon.tsx
@@ -1,0 +1,29 @@
+import React from 'react';
+import type { IconProps } from './types';
+
+/**
+ * ChevronRightIcon — typed SVG replacement for `@mui/icons-material/ChevronRight`.
+ *
+ * Material Icons single-stroke chevron pointing right, viewBox 0 0 24 24.
+ * Note: this is distinct from the existing `RightArrowIcon` (thicker
+ * double-stroke) and from the unrelated `chevron_right.tsx` glyph.
+ */
+export const ChevronRightIcon: React.FC<IconProps> = ({
+  width = 24,
+  height = 24,
+  fill = 'currentColor',
+  ...props
+}) => (
+  <svg
+    xmlns="http://www.w3.org/2000/svg"
+    width={width}
+    height={height}
+    viewBox="0 0 24 24"
+    fill={fill}
+    {...props}
+  >
+    <path d="M10 6L8.59 7.41 13.17 12l-4.58 4.59L10 18l6-6z" />
+  </svg>
+);
+
+export default ChevronRightIcon;

--- a/ui/assets/icons/EditIcon.tsx
+++ b/ui/assets/icons/EditIcon.tsx
@@ -1,0 +1,27 @@
+import React from 'react';
+import type { IconProps } from './types';
+
+/**
+ * EditIcon — typed SVG replacement for `@mui/icons-material/Edit`.
+ *
+ * Material Icons glyph (pencil), viewBox 0 0 24 24.
+ */
+export const EditIcon: React.FC<IconProps> = ({
+  width = 24,
+  height = 24,
+  fill = 'currentColor',
+  ...props
+}) => (
+  <svg
+    xmlns="http://www.w3.org/2000/svg"
+    width={width}
+    height={height}
+    viewBox="0 0 24 24"
+    fill={fill}
+    {...props}
+  >
+    <path d="M3 17.25V21h3.75L17.81 9.94l-3.75-3.75L3 17.25zM20.71 7.04a.996.996 0 0 0 0-1.41l-2.34-2.34a.996.996 0 0 0-1.41 0l-1.83 1.83 3.75 3.75 1.83-1.83z" />
+  </svg>
+);
+
+export default EditIcon;

--- a/ui/assets/icons/FullscreenExitIcon.tsx
+++ b/ui/assets/icons/FullscreenExitIcon.tsx
@@ -1,0 +1,27 @@
+import React from 'react';
+import type { IconProps } from './types';
+
+/**
+ * FullscreenExitIcon — typed SVG replacement for `@mui/icons-material/FullscreenExit`.
+ *
+ * Material Icons exit-fullscreen glyph, viewBox 0 0 24 24.
+ */
+export const FullscreenExitIcon: React.FC<IconProps> = ({
+  width = 24,
+  height = 24,
+  fill = 'currentColor',
+  ...props
+}) => (
+  <svg
+    xmlns="http://www.w3.org/2000/svg"
+    width={width}
+    height={height}
+    viewBox="0 0 24 24"
+    fill={fill}
+    {...props}
+  >
+    <path d="M5 16h3v3h2v-5H5v2zm3-8H5v2h5V5H8v3zm6 11h2v-3h3v-2h-5v5zm2-11V5h-2v5h5V8h-3z" />
+  </svg>
+);
+
+export default FullscreenExitIcon;

--- a/ui/assets/icons/FullscreenIcon.tsx
+++ b/ui/assets/icons/FullscreenIcon.tsx
@@ -1,0 +1,27 @@
+import React from 'react';
+import type { IconProps } from './types';
+
+/**
+ * FullscreenIcon — typed SVG replacement for `@mui/icons-material/Fullscreen`.
+ *
+ * Material Icons enter-fullscreen glyph, viewBox 0 0 24 24.
+ */
+export const FullscreenIcon: React.FC<IconProps> = ({
+  width = 24,
+  height = 24,
+  fill = 'currentColor',
+  ...props
+}) => (
+  <svg
+    xmlns="http://www.w3.org/2000/svg"
+    width={width}
+    height={height}
+    viewBox="0 0 24 24"
+    fill={fill}
+    {...props}
+  >
+    <path d="M7 14H5v5h5v-2H7v-3zm-2-4h2V7h3V5H5v5zm12 7h-3v2h5v-5h-2v3zM14 5v2h3v3h2V5h-5z" />
+  </svg>
+);
+
+export default FullscreenIcon;

--- a/ui/assets/icons/GetAppIcon.tsx
+++ b/ui/assets/icons/GetAppIcon.tsx
@@ -1,0 +1,27 @@
+import React from 'react';
+import type { IconProps } from './types';
+
+/**
+ * GetAppIcon — typed SVG replacement for `@mui/icons-material/GetApp`.
+ *
+ * Material Icons download arrow glyph, viewBox 0 0 24 24.
+ */
+export const GetAppIcon: React.FC<IconProps> = ({
+  width = 24,
+  height = 24,
+  fill = 'currentColor',
+  ...props
+}) => (
+  <svg
+    xmlns="http://www.w3.org/2000/svg"
+    width={width}
+    height={height}
+    viewBox="0 0 24 24"
+    fill={fill}
+    {...props}
+  >
+    <path d="M19 9h-4V3H9v6H5l7 7 7-7zM5 18v2h14v-2H5z" />
+  </svg>
+);
+
+export default GetAppIcon;

--- a/ui/assets/icons/LockIcon.tsx
+++ b/ui/assets/icons/LockIcon.tsx
@@ -1,0 +1,27 @@
+import React from 'react';
+import type { IconProps } from './types';
+
+/**
+ * LockIcon — typed SVG replacement for `@mui/icons-material/Lock`.
+ *
+ * Material Icons padlock glyph, viewBox 0 0 24 24.
+ */
+export const LockIcon: React.FC<IconProps> = ({
+  width = 24,
+  height = 24,
+  fill = 'currentColor',
+  ...props
+}) => (
+  <svg
+    xmlns="http://www.w3.org/2000/svg"
+    width={width}
+    height={height}
+    viewBox="0 0 24 24"
+    fill={fill}
+    {...props}
+  >
+    <path d="M18 8h-1V6c0-2.76-2.24-5-5-5S7 3.24 7 6v2H6c-1.1 0-2 .9-2 2v10c0 1.1.9 2 2 2h12c1.1 0 2-.9 2-2V10c0-1.1-.9-2-2-2zm-6 9c-1.1 0-2-.9-2-2s.9-2 2-2 2 .9 2 2-.9 2-2 2zm3.1-9H8.9V6c0-1.71 1.39-3.1 3.1-3.1 1.71 0 3.1 1.39 3.1 3.1v2z" />
+  </svg>
+);
+
+export default LockIcon;

--- a/ui/assets/icons/SaveIcon.tsx
+++ b/ui/assets/icons/SaveIcon.tsx
@@ -1,0 +1,27 @@
+import React from 'react';
+import type { IconProps } from './types';
+
+/**
+ * SaveIcon — typed SVG replacement for `@mui/icons-material/Save`.
+ *
+ * Material Icons floppy-disk glyph, viewBox 0 0 24 24.
+ */
+export const SaveIcon: React.FC<IconProps> = ({
+  width = 24,
+  height = 24,
+  fill = 'currentColor',
+  ...props
+}) => (
+  <svg
+    xmlns="http://www.w3.org/2000/svg"
+    width={width}
+    height={height}
+    viewBox="0 0 24 24"
+    fill={fill}
+    {...props}
+  >
+    <path d="M17 3H5c-1.11 0-2 .9-2 2v14c0 1.1.89 2 2 2h14c1.1 0 2-.9 2-2V7l-4-4zm-5 16c-1.66 0-3-1.34-3-3s1.34-3 3-3 3 1.34 3 3-1.34 3-3 3zm3-10H5V5h10v4z" />
+  </svg>
+);
+
+export default SaveIcon;

--- a/ui/assets/icons/SettingsIcon.tsx
+++ b/ui/assets/icons/SettingsIcon.tsx
@@ -1,0 +1,29 @@
+import React from 'react';
+import type { IconProps } from './types';
+
+/**
+ * SettingsIcon — typed SVG replacement for `@mui/icons-material/Settings`.
+ *
+ * Material Icons gear glyph, viewBox 0 0 24 24.
+ * Note: this is the canonical gear; the existing `ConfigurationIcon.tsx`
+ * uses a different glyph and is retained for its existing call sites.
+ */
+export const SettingsIcon: React.FC<IconProps> = ({
+  width = 24,
+  height = 24,
+  fill = 'currentColor',
+  ...props
+}) => (
+  <svg
+    xmlns="http://www.w3.org/2000/svg"
+    width={width}
+    height={height}
+    viewBox="0 0 24 24"
+    fill={fill}
+    {...props}
+  >
+    <path d="M19.14 12.94c.04-.3.06-.61.06-.94 0-.32-.02-.64-.07-.94l2.03-1.58a.49.49 0 0 0 .12-.61l-1.92-3.32a.488.488 0 0 0-.59-.22l-2.39.96c-.5-.38-1.03-.7-1.62-.94l-.36-2.54a.484.484 0 0 0-.48-.41h-3.84c-.24 0-.43.17-.47.41l-.36 2.54c-.59.24-1.13.57-1.62.94l-2.39-.96c-.22-.08-.47 0-.59.22L2.74 8.87c-.12.21-.08.47.12.61l2.03 1.58c-.05.3-.09.63-.09.94 0 .31.02.64.07.94l-2.03 1.58a.49.49 0 0 0-.12.61l1.92 3.32c.12.22.37.29.59.22l2.39-.96c.5.38 1.03.7 1.62.94l.36 2.54c.05.24.24.41.48.41h3.84c.24 0 .44-.17.47-.41l.36-2.54c.59-.24 1.13-.56 1.62-.94l2.39.96c.22.08.47 0 .59-.22l1.92-3.32c.12-.22.07-.47-.12-.61l-2.01-1.58zM12 15.6c-1.98 0-3.6-1.62-3.6-3.6s1.62-3.6 3.6-3.6 3.6 1.62 3.6 3.6-1.62 3.6-3.6 3.6z" />
+  </svg>
+);
+
+export default SettingsIcon;

--- a/ui/assets/icons/index.ts
+++ b/ui/assets/icons/index.ts
@@ -1,0 +1,44 @@
+/**
+ * Barrel of typed SVG icons for Meshery UI.
+ *
+ * This file exposes the canonical, typed SVG replacements for repeated
+ * `@mui/icons-material` imports, as part of Phase 2 of the UI restructure
+ * (parent #18657, sub-issue #18730).
+ *
+ * Conventions:
+ *  - Each icon is a typed React functional component accepting `IconProps`
+ *    (standard SVG props plus optional `width`/`height`/`fill` overrides).
+ *  - `fill` defaults to `currentColor` so icons inherit color from CSS.
+ *  - Each module also provides a `default` export for ergonomic
+ *    `import EditIcon from '...'` consumption.
+ *
+ * Downstream sub-issues (#18733-#18740) will swap the corresponding
+ * `@mui/icons-material/<Name>` imports across the codebase to use these
+ * barrel exports (or Sistent equivalents where Sistent ships the glyph).
+ * This issue is purely additive — no call sites are modified here.
+ */
+
+export type { IconProps } from './types';
+
+// Typed SVG replacements added in #18730 for icons used >=3 times in `ui/`.
+export { ArrowDropDownIcon } from './ArrowDropDownIcon';
+export { ChevronLeftIcon } from './ChevronLeftIcon';
+export { ChevronRightIcon } from './ChevronRightIcon';
+export { EditIcon } from './EditIcon';
+export { FullscreenExitIcon } from './FullscreenExitIcon';
+export { FullscreenIcon } from './FullscreenIcon';
+export { GetAppIcon } from './GetAppIcon';
+export { LockIcon } from './LockIcon';
+export { SaveIcon } from './SaveIcon';
+export { SettingsIcon } from './SettingsIcon';
+
+// Pre-existing typed icons in `ui/assets/icons/` whose glyphs also appear
+// >=3 times via `@mui/icons-material`. Re-exported here so that downstream
+// migrations can import the entire canonical set from a single path.
+//
+// Note: these are intentionally re-exported as `default` since the source
+// files only provide default exports today. Renaming their source exports
+// is out of scope for this purely-additive issue.
+export { default as DeleteIcon } from './DeleteIcon';
+export { default as ExpandMoreIcon } from './ExpandMoreIcon';
+export { default as InfoOutlinedIcon } from './InfoOutlined';

--- a/ui/assets/icons/types.ts
+++ b/ui/assets/icons/types.ts
@@ -1,0 +1,15 @@
+import type { SVGProps } from 'react';
+
+/**
+ * Shared icon prop contract for typed SVG icons in `ui/assets/icons/`.
+ *
+ * Each icon accepts standard SVG element props plus convenience overrides
+ * for size and color. `fill` defaults to `currentColor` so that the icon
+ * inherits color from CSS (`color`) by default — matching MUI icon behavior
+ * and Sistent icon conventions.
+ */
+export type IconProps = Omit<SVGProps<SVGSVGElement>, 'width' | 'height' | 'fill'> & {
+  width?: number | string;
+  height?: number | string;
+  fill?: string;
+};


### PR DESCRIPTION
## Summary

Adds typed SVG components in `ui/assets/icons/` for every `@mui/icons-material` icon used in **3 or more** files across `ui/`. Exposes them through a new barrel at `ui/assets/icons/index.ts` along with a shared `IconProps` type.

This PR is **purely additive** — no existing call sites or icon files are modified. Downstream sub-issues (#18733-#18740) will swap the `@mui/icons-material/<Name>` imports across the codebase to use these typed components (or to Sistent equivalents where Sistent ships the glyph).

Closes #18730. Refs #18657, #18654.

## Inventory

Produced by parsing every default and named import of `@mui/icons-material` across `ui/` and counting unique files per icon name.

### New typed icons added in this PR

| Icon | MUI source | Files using it |
|---|---|---|
| `EditIcon` | `Edit` | 5 |
| `GetAppIcon` | `GetApp` | 5 |
| `SaveIcon` | `Save` | 5 |
| `ArrowDropDownIcon` | `ArrowDropDown` | 4 |
| `ChevronLeftIcon` | `ChevronLeft` | 4 |
| `ChevronRightIcon` | `ChevronRight` | 4 |
| `FullscreenIcon` | `Fullscreen` | 4 |
| `FullscreenExitIcon` | `FullscreenExit` | 4 |
| `LockIcon` | `Lock` | 3 |
| `SettingsIcon` | `Settings` | 3 |

### Already present in `ui/assets/icons/` (no duplicates; re-exported from the new barrel for discoverability)

| Icon | MUI source | Files |
|---|---|---|
| `DeleteIcon` | `Delete` | 9 |
| `ExpandMoreIcon` | `ExpandMore` | 4 |
| `InfoOutlinedIcon` | `InfoOutlined` | 5 |

### Shipped by Sistent — downstream issues will swap directly to Sistent (per binding rules, no local copy added)

| MUI source | Sistent export | Files |
|---|---|---|
| `Close` | `CloseIcon` | 3 |
| `Public` | `PublicIcon` | 4 |

### Icons used in only 1-2 files

Intentionally **left as-is**. Per the parent #18657 plan, downstream domain-specific sub-issues (#18733-#18740) will replace these directly with Sistent equivalents during their migrations — not promoted to local typed copies here.

## Conventions

- Each icon is a typed `React.FC<IconProps>` with both named and default exports for ergonomic adoption.
- `fill` defaults to `'currentColor'` so icons inherit color from CSS (`color`), matching MUI/Sistent conventions.
- Shared `IconProps` type lives in `ui/assets/icons/types.ts`:
  ```ts
  export type IconProps = Omit<SVGProps<SVGSVGElement>, 'width' | 'height' | 'fill'> & {
    width?: number | string;
    height?: number | string;
    fill?: string;
  };
  ```
- Barrel `ui/assets/icons/index.ts` exposes the canonical set as named exports.
- SVG paths come from the Material Icons (Apache 2.0) glyph set so the visual output matches the existing `@mui/icons-material` rendering pixel-for-pixel.

## Why this is safe to merge first

- No call sites changed; no existing icons removed or renamed.
- All new icons live in `ui/assets/icons/` only.
- Unblocks parallel work on #18733, #18734, #18735, #18736, #18738, #18739, #18740 with zero file conflicts.

## Test plan

- [x] `npm run lint` — clean
- [x] `npx tsc --noEmit` — clean (passes under `strictNullChecks`, `exactOptionalPropertyTypes`, and `verbatimModuleSyntax`)
- [x] Pre-commit (eslint --fix + prettier --write via lint-staged) — clean
- [x] No behavior change to verify at runtime (purely additive icon files)
- [ ] CI green on PR