### PR TITLE
feat(server): add generic connection ping endpoint

### DIFF
--- a/server/handlers/connections_handlers.go
+++ b/server/handlers/connections_handlers.go
@@ -542,6 +542,127 @@ func (h *Handler) NotifySmOfConnectionStatusChange(context context.Context, user
 	return *eventBuilder.Build(), nil
 }
 
+// resolveMetricsCredential extracts the endpoint URL and API key for Grafana /
+// Prometheus connections. It writes an error response and returns ok=false on
+// any failure so the caller can return immediately.
+func (h *Handler) resolveMetricsCredential(
+	w http.ResponseWriter,
+	_ *http.Request,
+	connection *connections.Connection,
+	token string,
+	provider models.Provider,
+) (url string, apiKey string, ok bool) {
+	if connection.CredentialID == nil {
+		writeMeshkitError(w, ErrInvalidRequestObject(connection.Name+": no credential configured"), http.StatusBadRequest)
+		return "", "", false
+	}
+	url, urlOK := connection.Metadata["url"].(string)
+	if !urlOK || url == "" {
+		writeMeshkitError(w, ErrInvalidRequestObject(connection.Name+": metadata missing required 'url' field"), http.StatusBadRequest)
+		return "", "", false
+	}
+	cred, statusCode, err := provider.GetCredentialByID(token, core.UUIDOrUUIDNil(connection.CredentialID))
+	if err != nil {
+		writeMeshkitError(w, err, statusCode)
+		return "", "", false
+	}
+	apiKey, _ = cred.Secret["secret"].(string)
+	return url, apiKey, true
+}
+
+// ConnectionPingHandler performs an ad hoc connectivity check for any connection
+// identified by {connectionId} in the URL path. The check strategy depends on
+// the connection kind:
+//
+//   - kubernetes  — fetches the remote API-server version (same probe as
+//     /api/system/kubernetes/ping).
+//   - grafana     — validates the Grafana URL and API key stored in the
+//     connection credential.
+//   - prometheus  — validates the Prometheus URL and API key stored in the
+//     connection credential.
+//   - all others  — returns the current connection status recorded in the
+//     database without making an outbound call; the status field is the
+//     authoritative source of connectivity state for connection kinds that do
+//     not yet have a dedicated active-probe handler.
+//
+// GET /api/integrations/connections/{connectionId}/ping
+func (h *Handler) ConnectionPingHandler(w http.ResponseWriter, req *http.Request, _ *models.Preference, _ *models.User, provider models.Provider) {
+	connectionID := uuid.FromStringOrNil(mux.Vars(req)["connectionId"])
+	if connectionID == uuid.Nil {
+		err := ErrInvalidUUID(fmt.Errorf("invalid connection ID in path"))
+		h.log.Error(err)
+		writeMeshkitError(w, err, http.StatusBadRequest)
+		return
+	}
+
+	token, _ := req.Context().Value(models.TokenCtxKey).(string)
+	connection, statusCode, err := provider.GetConnectionByID(token, connectionID)
+	if err != nil {
+		h.log.Error(ErrQueryGet("connection"))
+		writeMeshkitError(w, ErrQueryGet("connection"), statusCode)
+		return
+	}
+
+	switch connection.Kind {
+	case "kubernetes":
+		k8sContext, err := provider.GetK8sContext(token, connectionID.String())
+		if err != nil {
+			writeMeshkitError(w, ErrInvalidKubeContext(err, connectionID.String()), http.StatusNotFound)
+			return
+		}
+		kubeclient, err := k8sContext.GenerateKubeHandler()
+		if err != nil {
+			writeMeshkitError(w, ErrInvalidKubeConfig(err, k8sContext.Name), http.StatusBadRequest)
+			return
+		}
+		version, err := kubeclient.KubeClient.ServerVersion()
+		if err != nil {
+			h.log.Error(ErrKubeVersion(err))
+			writeMeshkitError(w, ErrKubeVersion(err), http.StatusInternalServerError)
+			return
+		}
+		if err := json.NewEncoder(w).Encode(map[string]string{
+			"server_version": version.String(),
+		}); err != nil {
+			h.log.Error(models.ErrMarshal(err, "kube-server-version"))
+		}
+
+	case "grafana":
+		url, apiKey, ok := h.resolveMetricsCredential(w, req, connection, token, provider)
+		if !ok {
+			return
+		}
+		if err := h.config.GrafanaClient.Validate(req.Context(), url, apiKey); err != nil {
+			h.log.Error(models.ErrGrafanaScan(err))
+			writeMeshkitError(w, models.ErrGrafanaScan(err), http.StatusInternalServerError)
+			return
+		}
+		writeJSONEmptyObject(w, http.StatusOK)
+
+	case "prometheus":
+		url, apiKey, ok := h.resolveMetricsCredential(w, req, connection, token, provider)
+		if !ok {
+			return
+		}
+		if err := h.config.PrometheusClient.Validate(req.Context(), url, apiKey); err != nil {
+			h.log.Error(models.ErrPrometheusScan(err))
+			writeMeshkitError(w, models.ErrPrometheusScan(err), http.StatusInternalServerError)
+			return
+		}
+		writeJSONEmptyObject(w, http.StatusOK)
+
+	default:
+		if err := json.NewEncoder(w).Encode(map[string]string{
+			"name":   connection.Name,
+			"kind":   connection.Kind,
+			"status": string(connection.Status),
+		}); err != nil {
+			h.log.Error(models.ErrMarshal(err, "connection-ping"))
+			writeMeshkitError(w, models.ErrMarshal(err, "connection-ping"), http.StatusInternalServerError)
+		}
+	}
+}
+
 func (h *Handler) DeleteConnection(w http.ResponseWriter, req *http.Request, _ *models.Preference, user *models.User, provider models.Provider) {
 	connectionID := uuid.FromStringOrNil(mux.Vars(req)["connectionId"])
 	userID := user.ID

--- a/server/handlers/connections_handlers.go
+++ b/server/handlers/connections_handlers.go
@@ -566,7 +566,11 @@ func (h *Handler) resolveMetricsCredential(
 		writeMeshkitError(w, err, statusCode)
 		return "", "", false
 	}
-	apiKey, _ = cred.Secret["secret"].(string)
+	apiKey, ok = cred.Secret["secret"].(string)
+	if !ok {
+		writeMeshkitError(w, ErrInvalidRequestObject(connection.Name+": credential missing required 'secret' field"), http.StatusBadRequest)
+		return "", "", false
+	}
 	return url, apiKey, true
 }
 

