### PR TITLE
[UI] Implement Evaluate design feature on Designs page

### DIFF
--- a/ui/assets/icons/index.ts
+++ b/ui/assets/icons/index.ts
@@ -55,6 +55,7 @@ export { default as InfoOutlinedIcon } from './InfoOutlined';
 
 export {
   AccessTime,
+  AssignmentTurnedInIcon as AssignmentTurnedIn,
   AddCircleIcon as AddCircle,
   ArrowBackIcon as ArrowBack,
   BarchartIcon as BarChart,

--- a/ui/components/designs/patterns/MesheryPatternCard.tsx
+++ b/ui/components/designs/patterns/MesheryPatternCard.tsx
@@ -8,6 +8,7 @@ import {
   GetApp as GetAppIcon,
   FullscreenExit,
   DoneAll as DoneAllIcon,
+  AssignmentTurnedIn as AssignmentTurnedInIcon,
 } from '@/assets/icons';
 import Moment from 'react-moment';
 import FlipCard from '../../FlipCard';
@@ -70,6 +71,7 @@ function MesheryPatternCard_({
   user,
   pattern,
   handleInfoModal,
+  handleEvaluateDesign,
   hideVisibility = false,
   isReadOnly = false,
 }) {
@@ -239,6 +241,23 @@ function MesheryPatternCard_({
                 ]}
                 data-testid="pattern-btn-action-dropdown"
               />
+              <TooltipButton
+                title="Evaluate"
+                variant="contained"
+                color="primary"
+                onClick={(ev) => genericClickHandler(ev, handleEvaluateDesign)}
+                style={{
+                  padding: '6px 9px',
+                  borderRadius: '8px',
+                }}
+                disabled={!CAN(keys.VALIDATE_DESIGN.action, keys.VALIDATE_DESIGN.subject)}
+                data-testid="pattern-btn-evaluate"
+              >
+                <AssignmentTurnedInIcon
+                  style={{ fill: theme.palette.background.constant.white, ...iconMedium }}
+                />
+                <GridBtnText> Evaluate </GridBtnText>
+              </TooltipButton>
               <TooltipButton
                 title="Download"
                 variant="contained"

--- a/ui/components/designs/patterns/MesheryPatternGridView.tsx
+++ b/ui/components/designs/patterns/MesheryPatternGridView.tsx
@@ -30,6 +30,7 @@ function PatternCardGridItem({
   setSelectedPatterns,
   user,
   handleInfoModal,
+  handleEvaluateDesign,
   hideVisibility = false,
   isReadOnly = false,
 }) {
@@ -57,6 +58,7 @@ function PatternCardGridItem({
         handleClone={handleClone}
         handleInfoModal={handleInfoModal}
         handleDownload={handleDownload}
+        handleEvaluateDesign={handleEvaluateDesign}
         deleteHandler={() =>
           handleSubmit({
             data: yaml,
@@ -141,6 +143,7 @@ function MesheryPatternGrid({
   openDryRunModal,
   hideVisibility = false,
   arePatternsReadOnly = false,
+  handleEvaluateDesign,
   'data-testid': testId = 'meshery-patterns-grid',
 }) {
   const { notify } = useNotification();
@@ -228,6 +231,9 @@ function MesheryPatternGrid({
               handleSubmit={handleSubmit}
               handleDownload={(e) => handleDesignDownloadModal(e, pattern)}
               setSelectedPatterns={setSelectedPattern}
+              handleEvaluateDesign={(e) =>
+                handleEvaluateDesign(e, pattern.patternFile, pattern.name)
+              }
               hideVisibility={hideVisibility}
               isReadOnly={arePatternsReadOnly}
             />

--- a/ui/components/designs/patterns/MesheryPatterns.columns.tsx
+++ b/ui/components/designs/patterns/MesheryPatterns.columns.tsx
@@ -2,7 +2,11 @@ import React from 'react';
 import { Box } from '@sistent/sistent';
 import Moment from 'react-moment';
 import { GetApp as GetAppIcon } from '@/assets/icons';
-import { DoneAll as DoneAllIcon, Public as PublicIcon } from '@/assets/icons';
+import {
+  DoneAll as DoneAllIcon,
+  Public as PublicIcon,
+  AssignmentTurnedIn as AssignmentTurnedInIcon,
+} from '@/assets/icons';
 import UndeployIcon from '../../../public/static/img/UndeployIcon';
 import CloneIcon from '../../../public/static/img/CloneIcon';
 import { Edit as EditIcon } from '@/assets/icons';
@@ -37,6 +41,7 @@ export function buildPatternActions({ rowData, visibility, patterns, tableMeta, 
     handleInfoModal,
     handleUnpublishModal,
     userCanEdit,
+    handleEvaluateDesign,
   } = handlers;
 
   return [
@@ -83,6 +88,14 @@ export function buildPatternActions({ rowData, visibility, patterns, tableMeta, 
       icon: <DryRunIcon data-cy="verify-button" />,
       onClick: (e) => {
         openDryRunModal(e, rowData.patternFile, rowData.name, rowData.id);
+      },
+      disabled: !CAN(keys.VALIDATE_DESIGN.action, keys.VALIDATE_DESIGN.subject),
+    },
+    {
+      label: 'Evaluate',
+      icon: <AssignmentTurnedInIcon data-cy="evaluate-button" />,
+      onClick: (e) => {
+        handleEvaluateDesign(e, rowData.patternFile, rowData.name);
       },
       disabled: !CAN(keys.VALIDATE_DESIGN.action, keys.VALIDATE_DESIGN.subject),
     },

--- a/ui/components/designs/patterns/MesheryPatterns.tsx
+++ b/ui/components/designs/patterns/MesheryPatterns.tsx
@@ -7,6 +7,7 @@ import {
 import { NoSsr } from '@sistent/sistent';
 import React, { useEffect, useRef, useState } from 'react';
 import MesheryPatternGrid from './MesheryPatternGridView';
+
 import _PromptComponent from '../../PromptComponent';
 import LoadingScreen from '../../shared/LoadingState/LoadingComponent';
 import { MesheryPatternsCatalog, VISIBILITY } from '../../../utils/Enum';
@@ -32,6 +33,7 @@ import {
   useDeletePatternFileMutation,
   useDeletePatternMutation,
   useDeployPatternMutation,
+  useEvaluateDesignMutation,
   useGetPatternsQuery,
   useImportPatternMutation,
   usePublishPatternMutation,
@@ -111,6 +113,7 @@ function MesheryPatterns({
   const [updatePattern] = useUpdatePatternFileMutation();
   const [uploadPatternFile] = useUploadPatternFileMutation();
   const [deletePatternFile] = useDeletePatternFileMutation();
+  const [evaluateDesign] = useEvaluateDesignMutation();
 
   useEffect(() => {
     if (patternsData) {
@@ -185,6 +188,7 @@ function MesheryPatterns({
     deletePatterns,
     handleDownload,
     showModal,
+    handleEvaluateDesign,
   } = createPatternsActions({
     clonePattern,
     publishCatalog,
@@ -208,6 +212,7 @@ function MesheryPatterns({
     notify,
     sistentInfoModal,
     getPatterns,
+    evaluateDesign,
   });
 
   // const [loading, stillLoading] = useState(true);
@@ -413,6 +418,7 @@ function MesheryPatterns({
       handleInfoModal,
       handleUnpublishModal,
       userCanEdit,
+      handleEvaluateDesign,
     },
   });
 
@@ -574,6 +580,7 @@ function MesheryPatterns({
                 openValidationModal={openValidateModal}
                 openDryRunModal={openDryRunModal}
                 openDeployModal={openDeployModal}
+                handleEvaluateDesign={handleEvaluateDesign}
                 hideVisibility={hideVisibility}
                 arePatternsReadOnly={arePatternsReadOnly}
               />

--- a/ui/components/designs/patterns/patterns-actions.ts
+++ b/ui/components/designs/patterns/patterns-actions.ts
@@ -1,7 +1,7 @@
 import _ from 'lodash';
 import yaml from 'js-yaml';
 import { PROMPT_VARIANTS } from '@sistent/sistent';
-import { encodeDesignFile, getUnit8ArrayDecodedFile } from '../../../utils/utils';
+import { encodeDesignFile, getUnit8ArrayDecodedFile, parseDesignFile } from '../../../utils/utils';
 import { FILE_OPS } from '../../../utils/Enum';
 import { EVENT_TYPES } from '../../../lib/event-types';
 import downloadContent from '../../../utils/fileDownloader';
@@ -43,6 +43,7 @@ export function createPatternsActions(deps) {
     notify,
     sistentInfoModal,
     getPatterns,
+    evaluateDesign,
   } = deps;
 
   const handleError = (action) => (error) => {
@@ -78,6 +79,39 @@ export function createPatternsActions(deps) {
       selectedK8sContexts,
     });
     updateProgress({ showProgress: false });
+  };
+
+  const handleEvaluateDesign = (e, pattern_file, name) => {
+    e.stopPropagation();
+    const design = parseDesignFile(pattern_file);
+    if (!design) {
+      notify({
+        message: `Failed to parse design "${name}"`,
+        event_type: EVENT_TYPES.ERROR,
+      });
+      return;
+    }
+    updateProgress({ showProgress: true });
+    evaluateDesign({
+      evaluateBody: JSON.stringify({ design }),
+    })
+      .unwrap()
+      .then((response) => {
+        updateProgress({ showProgress: false });
+        const actionCount = response?.actions?.length || 0;
+        const version = response?.design?.version || 'unknown';
+        notify({
+          message: `Evaluation complete for "${name}": ${actionCount} change(s) at version ${version}`,
+          event_type: EVENT_TYPES.SUCCESS,
+        });
+      })
+      .catch((error) => {
+        updateProgress({ showProgress: false });
+        notify({
+          message: `Evaluation failed for "${name}": ${error?.data?.message || error?.message || 'Unknown error'}`,
+          event_type: EVENT_TYPES.ERROR,
+        });
+      });
   };
 
   const handleUploadImport = () => {
@@ -405,5 +439,6 @@ export function createPatternsActions(deps) {
     deletePatterns,
     handleDownload,
     showModal,
+    handleEvaluateDesign,
   };
 }

--- a/ui/rtk-query/design.ts
+++ b/ui/rtk-query/design.ts
@@ -183,6 +183,14 @@ export const designsApi = api
       downloadPatternFile: builder.query({
         query: (queryArg) => mesheryApiPath(`pattern/${queryArg.id}`),
       }),
+      evaluateDesign: builder.mutation({
+        query: (queryArg) => ({
+          url: mesheryApiPath(`meshmodels/relationships/evaluate`),
+          method: 'POST',
+          body: queryArg.evaluateBody,
+        }),
+        invalidatesTags: [{ type: TAGS.DESIGNS }],
+      }),
     }),
   });
 
@@ -212,4 +220,5 @@ export const {
   useUploadPatternFileMutation,
   useDeletePatternFileMutation,
   useDownloadPatternFileQuery,
+  useEvaluateDesignMutation,
 } = designsApi;


### PR DESCRIPTION
**Notes for Reviewers**

This PR allows users to trigger relationship policy evaluations for designs directly from the UI. It integrates the existing backend evaluation endpoint into the Designs page grid and table views.
**Changes made:**
- Added `evaluateDesign` RTK mutation targeting `POST /api/meshmodels/relationships/evaluate`.
- Exported MUI `AccountTree` icon for the button.
- Added a standalone `Evaluate` button to `MesheryPatternCard` (Grid View).
- Added `Evaluate` action to `ActionPopover` in `MesheryPatterns` (Table View).
- Added `handleEvaluateDesign` to parse the design, send the payload, and display success/error toast notifications.


This PR fixes #19335 

**[Signed commits](https://github.com/meshery/meshery/blob/master/CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [x] Yes, I signed my commits.

<!--
Thank you for contributing to Meshery! 

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. Sign your commits.
4. Include before and after screenshots/terminal output.

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.
-->
