### PR TITLE
fix(ui): correct useKubernetesHook import path in ConnectionTable

### DIFF
--- a/ui/components/connections/ConnectionTable.tsx
+++ b/ui/components/connections/ConnectionTable.tsx
@@ -7,7 +7,7 @@ import _PromptComponent from '../PromptComponent';
 import resetDatabase from '../graphql/queries/ResetDatabaseQuery';
 
 import { CONNECTION_KINDS, CONNECTION_STATES } from '../../utils/Enum';
-import useKubernetesHook from '../hooks/useKubernetesHook';
+import useKubernetesHook from '@/utils/hooks/useKubernetesHook';
 import { getResponsiveColumnVisibility } from '../../utils/responsive-column';
 import { useWindowDimensions } from '../../utils/dimension';
 import { useGetEnvironmentsQuery } from '../../rtk-query/environments';


### PR DESCRIPTION
## Summary

The ConnectionTable split landed in #19356 left a stale relative import in `ConnectionTable.tsx:10`:

```ts
import useKubernetesHook from '../hooks/useKubernetesHook';
```

That path does not resolve — the hook lives at `ui/utils/hooks/useKubernetesHook.tsx`. The Docker build was failing with `Module not found`, which in turn blocked every Phase 5.b modal migration PR (#19369–#19373) because Docker build is one of the required signals.

Switch to the project-aliased path `@/utils/hooks/useKubernetesHook` matching the import already used in `components/connections/metadata.tsx`.

## Test plan

- [x] `npx tsc --noEmit` clean
- [x] `npx eslint .` 0 errors (warnings unchanged)
- [x] `ui/components/connections/metadata.tsx` already uses the same path, so the import resolution is known to work