--- a/server/handlers/connections_handlers.go
+++ b/server/handlers/connections_handlers.go
@@ -570,20 +570,73 @@ func (h *Handler) resolveMetricsCredential(
 	return url, apiKey, true
 }
 
+// connectionPingFn is the signature for a per-kind ping probe.
+// Implementations write the response themselves and return an error on failure.
+type connectionPingFn func(h *Handler, w http.ResponseWriter, req *http.Request, connection *connections.Connection, token string, provider models.Provider) error
+
+// connectionPingRegistry maps a connection kind to its active-probe implementation.
+// To add support for a new connection kind, register its probe here — no changes
+// to ConnectionPingHandler are required.
+var connectionPingRegistry = map[string]connectionPingFn{
+	"kubernetes": pingKubernetes,
+	"grafana":    pingGrafana,
+	"prometheus":  pingPrometheus,
+}
+
+func pingKubernetes(h *Handler, w http.ResponseWriter, req *http.Request, connection *connections.Connection, token string, provider models.Provider) error {
+	connectionID := uuid.FromStringOrNil(mux.Vars(req)["connectionId"])
+	k8sContext, err := provider.GetK8sContext(token, connectionID.String())
+	if err != nil {
+		writeMeshkitError(w, ErrInvalidKubeContext(err, connectionID.String()), http.StatusNotFound)
+		return err
+	}
+	kubeclient, err := k8sContext.GenerateKubeHandler()
+	if err != nil {
+		writeMeshkitError(w, ErrInvalidKubeConfig(err, k8sContext.Name), http.StatusBadRequest)
+		return err
+	}
+	version, err := kubeclient.KubeClient.ServerVersion()
+	if err != nil {
+		h.log.Error(ErrKubeVersion(err))
+		writeMeshkitError(w, ErrKubeVersion(err), http.StatusInternalServerError)
+		return err
+	}
+	return json.NewEncoder(w).Encode(map[string]string{"server_version": version.String()})
+}
+
+func pingGrafana(h *Handler, w http.ResponseWriter, req *http.Request, connection *connections.Connection, token string, provider models.Provider) error {
+	url, apiKey, ok := h.resolveMetricsCredential(w, req, connection, token, provider)
+	if !ok {
+		return fmt.Errorf("could not resolve grafana credential")
+	}
+	if err := h.config.GrafanaClient.Validate(req.Context(), url, apiKey); err != nil {
+		h.log.Error(models.ErrGrafanaScan(err))
+		writeMeshkitError(w, models.ErrGrafanaScan(err), http.StatusInternalServerError)
+		return err
+	}
+	writeJSONEmptyObject(w, http.StatusOK)
+	return nil
+}
+
+func pingPrometheus(h *Handler, w http.ResponseWriter, req *http.Request, connection *connections.Connection, token string, provider models.Provider) error {
+	url, apiKey, ok := h.resolveMetricsCredential(w, req, connection, token, provider)
+	if !ok {
+		return fmt.Errorf("could not resolve prometheus credential")
+	}
+	if err := h.config.PrometheusClient.Validate(req.Context(), url, apiKey); err != nil {
+		h.log.Error(models.ErrPrometheusScan(err))
+		writeMeshkitError(w, models.ErrPrometheusScan(err), http.StatusInternalServerError)
+		return err
+	}
+	writeJSONEmptyObject(w, http.StatusOK)
+	return nil
+}
+
 // ConnectionPingHandler performs an ad hoc connectivity check for any connection
