### PR TITLE
[UI] Phase 2: Migrate utils/charts.ts hex literals to theme.palette.* (#18657)

### DIFF
--- a/ui/components/dashboard/charts/ConnectionCharts.tsx
+++ b/ui/components/dashboard/charts/ConnectionCharts.tsx
@@ -39,7 +39,7 @@ export default function ConnectionStatsChart() {
       data: {
         columns: chartData,
         type: donut(),
-        colors: dataToColors(chartData),
+        colors: dataToColors(chartData, theme),
         onclick: function () {
           router.push('/management/connections');
         },
@@ -66,7 +66,7 @@ export default function ConnectionStatsChart() {
         },
       },
     }),
-    [chartData, router],
+    [chartData, router, theme],
   );
 
   const canViewConnections = CAN(keys.VIEW_CONNECTIONS.action, keys.VIEW_CONNECTIONS.subject);

--- a/ui/components/dashboard/charts/DashboardMeshModelGraph.tsx
+++ b/ui/components/dashboard/charts/DashboardMeshModelGraph.tsx
@@ -42,7 +42,7 @@ function MeshModelContructs() {
       data: {
         columns: data,
         type: donut(),
-        colors: dataToColors(data),
+        colors: dataToColors(data, theme),
         onclick: function (d: { name: string }) {
           router.push(`/settings?settingsCategory=Registry&tab=${d.name}`);
         },
@@ -64,7 +64,7 @@ function MeshModelContructs() {
         },
       },
     }),
