### PR TITLE
chore: remove unused Docker push and description steps from CI workflow

### DIFF
--- a/.github/workflows/build-ui-and-server.yml
+++ b/.github/workflows/build-ui-and-server.yml
@@ -202,17 +202,3 @@ jobs:
           RELEASE_CHANNEL: "edge"
         run: |
           DOCKER_BUILDKIT=1 docker build -f install/docker/Dockerfile --no-cache -t meshery:edge-latest --build-arg TOKEN=test --build-arg GIT_COMMITSHA=${GITHUB_SHA::8} --build-arg RELEASE_CHANNEL=${RELEASE_CHANNEL} .
-          docker tag meshery:edge-latest meshery:edge-${GITHUB_SHA::8}
-      - name: Docker edge push
-        if: github.event_name != 'pull_request' && github.event_name != 'workflow_dispatch' && startsWith(github.ref, 'refs/tags/') && success()
-        run: |
-          docker push ${{ secrets.IMAGE_NAME }}:edge-latest
-          docker push ${{ secrets.IMAGE_NAME }}:edge-${GITHUB_REF/refs\/tags\//}
-          docker push ${{ secrets.IMAGE_NAME }}:edge-${GITHUB_SHA::8}
-      - name: Docker Hub Description
-        if: github.event_name != 'pull_request' && github.event_name != 'workflow_dispatch' && startsWith(github.ref, 'refs/tags/') && success()
-        uses: peter-evans/dockerhub-description@v5
-        with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_PASSWORD }}
-          repository: ${{ secrets.IMAGE_NAME }}


### PR DESCRIPTION
**Notes for Reviewers**

Recent unresolved merge conflicts were merged accidently during the fix previously deprecated workflow job was added back to workflow. This PR removes it again. https://github.com/meshery/meshery/pull/19103/changes