-// identified by {connectionId} in the URL path. The check strategy depends on
-// the connection kind:
+// identified by {connectionId} in the URL path.
 //
-//   - kubernetes  — fetches the remote API-server version (same probe as
-//     /api/system/kubernetes/ping).
-//   - grafana     — validates the Grafana URL and API key stored in the
-//     connection credential.
-//   - prometheus  — validates the Prometheus URL and API key stored in the
-//     connection credential.
-//   - all others  — returns the current connection status recorded in the
-//     database without making an outbound call; the status field is the
-//     authoritative source of connectivity state for connection kinds that do
-//     not yet have a dedicated active-probe handler.
+// Kinds with a registered probe in connectionPingRegistry get an active check.
+// All other kinds return the current status recorded in the database.
 //
 // GET /api/integrations/connections/{connectionId}/ping
 func (h *Handler) ConnectionPingHandler(w http.ResponseWriter, req *http.Request, _ *models.Preference, _ *models.User, provider models.Provider) {
@@ -603,63 +656,19 @@ func (h *Handler) ConnectionPingHandler(w http.ResponseWriter, req *http.Request
 		return
 	}
 
-	switch connection.Kind {
-	case "kubernetes":
-		k8sContext, err := provider.GetK8sContext(token, connectionID.String())
-		if err != nil {
-			writeMeshkitError(w, ErrInvalidKubeContext(err, connectionID.String()), http.StatusNotFound)
-			return
-		}
-		kubeclient, err := k8sContext.GenerateKubeHandler()
-		if err != nil {
-			writeMeshkitError(w, ErrInvalidKubeConfig(err, k8sContext.Name), http.StatusBadRequest)
-			return
-		}
-		version, err := kubeclient.KubeClient.ServerVersion()
-		if err != nil {
-			h.log.Error(ErrKubeVersion(err))
-			writeMeshkitError(w, ErrKubeVersion(err), http.StatusInternalServerError)
-			return
-		}
-		if err := json.NewEncoder(w).Encode(map[string]string{
-			"server_version": version.String(),
-		}); err != nil {
-			h.log.Error(models.ErrMarshal(err, "kube-server-version"))
-		}
+	if probe, ok := connectionPingRegistry[connection.Kind]; ok {
+		probe(h, w, req, connection, token, provider) //nolint:errcheck
+		return
+	}
 
-	case "grafana":
-		url, apiKey, ok := h.resolveMetricsCredential(w, req, connection, token, provider)
-		if !ok {
-			return
-		}
-		if err := h.config.GrafanaClient.Validate(req.Context(), url, apiKey); err != nil {
-			h.log.Error(models.ErrGrafanaScan(err))
-			writeMeshkitError(w, models.ErrGrafanaScan(err), http.StatusInternalServerError)
-			return
-		}
-		writeJSONEmptyObject(w, http.StatusOK)
-
-	case "prometheus":
-		url, apiKey, ok := h.resolveMetricsCredential(w, req, connection, token, provider)
-		if !ok {
-			return
-		}
-		if err := h.config.PrometheusClient.Validate(req.Context(), url, apiKey); err != nil {
-			h.log.Error(models.ErrPrometheusScan(err))
-			writeMeshkitError(w, models.ErrPrometheusScan(err), http.StatusInternalServerError)
-			return
-		}
-		writeJSONEmptyObject(w, http.StatusOK)
-
-	default:
-		if err := json.NewEncoder(w).Encode(map[string]string{
-			"name":   connection.Name,
-			"kind":   connection.Kind,
-			"status": string(connection.Status),
-		}); err != nil {
-			h.log.Error(models.ErrMarshal(err, "connection-ping"))
-			writeMeshkitError(w, models.ErrMarshal(err, "connection-ping"), http.StatusInternalServerError)
-		}
+	// No active probe registered — return DB status as authoritative state.
+	if err := json.NewEncoder(w).Encode(map[string]string{
+		"name":   connection.Name,
+		"kind":   connection.Kind,
+		"status": string(connection.Status),
+	}); err != nil {
+		h.log.Error(models.ErrMarshal(err, "connection-ping"))
+		writeMeshkitError(w, models.ErrMarshal(err, "connection-ping"), http.StatusInternalServerError)
 	}
 }
 

--- a/server/models/handlers.go
+++ b/server/models/handlers.go
@@ -205,6 +205,7 @@ type HandlerInterface interface {
 	UpdateConnectionById(w http.ResponseWriter, req *http.Request, prefObj *Preference, user *User, provider Provider)
 	DeleteConnection(w http.ResponseWriter, req *http.Request, prefObj *Preference, user *User, provider Provider)
 	ProcessConnectionRegistration(w http.ResponseWriter, req *http.Request, prefObj *Preference, user *User, provider Provider)
+	ConnectionPingHandler(w http.ResponseWriter, req *http.Request, prefObj *Preference, user *User, provider Provider)
 
 	ExportModel(w http.ResponseWriter, req *http.Request)
 

--- a/server/router/server.go
+++ b/server/router/server.go
@@ -427,6 +427,8 @@ func NewRouter(_ context.Context, h models.HandlerInterface, port int, g http.Ha
 		Methods("POST", "DELETE")
 	gMux.Handle("/api/integrations/connections/{connectionId}", h.ProviderMiddleware(h.AuthMiddleware(h.SessionInjectorMiddleware(h.DeleteConnection), models.ProviderAuth))).
 		Methods("DELETE")
+	gMux.Handle("/api/integrations/connections/{connectionId}/ping", h.ProviderMiddleware(h.AuthMiddleware(h.SessionInjectorMiddleware(h.ConnectionPingHandler), models.ProviderAuth))).
+		Methods("GET")
 
 	gMux.HandleFunc("/auth/redirect", func(w http.ResponseWriter, r *http.Request) {
 		token := r.URL.Query().Get("token")


### PR DESCRIPTION
## Description

Adds `GET /api/integrations/connections/{connectionId}/ping` — a single endpoint that performs an ad hoc connectivity check for **any** connection regardless of kind, closing the gap identified in #10560.

Currently only Kubernetes and Meshery Adapter chips support connectivity tests. This PR brings all connection types under a unified ping route.

## Motivation

The existing per-kind ping routes (`/api/system/kubernetes/ping`, `/api/telemetry/metrics/grafana/ping/{id}`, `/api/telemetry/metrics/ping/{id}`) cannot be used generically by the UI or mesheryctl without knowing the connection kind in advance. A unified endpoint at `/api/integrations/connections/{connectionId}/ping` lets any connection chip trigger a connectivity test with a single call.

## Implementation

Routing strategy inside `ConnectionPingHandler`:

| Kind | Probe |
|---|---|
| `kubernetes` | `GetK8sContext` → `GenerateKubeHandler` → `ServerVersion()` — same probe as `KubernetesPingHandler` |
| `grafana` | `GrafanaClient.Validate(url, apiKey)` — same probe as `GrafanaPingHandler` |
| `prometheus` | `PrometheusClient.Validate(url, apiKey)` — same probe as `PrometheusPingHandler` |
| all others (`meshery`, `github`, …) | returns `{"name", "kind", "status"}` from the connection record; the status field is the authoritative connectivity state for kinds without a dedicated active probe |

**Files changed (3):**
- `server/handlers/connections_handlers.go` — `ConnectionPingHandler` (~95 LOC)
- `server/models/handlers.go` — add `ConnectionPingHandler` to `HandlerInterface`
- `server/router/server.go` — register `GET /api/integrations/connections/{connectionId}/ping`

## Acceptance Tests

Per the criteria in #10560:

- `GET /api/integrations/connections/<k8s-id>/ping` → returns `{"server_version": "..."}` when the cluster is reachable; 5xx when not
- `GET /api/integrations/connections/<grafana-id>/ping` → `{}` (200) when Grafana is reachable; 500 when credentials are invalid
- `GET /api/integrations/connections/<prometheus-id>/ping` → same as Grafana
- `GET /api/integrations/connections/<meshery-id>/ping` → returns `{"name": "...", "kind": "meshery", "status": "connected"}` from DB state
- Invalid UUID → 400
- Unknown connection ID → 404

Closes #10560