-    [data],
+    [data, theme],
   );
 
   return (
@@ -120,7 +120,7 @@ function MeshModelCategories() {
     () => ({
       data: {
         columns: cleanedData,
-        colors: dataToColors(cleanedData),
+        colors: dataToColors(cleanedData, theme),
         type: donut(),
         onclick: function () {
           router.push('/settings?settingsCategory=Registry&tab=Models');
@@ -151,7 +151,7 @@ function MeshModelCategories() {
         show: false,
       },
     }),
-    [cleanedData],
+    [cleanedData, theme],
   );
 
   return (

--- a/ui/components/dashboard/charts/KubernetesConnectionChart.tsx
+++ b/ui/components/dashboard/charts/KubernetesConnectionChart.tsx
@@ -48,7 +48,7 @@ export default function KubernetesConnectionStatsChart() {
       data: {
         columns: chartData,
         type: donut(),
-        colors: dataToColors(chartData),
+        colors: dataToColors(chartData, theme),
         onclick: function () {
           router.push('/management/connections');
         },
@@ -75,7 +75,7 @@ export default function KubernetesConnectionStatsChart() {
         },
       },
     }),
-    [chartData, router],
+    [chartData, router, theme],
   );
 
   const canViewConnections = CAN(keys.VIEW_CONNECTIONS.action, keys.VIEW_CONNECTIONS.subject);

--- a/ui/components/dashboard/charts/MesheryConfigurationCharts.tsx
+++ b/ui/components/dashboard/charts/MesheryConfigurationCharts.tsx
@@ -57,7 +57,7 @@ export default function MesheryConfigurationChart() {
       data: {
         columns: chartData,
         type: donut(),
-        colors: dataToColors(chartData),
+        colors: dataToColors(chartData, theme),
         onclick: (dataPoint: { name: string }) => {
           const routeName = dataPoint.name.charAt(0).toLowerCase() + dataPoint.name.slice(1);
           router.push(`/configuration/${routeName}`);
@@ -81,7 +81,7 @@ export default function MesheryConfigurationChart() {
         },
       },
     }),
-    [chartData, router],
+    [chartData, router, theme],
   );
 
   return (

--- a/ui/components/dashboard/charts/WorkloadChart.tsx
+++ b/ui/components/dashboard/charts/WorkloadChart.tsx
@@ -7,6 +7,7 @@ import Link from 'next/link';
 import CAN from '@/utils/can';
 import { keys } from '@/utils/permission_constants';
 import { Box, MenuItem, Select, Typography } from '@sistent/sistent';
+import { useTheme } from '@/theme';
 
 type WorkloadResource = { kind?: string; count?: number };
 
@@ -25,6 +26,7 @@ export default function WorkloadChart({
   selectedNamespace = '',
   handleSetNamespace,
 }: WorkloadChartProps) {
+  const theme = useTheme();
   const chartData = useMemo(
     () =>
       (resourses || [])
@@ -38,7 +40,7 @@ export default function WorkloadChart({
       data: {
         columns: chartData,
         type: donut(),
-        colors: dataToColors(chartData),
+        colors: dataToColors(chartData, theme),
       },
       arc: {
         cornerRadius: {
@@ -65,7 +67,7 @@ export default function WorkloadChart({
         show: false,
       },
     }),
-    [chartData],
+    [chartData, theme],
   );
   const canViewConnections = CAN(keys.VIEW_CONNECTIONS.action, keys.VIEW_CONNECTIONS.subject);
 

--- a/ui/eslint.config.js
+++ b/ui/eslint.config.js
@@ -123,7 +123,6 @@ const legacyLiteralColorOffenders = [
   'components/telemetry/grafana/GrafanaDateRangePicker.tsx',
   'css/icons.styles.ts',
   'pages/extension/AccessMesheryModal.tsx',
-  'utils/charts.ts',
   'utils/custom-search.tsx',
 ];
 

--- a/ui/utils/charts.ts
+++ b/ui/utils/charts.ts
@@ -1,36 +1,40 @@
+import { darken, lighten, type Theme } from '@/theme';
+
 export const isValidColumnName = (name) => {
   return name !== '' && name !== ' ' && name != undefined && name != null;
 };
 
-export const CHART_COLORS = [
-  '#14232A', // Gunmetal
-  // '#213A45',
-  '#2E5261',
-  // '#294957',
-  '#3B697D', // Paynes' Gray
-  // '#396679',
-  '#4A839C',
-  // '#477E96', Teal Blue
-  '#5996B1',
-  // '#639CB5',
-  '#74A8BE',
-  // '#8Bb2C6',
-  '#90B9CB',
-  // '#AACCBD8', // Columbia Blue
-  '#CBDEE6',
-  // '#EEF4F7'
-];
+/**
+ * Donut/bar chart slice palette, derived from `theme.palette` so it adapts
+ * to light/dark mode. Callers must thread the active `theme` through because
+ * this `.ts` module cannot call `useTheme()` directly.
+ */
+export const getChartColors = (theme: Theme): string[] => {
+  const primary = theme.palette.primary.main;
+  const info = theme.palette.info.main;
+  return [
+    darken(primary, 0.6),
+    darken(primary, 0.35),
+    darken(primary, 0.15),
+    primary,
+    lighten(primary, 0.2),
+    lighten(info, 0.1),
+    lighten(info, 0.35),
+    lighten(info, 0.65),
+  ];
+};
 
-export const dataToColors = (data) => {
+export const dataToColors = (data, theme: Theme) => {
+  const palette = getChartColors(theme);
   const columns = data.map((item) => item[0]);
-  const colors = {};
+  const colors: Record<string, string> = {};
   let colorIdx = 0;
 
   columns.forEach((col) => {
-    if (colorIdx >= CHART_COLORS.length) {
+    if (colorIdx >= palette.length) {
       colorIdx = 0;
     }
-    colors[col] = CHART_COLORS[colorIdx];
+    colors[col] = palette[colorIdx];
     colorIdx += 1;
   });
 


### PR DESCRIPTION
## Summary

Replaces 15 raw hex literals in `ui/utils/charts.ts` (the next top hex-literal offender per `npm run audit:hex`) with Sistent theme tokens.

The file's only color-bearing export is `CHART_COLORS`, a hand-tuned gunmetal-to-columbia-blue gradient consumed by `dataToColors()` to assign donut chart slice colors. `CHART_COLORS` had no external callers (the only consumer is `dataToColors` itself), so the constant is replaced with `getChartColors(theme)`, a theme-aware factory that builds an 8-step ramp from `theme.palette.primary.main` and `theme.palette.info.main` via `darken()` / `lighten()` from `@/theme`.

Per the project convention that pure helpers can't call `useTheme()` directly, `dataToColors()` now takes a `theme` argument as well (Pattern A). All five direct consumers under `ui/components/dashboard/charts/` are updated to pass `theme` and to include it in their `useMemo` dependency lists:

- `ConnectionCharts.tsx` (already had `useTheme()`)
- `DashboardMeshModelGraph.tsx` (already had `useTheme()`, two call sites)
- `KubernetesConnectionChart.tsx` (already had `useTheme()`)
- `MesheryConfigurationCharts.tsx` (already had `useTheme()`)
- `WorkloadChart.tsx` (adds `useTheme()` import from `@/theme`)

Removes the file's entry from `legacyLiteralColorOffenders` in `ui/eslint.config.js` so the `no-restricted-syntax` rule starts enforcing here going forward.

Audit (before -> after):

```
AUDIT hex files=79 matches=250 hex=216 rgb=34
AUDIT hex files=78 matches=235 hex=201 rgb=34
```

Refs #18657
Refs #18654

## Test plan

- [x] `npx tsc --noEmit` clean (0 errors)
- [x] `npm run lint` (via `eslint -f json`) reports 0 new errors/warnings on changed files
- [x] `npm run audit:hex` drops to `files=78 matches=235` (-15 matches, file off the offenders list)
- [x] `grep -E '#[0-9a-fA-F]{3,8}|rgba?\(' ui/utils/charts.ts | wc -l` = 0
- [ ] Visual smoke: open the dashboard and verify the four donut charts (Connections, Configuration, Workloads, K8s Connection, Mesh Model) render with the new theme-derived palette in both light and dark mode