### PR TITLE
[UI] Phase 2: Migrate Pattern Service widgets to shared RJSFProvider (#18729)

### DIFF
--- a/ui/components/MesheryMeshInterface/PatternService/RJSFCustomComponents/ArrayFieldTemlate.tsx
+++ b/ui/components/MesheryMeshInterface/PatternService/RJSFCustomComponents/ArrayFieldTemlate.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { Box, Grid2, Paper, Button, IconButton, Typography, useTheme } from '@sistent/sistent';
-import AddIcon from '@mui/icons-material/Add';
+import AddIcon from '../../../../assets/icons/AddIcon';
 import SimpleAccordion from './Accordion';
 import { CustomTextTooltip } from '../CustomTextTooltip';
 import HelpOutlineIcon from '../../../../assets/icons/HelpOutlineIcon';

--- a/ui/components/MesheryMeshInterface/PatternService/RJSFCustomComponents/CustomSelectWidget.tsx
+++ b/ui/components/MesheryMeshInterface/PatternService/RJSFCustomComponents/CustomSelectWidget.tsx
@@ -8,8 +8,8 @@ import {
   InputLabel,
   useTheme,
 } from '@sistent/sistent';
-import HelpOutlineIcon from '@mui/icons-material/HelpOutlined';
-import ErrorOutlineIcon from '@mui/icons-material/ErrorOutlined';
+import HelpOutlineIcon from '../../../../assets/icons/HelpOutlineIcon';
+import ErrorOutlineIcon from '../../../../assets/icons/ErrorOutlineIcon';
 import { ERROR_COLOR } from '../../../../constants/colors';
 import { iconSmall } from '../../../../css/icons.styles';
 import { CustomTextTooltip } from '../CustomTextTooltip';


### PR DESCRIPTION
## Summary

- Eliminates the last direct `@mui/icons-material` imports under `ui/components/MesheryMeshInterface/PatternService/RJSFCustomComponents/` so every Pattern Service form widget is fully reachable through the shared `RJSFProvider` boundary established in #18727.
- Routes `AddIcon`, `HelpOutlineIcon`, and `ErrorOutlineIcon` through the existing typed SVG components in `ui/assets/icons/`, matching the pattern already used by sibling widgets (`CustomBaseInput`, `ObjectFieldTemplate`, `Accordion`, `ArrayFieldTemlate`'s help/error icons).
- After this PR: `rg "@rjsf/mui" ui/components ui/pages` matches only `ui/components/shared/FormFields/RJSFProvider.tsx`, and `rg "from '@mui|from '@material-ui|from '@rjsf/mui" ui/components/MesheryMeshInterface` returns zero matches.

## Background

Issue #18729 calls out two surfaces:
- `ui/components/MesheryMeshInterface/PatternService/RJSFCustomComponents/*`
- `ui/components/MesheryMeshInterface/PatternServiceForm.tsx`

When inventoried against `master`:
- `PatternServiceForm.tsx` already uses `@sistent/sistent` and the icon barrel — no changes needed.
- `RJSF.tsx` already consumes the shared `RJSFProvider` from `ui/components/shared/FormFields/RJSFProvider.tsx`.
- Of the 15 RJSFCustomComponents files, only two still imported MUI icons directly: `ArrayFieldTemlate.tsx` (Add) and `CustomSelectWidget.tsx` (HelpOutlined, ErrorOutlined).

This PR cleans those up by reusing the typed SVG icons that #18730 standardized.

## Scope discipline

The remaining entries for these files in `legacyRestrictedImportOffenders` (in `ui/eslint.config.js`) are intentionally left in place — both files still import `ERROR_COLOR` from `@/constants/colors`, which is a separate Phase 1 theming concern tracked by #18654/#18737 and is out of scope here.

## Coordination

- #18727 (`RJSFProvider` shared wrapper) — already merged.
- #18736 (design authoring MUI cleanup, which also touched `PatternServiceForm.tsx`) — already merged. This PR is rebased onto the post-#18736 `master` and contains no conflicts with it.

## Test plan

- [ ] CI green
- [ ] Lint: `rg "from '@rjsf/mui'" ui/components ui/pages` matches only `RJSFProvider.tsx`
- [ ] Lint: `rg "from '@mui|from '@material-ui'" ui/components/MesheryMeshInterface` returns no matches
- [ ] Pattern Service form rendering and submission unaffected (visual smoke test through Pattern editing flow)

Fixes #18729
Refs #18657, #18727, #18654