### PR TITLE
[UI] Phase 2: Drop direct MUI imports from dashboard surfaces (#18739)

### DIFF
--- a/ui/components/Dashboard/constants.ts
+++ b/ui/components/Dashboard/constants.ts
@@ -1,0 +1,7 @@
+// Shared dashboard constants.
+//
+// The `MuiTabs-scrollButtons` selector is the class Material UI applies to the
+// scroll buttons rendered inside a Sistent/MUI Tabs component. We keep the
+// literal here so the scoped dashboard surfaces can target that class without
+// importing `tabsClasses` from `@mui/material` (see #18739, parent #18657).
+export const TABS_SCROLL_BUTTONS_CLASS = 'MuiTabs-scrollButtons';

--- a/ui/components/Dashboard/index.tsx
+++ b/ui/components/Dashboard/index.tsx
@@ -32,7 +32,7 @@ import { DEFAULT_LAYOUT, LOCAL_PROVIDER_LAYOUT, OVERVIEW_LAYOUT } from './defaul
 import { applyMinSizeConstraints } from './layoutConstraints';
 import { useGetUserPrefQuery, useUpdateUserPrefMutation } from '@/rtk-query/user';
 import getWidgets from './widgets/getWidgets';
-import { tabsClasses } from '@mui/material';
+import { TABS_SCROLL_BUTTONS_CLASS } from './constants';
 import { useSelector } from 'react-redux';
 import useUnsavedChanges from './useUnsavedChanges';
 import UnsavedChangesModal from './UnsavedChangesModal';
@@ -344,7 +344,7 @@ const Dashboard = () => {
         <WrapperPaper>
           <Tabs
             sx={{
-              [`& .${tabsClasses.scrollButtons}`]: {
+              [`& .${TABS_SCROLL_BUTTONS_CLASS}`]: {
                 '&.Mui-disabled': { display: 'none' },
               },
             }}

--- a/ui/components/Dashboard/resources/resources-sub-menu.tsx
+++ b/ui/components/Dashboard/resources/resources-sub-menu.tsx
@@ -1,12 +1,12 @@
 import React, { useEffect, useMemo } from 'react';
 import ResourcesTable from './resources-table';
 import { TabPanel } from '../tabpanel';
+import { TABS_SCROLL_BUTTONS_CLASS } from '../constants';
 
 import { SecondaryTab, SecondaryTabs, WrapperPaper } from '../style';
 import GetKubernetesNodeIcon from '../utils';
 import { iconMedium } from 'css/icons.styles';
 import { styled } from '@sistent/sistent';
-import { tabsClasses } from '@mui/material';
 
 const DashboardIconText = styled('div')({
   display: 'flex',
@@ -80,7 +80,7 @@ const ResourcesSubMenu = ({
       <WrapperPaper>
         <SecondaryTabs
           sx={{
-            [`& .${tabsClasses.scrollButtons}`]: {
+            [`& .${TABS_SCROLL_BUTTONS_CLASS}`]: {
               '&.Mui-disabled': { display: 'none' },
             },
             '& .MuiTabs-scroller': {

--- a/ui/components/Dashboard/widgets/HoneyComb/HoneyCombComponent.tsx
+++ b/ui/components/Dashboard/widgets/HoneyComb/HoneyCombComponent.tsx
@@ -2,13 +2,15 @@ import React, { useCallback, useMemo, useState } from 'react';
 import ResponsiveHoneycomb from './ResponsiveHoneycomb';
 import Hexagon from './Hexagon';
 import {
+  ArrowDownwardIcon,
+  ArrowUpwardIcon,
   CustomTooltip,
   ErrorBoundary,
+  IconButton,
+  MenuItem,
+  Select,
   Skeleton,
   Typography,
-  Select,
-  MenuItem,
-  IconButton,
 } from '@sistent/sistent';
 import { useRouter } from 'next/router';
 import ConnectCluster from '../../charts/ConnectCluster';
@@ -23,8 +25,6 @@ import {
   ControlsContainer,
   NoResourcesText,
 } from '../../style';
-import ArrowUpwardIcon from '@mui/icons-material/ArrowUpward';
-import ArrowDownwardIcon from '@mui/icons-material/ArrowDownward';
 import {
   DEFAULT_GROUP_BY,
   SORT_DIRECTIONS,
@@ -129,11 +129,18 @@ const HoneycombComponent = ({
             </Select>
             <IconButton size="small" onClick={handleSortChange}>
               <CustomTooltip title="Sort by Count">
-                {sortDirection === SORT_DIRECTIONS.ASC ? (
-                  <ArrowUpwardIcon />
-                ) : (
-                  <ArrowDownwardIcon />
-                )}
+                {/*
+                 * Sistent's typed-SVG icons are functional components without
+                 * forwardRef, so Tooltip's cloneElement warns when used as a
+                 * direct child. Wrap them in a span to attach the ref safely.
+                 */}
+                <span>
+                  {sortDirection === SORT_DIRECTIONS.ASC ? (
+                    <ArrowUpwardIcon />
+                  ) : (
+                    <ArrowDownwardIcon />
+                  )}
+                </span>
               </CustomTooltip>
             </IconButton>
           </ControlsContainer>


### PR DESCRIPTION
## Summary

Implements Phase 2 sub-issue #18739 (parent #18657, master tracker #18654): the Dashboard feature container no longer imports directly from `@mui/*`.

- `ui/components/Dashboard/index.tsx` and `resources/resources-sub-menu.tsx` previously imported `tabsClasses` from `@mui/material` just to reference the `MuiTabs-scrollButtons` CSS class. Hoist the literal into a new discoverable `Dashboard/constants.ts` (`TABS_SCROLL_BUTTONS_CLASS`) so the dashboard tabs can keep the same scoped styling without the MUI import.
- `widgets/HoneyComb/HoneyCombComponent.tsx` switches `ArrowUpwardIcon` / `ArrowDownwardIcon` from `@mui/icons-material/*` to the Sistent re-exports (typed icons landed in #18730). Wraps them in a `<span>` inside `CustomTooltip` so `Tooltip`'s `cloneElement` can attach its ref to the wrapper rather than the Sistent typed-SVG (functional component, no `forwardRef`).
- All other Dashboard surfaces (`view.tsx`, `charts/**/*`, remaining widgets) were already Sistent-only and required no change.

After this change `rg "@mui/" ui/components/Dashboard` only matches a comment that documents why the literal class name was hoisted - there are no remaining `@mui/*` imports in `ui/components/Dashboard/**/*`.

Per parent #18657 sub-phase 1: package deps stay in place until the final cleanup issue.

## Acceptance checks (from #18739)

- Scoped dashboard files no longer import from `@mui/*` - verified via `rg`.
- Dashboard navigation, charts, and supporting views still render via Sistent equivalents (no component swap, just import source change for icons + class literal hoist).
- No new MUI icon imports introduced; both arrow icons come from `@sistent/sistent`.

## Test plan

- [x] `rg "@mui/" ui/components/Dashboard` returns only the docstring reference in `constants.ts`.
- [x] `eslint` clean on changed files (no new violations).
- [x] `tsc --noEmit` clean.
- [ ] CI green (lint + build).
- [ ] Manual: confirm `Dashboard` page renders, Tabs scroll buttons hide when disabled, Honeycomb sort toggle swaps the arrow icon and tooltip still shows.

Fixes #18739
Refs #18657, #18654, #18730

cc @miacycle @leecalcote @gnanirahulnutakki (prior #18770 was closed; this PR fully takes over the scope - no usable upstream branch remained to cherry-pick from).