### PR TITLE
[UI] Phase 2: Migrate @/themes/app callers to theme.palette.* (#18657)

### DIFF
--- a/ui/components/layout/NotificationCenter/constants.tsx
+++ b/ui/components/layout/NotificationCenter/constants.tsx
@@ -1,9 +1,9 @@
 import { NOTIFICATIONCOLORS } from '../../../themes';
 import AlertIcon from '../../../assets/icons/AlertIcon';
 import ErrorIcon from '../../../assets/icons/ErrorIcon';
-import { Colors } from '../../../themes/app';
 import ReadIcon from '../../../assets/icons/ReadIcon';
 import { InfoIcon } from '@sistent/sistent';
+import type { Theme } from '@sistent/sistent';
 
 export const SEVERITY = {
   INFO: 'informational',
@@ -28,13 +28,15 @@ export const STATUS = {
   UNREAD: 'unread',
 };
 
-export const STATUS_STYLE = {
+// Theme-aware status styles. Resolves to live palette tokens so dark/light
+// mode picks the correct value at render time instead of using hard-coded hex.
+export const getStatusStyle = (theme: Theme) => ({
   [STATUS.READ]: {
     icon: ReadIcon,
-    color: Colors.charcoal,
-    darkColor: '#BCC7CC',
+    color: theme.palette.text.primary,
+    darkColor: theme.palette.text.primary,
   },
-};
+});
 
 export const SEVERITY_STYLE = {
   [SEVERITY.INFO]: {

--- a/ui/components/layout/NotificationCenter/index.tsx
+++ b/ui/components/layout/NotificationCenter/index.tsx
@@ -21,7 +21,7 @@ import {
   SEVERITY,
   SEVERITY_STYLE,
   STATUS,
-  STATUS_STYLE,
+  getStatusStyle,
 } from './constants';
 import Notification from './notification';
 import {
@@ -193,6 +193,8 @@ const NotificationCountChip = ({ notificationStyle, count, type, handleClick, se
 
 const Header = ({ handleFilter, handleClose }) => {
   const uiConfig = useSelector((state) => state.events.ui);
+  const theme = useTheme();
+  const statusStyle = getStatusStyle(theme);
   const { data } = useGetEventsSummaryQuery({
     status: STATUS.UNREAD,
   });
@@ -236,7 +238,7 @@ const Header = ({ handleFilter, handleClose }) => {
           />
         ))}
         <NotificationCountChip
-          notificationStyle={STATUS_STYLE[STATUS.READ]}
+          notificationStyle={statusStyle[STATUS.READ]}
           handleClick={() => onClickStatus(STATUS.READ)}
           type={STATUS.READ}
           severity={STATUS.READ}

--- a/ui/components/meshery-mesh-interface/PatternService/RJSFCustomComponents/CustomFileWidget.tsx
+++ b/ui/components/meshery-mesh-interface/PatternService/RJSFCustomComponents/CustomFileWidget.tsx
@@ -1,12 +1,13 @@
 import React from 'react';
 import BaseInput from './CustomBaseInput';
 import { useRef } from 'react';
-import { Colors } from '@/themes/app';
+import { useTheme } from '@/theme';
 import { safeDisplayValue } from '../helper';
 
 const CustomFileWidget = (props) => {
   const inputType = 'file';
   const fileInputUpdated = useRef(false);
+  const theme = useTheme();
 
   /**
    * @param {React.ChangeEvent<HTMLInputElement>} event
@@ -41,7 +42,7 @@ const CustomFileWidget = (props) => {
             position: 'absolute',
             bottom: '10px',
             left: '6rem',
-            backgroundColor: Colors.keppelGreen,
+            backgroundColor: theme.palette.primary.main,
           }}
         >
           {safeDisplayValue(props.options.default)}

--- a/ui/components/meshery-mesh-interface/PatternService/helper.tsx
+++ b/ui/components/meshery-mesh-interface/PatternService/helper.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import _ from 'lodash';
-import { Colors } from '@/themes/app';
+import { useTheme } from '@/theme';
 
 /**
  * Returns a value safe to use as React child or tooltip/label text.
@@ -183,28 +183,38 @@ const sortProperties = (properties) => {
  * @returns
  */
 
-const getHyperLinkWithDescription = (description) => {
+const getHyperLinkWithDescription = (description, linkColor) => {
   const markdownLinkRegex = /\[([^\]]+)]\((https?:\/\/[^\s]+)\)/g;
   const urlRegex = /(https?:\/\/[^\s]+)/g;
 
   let processedDescription = description?.replace(markdownLinkRegex, (match, text, url) => {
-    return `<a href="${url}" style="color: ${Colors.keppelGreen};" target="_blank" rel="noreferrer">${text}</a>`;
+    return `<a href="${url}" style="color: ${linkColor};" target="_blank" rel="noreferrer">${text}</a>`;
   });
 
   if (!markdownLinkRegex.test(description)) {
     processedDescription = processedDescription?.replace(
       urlRegex,
       (url) =>
-        `<a href="${url}" style="color: ${Colors.keppelGreen};" target="_blank" rel="noreferrer">${url}</a>`,
+        `<a href="${url}" style="color: ${linkColor};" target="_blank" rel="noreferrer">${url}</a>`,
     );
   }
 
   return processedDescription;
 };
 
-export const getHyperLinkDiv = (text) => (
-  <div dangerouslySetInnerHTML={{ __html: getHyperLinkWithDescription(text) }} />
-);
+export const HyperLinkDiv = ({ text }) => {
+  const theme = useTheme();
+  return (
+    <div
+      dangerouslySetInnerHTML={{
+        __html: getHyperLinkWithDescription(text, theme.palette.primary.main),
+      }}
+    />
+  );
+};
+
+// Backward-compatible alias for legacy callers that imported `getHyperLinkDiv`.
+export const getHyperLinkDiv = (text) => <HyperLinkDiv text={text} />;
 /**
  * Returns the schema for the credentials.
  * @param {String} type

--- a/ui/components/registry/MesheryTreeView.tsx
+++ b/ui/components/registry/MesheryTreeView.tsx
@@ -16,7 +16,7 @@ import { CustomTextTooltip } from '@/components/meshery-mesh-interface/PatternSe
 import _ from 'lodash';
 import CollapseAllIcon from '@/assets/icons/CollapseAll';
 import ExpandAllIcon from '@/assets/icons/ExpandAll';
-import { Colors } from '@/themes/app';
+import { useTheme } from '@/theme';
 import { JustifyAndAlignCenter, MesheryTreeViewWrapper } from './MeshModel.style';
 import { useRegistryRouter } from './hooks';
 import MesheryTreeViewModel from './MesheryTreeViewModel';
@@ -64,6 +64,7 @@ const MesheryTreeView = React.memo(
   }: MesheryTreeViewProps) => {
     const { handleUpdateSelectedRoute, selectedItemUUID: routerSelectedItemUUID } =
       useRegistryRouter();
+    const theme = useTheme();
 
     const selectedItemUUID = externalSelectedItemUUID || routerSelectedItemUUID;
     const [expanded, setExpanded] = React.useState<string[]>([]);
@@ -324,7 +325,7 @@ const MesheryTreeView = React.memo(
           {data.length === 0 && !searchText ? (
             <JustifyAndAlignCenter style={{ height: '27rem' }}>
               {isLoading || (data.length === 0 && !searchText) ? (
-                <CircularProgress sx={{ color: Colors.keppelGreen }} />
+                <CircularProgress sx={{ color: theme.palette.primary.main }} />
               ) : (
                 <Typography>No {type.toLowerCase()} found</Typography>
               )}


### PR DESCRIPTION
## Summary

Phase 2 (Theme & Color Collapse) slice of the Meshery UI restructure. Migrates the 4 remaining direct importers of `@/themes/app` to Sistent theme tokens (`useTheme().palette.*`).

- **`components/registry/MesheryTreeView.tsx`** — `Colors.keppelGreen` -> `theme.palette.primary.main` on `CircularProgress` color.
- **`components/meshery-mesh-interface/PatternService/RJSFCustomComponents/CustomFileWidget.tsx`** — `Colors.keppelGreen` -> `theme.palette.primary.main` for label background.
- **`components/meshery-mesh-interface/PatternService/helper.tsx`** — introduces `HyperLinkDiv` React component that resolves link color via `useTheme().palette.primary.main`; keeps `getHyperLinkDiv` as a backward-compat alias. The internal `getHyperLinkWithDescription` helper now takes `linkColor` as a parameter.
- **`components/layout/NotificationCenter/constants.tsx`** — replaces the static `STATUS_STYLE` (which read `Colors.charcoal`) with a `getStatusStyle(theme)` factory. The sole consumer in `NotificationCenter/index.tsx` already had `useTheme`; it now calls the factory at render time.

`ui/themes/app.ts` is intentionally left in place — a follow-up cleanup PR will remove it once any remaining indirect references are migrated.

## Verification

- `npm run lint` -> 0 errors, 0 warnings (matches baseline).
- `npm run audit:hex` -> 296 (baseline 297; lower by 1 thanks to removing the inline `#3C494F`/`#BCC7CC` pair).
- `npm test` -> 68/68 passing.
- `grep -rE "from ['\"]@/themes/app['\"]" ui --include='*.ts*'` -> no matches.

Refs #18657
Refs #18654

## Test plan

- [ ] CI lint passes
- [ ] CI tests pass
- [ ] Visual smoke: open Settings -> Registry (loading state CircularProgress now uses primary color in both light + dark mode)
- [ ] Visual smoke: open NotificationCenter (the "read" status chip uses `theme.palette.text.primary` correctly in both themes)
- [ ] Visual smoke: trigger a credential form with a markdown link description (verify the link color comes from `theme.palette.primary.main`)
- [ ] Visual smoke: upload a file via RJSF (`CustomFileWidget`) and confirm the default-value label background matches the primary color