### PR TITLE
refactor(ui): separate provider capabilities from registry naming

### DIFF
--- a/ui/components/AppComponents.tsx
+++ b/ui/components/AppComponents.tsx
@@ -9,11 +9,11 @@ import { updateK8SConfig } from '@/store/slices/mesheryUi';
 import { StyledDrawer, StyledFooterBody, StyledFooterText } from '../themes/App.styles';
 
 type FooterProps = {
-  capabilitiesRegistry?: { restrictedAccess?: { isMesheryUiRestricted?: boolean } } | null;
+  providerCapabilities?: { restrictedAccess?: { isMesheryUiRestricted?: boolean } } | null;
   handleMesheryCommunityClick: () => void;
 };
 
-export const Footer = ({ capabilitiesRegistry, handleMesheryCommunityClick }: FooterProps) => {
+export const Footer = ({ providerCapabilities, handleMesheryCommunityClick }: FooterProps) => {
   const theme = useTheme();
   const isPlaygroundBuild = process.env.NEXT_PUBLIC_PLAYGROUND_BUILD === 'true';
   const { extensionType: extension } = useSelector((state) => state.ui);
@@ -36,7 +36,7 @@ export const Footer = ({ capabilitiesRegistry, handleMesheryCommunityClick }: Fo
         }}
       >
         <StyledFooterText onClick={handleMesheryCommunityClick}>
-          {capabilitiesRegistry?.restrictedAccess?.isMesheryUIRestricted || isPlaygroundBuild ? (
+          {providerCapabilities?.restrictedAccess?.isMesheryUIRestricted || isPlaygroundBuild ? (
             'ACCESS LIMITED IN MESHERY PLAYGROUND. DEPLOY MESHERY TO ACCESS ALL FEATURES.'
           ) : (
             <>

--- a/ui/components/ExtensionSandbox.tsx
+++ b/ui/components/ExtensionSandbox.tsx
@@ -224,7 +224,7 @@ const ExtensionSandbox = React.memo<ExtensionSandboxProps>(
       NavigatorSchema[] | UserPrefSchema[] | AccountSchema[] | CollaboratorSchema[]
     >([]);
     const [isLoading, setIsLoading] = useState<boolean>(true);
-    const { capabilitiesRegistry, isDrawerCollapsed } = useSelector((state: RootState) => state.ui);
+    const { providerCapabilities, isDrawerCollapsed } = useSelector((state: RootState) => state.ui);
     const dispatch = useDispatch();
 
     // close the drawer when extension is loaded/mounted
@@ -239,9 +239,9 @@ const ExtensionSandbox = React.memo<ExtensionSandboxProps>(
     );
 
     useEffect(() => {
-      if (capabilitiesRegistry && capabilitiesRegistry.extensions) {
+      if (providerCapabilities && providerCapabilities.extensions) {
         try {
-          const extensionData = capabilitiesRegistry.extensions[type];
+          const extensionData = providerCapabilities.extensions[type];
           const processedData = ExtensionPointSchemaValidator(type)(extensionData);
           setExtension(processedData);
           setIsLoading(false);
@@ -258,7 +258,7 @@ const ExtensionSandbox = React.memo<ExtensionSandboxProps>(
         setExtension([]);
         setIsLoading(true);
       };
-    }, [type, capabilitiesRegistry]);
+    }, [type, providerCapabilities]);
 
     const renderContent = (): React.ReactNode => {
       if (isLoading) {

--- a/ui/components/User.tsx
+++ b/ui/components/User.tsx
@@ -18,7 +18,7 @@ const User = (props) => {
   const capabilitiesLoadedRef = useRef(false);
   const { notify } = useNotification();
   const dispatch = useDispatch();
-  const { capabilitiesRegistry } = useSelector((state) => state.ui);
+  const { providerCapabilities } = useSelector((state) => state.ui);
   const {
     data: userData,
     isSuccess: isGetUserSuccess,
@@ -52,13 +52,13 @@ const User = (props) => {
   }, [userData, isGetUserSuccess, isGetUserError]);
 
   useEffect(() => {
-    if (!capabilitiesLoadedRef.current && capabilitiesRegistry) {
+    if (!capabilitiesLoadedRef.current && providerCapabilities) {
       capabilitiesLoadedRef.current = true;
       setAccount(
-        ExtensionPointSchemaValidator('account')(capabilitiesRegistry?.extensions?.account),
+        ExtensionPointSchemaValidator('account')(providerCapabilities?.extensions?.account),
       );
     }
-  }, [capabilitiesRegistry]);
+  }, [providerCapabilities]);
 
   const { color } = props;
 
@@ -67,7 +67,7 @@ const User = (props) => {
   const refURL = btoa(window.location.href);
 
   if (userData?.status == 'anonymous') {
-    const url = `${capabilitiesRegistry?.providerUrl}?anonymousUserID=${userData?.id}&source=${sourceURL}&ref=${refURL}`;
+    const url = `${providerCapabilities?.providerUrl}?anonymousUserID=${userData?.id}&source=${sourceURL}&ref=${refURL}`;
 
     return (
       <Link href={url}>

--- a/ui/components/designs/patterns/MesheryPatterns.tsx
+++ b/ui/components/designs/patterns/MesheryPatterns.tsx
@@ -451,8 +451,8 @@ function MesheryPatterns({
 
   useEffect(() => {
     if (capabilitiesData) {
-      const capabilitiesRegistry = capabilitiesData;
-      const patternsCatalogueCapability = capabilitiesRegistry?.capabilities.filter(
+      // `capabilitiesData.capabilities` is the provider-declared feature list.
+      const patternsCatalogueCapability = capabilitiesData?.capabilities?.filter(
         (val) => val.feature === MesheryPatternsCatalog,
       );
       if (patternsCatalogueCapability?.length > 0) setCanPublishPattern(true);

--- a/ui/components/filters/Filters.tsx
+++ b/ui/components/filters/Filters.tsx
@@ -404,8 +404,8 @@ function MesheryFilters() {
     };
 
     if (capabilitiesData) {
-      const capabilitiesRegistry = capabilitiesData;
-      const filtersCatalogCapability = capabilitiesRegistry?.capabilities.filter(
+      // `capabilitiesData.capabilities` is the provider-declared feature list.
+      const filtersCatalogCapability = capabilitiesData?.capabilities?.filter(
         (val) => val.feature === MesheryFiltersCatalog,
       );
       if (filtersCatalogCapability?.length > 0) setCanPublishFilter(true);

--- a/ui/components/layout/Header/HeaderMenu.tsx
+++ b/ui/components/layout/Header/HeaderMenu.tsx
@@ -28,7 +28,7 @@ function exportToJsonFile(jsonData, filename) {
  */
 const HeaderMenu = () => {
   const dispatch = useDispatch();
-  const { capabilitiesRegistry } = useSelector((state) => state.ui);
+  const { providerCapabilities } = useSelector((state) => state.ui);
   const [userLoaded, setUserLoaded] = useState(false);
   const [account, setAccount] = useState([]);
   const capabilitiesLoadedRef = useRef(false);
@@ -104,13 +104,13 @@ const HeaderMenu = () => {
   }, [isTokenError, tokenError, notify]);
 
   useEffect(() => {
-    if (!capabilitiesLoadedRef.current && capabilitiesRegistry) {
+    if (!capabilitiesLoadedRef.current && providerCapabilities) {
       capabilitiesLoadedRef.current = true;
       setAccount(
-        ExtensionPointSchemaValidator('account')(capabilitiesRegistry?.extensions?.account),
+        ExtensionPointSchemaValidator('account')(providerCapabilities?.extensions?.account),
       );
     }
-  }, [capabilitiesRegistry]);
+  }, [providerCapabilities]);
 
   const getAccountNavigationItems = () => {
     const accountItems = account.map((item) => ({

--- a/ui/components/layout/Navigator/Navigator.tsx
+++ b/ui/components/layout/Navigator/Navigator.tsx
@@ -151,7 +151,7 @@ const resolveNavigatorComponents = ({
   currentPath,
 }) => {
   const designPersistenceEnabled = Boolean(
-    capabilityRegistryObj?.capabilities?.some(
+    capabilityRegistryObj?.providerCapabilities?.some(
       (capability) => capability.feature === 'persist-meshery-patterns',
     ),
   );

--- a/ui/components/layout/Navigator/Navigator.tsx
+++ b/ui/components/layout/Navigator/Navigator.tsx
@@ -23,7 +23,7 @@ import {
 } from '@sistent/sistent';
 import ExtensionPointSchemaValidator from '../../../utils/ExtensionPointSchemaValidator';
 import { cursorNotAllowed, disabledStyle } from '../../../css/disableComponent.styles';
-import { CapabilitiesRegistry } from '../../../utils/disabledComponents';
+import { ProviderUiAccessControl } from '../../../utils/disabledComponents';
 import {
   CONFIGURATION,
   DASHBOARD,
@@ -68,8 +68,8 @@ import { useDispatch, useSelector } from 'react-redux';
 import {
   toggleDrawer,
   updateBetaBadge,
-  updateCapabilities,
   updateExtensionType,
+  updateProviderCapabilities,
   updateTitle,
 } from '@/store/slices/mesheryUi';
 import { useRouter } from 'next/router';
@@ -144,19 +144,19 @@ const buildLifecycleIcon = (adapterName, href, currentPath) => {
 };
 
 const resolveNavigatorComponents = ({
-  capabilityRegistryObj,
+  providerUiAccessControl,
   theme,
   meshAdapters,
   catalogVisibility,
   currentPath,
 }) => {
   const designPersistenceEnabled = Boolean(
-    capabilityRegistryObj?.providerCapabilities?.some(
+    providerUiAccessControl?.providerCapabilities?.some(
       (capability) => capability.feature === 'persist-meshery-patterns',
     ),
   );
 
-  return getNavigatorComponents(capabilityRegistryObj, theme).map((category) => {
+  return getNavigatorComponents(providerUiAccessControl, theme).map((category) => {
     if (category.id === LIFECYCLE) {
       return {
         ...category,
@@ -234,22 +234,22 @@ const NavigatorContent = () => {
   const [showHelperButton, setShowHelperButton] = useState(false);
   const [openItems, setOpenItems] = useState<string[]>([]);
   const [hoveredId, setHoveredId] = useState<string | null>(null);
-  const [capabilitiesRegistryObj, setCapabilitiesRegistryObj] =
-    useState<CapabilitiesRegistry | null>(null);
+  const [providerUiAccessControl, setProviderUiAccessControl] =
+    useState<ProviderUiAccessControl | null>(null);
   const [versionDetail, setVersionDetail] = useState(defaultVersionDetail);
   const navigatorComponents = useMemo(() => {
-    if (!capabilitiesRegistryObj) {
+    if (!providerUiAccessControl) {
       return [];
     }
 
     return resolveNavigatorComponents({
-      capabilityRegistryObj: capabilitiesRegistryObj,
+      providerUiAccessControl,
       theme,
       meshAdapters,
       catalogVisibility,
       currentPath,
     });
-  }, [capabilitiesRegistryObj, catalogVisibility, currentPath, meshAdapters, theme]);
+  }, [providerUiAccessControl, catalogVisibility, currentPath, meshAdapters, theme]);
 
   const ExternalLinkIcon = (
     <IconExternalLink
@@ -312,8 +312,8 @@ const NavigatorContent = () => {
       setNavigatorExtensions(
         ExtensionPointSchemaValidator('navigator')(result?.extensions?.navigator),
       );
-      setCapabilitiesRegistryObj(new CapabilitiesRegistry(result));
-      dispatch(updateCapabilities({ capabilitiesRegistry: result }));
+      setProviderUiAccessControl(new ProviderUiAccessControl(result));
+      dispatch(updateProviderCapabilities({ providerCapabilities: result }));
     }
     if (isError) {
       console.error('Error fetching capabilities', error);
@@ -652,14 +652,14 @@ const NavigatorContent = () => {
   const Title = (
     <div
       style={
-        !capabilitiesRegistryObj?.isNavigatorComponentEnabled([DASHBOARD]) ? cursorNotAllowed : {}
+        !providerUiAccessControl?.isNavigatorComponentEnabled([DASHBOARD]) ? cursorNotAllowed : {}
       }
     >
       <>
         <StyledListItem
           component="a"
           onClick={handleTitleClick}
-          disableLogo={!capabilitiesRegistryObj?.isNavigatorComponentEnabled([DASHBOARD])}
+          disableLogo={!providerUiAccessControl?.isNavigatorComponentEnabled([DASHBOARD])}
         >
           {isDrawerCollapsed ? (
             <>
@@ -876,12 +876,12 @@ const NavigatorContent = () => {
     <ChevronButtonWrapper
       isCollapsed={isDrawerCollapsed}
       style={
-        capabilitiesRegistryObj?.isNavigatorComponentEnabled?.([TOGGLER]) ? {} : cursorNotAllowed
+        providerUiAccessControl?.isNavigatorComponentEnabled?.([TOGGLER]) ? {} : cursorNotAllowed
       }
     >
       <div
         style={
-          capabilitiesRegistryObj?.isNavigatorComponentEnabled?.([TOGGLER]) ? {} : disabledStyle
+          providerUiAccessControl?.isNavigatorComponentEnabled?.([TOGGLER]) ? {} : disabledStyle
         }
         onClick={toggleMiniDrawer}
       >

--- a/ui/components/layout/Navigator/NavigatorExtension.tsx
+++ b/ui/components/layout/Navigator/NavigatorExtension.tsx
@@ -9,7 +9,7 @@ import PatternServiceFormCore from '../../meshery-mesh-interface/PatternServiceF
 import InfoModal from '../../shared/Modal/Information/InfoModal';
 import ConfigurationSubscription from '@/graphql/subscriptions/ConfigurationSubscription';
 import _PromptComponent from '../../PromptComponent';
-import { CapabilitiesRegistry } from '../../../utils/disabledComponents';
+import { ProviderUiAccessControl } from '../../../utils/disabledComponents';
 import { useNotification } from '../../../utils/hooks/useNotification';
 import Modal from '../../shared/Modal/Modal';
 import ExportModal from '../../shared/Modal/ExportModal';
@@ -85,7 +85,7 @@ function NavigatorExtensionError({ error }: { error: unknown }) {
 
 function NavigatorExtension({ url }: NavigatorExtensionProps) {
   const {
-    capabilitiesRegistry,
+    providerCapabilities,
     selectedK8sContexts,
     organization: currentOrganization,
   } = useSelector((state) => state.ui);
@@ -111,8 +111,10 @@ function NavigatorExtension({ url }: NavigatorExtensionProps) {
       ExportModal,
       GenericRJSFModal: Modal,
       _PromptComponent,
-      capabilitiesRegistry,
-      CapabilitiesRegistryClass: CapabilitiesRegistry,
+      providerCapabilities,
+      ProviderUiAccessControlClass: ProviderUiAccessControl,
+      // Backward-compatible alias for already-published remote extensions.
+      CapabilitiesRegistryClass: ProviderUiAccessControl,
       TypingFilter,
       useNotificationHook: useNotification,
       StructuredDataFormatter: FormatStructuredData,
@@ -138,7 +140,7 @@ function NavigatorExtension({ url }: NavigatorExtensionProps) {
       SetCurrentLoadedResourceInOrgWorkspaceSession: onLoadResource,
     }),
     [
-      capabilitiesRegistry,
+      providerCapabilities,
       currentOrganization,
       onLoadResource,
       openModalWithDefault,

--- a/ui/components/layout/Navigator/navigatorComponents.tsx
+++ b/ui/components/layout/Navigator/navigatorComponents.tsx
@@ -35,7 +35,7 @@ export const drawerIconsStyle = {
 };
 
 export const getNavigatorComponents = (
-  /** @type {CapabilitiesRegistry} */ capabilityRegistryObj,
+  /** @type {ProviderUiAccessControl} */ providerUiAccessControl,
   theme,
 ) => [
   {
@@ -44,7 +44,7 @@ export const getNavigatorComponents = (
     hovericon: <DashboardIcon style={drawerIconsStyle} />,
     href: '/',
     title: 'Dashboard',
-    show: capabilityRegistryObj.isNavigatorComponentEnabled([DASHBOARD]),
+    show: providerUiAccessControl.isNavigatorComponentEnabled([DASHBOARD]),
     link: true,
     submenu: true,
   },
@@ -55,14 +55,14 @@ export const getNavigatorComponents = (
     title: 'Lifecycle',
     link: true,
     href: '/management/connections',
-    show: capabilityRegistryObj.isNavigatorComponentEnabled([LIFECYCLE]),
+    show: providerUiAccessControl.isNavigatorComponentEnabled([LIFECYCLE]),
     submenu: true,
     children: [
       {
         id: CONNECTION,
         href: '/management/connections',
         title: 'Connections',
-        show: capabilityRegistryObj.isNavigatorComponentEnabled([LIFECYCLE, CONNECTION]),
+        show: providerUiAccessControl.isNavigatorComponentEnabled([LIFECYCLE, CONNECTION]),
         link: true,
         permission: {
           action: keys.VIEW_CONNECTIONS.action,
@@ -73,7 +73,7 @@ export const getNavigatorComponents = (
         id: ENVIRONMENT,
         href: '/management/environments',
         title: 'Environments',
-        show: capabilityRegistryObj.isNavigatorComponentEnabled([LIFECYCLE, ENVIRONMENT]),
+        show: providerUiAccessControl.isNavigatorComponentEnabled([LIFECYCLE, ENVIRONMENT]),
         link: true,
         permission: {
           action: keys.VIEW_ENVIRONMENTS.action,
@@ -84,7 +84,7 @@ export const getNavigatorComponents = (
         id: WORKSPACE,
         href: '/management/workspaces',
         title: 'Workspaces',
-        show: capabilityRegistryObj.isNavigatorComponentEnabled([LIFECYCLE, WORKSPACE]),
+        show: providerUiAccessControl.isNavigatorComponentEnabled([LIFECYCLE, WORKSPACE]),
         link: true,
         permission: {
           action: keys.VIEW_WORKSPACE.action,
@@ -111,7 +111,7 @@ export const getNavigatorComponents = (
     hovericon: <ConfigurationHover style={drawerIconsStyle} />,
     href: '/configuration/designs',
     title: 'Configuration',
-    show: capabilityRegistryObj.isNavigatorComponentEnabled([CONFIGURATION]),
+    show: providerUiAccessControl.isNavigatorComponentEnabled([CONFIGURATION]),
     link: true,
     submenu: true,
     children: [
@@ -135,7 +135,7 @@ export const getNavigatorComponents = (
         ),
         href: '/configuration/catalog',
         title: 'Catalog',
-        show: capabilityRegistryObj.isNavigatorComponentEnabled([CONFIGURATION, CATALOG]),
+        show: providerUiAccessControl.isNavigatorComponentEnabled([CONFIGURATION, CATALOG]),
         link: true,
         isBeta: true,
         permission: {
@@ -148,7 +148,7 @@ export const getNavigatorComponents = (
         icon: <PatternIcon style={{ ...drawerIconsStyle }} />,
         href: '/configuration/designs',
         title: 'Designs',
-        show: capabilityRegistryObj.isNavigatorComponentEnabled([CONFIGURATION, DESIGN]),
+        show: providerUiAccessControl.isNavigatorComponentEnabled([CONFIGURATION, DESIGN]),
         link: true,
         isBeta: true,
         permission: {
@@ -164,7 +164,7 @@ export const getNavigatorComponents = (
     hovericon: <PerformanceHover style={drawerIconsStyle} />,
     href: '/performance',
     title: 'Performance',
-    show: capabilityRegistryObj.isNavigatorComponentEnabled([PERFORMANCE]),
+    show: providerUiAccessControl.isNavigatorComponentEnabled([PERFORMANCE]),
     link: true,
     submenu: true,
     children: [
@@ -173,7 +173,7 @@ export const getNavigatorComponents = (
         icon: <TachographDigitalIcon fill={theme.palette.icon.default} />,
         href: '/performance/profiles',
         title: 'Profiles',
-        show: capabilityRegistryObj.isNavigatorComponentEnabled([PERFORMANCE, PROFILES]),
+        show: providerUiAccessControl.isNavigatorComponentEnabled([PERFORMANCE, PROFILES]),
         link: true,
         permission: {
           action: keys.VIEW_PERFORMANCE_PROFILES.action,
@@ -187,7 +187,7 @@ export const getNavigatorComponents = (
     icon: <ExtensionIcon style={drawerIconsStyle} />,
     hovericon: <ExtensionIcon style={drawerIconsStyle} />,
     title: 'Extensions',
-    show: capabilityRegistryObj.isNavigatorComponentEnabled([EXTENSIONS]),
+    show: providerUiAccessControl.isNavigatorComponentEnabled([EXTENSIONS]),
     width: 12,
     link: true,
     href: '/extensions',

--- a/ui/components/user-preferences/index.tsx
+++ b/ui/components/user-preferences/index.tsx
@@ -137,7 +137,7 @@ const UserPreference: React.FC<UserPreferenceProps> = (props) => {
   const [providerInfo, setProviderInfo] = useState<_ProviderInfo>({});
   const theme = useTheme();
   const dispatch = useDispatch();
-  const { capabilitiesRegistry } = useSelector((state) => state.ui);
+  const { providerCapabilities } = useSelector((state) => state.ui);
   const {
     data: userData,
     isSuccess: isUserDataFetched,
@@ -231,14 +231,14 @@ const UserPreference: React.FC<UserPreferenceProps> = (props) => {
   };
 
   useEffect(() => {
-    if (capabilitiesRegistry && !capabilitiesLoaded) {
+    if (providerCapabilities && !capabilitiesLoaded) {
       setCapabilitiesLoaded(true); // to prevent re-compute
       setUserPrefs(
-        ExtensionPointSchemaValidator('userPrefs')(capabilitiesRegistry?.extensions?.userPrefs),
+        ExtensionPointSchemaValidator('userPrefs')(providerCapabilities?.extensions?.userPrefs),
       );
-      setProviderType(capabilitiesRegistry?.providerType);
+      setProviderType(providerCapabilities?.providerType);
     }
-  }, [capabilitiesRegistry]);
+  }, [providerCapabilities]);
 
   useEffect(() => {
     if (isUserDataFetched && userData) {

--- a/ui/components/workspaces/SpacesSwitcher/MainDesignsContent.tsx
+++ b/ui/components/workspaces/SpacesSwitcher/MainDesignsContent.tsx
@@ -265,9 +265,9 @@ const MainDesignsContent = ({
   const isInitialFetch = isFetching && page === 0;
   const isEmpty = totalCount === 0;
   const shouldRenderDesigns = !isEmpty && !isInitialFetch;
-  const { capabilitiesRegistry } = useSelector((state) => state.ui);
+  const { providerCapabilities } = useSelector((state) => state.ui);
   const { organization: currentOrganization } = useSelector((state) => state.ui);
-  const providerUrl = capabilitiesRegistry?.providerUrl;
+  const providerUrl = providerCapabilities?.providerUrl;
   const [activeUsers] = useRoomActivity({
     providerUrl,
     getUserAccessToken: getUserAccessToken,

--- a/ui/components/workspaces/SpacesSwitcher/MainViewsContent.tsx
+++ b/ui/components/workspaces/SpacesSwitcher/MainViewsContent.tsx
@@ -200,9 +200,9 @@ const MainViewsContent = ({
   const isInitialFetch = isFetching && page === 0;
   const isEmpty = totalCount === 0;
   const shouldRenderDesigns = !isEmpty && !isInitialFetch;
-  const { capabilitiesRegistry } = useSelector((state) => state.ui);
+  const { providerCapabilities } = useSelector((state) => state.ui);
   const { organization: currentOrganization } = useSelector((state) => state.ui);
-  const providerUrl = capabilitiesRegistry?.providerUrl;
+  const providerUrl = providerCapabilities?.providerUrl;
   const [activeUsers] = useRoomActivity({
     providerUrl,
     getUserAccessToken: getUserAccessToken,

--- a/ui/pages/_app.tsx
+++ b/ui/pages/_app.tsx
@@ -103,10 +103,10 @@ import RegistryModalContextProvider from '@/utils/context/RegistryModalContextPr
 import { DynamicFullScreenLoader } from '@/components/shared/LoadingState/DynamicFullscreenLoader';
 
 export const mesheryExtensionRoute = '/extension/meshmap';
-function isMesheryUIRestrictedAndThePageIsNotPlayground(capabilitiesRegistry) {
+function isMesheryUIRestrictedAndThePageIsNotPlayground(providerCapabilities) {
   return (
     !window.location.pathname.startsWith(mesheryExtensionRoute) &&
-    capabilitiesRegistry?.restrictedAccess?.isMesheryUIRestricted
+    providerCapabilities?.restrictedAccess?.isMesheryUIRestricted
   );
 }
 
@@ -117,7 +117,7 @@ export function isExtensionOpen() {
 const MesheryApp = ({ Component, pageProps, relayEnvironment, emotionCache }) => {
   const pageContext = useMemo(() => getPageContext(), []);
   const { k8sConfig } = useSelector((state) => state.ui);
-  const { capabilitiesRegistry } = useSelector((state) => state.ui);
+  const { providerCapabilities } = useSelector((state) => state.ui);
   const { isDrawerCollapsed } = useSelector((state) => state.ui);
   const [fetchCredentialById] = useLazyGetCredentialByIdQuery();
   const [fetchSystemSync] = useLazyGetSystemSyncQuery();
@@ -477,7 +477,7 @@ const MesheryApp = ({ Component, pageProps, relayEnvironment, emotionCache }) =>
     // in case the meshery-ui is restricted, the user will be redirected to signup/extension page
     if (
       typeof window !== 'undefined' &&
-      isMesheryUIRestrictedAndThePageIsNotPlayground(capabilitiesRegistry)
+      isMesheryUIRestrictedAndThePageIsNotPlayground(providerCapabilities)
     ) {
       Router.push(mesheryExtensionRoute);
     }
@@ -493,7 +493,7 @@ const MesheryApp = ({ Component, pageProps, relayEnvironment, emotionCache }) =>
         initSubscriptions(ids);
       }
     }
-  }, [k8sConfig, capabilitiesRegistry]);
+  }, [k8sConfig, providerCapabilities]);
 
   const canShowNav = !state.isFullScreenMode && uiConfig?.components?.navigator !== false;
   const { extensionType } = useSelector((state) => state.ui);
@@ -578,7 +578,7 @@ const MesheryApp = ({ Component, pageProps, relayEnvironment, emotionCache }) =>
                                 </StyledMainContent>
                                 <Footer
                                   handleMesheryCommunityClick={handleMesheryCommunityClick}
-                                  capabilitiesRegistry={capabilitiesRegistry}
+                                  providerCapabilities={providerCapabilities}
                                 />
                               </StyledContentWrapper>
                             </NotificationCenterProvider>

--- a/ui/pages/extension/[...component].tsx
+++ b/ui/pages/extension/[...component].tsx
@@ -13,10 +13,10 @@ import { DynamicFullScreenLoader } from '@/components/shared/LoadingState/Dynami
 import { useGetProviderCapabilitiesQuery } from '@/rtk-query/user';
 import {
   updateBetaBadge,
-  updateCapabilities,
   updateExtensionType,
   updatePagePath,
   updateTitle,
+  updateProviderCapabilities,
 } from '@/store/slices/mesheryUi';
 import { useDispatch, useSelector } from 'react-redux';
 import { GetStaticPaths, GetStaticProps } from 'next';
@@ -48,19 +48,19 @@ function RemoteExtension() {
   const router = useRouter();
   const dispatch = useDispatch();
   const { extensionType } = useSelector((state) => state.ui);
-  const { data: capabilitiesRegistry, isLoading } = useGetProviderCapabilitiesQuery();
+  const { data: providerCapabilities, isLoading } = useGetProviderCapabilitiesQuery();
 
   // Resolve the active extension that matches the current path. Derived from
-  // capabilitiesRegistry rather than mirrored into local state to avoid
+  // providerCapabilities rather than mirrored into local state to avoid
   // duplicating Redux state and stale-closure bugs. The `typeof window`
   // guard prevents getPath() from crashing during static prerender
   // (this page uses getStaticPaths/getStaticProps).
   const matchedExtension = useMemo(() => {
     if (typeof window === 'undefined') return null;
-    if (!capabilitiesRegistry?.extensions) return null;
+    if (!providerCapabilities?.extensions) return null;
     const path = getPath();
-    for (const key of Object.keys(capabilitiesRegistry.extensions)) {
-      const value = capabilitiesRegistry.extensions[key];
+    for (const key of Object.keys(providerCapabilities.extensions)) {
+      const value = providerCapabilities.extensions[key];
       if (!Array.isArray(value)) continue;
       for (const comp of value) {
         if (
@@ -78,12 +78,12 @@ function RemoteExtension() {
       }
     }
     return null;
-  }, [capabilitiesRegistry, router.query.component]);
+  }, [providerCapabilities, router.query.component]);
 
   useEffect(() => {
-    if (!capabilitiesRegistry?.extensions) return;
-    dispatch(updateCapabilities({ capabilitiesRegistry }));
-  }, [dispatch, capabilitiesRegistry]);
+    if (!providerCapabilities?.extensions) return;
+    dispatch(updateProviderCapabilities({ providerCapabilities }));
+  }, [dispatch, providerCapabilities]);
 
   useEffect(() => {
     if (!matchedExtension) return;
@@ -103,7 +103,7 @@ function RemoteExtension() {
         <title>{`${matchedExtension?.title ?? ''} | Meshery`}</title>
       </Head>
       <DynamicFullScreenLoader isLoading={isLoading}>
-        {capabilitiesRegistry !== null && extensionType ? (
+        {providerCapabilities !== null && extensionType ? (
           <NoSsr>
             {extensionType === 'navigator' ? (
               <ExtensionSandbox type={extensionType} Extension={NavigatorExtension} />

--- a/ui/pages/extensions.tsx
+++ b/ui/pages/extensions.tsx
@@ -492,7 +492,7 @@ const Extensions = () => {
   const [updateUserPref] = useUpdateUserPrefMutation();
   const dispatch = useDispatch();
   const theme = useTheme();
-  const { capabilitiesRegistry } = useSelector((state) => state.ui);
+  const { providerCapabilities } = useSelector((state) => state.ui);
   const { data: userData } = useGetUserPrefQuery();
 
   const serverCatalogContent = userData?.usersExtensionPreferences?.catalogContent;
@@ -507,10 +507,10 @@ const Extensions = () => {
 
   const hasAccessToMeshMap = useMemo(
     () =>
-      !!capabilitiesRegistry?.extensions?.navigator?.some(
+      !!providerCapabilities?.extensions?.navigator?.some(
         (val: { title: string }) => val.title.toLowerCase() === EXTENSION_NAMES.KANVAS,
       ),
-    [capabilitiesRegistry],
+    [providerCapabilities],
   );
 
   const handleToggle = () => {

--- a/ui/store/slices/mesheryUi.ts
+++ b/ui/store/slices/mesheryUi.ts
@@ -16,7 +16,7 @@ const initialState = {
   isDrawerCollapsed: false,
   catalogVisibility: true,
   extensionType: '',
-  capabilitiesRegistry: null,
+  providerCapabilities: null,
   controllerState: null,
   connectionMetadataState: null, // store connection definition metadata for state and connection kind management
   organization: null,
@@ -68,8 +68,8 @@ const coreSlice = createSlice({
     updateExtensionType: (state, action) => {
       state.extensionType = action.payload.extensionType;
     },
-    updateCapabilities: (state, action) => {
-      state.capabilitiesRegistry = action.payload.capabilitiesRegistry;
+    updateProviderCapabilities: (state, action) => {
+      state.providerCapabilities = action.payload.providerCapabilities;
     },
     setConnectionMetadata: (state, action) => {
       state.connectionMetadataState = action.payload.connectionMetadataState;
@@ -104,7 +104,7 @@ export const {
   setControllerState,
   setMeshsyncSubscription,
   updateExtensionType,
-  updateCapabilities,
+  updateProviderCapabilities,
   setConnectionMetadata,
   setOrganization,
   setWorkspace,

--- a/ui/utils/__tests__/disabledComponents.test.ts
+++ b/ui/utils/__tests__/disabledComponents.test.ts
@@ -1,9 +1,9 @@
 import { describe, expect, it } from 'vitest';
-import { CapabilitiesRegistry } from '../disabledComponents';
+import { ProviderUiAccessControl } from '../disabledComponents';
 
-describe('CapabilitiesRegistry', () => {
+describe('ProviderUiAccessControl', () => {
   it('exposes provider capabilities as an array for UI guards', () => {
-    const registry = new CapabilitiesRegistry({
+    const registry = new ProviderUiAccessControl({
       capabilities: [{ feature: 'persist-meshery-patterns' }],
     });
 
@@ -11,7 +11,7 @@ describe('CapabilitiesRegistry', () => {
   });
 
   it('returns an empty capability list when the provider payload is malformed', () => {
-    const registry = new CapabilitiesRegistry({
+    const registry = new ProviderUiAccessControl({
       capabilities: { feature: 'persist-meshery-patterns' },
     });
 

--- a/ui/utils/__tests__/disabledComponents.test.ts
+++ b/ui/utils/__tests__/disabledComponents.test.ts
@@ -7,7 +7,7 @@ describe('CapabilitiesRegistry', () => {
       capabilities: [{ feature: 'persist-meshery-patterns' }],
     });
 
-    expect(registry.capabilities).toEqual([{ feature: 'persist-meshery-patterns' }]);
+    expect(registry.providerCapabilities).toEqual([{ feature: 'persist-meshery-patterns' }]);
   });
 
   it('returns an empty capability list when the provider payload is malformed', () => {
@@ -15,6 +15,6 @@ describe('CapabilitiesRegistry', () => {
       capabilities: { feature: 'persist-meshery-patterns' },
     });
 
-    expect(registry.capabilities).toEqual([]);
+    expect(registry.providerCapabilities).toEqual([]);
   });
 });

--- a/ui/utils/can.ts
+++ b/ui/utils/can.ts
@@ -1,7 +1,7 @@
 import { PureAbility } from '@casl/ability';
 import { createCanShow } from '@sistent/sistent';
 import _ from 'lodash';
-import { CapabilitiesRegistry } from './disabledComponents';
+import { ProviderUiAccessControl } from './disabledComponents';
 import { store } from '../store';
 import { mesheryEventBus } from './eventBus';
 
@@ -11,7 +11,7 @@ export default function CAN(action, subject) {
   return ability.can(action, _.lowerCase(subject));
 }
 
-const getCapabilitiesRegistry = () =>
-  new CapabilitiesRegistry(store.getState().capabilitiesRegistry);
+const getProviderUiAccessControl = () =>
+  new ProviderUiAccessControl(store.getState().providerCapabilities);
 
-export const CanShow = createCanShow(getCapabilitiesRegistry, CAN, () => mesheryEventBus);
+export const CanShow = createCanShow(getProviderUiAccessControl, CAN, () => mesheryEventBus);

--- a/ui/utils/disabledComponents.ts
+++ b/ui/utils/disabledComponents.ts
@@ -14,21 +14,13 @@ function recursivelySearchObjKey(obj, arr, index) {
 }
 
 /**
- * CapabilitiesRegistry is a UI component-access guard that wraps the raw provider
- * capabilities payload returned by /api/provider/capabilities.
+ * Wraps the raw /api/provider/capabilities payload and answers provider-driven
+ * UI access questions.
  *
- * Distinguish between two related but separate concepts:
- *
- *   • Provider capabilities  – the `{ feature, endpoint }[]` list inside the
- *     payload that describes which features the remote provider supports (e.g.
- *     "persist-meshery-patterns").  Access them via `providerCapabilities`.
- *
- *   • Component-access registry – the methods on this class
- *     (`isNavigatorComponentEnabled`, `isHeaderComponentEnabled`, …) that consult
- *     the provider's `restrictedAccess` block to decide whether individual UI
- *     components should be rendered (playground / restricted-mode guards).
+ * "Registry" in Meshery UI refers to the Model/Relationship Registry under
+ * ui/components/registry, so this helper deliberately avoids that name.
  */
-export class CapabilitiesRegistry {
+export class ProviderUiAccessControl {
   /** Raw payload from /api/provider/capabilities. */
   providerPayload;
   isPlaygroundEnv = false;

--- a/ui/utils/disabledComponents.ts
+++ b/ui/utils/disabledComponents.ts
@@ -13,18 +13,39 @@ function recursivelySearchObjKey(obj, arr, index) {
   return false;
 }
 
+/**
+ * CapabilitiesRegistry is a UI component-access guard that wraps the raw provider
+ * capabilities payload returned by /api/provider/capabilities.
+ *
+ * Distinguish between two related but separate concepts:
+ *
+ *   • Provider capabilities  – the `{ feature, endpoint }[]` list inside the
+ *     payload that describes which features the remote provider supports (e.g.
+ *     "persist-meshery-patterns").  Access them via `providerCapabilities`.
+ *
+ *   • Component-access registry – the methods on this class
+ *     (`isNavigatorComponentEnabled`, `isHeaderComponentEnabled`, …) that consult
+ *     the provider's `restrictedAccess` block to decide whether individual UI
+ *     components should be rendered (playground / restricted-mode guards).
+ */
 export class CapabilitiesRegistry {
-  capabilitiesRegistry;
+  /** Raw payload from /api/provider/capabilities. */
+  providerPayload;
   isPlaygroundEnv = false;
 
-  constructor(capabilitiesRegistry) {
-    this.capabilitiesRegistry = capabilitiesRegistry;
-    this.isPlaygroundEnv = capabilitiesRegistry?.restrictedAccess?.isMesheryUIRestricted || false;
+  constructor(providerPayload) {
+    this.providerPayload = providerPayload;
+    this.isPlaygroundEnv = providerPayload?.restrictedAccess?.isMesheryUIRestricted || false;
   }
 
-  get capabilities() {
-    return Array.isArray(this.capabilitiesRegistry?.capabilities)
-      ? this.capabilitiesRegistry.capabilities
+  /**
+   * The list of features the current provider declares it supports.
+   * Each entry is a `{ feature: string, endpoint: string }` object.
+   * Returns an empty array when the payload is absent or malformed.
+   */
+  get providerCapabilities() {
+    return Array.isArray(this.providerPayload?.capabilities)
+      ? this.providerPayload.capabilities
       : [];
   }
 
@@ -35,7 +56,7 @@ export class CapabilitiesRegistry {
 
     let walkerArray = ['restrictedAccess', 'allowedComponents', 'navigator', ...navigatorWalker];
 
-    const searchResult = recursivelySearchObjKey(this.capabilitiesRegistry, walkerArray, 0);
+    const searchResult = recursivelySearchObjKey(this.providerPayload, walkerArray, 0);
     if (_.isObject(searchResult) && _.isEmpty(searchResult)) {
       return false;
     }
@@ -49,7 +70,7 @@ export class CapabilitiesRegistry {
 
     let walkerArray = ['restrictedAccess', 'allowedComponents', 'header', ...headerWalker];
 
-    const searchResult = recursivelySearchObjKey(this.capabilitiesRegistry, walkerArray, 0);
+    const searchResult = recursivelySearchObjKey(this.providerPayload, walkerArray, 0);
     if (_.isObject(searchResult) && _.isEmpty(searchResult)) {
       return false;
     }
@@ -61,11 +82,11 @@ export class CapabilitiesRegistry {
       return true;
     }
 
-    if (!this.capabilitiesRegistry.extensions?.navigator) {
+    if (!this.providerPayload.extensions?.navigator) {
       return false;
     }
 
-    const navigatorObj = this.capabilitiesRegistry.extensions.navigator[0]?.allowedTo;
+    const navigatorObj = this.providerPayload.extensions.navigator[0]?.allowedTo;
 
     const searchResult = recursivelySearchObjKey(navigatorObj, walkerArray, 0);
     if (_.isObject(searchResult) && _.isEmpty(searchResult)) {

--- a/ui/utils/utils.tsx
+++ b/ui/utils/utils.tsx
@@ -483,8 +483,8 @@ export function isDesignOpenInKanvas() {
   return params.has('design') && params.get('mode') === KANVAS_MODE.DESIGN;
 }
 
-export const isKanvasEnabled = (capabilitiesRegistry) => {
-  const navigatorExtension = _.get(capabilitiesRegistry, 'extensions.navigator') || [];
+export const isKanvasEnabled = (providerCapabilities) => {
+  const navigatorExtension = _.get(providerCapabilities, 'extensions.navigator') || [];
   return navigatorExtension.some((ext) => ext.title === 'Kanvas');
 };
 
@@ -492,9 +492,9 @@ export const isOperatorEnabled = isKanvasEnabled;
 export const isKanvasDesignerEnabled = isKanvasEnabled;
 
 export const useIsKanvasEnabled = () => {
-  const { capabilitiesRegistry } = useSelector((state) => state.ui);
+  const { providerCapabilities } = useSelector((state) => state.ui);
 
-  return isKanvasEnabled(capabilitiesRegistry);
+  return isKanvasEnabled(providerCapabilities);
 };
 
 export const useIsOperatorEnabled = useIsKanvasEnabled;


### PR DESCRIPTION
## Summary

This follows up on #19337 by fully separating **provider capabilities** terminology from **Registry** terminology in the UI.

In Meshery, **Registry** refers to the Model/Relationship Registry UI under `ui/components/registry`. The provider `/capabilities` payload is a different concept and should not use `CapabilitiesRegistry` naming.

### Changes

**Provider access wrapper**
- Renames the wrapper class from `CapabilitiesRegistry` to `ProviderUiAccessControl`
- Keeps `providerCapabilities` as the safe array-backed feature list getter
- Updates navigator code to use `providerUiAccessControl` naming throughout

**Redux/UI state**
- Renames the stored `/api/provider/capabilities` payload from `capabilitiesRegistry` to `providerCapabilities`
- Renames the slice action from `updateCapabilities` to `updateProviderCapabilities`
- Updates all UI consumers accordingly (`_app`, extensions, header, user prefs, workspace switcher, utility hooks)

**Remote extension injection**
- Injects `providerCapabilities` and `ProviderUiAccessControlClass` into navigator extensions
- Preserves a backward-compatible `CapabilitiesRegistryClass` alias for already-published remote extensions

**Tests**
- Updates the regression test to assert against `ProviderUiAccessControl`

## Testing

```bash
cd ui && npx vitest run utils/__tests__/disabledComponents.test.ts rtk-query/__tests__/transforms.test.ts
cd ui && npx eslint components/layout/Navigator/Navigator.tsx components/layout/Navigator/NavigatorExtension.tsx components/layout/Navigator/navigatorComponents.tsx components/ExtensionSandbox.tsx components/AppComponents.tsx components/User.tsx components/user-preferences/index.tsx components/layout/Header/HeaderMenu.tsx components/workspaces/SpacesSwitcher/MainDesignsContent.tsx components/workspaces/SpacesSwitcher/MainViewsContent.tsx pages/_app.tsx pages/extensions.tsx pages/extension/[...component].tsx store/slices/mesheryUi.ts utils/disabledComponents.ts utils/can.ts utils/utils.tsx utils/__tests__/disabledComponents.test.ts
cd ui && npm run build
```

No behavior change is intended; this is a naming and clarity refactor to make provider capability code distinct from Registry UI concepts.