### PR TITLE
[server] Guard MeshSync metadata lookup when registry tables are absent

### DIFF
--- a/server/models/meshsync_events.go
+++ b/server/models/meshsync_events.go
@@ -2,6 +2,7 @@ package models
 
 import (
 	"fmt"
+	"strings"
 	"sync"
 
 	"github.com/meshery/meshkit/broker"
@@ -10,6 +11,7 @@ import (
 	"github.com/meshery/meshkit/logger"
 	"github.com/meshery/meshkit/utils"
 	"github.com/meshery/schemas/models/core"
+	modelv1beta1 "github.com/meshery/schemas/models/v1beta1/model"
 
 	meshsyncmodel "github.com/meshery/meshsync/pkg/model"
 	"github.com/meshery/schemas/models/v1beta3/component"
@@ -326,14 +328,24 @@ func (mh *MeshsyncDataHandler) getComponentMetadata(apiVersion string, kind stri
 		}
 	}()
 
-	// Query the database for the complete component definition
-	result := mh.dbHandler.Model(component.ComponentDefinition{}).Preload("Model").
+	if !mh.dbHandler.Migrator().HasTable(&component.ComponentDefinition{}) {
+		mh.log.Debug("Component registry table unavailable while looking up metadata for apiVersion: ", apiVersion, " kind: ", kind, ". Using default metadata.")
+		componentDef = component.ComponentDefinition{
+			Styles: &K8sMeshModelMetadata.Styles,
+		}
+		return
+	}
+
+	// Query the database for the complete component definition.
+	result := mh.dbHandler.Model(component.ComponentDefinition{}).
 		Where("component->>'version' = ? AND component->>'kind' = ?", apiVersion, kind).
 		First(&componentDef)
 
 	if result.Error != nil {
 		if result.Error == gorm.ErrRecordNotFound {
 			mh.log.Debug("No component definition found for apiVersion: ", apiVersion, " kind: ", kind, ". Using default metadata.")
+		} else if isMissingTableError(result.Error) {
+			mh.log.Debug("Component registry table unavailable while looking up metadata for apiVersion: ", apiVersion, " kind: ", kind, ". Using default metadata.")
 		} else {
 			mh.log.Error(ErrDBRead(result.Error))
 		}
@@ -344,7 +356,27 @@ func (mh *MeshsyncDataHandler) getComponentMetadata(apiVersion string, kind stri
 		return
 	}
 
+	if componentDef.ModelID != nil && mh.dbHandler.Migrator().HasTable(&modelv1beta1.ModelDefinition{}) {
+		modelDef := modelv1beta1.ModelDefinition{}
+		result = mh.dbHandler.Where("id = ?", componentDef.ModelID).First(&modelDef)
+		if result.Error == nil {
+			componentDef.Model = &modelDef
+		} else if result.Error != gorm.ErrRecordNotFound && !isMissingTableError(result.Error) {
+			mh.log.Error(ErrDBRead(result.Error))
+		}
+	}
+
 	return
+}
+
+func isMissingTableError(err error) bool {
+	if err == nil {
+		return false
+	}
+
+	msg := strings.ToLower(err.Error())
+
+	return strings.Contains(msg, "no such table") || strings.Contains(msg, "does not exist")
 }
 
 func (mh *MeshsyncDataHandler) Resync() error {

--- a/server/models/meshsync_events.go
+++ b/server/models/meshsync_events.go
@@ -328,14 +328,6 @@ func (mh *MeshsyncDataHandler) getComponentMetadata(apiVersion string, kind stri
 		}
 	}()
 
-	if !mh.dbHandler.Migrator().HasTable(&component.ComponentDefinition{}) {
-		mh.log.Debug("Component registry table unavailable while looking up metadata for apiVersion: ", apiVersion, " kind: ", kind, ". Using default metadata.")
-		componentDef = component.ComponentDefinition{
-			Styles: &K8sMeshModelMetadata.Styles,
-		}
-		return
-	}
-
 	// Query the database for the complete component definition.
 	result := mh.dbHandler.Model(component.ComponentDefinition{}).
 		Where("component->>'version' = ? AND component->>'kind' = ?", apiVersion, kind).
@@ -344,7 +336,7 @@ func (mh *MeshsyncDataHandler) getComponentMetadata(apiVersion string, kind stri
 	if result.Error != nil {
 		if result.Error == gorm.ErrRecordNotFound {
 			mh.log.Debug("No component definition found for apiVersion: ", apiVersion, " kind: ", kind, ". Using default metadata.")
-		} else if isMissingTableError(result.Error) {
+		} else if isMissingTableError(result.Error, component.ComponentDefinition{}.TableName()) {
 			mh.log.Debug("Component registry table unavailable while looking up metadata for apiVersion: ", apiVersion, " kind: ", kind, ". Using default metadata.")
 		} else {
 			mh.log.Error(ErrDBRead(result.Error))
@@ -356,12 +348,14 @@ func (mh *MeshsyncDataHandler) getComponentMetadata(apiVersion string, kind stri
 		return
 	}
 
-	if componentDef.ModelID != nil && mh.dbHandler.Migrator().HasTable(&modelv1beta1.ModelDefinition{}) {
+	if componentDef.ModelID != nil {
 		modelDef := modelv1beta1.ModelDefinition{}
-		result = mh.dbHandler.Where("id = ?", componentDef.ModelID).First(&modelDef)
+		result = mh.dbHandler.Session(&gorm.Session{NewDB: true}).Model(&modelv1beta1.ModelDefinition{}).
+			Where("id = ?", componentDef.ModelID).
+			First(&modelDef)
 		if result.Error == nil {
 			componentDef.Model = &modelDef
-		} else if result.Error != gorm.ErrRecordNotFound && !isMissingTableError(result.Error) {
+		} else if result.Error != gorm.ErrRecordNotFound && !isMissingTableError(result.Error, modelv1beta1.ModelDefinition{}.TableName()) {
 			mh.log.Error(ErrDBRead(result.Error))
 		}
 	}
@@ -369,14 +363,16 @@ func (mh *MeshsyncDataHandler) getComponentMetadata(apiVersion string, kind stri
 	return
 }
 
-func isMissingTableError(err error) bool {
+func isMissingTableError(err error, tableName string) bool {
 	if err == nil {
 		return false
 	}
 
 	msg := strings.ToLower(err.Error())
 
-	return strings.Contains(msg, "no such table") || strings.Contains(msg, "does not exist")
+	return strings.Contains(msg, "no such table: "+tableName) ||
+		strings.Contains(msg, `relation "`+tableName+`" does not exist`) ||
+		strings.Contains(msg, "."+tableName+"' doesn't exist")
 }
 
 func (mh *MeshsyncDataHandler) Resync() error {

--- a/server/models/meshsync_events_test.go
+++ b/server/models/meshsync_events_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/meshery/meshkit/database"
 	meshkitErrors "github.com/meshery/meshkit/errors"
 	"github.com/meshery/meshkit/logger"
+	modelv1beta1 "github.com/meshery/schemas/models/v1beta1/model"
 	"github.com/meshery/schemas/models/v1beta3/component"
 	"github.com/stretchr/testify/assert"
 	"gorm.io/driver/sqlite"
@@ -182,6 +183,82 @@ func TestGetComponentMetadataWithNilModel(t *testing.T) {
 	})
 }
 
+func TestGetComponentMetadataWithoutRegistryTablesFallsBackSilently(t *testing.T) {
+	db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{})
+	if err != nil {
+		t.Fatalf("Failed to create in-memory database: %v", err)
+	}
+
+	testLogger := &fakeMeshsyncLogger{}
+	handler := &MeshsyncDataHandler{
+		dbHandler: database.Handler{DB: db},
+		log:       testLogger,
+	}
+
+	data, model := handler.getComponentMetadata("v1", "Pod")
+
+	if data == nil {
+		t.Fatal("expected fallback metadata to be returned")
+	}
+
+	if model != "" {
+		t.Fatalf("expected empty model name, got %q", model)
+	}
+
+	if logged := testLogger.getLogged(); len(logged) != 0 {
+		t.Fatalf("expected no error logs when registry tables are absent, got %d", len(logged))
+	}
+}
+
+func TestGetComponentMetadataReturnsAssociatedModelName(t *testing.T) {
+	db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{})
+	if err != nil {
+		t.Fatalf("Failed to create in-memory database: %v", err)
+	}
+
+	if err := db.AutoMigrate(&modelv1beta1.ModelDefinition{}, &component.ComponentDefinition{}); err != nil {
+		t.Fatalf("Failed to migrate schema: %v", err)
+	}
+
+	modelID := uuid.FromStringOrNil("11111111-1111-1111-1111-111111111111")
+	componentID := uuid.FromStringOrNil("22222222-2222-2222-2222-222222222222")
+
+	modelDef := modelv1beta1.ModelDefinition{
+		ID:   modelID,
+		Name: "kubernetes",
+	}
+	if err := db.Create(&modelDef).Error; err != nil {
+		t.Fatalf("Failed to create model definition: %v", err)
+	}
+
+	componentDef := component.ComponentDefinition{
+		ID:      componentID,
+		ModelID: &modelID,
+		Component: component.Component{
+			Kind:    "Pod",
+			Version: "v1",
+		},
+	}
+	if err := db.Create(&componentDef).Error; err != nil {
+		t.Fatalf("Failed to create component definition: %v", err)
+	}
+
+	mockLogger, err := logger.New("test", logger.Options{})
+	if err != nil {
+		t.Fatalf("Failed to create logger: %v", err)
+	}
+
+	handler := &MeshsyncDataHandler{
+		dbHandler: database.Handler{DB: db},
+		log:       mockLogger,
+	}
+
+	_, modelName := handler.getComponentMetadata("v1", "Pod")
+	if modelName != "kubernetes" {
+		t.Fatalf("expected associated model name to be returned, got %q", modelName)
+	}
+}
+
 func TestMeshsyncDataHandlerStopStopsListeners(t *testing.T) {
 	stopCalled := make(chan struct{}, 1)
 	broker := &testMeshsyncBroker{}
@@ -243,10 +320,10 @@ func (f *fakeMeshsyncLogger) getLogged() []error {
 	return append([]error(nil), f.logged...)
 }
 
-func (f *fakeMeshsyncLogger) Info(description ...interface{}) {}
+func (f *fakeMeshsyncLogger) Info(description ...interface{})          {}
 func (f *fakeMeshsyncLogger) Infof(format string, args ...interface{}) {}
-func (f *fakeMeshsyncLogger) Debug(description ...interface{}) {}
-func (f *fakeMeshsyncLogger) Warn(err error) {}
+func (f *fakeMeshsyncLogger) Debug(description ...interface{})         {}
+func (f *fakeMeshsyncLogger) Warn(err error)                           {}
 
 func TestMeshsyncEventErrorWrappedWithMeshKit(t *testing.T) {
 	broker := &testMeshsyncBroker{}

--- a/server/models/meshsync_events_test.go
+++ b/server/models/meshsync_events_test.go
@@ -253,9 +253,18 @@ func TestGetComponentMetadataReturnsAssociatedModelName(t *testing.T) {
 		log:       mockLogger,
 	}
 
-	_, modelName := handler.getComponentMetadata("v1", "Pod")
+	data, modelName := handler.getComponentMetadata("v1", "Pod")
 	if modelName != "kubernetes" {
 		t.Fatalf("expected associated model name to be returned, got %q", modelName)
+	}
+
+	modelData, ok := data["model"].(map[string]interface{})
+	if !ok {
+		t.Fatalf("expected returned metadata to include the resolved model, got %#v", data["model"])
+	}
+
+	if got := modelData["name"]; got != "kubernetes" {
+		t.Fatalf("expected returned metadata to include model name %q, got %#v", "kubernetes", got)
 	}
 }
 


### PR DESCRIPTION
## Summary
- stop MeshSync component metadata lookups from erroring when registry tables have not been created yet
- avoid the fragile model preload by loading the component first and resolving the model name only when the model table is available
- add regression coverage for the missing-table fallback and the associated-model lookup path

## Testing
- go test ./server/models -run 'TestGetComponentMetadata|TestMeshsyncDataHandlerStop|TestMeshsyncEventErrorWrappedWithMeshKit'

## Notes
- `make golangci` still fails in the current branch due to pre-existing repository issues (missing Go 1.25 toolchain and duplicate error-code/staticcheck findings outside this change).