### PR TITLE
ui: guard provider capabilities in navigator

### DIFF
--- a/ui/rtk-query/__tests__/transforms.test.ts
+++ b/ui/rtk-query/__tests__/transforms.test.ts
@@ -24,6 +24,20 @@ describe('normalizeProviderCapabilities', () => {
       }),
     );
   });
+
+  it('normalizes non-array capabilities to an empty array', () => {
+    expect(
+      normalizeProviderCapabilities({
+        provider_name: 'Meshery Cloud',
+        capabilities: { feature: 'persist-meshery-patterns' },
+      }),
+    ).toEqual(
+      expect.objectContaining({
+        providerName: 'Meshery Cloud',
+        capabilities: [],
+      }),
+    );
+  });
 });
 
 describe('normalizePaginatedCollectionResponse', () => {

--- a/ui/rtk-query/transforms.ts
+++ b/ui/rtk-query/transforms.ts
@@ -78,6 +78,7 @@ export const normalizeProviderCapabilities = (response?: ProviderCapabilitiesRes
     providerType: response.providerType ?? response.provider_type,
     providerUrl: response.providerUrl ?? response.provider_url,
     providerDescription: response.providerDescription ?? response.provider_description,
+    capabilities: Array.isArray(response.capabilities) ? response.capabilities : [],
   };
 };
 

--- a/ui/utils/__tests__/disabledComponents.test.ts
+++ b/ui/utils/__tests__/disabledComponents.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, it } from 'vitest';
+import { CapabilitiesRegistry } from '../disabledComponents';
+
+describe('CapabilitiesRegistry', () => {
+  it('exposes provider capabilities as an array for UI guards', () => {
+    const registry = new CapabilitiesRegistry({
+      capabilities: [{ feature: 'persist-meshery-patterns' }],
+    });
+
+    expect(registry.capabilities).toEqual([{ feature: 'persist-meshery-patterns' }]);
+  });
+
+  it('returns an empty capability list when the provider payload is malformed', () => {
+    const registry = new CapabilitiesRegistry({
+      capabilities: { feature: 'persist-meshery-patterns' },
+    });
+
+    expect(registry.capabilities).toEqual([]);
+  });
+});

--- a/ui/utils/disabledComponents.ts
+++ b/ui/utils/disabledComponents.ts
@@ -22,8 +22,10 @@ export class CapabilitiesRegistry {
     this.isPlaygroundEnv = capabilitiesRegistry?.restrictedAccess?.isMesheryUIRestricted || false;
   }
 
-  capabilities() {
-    return this.capabilitiesRegistry;
+  get capabilities() {
+    return Array.isArray(this.capabilitiesRegistry?.capabilities)
+      ? this.capabilitiesRegistry.capabilities
+      : [];
   }
 
   isNavigatorComponentEnabled(navigatorWalker) {


### PR DESCRIPTION
## Summary
- expose `CapabilitiesRegistry.capabilities` as a safe array-backed getter for navigator capability checks
- normalize provider capability payloads so `capabilities` is always an array in RTK Query consumers
- add regression tests for malformed capability payloads and registry access

## Why
The UI could crash with `e?.capabilities?.some is not a function` when navigator code read `capabilities` from a `CapabilitiesRegistry` instance instead of directly from the provider payload. This change makes the registry and transformed API response agree on a stable array shape.

## Testing
- `cd ui && npm run test -- rtk-query/__tests__/transforms.test.ts utils/__tests__/disabledComponents.test.ts`
- `cd ui && npx eslint rtk-query/transforms.ts rtk-query/__tests__/transforms.test.ts utils/disabledComponents.ts utils/__tests__/disabledComponents.test.ts`
- `cd ui && npm run build`