### PR TITLE
[UI] Phase 2: Promote MesheryDateTimePicker into shared/DatePicker (#18728)

### DIFF
--- a/ui/components/shared/DatePicker/MesheryDateTimePicker.tsx
+++ b/ui/components/shared/DatePicker/MesheryDateTimePicker.tsx
@@ -1,5 +1,6 @@
 import React, { useState } from 'react';
 import { TextField } from '@sistent/sistent';
+// eslint-disable-next-line no-restricted-imports -- Central wrapper for @mui/x-date-pickers to satisfy UI guardrails.
 import { DateTimePicker } from '@mui/x-date-pickers/DateTimePicker';
 import moment, { Moment } from 'moment';
 

--- a/ui/components/shared/DatePicker/index.ts
+++ b/ui/components/shared/DatePicker/index.ts
@@ -1,3 +1,5 @@
-// eslint-disable-next-line no-restricted-imports -- Central wrapper for @mui/x-date-pickers to satisfy UI guardrails. Follow-up issue: [LINK_TO_ISSUE]
+// eslint-disable-next-line no-restricted-imports -- Central wrapper for @mui/x-date-pickers to satisfy UI guardrails. Tracked under #18728.
 export { LocalizationProvider } from '@mui/x-date-pickers/LocalizationProvider';
+// eslint-disable-next-line no-restricted-imports -- Central wrapper for @mui/x-date-pickers to satisfy UI guardrails. Tracked under #18728.
 export { AdapterMoment } from '@mui/x-date-pickers/AdapterMoment';
+export { default as MesheryDateTimePicker } from './MesheryDateTimePicker';

--- a/ui/components/telemetry/grafana/GrafanaDateRangePicker.tsx
+++ b/ui/components/telemetry/grafana/GrafanaDateRangePicker.tsx
@@ -18,7 +18,7 @@ import {
 import Moment from 'react-moment';
 import AccessTimeIcon from '@mui/icons-material/AccessTime';
 import PropTypes from 'prop-types';
-import MesheryDateTimePicker from '../../MesheryDateTimePicker';
+import { MesheryDateTimePicker } from '../../shared/DatePicker';
 import { Close } from '@mui/icons-material';
 
 const StyledDialog = styled(Dialog)(({ theme }) => ({

--- a/ui/eslint.config.js
+++ b/ui/eslint.config.js
@@ -45,7 +45,6 @@ const legacyRestrictedImportOffenders = [
   'components/Lifecycle/Workspaces/WorkspaceGridView.tsx',
   'components/MesheryAdapterPlayComponent.tsx',
   'components/MesheryChart.tsx',
-  'components/MesheryDateTimePicker.tsx',
   'components/MesheryMeshInterface/PatternService/RJSF.tsx',
   'components/MesheryMeshInterface/PatternService/RJSFCustomComponents/ArrayFieldTemlate.tsx',
   'components/MesheryMeshInterface/PatternService/RJSFCustomComponents/CustomFileWidget.tsx',


### PR DESCRIPTION
## Summary

Builds on the just-landed #19021 (which scaffolded `ui/components/shared/DatePicker/` and moved `LocalizationProvider`/`AdapterMoment` out of `pages/_app.tsx`).

This PR completes #18728 by promoting `MesheryDateTimePicker` into the shared wrapper folder so that **`ui/components/shared/DatePicker/` is the only app-level surface that touches `@mui/x-date-pickers`**.

### Changes
- Moves `ui/components/MesheryDateTimePicker.tsx` to `ui/components/shared/DatePicker/MesheryDateTimePicker.tsx` (discoverable filename per Phase 2 binding rules — no `index.tsx`-only).
- Re-exports `MesheryDateTimePicker` from the shared barrel (`ui/components/shared/DatePicker/index.ts`) alongside `LocalizationProvider` and `AdapterMoment`.
- Updates the only consumer (`ui/components/telemetry/grafana/GrafanaDateRangePicker.tsx`) to import from the shared barrel.
- Adds an explicit `eslint-disable-next-line no-restricted-imports` comment with rationale on the now-central `DateTimePicker` import.
- Removes `components/MesheryDateTimePicker.tsx` from `legacyRestrictedImportOffenders` in `ui/eslint.config.js` (no longer needed — the new location uses the per-line disable comment, and the file lives inside the shared wrapper).
- Replaces the placeholder `[LINK_TO_ISSUE]` comments in `index.ts` with the actual issue reference (#18728).

### Acceptance test (from issue)
`rg "@mui/x-date-pickers" ui --glob '*.{ts,tsx}'` now matches only files inside `ui/components/shared/DatePicker/`:

```
ui/components/shared/DatePicker/index.ts:2: ... '@mui/x-date-pickers/LocalizationProvider'
ui/components/shared/DatePicker/index.ts:4: ... '@mui/x-date-pickers/AdapterMoment'
ui/components/shared/DatePicker/MesheryDateTimePicker.tsx:4: ... '@mui/x-date-pickers/DateTimePicker'
```

The `eslint.config.js` `name: '@mui/x-date-pickers'` rule definition itself still appears in ripgrep results, but it is the policy definition (not an import). All three live import sites are within the central wrapper, each with a documented `eslint-disable` exemption.

### Phase 2 binding-rules check
- Sistent-only UI kit: yes (`TextField` still from `@sistent/sistent`).
- Tokens not literals: no color changes.
- `styled()` over inline: no styling changes; `GrafanaDateRangePicker` still wraps with `styled(MesheryDateTimePicker)`.
- Shared primitives in `ui/components/shared/`: yes, that is the point of this PR.
- 400/600/1000 line budgets: file is ~80 lines, well under all budgets.
- Discoverable filenames: `MesheryDateTimePicker.tsx`, not bare `index.tsx`.

### Why a new branch name suffix
A prior worktree had locked the `ui/phase-2/datepicker-18728` branch name with stale unrelated content (carrying ~hundreds of unrelated changes). Re-spawning on the stale branch would have been destructive, so this PR is opened from `ui/phase-2/datepicker-18728-v2` against a clean `origin/master`. The branch name is the only difference; the scope and issue mapping are identical.

Closes #18728
Refs #18657, #18654, #19021

## Test plan
- [ ] CI lint (`npm run lint`) passes.
- [ ] CI `audit:mui` runs and reports the trend.
- [ ] CI build succeeds.
- [ ] Manual smoke: Grafana date range picker renders and accepts input (the only consumer of `MesheryDateTimePicker`).