### PR TITLE
[UI] Fix stale unit test mocks

### DIFF
--- a/ui/components/connections/ConnectionChip.test.tsx
+++ b/ui/components/connections/ConnectionChip.test.tsx
@@ -26,11 +26,16 @@ vi.mock('@sistent/sistent', () => {
       </div>
     ),
     AssignmentTurnedInIcon: () => <svg data-testid="assignment-icon" />,
+    CancelIcon: () => <svg data-testid="cancel-icon" />,
+    CheckCircleIcon: () => <svg data-testid="check-circle-icon" />,
     CustomTooltip: ({ title, children }) => (
       <div data-testid="tooltip" data-title={String(title)}>
         {children}
       </div>
     ),
+    ExploreIcon: () => <svg data-testid="explore-icon" />,
+    HandymanIcon: () => <svg data-testid="handyman-icon" />,
+    RemoveIcon: () => <svg data-testid="remove-icon" />,
     Typography: ({ children }) => <span>{children}</span>,
     styled,
     createTheme: () => ({ breakpoints: {} }),

--- a/ui/components/layout/Navigator/NavigatorExtension.test.tsx
+++ b/ui/components/layout/Navigator/NavigatorExtension.test.tsx
@@ -77,7 +77,7 @@ vi.mock('../../shared/Modal/Modal', () => ({
   default: () => <div data-testid="modal" />,
 }));
 
-vi.mock('../../shared/Modal/ExportModal', () => ({
+vi.mock('../../designs/export/ExportDesignModal', () => ({
   default: () => <div data-testid="export-modal" />,
 }));
 
@@ -145,7 +145,7 @@ vi.mock('@/components/shared/FormFields/typing-filter', () => ({
 vi.mock('../../registry/CreateModelModal', () => ({ default: () => null }));
 vi.mock('../../registry/ImportModelModal', () => ({ default: () => null }));
 
-vi.mock('../../shared/Modal/ViewInfoModal', () => ({
+vi.mock('../../workspaces/ViewInfoModal', () => ({
   ViewInfoModal: () => null,
 }));
 

--- a/ui/components/registry/RegistryModal.test.tsx
+++ b/ui/components/registry/RegistryModal.test.tsx
@@ -67,7 +67,7 @@ vi.mock('@sistent/sistent', () => ({
         ...override,
         palette: { ...theme.palette, ...(override?.palette || {}) },
         transitions: { ...theme.transitions, ...(override?.transitions || {}) },
-        breakpoints: override?.breakpoints || theme.breakpoints,
+        breakpoints: { ...theme.breakpoints, ...(override?.breakpoints || {}) },
         spacing: override?.spacing || theme.spacing,
       }),
       createStableTheme(),

--- a/ui/components/registry/RegistryModal.test.tsx
+++ b/ui/components/registry/RegistryModal.test.tsx
@@ -6,24 +6,28 @@ let mediaQueryReturn = false;
 const RegistryModalContext = React.createContext<any>({});
 
 // Stable theme reference so setHeaderInfo effects don't loop.
-const stableTheme = {
-  palette: {
-    icon: { default: 'i', white: 'w' },
-    common: { white: 'w' },
-    mode: 'light',
-    background: { paper: '#fff' },
-  },
-  transitions: {
-    create: () => '',
-    easing: { sharp: '' },
-    duration: { enteringScreen: 0, leavingScreen: 0 },
-  },
-  breakpoints: {
-    up: () => '@media (min-width:600px)',
-    down: () => '@media (max-width:600px)',
-  },
-  spacing: (n: number) => n,
-};
+function createStableTheme() {
+  return {
+    palette: {
+      icon: { default: 'i', white: 'w' },
+      common: { white: 'w' },
+      mode: 'light',
+      background: { paper: '#fff' },
+    },
+    transitions: {
+      create: () => '',
+      easing: { sharp: '' },
+      duration: { enteringScreen: 0, leavingScreen: 0 },
+    },
+    breakpoints: {
+      up: () => '@media (min-width:600px)',
+      down: () => '@media (max-width:600px)',
+    },
+    spacing: (n: number) => n,
+  };
+}
+
+const stableTheme = createStableTheme();
 
 vi.mock('@sistent/sistent', () => ({
   ModalBody: ({ children }: any) => <div data-testid="modal-body">{children}</div>,
@@ -45,10 +49,29 @@ vi.mock('@sistent/sistent', () => ({
   ChevronLeftIcon: () => <svg data-testid="chev-left" />,
   ChevronRightIcon: () => <svg data-testid="chev-right" />,
   FileIcon: () => <svg data-testid="file-icon" />,
+  InfoIcon: () => <svg data-testid="info-icon" />,
   DatabaseIcon: () => <svg data-testid="database-icon" />,
   CustomTooltip: ({ children }: any) => <>{children}</>,
   useMediaQuery: () => mediaQueryReturn,
   useTheme: () => stableTheme,
+  alpha: (value: string) => value,
+  lighten: (value: string) => value,
+  ThemeProvider: ({ children }: any) => <>{children}</>,
+  ErrorBoundary: ({ children }: any) => <>{children}</>,
+  CssBaseline: () => null,
+  NoSsr: ({ children }: any) => <>{children}</>,
+  createTheme: (...overrides: any[]) =>
+    overrides.reduce(
+      (theme, override) => ({
+        ...theme,
+        ...override,
+        palette: { ...theme.palette, ...(override?.palette || {}) },
+        transitions: { ...theme.transitions, ...(override?.transitions || {}) },
+        breakpoints: override?.breakpoints || theme.breakpoints,
+        spacing: override?.spacing || theme.spacing,
+      }),
+      createStableTheme(),
+    ),
   Modal: ({ children, open, title }: any) =>
     open ? (
       <div data-testid="registry-modal" data-title={title}>
@@ -66,6 +89,14 @@ vi.mock('@sistent/sistent', () => ({
 
 vi.mock('@/assets/icons/Connection', () => ({ default: () => <svg /> }));
 vi.mock('@/assets/icons/Component', () => ({ default: () => <svg /> }));
+vi.mock('@/components/shared/Modal', () => ({
+  Modal: ({ children, isOpen, title }: any) =>
+    isOpen ? (
+      <div data-testid="registry-modal" data-title={title}>
+        {children}
+      </div>
+    ) : null,
+}));
 
 vi.mock('./MeshModelComponent', () => ({
   default: (props: any) => (

--- a/ui/components/shared/Modal/ViewInfoModal.test.tsx
+++ b/ui/components/shared/Modal/ViewInfoModal.test.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
-import { ViewInfoModal_, ViewInfoModal, UserChip, ActionBox } from './ViewInfoModal';
+import { ViewInfoModal_, ViewInfoModal, UserChip } from '../../workspaces/ViewInfoModal';
 
 const notify = vi.fn();
 const mockUpdateView = vi.fn().mockReturnValue({ unwrap: () => Promise.resolve() });
@@ -46,7 +46,7 @@ vi.mock('@/utils/hooks/useNotification', () => ({
 }));
 
 vi.mock('lib/event-types', () => ({
-  EVENT_TYPES: { INFO: 'info' },
+  EVENT_TYPES: { INFO: 'info', ERROR: 'error' },
 }));
 
 vi.mock('../../workspaces/SpacesSwitcher/hooks', () => ({
@@ -147,6 +147,12 @@ vi.mock('@sistent/sistent', () => {
         {children}
       </button>
     ),
+    createTheme: () => ({
+      breakpoints: {
+        down: () => '',
+        up: () => '',
+      },
+    }),
     useTheme: () => ({
       palette: {
         text: { primary: '#000' },
@@ -298,11 +304,5 @@ describe('ViewInfoModal', () => {
     );
 
     expect(screen.getByTestId('provider-wrapper')).toBeInTheDocument();
-  });
-});
-
-describe('ActionBox', () => {
-  it('is exported as a styled component', () => {
-    expect(ActionBox).toBeDefined();
   });
 });

--- a/ui/components/workspaces/ViewInfoModal.test.tsx
+++ b/ui/components/workspaces/ViewInfoModal.test.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
-import { ViewInfoModal_, ViewInfoModal, UserChip } from '../../workspaces/ViewInfoModal';
+import { ViewInfoModal_, ViewInfoModal, UserChip } from './ViewInfoModal';
 
 const notify = vi.fn();
 const mockUpdateView = vi.fn().mockReturnValue({ unwrap: () => Promise.resolve() });
@@ -49,7 +49,7 @@ vi.mock('lib/event-types', () => ({
   EVENT_TYPES: { INFO: 'info', ERROR: 'error' },
 }));
 
-vi.mock('../../workspaces/SpacesSwitcher/hooks', () => ({
+vi.mock('./SpacesSwitcher/hooks', () => ({
   handleUpdateViewVisibility: vi.fn(),
   viewPath: (view: any) => `/views/${view?.id}`,
 }));
@@ -71,13 +71,13 @@ vi.mock('@/assets/icons', () => ({
 
 vi.mock('rehype-sanitize', () => ({ default: () => null }));
 
-vi.mock('../../Markdown', () => ({
+vi.mock('../Markdown', () => ({
   MDEditor: ({ value, onChange }: any) => (
     <textarea data-testid="md-editor" value={value} onChange={(e) => onChange?.(e.target.value)} />
   ),
 }));
 
-vi.mock('../../meshery-mesh-interface/PatternService/RJSF_wrapper', () => ({
+vi.mock('../meshery-mesh-interface/PatternService/RJSF_wrapper', () => ({
   default: ({ formData, onChange, widgets }: any) => {
     const Widget = widgets?.markdown;
     return (


### PR DESCRIPTION
## Summary
- refresh stale UI unit test mocks so ConnectionChip and RegistryModal load current dependencies
- update NavigatorExtension and ViewInfoModal tests to follow the current component paths and exports
- remove obsolete ViewInfoModal test coverage for a deleted export

## Testing
- cd ui && npm test -- components/connections/ConnectionChip.test.tsx components/registry/RegistryModal.test.tsx components/layout/Navigator/NavigatorExtension.test.tsx components/shared/Modal/ViewInfoModal.test.tsx
- cd ui && npm run lint -- components/connections/ConnectionChip.test.tsx components/registry/RegistryModal.test.tsx components/layout/Navigator/NavigatorExtension.test.tsx components/shared/Modal/ViewInfoModal.test.tsx