### PR TITLE
[UI] Realign k8s context switcher on totalCount across the data path

### DIFF
--- a/ui/components/AppComponents.test.tsx
+++ b/ui/components/AppComponents.test.tsx
@@ -150,4 +150,32 @@ describe('KubernetesSubscription', () => {
     unmount();
     expect(disposeMock).toHaveBeenCalledTimes(1);
   });
+
+  it('passes through an already-camelCased subscription payload (GraphQL alias path)', () => {
+    render(<KubernetesSubscription setAppState={setAppStateMock} />);
+
+    act(() => {
+      subscriptionCallback?.({
+        k8sContext: {
+          totalCount: 4,
+          contexts: [
+            { id: 'ctx-1', name: 'a', connectionId: 'conn-1', createdBy: 'meshery' },
+            { id: 'ctx-2', name: 'b', connectionId: 'conn-2', createdBy: 'meshery' },
+          ],
+        },
+      });
+    });
+
+    expect(setAppStateMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        k8sContexts: expect.objectContaining({
+          totalCount: 4,
+          contexts: expect.arrayContaining([
+            expect.objectContaining({ id: 'ctx-1', connectionId: 'conn-1' }),
+            expect.objectContaining({ id: 'ctx-2', connectionId: 'conn-2' }),
+          ]),
+        }),
+      }),
+    );
+  });
 });

--- a/ui/components/layout/Header/Header.tsx
+++ b/ui/components/layout/Header/Header.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect, useContext, useMemo } from 'react';
+import React, { useState, useContext, useMemo } from 'react';
 import PropTypes from 'prop-types';
 import { NotificationDrawerButton } from '../NotificationCenter/index';
 import User from '../../User';
