### PR TITLE
[UI] Phase 2: Migrate registry/helper.ts hex literals to theme.palette.* (#18657)

### DIFF
--- a/ui/components/dashboard/view-component.tsx
+++ b/ui/components/dashboard/view-component.tsx
@@ -30,7 +30,7 @@ export const ColourContainer = styled('div')(({ theme }) => ({
 
 export const JSONViewFormatter = ({ data }: ResourceFormatterProps) => {
   const theme = useTheme();
-  const rjvTheme = reactJsonTheme(theme.palette.mode);
+  const rjvTheme = reactJsonTheme(theme);
 
   return (
     <ReactJson

--- a/ui/components/registry/MeshModelDetails.tsx
+++ b/ui/components/registry/MeshModelDetails.tsx
@@ -117,7 +117,7 @@ const RenderContents = ({
             }}
           >
             <ReactJson
-              theme={reactJsonTheme(theme.palette.mode)}
+              theme={reactJsonTheme(theme)}
               name={false}
               displayDataTypes={false}
               iconStyle="circle"

--- a/ui/components/registry/helper.ts
+++ b/ui/components/registry/helper.ts
@@ -1,6 +1,7 @@
 import { MODELS, REGISTRANTS, COMPONENTS, RELATIONSHIPS } from '@/constants/navigator';
 import _ from 'lodash';
 import { findNestedObject } from '@/utils/objects';
+import { alpha, type Theme } from '@/theme';
 
 /**
  * Retrieves filtered data for the details component based on the selected item ID.
@@ -116,7 +117,11 @@ export const removeDuplicateVersions = (data: Array<any>) => {
  * To style JSON viewing in react-json-tree.
  * Refer to base-16 theme styling guidelines for more info.
  * https://github.com/chriskempson/base16/blob/main/styling.md
- * @type {Object}
+ *
+ * Accepts a Sistent {@link Theme} so the base16 ramp can be derived from
+ * `theme.palette.*` tokens (no inline hex literals). Callers in components
+ * pass the result of `useTheme()` directly.
+ *
  * @property {string} base00 - BACKGROUND_COLOR
  * @property {string} base02 - OBJECT_OUTLINE_COLOR
  * @property {string} base04 - OBJECT_DETAILS_COLOR
@@ -126,21 +131,30 @@ export const removeDuplicateVersions = (data: Array<any>) => {
  * @property {string} base0D - ITEM_STRING_EXPANDED_COLOR, ARROW_COLOR
  * @property {string} base0E - BOOLEAN_COLOR, NUMBER_COLOR
  */
-export const reactJsonTheme = (themeType: string) => ({
-  base00: themeType === 'dark' ? '#303030' : '#ffffff',
-  base01: '#444c56',
-  base02: themeType === 'dark' ? '#586069' : '#abb2bf',
-  base03: '#6a737d',
-  base04: '#477E96',
-  base05: '#9ea7a6',
-  base06: '#d8dee9',
-  base07: themeType === 'dark' ? '#FFF3C5' : '#002B36',
-  base08: '#2a5491',
-  base09: '#d19a66',
-  base0A: '#EBC017',
-  base0B: '#237986',
-  base0C: '#56b6c2',
-  base0D: '#B1B6B8',
-  base0E: '#e1e6cf',
-  base0F: '#647881',
-});
+export const reactJsonTheme = (theme: Theme) => {
+  const isDark = theme.palette.mode === 'dark';
+  // Object-outline contrast needs more punch in dark mode where the
+  // background is already dim; in light mode a softer divider tone reads
+  // better against the white canvas.
+  const outline = isDark
+    ? alpha(theme.palette.text.primary, 0.32)
+    : alpha(theme.palette.text.primary, 0.16);
+  return {
+    base00: theme.palette.background.default,
+    base01: theme.palette.divider,
+    base02: outline,
+    base03: theme.palette.text.secondary,
+    base04: theme.palette.info.main,
+    base05: theme.palette.text.secondary,
+    base06: alpha(theme.palette.text.primary, 0.24),
+    base07: theme.palette.text.primary,
+    base08: theme.palette.error.main,
+    base09: theme.palette.warning.main,
+    base0A: theme.palette.warning.light,
+    base0B: theme.palette.success.main,
+    base0C: theme.palette.info.light,
+    base0D: theme.palette.info.main,
+    base0E: theme.palette.primary.main,
+    base0F: theme.palette.text.secondary,
+  };
+};

--- a/ui/eslint.config.js
+++ b/ui/eslint.config.js
@@ -103,7 +103,6 @@ const legacyLiteralColorOffenders = [
   'components/performance/style.tsx',
   'components/settings/MesherySettings.tsx',
   'components/registry/MeshModelDetails.tsx',
-  'components/registry/helper.ts',
   'components/workspaces/SpacesSwitcher/WorkspaceSwitcher.tsx',
   'components/workspaces/SpacesSwitcher/styles.tsx',
   'components/shared/FormFields/typing-filter/style.tsx',


### PR DESCRIPTION
## Summary

Replaces 19 raw hex literals in `ui/components/registry/helper.ts` (the next top hex-literal offender per `npm run audit:hex`) with Sistent theme tokens via `theme.palette.*` and `alpha()` from `@/theme`.

The file's only color-bearing export is `reactJsonTheme`, a base16 ramp consumed by `@microlink/react-json-view`. Because a `.ts` helper can't call `useTheme()` directly, the function signature is changed from `(themeType: string)` to `(theme: Theme)` (Pattern A). Both call sites already had `theme` in scope from `useTheme()` and now pass `theme` directly:

- `ui/components/dashboard/view-component.tsx` (`JSONViewFormatter`)
- `ui/components/registry/MeshModelDetails.tsx` (`RenderContents`)

### Base16 slot mapping

| Slot | Old hex | New token |
|---|---|---|
| `base00` (background) | `#303030` / `#ffffff` | `theme.palette.background.default` |
| `base01` (lighter bg) | `#444c56` | `theme.palette.divider` |
| `base02` (outline) | `#586069` / `#abb2bf` | `alpha(text.primary, 0.32 \| 0.16)` |
| `base03` (comments) | `#6a737d` | `theme.palette.text.secondary` |
| `base04` (object detail) | `#477E96` | `theme.palette.info.main` |
| `base05` (default fg) | `#9ea7a6` | `theme.palette.text.secondary` |
| `base06` (light fg) | `#d8dee9` | `alpha(text.primary, 0.24)` |
| `base07` (object keys) | `#FFF3C5` / `#002B36` | `theme.palette.text.primary` |
| `base08` (variables / errors) | `#2a5491` | `theme.palette.error.main` |
| `base09` (numbers / strings) | `#d19a66` | `theme.palette.warning.main` |
| `base0A` (classes / symbols) | `#EBC017` | `theme.palette.warning.light` |
| `base0B` (strings / inherited) | `#237986` | `theme.palette.success.main` |
| `base0C` (support / regex) | `#56b6c2` | `theme.palette.info.light` |
| `base0D` (arrows / expanded) | `#B1B6B8` | `theme.palette.info.main` |
| `base0E` (keywords / booleans) | `#e1e6cf` | `theme.palette.primary.main` |
| `base0F` (deprecated / embedded) | `#647881` | `theme.palette.text.secondary` |

The `base02` outline uses a punchier alpha in dark mode (0.32) so it reads against the dim canvas, and a softer tone (0.16) in light mode.

Removes the file's entry from `legacyLiteralColorOffenders` in `ui/eslint.config.js` so the `no-restricted-syntax` rule starts enforcing here going forward.

### Audit (before -> after)

```
AUDIT hex files=80 matches=269 hex=235 rgb=34
AUDIT hex files=79 matches=250 hex=216 rgb=34
```

Refs #18657
Refs #18654

## Test plan

- [x] `npm run lint` — 0 errors on changed files
- [x] `npx tsc --noEmit` — 0 type errors
- [x] `npm run audit:hex` — total drops from 269 to 250 (-19), files from 80 to 79 (-1)
- [x] `grep -E '#[0-9a-fA-F]{3,8}|rgba?\(' ui/components/registry/helper.ts` — 0 matches
- [ ] Visual check: open a registry model details view and confirm the JSON viewer renders with the new palette in both light and dark modes