### PR TITLE
fix(ui): falsy-color fallback on PatternServiceForm gradient second stop (post-#19329)

### DIFF
--- a/ui/components/meshery-mesh-interface/PatternServiceForm.tsx
+++ b/ui/components/meshery-mesh-interface/PatternServiceForm.tsx
@@ -92,7 +92,7 @@ function PatternServiceForm({
                 style={{
                   padding: '0 5px',
                   paddingLeft: 16,
-                  background: `linear-gradient(115deg, ${darken(color || '#607d8b', 0.2)} 0%, ${color} 100%)`,
+                  background: `linear-gradient(115deg, ${darken(color || '#607d8b', 0.2)} 0%, ${color || '#607d8b'} 100%)`,
                   height: '0.7rem !important',
                 }}
               >


### PR DESCRIPTION
## Summary
Post-merge Gemini review on #19329 ([comment 3234841487](https://github.com/meshery/meshery/pull/19329#discussion_r3234841487)) flagged that the `darken(color, ...)` migration in `PatternServiceForm.tsx` correctly added a falsy-color fallback for the first stop of the `linear-gradient(...)`, but the **second stop still emitted bare `${color}`** — yielding an invalid CSS gradient when `color` is `undefined`.

This one-line fix mirrors the same `color || '#607d8b'` fallback on the second stop.

## Test plan
- `npm run lint` — passes (no new warnings/errors).
- Visual verification: the gradient now renders valid CSS for both falsy and non-falsy `color` props.

Refs #18657
Refs #18654
Closes the Gemini high-priority finding on #19329.