### PR TITLE
[UI] Phase 2: Delete @/constants/colors after migrating to theme.palette.* (#18657)

### DIFF
--- a/ui/components/dashboard/charts/NodeStatusChart.tsx
+++ b/ui/components/dashboard/charts/NodeStatusChart.tsx
@@ -2,10 +2,10 @@ import React, { useMemo } from 'react';
 import { donut } from 'billboard.js';
 import BBChart from '../../BBChart';
 import { CircularProgress, KEPPEL, Typography, Stack } from '@sistent/sistent';
+import { useTheme } from '@/theme';
 import { getLegendTemplate } from './utils';
 import ConnectCluster from './ConnectCluster';
 import { LoadingContainer, ChartSectionWithColumn, LegendSection } from '../style';
-import { ERROR_COLOR } from '@/constants/colors';
 
 type NodeStatus = { status: string; count: number };
 
@@ -15,6 +15,7 @@ type NodeStatusChartProps = {
 };
 
 export const NodeStatusChart = ({ nodeData, isClusterLoading }: NodeStatusChartProps) => {
+  const theme = useTheme();
   const totalNodes = nodeData?.reduce((acc, node) => acc + node.count, 0);
   const columns = useMemo(() => nodeData?.map((node) => [node.status, node.count]), [nodeData]);
   const chartOptions = useMemo(
@@ -24,7 +25,7 @@ export const NodeStatusChart = ({ nodeData, isClusterLoading }: NodeStatusChartP
         type: donut(),
         colors: {
           Ready: KEPPEL,
-          'Not Ready': ERROR_COLOR,
+          'Not Ready': theme.palette.error.main,
         },
       },
       arc: {
@@ -54,7 +55,7 @@ export const NodeStatusChart = ({ nodeData, isClusterLoading }: NodeStatusChartP
         },
       },
     }),
-    [columns, totalNodes],
+    [columns, totalNodes, theme.palette.error.main],
   );
 
   return (

--- a/ui/components/dashboard/charts/PodStatusChart.tsx
+++ b/ui/components/dashboard/charts/PodStatusChart.tsx
@@ -9,11 +9,11 @@ import {
   TEAL_BLUE,
   Stack,
 } from '@sistent/sistent';
+import { useTheme } from '@/theme';
 import BBChart from '@/components/BBChart';
 import { getLegendTemplate } from './utils';
 import ConnectCluster from './ConnectCluster';
 import { LoadingContainer, ChartSectionWithColumn, LegendSection } from '../style';
-import { ERROR_COLOR } from '@/constants/colors';
 
 type PodStatus = { status: string; count: number };
 
@@ -23,6 +23,7 @@ type PodStatusChartProps = {
 };
 
 export const PodStatusChart = ({ podData, isClusterLoading }: PodStatusChartProps) => {
+  const theme = useTheme();
   const totalPods = podData?.reduce((acc, pod) => acc + pod.count, 0);
   const columns = useMemo(() => podData?.map((pod) => [pod.status, pod.count]), [podData]);
   const chartOptions = useMemo(
@@ -33,7 +34,7 @@ export const PodStatusChart = ({ podData, isClusterLoading }: PodStatusChartProp
         colors: {
           Running: KEPPEL,
           Pending: SAFFRON,
-          Failed: ERROR_COLOR,
+          Failed: theme.palette.error.main,
           Succeeded: TEAL_BLUE,
           Unknown: DARK_SLATE_GRAY,
         },
@@ -65,7 +66,7 @@ export const PodStatusChart = ({ podData, isClusterLoading }: PodStatusChartProp
         },
       },
     }),
-    [columns, totalPods],
+    [columns, totalPods, theme.palette.error.main],
   );
   return (
     <ChartSectionWithColumn>

--- a/ui/components/meshery-mesh-interface/PatternService/RJSFCustomComponents/ArrayFieldTemlate.tsx
+++ b/ui/components/meshery-mesh-interface/PatternService/RJSFCustomComponents/ArrayFieldTemlate.tsx
@@ -6,7 +6,6 @@ import { CustomTextTooltip } from '../CustomTextTooltip';
 import HelpOutlineIcon from '../../../../assets/icons/HelpOutlineIcon';
 import { isMultiSelect, getDefaultFormState } from '@rjsf/utils';
 import ErrorOutlineIcon from '../../../../assets/icons/ErrorOutlineIcon';
-import { ERROR_COLOR } from '../../../../constants/colors';
 import { iconSmall } from '../../../../css/icons.styles';
 import pluralize from 'pluralize';
 import { safeDisplayValue, safeStringTitle } from '../helper';
@@ -187,7 +186,7 @@ const DefaultNormalArrayFieldTemplate = (props) => {
             )}
             {props.rawErrors?.length > 0 && (
               <CustomTextTooltip
-                bgColor={ERROR_COLOR}
+                bgColor={theme.palette.error.main}
                 interactive={true}
                 title={safeStringTitle(
                   Array.isArray(props.rawErrors) ? props.rawErrors.join('  ') : props.rawErrors,

--- a/ui/components/meshery-mesh-interface/PatternService/RJSFCustomComponents/CustomBaseInput.tsx
+++ b/ui/components/meshery-mesh-interface/PatternService/RJSFCustomComponents/CustomBaseInput.tsx
@@ -10,7 +10,6 @@ import {
 import HelpOutlineIcon from '../../../../assets/icons/HelpOutlineIcon';
 import { CustomTextTooltip } from '../CustomTextTooltip';
 import ErrorOutlineIcon from '../../../../assets/icons/ErrorOutlineIcon';
-import { ERROR_COLOR } from '../../../../constants/colors';
 import { iconSmall } from '../../../../css/icons.styles';
 import { safeDisplayValue } from '../helper';
 
@@ -110,7 +109,7 @@ const BaseInput = (props) => {
               <InputAdornment position="start">
                 {props.rawErrors?.length > 0 && (
                   <CustomTextTooltip
-                    bgColor={ERROR_COLOR}
+                    bgColor={theme.palette.error.main}
                     flag={overrideFlag}
                     title={errorTitle}
                     interactive={true}

--- a/ui/components/meshery-mesh-interface/PatternService/RJSFCustomComponents/CustomSelectWidget.tsx
+++ b/ui/components/meshery-mesh-interface/PatternService/RJSFCustomComponents/CustomSelectWidget.tsx
@@ -10,7 +10,6 @@ import {
 } from '@sistent/sistent';
 import HelpOutlineIcon from '../../../../assets/icons/HelpOutlineIcon';
 import ErrorOutlineIcon from '../../../../assets/icons/ErrorOutlineIcon';
-import { ERROR_COLOR } from '../../../../constants/colors';
 import { iconSmall } from '../../../../css/icons.styles';
 import { CustomTextTooltip } from '../CustomTextTooltip';
 import {
@@ -94,7 +93,7 @@ export default function CustomSelectWidget({
             <InputAdornment position="start" style={{ position: 'absolute', right: '1rem' }}>
               {rawErrors?.length > 0 && (
                 <CustomTextTooltip
-                  bgColor={ERROR_COLOR}
+                  bgColor={theme.palette.error.main}
                   flag={formContext?.overrideFlag}
                   title={rawErrors?.join('  ')}
                   interactive={true}
@@ -103,7 +102,7 @@ export default function CustomSelectWidget({
                     <ErrorOutlineIcon
                       width="14px"
                       height="14px"
-                      fill={ERROR_COLOR}
+                      fill={theme.palette.error.main}
                       style={{ verticalAlign: 'middle', ...iconSmall }}
                     />
                   </IconButton>

--- a/ui/components/meshery-mesh-interface/PatternService/RJSFCustomComponents/ObjectFieldTemplate.tsx
+++ b/ui/components/meshery-mesh-interface/PatternService/RJSFCustomComponents/ObjectFieldTemplate.tsx
@@ -7,7 +7,6 @@ import HelpOutlineIcon from '../../../../assets/icons/HelpOutlineIcon';
 import ExpandMoreIcon from '../../../../assets/icons/ExpandMoreIcon';
 import ExpandLessIcon from '../../../../assets/icons/ExpandLessIcon';
 import ErrorOutlineIcon from '../../../../assets/icons/ErrorOutlineIcon';
-import { ERROR_COLOR } from '../../../../constants/colors';
 import { iconMedium, iconSmall } from '../../../../css/icons.styles';
 import { calculateGrid, safeStringTitle } from '../helper';
 
@@ -133,7 +132,7 @@ const ObjectFieldTemplate = ({
             )}
             {rawErrors.length !== 0 && (
               <CustomTextTooltip
-                bgColor={ERROR_COLOR}
+                bgColor={theme.palette.error.main}
                 title={safeStringTitle(Array.isArray(rawErrors) ? rawErrors.join('  ') : rawErrors)}
               >
                 <IconButton

--- a/ui/constants/colors.ts
+++ b/ui/constants/colors.ts
@@ -1,6 +1,0 @@
-// derived from Figma
-export const PRIMARY_COLOR = '#647881';
-export const SUCCESS_COLOR = '#83B71E';
-export const INFO_COLOR = '#2AC3D1';
-export const WARNING_COLOR = '#EBC017';
-export const ERROR_COLOR = '#B32700';

--- a/ui/eslint.config.js
+++ b/ui/eslint.config.js
@@ -515,10 +515,6 @@ module.exports = [
               name: '@/themes/index',
               message: 'Use @/theme and theme.palette.* instead of NOTIFICATIONCOLORS.',
             },
-            {
-              name: '@/constants/colors',
-              message: 'Use @/theme and theme.palette.* instead of legacy color constants.',
-            },
           ],
           patterns: [
             {


### PR DESCRIPTION
## Summary

- Migrated the 6 callers of `ERROR_COLOR` from `ui/constants/colors.ts` to `theme.palette.error.main` via `useTheme()` (functional components) — the only constant that was actually in use across the codebase.
- Deleted `ui/constants/colors.ts` (the other 4 Figma-derived constants — `PRIMARY_COLOR`, `SUCCESS_COLOR`, `INFO_COLOR`, `WARNING_COLOR` — had no callers).
- Removed the now-redundant `@/constants/colors` entry from the `no-restricted-imports` allowlist in `ui/eslint.config.js`.

## Migrated callers

1. `ui/components/dashboard/charts/NodeStatusChart.tsx`
2. `ui/components/dashboard/charts/PodStatusChart.tsx`
3. `ui/components/meshery-mesh-interface/PatternService/RJSFCustomComponents/ArrayFieldTemlate.tsx`
4. `ui/components/meshery-mesh-interface/PatternService/RJSFCustomComponents/CustomBaseInput.tsx`
5. `ui/components/meshery-mesh-interface/PatternService/RJSFCustomComponents/CustomSelectWidget.tsx`
6. `ui/components/meshery-mesh-interface/PatternService/RJSFCustomComponents/ObjectFieldTemplate.tsx`

Per the restructure plan ('4.2), Sistent's palette tokens are the source of truth; the small color shift from the Figma-derived hexes to Sistent's `error.main` is the intended outcome of this migration.

## Test plan

- [x] `npm run lint` passes with no new errors
- [x] `npm test` passes (68 tests, 15 files)
- [x] `grep -r 'from .@/constants/colors.' ui --include='*.ts*'` returns no results
- [x] `ui/constants/colors.ts` deleted
- [x] No new hex literals introduced (audit:hex unchanged at 261)

Refs #18657
Refs #18654