@@ -140,7 +140,9 @@ function K8sContextMenu({
 }) {
   const [anchorEl, setAnchorEl] = useState(false);
   const [showFullContextMenu, setShowFullContextMenu] = useState(false);
-  const [transformProperty, setTransformProperty] = useState(100);
+  // The dropdown slides up from below; its translate distance scales with the
+  // number of context rows it will render so it ends up flush against the badge.
+  const transformProperty = 100 + (contexts?.totalCount || 0) * 3.125;
   const deleteCtxtRef = React.createRef();
   const { notify } = useNotification();
   const [fetchSystemSync] = useLazyGetSystemSyncQuery();
@@ -246,9 +248,6 @@ function K8sContextMenu({
     open = showFullContextMenu;
   }
 
-  useEffect(() => {
-    setTransformProperty((prev) => prev + (contexts.totalCount ? contexts.totalCount * 3.125 : 0));
-  }, []);
   const [isConnectionOpenModal, setIsConnectionOpenModal] = useState(false);
 
   return (

--- a/ui/components/layout/Header/Header.tsx
+++ b/ui/components/layout/Header/Header.tsx
@@ -142,7 +142,7 @@ function K8sContextMenu({
   const [showFullContextMenu, setShowFullContextMenu] = useState(false);
   // The dropdown slides up from below; its translate distance scales with the
   // number of context rows it will render so it ends up flush against the badge.
-  const transformProperty = 100 + (contexts?.totalCount || 0) * 3.125;
+  const transformProperty = 100 + (contexts?.contexts?.length || 0) * 3.125;
   const deleteCtxtRef = React.createRef();
   const { notify } = useNotification();
   const [fetchSystemSync] = useLazyGetSystemSyncQuery();

--- a/ui/graphql/subscriptions/K8sContextSubscription.tsx
+++ b/ui/graphql/subscriptions/K8sContextSubscription.tsx
@@ -4,7 +4,7 @@ import { createSubscription } from 'lib/subscriptionHelper';
 const k8sContextSubscription = graphql`
   subscription K8sContextSubscription($selector: PageFilter!) {
     k8sContext: subscribeK8sContext(selector: $selector) {
-      total_count
+      totalCount: total_count
       contexts {
         id
         name

--- a/ui/graphql/subscriptions/__generated__/K8sContextSubscription.graphql.ts
+++ b/ui/graphql/subscriptions/__generated__/K8sContextSubscription.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<618276d0b05863710731d7859b7864cb>>
+ * @generated SignedSource<<5f3c62494eae6987fff43cb5441f66a4>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -40,7 +40,7 @@ export type K8sContextSubscription$data = {
       readonly updatedAt: string;
       readonly version: string;
     } | null | undefined>;
-    readonly total_count: number;
+    readonly totalCount: number;
   };
 };
 export type K8sContextSubscription = {
@@ -72,7 +72,7 @@ v1 = [
     "plural": false,
     "selections": [
       {
-        "alias": null,
+        "alias": "totalCount",
         "args": null,
         "kind": "ScalarField",
         "name": "total_count",
@@ -195,16 +195,16 @@ return {
     "selections": (v1/*: any*/)
   },
   "params": {
-    "cacheID": "1e512bbef451c100458530583edd6f05",
+    "cacheID": "21e06ecbe7a8788897700273f61d677c",
     "id": null,
     "metadata": {},
     "name": "K8sContextSubscription",
     "operationKind": "subscription",
-    "text": "subscription K8sContextSubscription(\n  $selector: PageFilter!\n) {\n  k8sContext: subscribeK8sContext(selector: $selector) {\n    total_count\n    contexts {\n      id\n      name\n      server\n      owner\n      createdBy\n      mesheryInstanceId\n      kubernetesServerId\n      deploymentType\n      updatedAt\n      createdAt\n      version\n      connectionId\n    }\n  }\n}\n"
+    "text": "subscription K8sContextSubscription(\n  $selector: PageFilter!\n) {\n  k8sContext: subscribeK8sContext(selector: $selector) {\n    totalCount: total_count\n    contexts {\n      id\n      name\n      server\n      owner\n      createdBy\n      mesheryInstanceId\n      kubernetesServerId\n      deploymentType\n      updatedAt\n      createdAt\n      version\n      connectionId\n    }\n  }\n}\n"
   }
 };
 })();
 
-(node as any).hash = "dd6309365102dfa11d8873daf998b343";
+(node as any).hash = "77758342e08fc786e2cc7a7af4bf7492";
 
 export default node;

--- a/ui/pages/_app.tsx
+++ b/ui/pages/_app.tsx
@@ -132,7 +132,7 @@ const MesheryApp = ({ Component, pageProps, relayEnvironment, emotionCache }) =>
     isDrawerCollapsed: false,
     isFullScreenMode: false,
     isLoading: true,
-    k8sContexts: [],
+    k8sContexts: { totalCount: 0, contexts: [] },
     activeK8sContexts: [],
     mesheryControllerSubscription: null,
     disposeK8sContextSubscription: null,


### PR DESCRIPTION
## Summary
Follow-up to #19381 closing the remaining gaps that let the header k8s
switcher render `0`. Three holistic fixes:

- **GraphQL alias.** Surface `K8sContextsPage.total_count` as `totalCount`
  via a query alias in `K8sContextSubscription`, so the wire shape
  matches what consumers read and the runtime normalizer no longer has
  to paper over the schema's snake_case for this field. The generated
  Relay artifact is updated to match.
- **Initial state shape.** `state.k8sContexts` was seeded as `[]` in
  `pages/_app.tsx` but every reader treats it as
  `{ totalCount, contexts }`. Until the subscription fired, the badge
  was reading `totalCount` off an array (always `undefined`). Seed with
  the object shape so the value is stable from mount.
- **Drop the stale-on-mount effect in `K8sContextMenu`.** The dropdown's
  translate distance was being computed inside a `useEffect` with empty
  deps, so it captured the initial (zero) count and never updated. Made
  it a plain computed value driven by `contexts?.totalCount`, removed
  the now-unused `transformProperty` state and `useEffect` import.

## Why this matters
`/cc @miacycle` — PR #19381 fixed the symptom at the subscription
callback by running `normalizeKubernetesContextsResponse`. That works,
but it leaves the latent shape/lifecycle bugs in place and keeps the
GraphQL schema mismatch implicit. This change closes those loops at
the source: the wire data, the initial state, and the consumer all
agree on `totalCount` from mount onward.

## Test plan
- [x] `npx vitest run components/AppComponents.test.tsx rtk-query/__tests__/transforms.test.ts` — 6 pass (added a new test covering the already-camelCased subscription payload)
- [x] `npx eslint --cache --quiet` on all touched files
- [x] `npx relay-compiler` regenerates the K8sContextSubscription artifact cleanly
- [ ] Smoke: load Meshery UI with >0 k8s connections and confirm the badge renders the real count from the first paint