### PR TITLE
[UI] Phase 5.a: Split MesheryPatterns into focused siblings (#18660)

### DIFF
--- a/ui/components/designs/patterns/MesheryPatterns.columns.tsx
+++ b/ui/components/designs/patterns/MesheryPatterns.columns.tsx
@@ -1,0 +1,410 @@
+import React from 'react';
+import { Box } from '@sistent/sistent';
+import Moment from 'react-moment';
+import { GetApp as GetAppIcon } from '@/assets/icons';
+import { DoneAll as DoneAllIcon, Public as PublicIcon } from '@/assets/icons';
+import UndeployIcon from '../../../public/static/img/UndeployIcon';
+import CloneIcon from '../../../public/static/img/CloneIcon';
+import { Edit as EditIcon } from '@/assets/icons';
+import { InfoOutlined as InfoOutlinedIcon } from '@/assets/icons';
+import { DefaultTableCell, SortableTableCell } from '../../connections/common';
+import CAN from '@/utils/can';
+import { keys } from '@/utils/permission_constants';
+import CheckIcon from '@/assets/icons/CheckIcon';
+import DryRunIcon from '@/assets/icons/DryRunIcon';
+import PatternConfigureIcon from '@/assets/icons/PatternConfigure';
+import ActionPopover from './ActionPopover';
+import CustomToolbarSelect from './CustomToolbarSelect';
+import { VISIBILITY } from '../../../utils/Enum';
+import { genericClickHandler } from './MesheryPatterns.constants';
+
+/**
+ * Builds the per-row action items list for the Designs table.
+ * Extracted from the original Actions-column customBodyRender so the
+ * entry-point file stays under the line-budget. Behavior is identical:
+ * the same set of actions are returned in the same order, and each item's
+ * onClick / disabled / condition values are wired to the same handlers.
+ */
+export function buildPatternActions({ rowData, visibility, patterns, tableMeta, handlers }) {
+  const {
+    handleOpenInConfigurator,
+    handleClone,
+    openValidateModal,
+    openDryRunModal,
+    openUndeployModal,
+    openDeployModal,
+    handleDesignDownloadModal,
+    handleInfoModal,
+    handleUnpublishModal,
+    userCanEdit,
+  } = handlers;
+
+  return [
+    {
+      label: 'Edit',
+      icon: <EditIcon fill="currentColor" />,
+      onClick: (e) => {
+        e.stopPropagation();
+        handleOpenInConfigurator(rowData.id);
+      },
+      disabled: !CAN(keys.EDIT_DESIGN.action, keys.EDIT_DESIGN.subject),
+      condition: userCanEdit(rowData),
+    },
+    {
+      label: 'Clone',
+      icon: <CloneIcon fill="currentColor" />,
+      onClick: (e) => {
+        e.stopPropagation();
+        handleClone(rowData.id, rowData.name);
+      },
+      disabled: !CAN(keys.CLONE_DESIGN.action, keys.CLONE_DESIGN.subject),
+      condition: visibility === VISIBILITY.PUBLISHED,
+    },
+    {
+      label: 'Edit',
+      icon: <PatternConfigureIcon />,
+      onClick: (e) => {
+        e.stopPropagation();
+        handleOpenInConfigurator(patterns[tableMeta.rowIndex].id);
+      },
+      disabled: !CAN(keys.EDIT_DESIGN.action, keys.EDIT_DESIGN.subject),
+      condition: visibility !== VISIBILITY.PUBLISHED,
+    },
+    {
+      label: 'Validate Design',
+      icon: <CheckIcon data-cy="verify-button" />,
+      onClick: (e) => {
+        openValidateModal(e, rowData.patternFile, rowData.name, rowData.id);
+      },
+      disabled: !CAN(keys.VALIDATE_DESIGN.action, keys.VALIDATE_DESIGN.subject),
+    },
+    {
+      label: 'Dry Run',
+      icon: <DryRunIcon data-cy="verify-button" />,
+      onClick: (e) => {
+        openDryRunModal(e, rowData.patternFile, rowData.name, rowData.id);
+      },
+      disabled: !CAN(keys.VALIDATE_DESIGN.action, keys.VALIDATE_DESIGN.subject),
+    },
+    {
+      label: 'Undeploy',
+      icon: <UndeployIcon fill="#F91313" data-cy="undeploy-button" />,
+      onClick: (e) => {
+        openUndeployModal(e, rowData.patternFile, rowData.name, rowData.id);
+      },
+      disabled: !CAN(keys.UNDEPLOY_DESIGN.action, keys.UNDEPLOY_DESIGN.subject),
+    },
+    {
+      label: 'Deploy',
+      icon: <DoneAllIcon data-cy="deploy-button" />,
+      onClick: (e) => {
+        openDeployModal(e, rowData.patternFile, rowData.name, rowData.id);
+      },
+      disabled: !CAN(keys.DEPLOY_DESIGN.action, keys.DEPLOY_DESIGN.subject),
+    },
+    {
+      label: 'Download',
+      icon: <GetAppIcon data-cy="download-button" />,
+      onClick: (e) => {
+        handleDesignDownloadModal(e, rowData);
+      },
+      disabled: !CAN(keys.DOWNLOAD_A_DESIGN.action, keys.DOWNLOAD_A_DESIGN.subject),
+    },
+    {
+      label: 'Design Information',
+      icon: <InfoOutlinedIcon data-cy="information-button" />,
+      onClick: (e) => {
+        genericClickHandler(e, () => handleInfoModal(rowData));
+      },
+      disabled: !CAN(keys.DETAILS_OF_DESIGN.action, keys.DETAILS_OF_DESIGN.subject),
+    },
+
+    /* Publish action can be done through Info modal so we might not need separate publish action */
+    /*{
+      label="Publish",
+      icon: <PublicIcon fill="#F91313" data-cy="publish-button" />,
+      onClick: (e) => handlePublishModal(e, rowData)(),
+      disabled: !CAN(keys.PUBLISH_DESIGN.action, keys.PUBLISH_DESIGN.subject),
+      condition: canPublishPattern && visibility !== VISIBILITY.PUBLISHED,
+    },*/
+
+    {
+      label: 'Unpublish',
+      icon: <PublicIcon fill="#F91313" data-cy="unpublish-button" />,
+      onClick: (e) => {
+        handleUnpublishModal(e, rowData)();
+      },
+      disabled: !CAN(keys.UNPUBLISH_DESIGN.action, keys.UNPUBLISH_DESIGN.subject),
+      condition: visibility === VISIBILITY.PUBLISHED,
+    },
+  ].filter((action) => action.condition === undefined || action.condition);
+}
+
+/**
+ * Builds the responsive-column view configuration used to determine which
+ * columns are visible at different viewport widths.
+ */
+export const PATTERN_COL_VIEWS = [
+  ['name', 'xs'],
+  ['created_at', 'm'],
+  ['updated_at', 'm'],
+  ['visibility', 's'],
+  ['Actions', 'xs'],
+];
+
+/**
+ * Builds the full column definition array for the Designs table.
+ *
+ * The Actions column's customBodyRender closes over `patterns` and the
+ * caller-supplied `handlers` so it picks up fresh state on every render;
+ * we therefore rebuild the columns inside the parent component on each
+ * render (matching the original behavior).
+ */
+export function buildPatternColumns({ patterns, handlers }) {
+  return [
+    {
+      name: 'name',
+      label: 'Name',
+      options: {
+        filter: false,
+        sort: true,
+        searchable: true,
+        customHeadRender: function CustomHead({ index, ...column }, sortColumn, columnMeta) {
+          return (
+            <SortableTableCell
+              index={index}
+              columnData={column}
+              columnMeta={columnMeta}
+              onSort={() => sortColumn(index)}
+            />
+          );
+        },
+      },
+    },
+    {
+      name: 'created_at',
+      label: 'Created At',
+      options: {
+        filter: false,
+        sort: true,
+        searchable: true,
+        customHeadRender: function CustomHead({ index, ...column }, sortColumn, columnMeta) {
+          return (
+            <SortableTableCell
+              index={index}
+              columnData={column}
+              columnMeta={columnMeta}
+              onSort={() => sortColumn(index)}
+            />
+          );
+        },
+        customBodyRender: function CustomBody(value) {
+          return <Moment format="LLLL">{value}</Moment>;
+        },
+      },
+    },
+    {
+      name: 'updated_at',
+      label: 'Update At',
+      options: {
+        filter: false,
+        sort: true,
+        searchable: true,
+        customHeadRender: function CustomHead({ index, ...column }, sortColumn, columnMeta) {
+          return (
+            <SortableTableCell
+              index={index}
+              columnData={column}
+              columnMeta={columnMeta}
+              onSort={() => sortColumn(index)}
+            />
+          );
+        },
+        customBodyRender: function CustomBody(value) {
+          return <Moment format="LLLL">{value}</Moment>;
+        },
+      },
+    },
+    {
+      name: 'visibility',
+      label: 'Visibility',
+      options: {
+        filter: false,
+        sort: true,
+        searchable: true,
+        customHeadRender: function CustomHead({ ...column }) {
+          return <DefaultTableCell columnData={column} />;
+        },
+      },
+    },
+    {
+      name: 'Actions',
+      label: 'Actions',
+      options: {
+        filter: false,
+        sort: false,
+        searchable: false,
+        customHeadRender: function CustomHead({ ...column }) {
+          return <DefaultTableCell columnData={column} />;
+        },
+        customBodyRender: function CustomBody(_, tableMeta) {
+          const rowData = patterns[tableMeta.rowIndex];
+          const visibility = patterns[tableMeta.rowIndex]?.visibility;
+          const actions = buildPatternActions({
+            rowData,
+            visibility,
+            patterns,
+            tableMeta,
+            handlers,
+          });
+
+          return (
+            <Box sx={{ display: 'flex', justifyContent: 'center' }}>
+              <ActionPopover actions={actions} />
+            </Box>
+          );
+        },
+      },
+    },
+  ];
+}
+
+/**
+ * Builds the `options` config for the Designs ResponsiveDataTable.
+ *
+ * Closes over caller-supplied state (patterns array, paging info) and
+ * caller-supplied callbacks (deletePatterns, showModal, setters,
+ * subscription init, etc.) so the table picks up fresh data on every
+ * render. Behavior matches the original inline `options` block one-for-one.
+ */
+export function buildPatternsTableOptions({
+  patterns,
+  columns,
+  count,
+  pageSize,
+  page,
+  search,
+  sortOrder,
+  user,
+  searchTimeout,
+  setPage,
+  setPageSize,
+  setSearch,
+  setSortOrder,
+  setSelectedRowData,
+  deletePatterns,
+  showModal,
+  initPatternsSubscription,
+}) {
+  return {
+    customToolbarSelect: (selectedRows, displayData, setSelectedRows) => (
+      <CustomToolbarSelect
+        selectedRows={selectedRows}
+        displayData={displayData}
+        setSelectedRows={setSelectedRows}
+        patterns={patterns}
+        deletePatterns={deletePatterns}
+        showModal={showModal}
+      />
+    ),
+    filter: false,
+    search: false,
+    viewColumns: false,
+    sort: !(user && user.userId === 'meshery'),
+    filterType: 'textField',
+    responsive: 'standard',
+    resizableColumns: true,
+    serverSide: true,
+    count,
+    rowsPerPage: pageSize,
+    fixedHeader: true,
+    page,
+    print: false,
+    download: false,
+    sortOrder: {
+      name: sortOrder.split(' ')[0],
+      direction: sortOrder.split(' ')[1],
+    },
+    textLabels: {
+      selectedRows: {
+        text: 'pattern(s) selected',
+      },
+    },
+
+    onCellClick: (_, meta) =>
+      meta.colIndex !== 3 && meta.colIndex !== 4 && setSelectedRowData(patterns[meta.rowIndex]),
+
+    onRowsDelete: async function handleDelete(row) {
+      const toBeDeleted = Object.keys(row.lookup).map((idx) => ({
+        id: patterns[idx]?.id,
+        name: patterns[idx]?.name,
+      }));
+      let response = await showModal(
+        toBeDeleted.length,
+        toBeDeleted.map((p) => ' ' + p.name),
+      );
+      if (response && response.trim().toUpperCase() === 'DELETE') {
+        deletePatterns({ patterns: toBeDeleted });
+      }
+      // if (response.toLowerCase() === "no")
+      // fetchPatterns(page, pageSize, search, sortOrder);
+    },
+
+    onTableChange: (action, tableState) => {
+      const sortInfo = tableState.announceText ? tableState.announceText.split(' : ') : [];
+      let order = '';
+      if (tableState.activeColumn) {
+        order = `${columns[tableState.activeColumn].name} desc`;
+      }
+
+      switch (action) {
+        case 'changePage':
+          initPatternsSubscription(tableState.page.toString(), pageSize.toString(), search, order);
+          setPage(tableState.page);
+          break;
+        case 'changeRowsPerPage':
+          initPatternsSubscription(
+            page.toString(),
+            tableState.rowsPerPage.toString(),
+            search,
+            order,
+          );
+          setPageSize(tableState.rowsPerPage);
+          break;
+        case 'search':
+          if (searchTimeout.current) {
+            clearTimeout(searchTimeout.current);
+          }
+          searchTimeout.current = setTimeout(() => {
+            if (search !== tableState.searchText) {
+              setSearch(tableState.searchText);
+            }
+          }, 500);
+          break;
+        case 'sort':
+          if (sortInfo.length === 2) {
+            if (sortInfo[1] === 'ascending') {
+              order = `${columns[tableState.activeColumn].name} asc`;
+            } else {
+              order = `${columns[tableState.activeColumn].name} desc`;
+            }
+          }
+          if (order !== sortOrder) {
+            initPatternsSubscription(page.toString(), pageSize.toString(), search, order);
+            setSortOrder(order);
+          }
+          break;
+      }
+    },
+    setRowProps: (row, dataIndex, rowIndex) => {
+      return {
+        'data-cy': `config-row-${rowIndex}`,
+      };
+    },
+    setTableProps: () => {
+      return {
+        'data-cy': 'filters-grid',
+      };
+    },
+  };
+}

--- a/ui/components/designs/patterns/MesheryPatterns.constants.tsx
+++ b/ui/components/designs/patterns/MesheryPatterns.constants.tsx
@@ -1,0 +1,51 @@
+export const ACTION_TYPES = {
+  FETCH_PATTERNS: {
+    name: 'FETCH_PATTERNS',
+    error_msg: 'Failed to fetch designs',
+  },
+  UPDATE_PATTERN: {
+    name: 'UPDATE_PATTERN',
+    error_msg: 'Failed to update design file',
+  },
+  DELETE_PATTERN: {
+    name: 'DELETE_PATTERN',
+    error_msg: 'Failed to delete design file',
+  },
+  DEPLOY_PATTERN: {
+    name: 'DEPLOY_PATTERN',
+    error_msg: 'Failed to deploy design file',
+  },
+  UNDEPLOY_PATTERN: {
+    name: 'UNDEPLOY_PATTERN',
+    error_msg: 'Failed to undeploy design file',
+  },
+  UPLOAD_PATTERN: {
+    name: 'UPLOAD_PATTERN',
+    error_msg: 'Failed to upload design file',
+  },
+  CLONE_PATTERN: {
+    name: 'CLONE_PATTERN',
+    error_msg: 'Failed to clone design file',
+  },
+  PUBLISH_CATALOG: {
+    name: 'PUBLISH_CATALOG',
+    error_msg: 'Failed to publish catalog',
+  },
+  UNPUBLISH_CATALOG: {
+    name: 'UNPUBLISH_CATALOG',
+    error_msg: 'Failed to unpublish catalog',
+  },
+  SCHEMA_FETCH: {
+    name: 'SCHEMA_FETCH',
+    error_msg: 'failed to fetch import schema',
+  },
+};
+
+export const genericClickHandler = (ev, fn) => {
+  ev.stopPropagation();
+  fn(ev);
+};
+
+export function resetSelectedPattern() {
+  return { show: false, pattern: null };
+}

--- a/ui/components/designs/patterns/MesheryPatterns.styled.tsx
+++ b/ui/components/designs/patterns/MesheryPatterns.styled.tsx
@@ -1,0 +1,44 @@
+import { Box, DialogTitle, Typography, styled } from '@sistent/sistent';
+import { AddCircleOutlined as AddIcon } from '@/assets/icons';
+
+export const ViewSwitchButton = styled(Box)(() => ({
+  justifySelf: 'flex-end',
+}));
+
+export const CreateButton = styled(Box)(() => ({
+  display: 'flex',
+  justifyContent: 'flex-start',
+  alignItems: 'center',
+  whiteSpace: 'nowrap',
+}));
+
+export const AddIconStyled = styled(AddIcon)(() => ({
+  paddingRight: '.35rem',
+}));
+
+export const SearchWrapper = styled(Box)(() => ({
+  justifySelf: 'flex-end',
+  marginLeft: 'auto',
+  paddingLeft: '1rem',
+  display: 'flex',
+  '@media (max-width: 965px)': {
+    width: 'max-content',
+  },
+}));
+
+export const BtnText = styled('span')(() => ({
+  display: 'block',
+  '@media (max-width: 765px)': {
+    display: 'none',
+  },
+}));
+
+export const YamlDialogTitle = styled(DialogTitle)(() => ({
+  display: 'flex',
+  justifyContent: 'space-between',
+  alignItems: 'end',
+}));
+
+export const YamlDialogTitleText = styled(Typography)(() => ({
+  flexGrow: 1,
+}));

--- a/ui/components/designs/patterns/MesheryPatterns.tsx
+++ b/ui/components/designs/patterns/MesheryPatterns.tsx
@@ -1,82 +1,32 @@
-/* eslint-disable react/display-name */
-
 import {
-  CustomColumnVisibilityControl,
-  CustomTooltip,
   OutlinedPatternIcon,
-  SearchBar,
-  UniversalFilter,
-  importDesignSchema,
-  importDesignUiSchema,
   publishCatalogItemSchema,
   publishCatalogItemUiSchema,
-  Box,
-  Dialog,
-  DialogActions,
-  DialogContent,
-  DialogTitle,
-  Divider,
-  IconButton,
   ResponsiveDataTable,
-  Typography,
-  styled,
-  PROMPT_VARIANTS,
 } from '@sistent/sistent';
 import { NoSsr } from '@sistent/sistent';
-import {
-  Close as CloseIcon,
-  Delete as DeleteIcon,
-  Fullscreen as FullscreenIcon,
-  GetApp as GetAppIcon,
-  FullscreenExit as FullscreenExitIcon,
-  Save as SaveIcon,
-  AddCircleOutlined as AddIcon,
-} from '@/assets/icons';
-import CustomToolbarSelect from './CustomToolbarSelect';
 import React, { useEffect, useRef, useState } from 'react';
-import { UnControlled as CodeMirror } from '../../CodeMirror';
-import Moment from 'react-moment';
-import { encodeDesignFile, getUnit8ArrayDecodedFile, parseDesignFile } from '../../../utils/utils';
-import ViewSwitch from '../../ViewSwitch';
 import MesheryPatternGrid from './MesheryPatternGridView';
-import UndeployIcon from '../../../public/static/img/UndeployIcon';
-import {
-  DoneAll as DoneAllIcon,
-  Public as PublicIcon,
-  Publish as PublishIcon,
-} from '@/assets/icons';
 import _PromptComponent from '../../PromptComponent';
 import LoadingScreen from '../../shared/LoadingState/LoadingComponent';
-import { FILE_OPS, MesheryPatternsCatalog, VISIBILITY } from '../../../utils/Enum';
-import CloneIcon from '../../../public/static/img/CloneIcon';
+import { MesheryPatternsCatalog, VISIBILITY } from '../../../utils/Enum';
 import { useRouter } from 'next/router';
-import { RJSFModalWrapper } from '../../shared/Modal/Modal';
-import downloadContent from '../../../utils/fileDownloader';
 import ConfigurationSubscription from '@/graphql/subscriptions/ConfigurationSubscription';
-import Pattern from '../../../public/static/img/drawer-icons/pattern_svg';
 import { useNotification } from '../../../utils/hooks/useNotification';
-import { EVENT_TYPES } from '../../../lib/event-types';
 import _ from 'lodash';
 import { getMeshModels } from '../../../api/meshmodel';
 import { modifyRJSFSchema } from '../../../utils/utils';
-import { Edit as EditIcon } from '@/assets/icons';
 import { updateVisibleColumns } from '../../../utils/responsive-column';
 import { useWindowDimensions } from '../../../utils/dimension';
 import InfoModal from '../../shared/Modal/Information/InfoModal';
-import { InfoOutlined as InfoOutlinedIcon } from '@/assets/icons';
-import { DefaultTableCell, SortableTableCell } from '../../connections/common';
 import DefaultError from '../../general/error-404/index';
 import CAN from '@/utils/can';
 import { keys } from '@/utils/permission_constants';
 import ExportModal from '../../shared/Modal/ExportModal';
-import { useModal, Modal as SistentModal, ModalBody } from '@sistent/sistent';
+import { useModal, Modal as SistentModal } from '@sistent/sistent';
 import PatternIcon from '@/assets/icons/Pattern';
-import DryRunIcon from '@/assets/icons/DryRunIcon';
 import { useActorRef } from '@xstate/react';
 import { designValidationMachine } from 'machines/validator/designValidator';
-import { UnDeployStepper, DeployStepper } from '../lifecycle/DeployStepper';
-import { DryRunDesign } from '../lifecycle/DryRun';
-import { DEPLOYMENT_TYPE } from '../lifecycle/common';
 import {
   useClonePatternMutation,
   useDeletePatternFileMutation,
@@ -90,178 +40,24 @@ import {
   useUpdatePatternFileMutation,
   useUploadPatternFileMutation,
 } from '@/rtk-query/design';
-import CheckIcon from '@/assets/icons/CheckIcon';
-import { ValidateDesign } from '../lifecycle/ValidateDesign';
-import PatternConfigureIcon from '@/assets/icons/PatternConfigure';
 // import { useGetUserPrefQuery } from '@/rtk-query/user';
 import { useGetProviderCapabilitiesQuery } from '@/rtk-query/user';
-import TooltipButton from '@/utils/TooltipButton';
-import { ToolWrapper } from '@/assets/styles/general/tool.styles';
-import yaml from 'js-yaml';
-import ActionPopover from './ActionPopover';
 import { useSelector } from 'react-redux';
-import { updateProgress } from '@/store/slices/mesheryUi';
+import { ACTION_TYPES, resetSelectedPattern } from './MesheryPatterns.constants';
+import YAMLEditor from './YAMLEditor';
+import { ImportDesignModal, PublishModal } from './MesheryPatternsModals';
+import MesheryPatternsToolbar from './MesheryPatternsToolbar';
+import {
+  buildPatternColumns,
+  buildPatternsTableOptions,
+  PATTERN_COL_VIEWS,
+} from './MesheryPatterns.columns';
+import { buildDesignLifecycleHandlers } from './design-lifecycle-handlers';
+import { createPatternsActions } from './patterns-actions';
 
-const genericClickHandler = (ev, fn) => {
-  ev.stopPropagation();
-  fn(ev);
-};
-
-const ViewSwitchButton = styled(Box)(() => ({
-  justifySelf: 'flex-end',
-}));
-
-const CreateButton = styled(Box)(() => ({
-  display: 'flex',
-  justifyContent: 'flex-start',
-  alignItems: 'center',
-  whiteSpace: 'nowrap',
-}));
-
-const AddIconStyled = styled(AddIcon)(() => ({
-  paddingRight: '.35rem',
-}));
-
-const SearchWrapper = styled(Box)(() => ({
-  justifySelf: 'flex-end',
-  marginLeft: 'auto',
-  paddingLeft: '1rem',
-  display: 'flex',
-  '@media (max-width: 965px)': {
-    width: 'max-content',
-  },
-}));
-
-const BtnText = styled('span')(() => ({
-  display: 'block',
-  '@media (max-width: 765px)': {
-    display: 'none',
-  },
-}));
-
-const YamlDialogTitle = styled(DialogTitle)(() => ({
-  display: 'flex',
-  justifyContent: 'space-between',
-  alignItems: 'end',
-}));
-
-const YamlDialogTitleText = styled(Typography)(() => ({
-  flexGrow: 1,
-}));
-
-function YAMLEditor({ pattern, onClose, onSubmit, isReadOnly = false }) {
-  const [yaml, setYaml] = useState(pattern.patternFile);
-  const [fullScreen, setFullScreen] = useState(false);
-
-  const toggleFullScreen = () => {
-    setFullScreen(!fullScreen);
-  };
-
-  const FullScreenCodeMirrorWrapper = styled('div')(() => ({
-    height: '100%',
-    '& .cm-editor': {
-      minHeight: '300px',
-      height: fullScreen ? '80vh' : '30vh',
-    },
-  }));
-
-  return (
-    <Dialog
-      onClose={onClose}
-      aria-labelledby="pattern-dialog-title"
-      open
-      maxWidth="md"
-      fullScreen={fullScreen}
-      fullWidth={!fullScreen}
-    >
-      <YamlDialogTitle
-        style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'end' }}
-        disableTypography
-        id="pattern-dialog-title"
-      >
-        <div>
-          <YamlDialogTitleText variant="h6">{pattern.name}</YamlDialogTitleText>
-        </div>
-        <div>
-          <CustomTooltip
-            placement="top"
-            title={fullScreen ? 'Exit Fullscreen' : 'Enter Fullscreen'}
-            onClick={toggleFullScreen}
-          >
-            {fullScreen ? <FullscreenExitIcon /> : <FullscreenIcon />}
-          </CustomTooltip>
-          <CustomTooltip placement="top" title="Exit" onClick={onClose}>
-            <CloseIcon />
-          </CustomTooltip>
-        </div>
-      </YamlDialogTitle>
-      <Divider variant="fullWidth" light />
-      <DialogContent>
-        <FullScreenCodeMirrorWrapper>
-          <CodeMirror
-            value={pattern.patternFile}
-            options={{
-              theme: 'material',
-              lineNumbers: true,
-              lineWrapping: true,
-              gutters: ['CodeMirror-lint-markers'],
-              // @ts-ignore
-              lint: true,
-              mode: 'text/x-yaml',
-              readOnly: isReadOnly,
-            }}
-            onChange={(_, data, val) => setYaml(val)}
-          />
-        </FullScreenCodeMirrorWrapper>
-      </DialogContent>
-      <Divider variant="fullWidth" light />
-      <DialogActions>
-        {isReadOnly ? null : (
-          <>
-            <CustomTooltip title="Update Design">
-              <IconButton
-                aria-label="Update"
-                disabled={!CAN(keys.EDIT_DESIGN.action, keys.EDIT_DESIGN.subject)}
-                onClick={() =>
-                  onSubmit({
-                    data: yaml,
-                    id: pattern.id,
-                    name: pattern.name,
-                    type: FILE_OPS.UPDATE,
-                    catalogData: pattern.catalogData,
-                  })
-                }
-              >
-                <SaveIcon />
-              </IconButton>
-            </CustomTooltip>
-            <CustomTooltip title="Delete Pattern">
-              <IconButton
-                aria-label="Delete"
-                disabled={!CAN(keys.DELETE_A_DESIGN.action, keys.DELETE_A_DESIGN.subject)}
-                onClick={() =>
-                  onSubmit({
-                    data: yaml,
-                    id: pattern.id,
-                    name: pattern.name,
-                    type: FILE_OPS.DELETE,
-                    catalogData: pattern.catalogData,
-                  })
-                }
-              >
-                <DeleteIcon />
-              </IconButton>
-            </CustomTooltip>
-          </>
-        )}
-      </DialogActions>
-    </Dialog>
-  );
-}
-
-function resetSelectedPattern() {
-  return { show: false, pattern: null };
-}
+// Re-export modal helpers so existing consumers
+// (`@/components/designs/patterns/MesheryPatterns`) keep working.
+export { ImportDesignModal };
 
 function MesheryPatterns({
   disableCreateImportDesignButton = false,
@@ -356,25 +152,6 @@ function MesheryPatterns({
   const sistentInfoModal = useModal({
     headerIcon: OutlinedPatternIcon,
   });
-  const handleDeploy = async ({ design, selectedK8sContexts }) => {
-    updateProgress({ showProgress: true });
-    await deployPatternMutation({
-      patternFile: encodeDesignFile(design),
-      patternId: design.id,
-      selectedK8sContexts,
-    });
-    updateProgress({ showProgress: false });
-  };
-
-  const handleUndeploy = async ({ design, selectedK8sContexts }) => {
-    updateProgress({ showProgress: true });
-    await undeployPatternMutation({
-      patternFile: encodeDesignFile(design),
-      patternId: design.id,
-      selectedK8sContexts,
-    });
-    updateProgress({ showProgress: false });
-  };
 
   const handleDownloadDialogClose = () => {
     setDownloadModal((prevState) => ({
@@ -393,55 +170,55 @@ function MesheryPatterns({
     }));
   };
 
+  const {
+    handleError,
+    resetSelectedRowData,
+    handleDeploy,
+    handleUndeploy,
+    handleUploadImport,
+    handleUploadImportClose,
+    handleInfoModalClose,
+    handleInfoModal,
+    handleUnpublishModal,
+    handlePublishModalClose,
+    handlePublish,
+    handleClone,
+    handleSubmit,
+    handleImportDesign,
+    deletePatterns,
+    handleDownload,
+    showModal,
+  } = createPatternsActions({
+    clonePattern,
+    publishCatalog,
+    unpublishCatalog,
+    deletePattern,
+    deletePatternFile,
+    importPattern,
+    updatePattern,
+    uploadPatternFile,
+    deployPatternMutation,
+    undeployPatternMutation,
+    modalRef,
+    meshModels,
+    infoModal,
+    publishModal,
+    user,
+    setImportModal,
+    setPublishModal,
+    setSelectedRowData,
+    setInfoModal,
+    notify,
+    sistentInfoModal,
+    getPatterns,
+  });
+
   // const [loading, stillLoading] = useState(true);
   const { width } = useWindowDimensions();
 
   const catalogVisibilityRef = useRef(false);
   const catalogContentRef = useRef();
   const disposeConfSubscriptionRef = useRef(null);
-
-  const ACTION_TYPES = {
-    FETCH_PATTERNS: {
-      name: 'FETCH_PATTERNS',
-      error_msg: 'Failed to fetch designs',
-    },
-    UPDATE_PATTERN: {
-      name: 'UPDATE_PATTERN',
-      error_msg: 'Failed to update design file',
-    },
-    DELETE_PATTERN: {
-      name: 'DELETE_PATTERN',
-      error_msg: 'Failed to delete design file',
-    },
-    DEPLOY_PATTERN: {
-      name: 'DEPLOY_PATTERN',
-      error_msg: 'Failed to deploy design file',
-    },
-    UNDEPLOY_PATTERN: {
-      name: 'UNDEPLOY_PATTERN',
-      error_msg: 'Failed to undeploy design file',
-    },
-    UPLOAD_PATTERN: {
-      name: 'UPLOAD_PATTERN',
-      error_msg: 'Failed to upload design file',
-    },
-    CLONE_PATTERN: {
-      name: 'CLONE_PATTERN',
-      error_msg: 'Failed to clone design file',
-    },
-    PUBLISH_CATALOG: {
-      name: 'PUBLISH_CATALOG',
-      error_msg: 'Failed to publish catalog',
-    },
-    UNPUBLISH_CATALOG: {
-      name: 'UNPUBLISH_CATALOG',
-      error_msg: 'Failed to unpublish catalog',
-    },
-    SCHEMA_FETCH: {
-      name: 'SCHEMA_FETCH',
-      error_msg: 'failed to fetch import schema',
-    },
-  };
 
   /**
    * Checking whether users are signed in under a provider that doesn't have
@@ -607,339 +384,14 @@ function MesheryPatterns({
     setPatterns(patterns?.filter((content) => content.visibility !== VISIBILITY.PUBLISHED) || []);
   };
 
-  const openDeployModal = (e, pattern_file, name) => {
-    const design = parseDesignFile(pattern_file);
-    e.stopPropagation();
-    designLifecycleModal.openModal({
-      title: `Deploy design "${name}"`,
-      headerIcon: <DoneAllIcon fill="#fff" height={'2rem'} width={'2rem'} />,
-      reactNode: (
-        <DeployStepper
-          handleClose={designLifecycleModal.closeModal}
-          validationMachine={designValidationActorRef}
-          design={design}
-          handleDeploy={handleDeploy}
-          deployment_type={DEPLOYMENT_TYPE.DEPLOY}
-          selectedK8sContexts={selectedK8sContexts}
-        />
-      ),
+  const { openDeployModal, openUndeployModal, openDryRunModal, openValidateModal } =
+    buildDesignLifecycleHandlers({
+      designLifecycleModal,
+      designValidationActorRef,
+      selectedK8sContexts,
+      handleDeploy,
+      handleUndeploy,
     });
-  };
-
-  const openUndeployModal = (e, pattern_file, name) => {
-    e.stopPropagation();
-    const design = parseDesignFile(pattern_file);
-    designLifecycleModal.openModal({
-      title: `Undeploy design "${name}"`,
-      headerIcon: <UndeployIcon fill="#fff" height={'2rem'} width={'2rem'} />,
-      reactNode: (
-        <UnDeployStepper
-          handleClose={designLifecycleModal.closeModal}
-          validationMachine={designValidationActorRef}
-          design={design}
-          handleUndeploy={handleUndeploy}
-          deployment_type={DEPLOYMENT_TYPE.UNDEPLOY}
-          selectedK8sContexts={selectedK8sContexts}
-        />
-      ),
-    });
-  };
-
-  const openDryRunModal = (e, pattern_file, name) => {
-    e.stopPropagation();
-
-    const design = parseDesignFile(pattern_file);
-    designLifecycleModal.openModal({
-      title: `Dryrun design "${name}"`,
-      headerIcon: <DryRunIcon fill="#fff" height={'2rem'} width={'2rem'} />,
-      reactNode: (
-        <ModalBody style={{ minWidth: '30rem', width: 'auto' }}>
-          <DryRunDesign
-            handleClose={designLifecycleModal.closeModal}
-            validationMachine={designValidationActorRef}
-            design={design}
-            deployment_type={DEPLOYMENT_TYPE.DEPLOY}
-            selectedK8sContexts={selectedK8sContexts}
-          />
-        </ModalBody>
-      ),
-    });
-  };
-
-  const openValidateModal = (e, pattern_file, name) => {
-    e.stopPropagation();
-
-    const design = parseDesignFile(pattern_file);
-    designLifecycleModal.openModal({
-      title: `Validate design "${name}"`,
-      headerIcon: <CheckIcon fill="#fff" height={'2rem'} width={'2rem'} />,
-      reactNode: (
-        <ModalBody style={{ minWidth: '30rem', width: 'auto' }}>
-          <ValidateDesign
-            handleClose={designLifecycleModal.closeModal}
-            validationMachine={designValidationActorRef}
-            design={design}
-            deployment_type={DEPLOYMENT_TYPE.DEPLOY}
-            selectedK8sContexts={selectedK8sContexts}
-          />
-        </ModalBody>
-      ),
-    });
-  };
-
-  const handleUploadImport = () => {
-    setImportModal({
-      open: true,
-    });
-  };
-
-  const handleUploadImportClose = () => {
-    setImportModal({
-      open: false,
-    });
-  };
-
-  const handleInfoModalClose = () => {
-    sistentInfoModal.closeModal();
-    setInfoModal({
-      open: false,
-    });
-  };
-
-  const handleInfoModal = (pattern) => {
-    sistentInfoModal.openModal({
-      title: pattern.name,
-    });
-
-    setInfoModal({
-      open: true,
-      ownerID: pattern.userId,
-      selectedResource: pattern,
-    });
-  };
-
-  // const handlePublishModal = (ev, pattern) => {
-  //   if (canPublishPattern) {
-  //     ev.stopPropagation();
-  //     setPublishModal({
-  //       open: true,
-  //       pattern: pattern,
-  //       name: '',
-  //     });
-  //   }
-  // };
-
-  const handleUnpublishModal = (ev, pattern) => {
-    return async () => {
-      let response = await modalRef.current.show({
-        title: `Unpublish Catalog item?`,
-        subtitle: `Are you sure you want to unpublish ${pattern?.name}?`,
-        variant: PROMPT_VARIANTS.DANGER,
-        primaryOption: 'UNPUBLISH',
-        showInfoIcon:
-          "Unpublishing a catolog item removes the item from the public-facing catalog (a public website accessible to anonymous visitors at meshery.io/catalog). The catalog item's visibility will change to either public (or private with a subscription). The ability to for other users to continue to access, edit, clone and collaborate on your content depends upon the assigned visibility level (public or private). Prior collaborators (users with whom you have shared your catalog item) will retain access. However, you can always republish it whenever you want. Remember: unpublished catalog items can still be available to other users if that item is set to public visibility. For detailed information, please refer to the [documentation](https://docs.meshery.io/concepts/designs).",
-      });
-      if (response === 'UNPUBLISH') {
-        updateProgress({ showProgress: true });
-        unpublishCatalog({
-          unpublishBody: JSON.stringify({ id: pattern?.id }),
-        })
-          .unwrap()
-          .then(() => {
-            updateProgress({ showProgress: false });
-            notify({
-              message: `Design Unpublished`,
-              event_type: EVENT_TYPES.SUCCESS,
-            });
-          })
-          .catch(() => {
-            updateProgress({ showProgress: false });
-            handleError(ACTION_TYPES.UNPUBLISH_CATALOG);
-          });
-      }
-    };
-  };
-
-  const handlePublishModalClose = () => {
-    setPublishModal({
-      open: false,
-      pattern: {},
-      name: '',
-    });
-  };
-
-  const handlePublish = (formData) => {
-    const compatibilityStore = _.uniqBy(meshModels, (model) => _.toLower(model.displayName))
-      ?.filter((model) =>
-        formData?.compatibility?.some((comp) => _.toLower(comp) === _.toLower(model.displayName)),
-      )
-      ?.map((model) => model.name);
-
-    const payload = {
-      id: infoModal.selectedResource?.id,
-      catalogData: {
-        ...formData,
-        compatibility: compatibilityStore,
-        type: _.toLower(formData?.type),
-      },
-    };
-    updateProgress({ showProgress: true });
-    publishCatalog({
-      publishBody: JSON.stringify(payload),
-    })
-      .unwrap()
-      .then(() => {
-        updateProgress({ showProgress: false });
-        if (user.roleNames.includes('admin')) {
-          notify({
-            message: `${publishModal?.name} Design Published`,
-            event_type: EVENT_TYPES.SUCCESS,
-          });
-        } else {
-          notify({
-            message:
-              'Design queued for publishing into Meshery Catalog. Maintainers notified for review',
-            event_type: EVENT_TYPES.SUCCESS,
-          });
-        }
-      })
-      .catch(() => {
-        updateProgress({ showProgress: false });
-        handleError(ACTION_TYPES.PUBLISH_CATALOG);
-      });
-  };
-
-  function handleClone(patternID, name) {
-    updateProgress({ showProgress: true });
-    clonePattern({
-      body: JSON.stringify({ name: name + ' (Copy)' }),
-      patternID: patternID,
-    })
-      .unwrap()
-      .then(() => {
-        updateProgress({ showProgress: false });
-        notify({
-          message: `"${name}" Design cloned`,
-          event_type: EVENT_TYPES.SUCCESS,
-        });
-      })
-      .catch(() => {
-        updateProgress({ showProgress: false });
-        notify({
-          message: `Failed to clone "${name}" Design`,
-          event_type: EVENT_TYPES.ERROR,
-        });
-      });
-  }
-
-  const handleError = (action) => (error) => {
-    updateProgress({ showProgress: false });
-
-    notify({
-      message: `${action.error_msg}: ${error}`,
-      event_type: EVENT_TYPES.ERROR,
-    });
-  };
-
-  function resetSelectedRowData() {
-    return () => {
-      setSelectedRowData(null);
-    };
-  }
-
-  async function handleSubmit({ data, id, name, type, metadata, catalogData }) {
-    updateProgress({ showProgress: true });
-    if (type === FILE_OPS.DELETE) {
-      const response = await showModal(1, name);
-      if (response == 'CANCEL') {
-        updateProgress({ showProgress: false });
-        return;
-      }
-      deletePatternFile({
-        id: id,
-      })
-        .unwrap()
-        .then(() => {
-          updateProgress({ showProgress: false });
-          notify({ message: `"${name}" Design deleted`, event_type: EVENT_TYPES.SUCCESS });
-          getPatterns();
-          resetSelectedRowData()();
-        })
-        .catch(() => {
-          updateProgress({ showProgress: false });
-          handleError(ACTION_TYPES.DELETE_PATTERN);
-        });
-    }
-
-    if (type === FILE_OPS.UPDATE) {
-      const design = yaml.load(data);
-
-      updatePattern({
-        updateBody: JSON.stringify({
-          id,
-          name: data.name,
-          designFile: design,
-          catalogData,
-        }),
-      })
-        .unwrap()
-        .then(() => {
-          updateProgress({ showProgress: false });
-          notify({ message: `"${name}" Design updated`, event_type: EVENT_TYPES.SUCCESS });
-        })
-        .catch(() => {
-          updateProgress({ showProgress: false });
-          handleError(ACTION_TYPES.UPDATE_PATTERN);
-        });
-    }
-
-    if (type === FILE_OPS.FILE_UPLOAD || type === FILE_OPS.URL_UPLOAD) {
-      let body;
-      if (type === FILE_OPS.FILE_UPLOAD) {
-        body = JSON.stringify({
-          patternData: {
-            name: metadata?.name || name,
-            patternFile: getUnit8ArrayDecodedFile(data),
-            catalogData,
-          },
-          save: true,
-        });
-      }
-      if (type === FILE_OPS.URL_UPLOAD) {
-        body = JSON.stringify({
-          url: data,
-          save: true,
-          name: metadata?.name || name,
-          catalogData,
-        });
-      }
-      uploadPatternFile({
-        uploadBody: body,
-      })
-        .unwrap()
-        .then(() => {
-          updateProgress({ showProgress: false });
-        })
-        .catch(() => {
-          updateProgress({ showProgress: false });
-          handleError(ACTION_TYPES.UPLOAD_PATTERN);
-        });
-    }
-  }
-
-  const handleDownload = (e, design, source_type, params) => {
-    e.stopPropagation();
-    updateProgress({ showProgress: true });
-    try {
-      let id = design.id;
-      let name = design.name;
-      downloadContent({ id, name, type: 'pattern', source_type, params });
-      updateProgress({ showProgress: false });
-      notify({ message: `"${name}" design downloaded`, event_type: EVENT_TYPES.INFO });
-    } catch (e) {
-      console.error(e);
-    }
-  };
 
   const userCanEdit = (pattern) => {
     return (
@@ -951,212 +403,21 @@ function MesheryPatterns({
     router.push('/configuration/designs/configurator?design_id=' + id);
   };
 
-  let colViews = [
-    ['name', 'xs'],
-    ['created_at', 'm'],
-    ['updated_at', 'm'],
-    ['visibility', 's'],
-    ['Actions', 'xs'],
-  ];
-
-  const columns = [
-    {
-      name: 'name',
-      label: 'Name',
-      options: {
-        filter: false,
-        sort: true,
-        searchable: true,
-        customHeadRender: function CustomHead({ index, ...column }, sortColumn, columnMeta) {
-          return (
-            <SortableTableCell
-              index={index}
-              columnData={column}
-              columnMeta={columnMeta}
-              onSort={() => sortColumn(index)}
-            />
-          );
-        },
-      },
+  const columns = buildPatternColumns({
+    patterns,
+    handlers: {
+      handleOpenInConfigurator,
+      handleClone,
+      openValidateModal,
+      openDryRunModal,
+      openUndeployModal,
+      openDeployModal,
+      handleDesignDownloadModal,
+      handleInfoModal,
+      handleUnpublishModal,
+      userCanEdit,
     },
-    {
-      name: 'created_at',
-      label: 'Created At',
-      options: {
-        filter: false,
-        sort: true,
-        searchable: true,
-        customHeadRender: function CustomHead({ index, ...column }, sortColumn, columnMeta) {
-          return (
-            <SortableTableCell
-              index={index}
-              columnData={column}
-              columnMeta={columnMeta}
-              onSort={() => sortColumn(index)}
-            />
-          );
-        },
-        customBodyRender: function CustomBody(value) {
-          return <Moment format="LLLL">{value}</Moment>;
-        },
-      },
-    },
-    {
-      name: 'updated_at',
-      label: 'Update At',
-      options: {
-        filter: false,
-        sort: true,
-        searchable: true,
-        customHeadRender: function CustomHead({ index, ...column }, sortColumn, columnMeta) {
-          return (
-            <SortableTableCell
-              index={index}
-              columnData={column}
-              columnMeta={columnMeta}
-              onSort={() => sortColumn(index)}
-            />
-          );
-        },
-        customBodyRender: function CustomBody(value) {
-          return <Moment format="LLLL">{value}</Moment>;
-        },
-      },
-    },
-    {
-      name: 'visibility',
-      label: 'Visibility',
-      options: {
-        filter: false,
-        sort: true,
-        searchable: true,
-        customHeadRender: function CustomHead({ ...column }) {
-          return <DefaultTableCell columnData={column} />;
-        },
-      },
-    },
-    {
-      name: 'Actions',
-      label: 'Actions',
-      options: {
-        filter: false,
-        sort: false,
-        searchable: false,
-        customHeadRender: function CustomHead({ ...column }) {
-          return <DefaultTableCell columnData={column} />;
-        },
-        customBodyRender: function CustomBody(_, tableMeta) {
-          const rowData = patterns[tableMeta.rowIndex];
-          const visibility = patterns[tableMeta.rowIndex]?.visibility;
-          const actions = [
-            {
-              label: 'Edit',
-              icon: <EditIcon fill="currentColor" />,
-              onClick: (e) => {
-                e.stopPropagation();
-                handleOpenInConfigurator(rowData.id);
-              },
-              disabled: !CAN(keys.EDIT_DESIGN.action, keys.EDIT_DESIGN.subject),
-              condition: userCanEdit(rowData),
-            },
-            {
-              label: 'Clone',
-              icon: <CloneIcon fill="currentColor" />,
-              onClick: (e) => {
-                e.stopPropagation();
-                handleClone(rowData.id, rowData.name);
-              },
-              disabled: !CAN(keys.CLONE_DESIGN.action, keys.CLONE_DESIGN.subject),
-              condition: visibility === VISIBILITY.PUBLISHED,
-            },
-            {
-              label: 'Edit',
-              icon: <PatternConfigureIcon />,
-              onClick: (e) => {
-                e.stopPropagation();
-                handleOpenInConfigurator(patterns[tableMeta.rowIndex].id);
-              },
-              disabled: !CAN(keys.EDIT_DESIGN.action, keys.EDIT_DESIGN.subject),
-              condition: visibility !== VISIBILITY.PUBLISHED,
-            },
-            {
-              label: 'Validate Design',
-              icon: <CheckIcon data-cy="verify-button" />,
-              onClick: (e) => {
-                openValidateModal(e, rowData.patternFile, rowData.name, rowData.id);
-              },
-              disabled: !CAN(keys.VALIDATE_DESIGN.action, keys.VALIDATE_DESIGN.subject),
-            },
-            {
-              label: 'Dry Run',
-              icon: <DryRunIcon data-cy="verify-button" />,
-              onClick: (e) => {
-                openDryRunModal(e, rowData.patternFile, rowData.name, rowData.id);
-              },
-              disabled: !CAN(keys.VALIDATE_DESIGN.action, keys.VALIDATE_DESIGN.subject),
-            },
-            {
-              label: 'Undeploy',
-              icon: <UndeployIcon fill="#F91313" data-cy="undeploy-button" />,
-              onClick: (e) => {
-                openUndeployModal(e, rowData.patternFile, rowData.name, rowData.id);
-              },
-              disabled: !CAN(keys.UNDEPLOY_DESIGN.action, keys.UNDEPLOY_DESIGN.subject),
-            },
-            {
-              label: 'Deploy',
-              icon: <DoneAllIcon data-cy="deploy-button" />,
-              onClick: (e) => {
-                openDeployModal(e, rowData.patternFile, rowData.name, rowData.id);
-              },
-              disabled: !CAN(keys.DEPLOY_DESIGN.action, keys.DEPLOY_DESIGN.subject),
-            },
-            {
-              label: 'Download',
-              icon: <GetAppIcon data-cy="download-button" />,
-              onClick: (e) => {
-                handleDesignDownloadModal(e, rowData);
-              },
-              disabled: !CAN(keys.DOWNLOAD_A_DESIGN.action, keys.DOWNLOAD_A_DESIGN.subject),
-            },
-            {
-              label: 'Design Information',
-              icon: <InfoOutlinedIcon data-cy="information-button" />,
-              onClick: (e) => {
-                genericClickHandler(e, () => handleInfoModal(rowData));
-              },
-              disabled: !CAN(keys.DETAILS_OF_DESIGN.action, keys.DETAILS_OF_DESIGN.subject),
-            },
-
-            /* Publish action can be done through Info modal so we might not need separate publish action */
-            /*{
-              label="Publish",
-              icon: <PublicIcon fill="#F91313" data-cy="publish-button" />,
-              onClick: (e) => handlePublishModal(e, rowData)(),
-              disabled: !CAN(keys.PUBLISH_DESIGN.action, keys.PUBLISH_DESIGN.subject),
-              condition: canPublishPattern && visibility !== VISIBILITY.PUBLISHED,
-            },*/
-
-            {
-              label: 'Unpublish',
-              icon: <PublicIcon fill="#F91313" data-cy="unpublish-button" />,
-              onClick: (e) => {
-                handleUnpublishModal(e, rowData)();
-              },
-              disabled: !CAN(keys.UNPUBLISH_DESIGN.action, keys.UNPUBLISH_DESIGN.subject),
-              condition: visibility === VISIBILITY.PUBLISHED,
-            },
-          ].filter((action) => action.condition === undefined || action.condition);
-
-          return (
-            <Box sx={{ display: 'flex', justifyContent: 'center' }}>
-              <ActionPopover actions={actions} />
-            </Box>
-          );
-        },
-      },
-    },
-  ];
+  });
 
   columns.forEach((column, idx) => {
     if (column.name === sortOrder.split(' ')[0]) {
@@ -1167,7 +428,7 @@ function MesheryPatterns({
   const [tableCols, updateCols] = useState(columns);
 
   const [columnVisibility, setColumnVisibility] = useState(() => {
-    let showCols = updateVisibleColumns(colViews, width);
+    let showCols = updateVisibleColumns(PATTERN_COL_VIEWS, width);
     // Initialize column visibility based on the original columns' visibility
     const initialVisibility = {};
     columns.forEach((col) => {
@@ -1178,153 +439,25 @@ function MesheryPatterns({
     return initialVisibility;
   });
 
-  async function showModal(count, patterns) {
-    let response = await modalRef.current.show({
-      title: `Delete ${count ? count : ''} Design${count > 1 ? 's' : ''}?`,
-
-      subtitle: `Are you sure you want to delete the ${patterns} design${count > 1 ? 's' : ''}?`,
-      variant: PROMPT_VARIANTS.DANGER,
-      primaryOption: 'DELETE',
-    });
-    return response;
-  }
-
-  async function deletePatterns(patterns) {
-    const jsonPatterns = JSON.stringify(patterns);
-
-    updateProgress({ showProgress: true });
-    deletePattern({
-      deleteBody: jsonPatterns,
-    })
-      .unwrap()
-      .then(() => {
-        updateProgress({ showProgress: false });
-        setTimeout(() => {
-          notify({
-            message: `${patterns.patterns.length} Designs deleted`,
-            event_type: EVENT_TYPES.SUCCESS,
-          });
-          getPatterns();
-          resetSelectedRowData()();
-        }, 1200);
-      })
-      .catch(() => {
-        updateProgress({ showProgress: false });
-        handleError(ACTION_TYPES.DELETE_PATTERN);
-      });
-  }
-
-  const options = {
-    customToolbarSelect: (selectedRows, displayData, setSelectedRows) => (
-      <CustomToolbarSelect
-        selectedRows={selectedRows}
-        displayData={displayData}
-        setSelectedRows={setSelectedRows}
-        patterns={patterns}
-        deletePatterns={deletePatterns}
-        showModal={showModal}
-      />
-    ),
-    filter: false,
-    search: false,
-    viewColumns: false,
-    sort: !(user && user.userId === 'meshery'),
-    filterType: 'textField',
-    responsive: 'standard',
-    resizableColumns: true,
-    serverSide: true,
+  const options = buildPatternsTableOptions({
+    patterns,
+    columns,
     count,
-    rowsPerPage: pageSize,
-    fixedHeader: true,
+    pageSize,
     page,
-    print: false,
-    download: false,
-    sortOrder: {
-      name: sortOrder.split(' ')[0],
-      direction: sortOrder.split(' ')[1],
-    },
-    textLabels: {
-      selectedRows: {
-        text: 'pattern(s) selected',
-      },
-    },
-
-    onCellClick: (_, meta) =>
-      meta.colIndex !== 3 && meta.colIndex !== 4 && setSelectedRowData(patterns[meta.rowIndex]),
-
-    onRowsDelete: async function handleDelete(row) {
-      const toBeDeleted = Object.keys(row.lookup).map((idx) => ({
-        id: patterns[idx]?.id,
-        name: patterns[idx]?.name,
-      }));
-      let response = await showModal(
-        toBeDeleted.length,
-        toBeDeleted.map((p) => ' ' + p.name),
-      );
-      if (response && response.trim().toUpperCase() === 'DELETE') {
-        deletePatterns({ patterns: toBeDeleted });
-      }
-      // if (response.toLowerCase() === "no")
-      // fetchPatterns(page, pageSize, search, sortOrder);
-    },
-
-    onTableChange: (action, tableState) => {
-      const sortInfo = tableState.announceText ? tableState.announceText.split(' : ') : [];
-      let order = '';
-      if (tableState.activeColumn) {
-        order = `${columns[tableState.activeColumn].name} desc`;
-      }
-
-      switch (action) {
-        case 'changePage':
-          initPatternsSubscription(tableState.page.toString(), pageSize.toString(), search, order);
-          setPage(tableState.page);
-          break;
-        case 'changeRowsPerPage':
-          initPatternsSubscription(
-            page.toString(),
-            tableState.rowsPerPage.toString(),
-            search,
-            order,
-          );
-          setPageSize(tableState.rowsPerPage);
-          break;
-        case 'search':
-          if (searchTimeout.current) {
-            clearTimeout(searchTimeout.current);
-          }
-          searchTimeout.current = setTimeout(() => {
-            if (search !== tableState.searchText) {
-              setSearch(tableState.searchText);
-            }
-          }, 500);
-          break;
-        case 'sort':
-          if (sortInfo.length === 2) {
-            if (sortInfo[1] === 'ascending') {
-              order = `${columns[tableState.activeColumn].name} asc`;
-            } else {
-              order = `${columns[tableState.activeColumn].name} desc`;
-            }
-          }
-          if (order !== sortOrder) {
-            initPatternsSubscription(page.toString(), pageSize.toString(), search, order);
-            setSortOrder(order);
-          }
-          break;
-      }
-    },
-    setRowProps: (row, dataIndex, rowIndex) => {
-      return {
-        'data-cy': `config-row-${rowIndex}`,
-      };
-    },
-    setTableProps: () => {
-      return {
-        'data-cy': 'filters-grid',
-      };
-    },
-  };
+    search,
+    sortOrder,
+    user,
+    searchTimeout,
+    setPage,
+    setPageSize,
+    setSearch,
+    setSortOrder,
+    setSelectedRowData,
+    deletePatterns,
+    showModal,
+    initPatternsSubscription,
+  });
 
   if (ispatternsLoading) {
     return (
@@ -1332,59 +465,6 @@ function MesheryPatterns({
         <LoadingScreen animatedIcon="AnimatedMeshPattern" message={`Loading ${pageTitle}...`} />
       </>
     );
-  }
-
-  /**
-   * Gets the data of Import Filter and handles submit operation
-   *
-   * @param {{
-   * uploadType: ("File Upload"| "URL Import");
-   * name: string;
-   * url: string;
-   * file: string;
-   * }} data
-   */
-  function handleImportDesign(data) {
-    updateProgress({ showProgress: true });
-    const { uploadType, name, url, file } = data;
-
-    let requestBody = null;
-    switch (uploadType) {
-      case 'File Upload': {
-        const fileElement = document.getElementById('root_file');
-        const fileName = fileElement.files[0].name;
-        requestBody = JSON.stringify({
-          name,
-          file_name: fileName,
-          file: getUnit8ArrayDecodedFile(file),
-        });
-        break;
-      }
-      case 'URL Import':
-        requestBody = JSON.stringify({
-          url,
-          name,
-        });
-        break;
-    }
-
-    importPattern({
-      importBody: requestBody,
-    })
-      .unwrap()
-      .then(() => {
-        updateProgress({ showProgress: false });
-        notify({
-          message: `"${name}" design uploaded`,
-          event_type: EVENT_TYPES.SUCCESS,
-        });
-        setImportModal((prev) => ({ ...prev, open: false }));
-        getPatterns();
-      })
-      .catch(() => {
-        updateProgress({ showProgress: false });
-        handleError(ACTION_TYPES.UPLOAD_PATTERN);
-      });
   }
 
   const filter = {
@@ -1423,108 +503,32 @@ function MesheryPatterns({
                 isReadOnly={arePatternsReadOnly}
               />
             )}
-            <ToolWrapper>
-              {width < 600 && isSearchExpanded ? null : (
-                <CreateButton style={{ display: 'flex' }}>
-                  {!selectedPattern.show && (patterns.length >= 0 || viewType === 'table') && (
-                    <div>
-                      {disableCreateImportDesignButton ? null : (
-                        <div style={{ display: 'flex', order: '1' }}>
-                          <TooltipButton
-                            title="Create Design"
-                            data-testid="meshery-patterns-create-design-btn"
-                            aria-label="Add Pattern"
-                            variant="contained"
-                            color="primary"
-                            size="large"
-                            // @ts-ignore
-                            onClick={() => router.push('designs/configurator')}
-                            style={{ display: 'flex', marginRight: '2rem' }}
-                            disabled={
-                              !CAN(keys.CREATE_NEW_DESIGN.action, keys.CREATE_NEW_DESIGN.subject)
-                            }
-                          >
-                            <AddIconStyled />
-                            <BtnText> Create Design </BtnText>
-                          </TooltipButton>
-                          <TooltipButton
-                            title="Import Design"
-                            data-testid="meshery-patterns-import-design-btn"
-                            aria-label="Add Pattern"
-                            variant="contained"
-                            color="primary"
-                            size="large"
-                            // @ts-ignore
-                            onClick={handleUploadImport}
-                            style={{ display: 'flex', marginRight: '2rem', marginLeft: '-0.6rem' }}
-                            disabled={!CAN(keys.IMPORT_DESIGN.action, keys.IMPORT_DESIGN.subject)}
-                          >
-                            <AddIconStyled>
-                              <PublishIcon />
-                            </AddIconStyled>
-                            <BtnText> Import Design </BtnText>
-                          </TooltipButton>
-                        </div>
-                      )}
-                    </div>
-                  )}
-                  {!selectedPattern.show && (
-                    <div style={{ display: 'flex' }}>
-                      {/* <StyledCatalogFilter>
-                      <CatalogFilter
-                        catalogVisibility={catalogVisibility}
-                        handleCatalogVisibility={handleCatalogVisibility}
-                        classes={classes}
-                      />
-                      </StyledCatalogFilter>*/}
-                    </div>
-                  )}
-                </CreateButton>
-              )}
-              <SearchWrapper style={{ display: 'flex' }}>
-                <>
-                  <SearchBar
-                    onSearch={(value) => {
-                      setSearch(value);
-                      initPatternsSubscription(
-                        page.toString(),
-                        pageSize.toString(),
-                        value,
-                        sortOrder,
-                      );
-                    }}
-                    expanded={isSearchExpanded}
-                    setExpanded={setIsSearchExpanded}
-                    placeholder={`Search ${pageTitle.toLowerCase()}...`}
-                    data-testid="meshery-patterns-search-bar"
-                  />
-                  {disableUniversalFilter ? null : (
-                    <UniversalFilter
-                      id="ref"
-                      filters={filter}
-                      selectedFilters={selectedFilters}
-                      setSelectedFilters={setSelectedFilters}
-                      handleApplyFilter={handleApplyFilter}
-                      data-testid="meshery-patterns-universal-filter"
-                    />
-                  )}
-                  {viewType === 'table' && (
-                    <CustomColumnVisibilityControl
-                      data-testid="meshery-patterns-column-visibility-control"
-                      id="ref"
-                      columns={columns}
-                      customToolsProps={{ columnVisibility, setColumnVisibility }}
-                    />
-                  )}
-                </>
-
-                {!selectedPattern.show && (
-                  <ViewSwitchButton>
-                    <ViewSwitch view={viewType} changeView={setViewType} />
-                  </ViewSwitchButton>
-                )}
-              </SearchWrapper>
-            </ToolWrapper>
+            <MesheryPatternsToolbar
+              width={width}
+              isSearchExpanded={isSearchExpanded}
+              setIsSearchExpanded={setIsSearchExpanded}
+              selectedPattern={selectedPattern}
+              patterns={patterns}
+              viewType={viewType}
+              setViewType={setViewType}
+              disableCreateImportDesignButton={disableCreateImportDesignButton}
+              disableUniversalFilter={disableUniversalFilter}
+              pageTitle={pageTitle}
+              router={router}
+              handleUploadImport={handleUploadImport}
+              setSearch={setSearch}
+              initPatternsSubscription={initPatternsSubscription}
+              page={page}
+              pageSize={pageSize}
+              sortOrder={sortOrder}
+              filter={filter}
+              selectedFilters={selectedFilters}
+              setSelectedFilters={setSelectedFilters}
+              handleApplyFilter={handleApplyFilter}
+              columns={columns}
+              columnVisibility={columnVisibility}
+              setColumnVisibility={setColumnVisibility}
+            />
             {!selectedPattern.show && viewType === 'table' && (
               <>
                 {/* <StyledRow> */}
@@ -1617,65 +621,6 @@ function MesheryPatterns({
     </>
   );
 }
-
-export const ImportDesignModal = React.memo((props) => {
-  const { handleClose, handleImportDesign } = props;
-
-  return (
-    <>
-      <>
-        <SistentModal
-          open={true}
-          closeModal={handleClose}
-          headerIcon={
-            <Pattern fill="#fff" style={{ height: '24px', width: '24px', fonSize: '1.45rem' }} />
-          }
-          maxWidth="sm"
-          title="Import Design"
-          data-testid="import-design-modal"
-        >
-          <RJSFModalWrapper
-            schema={importDesignSchema}
-            uiSchema={importDesignUiSchema}
-            handleSubmit={handleImportDesign}
-            submitBtnText="Import"
-            handleClose={handleClose}
-          />
-        </SistentModal>
-      </>
-    </>
-  );
-});
-
-const PublishModal = React.memo((props) => {
-  const { handleClose, handleSubmit, title } = props;
-
-  return (
-    <>
-      <>
-        <SistentModal
-          open={true}
-          closeModal={handleClose}
-          aria-label="catalog publish"
-          title={title}
-          headerIcon={
-            <Pattern fill="#fff" style={{ height: '24px', width: '24px', fonSize: '1.45rem' }} />
-          }
-          maxWidth="sm"
-        >
-          <RJSFModalWrapper
-            schema={publishCatalogItemSchema}
-            uiSchema={publishCatalogItemUiSchema}
-            handleSubmit={handleSubmit}
-            submitBtnText="Submit for Approval"
-            handleClose={handleClose}
-            helpText="Upon submitting your catalog item, an approval flow will be initiated.[Learn more](https://docs.meshery.io/concepts/catalog)"
-          />
-        </SistentModal>
-      </>
-    </>
-  );
-});
 
 // @ts-ignore
 export default MesheryPatterns;

--- a/ui/components/designs/patterns/MesheryPatternsModals.tsx
+++ b/ui/components/designs/patterns/MesheryPatternsModals.tsx
@@ -1,0 +1,71 @@
+/* eslint-disable react/display-name */
+
+import React from 'react';
+import {
+  importDesignSchema,
+  importDesignUiSchema,
+  publishCatalogItemSchema,
+  publishCatalogItemUiSchema,
+  Modal as SistentModal,
+} from '@sistent/sistent';
+import { RJSFModalWrapper } from '../../shared/Modal/Modal';
+import Pattern from '../../../public/static/img/drawer-icons/pattern_svg';
+
+export const ImportDesignModal = React.memo((props) => {
+  const { handleClose, handleImportDesign } = props;
+
+  return (
+    <>
+      <>
+        <SistentModal
+          open={true}
+          closeModal={handleClose}
+          headerIcon={
+            <Pattern fill="#fff" style={{ height: '24px', width: '24px', fonSize: '1.45rem' }} />
+          }
+          maxWidth="sm"
+          title="Import Design"
+          data-testid="import-design-modal"
+        >
+          <RJSFModalWrapper
+            schema={importDesignSchema}
+            uiSchema={importDesignUiSchema}
+            handleSubmit={handleImportDesign}
+            submitBtnText="Import"
+            handleClose={handleClose}
+          />
+        </SistentModal>
+      </>
+    </>
+  );
+});
+
+export const PublishModal = React.memo((props) => {
+  const { handleClose, handleSubmit, title } = props;
+
+  return (
+    <>
+      <>
+        <SistentModal
+          open={true}
+          closeModal={handleClose}
+          aria-label="catalog publish"
+          title={title}
+          headerIcon={
+            <Pattern fill="#fff" style={{ height: '24px', width: '24px', fonSize: '1.45rem' }} />
+          }
+          maxWidth="sm"
+        >
+          <RJSFModalWrapper
+            schema={publishCatalogItemSchema}
+            uiSchema={publishCatalogItemUiSchema}
+            handleSubmit={handleSubmit}
+            submitBtnText="Submit for Approval"
+            handleClose={handleClose}
+            helpText="Upon submitting your catalog item, an approval flow will be initiated.[Learn more](https://docs.meshery.io/concepts/catalog)"
+          />
+        </SistentModal>
+      </>
+    </>
+  );
+});

--- a/ui/components/designs/patterns/MesheryPatternsToolbar.tsx
+++ b/ui/components/designs/patterns/MesheryPatternsToolbar.tsx
@@ -1,0 +1,148 @@
+import React from 'react';
+import { CustomColumnVisibilityControl, SearchBar, UniversalFilter } from '@sistent/sistent';
+import { Publish as PublishIcon } from '@/assets/icons';
+import ViewSwitch from '../../ViewSwitch';
+import CAN from '@/utils/can';
+import { keys } from '@/utils/permission_constants';
+import TooltipButton from '@/utils/TooltipButton';
+import { ToolWrapper } from '@/assets/styles/general/tool.styles';
+import {
+  ViewSwitchButton,
+  CreateButton,
+  AddIconStyled,
+  SearchWrapper,
+  BtnText,
+} from './MesheryPatterns.styled';
+
+/**
+ * Header toolbar for the Designs page.
+ *
+ * Extracted from MesheryPatterns.tsx mechanically — same DOM tree, same
+ * behavior. The parent supplies every callback / piece of state via props.
+ */
+function MesheryPatternsToolbar({
+  width,
+  isSearchExpanded,
+  setIsSearchExpanded,
+  selectedPattern,
+  patterns,
+  viewType,
+  setViewType,
+  disableCreateImportDesignButton,
+  disableUniversalFilter,
+  pageTitle,
+  router,
+  handleUploadImport,
+  setSearch,
+  initPatternsSubscription,
+  page,
+  pageSize,
+  sortOrder,
+  filter,
+  selectedFilters,
+  setSelectedFilters,
+  handleApplyFilter,
+  columns,
+  columnVisibility,
+  setColumnVisibility,
+}) {
+  return (
+    <ToolWrapper>
+      {width < 600 && isSearchExpanded ? null : (
+        <CreateButton style={{ display: 'flex' }}>
+          {!selectedPattern.show && (patterns.length >= 0 || viewType === 'table') && (
+            <div>
+              {disableCreateImportDesignButton ? null : (
+                <div style={{ display: 'flex', order: '1' }}>
+                  <TooltipButton
+                    title="Create Design"
+                    data-testid="meshery-patterns-create-design-btn"
+                    aria-label="Add Pattern"
+                    variant="contained"
+                    color="primary"
+                    size="large"
+                    // @ts-ignore
+                    onClick={() => router.push('designs/configurator')}
+                    style={{ display: 'flex', marginRight: '2rem' }}
+                    disabled={!CAN(keys.CREATE_NEW_DESIGN.action, keys.CREATE_NEW_DESIGN.subject)}
+                  >
+                    <AddIconStyled />
+                    <BtnText> Create Design </BtnText>
+                  </TooltipButton>
+                  <TooltipButton
+                    title="Import Design"
+                    data-testid="meshery-patterns-import-design-btn"
+                    aria-label="Add Pattern"
+                    variant="contained"
+                    color="primary"
+                    size="large"
+                    // @ts-ignore
+                    onClick={handleUploadImport}
+                    style={{ display: 'flex', marginRight: '2rem', marginLeft: '-0.6rem' }}
+                    disabled={!CAN(keys.IMPORT_DESIGN.action, keys.IMPORT_DESIGN.subject)}
+                  >
+                    <AddIconStyled>
+                      <PublishIcon />
+                    </AddIconStyled>
+                    <BtnText> Import Design </BtnText>
+                  </TooltipButton>
+                </div>
+              )}
+            </div>
+          )}
+          {!selectedPattern.show && (
+            <div style={{ display: 'flex' }}>
+              {/* <StyledCatalogFilter>
+              <CatalogFilter
+                catalogVisibility={catalogVisibility}
+                handleCatalogVisibility={handleCatalogVisibility}
+                classes={classes}
+              />
+              </StyledCatalogFilter>*/}
+            </div>
+          )}
+        </CreateButton>
+      )}
+      <SearchWrapper style={{ display: 'flex' }}>
+        <>
+          <SearchBar
+            onSearch={(value) => {
+              setSearch(value);
+              initPatternsSubscription(page.toString(), pageSize.toString(), value, sortOrder);
+            }}
+            expanded={isSearchExpanded}
+            setExpanded={setIsSearchExpanded}
+            placeholder={`Search ${pageTitle.toLowerCase()}...`}
+            data-testid="meshery-patterns-search-bar"
+          />
+          {disableUniversalFilter ? null : (
+            <UniversalFilter
+              id="ref"
+              filters={filter}
+              selectedFilters={selectedFilters}
+              setSelectedFilters={setSelectedFilters}
+              handleApplyFilter={handleApplyFilter}
+              data-testid="meshery-patterns-universal-filter"
+            />
+          )}
+          {viewType === 'table' && (
+            <CustomColumnVisibilityControl
+              data-testid="meshery-patterns-column-visibility-control"
+              id="ref"
+              columns={columns}
+              customToolsProps={{ columnVisibility, setColumnVisibility }}
+            />
+          )}
+        </>
+
+        {!selectedPattern.show && (
+          <ViewSwitchButton>
+            <ViewSwitch view={viewType} changeView={setViewType} />
+          </ViewSwitchButton>
+        )}
+      </SearchWrapper>
+    </ToolWrapper>
+  );
+}
+
+export default MesheryPatternsToolbar;

--- a/ui/components/designs/patterns/YAMLEditor.tsx
+++ b/ui/components/designs/patterns/YAMLEditor.tsx
@@ -1,0 +1,134 @@
+import React, { useState } from 'react';
+import {
+  CustomTooltip,
+  Dialog,
+  DialogActions,
+  DialogContent,
+  Divider,
+  IconButton,
+  styled,
+} from '@sistent/sistent';
+import {
+  Close as CloseIcon,
+  Delete as DeleteIcon,
+  Fullscreen as FullscreenIcon,
+  FullscreenExit as FullscreenExitIcon,
+  Save as SaveIcon,
+} from '@/assets/icons';
+import { UnControlled as CodeMirror } from '../../CodeMirror';
+import { FILE_OPS } from '../../../utils/Enum';
+import CAN from '@/utils/can';
+import { keys } from '@/utils/permission_constants';
+import { YamlDialogTitle, YamlDialogTitleText } from './MesheryPatterns.styled';
+
+function YAMLEditor({ pattern, onClose, onSubmit, isReadOnly = false }) {
+  const [yaml, setYaml] = useState(pattern.patternFile);
+  const [fullScreen, setFullScreen] = useState(false);
+
+  const toggleFullScreen = () => {
+    setFullScreen(!fullScreen);
+  };
+
+  const FullScreenCodeMirrorWrapper = styled('div')(() => ({
+    height: '100%',
+    '& .cm-editor': {
+      minHeight: '300px',
+      height: fullScreen ? '80vh' : '30vh',
+    },
+  }));
+
+  return (
+    <Dialog
+      onClose={onClose}
+      aria-labelledby="pattern-dialog-title"
+      open
+      maxWidth="md"
+      fullScreen={fullScreen}
+      fullWidth={!fullScreen}
+    >
+      <YamlDialogTitle
+        style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'end' }}
+        disableTypography
+        id="pattern-dialog-title"
+      >
+        <div>
+          <YamlDialogTitleText variant="h6">{pattern.name}</YamlDialogTitleText>
+        </div>
+        <div>
+          <CustomTooltip
+            placement="top"
+            title={fullScreen ? 'Exit Fullscreen' : 'Enter Fullscreen'}
+            onClick={toggleFullScreen}
+          >
+            {fullScreen ? <FullscreenExitIcon /> : <FullscreenIcon />}
+          </CustomTooltip>
+          <CustomTooltip placement="top" title="Exit" onClick={onClose}>
+            <CloseIcon />
+          </CustomTooltip>
+        </div>
+      </YamlDialogTitle>
+      <Divider variant="fullWidth" light />
+      <DialogContent>
+        <FullScreenCodeMirrorWrapper>
+          <CodeMirror
+            value={pattern.patternFile}
+            options={{
+              theme: 'material',
+              lineNumbers: true,
+              lineWrapping: true,
+              gutters: ['CodeMirror-lint-markers'],
+              // @ts-ignore
+              lint: true,
+              mode: 'text/x-yaml',
+              readOnly: isReadOnly,
+            }}
+            onChange={(_, data, val) => setYaml(val)}
+          />
+        </FullScreenCodeMirrorWrapper>
+      </DialogContent>
+      <Divider variant="fullWidth" light />
+      <DialogActions>
+        {isReadOnly ? null : (
+          <>
+            <CustomTooltip title="Update Design">
+              <IconButton
+                aria-label="Update"
+                disabled={!CAN(keys.EDIT_DESIGN.action, keys.EDIT_DESIGN.subject)}
+                onClick={() =>
+                  onSubmit({
+                    data: yaml,
+                    id: pattern.id,
+                    name: pattern.name,
+                    type: FILE_OPS.UPDATE,
+                    catalogData: pattern.catalogData,
+                  })
+                }
+              >
+                <SaveIcon />
+              </IconButton>
+            </CustomTooltip>
+            <CustomTooltip title="Delete Pattern">
+              <IconButton
+                aria-label="Delete"
+                disabled={!CAN(keys.DELETE_A_DESIGN.action, keys.DELETE_A_DESIGN.subject)}
+                onClick={() =>
+                  onSubmit({
+                    data: yaml,
+                    id: pattern.id,
+                    name: pattern.name,
+                    type: FILE_OPS.DELETE,
+                    catalogData: pattern.catalogData,
+                  })
+                }
+              >
+                <DeleteIcon />
+              </IconButton>
+            </CustomTooltip>
+          </>
+        )}
+      </DialogActions>
+    </Dialog>
+  );
+}
+
+export default YAMLEditor;

--- a/ui/components/designs/patterns/design-lifecycle-handlers.tsx
+++ b/ui/components/designs/patterns/design-lifecycle-handlers.tsx
@@ -1,0 +1,109 @@
+import React from 'react';
+import { ModalBody } from '@sistent/sistent';
+import { DoneAll as DoneAllIcon } from '@/assets/icons';
+import UndeployIcon from '../../../public/static/img/UndeployIcon';
+import DryRunIcon from '@/assets/icons/DryRunIcon';
+import CheckIcon from '@/assets/icons/CheckIcon';
+import { UnDeployStepper, DeployStepper } from '../lifecycle/DeployStepper';
+import { DryRunDesign } from '../lifecycle/DryRun';
+import { ValidateDesign } from '../lifecycle/ValidateDesign';
+import { DEPLOYMENT_TYPE } from '../lifecycle/common';
+import { parseDesignFile } from '../../../utils/utils';
+
+/**
+ * Builds the four design-lifecycle modal openers (deploy / undeploy /
+ * dryrun / validate).
+ *
+ * Each returned function preserves the exact behavior of the original
+ * inline definitions in MesheryPatterns.tsx — same modal title strings,
+ * same icons, same stepper / modal-body wrapping, same arg shapes.
+ */
+export function buildDesignLifecycleHandlers({
+  designLifecycleModal,
+  designValidationActorRef,
+  selectedK8sContexts,
+  handleDeploy,
+  handleUndeploy,
+}) {
+  const openDeployModal = (e, pattern_file, name) => {
+    const design = parseDesignFile(pattern_file);
+    e.stopPropagation();
+    designLifecycleModal.openModal({
+      title: `Deploy design "${name}"`,
+      headerIcon: <DoneAllIcon fill="#fff" height={'2rem'} width={'2rem'} />,
+      reactNode: (
+        <DeployStepper
+          handleClose={designLifecycleModal.closeModal}
+          validationMachine={designValidationActorRef}
+          design={design}
+          handleDeploy={handleDeploy}
+          deployment_type={DEPLOYMENT_TYPE.DEPLOY}
+          selectedK8sContexts={selectedK8sContexts}
+        />
+      ),
+    });
+  };
+
+  const openUndeployModal = (e, pattern_file, name) => {
+    e.stopPropagation();
+    const design = parseDesignFile(pattern_file);
+    designLifecycleModal.openModal({
+      title: `Undeploy design "${name}"`,
+      headerIcon: <UndeployIcon fill="#fff" height={'2rem'} width={'2rem'} />,
+      reactNode: (
+        <UnDeployStepper
+          handleClose={designLifecycleModal.closeModal}
+          validationMachine={designValidationActorRef}
+          design={design}
+          handleUndeploy={handleUndeploy}
+          deployment_type={DEPLOYMENT_TYPE.UNDEPLOY}
+          selectedK8sContexts={selectedK8sContexts}
+        />
+      ),
+    });
+  };
+
+  const openDryRunModal = (e, pattern_file, name) => {
+    e.stopPropagation();
+
+    const design = parseDesignFile(pattern_file);
+    designLifecycleModal.openModal({
+      title: `Dryrun design "${name}"`,
+      headerIcon: <DryRunIcon fill="#fff" height={'2rem'} width={'2rem'} />,
+      reactNode: (
+        <ModalBody style={{ minWidth: '30rem', width: 'auto' }}>
+          <DryRunDesign
+            handleClose={designLifecycleModal.closeModal}
+            validationMachine={designValidationActorRef}
+            design={design}
+            deployment_type={DEPLOYMENT_TYPE.DEPLOY}
+            selectedK8sContexts={selectedK8sContexts}
+          />
+        </ModalBody>
+      ),
+    });
+  };
+
+  const openValidateModal = (e, pattern_file, name) => {
+    e.stopPropagation();
+
+    const design = parseDesignFile(pattern_file);
+    designLifecycleModal.openModal({
+      title: `Validate design "${name}"`,
+      headerIcon: <CheckIcon fill="#fff" height={'2rem'} width={'2rem'} />,
+      reactNode: (
+        <ModalBody style={{ minWidth: '30rem', width: 'auto' }}>
+          <ValidateDesign
+            handleClose={designLifecycleModal.closeModal}
+            validationMachine={designValidationActorRef}
+            design={design}
+            deployment_type={DEPLOYMENT_TYPE.DEPLOY}
+            selectedK8sContexts={selectedK8sContexts}
+          />
+        </ModalBody>
+      ),
+    });
+  };
+
+  return { openDeployModal, openUndeployModal, openDryRunModal, openValidateModal };
+}

--- a/ui/components/designs/patterns/patterns-actions.ts
+++ b/ui/components/designs/patterns/patterns-actions.ts
@@ -1,0 +1,409 @@
+import _ from 'lodash';
+import yaml from 'js-yaml';
+import { PROMPT_VARIANTS } from '@sistent/sistent';
+import { encodeDesignFile, getUnit8ArrayDecodedFile } from '../../../utils/utils';
+import { FILE_OPS } from '../../../utils/Enum';
+import { EVENT_TYPES } from '../../../lib/event-types';
+import downloadContent from '../../../utils/fileDownloader';
+import { updateProgress } from '@/store/slices/mesheryUi';
+import { ACTION_TYPES } from './MesheryPatterns.constants';
+
+/**
+ * Factory that returns the full set of CRUD / publish / clone / download
+ * handlers used by the Designs page. Behavior is identical to the
+ * original inline definitions in MesheryPatterns.tsx — the same RTK
+ * mutations are called with the same payloads, the same notifications
+ * are emitted, and the same modal/notification side-effects fire.
+ */
+export function createPatternsActions(deps) {
+  const {
+    // RTK mutations
+    clonePattern,
+    publishCatalog,
+    unpublishCatalog,
+    deletePattern,
+    deletePatternFile,
+    importPattern,
+    updatePattern,
+    uploadPatternFile,
+    deployPatternMutation,
+    undeployPatternMutation,
+    // refs / state
+    modalRef,
+    meshModels,
+    infoModal,
+    publishModal,
+    user,
+    // setters
+    setImportModal,
+    setPublishModal,
+    setSelectedRowData,
+    setInfoModal,
+    // helpers
+    notify,
+    sistentInfoModal,
+    getPatterns,
+  } = deps;
+
+  const handleError = (action) => (error) => {
+    updateProgress({ showProgress: false });
+
+    notify({
+      message: `${action.error_msg}: ${error}`,
+      event_type: EVENT_TYPES.ERROR,
+    });
+  };
+
+  function resetSelectedRowData() {
+    return () => {
+      setSelectedRowData(null);
+    };
+  }
+
+  const handleDeploy = async ({ design, selectedK8sContexts }) => {
+    updateProgress({ showProgress: true });
+    await deployPatternMutation({
+      patternFile: encodeDesignFile(design),
+      patternId: design.id,
+      selectedK8sContexts,
+    });
+    updateProgress({ showProgress: false });
+  };
+
+  const handleUndeploy = async ({ design, selectedK8sContexts }) => {
+    updateProgress({ showProgress: true });
+    await undeployPatternMutation({
+      patternFile: encodeDesignFile(design),
+      patternId: design.id,
+      selectedK8sContexts,
+    });
+    updateProgress({ showProgress: false });
+  };
+
+  const handleUploadImport = () => {
+    setImportModal({
+      open: true,
+    });
+  };
+
+  const handleUploadImportClose = () => {
+    setImportModal({
+      open: false,
+    });
+  };
+
+  const handleInfoModalClose = () => {
+    sistentInfoModal.closeModal();
+    setInfoModal({
+      open: false,
+    });
+  };
+
+  const handleInfoModal = (pattern) => {
+    sistentInfoModal.openModal({
+      title: pattern.name,
+    });
+
+    setInfoModal({
+      open: true,
+      ownerID: pattern.userId,
+      selectedResource: pattern,
+    });
+  };
+
+  const handleUnpublishModal = (ev, pattern) => {
+    return async () => {
+      let response = await modalRef.current.show({
+        title: `Unpublish Catalog item?`,
+        subtitle: `Are you sure you want to unpublish ${pattern?.name}?`,
+        variant: PROMPT_VARIANTS.DANGER,
+        primaryOption: 'UNPUBLISH',
+        showInfoIcon:
+          "Unpublishing a catolog item removes the item from the public-facing catalog (a public website accessible to anonymous visitors at meshery.io/catalog). The catalog item's visibility will change to either public (or private with a subscription). The ability to for other users to continue to access, edit, clone and collaborate on your content depends upon the assigned visibility level (public or private). Prior collaborators (users with whom you have shared your catalog item) will retain access. However, you can always republish it whenever you want. Remember: unpublished catalog items can still be available to other users if that item is set to public visibility. For detailed information, please refer to the [documentation](https://docs.meshery.io/concepts/designs).",
+      });
+      if (response === 'UNPUBLISH') {
+        updateProgress({ showProgress: true });
+        unpublishCatalog({
+          unpublishBody: JSON.stringify({ id: pattern?.id }),
+        })
+          .unwrap()
+          .then(() => {
+            updateProgress({ showProgress: false });
+            notify({
+              message: `Design Unpublished`,
+              event_type: EVENT_TYPES.SUCCESS,
+            });
+          })
+          .catch(() => {
+            updateProgress({ showProgress: false });
+            handleError(ACTION_TYPES.UNPUBLISH_CATALOG);
+          });
+      }
+    };
+  };
+
+  const handlePublishModalClose = () => {
+    setPublishModal({
+      open: false,
+      pattern: {},
+      name: '',
+    });
+  };
+
+  const handlePublish = (formData) => {
+    const compatibilityStore = _.uniqBy(meshModels, (model) => _.toLower(model.displayName))
+      ?.filter((model) =>
+        formData?.compatibility?.some((comp) => _.toLower(comp) === _.toLower(model.displayName)),
+      )
+      ?.map((model) => model.name);
+
+    const payload = {
+      id: infoModal.selectedResource?.id,
+      catalogData: {
+        ...formData,
+        compatibility: compatibilityStore,
+        type: _.toLower(formData?.type),
+      },
+    };
+    updateProgress({ showProgress: true });
+    publishCatalog({
+      publishBody: JSON.stringify(payload),
+    })
+      .unwrap()
+      .then(() => {
+        updateProgress({ showProgress: false });
+        if (user.roleNames.includes('admin')) {
+          notify({
+            message: `${publishModal?.name} Design Published`,
+            event_type: EVENT_TYPES.SUCCESS,
+          });
+        } else {
+          notify({
+            message:
+              'Design queued for publishing into Meshery Catalog. Maintainers notified for review',
+            event_type: EVENT_TYPES.SUCCESS,
+          });
+        }
+      })
+      .catch(() => {
+        updateProgress({ showProgress: false });
+        handleError(ACTION_TYPES.PUBLISH_CATALOG);
+      });
+  };
+
+  function handleClone(patternID, name) {
+    updateProgress({ showProgress: true });
+    clonePattern({
+      body: JSON.stringify({ name: name + ' (Copy)' }),
+      patternID: patternID,
+    })
+      .unwrap()
+      .then(() => {
+        updateProgress({ showProgress: false });
+        notify({
+          message: `"${name}" Design cloned`,
+          event_type: EVENT_TYPES.SUCCESS,
+        });
+      })
+      .catch(() => {
+        updateProgress({ showProgress: false });
+        notify({
+          message: `Failed to clone "${name}" Design`,
+          event_type: EVENT_TYPES.ERROR,
+        });
+      });
+  }
+
+  async function showModal(count, patterns) {
+    let response = await modalRef.current.show({
+      title: `Delete ${count ? count : ''} Design${count > 1 ? 's' : ''}?`,
+
+      subtitle: `Are you sure you want to delete the ${patterns} design${count > 1 ? 's' : ''}?`,
+      variant: PROMPT_VARIANTS.DANGER,
+      primaryOption: 'DELETE',
+    });
+    return response;
+  }
+
+  async function handleSubmit({ data, id, name, type, metadata, catalogData }) {
+    updateProgress({ showProgress: true });
+    if (type === FILE_OPS.DELETE) {
+      const response = await showModal(1, name);
+      if (response == 'CANCEL') {
+        updateProgress({ showProgress: false });
+        return;
+      }
+      deletePatternFile({
+        id: id,
+      })
+        .unwrap()
+        .then(() => {
+          updateProgress({ showProgress: false });
+          notify({ message: `"${name}" Design deleted`, event_type: EVENT_TYPES.SUCCESS });
+          getPatterns();
+          resetSelectedRowData()();
+        })
+        .catch(() => {
+          updateProgress({ showProgress: false });
+          handleError(ACTION_TYPES.DELETE_PATTERN);
+        });
+    }
+
+    if (type === FILE_OPS.UPDATE) {
+      const design = yaml.load(data);
+
+      updatePattern({
+        updateBody: JSON.stringify({
+          id,
+          name: data.name,
+          designFile: design,
+          catalogData,
+        }),
+      })
+        .unwrap()
+        .then(() => {
+          updateProgress({ showProgress: false });
+          notify({ message: `"${name}" Design updated`, event_type: EVENT_TYPES.SUCCESS });
+        })
+        .catch(() => {
+          updateProgress({ showProgress: false });
+          handleError(ACTION_TYPES.UPDATE_PATTERN);
+        });
+    }
+
+    if (type === FILE_OPS.FILE_UPLOAD || type === FILE_OPS.URL_UPLOAD) {
+      let body;
+      if (type === FILE_OPS.FILE_UPLOAD) {
+        body = JSON.stringify({
+          patternData: {
+            name: metadata?.name || name,
+            patternFile: getUnit8ArrayDecodedFile(data),
+            catalogData,
+          },
+          save: true,
+        });
+      }
+      if (type === FILE_OPS.URL_UPLOAD) {
+        body = JSON.stringify({
+          url: data,
+          save: true,
+          name: metadata?.name || name,
+          catalogData,
+        });
+      }
+      uploadPatternFile({
+        uploadBody: body,
+      })
+        .unwrap()
+        .then(() => {
+          updateProgress({ showProgress: false });
+        })
+        .catch(() => {
+          updateProgress({ showProgress: false });
+          handleError(ACTION_TYPES.UPLOAD_PATTERN);
+        });
+    }
+  }
+
+  function handleImportDesign(data) {
+    updateProgress({ showProgress: true });
+    const { uploadType, name, url, file } = data;
+
+    let requestBody = null;
+    switch (uploadType) {
+      case 'File Upload': {
+        const fileElement = document.getElementById('root_file');
+        const fileName = fileElement.files[0].name;
+        requestBody = JSON.stringify({
+          name,
+          file_name: fileName,
+          file: getUnit8ArrayDecodedFile(file),
+        });
+        break;
+      }
+      case 'URL Import':
+        requestBody = JSON.stringify({
+          url,
+          name,
+        });
+        break;
+    }
+
+    importPattern({
+      importBody: requestBody,
+    })
+      .unwrap()
+      .then(() => {
+        updateProgress({ showProgress: false });
+        notify({
+          message: `"${name}" design uploaded`,
+          event_type: EVENT_TYPES.SUCCESS,
+        });
+        setImportModal((prev) => ({ ...prev, open: false }));
+        getPatterns();
+      })
+      .catch(() => {
+        updateProgress({ showProgress: false });
+        handleError(ACTION_TYPES.UPLOAD_PATTERN);
+      });
+  }
+
+  function deletePatterns(patterns) {
+    const jsonPatterns = JSON.stringify(patterns);
+
+    updateProgress({ showProgress: true });
+    deletePattern({
+      deleteBody: jsonPatterns,
+    })
+      .unwrap()
+      .then(() => {
+        updateProgress({ showProgress: false });
+        setTimeout(() => {
+          notify({
+            message: `${patterns.patterns.length} Designs deleted`,
+            event_type: EVENT_TYPES.SUCCESS,
+          });
+          getPatterns();
+          resetSelectedRowData()();
+        }, 1200);
+      })
+      .catch(() => {
+        updateProgress({ showProgress: false });
+        handleError(ACTION_TYPES.DELETE_PATTERN);
+      });
+  }
+
+  const handleDownload = (e, design, source_type, params) => {
+    e.stopPropagation();
+    updateProgress({ showProgress: true });
+    try {
+      let id = design.id;
+      let name = design.name;
+      downloadContent({ id, name, type: 'pattern', source_type, params });
+      updateProgress({ showProgress: false });
+      notify({ message: `"${name}" design downloaded`, event_type: EVENT_TYPES.INFO });
+    } catch (e) {
+      console.error(e);
+    }
+  };
+
+  return {
+    handleError,
+    resetSelectedRowData,
+    handleDeploy,
+    handleUndeploy,
+    handleUploadImport,
+    handleUploadImportClose,
+    handleInfoModalClose,
+    handleInfoModal,
+    handleUnpublishModal,
+    handlePublishModalClose,
+    handlePublish,
+    handleClone,
+    handleSubmit,
+    handleImportDesign,
+    deletePatterns,
+    handleDownload,
+    showModal,
+  };
+}

--- a/ui/eslint.config.js
+++ b/ui/eslint.config.js
@@ -87,7 +87,10 @@ const legacyLiteralColorOffenders = [
   'components/meshery-mesh-interface/PatternServiceForm.tsx',
   'components/designs/patterns/MesheryPatternCard.tsx',
   'components/designs/patterns/MesheryPatternGridView.tsx',
+  'components/designs/patterns/MesheryPatterns.columns.tsx',
   'components/designs/patterns/MesheryPatterns.tsx',
+  'components/designs/patterns/MesheryPatternsModals.tsx',
+  'components/designs/patterns/design-lifecycle-handlers.tsx',
   'components/designs/patterns/style.tsx',
   'components/layout/Navigator/NavigatorExtension.tsx',
   'components/layout/NotificationCenter/constants.tsx',
@@ -128,7 +131,6 @@ const legacyLiteralColorOffenders = [
 ];
 
 const legacyMaxLineOffenders = [
-  'components/designs/patterns/MesheryPatterns.tsx',
   'components/performance/index.tsx',
   'components/connections/ConnectionTable.tsx',
   'components/filters/Filters.tsx',
@@ -233,6 +235,7 @@ const legacyInlineStyleOffenders = [
   'components/designs/patterns/MesheryPatternCard.tsx',
   'components/designs/patterns/MesheryPatternGridView.tsx',
   'components/designs/patterns/MesheryPatterns.tsx',
+  'components/designs/patterns/MesheryPatternsToolbar.tsx',
   'components/MesheryPlayComponent.tsx',
   'components/MesheryProgressBar.tsx',
   'components/MesherySettingsEnvButtons.tsx',


### PR DESCRIPTION
## Summary

Mechanically splits the 1,679-line `ui/components/designs/patterns/MesheryPatterns.tsx` — the largest remaining giant in `ui/` — into a set of focused sibling files. The entry-point file drops below the 600-line warn threshold and is removed from `legacyMaxLineOffenders` in `ui/eslint.config.js`.

Behavior, the default export, the prop signature, the Redux/RTK state shape, and the rendered DOM are unchanged. Each extracted file is a verbatim lift of the original code wired back through a factory function or a prop-driven sub-component — no hex literals or MUI imports were migrated (those stay allowlisted for a later Phase-2 pass).

### New files (all in `ui/components/designs/patterns/`)

- `MesheryPatterns.styled.tsx`        — `styled()` definitions
- `MesheryPatterns.constants.tsx`     — `ACTION_TYPES` + small helpers
- `MesheryPatterns.columns.tsx`       — table columns + options builders
- `MesheryPatternsToolbar.tsx`        — header toolbar JSX
- `MesheryPatternsModals.tsx`         — `ImportDesignModal` + `PublishModal`
- `YAMLEditor.tsx`                    — in-place YAML edit dialog
- `design-lifecycle-handlers.tsx`     — deploy/undeploy/dryrun/validate modal openers
- `patterns-actions.ts`               — CRUD / publish / clone / download handler factory

### eslint.config.js

- `MesheryPatterns.tsx` removed from `legacyMaxLineOffenders`
- new sibling files added to `legacyLiteralColorOffenders` and `legacyInlineStyleOffenders` where applicable

### Audit output

```
AUDIT size over_warn=11 over_hard=3
```
(was `over_warn=12 over_hard=4`)

Refs #18660
Refs #18654

## Test plan

- [x] `npx tsc --noEmit` is clean
- [x] `npx eslint .` reports 0 errors (warnings unchanged at legacy baseline)
- [x] `node scripts/audit-size.js` shows `over_hard=3` (down from 4) and `MesheryPatterns.tsx` no longer appears
- [x] Default export `MesheryPatterns` and named export `ImportDesignModal` preserved (consumers in `pages/configuration/designs/index.tsx`, `pages/configuration/catalog.tsx`, and `components/workspaces/SpacesSwitcher/components.tsx` need no changes)
- [ ] Smoke-test the Designs page: list loads, create/import buttons enabled, search/filter/column-visibility/view-switch work, YAML editor opens on row click, deploy/undeploy/dryrun/validate modals open from the row action menu, info modal opens, publish/unpublish flows fire