### PR TITLE
[UI] Phase 3: Final cleanup — GlobalStyles via @/theme + audit:mui wrapper allowlist (#18658)

### DIFF
--- a/ui/components/relationship-builder/RelationshipFormStepper.tsx
+++ b/ui/components/relationship-builder/RelationshipFormStepper.tsx
@@ -13,8 +13,7 @@ import {
   Grid2,
   MenuItem,
 } from '@sistent/sistent';
-// eslint-disable-next-line no-restricted-imports -- GlobalStyles has no @sistent/sistent equivalent yet; tracked as the final straggler for Phase 2.
-import { GlobalStyles } from '@mui/material';
+import { GlobalStyles } from '@/theme';
 import { styled, DescriptionIcon, CodeIcon } from '@sistent/sistent';
 import { RelationshipDefinitionV1Beta2OpenApiSchema } from '@meshery/schemas';
 import {

--- a/ui/docs/THEMING.md
+++ b/ui/docs/THEMING.md
@@ -42,6 +42,9 @@ Bridged from MUI (until Sistent re-exports them) so callers can still go
 through the project-local front door:
 
 - **Color helpers** — `darken`
+- **Global primitives** — `GlobalStyles` (used for one-off escape hatches
+  like cross-portal z-index overrides; routed through `@/theme` so app code
+  stays off `@mui/material` directly)
 
 ### What it adds locally
 
@@ -278,15 +281,15 @@ In practice, 90%+ of components in this codebase should be `styled()`.
 A migration table for the legacy modules that the lint rules and the
 restructure plan call out for deletion:
 
-| Legacy import                                                          | Replace with                                                  |
-| ---------------------------------------------------------------------- | ------------------------------------------------------------- |
-| `import { Colors } from '@/themes/app'`                                | `theme.palette.*` (e.g. `theme.palette.error.main`)           |
-| `import { notificationColors, darkNotificationColors } from '@/themes/app'` | `theme.palette.*` (the theme handles the dark variant)   |
-| `import { NOTIFICATIONCOLORS } from '@/themes'`                        | `theme.palette.*`                                             |
-| `import { PRIMARY_COLOR } from '@/constants/colors'`                   | `theme.palette.primary.main`                                  |
-| `import { lightenOrDarkenColor } from '@/utils/lightenOrDarkenColor'`  | `import { lighten, darken } from '@/theme'`. The legacy helper accepts percent (`-100..100`); the MUI utilities take a coefficient (`0..1`). Convert by dividing by 100 and using `darken` for negative percents, `lighten` for positive. |
-| `import { styled } from '@/theme/index'`                               | `import { styled } from '@/theme'`                            |
-| `import { ... } from '@mui/material'`                                  | `import { ... } from '@sistent/sistent'`                      |
+| Legacy import                                                               | Replace with                                                                                                                                                                                                                              |
+| --------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `import { Colors } from '@/themes/app'`                                     | `theme.palette.*` (e.g. `theme.palette.error.main`)                                                                                                                                                                                       |
+| `import { notificationColors, darkNotificationColors } from '@/themes/app'` | `theme.palette.*` (the theme handles the dark variant)                                                                                                                                                                                    |
+| `import { NOTIFICATIONCOLORS } from '@/themes'`                             | `theme.palette.*`                                                                                                                                                                                                                         |
+| `import { PRIMARY_COLOR } from '@/constants/colors'`                        | `theme.palette.primary.main`                                                                                                                                                                                                              |
+| `import { lightenOrDarkenColor } from '@/utils/lightenOrDarkenColor'`       | `import { lighten, darken } from '@/theme'`. The legacy helper accepts percent (`-100..100`); the MUI utilities take a coefficient (`0..1`). Convert by dividing by 100 and using `darken` for negative percents, `lighten` for positive. |
+| `import { styled } from '@/theme/index'`                                    | `import { styled } from '@/theme'`                                                                                                                                                                                                        |
+| `import { ... } from '@mui/material'`                                       | `import { ... } from '@sistent/sistent'`                                                                                                                                                                                                  |
 
 For the underlying ESLint configuration that enforces these mappings, see
 the `no-restricted-imports` block in

--- a/ui/eslint.config.js
+++ b/ui/eslint.config.js
@@ -34,11 +34,20 @@ const patchedNextConfig = nextConfig.map((cfg) => {
 // The remaining boundaries are:
 //   - `assets/icons/index.ts` — the canonical icon barrel itself, which
 //     centrally re-exports `@mui/icons-material` glyphs (#18736, #18744).
+//   - `theme/index.ts` — the project-local theme entry point, which bridges
+//     a handful of primitives (`darken`, `GlobalStyles`) from `@mui/material`
+//     until Sistent re-exports them. Each bridged import opts in via a
+//     line-scoped `eslint-disable-next-line no-restricted-imports` comment
+//     rather than relying on this allowlist.
 //   - Shared wrappers under `components/shared/{DatePicker,TreeView,FormFields}/`
 //     opt in via a local `eslint-disable no-restricted-imports` comment
 //     (line-scoped `-next-line` for single-import files, file-scoped block
 //     comment for the TreeView wrapper that re-exports several names)
 //     rather than relying on this allowlist.
+//
+// The audit script (`scripts/audit-mui.js`) keeps a matching list of
+// approved wrappers (`APPROVED_WRAPPERS`) so the trend line reports only
+// *unmigrated* MUI usage. Keep the two lists in sync when adding entries.
 const legacyRestrictedImportOffenders = ['assets/icons/index.ts'];
 
 const legacyLiteralColorOffenders = [

--- a/ui/scripts/audit-mui.js
+++ b/ui/scripts/audit-mui.js
@@ -29,6 +29,27 @@ const path = require('path');
 
 const UI_ROOT = path.resolve(__dirname, '..');
 
+// Approved single-boundary wrappers around @mui/* and @rjsf/mui.
+//
+// These files are the *only* places in the codebase allowed to import from
+// the legacy MUI / RJSF packages, per the UI restructure plan §1.3 and the
+// Phase 3 issue (#18657). They exist because Sistent doesn't yet expose the
+// underlying primitives (`GlobalStyles`, `darken`, the date pickers, the
+// tree view, the RJSF theme adapter); every other consumer goes through
+// `@/theme` or the shared component wrappers, not `@mui/*` directly.
+//
+// Excluded from the audit count so the trend line tracks *unmigrated* MUI
+// usage rather than the approved bridge. Adding a new entry should require
+// an open issue and a code review — the goal is to keep this list small
+// and to drain it as Sistent grows.
+const APPROVED_WRAPPERS = new Set([
+  'theme/index.ts',
+  'components/shared/TreeView/TreeView.tsx',
+  'components/shared/DatePicker/index.ts',
+  'components/shared/DatePicker/MesheryDateTimePicker.tsx',
+  'components/shared/FormFields/RJSFProvider.tsx',
+]);
+
 // Directories under ui/ that are scanned.
 const SCAN_DIRS = [
   'components',
@@ -107,10 +128,15 @@ function main() {
 
   const offenders = [];
   let totalMatches = 0;
+  let skippedWrappers = 0;
   for (const file of files) {
     const matches = scanFile(file);
     if (matches.length === 0) continue;
     const rel = path.relative(UI_ROOT, file);
+    if (APPROVED_WRAPPERS.has(rel)) {
+      skippedWrappers += 1;
+      continue;
+    }
     offenders.push({ file: rel, count: matches.length, imports: matches });
     totalMatches += matches.length;
   }
@@ -123,6 +149,8 @@ function main() {
           audit: 'mui',
           files: offenders.length,
           matches: totalMatches,
+          approvedWrappers: APPROVED_WRAPPERS.size,
+          approvedWrappersWithMuiImports: skippedWrappers,
           offenders,
         },
         null,
@@ -155,7 +183,8 @@ function main() {
 
   process.stdout.write('Summary:\n');
   process.stdout.write(`  Files:   ${offenders.length}\n`);
-  process.stdout.write(`  Matches: ${totalMatches}\n\n`);
+  process.stdout.write(`  Matches: ${totalMatches}\n`);
+  process.stdout.write(`  Approved wrappers (excluded from count): ${APPROVED_WRAPPERS.size}\n\n`);
   process.stdout.write(`AUDIT mui files=${offenders.length} matches=${totalMatches}\n`);
 }
 

--- a/ui/theme/index.ts
+++ b/ui/theme/index.ts
@@ -55,6 +55,12 @@ export {
 // eslint-disable-next-line no-restricted-imports
 export { darken } from '@mui/material';
 
+// Bridged from MUI: Sistent doesn't yet export GlobalStyles. Routed through
+// `@/theme` so the rest of the app can stay off `@mui/material` directly;
+// this is the project's approved single bridge.
+// eslint-disable-next-line no-restricted-imports
+export { GlobalStyles } from '@mui/material';
+
 export type { Theme };
 
 export const palette = {


### PR DESCRIPTION
## Summary

Eliminates the final stray `@mui/material` import in app code and teaches the audit script to report only *unmigrated* MUI usage, so the trend line stops counting the approved single-boundary wrappers (per restructure plan §1.3) against the migration.

After this PR, `audit:mui` reports:

```
AUDIT mui files=0 matches=0
```

— the Phase 3 acceptance criterion. The five intentional MUI bridges (`theme/index.ts` and the four `components/shared/{DatePicker,TreeView,FormFields}/` wrappers) are excluded from the count via a new `APPROVED_WRAPPERS` allowlist; the human summary surfaces an extra `Approved wrappers (excluded from count): 5` line so the trend remains honest.

## Changes

- **`ui/theme/index.ts`** — bridge `GlobalStyles` from `@mui/material` alongside the existing `darken` re-export. Same `eslint-disable-next-line no-restricted-imports` + "why" comment pattern.
- **`ui/components/relationship-builder/RelationshipFormStepper.tsx`** — one-line import migration: `GlobalStyles` now comes from `@/theme` instead of `@mui/material`. The local file-scoped eslint-disable is gone with it.
- **`ui/scripts/audit-mui.js`** — add `APPROVED_WRAPPERS` set near the top with a comment block explaining the design rule (entries should require an open issue and code review). Files in the set are skipped during the scan; the summary now reports the wrapper count separately so trend tracking stays accurate.
- **`ui/docs/THEMING.md`** — document `GlobalStyles` alongside `darken` in the "Bridged from MUI" section.
- **`ui/eslint.config.js`** — extend the `legacyRestrictedImportOffenders` comment to note `theme/index.ts` as the project-local MUI bridge and to cross-reference the matching `APPROVED_WRAPPERS` list in `scripts/audit-mui.js`.

Removing the direct `@mui/*` dependencies from `package.json` (Phase 3 exit criterion #2, "MUI only as transitive dep") is a follow-up PR.

Refs #18658
Refs #18654

## Test plan

- [x] `npm run lint` — passes (0 errors; 4 pre-existing warnings unrelated to this change)
- [x] `npm run audit:mui` — reports `AUDIT mui files=0 matches=0` with `Approved wrappers (excluded from count): 5`
- [x] `npm test` — 68 tests pass across 15 files
- [x] `grep -rE "from ['\"]@mui/material['\"]" ui/components --include='*.ts*' | grep -v "^ui/components/shared/"` — returns nothing (no stray `@mui/material` imports outside approved shared wrappers, of which there are currently none in `components/`)
- [x] DCO sign-off included