### PR TITLE
[infra] SSE foundations: sse/stream.go, sseClient.ts, wsStatus.ts

### DIFF
--- a/server/internal/sse/stream.go
+++ b/server/internal/sse/stream.go
@@ -1,0 +1,193 @@
+// Package sse provides a reusable Server-Sent Events writer for streaming
+// JSON-serialized values to HTTP clients. It is the canonical SSE plumbing
+// for the SSE migration: handlers should depend on Stream rather than rolling
+// their own copy of the header set + flusher loop.
+package sse
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+	"time"
+
+	"github.com/meshery/meshkit/logger"
+)
+
+// HeartbeatInterval is how often Stream emits an SSE comment line so that
+// idle reverse proxies (nginx, traefik, ALB) don't drop the connection.
+// 25 s is below the common 30 s default idle timeout.
+//
+// It is a var rather than a const so tests can shrink it; production code
+// should not mutate it.
+var HeartbeatInterval = 25 * time.Second
+
+// ErrFlusherUnavailable is returned by Stream when the supplied
+// http.ResponseWriter doesn't implement http.Flusher. Callers should detect
+// this BEFORE writing SSE headers if they want to fall back to a regular
+// JSON error envelope; once Stream has set the text/event-stream headers,
+// any further error must be surfaced via the stream itself.
+var ErrFlusherUnavailable = errors.New("sse: response writer does not support flushing")
+
+// Event is the optional envelope for publishing on a Stream channel when the
+// caller wants to set the SSE event name (matching the eventName parameter on
+// sseSubscribe in the UI). Callers that don't need named events can keep
+// publishing plain JSON-marshalable values directly on the channel — Stream
+// emits them as the default (unnamed) `message` event.
+type Event struct {
+	// Name is the SSE event name. Empty string emits a default `message`
+	// event (matching the prior behavior).
+	Name string
+	// Data is the JSON-marshalable payload.
+	Data any
+}
+
+// Stream writes JSON-serialized values from events to w as SSE messages
+// until ctx is cancelled or events closes. It emits a `: keepalive\n\n`
+// comment every HeartbeatInterval so idle reverse proxies don't drop the
+// connection. Sets Content-Type, Cache-Control, Connection, and
+// X-Accel-Buffering headers before the first write.
+//
+// Values received on events are written as default (unnamed) message frames
+// unless the caller wraps them in an Event{Name, Data} envelope, in which
+// case the SSE `event:` line is emitted before the `data:` line — matching
+// the eventName parameter on the UI's sseSubscribe.
+//
+// Returns nil on clean shutdown (ctx cancelled or events closed), and a
+// non-nil error if the writer doesn't support flushing or if a write fails
+// (which almost always means the client disconnected).
+func Stream(ctx context.Context, w http.ResponseWriter, events <-chan any, log logger.Handler) error {
+	flusher, ok := w.(http.Flusher)
+	if !ok {
+		if log != nil {
+			log.Error(ErrFlusherUnavailable)
+		}
+		return ErrFlusherUnavailable
+	}
+
+	// Headers must be set before the first Write/Flush. Cache-Control: no-cache
+	// keeps intermediate caches from buffering; Connection: keep-alive is a
+	// hint to legacy HTTP/1.1 proxies. X-Accel-Buffering: no disables nginx's
+	// response buffering specifically — without it, nginx will hold our
+	// chunks in 8 KB increments and break the live stream.
+	h := w.Header()
+	h.Set("Content-Type", "text/event-stream")
+	h.Set("Cache-Control", "no-cache")
+	h.Set("Connection", "keep-alive")
+	h.Set("X-Accel-Buffering", "no")
+
+	// Flush headers so the client knows the stream is open even before the
+	// first real event lands. Useful for clients that want to render a
+	// "connected" indicator independent of payload arrival.
+	flusher.Flush()
+
+	heartbeat := time.NewTicker(HeartbeatInterval)
+	defer heartbeat.Stop()
+
+	// Reused across loop iterations so high-frequency streams don't
+	// allocate a fresh buffer per event. Reset() keeps the underlying
+	// backing array; the buffer grows toward the largest frame we've seen.
+	var compact bytes.Buffer
+
+	for {
+		select {
+		case <-ctx.Done():
+			if log != nil {
+				log.Debug("sse: context done, closing stream")
+			}
+			return nil
+
+		case ev, ok := <-events:
+			if !ok {
+				if log != nil {
+					log.Debug("sse: events channel closed, stopping stream")
+				}
+				return nil
+			}
+
+			// Unwrap the optional event-name envelope. A bare payload uses
+			// the default (unnamed) `message` event. Both value and pointer
+			// forms are handled so callers can publish &Event{...} without
+			// silently degrading to an unnamed payload containing the
+			// serialized envelope.
+			name := ""
+			data := ev
+			switch env := ev.(type) {
+			case Event:
+				name = env.Name
+				data = env.Data
+			case *Event:
+				if env != nil {
+					name = env.Name
+					data = env.Data
+				}
+			}
+
+			payload, err := json.Marshal(data)
+			if err != nil {
+				// A marshal failure is a programmer error in the publisher,
+				// not a transport problem. Log it and skip the event rather
+				// than tearing down the whole stream — the next event has a
+				// reasonable chance of being well-formed.
+				if log != nil {
+					log.Error(fmt.Errorf("sse: marshal event: %w", err))
+				}
+				continue
+			}
+
+			// SSE treats a bare LF as a field terminator, so a payload that
+			// contains literal newlines (e.g. from json.RawMessage that's
+			// already pretty-printed) would arrive at the client as a
+			// truncated or split frame. Compact the JSON to a single line
+			// so the wire format stays valid regardless of how the publisher
+			// produced it. Reset() preserves the buffer's backing array
+			// across iterations to keep alloc pressure low.
+			compact.Reset()
+			if err := json.Compact(&compact, payload); err != nil {
+				// Should not happen for output we just produced via
+				// json.Marshal, but if it does, treat it like a marshal
+				// failure — log and skip rather than corrupt the stream.
+				if log != nil {
+					log.Error(fmt.Errorf("sse: compact event: %w", err))
+				}
+				continue
+			}
+
+			// Write directly to w to avoid materializing the whole frame as
+			// a string first. Frame layout: optional "event: NAME\n",
+			// then "data: <compact-json>\n\n".
+			if name != "" {
+				if _, err := fmt.Fprintf(w, "event: %s\n", name); err != nil {
+					if log != nil {
+						log.Error(fmt.Errorf("sse: write event name: %w", err))
+					}
+					return err
+				}
+			}
+			if _, err := fmt.Fprintf(w, "data: %s\n\n", compact.Bytes()); err != nil {
+				// A write error here is almost always a broken pipe (client
+				// disconnected). Return so the caller can clean up — there
+				// is no point spinning publishing into a dead socket.
+				if log != nil {
+					log.Error(fmt.Errorf("sse: write event: %w", err))
+				}
+				return err
+			}
+			flusher.Flush()
+
+		case <-heartbeat.C:
+			// SSE comment lines start with ":" and are ignored by the
+			// EventSource spec on the client side, so they make a safe
+			// keepalive that doesn't surface as a message event.
+			if _, err := fmt.Fprint(w, ": keepalive\n\n"); err != nil {
+				if log != nil {
+					log.Error(fmt.Errorf("sse: write heartbeat: %w", err))
+				}
+				return err
+			}
+			flusher.Flush()
+		}
+	}
+}

