### PR TITLE
[UI] Fix k8s context switcher count

### DIFF
--- a/ui/components/AppComponents.test.tsx
+++ b/ui/components/AppComponents.test.tsx
@@ -1,0 +1,153 @@
+import React from 'react';
+import { act, render } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { KubernetesSubscription } from './AppComponents';
+
+const dispatchMock = vi.fn();
+const setAppStateMock = vi.fn();
+const disposeMock = vi.fn();
+const subscribeK8sContextMock = vi.fn();
+let subscriptionCallback: ((result: Record<string, unknown>) => void) | undefined;
+
+vi.mock('react-redux', () => ({
+  useDispatch: () => dispatchMock,
+  useSelector: (selector: (state: Record<string, unknown>) => unknown) =>
+    selector({ ui: { extensionType: '' } }),
+}));
+
+vi.mock('@/graphql/subscriptions/K8sContextSubscription', () => ({
+  default: (
+    callback: (result: Record<string, unknown>) => void,
+    variables: Record<string, unknown>,
+  ) => {
+    subscriptionCallback = callback;
+    return subscribeK8sContextMock(callback, variables);
+  },
+}));
+
+vi.mock('@/utils/can', () => ({
+  default: () => true,
+}));
+
+vi.mock('@/utils/permission_constants', () => ({
+  keys: {
+    VIEW_ALL_KUBERNETES_CLUSTERS: { action: 'view', subject: 'k8s' },
+  },
+}));
+
+vi.mock('@/store/slices/mesheryUi', () => ({
+  updateK8SConfig: (payload: Record<string, unknown>) => ({
+    type: 'core/updateK8SConfig',
+    payload,
+  }),
+}));
+
+vi.mock('@sistent/sistent', () => ({
+  FavoriteIcon: () => null,
+  Hidden: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+  Typography: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+  useTheme: () => ({
+    palette: {
+      mode: 'light',
+      text: { default: '#000', disabled: '#666' },
+      background: { brand: { default: '#00b39f' } },
+    },
+  }),
+}));
+
+vi.mock('./layout/Navigator/Navigator', () => ({
+  default: () => null,
+}));
+
+vi.mock('../themes/App.styles', () => ({
+  StyledDrawer: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  StyledFooterBody: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  StyledFooterText: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+}));
+
+describe('KubernetesSubscription', () => {
+  beforeEach(() => {
+    dispatchMock.mockReset();
+    setAppStateMock.mockReset();
+    disposeMock.mockReset();
+    subscribeK8sContextMock.mockReset();
+    subscriptionCallback = undefined;
+
+    subscribeK8sContextMock.mockReturnValue({ dispose: disposeMock });
+  });
+
+  it('normalizes subscription payloads before storing contexts and connection config', () => {
+    const { unmount } = render(<KubernetesSubscription setAppState={setAppStateMock} />);
+
+    expect(subscribeK8sContextMock).toHaveBeenCalledWith(
+      expect.any(Function),
+      expect.objectContaining({
+        selector: { page: '', pageSize: '10', order: '', search: '' },
+      }),
+    );
+    expect(setAppStateMock).toHaveBeenCalledWith({
+      disposeK8sContextSubscription: expect.any(Function),
+    });
+
+    act(() => {
+      subscriptionCallback?.({
+        k8sContext: {
+          total_count: 2,
+          contexts: [
+            {
+              id: 'ctx-1',
+              name: 'prod-us',
+              connection_id: 'conn-1',
+              created_by: 'meshery',
+            },
+            {
+              id: 'ctx-2',
+              name: 'prod-eu',
+              connection_id: 'conn-2',
+              created_by: 'meshery',
+            },
+          ],
+        },
+      });
+    });
+
+    expect(setAppStateMock).toHaveBeenCalledWith({
+      k8sContexts: expect.objectContaining({
+        totalCount: 2,
+        contexts: [
+          expect.objectContaining({
+            id: 'ctx-1',
+            connectionId: 'conn-1',
+            createdBy: 'meshery',
+          }),
+          expect.objectContaining({
+            id: 'ctx-2',
+            connectionId: 'conn-2',
+            createdBy: 'meshery',
+          }),
+        ],
+      }),
+      activeK8sContexts: ['ctx-1', 'ctx-2', 'all'],
+    });
+    expect(dispatchMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        type: 'core/updateK8SConfig',
+        payload: {
+          k8sConfig: [
+            expect.objectContaining({
+              id: 'ctx-1',
+              connectionId: 'conn-1',
+            }),
+            expect.objectContaining({
+              id: 'ctx-2',
+              connectionId: 'conn-2',
+            }),
+          ],
+        },
+      }),
+    );
+
+    unmount();
+    expect(disposeMock).toHaveBeenCalledTimes(1);
+  });
+});

--- a/ui/components/AppComponents.tsx
+++ b/ui/components/AppComponents.tsx
@@ -5,6 +5,7 @@ import subscribeK8sContext from '@/graphql/subscriptions/K8sContextSubscription'
 import CAN from '@/utils/can';
 import { keys } from '@/utils/permission_constants';
 import { useDispatch, useSelector } from 'react-redux';
+import { normalizeKubernetesContextsResponse } from '@/rtk-query/transforms';
 import { updateK8SConfig } from '@/store/slices/mesheryUi';
 import { StyledDrawer, StyledFooterBody, StyledFooterText } from '../themes/App.styles';
 
@@ -70,18 +71,19 @@ export const KubernetesSubscription = ({ setAppState }: { setAppState: SetAppSta
 
     const subscription = subscribeK8sContext(
       (result) => {
+        const normalizedK8sContext = normalizeKubernetesContextsResponse(result?.k8sContext);
         const allContexts: string[] = [];
-        if (result.k8sContext?.contexts?.length > 0) {
-          result.k8sContext.contexts.forEach((ctx: { id: string }) => allContexts.push(ctx.id));
+        if (normalizedK8sContext?.contexts?.length > 0) {
+          normalizedK8sContext.contexts.forEach((ctx: { id: string }) => allContexts.push(ctx.id));
           allContexts.push('all');
         }
 
         setAppState({
-          k8sContexts: result.k8sContext,
+          k8sContexts: normalizedK8sContext,
           activeK8sContexts: allContexts,
         });
 
-        dispatch(updateK8SConfig({ k8sConfig: result.k8sContext.contexts }));
+        dispatch(updateK8SConfig({ k8sConfig: normalizedK8sContext?.contexts ?? [] }));
       },
       {
         selector: { page: '', pageSize: '10', order: '', search: '' },


### PR DESCRIPTION
## Summary
- normalize subscribed Kubernetes context data before storing it in UI state
- fix the header k8s switcher badge so it reads the actual connection count
- add a regression test for the subscription path

## Tests
- cd ui && npm run lint -- components/AppComponents.tsx components/AppComponents.test.tsx
- cd ui && npm test -- components/AppComponents.test.tsx components/layout/Header/Header.test.tsx rtk-query/__tests__/transforms.test.ts