### PR TITLE
[UI] Improve notification fetch error copy

### DIFF
--- a/ui/store/middleware/__tests__/rtkErrorMiddleware.test.ts
+++ b/ui/store/middleware/__tests__/rtkErrorMiddleware.test.ts
@@ -2,19 +2,23 @@ import { describe, expect, it, vi, beforeEach, afterEach } from 'vitest';
 import { rtkErrorMiddleware } from '../rtkErrorMiddleware';
 import { pushEvent } from '../../slices/events';
 
-const makeRejectedAction = (overrides: any = {}) => ({
-  type: 'someApi/executeQuery/rejected',
-  meta: {
-    arg: { endpointName: 'getThing' },
-    requestId: 'req-1',
-    requestStatus: 'rejected',
-    rejectedWithValue: true,
-    ...overrides.meta,
-  },
-  payload: overrides.payload ?? { status: 500, data: { message: 'Server exploded' } },
-  error: { message: 'Rejected' },
-  ...overrides,
-});
+const makeRejectedAction = (overrides: any = {}) => {
+  const { meta: metaOverrides, payload, error, ...rest } = overrides;
+
+  return {
+    type: 'someApi/executeQuery/rejected',
+    meta: {
+      arg: { endpointName: 'getThing' },
+      requestId: 'req-1',
+      requestStatus: 'rejected',
+      rejectedWithValue: true,
+      ...metaOverrides,
+    },
+    payload: payload ?? { status: 500, data: { message: 'Server exploded' } },
+    error: { message: 'Rejected', ...error },
+    ...rest,
+  };
+};
 
 const makeStoreApi = () => ({
   dispatch: vi.fn(),
@@ -54,7 +58,7 @@ describe('rtkErrorMiddleware', () => {
     const dispatched = storeApi.dispatch.mock.calls[0][0];
     expect(dispatched.type).toBe(pushEvent({} as any).type);
     expect(dispatched.payload.severity).toBe('error');
-    expect(dispatched.payload.description).toBe('getThing: Boom');
+    expect(dispatched.payload.description).toBe('Unable to load thing: Boom');
     expect(dispatched.payload.action).toBe('api_error');
     expect(dispatched.payload.category).toBe('api');
     // Avoid a race against wall-clock millisecond drift on slow CI runners:
@@ -94,7 +98,9 @@ describe('rtkErrorMiddleware', () => {
         payload: { status: 500, data: { message: 'Specific message' } },
       }),
     );
-    expect(storeApi.dispatch.mock.calls[0][0].payload.description).toContain('Specific message');
+    expect(storeApi.dispatch.mock.calls[0][0].payload.description).toBe(
+      'Unable to load thing: Specific message',
+    );
   });
 
   it('falls back to data.error when data.message is missing', () => {
@@ -105,8 +111,8 @@ describe('rtkErrorMiddleware', () => {
         payload: { status: 500, data: { error: 'Error from data.error' } },
       }),
     );
-    expect(storeApi.dispatch.mock.calls[0][0].payload.description).toContain(
-      'Error from data.error',
+    expect(storeApi.dispatch.mock.calls[0][0].payload.description).toBe(
+      'Unable to load thing: Error from data.error',
     );
   });
 
@@ -116,7 +122,9 @@ describe('rtkErrorMiddleware', () => {
     rtkErrorMiddleware(storeApi as any)(next)(
       makeRejectedAction({ payload: { status: 500, error: 'Plain error' } }),
     );
-    expect(storeApi.dispatch.mock.calls[0][0].payload.description).toContain('Plain error');
+    expect(storeApi.dispatch.mock.calls[0][0].payload.description).toBe(
+      'Unable to load thing: Plain error',
+    );
   });
 
   it('falls back to "Request failed (status)" when no message/error is present', () => {
@@ -124,7 +132,7 @@ describe('rtkErrorMiddleware', () => {
     const next = vi.fn();
     rtkErrorMiddleware(storeApi as any)(next)(makeRejectedAction({ payload: { status: 503 } }));
     expect(storeApi.dispatch.mock.calls[0][0].payload.description).toContain(
-      'Request failed (503)',
+      'Unable to load thing. Request failed (503).',
     );
   });
 
@@ -133,7 +141,7 @@ describe('rtkErrorMiddleware', () => {
     const next = vi.fn();
     rtkErrorMiddleware(storeApi as any)(next)(makeRejectedAction({ payload: {} }));
     expect(storeApi.dispatch.mock.calls[0][0].payload.description).toContain(
-      'Request failed (unknown status)',
+      'Unable to load thing. Request failed (unknown status).',
     );
   });
 
@@ -144,7 +152,7 @@ describe('rtkErrorMiddleware', () => {
       makeRejectedAction({ payload: { originalStatus: 502 } }),
     );
     expect(storeApi.dispatch.mock.calls[0][0].payload.description).toContain(
-      'Request failed (502)',
+      'Unable to load thing. Request failed (502).',
     );
   });
 
@@ -157,7 +165,42 @@ describe('rtkErrorMiddleware', () => {
       meta: { requestId: 'req-1', requestStatus: 'rejected', rejectedWithValue: true },
     };
     rtkErrorMiddleware(storeApi as any)(next)(action);
-    expect(storeApi.dispatch.mock.calls[0][0].payload.description).toContain('API call:');
+    expect(storeApi.dispatch.mock.calls[0][0].payload.description).toContain(
+      'Unable to complete api call: err',
+    );
+  });
+
+  it('turns fetch errors into user-friendly notification copy for notification center events', () => {
+    const storeApi = makeStoreApi();
+    const next = vi.fn();
+    rtkErrorMiddleware(storeApi as any)(next)(
+      makeRejectedAction({
+        meta: { arg: { endpointName: 'getEvents' } },
+        payload: { status: 'FETCH_ERROR', error: 'TypeError: Failed to fetch' },
+      }),
+    );
+
+    expect(storeApi.dispatch.mock.calls[0][0].payload.description).toBe(
+      'Unable to load notifications. Check your connection and try again.',
+    );
+    expect(console.error).toHaveBeenCalledWith(
+      expect.stringContaining('[RTK Query] getEvents failed:'),
+      'TypeError: Failed to fetch',
+    );
+  });
+
+  it('formats timeout errors with retry-oriented copy', () => {
+    const storeApi = makeStoreApi();
+    const next = vi.fn();
+    rtkErrorMiddleware(storeApi as any)(next)(
+      makeRejectedAction({
+        payload: { status: 'TIMEOUT_ERROR', error: 'Request timed out' },
+      }),
+    );
+
+    expect(storeApi.dispatch.mock.calls[0][0].payload.description).toBe(
+      'Timed out while trying to load thing. Please try again.',
+    );
   });
 
   it('logs the error via console.error', () => {

--- a/ui/store/middleware/rtkErrorMiddleware.ts
+++ b/ui/store/middleware/rtkErrorMiddleware.ts
@@ -1,6 +1,77 @@
 import { isRejectedWithValue, Middleware } from '@reduxjs/toolkit';
 import { pushEvent } from '../slices/events';
 
+const ENDPOINT_RESOURCE_LABELS: Record<string, string> = {
+  getEvents: 'notifications',
+  getEventsSummary: 'notifications',
+  deleteEvent: 'notification',
+  deleteEvents: 'notifications',
+  updateEvents: 'notifications',
+  updateStatus: 'notification status',
+  getEventFilters: 'notification filters',
+  getEventConfig: 'notification settings',
+  updateEventConfig: 'notification settings',
+};
+
+const getEndpointOperation = (endpointName: string) => {
+  if (/^(get|list|fetch)/i.test(endpointName)) {
+    return 'load';
+  }
+
+  if (/^(create|add)/i.test(endpointName)) {
+    return 'create';
+  }
+
+  if (/^(update|edit|set)/i.test(endpointName)) {
+    return 'update';
+  }
+
+  if (/^(delete|remove)/i.test(endpointName)) {
+    return 'delete';
+  }
+
+  return 'complete';
+};
+
+const getEndpointResource = (endpointName: string) => {
+  if (ENDPOINT_RESOURCE_LABELS[endpointName]) {
+    return ENDPOINT_RESOURCE_LABELS[endpointName];
+  }
+
+  const withoutVerb = endpointName.replace(
+    /^(get|list|fetch|create|add|update|edit|set|delete|remove)/i,
+    '',
+  );
+  const resource = withoutVerb
+    .replace(/([a-z0-9])([A-Z])/g, '$1 $2')
+    .replace(/[_-]+/g, ' ')
+    .trim()
+    .toLowerCase();
+
+  return resource || 'request';
+};
+
+const buildErrorDescription = (endpointName: string, payload: any) => {
+  const status = payload?.status || payload?.originalStatus;
+  const resource = getEndpointResource(endpointName);
+  const operation = getEndpointOperation(endpointName);
+  const rawErrorMessage = payload?.data?.message || payload?.data?.error || payload?.error;
+
+  if (status === 'FETCH_ERROR') {
+    return `Unable to ${operation} ${resource}. Check your connection and try again.`;
+  }
+
+  if (status === 'TIMEOUT_ERROR') {
+    return `Timed out while trying to ${operation} ${resource}. Please try again.`;
+  }
+
+  if (rawErrorMessage) {
+    return `Unable to ${operation} ${resource}: ${rawErrorMessage}`;
+  }
+
+  return `Unable to ${operation} ${resource}. Request failed (${status || 'unknown status'}).`;
+};
+
 /**
  * RTK Query middleware that dispatches error events into the notification
  * system for failed API calls. Skips 401 errors (handled by authMiddleware).
@@ -20,6 +91,7 @@ export const rtkErrorMiddleware: Middleware = (storeApi) => (next) => (action) =
       action.payload?.data?.error ||
       action.payload?.error ||
       `Request failed (${status || 'unknown status'})`;
+    const description = buildErrorDescription(endpointName, action.payload);
 
     console.error(`[RTK Query] ${endpointName} failed:`, errorMessage);
 
@@ -27,7 +99,7 @@ export const rtkErrorMiddleware: Middleware = (storeApi) => (next) => (action) =
       pushEvent({
         id: `rtk-error-${Date.now()}`,
         severity: 'error',
-        description: `${endpointName}: ${errorMessage}`,
+        description,
         action: 'api_error',
         category: 'api',
         createdAt: new Date().toISOString(),


### PR DESCRIPTION
## Summary
- replace raw RTK Query endpoint and transport errors with user-facing notification copy
- map notification-center event endpoints to `notifications` so `getEvents: TypeError: Failed to fetch` no longer reaches users
- add regression coverage for fetch and timeout failures in the RTK error middleware

## Testing
- cd ui && ./node_modules/.bin/vitest run store/middleware/__tests__/rtkErrorMiddleware.test.ts rtk-query/__tests__/notificationCenter.test.ts
- cd ui && ./node_modules/.bin/eslint store/middleware/rtkErrorMiddleware.ts store/middleware/__tests__/rtkErrorMiddleware.test.ts