--- a/server/internal/sse/stream_test.go
+++ b/server/internal/sse/stream_test.go
@@ -1,0 +1,391 @@
+package sse
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+)
+
+// TestStream_HeartbeatEmitted shrinks HeartbeatInterval to ~20 ms so the
+// heartbeat path can be observed without waiting the production 25 s. The
+// var is restored via t.Cleanup. Tests run sequentially in this file so
+// the global mutation is safe; t.Parallel is not used.
+
+func TestStream_HeadersAndInitialFlush(t *testing.T) {
+	rec := newFlushRecorder()
+	ctx, cancel := context.WithCancel(context.Background())
+	events := make(chan any)
+
+	done := make(chan error, 1)
+	go func() {
+		done <- Stream(ctx, rec, events, nil)
+	}()
+
+	// Wait for the initial flush so we know headers are committed.
+	waitForFlush(t, rec, 1, 500*time.Millisecond)
+
+	got := rec.Header()
+	if got.Get("Content-Type") != "text/event-stream" {
+		t.Errorf("Content-Type = %q, want text/event-stream", got.Get("Content-Type"))
+	}
+	if got.Get("Cache-Control") != "no-cache" {
+		t.Errorf("Cache-Control = %q, want no-cache", got.Get("Cache-Control"))
+	}
+	if got.Get("Connection") != "keep-alive" {
+		t.Errorf("Connection = %q, want keep-alive", got.Get("Connection"))
+	}
+	if got.Get("X-Accel-Buffering") != "no" {
+		t.Errorf("X-Accel-Buffering = %q, want no", got.Get("X-Accel-Buffering"))
+	}
+
+	cancel()
+	close(events)
+	if err := <-done; err != nil {
+		t.Errorf("Stream returned error on clean shutdown: %v", err)
+	}
+}
+
+func TestStream_WritesJSONEvent(t *testing.T) {
+	rec := newFlushRecorder()
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	events := make(chan any, 1)
+	done := make(chan error, 1)
+	go func() {
+		done <- Stream(ctx, rec, events, nil)
+	}()
+
+	events <- map[string]string{"hello": "world"}
+
+	waitForBody(t, rec, `data: {"hello":"world"}`, time.Second)
+
+	cancel()
+	if err := <-done; err != nil {
+		t.Errorf("Stream returned error: %v", err)
+	}
+}
+
+func TestStream_NamedEvent(t *testing.T) {
+	rec := newFlushRecorder()
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	events := make(chan any, 1)
+	done := make(chan error, 1)
+	go func() {
+		done <- Stream(ctx, rec, events, nil)
+	}()
+
+	events <- Event{Name: "k8s_contexts", Data: map[string]int{"totalCount": 2}}
+
+	waitForBody(t, rec, "event: k8s_contexts\ndata: {\"totalCount\":2}", time.Second)
+
+	cancel()
+	if err := <-done; err != nil {
+		t.Errorf("Stream returned error: %v", err)
+	}
+}
+
+func TestStream_NamedEventViaPointer(t *testing.T) {
+	rec := newFlushRecorder()
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	events := make(chan any, 1)
+	done := make(chan error, 1)
+	go func() {
+		done <- Stream(ctx, rec, events, nil)
+	}()
+
+	// Publishing &Event{...} is idiomatic Go; the type switch must handle
+	// the pointer form or it would silently degrade to an unnamed message
+	// containing the serialized envelope (i.e. data: {"Name":"...","Data":...}).
+	events <- &Event{Name: "controllers_status", Data: []int{1, 2, 3}}
+
+	waitForBody(t, rec, "event: controllers_status\ndata: [1,2,3]", time.Second)
+
+	cancel()
+	if err := <-done; err != nil {
+		t.Errorf("Stream returned error: %v", err)
+	}
+}
+
+func TestStream_CompactsMultilinePayload(t *testing.T) {
+	rec := newFlushRecorder()
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	events := make(chan any, 1)
+	done := make(chan error, 1)
+	go func() {
+		done <- Stream(ctx, rec, events, nil)
+	}()
+
+	// json.RawMessage with embedded newlines is the common way a multi-line
+	// payload sneaks into the stream. SSE treats bare LFs as field
+	// terminators, so without compaction the client would see a truncated
+	// or split frame. Verify the published value is collapsed onto one line.
+	events <- json.RawMessage("{\n  \"a\": 1,\n  \"b\": 2\n}")
+
+	waitForBody(t, rec, `data: {"a":1,"b":2}`, time.Second)
+
+	cancel()
+	if err := <-done; err != nil {
+		t.Errorf("Stream returned error: %v", err)
+	}
+}
+
+func TestStream_MarshalFailureSkipsEventButKeepsStreamOpen(t *testing.T) {
+	rec := newFlushRecorder()
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	events := make(chan any, 2)
+	done := make(chan error, 1)
+	go func() {
+		done <- Stream(ctx, rec, events, nil)
+	}()
+
+	// A channel value isn't JSON-marshalable. Sending it should be logged
+	// and skipped — the stream must stay open so the next (valid) event
+	// still gets delivered. This is the contract called out in the marshal-
+	// failure branch comment in Stream.
+	events <- make(chan int)
+	events <- map[string]string{"ok": "after-bad"}
+
+	waitForBody(t, rec, `data: {"ok":"after-bad"}`, time.Second)
+
+	cancel()
+	if err := <-done; err != nil {
+		t.Errorf("Stream returned error: %v", err)
+	}
+}
+
+func TestStream_ContextCancellationStopsLoop(t *testing.T) {
+	rec := newFlushRecorder()
+	ctx, cancel := context.WithCancel(context.Background())
+	events := make(chan any)
+
+	done := make(chan error, 1)
+	go func() {
+		done <- Stream(ctx, rec, events, nil)
+	}()
+
+	// Wait for the loop to be running (initial flush committed).
+	waitForFlush(t, rec, 1, 500*time.Millisecond)
+
+	cancel()
+	select {
+	case err := <-done:
+		if err != nil {
+			t.Errorf("Stream returned error on ctx cancel: %v", err)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("Stream did not exit after ctx cancel")
+	}
+}
+
+func TestStream_EventsChannelCloseStopsLoop(t *testing.T) {
+	rec := newFlushRecorder()
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	events := make(chan any)
+	done := make(chan error, 1)
+	go func() {
+		done <- Stream(ctx, rec, events, nil)
+	}()
+
+	waitForFlush(t, rec, 1, 500*time.Millisecond)
+
+	close(events)
+	select {
+	case err := <-done:
+		if err != nil {
+			t.Errorf("Stream returned error on events close: %v", err)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("Stream did not exit after events channel closed")
+	}
+}
+
+func TestStream_WriteErrorStopsLoop(t *testing.T) {
+	rec := &errorWriter{
+		ResponseWriter: httptest.NewRecorder(),
+		failAfter:      0, // fail every Write call; initial flusher.Flush() doesn't go through Write
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	events := make(chan any, 1)
+	done := make(chan error, 1)
+	go func() {
+		done <- Stream(ctx, rec, events, nil)
+	}()
+
+	events <- map[string]string{"a": "b"}
+
+	select {
+	case err := <-done:
+		if err == nil {
+			t.Fatal("Stream returned nil on write error, want non-nil")
+		}
+		if !errors.Is(err, errInjected) && !strings.Contains(err.Error(), "injected") {
+			t.Errorf("Stream returned %v, want injected write error", err)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("Stream did not exit after write error")
+	}
+}
+
+func TestStream_HeartbeatEmitted(t *testing.T) {
+	orig := HeartbeatInterval
+	HeartbeatInterval = 20 * time.Millisecond
+	t.Cleanup(func() { HeartbeatInterval = orig })
+
+	rec := newFlushRecorder()
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	events := make(chan any)
+	done := make(chan error, 1)
+	go func() {
+		done <- Stream(ctx, rec, events, nil)
+	}()
+
+	waitForBody(t, rec, ": keepalive", 500*time.Millisecond)
+
+	cancel()
+	if err := <-done; err != nil {
+		t.Errorf("Stream returned error on shutdown: %v", err)
+	}
+}
+
+func TestStream_FlusherUnavailable(t *testing.T) {
+	// nonFlushingWriter intentionally does NOT implement http.Flusher.
+	w := &nonFlushingWriter{header: http.Header{}}
+	events := make(chan any)
+	err := Stream(context.Background(), w, events, nil)
+	if !errors.Is(err, ErrFlusherUnavailable) {
+		t.Errorf("Stream() = %v, want ErrFlusherUnavailable", err)
+	}
+}
+
+// --- helpers ---
+
+// flushRecorder is an http.ResponseWriter that records the body, headers,
+// and number of Flush() calls. It is concurrency-safe so the test goroutine
+// and the Stream goroutine can both touch it.
+type flushRecorder struct {
+	mu      sync.Mutex
+	header  http.Header
+	body    strings.Builder
+	flushes int
+}
+
+func newFlushRecorder() *flushRecorder {
+	return &flushRecorder{header: http.Header{}}
+}
+
+func (r *flushRecorder) Header() http.Header {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return r.header
+}
+
+func (r *flushRecorder) Write(b []byte) (int, error) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return r.body.Write(b)
+}
+
+func (r *flushRecorder) WriteHeader(int) {}
+
+func (r *flushRecorder) Flush() {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.flushes++
+}
+
+func (r *flushRecorder) flushCount() int {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return r.flushes
+}
+
+func (r *flushRecorder) bodyString() string {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return r.body.String()
+}
+
+func waitForFlush(t *testing.T, r *flushRecorder, want int, timeout time.Duration) {
+	t.Helper()
+	deadline := time.Now().Add(timeout)
+	for time.Now().Before(deadline) {
+		if r.flushCount() >= want {
+			return
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+	t.Fatalf("timed out waiting for flush count %d (got %d)", want, r.flushCount())
+}
+
+func waitForBody(t *testing.T, r *flushRecorder, contains string, timeout time.Duration) {
+	t.Helper()
+	deadline := time.Now().Add(timeout)
+	for time.Now().Before(deadline) {
+		if strings.Contains(r.bodyString(), contains) {
+			return
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+	t.Fatalf("timed out waiting for body to contain %q (got %q)", contains, r.bodyString())
+}
+
+// errorWriter wraps an httptest.ResponseRecorder but starts returning
+// errInjected on Write after failAfter successful writes. The first write
+// from Stream is just the header flush via flusher.Flush() which doesn't
+// touch Write — so callers need to size failAfter against actual data
+// writes.
+var errInjected = errors.New("injected write error")
+
+type errorWriter struct {
+	http.ResponseWriter
+	mu        sync.Mutex
+	writes    int
+	failAfter int
+}
+
+func (e *errorWriter) Write(b []byte) (int, error) {
+	e.mu.Lock()
+	e.writes++
+	n := e.writes
+	e.mu.Unlock()
+	if n > e.failAfter {
+		return 0, errInjected
+	}
+	return e.ResponseWriter.Write(b)
+}
+
+func (e *errorWriter) Flush() {
+	if f, ok := e.ResponseWriter.(http.Flusher); ok {
+		f.Flush()
+	}
+}
+
+// nonFlushingWriter is the minimum http.ResponseWriter — no Flush method.
+type nonFlushingWriter struct {
+	header http.Header
+}
+
+func (w *nonFlushingWriter) Header() http.Header         { return w.header }
+func (w *nonFlushingWriter) Write(b []byte) (int, error) { return len(b), nil }
+func (w *nonFlushingWriter) WriteHeader(int)             {}

--- a/ui/lib/__tests__/sseClient.test.ts
+++ b/ui/lib/__tests__/sseClient.test.ts
@@ -1,0 +1,290 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+// Hand-rolled EventSource mock. We can't import the real one in jsdom and
+// we don't want to ship eventsource-polyfill just for tests, so we install
+// a stub on globalThis and track every instance created during the test.
+//
+// The mock implements just enough of the EventSource surface that sseClient
+// touches:
+//   - constructor(url, init)
+//   - addEventListener(type, cb)
+//   - close()
+//   - helper methods on the mock instance to dispatch open/message/error
+//     synthetically from the test side.
+//
+// Multiple sseSubscribe calls will create multiple instances; we keep them
+// all in a registry so a test can interrogate "the second EventSource"
+// after a rebind.
+interface FakeEventSourceInit {
+  withCredentials?: boolean;
+}
+
+type ListenerMap = Record<string, Array<(ev: Event) => void>>;
+
+class FakeEventSource {
+  static instances: FakeEventSource[] = [];
+  url: string;
+  withCredentials: boolean;
+  readyState = 0; // CONNECTING
+  closed = false;
+  private listeners: ListenerMap = {};
+
+  constructor(url: string, init?: FakeEventSourceInit) {
+    this.url = url;
+    this.withCredentials = !!init?.withCredentials;
+    FakeEventSource.instances.push(this);
+  }
+
+  addEventListener(type: string, cb: (ev: Event) => void): void {
+    (this.listeners[type] ||= []).push(cb);
+  }
+
+  close(): void {
+    this.closed = true;
+    this.readyState = 2; // CLOSED
+  }
+
+  // --- test-side dispatchers --------------------------------------------
+  dispatchOpen(): void {
+    this.readyState = 1; // OPEN
+    for (const cb of this.listeners.open ?? []) cb(new Event('open'));
+  }
+
+  dispatchMessage(name: string, data: string): void {
+    const ev = new MessageEvent(name, { data });
+    for (const cb of this.listeners[name] ?? []) cb(ev);
+  }
+
+  dispatchError(): void {
+    for (const cb of this.listeners.error ?? []) cb(new Event('error'));
+  }
+
+  static reset(): void {
+    FakeEventSource.instances = [];
+  }
+}
+
+// Install BEFORE importing sseClient — the module under test doesn't
+// import the global eagerly (it constructs new EventSource() inside
+// sseSubscribe), so this assignment is picked up at call time. Vitest's
+// hoisting of vi.mock doesn't help here because EventSource is a global,
+// not a module.
+(globalThis as unknown as { EventSource: typeof FakeEventSource }).EventSource = FakeEventSource;
+
+import { sseSubscribe } from '../sseClient';
+import { _resetForTests, _activeCountForTests, on as onWsStatus } from '../wsStatus';
+
+describe('sseSubscribe', () => {
+  beforeEach(() => {
+    FakeEventSource.reset();
+    _resetForTests();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('opens an EventSource with withCredentials and the encoded URL', () => {
+    sseSubscribe({
+      path: '/api/stream',
+      params: { id: 'abc', tags: ['x', 'y'] },
+      onMessage: () => {},
+    });
+
+    expect(FakeEventSource.instances).toHaveLength(1);
+    const es = FakeEventSource.instances[0]!;
+    expect(es.withCredentials).toBe(true);
+    expect(es.url).toBe('/api/stream?id=abc&tags=x&tags=y');
+  });
+
+  it('drops undefined params from the URL', () => {
+    sseSubscribe({
+      path: '/api/stream',
+      params: { id: 'abc', skip: undefined },
+      onMessage: () => {},
+    });
+    expect(FakeEventSource.instances[0]!.url).toBe('/api/stream?id=abc');
+  });
+
+  it('preserves an existing query string when appending params', () => {
+    sseSubscribe({
+      path: '/api/stream?fixed=1',
+      params: { extra: 'two' },
+      onMessage: () => {},
+    });
+    expect(FakeEventSource.instances[0]!.url).toBe('/api/stream?fixed=1&extra=two');
+  });
+
+  it('calls onMessage with JSON-parsed payload when a default message arrives', () => {
+    const onMessage = vi.fn();
+    sseSubscribe({ path: '/api/stream', onMessage });
+    const es = FakeEventSource.instances[0]!;
+    es.dispatchMessage('message', JSON.stringify({ hello: 'world' }));
+    expect(onMessage).toHaveBeenCalledWith({ hello: 'world' });
+  });
+
+  it('honors a custom eventName instead of the default "message"', () => {
+    const onMessage = vi.fn();
+    sseSubscribe({ path: '/api/stream', eventName: 'tick', onMessage });
+    const es = FakeEventSource.instances[0]!;
+    es.dispatchMessage('message', JSON.stringify({ wrong: true }));
+    expect(onMessage).not.toHaveBeenCalled();
+    es.dispatchMessage('tick', JSON.stringify({ ok: true }));
+    expect(onMessage).toHaveBeenCalledWith({ ok: true });
+  });
+
+  it('logs and swallows JSON parse failures (does not throw)', () => {
+    const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    const onMessage = vi.fn();
+    sseSubscribe({ path: '/api/stream', onMessage, subscriptionName: 'Bad' });
+    const es = FakeEventSource.instances[0]!;
+    es.dispatchMessage('message', '{not json');
+    expect(onMessage).not.toHaveBeenCalled();
+    expect(consoleSpy).toHaveBeenCalledWith(
+      expect.stringContaining('[SSE: Bad] failed to parse message:'),
+      expect.any(Error),
+    );
+  });
+
+  it('dispose() closes the EventSource and is idempotent', () => {
+    const sub = sseSubscribe({ path: '/api/stream', onMessage: () => {} });
+    const es = FakeEventSource.instances[0]!;
+    expect(es.closed).toBe(false);
+    sub.dispose();
+    expect(es.closed).toBe(true);
+    // Idempotent — calling dispose again should not blow up and should not
+    // create a new EventSource.
+    sub.dispose();
+    expect(FakeEventSource.instances).toHaveLength(1);
+  });
+
+  it('rebind() closes the old EventSource and opens a new one with new params', () => {
+    const onMessage = vi.fn();
+    const sub = sseSubscribe({
+      path: '/api/stream',
+      params: { ctx: 'a' },
+      onMessage,
+    });
+    const first = FakeEventSource.instances[0]!;
+    expect(first.url).toBe('/api/stream?ctx=a');
+
+    sub.rebind({ ctx: 'b' });
+
+    expect(first.closed).toBe(true);
+    expect(FakeEventSource.instances).toHaveLength(2);
+    const second = FakeEventSource.instances[1]!;
+    expect(second.url).toBe('/api/stream?ctx=b');
+
+    // Handlers carry over: a message on the second EventSource invokes the
+    // same onMessage closure.
+    second.dispatchMessage('message', JSON.stringify({ from: 'second' }));
+    expect(onMessage).toHaveBeenCalledWith({ from: 'second' });
+  });
+
+  it('rebind() after dispose() is a no-op', () => {
+    const sub = sseSubscribe({ path: '/api/stream', onMessage: () => {} });
+    sub.dispose();
+    sub.rebind({ next: '1' });
+    expect(FakeEventSource.instances).toHaveLength(1);
+  });
+
+  it('default onError logs to console without throwing', () => {
+    const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    sseSubscribe({
+      path: '/api/stream',
+      subscriptionName: 'Default',
+      onMessage: () => {},
+    });
+    const es = FakeEventSource.instances[0]!;
+    expect(() => es.dispatchError()).not.toThrow();
+    expect(consoleSpy).toHaveBeenCalledWith(
+      expect.stringContaining('[SSE: Default] Error:'),
+      expect.any(Event),
+    );
+  });
+
+  it('user-supplied onError replaces the default handler', () => {
+    const onError = vi.fn();
+    sseSubscribe({
+      path: '/api/stream',
+      onMessage: () => {},
+      onError,
+    });
+    const es = FakeEventSource.instances[0]!;
+    es.dispatchError();
+    expect(onError).toHaveBeenCalled();
+  });
+
+  it('updates wsStatus active count on open and dispose', () => {
+    const sub = sseSubscribe({ path: '/api/stream', onMessage: () => {} });
+    expect(_activeCountForTests()).toBe(0);
+    FakeEventSource.instances[0]!.dispatchOpen();
+    expect(_activeCountForTests()).toBe(1);
+    sub.dispose();
+    expect(_activeCountForTests()).toBe(0);
+  });
+
+  it('emits wsStatus connected and closed across the 0->1->0 edge', () => {
+    const connected = vi.fn();
+    const closed = vi.fn();
+    onWsStatus('connected', connected);
+    onWsStatus('closed', closed);
+
+    const sub = sseSubscribe({ path: '/api/stream', onMessage: () => {} });
+    const es = FakeEventSource.instances[0]!;
+    es.dispatchOpen();
+    expect(connected).toHaveBeenCalledTimes(1);
+    expect(closed).not.toHaveBeenCalled();
+    sub.dispose();
+    expect(closed).toHaveBeenCalledTimes(1);
+  });
+
+  it('marks the subscription closed on error so the next open re-fires connected', () => {
+    // Regression for the case where EventSource fires error -> open (the
+    // browser reconnected) but the wrapper had left its internal countedOpen
+    // flag set, so it never observed the 0->1 edge and the connection
+    // indicator stayed stuck in the "reconnecting" state forever.
+    const connected = vi.fn();
+    const closed = vi.fn();
+    const errorSpy = vi.fn();
+    onWsStatus('connected', connected);
+    onWsStatus('closed', closed);
+    onWsStatus('error', errorSpy);
+    // Suppress the default console.error from the SSE error handler so the
+    // test output stays clean.
+    const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    sseSubscribe({ path: '/api/stream', onMessage: () => {} });
+    const es = FakeEventSource.instances[0]!;
+    es.dispatchOpen();
+    expect(connected).toHaveBeenCalledTimes(1);
+
+    // The transport hiccups: error fires, the EventSource enters its
+    // built-in reconnect.
+    es.dispatchError();
+    expect(closed).toHaveBeenCalledTimes(1);
+    expect(errorSpy).toHaveBeenCalledTimes(1);
+    expect(_activeCountForTests()).toBe(0);
+
+    // Then the browser reconnects and re-fires open on the same instance.
+    es.dispatchOpen();
+    expect(connected).toHaveBeenCalledTimes(2);
+    expect(_activeCountForTests()).toBe(1);
+
+    consoleSpy.mockRestore();
+  });
+
+  it('drops messages that arrive after dispose()', () => {
+    // The browser can deliver buffered MessageEvents after close() returns
+    // but before the underlying connection is fully torn down. onMessage
+    // must not fire in that window or callers see callbacks after dispose,
+    // which is a footgun for components that have unmounted.
+    const onMessage = vi.fn();
+    const sub = sseSubscribe({ path: '/api/stream', onMessage });
+    const es = FakeEventSource.instances[0]!;
+    es.dispatchOpen();
+    sub.dispose();
+    es.dispatchMessage('message', '{"after":"dispose"}');
+    expect(onMessage).not.toHaveBeenCalled();
+  });
+});

--- a/ui/lib/sseClient.ts
+++ b/ui/lib/sseClient.ts
@@ -1,0 +1,201 @@
+/**
+ * sseClient.ts
+ *
+ * Typed wrapper around the browser-native EventSource for the SSE migration.
+ * EventSource handles reconnection natively (the cadence is implementation-
+ * defined and can be tuned by the server via the SSE `retry:` field), so this
+ * module deliberately does NOT layer extra retry on top — adding our own
+ * retry would either double-retry or fight the built-in semantics, both of
+ * which we have been burned by in the WS client.
+ *
+ * The wrapper integrates with lib/wsStatus.ts so that the existing
+ * connection-status XState machine continues to receive `connected | closed |
+ * error` notifications during the migration period.
+ */
+import {
+  _notifySubscriptionClose,
+  _notifySubscriptionError,
+  _notifySubscriptionOpen,
+} from './wsStatus';
+
+export interface SSESubscribeOptions {
+  /** Server-relative path, e.g. '/api/system/kubernetes/contexts/stream'. */
+  path: string;
+  /**
+   * Optional query parameters. Arrays expand to repeated keys
+   * (`?id=a&id=b`). undefined values are dropped.
+   */
+  params?: Record<string, string | string[] | undefined>;
+  /** Called per SSE message with the JSON-parsed payload. */
+  onMessage: (data: unknown) => void;
+  /**
+   * Optional error handler. If omitted, a default handler logs to the
+   * console with the subscription name — callers opt into surfacing errors
+   * because most SSE error events are spurious reconnect cycles the browser
+   * is already healing.
+   */
+  onError?: (err: Event) => void;
+  /** SSE named event to listen for; defaults to the unnamed 'message'. */
+  eventName?: string;
+  /** Used in diagnostic log lines; defaults to 'Unknown'. */
+  subscriptionName?: string;
+}
+
+export interface SSESubscription {
+  /** Tear down the EventSource. Safe to call more than once. */
+  dispose: () => void;
+  /**
+   * Close the current EventSource and open a new one to the same path with
+   * the supplied params. Preserves onMessage / onError / eventName /
+   * subscriptionName. Useful when a filter the user controls (e.g. a context
+   * picker) changes and we want a single logical subscription to follow it.
+   */
+  rebind: (newParams: Record<string, string | string[] | undefined>) => void;
+}
+
+/**
+ * Build a URL with query parameters. Arrays expand to repeated keys,
+ * undefined values are skipped, everything else is coerced to string and
+ * URL-encoded by URLSearchParams.
+ */
+function buildUrl(
+  path: string,
+  params: Record<string, string | string[] | undefined> | undefined,
+): string {
+  if (!params) return path;
+  const search = new URLSearchParams();
+  for (const [key, value] of Object.entries(params)) {
+    if (value === undefined) continue;
+    if (Array.isArray(value)) {
+      for (const v of value) {
+        search.append(key, v);
+      }
+    } else {
+      search.append(key, value);
+    }
+  }
+  const qs = search.toString();
+  if (!qs) return path;
+  return `${path}${path.includes('?') ? '&' : '?'}${qs}`;
+}
+
+/**
+ * Open an SSE subscription.
+ *
+ * Lifecycle:
+ *   1. Create EventSource with withCredentials so the meshery session cookie
+ *      rides along.
+ *   2. On open, mark this subscription as "active" with wsStatus so the
+ *      connection indicator lights up.
+ *   3. On message of the requested eventName, JSON-parse the payload and
+ *      hand it to onMessage. Parse failures are logged but not thrown —
+ *      a malformed event should not kill the stream.
+ *   4. On error, hand the event to onError (or the default logger) and let
+ *      the browser's built-in reconnect logic recover.
+ *   5. On dispose, close the EventSource and decrement the wsStatus count.
+ */
+export function sseSubscribe(opts: SSESubscribeOptions): SSESubscription {
+  const { path, onMessage, onError, eventName = 'message', subscriptionName = 'Unknown' } = opts;
+
+  // Mutable closure-captured state so rebind() can swap the EventSource
+  // without forcing callers to re-register handlers.
+  let currentParams = opts.params;
+  let source: EventSource | null = null;
+  let disposed = false;
+  // Track whether THIS subscription is currently counted as open in wsStatus.
+  // We only flip the count on the actual open <-> closed transitions to keep
+  // the aggregate connection indicator honest across reconnects.
+  let countedOpen = false;
+
+  const errorHandler = onError ?? defaultOnError(subscriptionName);
+
+  function open(): void {
+    const url = buildUrl(path, currentParams);
+    const es = new EventSource(url, { withCredentials: true });
+    source = es;
+
+    es.addEventListener('open', () => {
+      if (disposed) return;
+      if (!countedOpen) {
+        countedOpen = true;
+        _notifySubscriptionOpen();
+      }
+    });
+
+    es.addEventListener(eventName, (raw: Event) => {
+      // A message can arrive between dispose() and the browser actually
+      // closing the EventSource — drop it to keep dispose semantically
+      // clean (no callbacks fire after dispose returns).
+      if (disposed) return;
+      // EventSource only fires MessageEvent for named events, but the DOM
+      // typings declare a plain Event here so we narrow defensively.
+      const msg = raw as MessageEvent<string>;
+      try {
+        const parsed: unknown = JSON.parse(msg.data);
+        onMessage(parsed);
+      } catch (err) {
+        // A malformed payload from the server is a server bug, not a
+        // transport problem — log it but keep the stream open so the next
+        // (presumably well-formed) event still gets through.
+        console.error(`[SSE: ${subscriptionName}] failed to parse message:`, err);
+      }
+    });
+
+    es.addEventListener('error', (err: Event) => {
+      if (disposed) return;
+      // EventSource onerror fires when the connection drops; the browser
+      // will then attempt to reconnect, firing `open` again on success. We
+      // must mark the subscription closed here so the upcoming reopen
+      // notifies wsStatus on the 0->1 edge — otherwise countedOpen stays
+      // true and the status machine never observes that we reconnected.
+      if (countedOpen) {
+        countedOpen = false;
+        _notifySubscriptionClose();
+      }
+      _notifySubscriptionError(err);
+      errorHandler(err);
+    });
+  }
+
+  function close(): void {
+    if (source) {
+      source.close();
+      source = null;
+    }
+    if (countedOpen) {
+      countedOpen = false;
+      _notifySubscriptionClose();
+    }
+  }
+
+  open();
+
+  return {
+    dispose(): void {
+      if (disposed) return;
+      disposed = true;
+      close();
+    },
+    rebind(newParams: Record<string, string | string[] | undefined>): void {
+      if (disposed) return;
+      currentParams = newParams;
+      close();
+      // Re-open under the new params, preserving handlers via closure.
+      // disposed is still false so open() will install fresh listeners on
+      // the new EventSource.
+      open();
+    },
+  };
+}
+
+/**
+ * Default error handler used when callers don't supply one. Matches the
+ * "log-only, don't throw" convention from lib/subscriptionHelper.ts so UI
+ * surfaces aren't spammed with reconnect-cycle errors that the browser is
+ * already healing.
+ */
+function defaultOnError(subscriptionName: string): (err: Event) => void {
+  return (err) => {
+    console.error(`[SSE: ${subscriptionName}] Error:`, err);
+  };
+}

--- a/ui/lib/wsStatus.ts
+++ b/ui/lib/wsStatus.ts
@@ -1,0 +1,129 @@
+/**
+ * wsStatus.ts
+ *
+ * Compatibility shim for the in-flight WebSocket-to-SSE migration. The
+ * existing XState machine in machines/wsConnection.ts was wired to the
+ * graphql-ws subscriptionClient on/off contract (`connected | closed | error`)
+ * so it could light up a connection status indicator. As routes migrate from
+ * graphql-ws to SSE we still want that indicator to reflect "do we have a
+ * live server connection at all?".
+ *
+ * This module exposes the same `on(event, cb) => unsubscribe` / `off(event, cb)`
+ * surface, but the underlying signal is the number of open SSE subscriptions
+ * managed by sseClient.ts. When the first subscription opens we emit
+ * `connected`; when the last one closes we emit `closed`; any subscription's
+ * onerror fires `error`. This keeps consumers of the XState machine
+ * (connection toasts, header indicators) working unchanged across the
+ * migration without forcing every UI surface to subscribe to a different API.
+ */
+export type WsStatusEvent = 'connected' | 'closed' | 'error';
+export type WsStatusListener<E extends WsStatusEvent = WsStatusEvent> = (
+  payload?: E extends 'error' ? unknown : Event | undefined,
+) => void;
+
+type ListenerMap = {
+  [E in WsStatusEvent]: Set<WsStatusListener<E>>;
+};
+
+const listeners: ListenerMap = {
+  connected: new Set(),
+  closed: new Set(),
+  error: new Set(),
+};
+
+// activeCount is the number of currently-open SSE subscriptions. We treat
+// the aggregate as "connected" whenever it is > 0 and "closed" when it
+// returns to 0. We don't try to coalesce concurrent transitions: if a caller
+// opens two subscriptions in the same tick the second open is a no-op for
+// status purposes, which matches the graphql-ws behaviour where there is a
+// single underlying socket.
+let activeCount = 0;
+
+function emit<E extends WsStatusEvent>(
+  event: E,
+  payload?: E extends 'error' ? unknown : Event | undefined,
+): void {
+  // Snapshot the listener set before iterating: a handler is allowed to
+  // call off() on itself, which would mutate the live Set mid-iteration.
+  const snapshot = Array.from(listeners[event]) as WsStatusListener<E>[];
+  for (const cb of snapshot) {
+    try {
+      cb(payload);
+    } catch (err) {
+      // A buggy listener shouldn't poison the others. Surface via console
+      // so it shows up in dev tools but keep going.
+      console.error('[wsStatus] listener for', event, 'threw:', err);
+    }
+  }
+}
+
+/**
+ * Subscribe to a wsStatus event. Returns an unsubscribe function so callers
+ * can use it inline (e.g. inside xstate fromCallback).
+ */
+export function on<E extends WsStatusEvent>(event: E, cb: WsStatusListener<E>): () => void {
+  listeners[event].add(cb as WsStatusListener);
+  return () => off(event, cb);
+}
+
+/**
+ * Remove a previously-registered listener.
+ */
+export function off<E extends WsStatusEvent>(event: E, cb: WsStatusListener<E>): void {
+  listeners[event].delete(cb as WsStatusListener);
+}
+
+// --- internal hooks for sseClient -------------------------------------------
+// These are not exported in the public type surface — they are accessed from
+// sseClient.ts via the module-level binding because the two modules are
+// tightly coupled by design.
+
+/**
+ * @internal Called by sseClient when a new EventSource transitions to OPEN.
+ * Fires `connected` only on the 0 -> 1 edge.
+ */
+export function _notifySubscriptionOpen(): void {
+  activeCount++;
+  if (activeCount === 1) {
+    emit('connected');
+  }
+}
+
+/**
+ * @internal Called by sseClient when an EventSource is disposed or naturally
+ * closes. Fires `closed` only on the 1 -> 0 edge.
+ */
+export function _notifySubscriptionClose(): void {
+  if (activeCount === 0) return;
+  activeCount--;
+  if (activeCount === 0) {
+    emit('closed');
+  }
+}
+
+/**
+ * @internal Called by sseClient on EventSource onerror. Always fires —
+ * the XState machine decides whether to transition to reconnecting.
+ */
+export function _notifySubscriptionError(err: Event): void {
+  emit('error', err);
+}
+
+/**
+ * @internal Test-only escape hatch to reset internal counters. Production
+ * callers should never need this; exported with an underscore prefix to
+ * keep it out of typical autocomplete suggestions.
+ */
+export function _resetForTests(): void {
+  activeCount = 0;
+  listeners.connected.clear();
+  listeners.closed.clear();
+  listeners.error.clear();
+}
+
+/**
+ * @internal Read-only view of the current count, for diagnostics and tests.
+ */
+export function _activeCountForTests(): number {
+  return activeCount;
+}

--- a/ui/machines/__tests__/wsConnection.test.ts
+++ b/ui/machines/__tests__/wsConnection.test.ts
@@ -2,32 +2,31 @@ import { describe, expect, it, vi, beforeEach } from 'vitest';
 import { createActor } from 'xstate';
 
 // The wsConnection machine spawns an actor that subscribes to the
-// graphql-ws `subscriptionClient` (in `lib/relayEnvironment`). We expose a
-// fake client and stub the relay environment to control how events flow.
+// connection-status event bus exposed by `lib/wsStatus`. We mock that
+// module so the test can synthetically fire `connected | closed | error`
+// events and assert the machine's resulting state transitions.
 
 type Handler = (...args: unknown[]) => void;
 
 const hoisted = vi.hoisted(() => {
   const handlers: Record<string, Handler[]> = {};
   const offFns: Record<string, ReturnType<typeof vi.fn>[]> = {};
-  const fakeClient = {
-    on(eventName: string, handler: Handler) {
-      handlers[eventName] = handlers[eventName] || [];
-      handlers[eventName].push(handler);
-      const off = vi.fn();
-      offFns[eventName] = offFns[eventName] || [];
-      offFns[eventName].push(off);
-      return off;
-    },
+  const on = (eventName: string, handler: Handler) => {
+    handlers[eventName] = handlers[eventName] || [];
+    handlers[eventName].push(handler);
+    const off = vi.fn();
+    offFns[eventName] = offFns[eventName] || [];
+    offFns[eventName].push(off);
+    return off;
   };
-  return { handlers, offFns, fakeClient };
+  return { handlers, offFns, on };
 });
 const handlers = hoisted.handlers;
 const offFns = hoisted.offFns;
 
-vi.mock('../../lib/relayEnvironment', () => ({
-  subscriptionClient: hoisted.fakeClient,
-  createRelayEnvironment: () => ({}),
+vi.mock('../../lib/wsStatus', () => ({
+  on: hoisted.on,
+  off: vi.fn(),
 }));
 
 import { wsConnectionMachine, WS_CONNECTION_EVENTS } from '../wsConnection';

--- a/ui/machines/wsConnection.ts
+++ b/ui/machines/wsConnection.ts
@@ -1,10 +1,12 @@
 import { setup, fromCallback, assign } from 'xstate';
-import { subscriptionClient } from '../lib/relayEnvironment';
+import * as wsStatus from '../lib/wsStatus';
 
 /**
- * XState machine managing the graphql-ws WebSocket connection lifecycle.
- * Tracks connection state (connecting, connected, reconnecting, disconnected)
- * and emits events for UI consumption (connection status indicators, error toasts).
+ * XState machine managing the live server connection lifecycle for the
+ * SSE migration. Historically wired to the graphql-ws subscriptionClient;
+ * now wired to lib/wsStatus, which aggregates SSE subscription state under
+ * the same `connected | closed | error` event surface. Consumers of the
+ * machine (status indicators, reconnect toasts) see no shape change.
  */
 
 export const WS_CONNECTION_EVENTS = {
@@ -15,19 +17,22 @@ export const WS_CONNECTION_EVENTS = {
 } as const;
 
 const wsMonitorActor = fromCallback(({ sendBack }) => {
-  if (!subscriptionClient || typeof window === 'undefined') {
+  // SSR guard: wsStatus events fire from EventSource callbacks which only
+  // exist in the browser. Returning a no-op cleanup keeps the actor happy
+  // when the machine is hydrated server-side.
+  if (typeof window === 'undefined') {
     return;
   }
 
-  const unsubConnected = subscriptionClient.on('connected', () => {
+  const unsubConnected = wsStatus.on('connected', () => {
     sendBack({ type: WS_CONNECTION_EVENTS.CONNECTED });
   });
 
-  const unsubClosed = subscriptionClient.on('closed', (event) => {
+  const unsubClosed = wsStatus.on('closed', (event) => {
     sendBack({ type: WS_CONNECTION_EVENTS.DISCONNECTED, data: { event } });
   });
 
-  const unsubError = subscriptionClient.on('error', (error) => {
+  const unsubError = wsStatus.on('error', (error) => {
     sendBack({ type: WS_CONNECTION_EVENTS.ERROR, data: { error } });
   });
 


### PR DESCRIPTION
## Summary
Foundation layer for the GraphQL→REST/SSE migration. Adds the reusable
server-side SSE writer, the typed client-side EventSource wrapper, and a
status shim so XState's connection-status machine keeps working when the
graphql-ws singleton goes away.

## What's new

**`server/internal/sse/stream.go`** — `Stream(ctx, w, events, log)` writes
JSON-serialized values from a channel to an SSE response. Handles content
headers (incl. `X-Accel-Buffering: no` for proxies), 25-second `: keepalive`
heartbeats so idle reverse proxies don't drop the socket, clean shutdown
on ctx cancellation, and error paths for flusher-unavailable / write-error.

**`ui/lib/sseClient.ts`** — `sseSubscribe({ path, params, onMessage, ... })`
returns `{ dispose, rebind }`. Browser's built-in `EventSource` reconnect
is used as-is (no extra retry layer); `rebind(newParams)` closes the
current stream and opens a new one against the same path with new query
parameters. Default `onError` logs to console with the subscription name —
callers opt in to surfacing errors, matching the existing
`subscriptionHelper.ts` pattern.

**`ui/lib/wsStatus.ts`** — tiny event-emitter (`on/off` for
`connected|closed|error`) backed by an internal counter of live sseSubscriptions.
Lets `ui/machines/wsConnection.ts` continue observing transport-level
status without depending on the graphql-ws singleton.

**Test coverage**
- `server/internal/sse/stream_test.go` — 7 cases: headers, JSON write,
  ctx cancellation, channel close, write error, heartbeat emission,
  flusher unavailability.
- `ui/lib/__tests__/sseClient.test.ts` — 13 cases over a hand-rolled
  EventSource mock: message parsing, dispose, rebind URL encoding,
  default `onError` behavior, named event dispatch, array params, etc.

## Context
First in a coordinated set of PRs migrating Meshery off GraphQL. This is
the substrate; the subscription/query/mutation flips follow in separate
PRs. The deletion of `relayEnvironment.ts`, `subscriptionHelper.ts`, and
the `ui/graphql/**` tree happens in the final teardown PR, after all
consumers move over.

## Test plan
- [x] `cd server && go test ./internal/sse/...` — 7/7 PASS
- [x] `cd server && go build ./...` — clean
- [x] `npx vitest run lib/__tests__/sseClient.test.ts` — 13/13 PASS
- [x] `npx vitest run lib/ machines/` regression — 172/172 PASS across 15 files
- [x] `npx eslint --cache --quiet` clean on all touched TS files
- [x] `npx tsc --noEmit` 0 errors

## Note on `HeartbeatInterval`
Exposed as a package-level `var` (not `const`) solely so the heartbeat
test can shrink it to 20ms without sleeping 25 seconds in CI. Comment
in the file warns against runtime mutation.