### PR TITLE
[server] Add REST and SSE endpoints replacing GraphQL operations

### DIFF
--- a/server/handlers/cluster_resources_handler.go
+++ b/server/handlers/cluster_resources_handler.go
@@ -1,0 +1,93 @@
+// Package handlers :  collection of handlers (aka "HTTP middleware")
+package handlers
+
+import (
+	"database/sql"
+	"encoding/json"
+	"net/http"
+
+	"github.com/meshery/meshery/server/internal/graphql/model"
+	"github.com/meshery/meshery/server/models"
+)
+
+// clusterResourcesQuery counts the kubernetes_resources rows grouped by kind,
+// scoped to the supplied cluster IDs and (optionally) namespace. Mirrors the
+// SQL used in server/internal/graphql/resolver/kubernetes.go:getClusterResources
+// because the resolver function is package-private — duplicating here is
+// preferable to widening the resolver's surface for code that the GraphQL
+// teardown PR will delete.
+//
+// Three legs unioned together:
+//  1. Cluster-scoped resources (no namespace, kind != "Namespace")
+//  2. Namespaced resources matching the supplied namespace
+//  3. Namespace resources themselves (kind == "Namespace")
+const clusterResourcesQuery = `
+	SELECT count(kind) as count, kind FROM kubernetes_resources kr LEFT JOIN kubernetes_resource_object_meta rom on kr.id = rom.id
+		WHERE kr.kind <> 'Namespace' AND rom.namespace = '' AND kr.cluster_id IN (?) GROUP BY kind
+			UNION
+	SELECT count(kind) as count, kind FROM kubernetes_resources kr LEFT JOIN kubernetes_resource_object_meta rom on kr.id = rom.id
+		WHERE rom.namespace IN (?) AND kr.cluster_id IN (?) GROUP BY kind
+			UNION
+	SELECT count(kind) as count, kind FROM kubernetes_resources kr
+		WHERE kr.kind = 'Namespace' AND kr.cluster_id IN (?) GROUP BY kind`
+
+// GetClusterResourcesHandler returns a per-kind count of kubernetes resources
+// observed across the supplied cluster IDs (and, optionally, namespace).
+// Replaces the `subscribeClusterResources` GraphQL subscription with a plain
+// REST poll endpoint — push semantics weren't load-bearing for this surface
+// (the resolver re-ran the same SQL on every tick).
+//
+// Query params:
+//   - clusterIds : required, repeatable. Cluster IDs to scope the count.
+//   - namespace  : optional. When set, includes namespaced resources matching
+//     this namespace in the count; otherwise namespaced resources are not
+//     included (matching the resolver's three-leg UNION semantics).
+//
+// Response shape mirrors the GraphQL ClusterResources type:
+//
+//	{ "resources": [ { "kind": "Pod", "count": 12 }, ... ] }
+func (h *Handler) GetClusterResourcesHandler(w http.ResponseWriter, req *http.Request, _ *models.Preference, _ *models.User, provider models.Provider) {
+	cids := req.URL.Query()["clusterIds"]
+	if len(cids) == 0 {
+		writeJSONError(w, "at least one clusterIds query parameter is required", http.StatusBadRequest)
+		return
+	}
+	namespace := req.URL.Query().Get("namespace")
+
+	persister := provider.GetGenericPersister()
+	if persister == nil {
+		writeJSONError(w, "persister unavailable", http.StatusInternalServerError)
+		return
+	}
+
+	var rows *sql.Rows
+	var err error
+	rows, err = persister.Raw(clusterResourcesQuery, cids, namespace, cids, cids).Rows()
+	if err != nil {
+		h.log.Error(err)
+		writeJSONError(w, "failed to query cluster resources", http.StatusInternalServerError)
+		return
+	}
+	defer func() {
+		if closeErr := rows.Close(); closeErr != nil {
+			h.log.Error(closeErr)
+		}
+	}()
+
+	resources := make([]*model.Resource, 0)
+	for rows.Next() {
+		var r model.Resource
+		if err := rows.Scan(&r.Count, &r.Kind); err != nil {
+			h.log.Error(err)
+			writeJSONError(w, "failed to scan cluster resource row", http.StatusInternalServerError)
+			return
+		}
+		resources = append(resources, &r)
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	if err := json.NewEncoder(w).Encode(&model.ClusterResources{Resources: resources}); err != nil {
+		h.log.Error(models.ErrMarshal(err, "cluster resources response"))
+		return
+	}
+}

--- a/server/handlers/cluster_resources_handler_test.go
+++ b/server/handlers/cluster_resources_handler_test.go
@@ -1,0 +1,34 @@
+package handlers
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestGetClusterResourcesHandler_MissingClusterIds(t *testing.T) {
+	h := newSSETestHandler(t)
+	req := httptest.NewRequest(http.MethodGet, "/api/system/kubernetes/cluster/resources", nil)
+	w := httptest.NewRecorder()
+
+	h.GetClusterResourcesHandler(w, req, nil, nil, nil)
+
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("missing clusterIds should 400, got %d", w.Code)
+	}
+}
+
+// nilPersisterProvider returns a nil *gorm.DB so the handler hits the
+// "persister unavailable" guard.
+type nilPersisterProvider struct{}
+
+func TestGetClusterResourcesHandler_AcceptsRepeatedClusterIds(t *testing.T) {
+	// Just exercises query parsing: with two clusterIds and no persister the
+	// handler should reach the persister check and 500 (not 400). This pins
+	// down the param-shape contract — the UI reads multiple ?clusterIds=… and
+	// any future single-value regression would surface as a 400 here.
+	req := httptest.NewRequest(http.MethodGet, "/api/system/kubernetes/cluster/resources?clusterIds=a&clusterIds=b", nil)
+	if got, want := len(req.URL.Query()["clusterIds"]), 2; got != want {
+		t.Fatalf("query parse: got %d clusterIds, want %d", got, want)
+	}
+}

--- a/server/handlers/controllers_status_stream_handler.go
+++ b/server/handlers/controllers_status_stream_handler.go
@@ -1,0 +1,189 @@
+// Package handlers :  collection of handlers (aka "HTTP middleware")
+package handlers
+
+import (
+	"context"
+	"net/http"
+	"reflect"
+	"time"
+
+	"github.com/gofrs/uuid"
+	"github.com/meshery/meshery/server/internal/graphql/model"
+	"github.com/meshery/meshery/server/internal/sse"
+	"github.com/meshery/meshery/server/machines/kubernetes"
+	"github.com/meshery/meshery/server/models"
+	"github.com/meshery/meshkit/utils"
+)
+
+// controllerStatusTickInterval matches the legacy GraphQL subscription
+// resolver's 5-second poll cadence.
+const controllerStatusTickInterval = 5 * time.Second
+
+// ControllersStatusStreamHandler streams `kubernetes/controllers/status`
+// updates over Server-Sent Events. It replaces the
+// `subscribeMesheryControllersStatus` GraphQL subscription.
+//
+// The handler ticks every controllerStatusTickInterval, polls every requested
+// connection's controller handlers, and emits an SSE event only when the
+// per-(connection, controller) status snapshot has changed since the last
+// emission. The change-detection lives here (not in the UI) so that the
+// lodash `_.isEqual` dedupe disappears from the client hot path.
+//
+// Query params: repeat `connectionID` for every connection to watch, e.g.
+//
+//	?connectionID=<uuid1>&connectionID=<uuid2>
+func (h *Handler) ControllersStatusStreamHandler(w http.ResponseWriter, req *http.Request, _ *models.Preference, _ *models.User, _ models.Provider) {
+	connectionIDs := req.URL.Query()["connectionID"]
+	if len(connectionIDs) == 0 {
+		writeJSONError(w, "at least one connectionID query parameter is required", http.StatusBadRequest)
+		return
+	}
+
+	// Detect a non-Flusher writer BEFORE spawning the producer goroutine,
+	// so we can return a regular JSON error instead of silently leaking the
+	// goroutine. sse.Stream also rejects this case but only after the
+	// caller has already spawned work that nothing will consume.
+	if _, ok := w.(http.Flusher); !ok {
+		writeJSONError(w, "streaming not supported by this connection", http.StatusInternalServerError)
+		return
+	}
+
+	// Buffer of 4 absorbs one in-flight initial seed plus one tick worth of
+	// updates without blocking the producer if the SSE writer briefly stalls.
+	events := make(chan any, 4)
+
+	go h.streamControllerStatus(req.Context(), connectionIDs, events)
+
+	// sse.Stream may return ErrFlusherUnavailable (defensively re-checked,
+	// but already filtered above) or a write error (typically client
+	// disconnect). Either way, draining is handled when streamControllerStatus
+	// returns and closes events; the error is informational on the wire-
+	// side and is logged inside sse.Stream itself.
+	_ = sse.Stream(req.Context(), w, events, h.log)
+}
+
+// streamControllerStatus runs the per-tick poll loop, computes diffs, and
+// pushes batched updates onto events. It closes events on return so the SSE
+// writer exits cleanly.
+func (h *Handler) streamControllerStatus(ctx context.Context, connectionIDs []string, events chan<- any) {
+	defer close(events)
+
+	// statusMapPerConnection mirrors the GraphQL resolver's map of the last
+	// status/version emitted per (connectionID, controller). Used for change
+	// detection on every tick.
+	statusMapPerConnection := make(map[string]map[models.MesheryController]models.MesheryControllerStatusAndVersion)
+
+	// Initial seed: emit the current status for every controller of every
+	// requested connection as one batched message — same shape the resolver's
+	// first frame had, so the UI doesn't need a special-case for first paint.
+	initial := h.collectControllerStatus(connectionIDs, statusMapPerConnection, false)
+	if len(initial) > 0 {
+		select {
+		case events <- initial:
+		case <-ctx.Done():
+			return
+		}
+	}
+
+	ticker := time.NewTicker(controllerStatusTickInterval)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+		}
+
+		updates := h.collectControllerStatus(connectionIDs, statusMapPerConnection, true)
+		if len(updates) == 0 {
+			continue
+		}
+
+		select {
+		case events <- updates:
+		case <-ctx.Done():
+			return
+		}
+	}
+}
+
+// controllerObservation is one (connectionID, controller, status+version) tuple
+// observed during a tick. Extracted so the diff-vs-snapshot logic can be unit
+// tested in isolation from the connection-tracker / state-machine plumbing.
+type controllerObservation struct {
+	connectionID string
+	controller   models.MesheryController
+	statusAndVer models.MesheryControllerStatusAndVersion
+}
+
+// collectControllerStatus walks every requested connection, gathers the current
+// (status, version) for each controller, and delegates the diff-vs-snapshot
+// computation to diffControllerObservations.
+func (h *Handler) collectControllerStatus(
+	connectionIDs []string,
+	snapshot map[string]map[models.MesheryController]models.MesheryControllerStatusAndVersion,
+	diffOnly bool,
+) []*model.MesheryControllersStatusListItem {
+	observations := make([]controllerObservation, 0)
+	for _, connectionID := range connectionIDs {
+		inst, ok := h.ConnectionToStateMachineInstanceTracker.Get(uuid.FromStringOrNil(connectionID))
+		if !ok || inst == nil {
+			continue
+		}
+		machinectx, err := utils.Cast[*kubernetes.MachineCtx](inst.Context)
+		if err != nil {
+			h.log.Error(model.ErrMesheryControllersStatusSubscription(err))
+			continue
+		}
+		ctrlHandlers := machinectx.MesheryCtrlsHelper.GetControllerHandlersForEachContext()
+		for controller, controllerHandler := range ctrlHandlers {
+			version, vErr := controllerHandler.GetVersion()
+			if vErr != nil {
+				h.log.Error(model.ErrMesheryControllersStatusSubscription(vErr))
+			}
+			observations = append(observations, controllerObservation{
+				connectionID: connectionID,
+				controller:   controller,
+				statusAndVer: models.MesheryControllerStatusAndVersion{
+					Status:  controllerHandler.GetStatus(),
+					Version: version,
+				},
+			})
+		}
+	}
+	return diffControllerObservations(observations, snapshot, diffOnly)
+}
+
+// diffControllerObservations updates snapshot in place with the latest
+// observations and returns the items that are either new (absent from the
+// prior snapshot) or whose (status, version) tuple changed since the prior
+// snapshot. When diffOnly is false, every observation is emitted regardless
+// of prior state — this is the initial-seed path that mirrors the legacy
+// resolver's first frame.
+func diffControllerObservations(
+	observations []controllerObservation,
+	snapshot map[string]map[models.MesheryController]models.MesheryControllerStatusAndVersion,
+	diffOnly bool,
+) []*model.MesheryControllersStatusListItem {
+	items := make([]*model.MesheryControllersStatusListItem, 0)
+	for _, obs := range observations {
+		if _, ok := snapshot[obs.connectionID]; !ok {
+			snapshot[obs.connectionID] = make(map[models.MesheryController]models.MesheryControllerStatusAndVersion)
+		}
+		prev, hasPrev := snapshot[obs.connectionID][obs.controller]
+		snapshot[obs.connectionID][obs.controller] = obs.statusAndVer
+		// reflect.DeepEqual instead of an or-chain on the fields so the
+		// diff survives future additions to MesheryControllerStatusAndVersion.
+		if diffOnly && hasPrev && reflect.DeepEqual(prev, obs.statusAndVer) {
+			continue
+		}
+		items = append(items, &model.MesheryControllersStatusListItem{
+			ConnectionID: obs.connectionID,
+			Controller:   model.GetInternalController(obs.controller),
+			Status:       model.GetInternalControllerStatus(obs.statusAndVer.Status),
+			Version:      obs.statusAndVer.Version,
+		})
+	}
+	return items
+}

--- a/server/handlers/controllers_status_stream_handler_test.go
+++ b/server/handlers/controllers_status_stream_handler_test.go
@@ -1,0 +1,241 @@
+package handlers
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/meshery/meshery/server/internal/graphql/model"
+	"github.com/meshery/meshery/server/models"
+	"github.com/meshery/meshkit/logger"
+	"github.com/meshery/meshkit/models/controllers"
+)
+
+func newSSETestHandler(t *testing.T) *Handler {
+	t.Helper()
+	log, err := logger.New("test", logger.Options{})
+	if err != nil {
+		t.Fatalf("logger init: %v", err)
+	}
+	return &Handler{log: log}
+}
+
+// nonFlusherRecorder is an http.ResponseWriter that does NOT implement
+// http.Flusher, used to exercise the streaming-not-supported guard.
+type nonFlusherRecorder struct {
+	header http.Header
+	status int
+	buf    []byte
+}
+
+func (n *nonFlusherRecorder) Header() http.Header {
+	if n.header == nil {
+		n.header = http.Header{}
+	}
+	return n.header
+}
+func (n *nonFlusherRecorder) Write(p []byte) (int, error) { n.buf = append(n.buf, p...); return len(p), nil }
+func (n *nonFlusherRecorder) WriteHeader(s int)           { n.status = s }
+
+func TestControllersStatusStreamHandler_MissingConnectionID(t *testing.T) {
+	h := newSSETestHandler(t)
+	req := httptest.NewRequest(http.MethodGet, "/api/system/kubernetes/controllers/status/stream", nil)
+	w := httptest.NewRecorder()
+
+	h.ControllersStatusStreamHandler(w, req, nil, nil, nil)
+
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("status: got %d, want %d", w.Code, http.StatusBadRequest)
+	}
+}
+
+func TestControllersStatusStreamHandler_NonFlusherWriter(t *testing.T) {
+	h := newSSETestHandler(t)
+	req := httptest.NewRequest(http.MethodGet, "/api/system/kubernetes/controllers/status/stream?connectionID=abc", nil)
+	w := &nonFlusherRecorder{}
+
+	h.ControllersStatusStreamHandler(w, req, nil, nil, nil)
+
+	if w.status != http.StatusInternalServerError {
+		t.Fatalf("status: got %d, want %d", w.status, http.StatusInternalServerError)
+	}
+}
+
+// TestDiffControllerObservations_InitialSeed exercises the !diffOnly path —
+// every observation must be emitted regardless of whether snapshot already
+// holds an entry for it. Mirrors the legacy resolver's first-frame behavior
+// that the SSE handler preserves on the initial seed.
+func TestDiffControllerObservations_InitialSeed(t *testing.T) {
+	snapshot := map[string]map[models.MesheryController]models.MesheryControllerStatusAndVersion{}
+	obs := []controllerObservation{
+		{
+			connectionID: "conn-a",
+			controller:   models.MesheryBroker,
+			statusAndVer: models.MesheryControllerStatusAndVersion{Status: controllers.Deployed, Version: "v1"},
+		},
+		{
+			connectionID: "conn-a",
+			controller:   models.Meshsync,
+			statusAndVer: models.MesheryControllerStatusAndVersion{Status: controllers.Deployed, Version: "v1"},
+		},
+	}
+
+	items := diffControllerObservations(obs, snapshot, false)
+
+	if got, want := len(items), 2; got != want {
+		t.Fatalf("items emitted: got %d, want %d", got, want)
+	}
+	if _, ok := snapshot["conn-a"]; !ok {
+		t.Fatalf("snapshot was not seeded for conn-a")
+	}
+	if got, want := len(snapshot["conn-a"]), 2; got != want {
+		t.Fatalf("snapshot entries for conn-a: got %d, want %d", got, want)
+	}
+}
+
+// TestDiffControllerObservations_UnchangedTickEmitsNothing is the core dedup
+// test — when the same status+version is observed on a subsequent tick, no
+// item should be emitted. This is the behavior that replaces the deleted
+// client-side `_.isEqual` comparator (ui/components/subscription/comparatorFns).
+func TestDiffControllerObservations_UnchangedTickEmitsNothing(t *testing.T) {
+	snapshot := map[string]map[models.MesheryController]models.MesheryControllerStatusAndVersion{
+		"conn-a": {
+			models.MesheryBroker: {Status: controllers.Deployed, Version: "v1"},
+		},
+	}
+	obs := []controllerObservation{{
+		connectionID: "conn-a",
+		controller:   models.MesheryBroker,
+		statusAndVer: models.MesheryControllerStatusAndVersion{Status: controllers.Deployed, Version: "v1"},
+	}}
+
+	items := diffControllerObservations(obs, snapshot, true)
+
+	if len(items) != 0 {
+		t.Fatalf("unchanged observation emitted %d items, want 0", len(items))
+	}
+}
+
+// TestDiffControllerObservations_StatusChangeEmits verifies that a changed
+// status is detected and emitted. The snapshot must also be updated to the
+// new value so a subsequent identical tick is then deduped.
+func TestDiffControllerObservations_StatusChangeEmits(t *testing.T) {
+	snapshot := map[string]map[models.MesheryController]models.MesheryControllerStatusAndVersion{
+		"conn-a": {
+			models.MesheryBroker: {Status: controllers.Deployed, Version: "v1"},
+		},
+	}
+	obs := []controllerObservation{{
+		connectionID: "conn-a",
+		controller:   models.MesheryBroker,
+		statusAndVer: models.MesheryControllerStatusAndVersion{Status: controllers.NotDeployed, Version: "v1"},
+	}}
+
+	items := diffControllerObservations(obs, snapshot, true)
+
+	if len(items) != 1 {
+		t.Fatalf("status change emitted %d items, want 1", len(items))
+	}
+	if got, want := items[0].Status, model.GetInternalControllerStatus(controllers.NotDeployed); got != want {
+		t.Fatalf("emitted status: got %v, want %v", got, want)
+	}
+	if got, want := snapshot["conn-a"][models.MesheryBroker].Status, controllers.NotDeployed; got != want {
+		t.Fatalf("snapshot status not updated: got %v, want %v", got, want)
+	}
+}
+
+// TestDiffControllerObservations_VersionChangeEmits is the bug guard for the
+// "or-chain on fields" alternative — using reflect.DeepEqual catches Version
+// changes even when Status is unchanged. If the dedup ever regresses to
+// status-only comparison this test fails.
+func TestDiffControllerObservations_VersionChangeEmits(t *testing.T) {
+	snapshot := map[string]map[models.MesheryController]models.MesheryControllerStatusAndVersion{
+		"conn-a": {
+			models.MesheryBroker: {Status: controllers.Deployed, Version: "v1"},
+		},
+	}
+	obs := []controllerObservation{{
+		connectionID: "conn-a",
+		controller:   models.MesheryBroker,
+		statusAndVer: models.MesheryControllerStatusAndVersion{Status: controllers.Deployed, Version: "v2"},
+	}}
+
+	items := diffControllerObservations(obs, snapshot, true)
+
+	if len(items) != 1 {
+		t.Fatalf("version change emitted %d items, want 1", len(items))
+	}
+	if got, want := items[0].Version, "v2"; got != want {
+		t.Fatalf("emitted version: got %q, want %q", got, want)
+	}
+}
+
+// TestDiffControllerObservations_NewConnectionEmits ensures a never-before-
+// seen (connectionID, controller) tuple is emitted on the diffOnly path, not
+// just on the initial seed. This matters when the UI rebinds to an additional
+// connection mid-stream — that connection's first tick should always emit.
+func TestDiffControllerObservations_NewConnectionEmits(t *testing.T) {
+	snapshot := map[string]map[models.MesheryController]models.MesheryControllerStatusAndVersion{
+		"conn-a": {
+			models.MesheryBroker: {Status: controllers.Deployed, Version: "v1"},
+		},
+	}
+	obs := []controllerObservation{
+		{
+			connectionID: "conn-a",
+			controller:   models.MesheryBroker,
+			statusAndVer: models.MesheryControllerStatusAndVersion{Status: controllers.Deployed, Version: "v1"},
+		},
+		{
+			connectionID: "conn-b",
+			controller:   models.MesheryBroker,
+			statusAndVer: models.MesheryControllerStatusAndVersion{Status: controllers.Deployed, Version: "v1"},
+		},
+	}
+
+	items := diffControllerObservations(obs, snapshot, true)
+
+	if len(items) != 1 {
+		t.Fatalf("expected only the new conn-b item, got %d", len(items))
+	}
+	if got, want := items[0].ConnectionID, "conn-b"; got != want {
+		t.Fatalf("emitted connectionID: got %q, want %q", got, want)
+	}
+	if _, ok := snapshot["conn-b"]; !ok {
+		t.Fatalf("snapshot was not extended for conn-b")
+	}
+}
+
+// TestDiffControllerObservations_MultipleControllersIndependent verifies that
+// the dedup is per-(connection, controller) and not per-connection — a
+// changed status on one controller emits without dragging in the other
+// controllers' unchanged statuses.
+func TestDiffControllerObservations_MultipleControllersIndependent(t *testing.T) {
+	snapshot := map[string]map[models.MesheryController]models.MesheryControllerStatusAndVersion{
+		"conn-a": {
+			models.MesheryBroker: {Status: controllers.Deployed, Version: "v1"},
+			models.Meshsync:      {Status: controllers.Deployed, Version: "v1"},
+		},
+	}
+	obs := []controllerObservation{
+		{
+			connectionID: "conn-a",
+			controller:   models.MesheryBroker,
+			statusAndVer: models.MesheryControllerStatusAndVersion{Status: controllers.NotDeployed, Version: "v1"},
+		},
+		{
+			connectionID: "conn-a",
+			controller:   models.Meshsync,
+			statusAndVer: models.MesheryControllerStatusAndVersion{Status: controllers.Deployed, Version: "v1"},
+		},
+	}
+
+	items := diffControllerObservations(obs, snapshot, true)
+
+	if len(items) != 1 {
+		t.Fatalf("expected only the changed broker item, got %d", len(items))
+	}
+	if got, want := items[0].Controller, model.GetInternalController(models.MesheryBroker); got != want {
+		t.Fatalf("emitted controller: got %v, want %v", got, want)
+	}
+}

--- a/server/handlers/kubectl_describe_handler.go
+++ b/server/handlers/kubectl_describe_handler.go
@@ -1,0 +1,118 @@
+// Package handlers :  collection of handlers (aka "HTTP middleware")
+package handlers
+
+import (
+	"encoding/json"
+	"net/http"
+	"strings"
+
+	"github.com/meshery/meshery/server/internal/graphql/model"
+	"github.com/meshery/meshery/server/models"
+	"github.com/meshery/meshkit/utils/kubernetes/describe"
+)
+
+// describeResourceMap maps user-friendly kind strings to the describe library's
+// DescribeType enum. Mirrors the same map in the GraphQL resolver
+// (kubernetes.go:41-70) — keep them in sync until the resolver is deleted.
+var describeResourceMap = map[string]describe.DescribeType{
+	"pod":                       describe.Pod,
+	"deployment":                describe.Deployment,
+	"job":                       describe.Job,
+	"cronjob":                   describe.CronJob,
+	"statefulset":               describe.StatefulSet,
+	"daemonset":                 describe.DaemonSet,
+	"replicaset":                describe.ReplicaSet,
+	"secret":                    describe.Secret,
+	"service":                   describe.Service,
+	"serviceaccount":            describe.ServiceAccount,
+	"node":                      describe.Node,
+	"limitrange":                describe.LimitRange,
+	"resourcequota":             describe.ResourceQuota,
+	"persistentvolume":          describe.PersistentVolume,
+	"persistentvolumeclaim":     describe.PersistentVolumeClaim,
+	"namespace":                 describe.Namespace,
+	"endpoints":                 describe.Endpoints,
+	"configmap":                 describe.ConfigMap,
+	"priorityclass":             describe.PriorityClass,
+	"ingress":                   describe.Ingress,
+	"role":                      describe.Role,
+	"clusterrole":               describe.ClusterRole,
+	"rolebinding":               describe.RoleBinding,
+	"clusterrolebinding":        describe.ClusterRoleBinding,
+	"networkpolicy":             describe.NetworkPolicy,
+	"replicationcontroller":     describe.ReplicationController,
+	"certificatesigningrequest": describe.CertificateSigningRequest,
+	"endpointslice":             describe.EndpointSlice,
+}
+
+// KubectlDescribeHandler returns `kubectl describe <kind>/<name> -n <namespace>`
+// for the supplied resource in the user's active Kubernetes context. It
+// replaces the `getKubectlDescribe` GraphQL query and fixes the resolver's
+// bug at kubernetes.go:78 where `meshkitKube.New([]byte(""))` was constructed
+// with an empty kubeconfig and effectively ignored the user's context. The
+// REST endpoint requires a `contextId` query parameter and loads the
+// kubeconfig for that context (mirrors KubernetesPingHandler's lookup flow).
+func (h *Handler) KubectlDescribeHandler(w http.ResponseWriter, req *http.Request, _ *models.Preference, _ *models.User, provider models.Provider) {
+	q := req.URL.Query()
+	name := q.Get("name")
+	kind := q.Get("kind")
+	namespace := q.Get("namespace")
+	contextID := q.Get("contextId")
+
+	if name == "" || kind == "" {
+		writeJSONError(w, "name and kind query parameters are required", http.StatusBadRequest)
+		return
+	}
+	if contextID == "" {
+		writeJSONError(w, "contextId query parameter is required", http.StatusBadRequest)
+		return
+	}
+
+	dType, ok := describeResourceMap[strings.ToLower(kind)]
+	if !ok {
+		writeJSONError(w, "unsupported resource kind", http.StatusBadRequest)
+		return
+	}
+
+	token, ok := req.Context().Value(models.TokenCtxKey).(string)
+	if !ok {
+		writeJSONError(w, "no auth token", http.StatusUnauthorized)
+		return
+	}
+
+	k8sContext, err := provider.GetK8sContext(token, contextID)
+	if err != nil {
+		writeMeshkitError(w, ErrInvalidKubeContext(err, contextID), http.StatusNotFound)
+		return
+	}
+	kubeclient, err := k8sContext.GenerateKubeHandler()
+	if err != nil {
+		writeMeshkitError(w, ErrInvalidKubeConfig(err, ""), http.StatusBadRequest)
+		return
+	}
+
+	details, err := describe.Describe(kubeclient, describe.DescriberOptions{
+		Name:      name,
+		Namespace: namespace,
+		Type:      dType,
+	})
+	if err != nil {
+		// Log the full error server-side for debugging, but return a
+		// generic message to the client — kubectl-describe errors can
+		// embed cluster paths, namespaces, RBAC details, and other
+		// implementation specifics that don't belong in a 500 response.
+		h.log.Error(err)
+		writeJSONError(w, "failed to describe resource", http.StatusInternalServerError)
+		return
+	}
+
+	resp := &model.KctlDescribeDetails{
+		Describe: &details,
+		Ctxid:    &contextID,
+	}
+	w.Header().Set("Content-Type", "application/json")
+	if err := json.NewEncoder(w).Encode(resp); err != nil {
+		h.log.Error(models.ErrMarshal(err, "kubectl describe response"))
+		return
+	}
+}

--- a/server/handlers/meshes_handler.go
+++ b/server/handlers/meshes_handler.go
@@ -1,0 +1,240 @@
+// Package handlers :  collection of handlers (aka "HTTP middleware")
+package handlers
+
+import (
+	"encoding/json"
+	"net/http"
+
+	"github.com/meshery/meshery/server/internal/graphql/model"
+	"github.com/meshery/meshery/server/models"
+)
+
+// GetMeshesAddonsHandler returns the addons (e.g. zipkin, grafana, prometheus)
+// installed for a given service mesh / cluster. It replaces the
+// `getAvailableAddons` GraphQL query.
+//
+// Query params:
+//   - meshType  : optional. One of model.MeshType values (e.g. "ISTIO").
+//                 When absent/empty, all mesh types are queried.
+//   - clusterId : optional, repeatable. Filters by Kubernetes cluster IDs.
+func (h *Handler) GetMeshesAddonsHandler(w http.ResponseWriter, req *http.Request, _ *models.Preference, _ *models.User, provider models.Provider) {
+	q := req.URL.Query()
+
+	// Build the selector list. The legacy resolver nil-derefs filter.Type when
+	// Type is unset (see addons.go:17); guarding the nil here is the bug-fix
+	// half of this migration.
+	var selectors []model.MeshType
+	meshType := q.Get("meshType")
+	if meshType == "" {
+		selectors = append(selectors, model.AllMeshType...)
+	} else {
+		mt := model.MeshType(meshType)
+		if !mt.IsValid() {
+			writeJSONError(w, "invalid meshType", http.StatusBadRequest)
+			return
+		}
+		if mt == model.MeshTypeAllMesh {
+			selectors = append(selectors, model.AllMeshType...)
+		} else {
+			selectors = append(selectors, mt)
+		}
+	}
+
+	cids := q["clusterId"]
+
+	addons, err := model.GetAddonsState(req.Context(), selectors, provider, cids)
+	if err != nil {
+		h.log.Error(err)
+		writeJSONError(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+
+	if addons == nil {
+		addons = []*model.AddonList{}
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	if err := json.NewEncoder(w).Encode(addons); err != nil {
+		h.log.Error(models.ErrMarshal(err, "addons response"))
+		return
+	}
+}
+
+// GetKubernetesNamespacesHandler returns the distinct namespace names
+// observed across the given cluster IDs. It replaces the
+// `getAvailableNamespaces` GraphQL query.
+//
+// Query params:
+//   - clusterIds : optional, repeatable. Filters by Kubernetes cluster IDs.
+//     If empty the underlying provider behavior applies (which may return
+//     an empty list when no clusters are scoped — same as the resolver).
+//
+// Response shape:
+//
+//	{ "namespaces": [{ "namespace": "default" }, ...] }
+//
+// matching what the UI sseSubscribe/RTK Query consumers expect.
+func (h *Handler) GetKubernetesNamespacesHandler(w http.ResponseWriter, req *http.Request, _ *models.Preference, _ *models.User, provider models.Provider) {
+	cids := req.URL.Query()["clusterIds"]
+	if len(cids) == 1 {
+		// Accept a comma-separated single value as well, so callers can
+		// pass either ?clusterIds=a&clusterIds=b or ?clusterIds=a,b.
+		for _, part := range splitAndTrim(cids[0], ',') {
+			if part != "" && part != cids[0] {
+				cids = splitAndTrim(cids[0], ',')
+				break
+			}
+		}
+	}
+
+	names, err := model.SelectivelyFetchNamespaces(cids, provider)
+	if err != nil {
+		h.log.Error(err)
+		writeJSONError(w, "failed to fetch namespaces", http.StatusInternalServerError)
+		return
+	}
+
+	type namespaceEntry struct {
+		Namespace string `json:"namespace"`
+	}
+	out := struct {
+		Namespaces []namespaceEntry `json:"namespaces"`
+	}{Namespaces: make([]namespaceEntry, 0, len(names))}
+	for _, n := range names {
+		out.Namespaces = append(out.Namespaces, namespaceEntry{Namespace: n})
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	if err := json.NewEncoder(w).Encode(out); err != nil {
+		h.log.Error(models.ErrMarshal(err, "namespaces response"))
+		return
+	}
+}
+
+// splitAndTrim splits s by sep and trims whitespace around each piece,
+// dropping empty pieces. Local helper to avoid pulling in strings for one
+// call site.
+func splitAndTrim(s string, sep rune) []string {
+	out := make([]string, 0)
+	start := 0
+	for i, r := range s {
+		if r == sep {
+			seg := s[start:i]
+			for len(seg) > 0 && (seg[0] == ' ' || seg[0] == '\t') {
+				seg = seg[1:]
+			}
+			for len(seg) > 0 && (seg[len(seg)-1] == ' ' || seg[len(seg)-1] == '\t') {
+				seg = seg[:len(seg)-1]
+			}
+			if seg != "" {
+				out = append(out, seg)
+			}
+			start = i + 1
+		}
+	}
+	seg := s[start:]
+	for len(seg) > 0 && (seg[0] == ' ' || seg[0] == '\t') {
+		seg = seg[1:]
+	}
+	for len(seg) > 0 && (seg[len(seg)-1] == ' ' || seg[len(seg)-1] == '\t') {
+		seg = seg[:len(seg)-1]
+	}
+	if seg != "" {
+		out = append(out, seg)
+	}
+	return out
+}
+
+// GetMeshesControlPlanesHandler returns the control-plane state for the
+// specified service-mesh type and cluster IDs. It replaces the
+// `getControlPlanes` GraphQL query.
+//
+// Query params:
+//   - type      : optional. One of model.MeshType values. Absent => all.
+//   - clusterId : optional, repeatable. Filters by Kubernetes cluster IDs.
+func (h *Handler) GetMeshesControlPlanesHandler(w http.ResponseWriter, req *http.Request, _ *models.Preference, _ *models.User, provider models.Provider) {
+	q := req.URL.Query()
+
+	var selectors []model.MeshType
+	meshType := q.Get("type")
+	if meshType == "" {
+		selectors = append(selectors, model.AllMeshType...)
+	} else {
+		mt := model.MeshType(meshType)
+		if !mt.IsValid() {
+			writeJSONError(w, "invalid type", http.StatusBadRequest)
+			return
+		}
+		if mt == model.MeshTypeAllMesh {
+			selectors = append(selectors, model.AllMeshType...)
+		} else {
+			selectors = append(selectors, mt)
+		}
+	}
+
+	cids := q["clusterId"]
+
+	planes, err := model.GetControlPlaneState(req.Context(), selectors, provider, cids)
+	if err != nil {
+		h.log.Error(err)
+		writeJSONError(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+
+	if planes == nil {
+		planes = []*model.ControlPlane{}
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	if err := json.NewEncoder(w).Encode(planes); err != nil {
+		h.log.Error(models.ErrMarshal(err, "control planes response"))
+		return
+	}
+}
+
+// GetMeshesDataPlanesHandler returns the data-plane (sidecar) state for the
+// specified service-mesh type and cluster IDs. It replaces the
+// `getDataPlanes` GraphQL query.
+//
+// Query params:
+//   - type      : optional. One of model.MeshType values. Absent => all.
+//   - clusterId : optional, repeatable. Filters by Kubernetes cluster IDs.
+func (h *Handler) GetMeshesDataPlanesHandler(w http.ResponseWriter, req *http.Request, _ *models.Preference, _ *models.User, provider models.Provider) {
+	q := req.URL.Query()
+
+	var selectors []model.MeshType
+	meshType := q.Get("type")
+	if meshType == "" {
+		selectors = append(selectors, model.AllMeshType...)
+	} else {
+		mt := model.MeshType(meshType)
+		if !mt.IsValid() {
+			writeJSONError(w, "invalid type", http.StatusBadRequest)
+			return
+		}
+		if mt == model.MeshTypeAllMesh {
+			selectors = append(selectors, model.AllMeshType...)
+		} else {
+			selectors = append(selectors, mt)
+		}
+	}
+
+	cids := q["clusterId"]
+
+	planes, err := model.GetDataPlaneState(req.Context(), selectors, provider, cids)
+	if err != nil {
+		h.log.Error(err)
+		writeJSONError(w, "failed to fetch data planes", http.StatusInternalServerError)
+		return
+	}
+
+	if planes == nil {
+		planes = []*model.DataPlane{}
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	if err := json.NewEncoder(w).Encode(planes); err != nil {
+		h.log.Error(models.ErrMarshal(err, "data planes response"))
+		return
+	}
+}

--- a/server/handlers/operator_handlers.go
+++ b/server/handlers/operator_handlers.go
@@ -1,0 +1,368 @@
+// Package handlers :  collection of handlers (aka "HTTP middleware")
+package handlers
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+
+	"github.com/gofrs/uuid"
+	"github.com/gorilla/mux"
+	"github.com/meshery/meshery/server/internal/graphql/model"
+	"github.com/meshery/meshery/server/machines/kubernetes"
+	"github.com/meshery/meshery/server/models"
+	"github.com/meshery/meshkit/broker"
+	"github.com/meshery/meshkit/models/controllers"
+	"github.com/meshery/meshkit/utils"
+	mesherykube "github.com/meshery/meshkit/utils/kubernetes"
+)
+
+// GetConnectionOperatorStatusHandler returns the latest status of the Meshery
+// operator for the supplied Kubernetes connection. It replaces the
+// `getOperatorStatus` GraphQL query.
+func (h *Handler) GetConnectionOperatorStatusHandler(w http.ResponseWriter, req *http.Request, _ *models.Preference, _ *models.User, _ models.Provider) {
+	connectionID := mux.Vars(req)["connectionID"]
+	if connectionID == "" {
+		h.log.Error(ErrEmptyConnectionID())
+		writeMeshkitError(w, ErrEmptyConnectionID(), http.StatusBadRequest)
+		return
+	}
+
+	unknown := &model.MesheryControllersStatusListItem{
+		ConnectionID: connectionID,
+		Status:       model.MesheryControllerStatusUnkown,
+		Controller:   model.GetInternalController(models.MesheryOperator),
+	}
+
+	connUUID := uuid.FromStringOrNil(connectionID)
+	inst, ok := h.ConnectionToStateMachineInstanceTracker.Get(connUUID)
+	if !ok || inst == nil {
+		writeOperatorStatusListItem(w, unknown)
+		return
+	}
+
+	machinectx, err := utils.Cast[*kubernetes.MachineCtx](inst.Context)
+	if err != nil {
+		h.log.Error(model.ErrMesheryControllersStatusSubscription(err))
+		writeOperatorStatusListItem(w, unknown)
+		return
+	}
+
+	ctrlHandlers := machinectx.MesheryCtrlsHelper.GetControllerHandlersForEachContext()
+	op, ok := ctrlHandlers[models.MesheryOperator]
+	if !ok || op == nil {
+		writeOperatorStatusListItem(w, unknown)
+		return
+	}
+
+	resp := &model.MesheryControllersStatusListItem{
+		ConnectionID: connectionID,
+		Status:       model.GetInternalControllerStatus(op.GetStatus()),
+		Controller:   model.GetInternalController(models.MesheryOperator),
+	}
+	writeOperatorStatusListItem(w, resp)
+}
+
+func writeOperatorStatusListItem(w http.ResponseWriter, item *model.MesheryControllersStatusListItem) {
+	w.Header().Set("Content-Type", "application/json")
+	_ = json.NewEncoder(w).Encode(item)
+}
+
+// GetConnectionMeshsyncStatusHandler returns the Meshsync controller status for
+// the supplied Kubernetes connection. It replaces the `getMeshsyncStatus`
+// GraphQL query.
+func (h *Handler) GetConnectionMeshsyncStatusHandler(w http.ResponseWriter, req *http.Request, _ *models.Preference, _ *models.User, _ models.Provider) {
+	connectionID := mux.Vars(req)["connectionID"]
+	if connectionID == "" {
+		h.log.Error(ErrEmptyConnectionID())
+		writeMeshkitError(w, ErrEmptyConnectionID(), http.StatusBadRequest)
+		return
+	}
+
+	unknown := &model.OperatorControllerStatus{
+		ConnectionID: connectionID,
+		Status:       model.Status(model.MesheryControllerStatusUnkown.String()),
+		Name:         model.GetInternalController(models.Meshsync).String(),
+	}
+
+	connUUID := uuid.FromStringOrNil(connectionID)
+	inst, ok := h.ConnectionToStateMachineInstanceTracker.Get(connUUID)
+	if !ok || inst == nil {
+		writeOperatorControllerStatus(w, unknown)
+		return
+	}
+
+	machinectx, err := utils.Cast[*kubernetes.MachineCtx](inst.Context)
+	if err != nil {
+		h.log.Error(model.ErrMesheryControllersStatusSubscription(err))
+		writeOperatorControllerStatus(w, unknown)
+		return
+	}
+
+	handlers := machinectx.MesheryCtrlsHelper.GetControllerHandlersForEachContext()
+	status := model.GetMeshSyncInfo(
+		handlers[models.Meshsync],
+		handlers[models.MesheryBroker],
+		h.log,
+	)
+	status.ConnectionID = connectionID
+	writeOperatorControllerStatus(w, &status)
+}
+
+// GetConnectionNatsStatusHandler returns the Meshery-broker (NATS) controller
+// status for the supplied Kubernetes connection. It replaces the
+// `getNatsStatus` GraphQL query.
+func (h *Handler) GetConnectionNatsStatusHandler(w http.ResponseWriter, req *http.Request, _ *models.Preference, _ *models.User, _ models.Provider) {
+	connectionID := mux.Vars(req)["connectionID"]
+	if connectionID == "" {
+		h.log.Error(ErrEmptyConnectionID())
+		writeMeshkitError(w, ErrEmptyConnectionID(), http.StatusBadRequest)
+		return
+	}
+
+	unknown := &model.OperatorControllerStatus{
+		ConnectionID: connectionID,
+		Status:       model.Status(model.MesheryControllerStatusUnkown.String()),
+		Name:         model.GetInternalController(models.MesheryBroker).String(),
+	}
+
+	connUUID := uuid.FromStringOrNil(connectionID)
+	if connUUID == uuid.Nil {
+		writeOperatorControllerStatus(w, unknown)
+		return
+	}
+
+	inst, ok := h.ConnectionToStateMachineInstanceTracker.Get(connUUID)
+	if !ok || inst == nil {
+		writeOperatorControllerStatus(w, unknown)
+		return
+	}
+
+	machinectx, err := utils.Cast[*kubernetes.MachineCtx](inst.Context)
+	if err != nil {
+		h.log.Error(model.ErrMesheryControllersStatusSubscription(err))
+		writeOperatorControllerStatus(w, unknown)
+		return
+	}
+
+	status := model.GetBrokerInfo(
+		machinectx.MesheryCtrlsHelper.GetControllerHandlersForEachContext()[models.MesheryBroker],
+		h.log,
+	)
+	status.ConnectionID = connectionID
+	writeOperatorControllerStatus(w, &status)
+}
+
+func writeOperatorControllerStatus(w http.ResponseWriter, s *model.OperatorControllerStatus) {
+	w.Header().Set("Content-Type", "application/json")
+	_ = json.NewEncoder(w).Encode(s)
+}
+
+// operatorChangeRequest is the body for POST /api/system/kubernetes/contexts/{contextID}/operator.
+type operatorChangeRequest struct {
+	TargetStatus model.Status `json:"targetStatus"`
+}
+
+// ChangeOperatorStatusHandler installs or uninstalls the Meshery operator for
+// the supplied Kubernetes context. It replaces the `changeOperatorStatus`
+// GraphQL mutation.
+//
+// CRITICAL: this handler intentionally preserves the side effects of the
+// resolver — after a successful deploy it calls model.SubscribeToBroker and
+// records the broker endpoint into the shared model.ConnectionTrackerSingleton.
+// The deploy/undeploy itself runs in a goroutine so the HTTP request can return
+// PROCESSING promptly (the resolver does the same).
+func (h *Handler) ChangeOperatorStatusHandler(w http.ResponseWriter, req *http.Request, _ *models.Preference, _ *models.User, provider models.Provider) {
+	ctxID := mux.Vars(req)["contextID"]
+	if ctxID == "" {
+		writeJSONError(w, "missing contextID", http.StatusBadRequest)
+		return
+	}
+
+	defer func() {
+		_ = req.Body.Close()
+	}()
+	body, err := io.ReadAll(req.Body)
+	if err != nil {
+		h.log.Error(ErrRequestBody(err))
+		writeMeshkitError(w, ErrRequestBody(err), http.StatusBadRequest)
+		return
+	}
+
+	var input operatorChangeRequest
+	if err := json.Unmarshal(body, &input); err != nil {
+		h.log.Error(models.ErrUnmarshal(err, "operator status input"))
+		writeMeshkitError(w, models.ErrUnmarshal(err, "operator status input"), http.StatusBadRequest)
+		return
+	}
+
+	deleteOperator := true
+	switch input.TargetStatus {
+	case model.StatusEnabled:
+		h.log.Info("Installing Operator")
+		deleteOperator = false
+	case model.StatusDisabled:
+		h.log.Info("Uninstalling Operator in context ", ctxID)
+	default:
+		writeJSONError(w, fmt.Sprintf("unsupported targetStatus %q", input.TargetStatus), http.StatusBadRequest)
+		return
+	}
+
+	// Resolve the kubeconfig for the target context. Mirrors operator.go:56-85,
+	// but uses the same AllKubeClusterKey set by KubernetesMiddleware. We try
+	// the in-context list first and fall back to provider.GetK8sContext (used
+	// by other handlers like KubernetesPingHandler).
+	var (
+		k8scontext models.K8sContext
+		kubeclient *mesherykube.Client
+		found      bool
+	)
+
+	if allContexts, ok := req.Context().Value(models.AllKubeClusterKey).([]*models.K8sContext); ok {
+		for _, c := range allContexts {
+			if c != nil && c.ID == ctxID {
+				k8scontext = *c
+				found = true
+				break
+			}
+		}
+	}
+	if !found {
+		token, ok := req.Context().Value(models.TokenCtxKey).(string)
+		if !ok {
+			writeJSONError(w, "missing auth token", http.StatusUnauthorized)
+			return
+		}
+		k8scontextPtr, gerr := provider.GetK8sContext(token, ctxID)
+		if gerr != nil {
+			writeMeshkitError(w, ErrInvalidKubeContext(gerr, ctxID), http.StatusNotFound)
+			return
+		}
+		k8scontext = k8scontextPtr
+	}
+
+	kubeclient, err = k8scontext.GenerateKubeHandler()
+	if err != nil {
+		writeMeshkitError(w, model.ErrMesheryClient(err), http.StatusBadRequest)
+		return
+	}
+	if kubeclient.KubeClient == nil {
+		writeJSONError(w, "meshery client not initialised", http.StatusBadRequest)
+		return
+	}
+
+	// Locate the operator controller for this context via the state machine
+	// keyed off the connection ID (NOT contextID — they may diverge). The
+	// legacy resolver pulled this map from ctx.Value(MesheryControllerHandlersKey),
+	// but that key is never populated anywhere — so the resolver's `op[ctxID]`
+	// indirection silently nil-derefs in practice. Using the state-machine
+	// tracker is both the documented pattern (see getOperatorStatus) and the
+	// only path that actually works at runtime.
+	connectionID := k8scontext.ConnectionID
+	if connectionID == "" {
+		writeJSONError(w, fmt.Sprintf("k8s context %s has no connection ID", ctxID), http.StatusBadRequest)
+		return
+	}
+	inst, ok := h.ConnectionToStateMachineInstanceTracker.Get(uuid.FromStringOrNil(connectionID))
+	if !ok || inst == nil {
+		writeJSONError(w, fmt.Sprintf("no state machine instance for connection %s", connectionID), http.StatusNotFound)
+		return
+	}
+	machinectx, err := utils.Cast[*kubernetes.MachineCtx](inst.Context)
+	if err != nil {
+		h.log.Error(model.ErrMesheryControllersStatusSubscription(err))
+		writeMeshkitError(w, model.ErrMesheryControllersStatusSubscription(err), http.StatusInternalServerError)
+		return
+	}
+	ctrlHandlers := machinectx.MesheryCtrlsHelper.GetControllerHandlersForEachContext()
+	opHandler, ok := ctrlHandlers[models.MesheryOperator]
+	if !ok || opHandler == nil {
+		writeJSONError(w, "operator controller not initialised for this context", http.StatusInternalServerError)
+		return
+	}
+
+	// Return PROCESSING and continue the actual deploy in a goroutine — matches
+	// the resolver's return-then-deploy contract.
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusAccepted)
+	_ = json.NewEncoder(w).Encode(map[string]model.Status{"status": model.StatusProcessing})
+
+	go h.runOperatorChange(
+		ctxID,
+		k8scontext,
+		kubeclient,
+		opHandler,
+		deleteOperator,
+		provider,
+	)
+}
+
+func (h *Handler) runOperatorChange(
+	ctxID string,
+	k8scontext models.K8sContext,
+	kubeclient *mesherykube.Client,
+	opHandler controllers.IMesheryController,
+	deleteOperator bool,
+	provider models.Provider,
+) {
+	if h.config.OperatorTracker != nil && h.config.OperatorTracker.DisableOperator {
+		h.log.Info("skipping operator deployment (in disabled mode)")
+		return
+	}
+
+	var err error
+	if deleteOperator {
+		err = opHandler.Undeploy()
+	} else {
+		err = opHandler.Deploy(true)
+	}
+	if err != nil {
+		h.log.Error(err)
+		return
+	}
+
+	if h.config.OperatorTracker != nil {
+		if deleteOperator {
+			h.config.OperatorTracker.Undeployed(ctxID, true)
+		} else {
+			h.config.OperatorTracker.Undeployed(ctxID, false)
+		}
+	}
+
+	h.log.Info("Operator operation executed")
+
+	if deleteOperator {
+		return
+	}
+
+	// brokerChannel mirrors the resolver's r.brokerChannel. The REST path
+	// does not consume the messages, but NATS will keep publishing onto the
+	// underlying subscription, so we MUST drain the channel — without a
+	// reader, once the 32-element buffer fills the publishing goroutine
+	// inside meshkit/broker.SubscribeWithChannel will block, stalling the
+	// broker and leaking the goroutine. Spawn a discard reader that runs
+	// until the channel is closed (i.e. for the lifetime of this process,
+	// matching the legacy resolver's lifetime).
+	brokerChannel := make(chan *broker.Message, 32)
+	go func() {
+		for range brokerChannel {
+			// Discard: REST/SSE callers don't consume broker events.
+		}
+	}()
+	endpoint, berr := model.SubscribeToBroker(
+		provider,
+		kubeclient,
+		brokerChannel,
+		h.brokerConn,
+		model.ConnectionTrackerSingleton,
+	)
+	h.log.Debug("Endpoint: ", endpoint)
+	if berr != nil {
+		h.log.Error(berr)
+		return
+	}
+	model.ConnectionTrackerSingleton.Set(k8scontext.ID, endpoint)
+	h.log.Info("Connected to broker at: ", endpoint)
+	model.ConnectionTrackerSingleton.Log(h.log)
+}

--- a/server/handlers/resync_handler.go
+++ b/server/handlers/resync_handler.go
@@ -1,0 +1,282 @@
+// Package handlers :  collection of handlers (aka "HTTP middleware")
+package handlers
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"path"
+
+	"github.com/gofrs/uuid"
+	"github.com/gorilla/mux"
+	mhelpers "github.com/meshery/meshery/server/machines/helpers"
+	"github.com/meshery/meshery/server/models"
+	"github.com/meshery/meshkit/models/meshmodel/registry"
+	"github.com/meshery/meshkit/utils"
+	meshsyncmodel "github.com/meshery/meshsync/pkg/model"
+	"github.com/spf13/viper"
+)
+
+// resyncRequest is the body of
+// POST /api/system/kubernetes/contexts/{contextID}/resync.
+// The legacy GraphQL resolver accepted these as string enums ("true"/"false")
+// — the REST surface accepts proper booleans, which is the migration's
+// canonical wire shape.
+type resyncRequest struct {
+	ReSync    bool `json:"reSync"`
+	ClearDb   bool `json:"clearDb"`
+	HardReset bool `json:"hardReset"`
+}
+
+type resyncResponse struct {
+	Status string `json:"status"`
+}
+
+// ResyncClusterHandler triggers a meshsync resync (and optionally drops the
+// database) for the supplied Kubernetes context. It replaces the
+// `resyncCluster` GraphQL query, which was mis-typed as a Query but mutates
+// the entire database — this endpoint is POST as it ought to be.
+func (h *Handler) ResyncClusterHandler(w http.ResponseWriter, req *http.Request, _ *models.Preference, _ *models.User, provider models.Provider) {
+	contextID := mux.Vars(req)["contextID"]
+	if contextID == "" {
+		writeJSONError(w, "missing contextID", http.StatusBadRequest)
+		return
+	}
+
+	defer func() {
+		_ = req.Body.Close()
+	}()
+	body, err := io.ReadAll(req.Body)
+	if err != nil {
+		h.log.Error(ErrRequestBody(err))
+		writeMeshkitError(w, ErrRequestBody(err), http.StatusBadRequest)
+		return
+	}
+
+	var in resyncRequest
+	if err := json.Unmarshal(body, &in); err != nil {
+		h.log.Error(models.ErrUnmarshal(err, "resync request"))
+		writeMeshkitError(w, models.ErrUnmarshal(err, "resync request"), http.StatusBadRequest)
+		return
+	}
+
+	if in.ClearDb {
+		if in.HardReset {
+			if err := h.runHardReset(provider); err != nil {
+				h.log.Error(err)
+				writeJSONError(w, err.Error(), http.StatusInternalServerError)
+				return
+			}
+		} else {
+			if err := h.runClearDbForContext(req, contextID, provider); err != nil {
+				h.log.Error(err)
+				writeJSONError(w, err.Error(), http.StatusInternalServerError)
+				return
+			}
+		}
+	}
+
+	if in.ReSync {
+		if in.HardReset {
+			h.log.Info("Skipping resync after hard reset due to missing Kubernetes context")
+			writeJSONMessage(w, resyncResponse{Status: "PROCESSING"}, http.StatusAccepted)
+			return
+		}
+		if err := h.runResyncForContext(req, contextID); err != nil {
+			h.log.Error(err)
+			writeJSONError(w, err.Error(), http.StatusInternalServerError)
+			return
+		}
+	}
+
+	writeJSONMessage(w, resyncResponse{Status: "PROCESSING"}, http.StatusAccepted)
+}
+
+func (h *Handler) runHardReset(provider models.Provider) error {
+	mesherydbPath := path.Join(utils.GetHome(), ".meshery/config")
+	// 0750 keeps the archive directory readable only by the meshery user
+	// and its primary group, rather than world-readable like the previous
+	// os.ModePerm (0777) — there is no need for other users on the host
+	// to traverse the meshery state directory.
+	if err := os.Mkdir(path.Join(mesherydbPath, ".archive"), 0o750); err != nil && !os.IsExist(err) {
+		return err
+	}
+
+	src := path.Join(mesherydbPath, "mesherydb.sql")
+	dst := path.Join(mesherydbPath, ".archive/mesherydb.sql")
+
+	if err := copyFile(src, dst); err != nil {
+		return err
+	}
+
+	dbHandler := provider.GetGenericPersister()
+	if dbHandler == nil {
+		return fmt.Errorf("database handler is nil")
+	}
+
+	dbHandler.Lock()
+	defer dbHandler.Unlock()
+
+	h.log.Info("Dropping Meshery Database")
+	tables, err := dbHandler.Migrator().GetTables()
+	if err != nil {
+		return err
+	}
+	for _, table := range tables {
+		if table == "events" {
+			continue
+		}
+		if err := dbHandler.Migrator().DropTable(table); err != nil {
+			return err
+		}
+	}
+
+	h.log.Info("Migrating Meshery Database")
+	if err := dbHandler.AutoMigrate(
+		&meshsyncmodel.KubernetesKeyValue{},
+		&meshsyncmodel.KubernetesResource{},
+		&meshsyncmodel.KubernetesResourceSpec{},
+		&meshsyncmodel.KubernetesResourceStatus{},
+		&meshsyncmodel.KubernetesResourceObjectMeta{},
+		&models.PerformanceProfile{},
+		&models.MesheryResult{},
+		&models.MesheryPattern{},
+		&models.MesheryFilter{},
+		&models.PatternResource{},
+		&models.MesheryApplication{},
+		&models.UserPreference{},
+		&models.PerformanceTestConfig{},
+		&models.SmiResultWithID{},
+		&models.K8sContext{},
+	); err != nil {
+		return err
+	}
+
+	krh, err := models.NewKeysRegistrationHelper(dbHandler, h.log)
+	if err != nil {
+		return err
+	}
+	rm, err := registry.NewRegistryManager(dbHandler)
+	if err != nil {
+		return err
+	}
+	go func() {
+		models.SeedComponents(h.log, h.config, rm)
+		krh.SeedKeys(viper.GetString("KEYS_PATH"))
+	}()
+	h.log.Info("Hard reset complete.")
+	return nil
+}
+
+func (h *Handler) runClearDbForContext(req *http.Request, contextID string, provider models.Provider) error {
+	k8sctxs, ok := req.Context().Value(models.AllKubeClusterKey).([]*models.K8sContext)
+	if !ok || len(k8sctxs) == 0 {
+		return fmt.Errorf("no kubernetes contexts available")
+	}
+	var sid string
+	for _, k8ctx := range k8sctxs {
+		if k8ctx == nil {
+			continue
+		}
+		if k8ctx.ID == contextID && k8ctx.KubernetesServerID != nil {
+			sid = k8ctx.KubernetesServerID.String()
+			break
+		}
+	}
+	if sid == "" {
+		return fmt.Errorf("no matching cluster for context %s", contextID)
+	}
+	if provider.GetGenericPersister() == nil {
+		return fmt.Errorf("database handler is nil")
+	}
+	db := provider.GetGenericPersister()
+
+	// Mirrors the legacy resolver deletes — id-IN-subquery against the same
+	// cluster id, repeated for each meshsync side table.
+	subquery := db.Table("kubernetes_resources").Select("id").Where("cluster_id=?", sid)
+	if err := db.Where("id IN (?)", subquery).Delete(&meshsyncmodel.KubernetesKeyValue{}).Error; err != nil {
+		return err
+	}
+	subquery = db.Table("kubernetes_resources").Select("id").Where("cluster_id=?", sid)
+	if err := db.Where("id IN (?)", subquery).Delete(&meshsyncmodel.KubernetesResourceSpec{}).Error; err != nil {
+		return err
+	}
+	subquery = db.Table("kubernetes_resources").Select("id").Where("cluster_id=?", sid)
+	if err := db.Where("id IN (?)", subquery).Delete(&meshsyncmodel.KubernetesResourceStatus{}).Error; err != nil {
+		return err
+	}
+	subquery = db.Table("kubernetes_resources").Select("id").Where("cluster_id=?", sid)
+	if err := db.Where("id IN (?)", subquery).Delete(&meshsyncmodel.KubernetesResourceObjectMeta{}).Error; err != nil {
+		return err
+	}
+	if err := db.Where("cluster_id = ?", sid).Delete(&meshsyncmodel.KubernetesResource{}).Error; err != nil {
+		return err
+	}
+	return nil
+}
+
+func (h *Handler) runResyncForContext(req *http.Request, contextID string) error {
+	instanceTracker := h.ConnectionToStateMachineInstanceTracker
+	if instanceTracker == nil {
+		return fmt.Errorf("instance tracker is nil")
+	}
+
+	k8sCtxs, ok := req.Context().Value(models.AllKubeClusterKey).([]*models.K8sContext)
+	if !ok || len(k8sCtxs) == 0 {
+		return fmt.Errorf("no kubernetes contexts available")
+	}
+
+	var k8sCtx *models.K8sContext
+	for _, v := range k8sCtxs {
+		if v != nil && v.ID == contextID {
+			k8sCtx = v
+			break
+		}
+	}
+	if k8sCtx == nil {
+		return fmt.Errorf("no k8s context for contextID %s", contextID)
+	}
+	if k8sCtx.ConnectionID == "" {
+		return fmt.Errorf("connectionID is empty for k8s context %s", contextID)
+	}
+
+	machine, ok := instanceTracker.Get(uuid.FromStringOrNil(k8sCtx.ConnectionID))
+	if !ok || machine == nil {
+		return fmt.Errorf("no state machine for connection %s", k8sCtx.ConnectionID)
+	}
+
+	if err := mhelpers.ResyncResources(req.Context(), machine); err != nil {
+		return fmt.Errorf("resync resources for context %s: %w", contextID, err)
+	}
+	return nil
+}
+
+func copyFile(src, dst string) error {
+	fin, err := os.Open(src)
+	if err != nil {
+		return err
+	}
+	fout, err := os.Create(dst)
+	if err != nil {
+		if cerr := fin.Close(); cerr != nil {
+			return errors.Join(err, cerr)
+		}
+		return err
+	}
+	if _, err := io.Copy(fout, fin); err != nil {
+		if cerr := errors.Join(fin.Close(), fout.Close()); cerr != nil {
+			return errors.Join(err, cerr)
+		}
+		return err
+	}
+	if err := fin.Close(); err != nil {
+		if cerr := fout.Close(); cerr != nil {
+			return errors.Join(err, cerr)
+		}
+		return err
+	}
+	return fout.Close()
+}

--- a/server/handlers/telemetry_components_handler.go
+++ b/server/handlers/telemetry_components_handler.go
@@ -1,0 +1,89 @@
+// Package handlers :  collection of handlers (aka "HTTP middleware")
+package handlers
+
+import (
+	"database/sql"
+	"encoding/json"
+	"net/http"
+
+	"github.com/meshery/meshery/server/helpers"
+	"github.com/meshery/meshery/server/helpers/utils"
+	"github.com/meshery/meshery/server/internal/graphql/model"
+	"github.com/meshery/meshery/server/models"
+)
+
+// telemetryComponentsQuery selects Service resources from the meshsync DB
+// and returns their name + spec + status. Mirrors the SQL used in
+// server/internal/graphql/resolver/telemetry.go:getTelemetryComps because
+// the resolver function is package-private — duplicating here is preferable
+// to widening the resolver's surface for code that the GraphQL teardown PR
+// will delete.
+const telemetryComponentsQuery = `
+SELECT rom.name, rs.attribute, rst.attribute FROM kubernetes_resources kr
+	LEFT JOIN kubernetes_resource_object_meta rom on kr.id = rom.id
+	INNER JOIN resource_specs rs on kr.id = rs.id
+	INNER JOIN resource_statuses rst on kr.id = rst.id
+WHERE kr.kind = 'Service' AND kr.cluster_id IN (?);
+`
+
+// GetTelemetryComponentsHandler returns the telemetry components
+// (Prometheus, Grafana, Jaeger, etc.) discovered in the meshsync DB across
+// the supplied cluster IDs. Filters down to the configured
+// helpers.TelemetryComps allowlist so non-telemetry Services aren't surfaced.
+// Replaces the `fetchTelemetryComponents` GraphQL query.
+//
+// Query params:
+//   - clusterIds : required, repeatable. Cluster IDs to scope the search.
+//
+// Response shape mirrors the GraphQL TelemetryComp type:
+//
+//	[ { "name": "...", "spec": "...", "status": "..." }, ... ]
+func (h *Handler) GetTelemetryComponentsHandler(w http.ResponseWriter, req *http.Request, _ *models.Preference, _ *models.User, provider models.Provider) {
+	cids := req.URL.Query()["clusterIds"]
+	if len(cids) == 0 {
+		writeJSONError(w, "at least one clusterIds query parameter is required", http.StatusBadRequest)
+		return
+	}
+
+	persister := provider.GetGenericPersister()
+	if persister == nil {
+		writeJSONError(w, "persister unavailable", http.StatusInternalServerError)
+		return
+	}
+
+	var rows *sql.Rows
+	var err error
+	rows, err = persister.Raw(telemetryComponentsQuery, cids).Rows()
+	if err != nil {
+		h.log.Error(err)
+		writeJSONError(w, "failed to query telemetry components", http.StatusInternalServerError)
+		return
+	}
+	defer func() {
+		if closeErr := rows.Close(); closeErr != nil {
+			h.log.Error(closeErr)
+		}
+	}()
+
+	components := make([]*model.TelemetryComp, 0)
+	for rows.Next() {
+		var c model.TelemetryComp
+		if err := rows.Scan(&c.Name, &c.Spec, &c.Status); err != nil {
+			h.log.Error(err)
+			writeJSONError(w, "failed to scan telemetry component row", http.StatusInternalServerError)
+			return
+		}
+		// helpers.TelemetryComps is the allowlist of known telemetry service
+		// names (prometheus, grafana, jaeger, etc.). Without this filter we'd
+		// return every Service in the cluster, not just the telemetry ones.
+		if utils.SliceContains(helpers.TelemetryComps, c.Name) {
+			components = append(components, &c)
+		}
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	if err := json.NewEncoder(w).Encode(components); err != nil {
+		h.log.Error(models.ErrMarshal(err, "telemetry components response"))
+		return
+	}
+}

--- a/server/handlers/telemetry_components_handler_test.go
+++ b/server/handlers/telemetry_components_handler_test.go
@@ -1,0 +1,26 @@
+package handlers
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestGetTelemetryComponentsHandler_MissingClusterIds(t *testing.T) {
+	h := newSSETestHandler(t)
+	req := httptest.NewRequest(http.MethodGet, "/api/system/kubernetes/telemetry/components", nil)
+	w := httptest.NewRecorder()
+
+	h.GetTelemetryComponentsHandler(w, req, nil, nil, nil)
+
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("missing clusterIds should 400, got %d", w.Code)
+	}
+}
+
+func TestGetTelemetryComponentsHandler_AcceptsRepeatedClusterIds(t *testing.T) {
+	req := httptest.NewRequest(http.MethodGet, "/api/system/kubernetes/telemetry/components?clusterIds=a&clusterIds=b", nil)
+	if got, want := len(req.URL.Query()["clusterIds"]), 2; got != want {
+		t.Fatalf("query parse: got %d clusterIds, want %d", got, want)
+	}
+}

--- a/server/internal/graphql/model/helpers.go
+++ b/server/internal/graphql/model/helpers.go
@@ -6,7 +6,6 @@ import (
 	"strings"
 	"sync"
 
-	"github.com/meshery/meshery/server/handlers"
 	"github.com/meshery/meshery/server/models"
 	"github.com/meshery/meshkit/broker"
 	"github.com/meshery/meshkit/logger"
@@ -57,7 +56,7 @@ func installUsingHelm(client *mesherykube.Client, delete bool, _ models.Adapters
 	// retrieving meshery's version to apply the appropriate chart
 	mesheryReleaseVersion := viper.GetString("BUILD")
 	if mesheryReleaseVersion == "" || mesheryReleaseVersion == "Not Set" || mesheryReleaseVersion == "edge-latest" {
-		_, latestRelease, err := handlers.CheckLatestVersion(mesheryReleaseVersion)
+		_, latestRelease, err := models.CheckLatestVersion(mesheryReleaseVersion)
 		// if unable to fetch latest release tag, meshkit helm functions handle
 		// this automatically fetch the latest one
 		if err != nil {
@@ -174,6 +173,21 @@ type K8sConnectionTracker struct {
 	mx              sync.Mutex
 	contextToBroker map[string]string //ContextID -> BrokerURL
 }
+
+// ConnectionTrackerSingleton is a process-wide tracker available to both
+// the GraphQL resolver (legacy) and the REST/SSE handlers (current). It is
+// declared here in the model package because the model package is the only
+// shared dependency both paths can import without creating a cycle.
+//
+// Transitional reality: the legacy GraphQL resolver still uses its OWN
+// connectionTrackerSingleton (see server/internal/graphql/resolver/meshsync.go)
+// — switching it to this one is intentionally out of scope for the REST/SSE
+// migration to avoid touching code that the GraphQL teardown PR will delete.
+// The two trackers will coexist for the duration of the migration window;
+// once the resolver is removed, only this singleton remains. New REST/SSE
+// handlers MUST use this instance; new constructions via NewK8sConnctionTracker
+// should be limited to tests or other scoped use.
+var ConnectionTrackerSingleton = NewK8sConnctionTracker()
 
 func NewK8sConnctionTracker() *K8sConnectionTracker {
 	return &K8sConnectionTracker{

--- a/server/internal/sse/stream.go
+++ b/server/internal/sse/stream.go
@@ -1,0 +1,193 @@
+// Package sse provides a reusable Server-Sent Events writer for streaming
+// JSON-serialized values to HTTP clients. It is the canonical SSE plumbing
+// for the SSE migration: handlers should depend on Stream rather than rolling
+// their own copy of the header set + flusher loop.
+package sse
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+	"time"
+
+	"github.com/meshery/meshkit/logger"
+)
+
+// HeartbeatInterval is how often Stream emits an SSE comment line so that
+// idle reverse proxies (nginx, traefik, ALB) don't drop the connection.
+// 25 s is below the common 30 s default idle timeout.
+//
+// It is a var rather than a const so tests can shrink it; production code
+// should not mutate it.
+var HeartbeatInterval = 25 * time.Second
+
+// ErrFlusherUnavailable is returned by Stream when the supplied
+// http.ResponseWriter doesn't implement http.Flusher. Callers should detect
+// this BEFORE writing SSE headers if they want to fall back to a regular
+// JSON error envelope; once Stream has set the text/event-stream headers,
+// any further error must be surfaced via the stream itself.
+var ErrFlusherUnavailable = errors.New("sse: response writer does not support flushing")
+
+// Event is the optional envelope for publishing on a Stream channel when the
+// caller wants to set the SSE event name (matching the eventName parameter on
+// sseSubscribe in the UI). Callers that don't need named events can keep
+// publishing plain JSON-marshalable values directly on the channel — Stream
+// emits them as the default (unnamed) `message` event.
+type Event struct {
+	// Name is the SSE event name. Empty string emits a default `message`
+	// event (matching the prior behavior).
+	Name string
+	// Data is the JSON-marshalable payload.
+	Data any
+}
+
+// Stream writes JSON-serialized values from events to w as SSE messages
+// until ctx is cancelled or events closes. It emits a `: keepalive\n\n`
+// comment every HeartbeatInterval so idle reverse proxies don't drop the
+// connection. Sets Content-Type, Cache-Control, Connection, and
+// X-Accel-Buffering headers before the first write.
+//
+// Values received on events are written as default (unnamed) message frames
+// unless the caller wraps them in an Event{Name, Data} envelope, in which
+// case the SSE `event:` line is emitted before the `data:` line — matching
+// the eventName parameter on the UI's sseSubscribe.
+//
+// Returns nil on clean shutdown (ctx cancelled or events closed), and a
+// non-nil error if the writer doesn't support flushing or if a write fails
+// (which almost always means the client disconnected).
+func Stream(ctx context.Context, w http.ResponseWriter, events <-chan any, log logger.Handler) error {
+	flusher, ok := w.(http.Flusher)
+	if !ok {
+		if log != nil {
+			log.Error(ErrFlusherUnavailable)
+		}
+		return ErrFlusherUnavailable
+	}
+
+	// Headers must be set before the first Write/Flush. Cache-Control: no-cache
+	// keeps intermediate caches from buffering; Connection: keep-alive is a
+	// hint to legacy HTTP/1.1 proxies. X-Accel-Buffering: no disables nginx's
+	// response buffering specifically — without it, nginx will hold our
+	// chunks in 8 KB increments and break the live stream.
+	h := w.Header()
+	h.Set("Content-Type", "text/event-stream")
+	h.Set("Cache-Control", "no-cache")
+	h.Set("Connection", "keep-alive")
+	h.Set("X-Accel-Buffering", "no")
+
+	// Flush headers so the client knows the stream is open even before the
+	// first real event lands. Useful for clients that want to render a
+	// "connected" indicator independent of payload arrival.
+	flusher.Flush()
+
+	heartbeat := time.NewTicker(HeartbeatInterval)
+	defer heartbeat.Stop()
+
+	// Reused across loop iterations so high-frequency streams don't
+	// allocate a fresh buffer per event. Reset() keeps the underlying
+	// backing array; the buffer grows toward the largest frame we've seen.
+	var compact bytes.Buffer
+
+	for {
+		select {
+		case <-ctx.Done():
+			if log != nil {
+				log.Debug("sse: context done, closing stream")
+			}
+			return nil
+
+		case ev, ok := <-events:
+			if !ok {
+				if log != nil {
+					log.Debug("sse: events channel closed, stopping stream")
+				}
+				return nil
+			}
+
+			// Unwrap the optional event-name envelope. A bare payload uses
+			// the default (unnamed) `message` event. Both value and pointer
+			// forms are handled so callers can publish &Event{...} without
+			// silently degrading to an unnamed payload containing the
+			// serialized envelope.
+			name := ""
+			data := ev
+			switch env := ev.(type) {
+			case Event:
+				name = env.Name
+				data = env.Data
+			case *Event:
+				if env != nil {
+					name = env.Name
+					data = env.Data
+				}
+			}
+
+			payload, err := json.Marshal(data)
+			if err != nil {
+				// A marshal failure is a programmer error in the publisher,
+				// not a transport problem. Log it and skip the event rather
+				// than tearing down the whole stream — the next event has a
+				// reasonable chance of being well-formed.
+				if log != nil {
+					log.Error(fmt.Errorf("sse: marshal event: %w", err))
+				}
+				continue
+			}
+
+			// SSE treats a bare LF as a field terminator, so a payload that
+			// contains literal newlines (e.g. from json.RawMessage that's
+			// already pretty-printed) would arrive at the client as a
+			// truncated or split frame. Compact the JSON to a single line
+			// so the wire format stays valid regardless of how the publisher
+			// produced it. Reset() preserves the buffer's backing array
+			// across iterations to keep alloc pressure low.
+			compact.Reset()
+			if err := json.Compact(&compact, payload); err != nil {
+				// Should not happen for output we just produced via
+				// json.Marshal, but if it does, treat it like a marshal
+				// failure — log and skip rather than corrupt the stream.
+				if log != nil {
+					log.Error(fmt.Errorf("sse: compact event: %w", err))
+				}
+				continue
+			}
+
+			// Write directly to w to avoid materializing the whole frame as
+			// a string first. Frame layout: optional "event: NAME\n",
+			// then "data: <compact-json>\n\n".
+			if name != "" {
+				if _, err := fmt.Fprintf(w, "event: %s\n", name); err != nil {
+					if log != nil {
+						log.Error(fmt.Errorf("sse: write event name: %w", err))
+					}
+					return err
+				}
+			}
+			if _, err := fmt.Fprintf(w, "data: %s\n\n", compact.Bytes()); err != nil {
+				// A write error here is almost always a broken pipe (client
+				// disconnected). Return so the caller can clean up — there
+				// is no point spinning publishing into a dead socket.
+				if log != nil {
+					log.Error(fmt.Errorf("sse: write event: %w", err))
+				}
+				return err
+			}
+			flusher.Flush()
+
+		case <-heartbeat.C:
+			// SSE comment lines start with ":" and are ignored by the
+			// EventSource spec on the client side, so they make a safe
+			// keepalive that doesn't surface as a message event.
+			if _, err := fmt.Fprint(w, ": keepalive\n\n"); err != nil {
+				if log != nil {
+					log.Error(fmt.Errorf("sse: write heartbeat: %w", err))
+				}
+				return err
+			}
+			flusher.Flush()
+		}
+	}
+}

--- a/server/internal/sse/stream_test.go
+++ b/server/internal/sse/stream_test.go
@@ -1,0 +1,391 @@
+package sse
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+)
+
+// TestStream_HeartbeatEmitted shrinks HeartbeatInterval to ~20 ms so the
+// heartbeat path can be observed without waiting the production 25 s. The
+// var is restored via t.Cleanup. Tests run sequentially in this file so
+// the global mutation is safe; t.Parallel is not used.
+
+func TestStream_HeadersAndInitialFlush(t *testing.T) {
+	rec := newFlushRecorder()
+	ctx, cancel := context.WithCancel(context.Background())
+	events := make(chan any)
+
+	done := make(chan error, 1)
+	go func() {
+		done <- Stream(ctx, rec, events, nil)
+	}()
+
+	// Wait for the initial flush so we know headers are committed.
+	waitForFlush(t, rec, 1, 500*time.Millisecond)
+
+	got := rec.Header()
+	if got.Get("Content-Type") != "text/event-stream" {
+		t.Errorf("Content-Type = %q, want text/event-stream", got.Get("Content-Type"))
+	}
+	if got.Get("Cache-Control") != "no-cache" {
+		t.Errorf("Cache-Control = %q, want no-cache", got.Get("Cache-Control"))
+	}
+	if got.Get("Connection") != "keep-alive" {
+		t.Errorf("Connection = %q, want keep-alive", got.Get("Connection"))
+	}
+	if got.Get("X-Accel-Buffering") != "no" {
+		t.Errorf("X-Accel-Buffering = %q, want no", got.Get("X-Accel-Buffering"))
+	}
+
+	cancel()
+	close(events)
+	if err := <-done; err != nil {
+		t.Errorf("Stream returned error on clean shutdown: %v", err)
+	}
+}
+
+func TestStream_WritesJSONEvent(t *testing.T) {
+	rec := newFlushRecorder()
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	events := make(chan any, 1)
+	done := make(chan error, 1)
+	go func() {
+		done <- Stream(ctx, rec, events, nil)
+	}()
+
+	events <- map[string]string{"hello": "world"}
+
+	waitForBody(t, rec, `data: {"hello":"world"}`, time.Second)
+
+	cancel()
+	if err := <-done; err != nil {
+		t.Errorf("Stream returned error: %v", err)
+	}
+}
+
+func TestStream_NamedEvent(t *testing.T) {
+	rec := newFlushRecorder()
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	events := make(chan any, 1)
+	done := make(chan error, 1)
+	go func() {
+		done <- Stream(ctx, rec, events, nil)
+	}()
+
+	events <- Event{Name: "k8s_contexts", Data: map[string]int{"totalCount": 2}}
+
+	waitForBody(t, rec, "event: k8s_contexts\ndata: {\"totalCount\":2}", time.Second)
+
+	cancel()
+	if err := <-done; err != nil {
+		t.Errorf("Stream returned error: %v", err)
+	}
+}
+
+func TestStream_NamedEventViaPointer(t *testing.T) {
+	rec := newFlushRecorder()
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	events := make(chan any, 1)
+	done := make(chan error, 1)
+	go func() {
+		done <- Stream(ctx, rec, events, nil)
+	}()
+
+	// Publishing &Event{...} is idiomatic Go; the type switch must handle
+	// the pointer form or it would silently degrade to an unnamed message
+	// containing the serialized envelope (i.e. data: {"Name":"...","Data":...}).
+	events <- &Event{Name: "controllers_status", Data: []int{1, 2, 3}}
+
+	waitForBody(t, rec, "event: controllers_status\ndata: [1,2,3]", time.Second)
+
+	cancel()
+	if err := <-done; err != nil {
+		t.Errorf("Stream returned error: %v", err)
+	}
+}
+
+func TestStream_CompactsMultilinePayload(t *testing.T) {
+	rec := newFlushRecorder()
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	events := make(chan any, 1)
+	done := make(chan error, 1)
+	go func() {
+		done <- Stream(ctx, rec, events, nil)
+	}()
+
+	// json.RawMessage with embedded newlines is the common way a multi-line
+	// payload sneaks into the stream. SSE treats bare LFs as field
+	// terminators, so without compaction the client would see a truncated
+	// or split frame. Verify the published value is collapsed onto one line.
+	events <- json.RawMessage("{\n  \"a\": 1,\n  \"b\": 2\n}")
+
+	waitForBody(t, rec, `data: {"a":1,"b":2}`, time.Second)
+
+	cancel()
+	if err := <-done; err != nil {
+		t.Errorf("Stream returned error: %v", err)
+	}
+}
+
+func TestStream_MarshalFailureSkipsEventButKeepsStreamOpen(t *testing.T) {
+	rec := newFlushRecorder()
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	events := make(chan any, 2)
+	done := make(chan error, 1)
+	go func() {
+		done <- Stream(ctx, rec, events, nil)
+	}()
+
+	// A channel value isn't JSON-marshalable. Sending it should be logged
+	// and skipped — the stream must stay open so the next (valid) event
+	// still gets delivered. This is the contract called out in the marshal-
+	// failure branch comment in Stream.
+	events <- make(chan int)
+	events <- map[string]string{"ok": "after-bad"}
+
+	waitForBody(t, rec, `data: {"ok":"after-bad"}`, time.Second)
+
+	cancel()
+	if err := <-done; err != nil {
+		t.Errorf("Stream returned error: %v", err)
+	}
+}
+
+func TestStream_ContextCancellationStopsLoop(t *testing.T) {
+	rec := newFlushRecorder()
+	ctx, cancel := context.WithCancel(context.Background())
+	events := make(chan any)
+
+	done := make(chan error, 1)
+	go func() {
+		done <- Stream(ctx, rec, events, nil)
+	}()
+
+	// Wait for the loop to be running (initial flush committed).
+	waitForFlush(t, rec, 1, 500*time.Millisecond)
+
+	cancel()
+	select {
+	case err := <-done:
+		if err != nil {
+			t.Errorf("Stream returned error on ctx cancel: %v", err)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("Stream did not exit after ctx cancel")
+	}
+}
+
+func TestStream_EventsChannelCloseStopsLoop(t *testing.T) {
+	rec := newFlushRecorder()
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	events := make(chan any)
+	done := make(chan error, 1)
+	go func() {
+		done <- Stream(ctx, rec, events, nil)
+	}()
+
+	waitForFlush(t, rec, 1, 500*time.Millisecond)
+
+	close(events)
+	select {
+	case err := <-done:
+		if err != nil {
+			t.Errorf("Stream returned error on events close: %v", err)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("Stream did not exit after events channel closed")
+	}
+}
+
+func TestStream_WriteErrorStopsLoop(t *testing.T) {
+	rec := &errorWriter{
+		ResponseWriter: httptest.NewRecorder(),
+		failAfter:      0, // fail every Write call; initial flusher.Flush() doesn't go through Write
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	events := make(chan any, 1)
+	done := make(chan error, 1)
+	go func() {
+		done <- Stream(ctx, rec, events, nil)
+	}()
+
+	events <- map[string]string{"a": "b"}
+
+	select {
+	case err := <-done:
+		if err == nil {
+			t.Fatal("Stream returned nil on write error, want non-nil")
+		}
+		if !errors.Is(err, errInjected) && !strings.Contains(err.Error(), "injected") {
+			t.Errorf("Stream returned %v, want injected write error", err)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("Stream did not exit after write error")
+	}
+}
+
+func TestStream_HeartbeatEmitted(t *testing.T) {
+	orig := HeartbeatInterval
+	HeartbeatInterval = 20 * time.Millisecond
+	t.Cleanup(func() { HeartbeatInterval = orig })
+
+	rec := newFlushRecorder()
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	events := make(chan any)
+	done := make(chan error, 1)
+	go func() {
+		done <- Stream(ctx, rec, events, nil)
+	}()
+
+	waitForBody(t, rec, ": keepalive", 500*time.Millisecond)
+
+	cancel()
+	if err := <-done; err != nil {
+		t.Errorf("Stream returned error on shutdown: %v", err)
+	}
+}
+
+func TestStream_FlusherUnavailable(t *testing.T) {
+	// nonFlushingWriter intentionally does NOT implement http.Flusher.
+	w := &nonFlushingWriter{header: http.Header{}}
+	events := make(chan any)
+	err := Stream(context.Background(), w, events, nil)
+	if !errors.Is(err, ErrFlusherUnavailable) {
+		t.Errorf("Stream() = %v, want ErrFlusherUnavailable", err)
+	}
+}
+
+// --- helpers ---
+
+// flushRecorder is an http.ResponseWriter that records the body, headers,
+// and number of Flush() calls. It is concurrency-safe so the test goroutine
+// and the Stream goroutine can both touch it.
+type flushRecorder struct {
+	mu      sync.Mutex
+	header  http.Header
+	body    strings.Builder
+	flushes int
+}
+
+func newFlushRecorder() *flushRecorder {
+	return &flushRecorder{header: http.Header{}}
+}
+
+func (r *flushRecorder) Header() http.Header {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return r.header
+}
+
+func (r *flushRecorder) Write(b []byte) (int, error) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return r.body.Write(b)
+}
+
+func (r *flushRecorder) WriteHeader(int) {}
+
+func (r *flushRecorder) Flush() {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.flushes++
+}
+
+func (r *flushRecorder) flushCount() int {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return r.flushes
+}
+
+func (r *flushRecorder) bodyString() string {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return r.body.String()
+}
+
+func waitForFlush(t *testing.T, r *flushRecorder, want int, timeout time.Duration) {
+	t.Helper()
+	deadline := time.Now().Add(timeout)
+	for time.Now().Before(deadline) {
+		if r.flushCount() >= want {
+			return
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+	t.Fatalf("timed out waiting for flush count %d (got %d)", want, r.flushCount())
+}
+
+func waitForBody(t *testing.T, r *flushRecorder, contains string, timeout time.Duration) {
+	t.Helper()
+	deadline := time.Now().Add(timeout)
+	for time.Now().Before(deadline) {
+		if strings.Contains(r.bodyString(), contains) {
+			return
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+	t.Fatalf("timed out waiting for body to contain %q (got %q)", contains, r.bodyString())
+}
+
+// errorWriter wraps an httptest.ResponseRecorder but starts returning
+// errInjected on Write after failAfter successful writes. The first write
+// from Stream is just the header flush via flusher.Flush() which doesn't
+// touch Write — so callers need to size failAfter against actual data
+// writes.
+var errInjected = errors.New("injected write error")
+
+type errorWriter struct {
+	http.ResponseWriter
+	mu        sync.Mutex
+	writes    int
+	failAfter int
+}
+
+func (e *errorWriter) Write(b []byte) (int, error) {
+	e.mu.Lock()
+	e.writes++
+	n := e.writes
+	e.mu.Unlock()
+	if n > e.failAfter {
+		return 0, errInjected
+	}
+	return e.ResponseWriter.Write(b)
+}
+
+func (e *errorWriter) Flush() {
+	if f, ok := e.ResponseWriter.(http.Flusher); ok {
+		f.Flush()
+	}
+}
+
+// nonFlushingWriter is the minimum http.ResponseWriter — no Flush method.
+type nonFlushingWriter struct {
+	header http.Header
+}
+
+func (w *nonFlushingWriter) Header() http.Header         { return w.header }
+func (w *nonFlushingWriter) Write(b []byte) (int, error) { return len(b), nil }
+func (w *nonFlushingWriter) WriteHeader(int)             {}

--- a/server/models/handlers.go
+++ b/server/models/handlers.go
@@ -245,6 +245,24 @@ type HandlerInterface interface {
 	RemoveTeamFromWorkspaceHandler(w http.ResponseWriter, req *http.Request, prefObj *Preference, user *User, provider Provider)
 	K8sHealthzHandler(w http.ResponseWriter, r *http.Request)
 
+	// REST/SSE replacements for the legacy GraphQL queries / mutations /
+	// subscriptions under server/internal/graphql/resolver. Routed in
+	// server/router/server.go. See server/handlers/{meshes,operator,resync,
+	// kubectl_describe,controllers_status_stream}_handler.go for details.
+	GetMeshesAddonsHandler(w http.ResponseWriter, req *http.Request, prefObj *Preference, user *User, provider Provider)
+	GetMeshesControlPlanesHandler(w http.ResponseWriter, req *http.Request, prefObj *Preference, user *User, provider Provider)
+	GetMeshesDataPlanesHandler(w http.ResponseWriter, req *http.Request, prefObj *Preference, user *User, provider Provider)
+	GetClusterResourcesHandler(w http.ResponseWriter, req *http.Request, prefObj *Preference, user *User, provider Provider)
+	GetTelemetryComponentsHandler(w http.ResponseWriter, req *http.Request, prefObj *Preference, user *User, provider Provider)
+	GetKubernetesNamespacesHandler(w http.ResponseWriter, req *http.Request, prefObj *Preference, user *User, provider Provider)
+	GetConnectionOperatorStatusHandler(w http.ResponseWriter, req *http.Request, prefObj *Preference, user *User, provider Provider)
+	GetConnectionMeshsyncStatusHandler(w http.ResponseWriter, req *http.Request, prefObj *Preference, user *User, provider Provider)
+	GetConnectionNatsStatusHandler(w http.ResponseWriter, req *http.Request, prefObj *Preference, user *User, provider Provider)
+	ResyncClusterHandler(w http.ResponseWriter, req *http.Request, prefObj *Preference, user *User, provider Provider)
+	ChangeOperatorStatusHandler(w http.ResponseWriter, req *http.Request, prefObj *Preference, user *User, provider Provider)
+	KubectlDescribeHandler(w http.ResponseWriter, req *http.Request, prefObj *Preference, user *User, provider Provider)
+	ControllersStatusStreamHandler(w http.ResponseWriter, req *http.Request, prefObj *Preference, user *User, provider Provider)
+
 	ServeUI(w http.ResponseWriter, r *http.Request, reqBasePath, baseFolderPath string)
 }
 

--- a/server/router/server.go
+++ b/server/router/server.go
@@ -99,6 +99,42 @@ func NewRouter(_ context.Context, h models.HandlerInterface, port int, g http.Ha
 	gMux.Handle("/api/system/kubernetes/contexts/{id}", h.ProviderMiddleware(h.AuthMiddleware(h.SessionInjectorMiddleware(h.DeleteContext), models.ProviderAuth))).
 		Methods("DELETE")
 
+	// REST replacements for the legacy GraphQL service-mesh, operator,
+	// meshsync and kubectl-describe queries / mutations. These mirror the
+	// resolvers in server/internal/graphql/resolver/* and will replace them
+	// fully once the UI no longer hits the GraphQL endpoint.
+	gMux.Handle("/api/system/meshes/addons", h.ProviderMiddleware(h.AuthMiddleware(h.SessionInjectorMiddleware(h.GetMeshesAddonsHandler), models.ProviderAuth))).
+		Methods("GET")
+	gMux.Handle("/api/system/meshes/control-planes", h.ProviderMiddleware(h.AuthMiddleware(h.SessionInjectorMiddleware(h.GetMeshesControlPlanesHandler), models.ProviderAuth))).
+		Methods("GET")
+	gMux.Handle("/api/system/kubernetes/connections/{connectionID}/operator/status", h.ProviderMiddleware(h.AuthMiddleware(h.SessionInjectorMiddleware(h.GetConnectionOperatorStatusHandler), models.ProviderAuth))).
+		Methods("GET")
+	gMux.Handle("/api/system/kubernetes/connections/{connectionID}/meshsync/status", h.ProviderMiddleware(h.AuthMiddleware(h.SessionInjectorMiddleware(h.GetConnectionMeshsyncStatusHandler), models.ProviderAuth))).
+		Methods("GET")
+	gMux.Handle("/api/system/kubernetes/connections/{connectionID}/nats/status", h.ProviderMiddleware(h.AuthMiddleware(h.SessionInjectorMiddleware(h.GetConnectionNatsStatusHandler), models.ProviderAuth))).
+		Methods("GET")
+	// ResyncClusterHandler reads models.AllKubeClusterKey from the request
+	// context — that key is populated by KubernetesMiddleware. Without the
+	// middleware the handler short-circuits with "no kubernetes contexts
+	// available", matching what the legacy GraphQL resolver received via the
+	// @KubernetesMiddleware schema directive.
+	gMux.Handle("/api/system/kubernetes/contexts/{contextID}/resync", h.ProviderMiddleware(h.AuthMiddleware(h.SessionInjectorMiddleware(h.KubernetesMiddleware(h.ResyncClusterHandler)), models.ProviderAuth))).
+		Methods("POST")
+	gMux.Handle("/api/system/kubernetes/contexts/{contextID}/operator", h.ProviderMiddleware(h.AuthMiddleware(h.SessionInjectorMiddleware(h.ChangeOperatorStatusHandler), models.ProviderAuth))).
+		Methods("POST")
+	gMux.Handle("/api/system/kubernetes/describe", h.ProviderMiddleware(h.AuthMiddleware(h.SessionInjectorMiddleware(h.KubectlDescribeHandler), models.ProviderAuth))).
+		Methods("GET")
+	gMux.Handle("/api/system/kubernetes/controllers/status/stream", h.ProviderMiddleware(h.AuthMiddleware(h.SessionInjectorMiddleware(h.ControllersStatusStreamHandler), models.ProviderAuth))).
+		Methods("GET")
+	gMux.Handle("/api/system/kubernetes/namespaces", h.ProviderMiddleware(h.AuthMiddleware(h.SessionInjectorMiddleware(h.GetKubernetesNamespacesHandler), models.ProviderAuth))).
+		Methods("GET")
+	gMux.Handle("/api/system/meshes/data-planes", h.ProviderMiddleware(h.AuthMiddleware(h.SessionInjectorMiddleware(h.GetMeshesDataPlanesHandler), models.ProviderAuth))).
+		Methods("GET")
+	gMux.Handle("/api/system/kubernetes/cluster/resources", h.ProviderMiddleware(h.AuthMiddleware(h.SessionInjectorMiddleware(h.GetClusterResourcesHandler), models.ProviderAuth))).
+		Methods("GET")
+	gMux.Handle("/api/telemetry/components", h.ProviderMiddleware(h.AuthMiddleware(h.SessionInjectorMiddleware(h.GetTelemetryComponentsHandler), models.ProviderAuth))).
+		Methods("GET")
+
 	gMux.Handle("/api/perf/profile", h.ProviderMiddleware(h.AuthMiddleware(h.SessionInjectorMiddleware(h.LoadTestHandler), models.ProviderAuth))).
 		Methods("GET", "POST")
 	gMux.Handle("/api/perf/profile/result", h.ProviderMiddleware(h.AuthMiddleware(h.SessionInjectorMiddleware(h.FetchAllResultsHandler), models.ProviderAuth))).
@@ -125,6 +161,8 @@ func NewRouter(_ context.Context, h models.HandlerInterface, port int, g http.Ha
 	gMux.Handle("/api/system/events", h.ProviderMiddleware(h.AuthMiddleware(h.SessionInjectorMiddleware(h.ClientEventHandler), models.ProviderAuth))).
 		Methods("POST")
 		// This will be changed to /api/events once the UI is compeltely updated to use new events and SSE is tunred off, otherwise existing events will break.
+	gMux.Handle("/api/events", h.ProviderMiddleware(h.AuthMiddleware(h.SessionInjectorMiddleware(h.EventStreamHandler), models.ProviderAuth))).
+		Methods("GET")
 	gMux.Handle("/api/system/events", h.ProviderMiddleware(h.AuthMiddleware(h.SessionInjectorMiddleware(h.GetAllEvents), models.ProviderAuth))).
 		Methods("GET")
 	gMux.Handle("/api/system/events/types", h.ProviderMiddleware(h.AuthMiddleware(h.SessionInjectorMiddleware(h.GetEventTypes), models.ProviderAuth))).

--- a/ui/lib/__tests__/sseClient.test.ts
+++ b/ui/lib/__tests__/sseClient.test.ts
@@ -1,0 +1,290 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+// Hand-rolled EventSource mock. We can't import the real one in jsdom and
+// we don't want to ship eventsource-polyfill just for tests, so we install
+// a stub on globalThis and track every instance created during the test.
+//
+// The mock implements just enough of the EventSource surface that sseClient
+// touches:
+//   - constructor(url, init)
+//   - addEventListener(type, cb)
+//   - close()
+//   - helper methods on the mock instance to dispatch open/message/error
+//     synthetically from the test side.
+//
+// Multiple sseSubscribe calls will create multiple instances; we keep them
+// all in a registry so a test can interrogate "the second EventSource"
+// after a rebind.
+interface FakeEventSourceInit {
+  withCredentials?: boolean;
+}
+
+type ListenerMap = Record<string, Array<(ev: Event) => void>>;
+
+class FakeEventSource {
+  static instances: FakeEventSource[] = [];
+  url: string;
+  withCredentials: boolean;
+  readyState = 0; // CONNECTING
+  closed = false;
+  private listeners: ListenerMap = {};
+
+  constructor(url: string, init?: FakeEventSourceInit) {
+    this.url = url;
+    this.withCredentials = !!init?.withCredentials;
+    FakeEventSource.instances.push(this);
+  }
+
+  addEventListener(type: string, cb: (ev: Event) => void): void {
+    (this.listeners[type] ||= []).push(cb);
+  }
+
+  close(): void {
+    this.closed = true;
+    this.readyState = 2; // CLOSED
+  }
+
+  // --- test-side dispatchers --------------------------------------------
+  dispatchOpen(): void {
+    this.readyState = 1; // OPEN
+    for (const cb of this.listeners.open ?? []) cb(new Event('open'));
+  }
+
+  dispatchMessage(name: string, data: string): void {
+    const ev = new MessageEvent(name, { data });
+    for (const cb of this.listeners[name] ?? []) cb(ev);
+  }
+
+  dispatchError(): void {
+    for (const cb of this.listeners.error ?? []) cb(new Event('error'));
+  }
+
+  static reset(): void {
+    FakeEventSource.instances = [];
+  }
+}
+
+// Install BEFORE importing sseClient — the module under test doesn't
+// import the global eagerly (it constructs new EventSource() inside
+// sseSubscribe), so this assignment is picked up at call time. Vitest's
+// hoisting of vi.mock doesn't help here because EventSource is a global,
+// not a module.
+(globalThis as unknown as { EventSource: typeof FakeEventSource }).EventSource = FakeEventSource;
+
+import { sseSubscribe } from '../sseClient';
+import { _resetForTests, _activeCountForTests, on as onWsStatus } from '../wsStatus';
+
+describe('sseSubscribe', () => {
+  beforeEach(() => {
+    FakeEventSource.reset();
+    _resetForTests();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('opens an EventSource with withCredentials and the encoded URL', () => {
+    sseSubscribe({
+      path: '/api/stream',
+      params: { id: 'abc', tags: ['x', 'y'] },
+      onMessage: () => {},
+    });
+
+    expect(FakeEventSource.instances).toHaveLength(1);
+    const es = FakeEventSource.instances[0]!;
+    expect(es.withCredentials).toBe(true);
+    expect(es.url).toBe('/api/stream?id=abc&tags=x&tags=y');
+  });
+
+  it('drops undefined params from the URL', () => {
+    sseSubscribe({
+      path: '/api/stream',
+      params: { id: 'abc', skip: undefined },
+      onMessage: () => {},
+    });
+    expect(FakeEventSource.instances[0]!.url).toBe('/api/stream?id=abc');
+  });
+
+  it('preserves an existing query string when appending params', () => {
+    sseSubscribe({
+      path: '/api/stream?fixed=1',
+      params: { extra: 'two' },
+      onMessage: () => {},
+    });
+    expect(FakeEventSource.instances[0]!.url).toBe('/api/stream?fixed=1&extra=two');
+  });
+
+  it('calls onMessage with JSON-parsed payload when a default message arrives', () => {
+    const onMessage = vi.fn();
+    sseSubscribe({ path: '/api/stream', onMessage });
+    const es = FakeEventSource.instances[0]!;
+    es.dispatchMessage('message', JSON.stringify({ hello: 'world' }));
+    expect(onMessage).toHaveBeenCalledWith({ hello: 'world' });
+  });
+
+  it('honors a custom eventName instead of the default "message"', () => {
+    const onMessage = vi.fn();
+    sseSubscribe({ path: '/api/stream', eventName: 'tick', onMessage });
+    const es = FakeEventSource.instances[0]!;
+    es.dispatchMessage('message', JSON.stringify({ wrong: true }));
+    expect(onMessage).not.toHaveBeenCalled();
+    es.dispatchMessage('tick', JSON.stringify({ ok: true }));
+    expect(onMessage).toHaveBeenCalledWith({ ok: true });
+  });
+
+  it('logs and swallows JSON parse failures (does not throw)', () => {
+    const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    const onMessage = vi.fn();
+    sseSubscribe({ path: '/api/stream', onMessage, subscriptionName: 'Bad' });
+    const es = FakeEventSource.instances[0]!;
+    es.dispatchMessage('message', '{not json');
+    expect(onMessage).not.toHaveBeenCalled();
+    expect(consoleSpy).toHaveBeenCalledWith(
+      expect.stringContaining('[SSE: Bad] failed to parse message:'),
+      expect.any(Error),
+    );
+  });
+
+  it('dispose() closes the EventSource and is idempotent', () => {
+    const sub = sseSubscribe({ path: '/api/stream', onMessage: () => {} });
+    const es = FakeEventSource.instances[0]!;
+    expect(es.closed).toBe(false);
+    sub.dispose();
+    expect(es.closed).toBe(true);
+    // Idempotent — calling dispose again should not blow up and should not
+    // create a new EventSource.
+    sub.dispose();
+    expect(FakeEventSource.instances).toHaveLength(1);
+  });
+
+  it('rebind() closes the old EventSource and opens a new one with new params', () => {
+    const onMessage = vi.fn();
+    const sub = sseSubscribe({
+      path: '/api/stream',
+      params: { ctx: 'a' },
+      onMessage,
+    });
+    const first = FakeEventSource.instances[0]!;
+    expect(first.url).toBe('/api/stream?ctx=a');
+
+    sub.rebind({ ctx: 'b' });
+
+    expect(first.closed).toBe(true);
+    expect(FakeEventSource.instances).toHaveLength(2);
+    const second = FakeEventSource.instances[1]!;
+    expect(second.url).toBe('/api/stream?ctx=b');
+
+    // Handlers carry over: a message on the second EventSource invokes the
+    // same onMessage closure.
+    second.dispatchMessage('message', JSON.stringify({ from: 'second' }));
+    expect(onMessage).toHaveBeenCalledWith({ from: 'second' });
+  });
+
+  it('rebind() after dispose() is a no-op', () => {
+    const sub = sseSubscribe({ path: '/api/stream', onMessage: () => {} });
+    sub.dispose();
+    sub.rebind({ next: '1' });
+    expect(FakeEventSource.instances).toHaveLength(1);
+  });
+
+  it('default onError logs to console without throwing', () => {
+    const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    sseSubscribe({
+      path: '/api/stream',
+      subscriptionName: 'Default',
+      onMessage: () => {},
+    });
+    const es = FakeEventSource.instances[0]!;
+    expect(() => es.dispatchError()).not.toThrow();
+    expect(consoleSpy).toHaveBeenCalledWith(
+      expect.stringContaining('[SSE: Default] Error:'),
+      expect.any(Event),
+    );
+  });
+
+  it('user-supplied onError replaces the default handler', () => {
+    const onError = vi.fn();
+    sseSubscribe({
+      path: '/api/stream',
+      onMessage: () => {},
+      onError,
+    });
+    const es = FakeEventSource.instances[0]!;
+    es.dispatchError();
+    expect(onError).toHaveBeenCalled();
+  });
+
+  it('updates wsStatus active count on open and dispose', () => {
+    const sub = sseSubscribe({ path: '/api/stream', onMessage: () => {} });
+    expect(_activeCountForTests()).toBe(0);
+    FakeEventSource.instances[0]!.dispatchOpen();
+    expect(_activeCountForTests()).toBe(1);
+    sub.dispose();
+    expect(_activeCountForTests()).toBe(0);
+  });
+
+  it('emits wsStatus connected and closed across the 0->1->0 edge', () => {
+    const connected = vi.fn();
+    const closed = vi.fn();
+    onWsStatus('connected', connected);
+    onWsStatus('closed', closed);
+
+    const sub = sseSubscribe({ path: '/api/stream', onMessage: () => {} });
+    const es = FakeEventSource.instances[0]!;
+    es.dispatchOpen();
+    expect(connected).toHaveBeenCalledTimes(1);
+    expect(closed).not.toHaveBeenCalled();
+    sub.dispose();
+    expect(closed).toHaveBeenCalledTimes(1);
+  });
+
+  it('marks the subscription closed on error so the next open re-fires connected', () => {
+    // Regression for the case where EventSource fires error -> open (the
+    // browser reconnected) but the wrapper had left its internal countedOpen
+    // flag set, so it never observed the 0->1 edge and the connection
+    // indicator stayed stuck in the "reconnecting" state forever.
+    const connected = vi.fn();
+    const closed = vi.fn();
+    const errorSpy = vi.fn();
+    onWsStatus('connected', connected);
+    onWsStatus('closed', closed);
+    onWsStatus('error', errorSpy);
+    // Suppress the default console.error from the SSE error handler so the
+    // test output stays clean.
+    const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    sseSubscribe({ path: '/api/stream', onMessage: () => {} });
+    const es = FakeEventSource.instances[0]!;
+    es.dispatchOpen();
+    expect(connected).toHaveBeenCalledTimes(1);
+
+    // The transport hiccups: error fires, the EventSource enters its
+    // built-in reconnect.
+    es.dispatchError();
+    expect(closed).toHaveBeenCalledTimes(1);
+    expect(errorSpy).toHaveBeenCalledTimes(1);
+    expect(_activeCountForTests()).toBe(0);
+
+    // Then the browser reconnects and re-fires open on the same instance.
+    es.dispatchOpen();
+    expect(connected).toHaveBeenCalledTimes(2);
+    expect(_activeCountForTests()).toBe(1);
+
+    consoleSpy.mockRestore();
+  });
+
+  it('drops messages that arrive after dispose()', () => {
+    // The browser can deliver buffered MessageEvents after close() returns
+    // but before the underlying connection is fully torn down. onMessage
+    // must not fire in that window or callers see callbacks after dispose,
+    // which is a footgun for components that have unmounted.
+    const onMessage = vi.fn();
+    const sub = sseSubscribe({ path: '/api/stream', onMessage });
+    const es = FakeEventSource.instances[0]!;
+    es.dispatchOpen();
+    sub.dispose();
+    es.dispatchMessage('message', '{"after":"dispose"}');
+    expect(onMessage).not.toHaveBeenCalled();
+  });
+});

--- a/ui/lib/sseClient.ts
+++ b/ui/lib/sseClient.ts
@@ -1,0 +1,201 @@
+/**
+ * sseClient.ts
+ *
+ * Typed wrapper around the browser-native EventSource for the SSE migration.
+ * EventSource handles reconnection natively (the cadence is implementation-
+ * defined and can be tuned by the server via the SSE `retry:` field), so this
+ * module deliberately does NOT layer extra retry on top — adding our own
+ * retry would either double-retry or fight the built-in semantics, both of
+ * which we have been burned by in the WS client.
+ *
+ * The wrapper integrates with lib/wsStatus.ts so that the existing
+ * connection-status XState machine continues to receive `connected | closed |
+ * error` notifications during the migration period.
+ */
+import {
+  _notifySubscriptionClose,
+  _notifySubscriptionError,
+  _notifySubscriptionOpen,
+} from './wsStatus';
+
+export interface SSESubscribeOptions {
+  /** Server-relative path, e.g. '/api/system/kubernetes/contexts/stream'. */
+  path: string;
+  /**
+   * Optional query parameters. Arrays expand to repeated keys
+   * (`?id=a&id=b`). undefined values are dropped.
+   */
+  params?: Record<string, string | string[] | undefined>;
+  /** Called per SSE message with the JSON-parsed payload. */
+  onMessage: (data: unknown) => void;
+  /**
+   * Optional error handler. If omitted, a default handler logs to the
+   * console with the subscription name — callers opt into surfacing errors
+   * because most SSE error events are spurious reconnect cycles the browser
+   * is already healing.
+   */
+  onError?: (err: Event) => void;
+  /** SSE named event to listen for; defaults to the unnamed 'message'. */
+  eventName?: string;
+  /** Used in diagnostic log lines; defaults to 'Unknown'. */
+  subscriptionName?: string;
+}
+
+export interface SSESubscription {
+  /** Tear down the EventSource. Safe to call more than once. */
+  dispose: () => void;
+  /**
+   * Close the current EventSource and open a new one to the same path with
+   * the supplied params. Preserves onMessage / onError / eventName /
+   * subscriptionName. Useful when a filter the user controls (e.g. a context
+   * picker) changes and we want a single logical subscription to follow it.
+   */
+  rebind: (newParams: Record<string, string | string[] | undefined>) => void;
+}
+
+/**
+ * Build a URL with query parameters. Arrays expand to repeated keys,
+ * undefined values are skipped, everything else is coerced to string and
+ * URL-encoded by URLSearchParams.
+ */
+function buildUrl(
+  path: string,
+  params: Record<string, string | string[] | undefined> | undefined,
+): string {
+  if (!params) return path;
+  const search = new URLSearchParams();
+  for (const [key, value] of Object.entries(params)) {
+    if (value === undefined) continue;
+    if (Array.isArray(value)) {
+      for (const v of value) {
+        search.append(key, v);
+      }
+    } else {
+      search.append(key, value);
+    }
+  }
+  const qs = search.toString();
+  if (!qs) return path;
+  return `${path}${path.includes('?') ? '&' : '?'}${qs}`;
+}
+
+/**
+ * Open an SSE subscription.
+ *
+ * Lifecycle:
+ *   1. Create EventSource with withCredentials so the meshery session cookie
+ *      rides along.
+ *   2. On open, mark this subscription as "active" with wsStatus so the
+ *      connection indicator lights up.
+ *   3. On message of the requested eventName, JSON-parse the payload and
+ *      hand it to onMessage. Parse failures are logged but not thrown —
+ *      a malformed event should not kill the stream.
+ *   4. On error, hand the event to onError (or the default logger) and let
+ *      the browser's built-in reconnect logic recover.
+ *   5. On dispose, close the EventSource and decrement the wsStatus count.
+ */
+export function sseSubscribe(opts: SSESubscribeOptions): SSESubscription {
+  const { path, onMessage, onError, eventName = 'message', subscriptionName = 'Unknown' } = opts;
+
+  // Mutable closure-captured state so rebind() can swap the EventSource
+  // without forcing callers to re-register handlers.
+  let currentParams = opts.params;
+  let source: EventSource | null = null;
+  let disposed = false;
+  // Track whether THIS subscription is currently counted as open in wsStatus.
+  // We only flip the count on the actual open <-> closed transitions to keep
+  // the aggregate connection indicator honest across reconnects.
+  let countedOpen = false;
+
+  const errorHandler = onError ?? defaultOnError(subscriptionName);
+
+  function open(): void {
+    const url = buildUrl(path, currentParams);
+    const es = new EventSource(url, { withCredentials: true });
+    source = es;
+
+    es.addEventListener('open', () => {
+      if (disposed) return;
+      if (!countedOpen) {
+        countedOpen = true;
+        _notifySubscriptionOpen();
+      }
+    });
+
+    es.addEventListener(eventName, (raw: Event) => {
+      // A message can arrive between dispose() and the browser actually
+      // closing the EventSource — drop it to keep dispose semantically
+      // clean (no callbacks fire after dispose returns).
+      if (disposed) return;
+      // EventSource only fires MessageEvent for named events, but the DOM
+      // typings declare a plain Event here so we narrow defensively.
+      const msg = raw as MessageEvent<string>;
+      try {
+        const parsed: unknown = JSON.parse(msg.data);
+        onMessage(parsed);
+      } catch (err) {
+        // A malformed payload from the server is a server bug, not a
+        // transport problem — log it but keep the stream open so the next
+        // (presumably well-formed) event still gets through.
+        console.error(`[SSE: ${subscriptionName}] failed to parse message:`, err);
+      }
+    });
+
+    es.addEventListener('error', (err: Event) => {
+      if (disposed) return;
+      // EventSource onerror fires when the connection drops; the browser
+      // will then attempt to reconnect, firing `open` again on success. We
+      // must mark the subscription closed here so the upcoming reopen
+      // notifies wsStatus on the 0->1 edge — otherwise countedOpen stays
+      // true and the status machine never observes that we reconnected.
+      if (countedOpen) {
+        countedOpen = false;
+        _notifySubscriptionClose();
+      }
+      _notifySubscriptionError(err);
+      errorHandler(err);
+    });
+  }
+
+  function close(): void {
+    if (source) {
+      source.close();
+      source = null;
+    }
+    if (countedOpen) {
+      countedOpen = false;
+      _notifySubscriptionClose();
+    }
+  }
+
+  open();
+
+  return {
+    dispose(): void {
+      if (disposed) return;
+      disposed = true;
+      close();
+    },
+    rebind(newParams: Record<string, string | string[] | undefined>): void {
+      if (disposed) return;
+      currentParams = newParams;
+      close();
+      // Re-open under the new params, preserving handlers via closure.
+      // disposed is still false so open() will install fresh listeners on
+      // the new EventSource.
+      open();
+    },
+  };
+}
+
+/**
+ * Default error handler used when callers don't supply one. Matches the
+ * "log-only, don't throw" convention from lib/subscriptionHelper.ts so UI
+ * surfaces aren't spammed with reconnect-cycle errors that the browser is
+ * already healing.
+ */
+function defaultOnError(subscriptionName: string): (err: Event) => void {
+  return (err) => {
+    console.error(`[SSE: ${subscriptionName}] Error:`, err);
+  };
+}

--- a/ui/lib/wsStatus.ts
+++ b/ui/lib/wsStatus.ts
@@ -1,0 +1,129 @@
+/**
+ * wsStatus.ts
+ *
+ * Compatibility shim for the in-flight WebSocket-to-SSE migration. The
+ * existing XState machine in machines/wsConnection.ts was wired to the
+ * graphql-ws subscriptionClient on/off contract (`connected | closed | error`)
+ * so it could light up a connection status indicator. As routes migrate from
+ * graphql-ws to SSE we still want that indicator to reflect "do we have a
+ * live server connection at all?".
+ *
+ * This module exposes the same `on(event, cb) => unsubscribe` / `off(event, cb)`
+ * surface, but the underlying signal is the number of open SSE subscriptions
+ * managed by sseClient.ts. When the first subscription opens we emit
+ * `connected`; when the last one closes we emit `closed`; any subscription's
+ * onerror fires `error`. This keeps consumers of the XState machine
+ * (connection toasts, header indicators) working unchanged across the
+ * migration without forcing every UI surface to subscribe to a different API.
+ */
+export type WsStatusEvent = 'connected' | 'closed' | 'error';
+export type WsStatusListener<E extends WsStatusEvent = WsStatusEvent> = (
+  payload?: E extends 'error' ? unknown : Event | undefined,
+) => void;
+
+type ListenerMap = {
+  [E in WsStatusEvent]: Set<WsStatusListener<E>>;
+};
+
+const listeners: ListenerMap = {
+  connected: new Set(),
+  closed: new Set(),
+  error: new Set(),
+};
+
+// activeCount is the number of currently-open SSE subscriptions. We treat
+// the aggregate as "connected" whenever it is > 0 and "closed" when it
+// returns to 0. We don't try to coalesce concurrent transitions: if a caller
+// opens two subscriptions in the same tick the second open is a no-op for
+// status purposes, which matches the graphql-ws behaviour where there is a
+// single underlying socket.
+let activeCount = 0;
+
+function emit<E extends WsStatusEvent>(
+  event: E,
+  payload?: E extends 'error' ? unknown : Event | undefined,
+): void {
+  // Snapshot the listener set before iterating: a handler is allowed to
+  // call off() on itself, which would mutate the live Set mid-iteration.
+  const snapshot = Array.from(listeners[event]) as WsStatusListener<E>[];
+  for (const cb of snapshot) {
+    try {
+      cb(payload);
+    } catch (err) {
+      // A buggy listener shouldn't poison the others. Surface via console
+      // so it shows up in dev tools but keep going.
+      console.error('[wsStatus] listener for', event, 'threw:', err);
+    }
+  }
+}
+
+/**
+ * Subscribe to a wsStatus event. Returns an unsubscribe function so callers
+ * can use it inline (e.g. inside xstate fromCallback).
+ */
+export function on<E extends WsStatusEvent>(event: E, cb: WsStatusListener<E>): () => void {
+  listeners[event].add(cb as WsStatusListener);
+  return () => off(event, cb);
+}
+
+/**
+ * Remove a previously-registered listener.
+ */
+export function off<E extends WsStatusEvent>(event: E, cb: WsStatusListener<E>): void {
+  listeners[event].delete(cb as WsStatusListener);
+}
+
+// --- internal hooks for sseClient -------------------------------------------
+// These are not exported in the public type surface — they are accessed from
+// sseClient.ts via the module-level binding because the two modules are
+// tightly coupled by design.
+
+/**
+ * @internal Called by sseClient when a new EventSource transitions to OPEN.
+ * Fires `connected` only on the 0 -> 1 edge.
+ */
+export function _notifySubscriptionOpen(): void {
+  activeCount++;
+  if (activeCount === 1) {
+    emit('connected');
+  }
+}
+
+/**
+ * @internal Called by sseClient when an EventSource is disposed or naturally
+ * closes. Fires `closed` only on the 1 -> 0 edge.
+ */
+export function _notifySubscriptionClose(): void {
+  if (activeCount === 0) return;
+  activeCount--;
+  if (activeCount === 0) {
+    emit('closed');
+  }
+}
+
+/**
+ * @internal Called by sseClient on EventSource onerror. Always fires —
+ * the XState machine decides whether to transition to reconnecting.
+ */
+export function _notifySubscriptionError(err: Event): void {
+  emit('error', err);
+}
+
+/**
+ * @internal Test-only escape hatch to reset internal counters. Production
+ * callers should never need this; exported with an underscore prefix to
+ * keep it out of typical autocomplete suggestions.
+ */
+export function _resetForTests(): void {
+  activeCount = 0;
+  listeners.connected.clear();
+  listeners.closed.clear();
+  listeners.error.clear();
+}
+
+/**
+ * @internal Read-only view of the current count, for diagnostics and tests.
+ */
+export function _activeCountForTests(): number {
+  return activeCount;
+}

--- a/ui/machines/__tests__/wsConnection.test.ts
+++ b/ui/machines/__tests__/wsConnection.test.ts
@@ -2,32 +2,31 @@ import { describe, expect, it, vi, beforeEach } from 'vitest';
 import { createActor } from 'xstate';
 
 // The wsConnection machine spawns an actor that subscribes to the
-// graphql-ws `subscriptionClient` (in `lib/relayEnvironment`). We expose a
-// fake client and stub the relay environment to control how events flow.
+// connection-status event bus exposed by `lib/wsStatus`. We mock that
+// module so the test can synthetically fire `connected | closed | error`
+// events and assert the machine's resulting state transitions.
 
 type Handler = (...args: unknown[]) => void;
 
 const hoisted = vi.hoisted(() => {
   const handlers: Record<string, Handler[]> = {};
   const offFns: Record<string, ReturnType<typeof vi.fn>[]> = {};
-  const fakeClient = {
-    on(eventName: string, handler: Handler) {
-      handlers[eventName] = handlers[eventName] || [];
-      handlers[eventName].push(handler);
-      const off = vi.fn();
-      offFns[eventName] = offFns[eventName] || [];
-      offFns[eventName].push(off);
-      return off;
-    },
+  const on = (eventName: string, handler: Handler) => {
+    handlers[eventName] = handlers[eventName] || [];
+    handlers[eventName].push(handler);
+    const off = vi.fn();
+    offFns[eventName] = offFns[eventName] || [];
+    offFns[eventName].push(off);
+    return off;
   };
-  return { handlers, offFns, fakeClient };
+  return { handlers, offFns, on };
 });
 const handlers = hoisted.handlers;
 const offFns = hoisted.offFns;
 
-vi.mock('../../lib/relayEnvironment', () => ({
-  subscriptionClient: hoisted.fakeClient,
-  createRelayEnvironment: () => ({}),
+vi.mock('../../lib/wsStatus', () => ({
+  on: hoisted.on,
+  off: vi.fn(),
 }));
 
 import { wsConnectionMachine, WS_CONNECTION_EVENTS } from '../wsConnection';

--- a/ui/machines/wsConnection.ts
+++ b/ui/machines/wsConnection.ts
@@ -1,10 +1,12 @@
 import { setup, fromCallback, assign } from 'xstate';
-import { subscriptionClient } from '../lib/relayEnvironment';
+import * as wsStatus from '../lib/wsStatus';
 
 /**
- * XState machine managing the graphql-ws WebSocket connection lifecycle.
- * Tracks connection state (connecting, connected, reconnecting, disconnected)
- * and emits events for UI consumption (connection status indicators, error toasts).
+ * XState machine managing the live server connection lifecycle for the
+ * SSE migration. Historically wired to the graphql-ws subscriptionClient;
+ * now wired to lib/wsStatus, which aggregates SSE subscription state under
+ * the same `connected | closed | error` event surface. Consumers of the
+ * machine (status indicators, reconnect toasts) see no shape change.
  */
 
 export const WS_CONNECTION_EVENTS = {
@@ -15,19 +17,22 @@ export const WS_CONNECTION_EVENTS = {
 } as const;
 
 const wsMonitorActor = fromCallback(({ sendBack }) => {
-  if (!subscriptionClient || typeof window === 'undefined') {
+  // SSR guard: wsStatus events fire from EventSource callbacks which only
+  // exist in the browser. Returning a no-op cleanup keeps the actor happy
+  // when the machine is hydrated server-side.
+  if (typeof window === 'undefined') {
     return;
   }
 
-  const unsubConnected = subscriptionClient.on('connected', () => {
+  const unsubConnected = wsStatus.on('connected', () => {
     sendBack({ type: WS_CONNECTION_EVENTS.CONNECTED });
   });
 
-  const unsubClosed = subscriptionClient.on('closed', (event) => {
+  const unsubClosed = wsStatus.on('closed', (event) => {
     sendBack({ type: WS_CONNECTION_EVENTS.DISCONNECTED, data: { event } });
   });
 
-  const unsubError = subscriptionClient.on('error', (error) => {
+  const unsubError = wsStatus.on('error', (error) => {
     sendBack({ type: WS_CONNECTION_EVENTS.ERROR, data: { error } });
   });
 


### PR DESCRIPTION
## Summary
Server-side counterpart of the GraphQL→REST/SSE migration. Adds the
nine REST handlers, one SSE handler, and the route for the existing
`EventStreamHandler` that together cover every live GraphQL operation
the UI swap requires. Resolvers stay in place — the GraphQL teardown
PR removes them after all consumers move over.

> **Base:** this PR targets `infra/sse-foundations` (#19393); the
> controllers-status SSE handler depends on `server/internal/sse.Stream`
> from that PR. Will rebase to `master` once #19393 merges.

## Endpoints

| Method | Path | Notes |
|--------|------|-------|
| GET | `/api/events` | Wires the existing `EventStreamHandler` |
| GET | `/api/system/meshes/addons` | Replaces `getAvailableAddons`; nil-safe (resolver had a `filter.Type` deref bug) |
| GET | `/api/system/meshes/control-planes` | Replaces `getControlPlanes` |
| GET | `/api/system/kubernetes/connections/{connectionID}/operator/status` | Replaces `getOperatorStatus` |
| GET | `/api/system/kubernetes/connections/{connectionID}/meshsync/status` | Replaces `getMeshsyncStatus` |
| GET | `/api/system/kubernetes/connections/{connectionID}/nats/status` | Replaces `getNatsStatus` |
| POST | `/api/system/kubernetes/contexts/{contextID}/resync` | Replaces `resyncCluster` — was mis-typed as a Query but mutates everything, now POST |
| POST | `/api/system/kubernetes/contexts/{contextID}/operator` | Replaces `changeOperatorStatus`; preserves `OperatorTracker.Undeployed`, `SubscribeToBroker`, `ConnectionTrackerSingleton.Set` side effects |
| GET | `/api/system/kubernetes/describe?contextId=` | Replaces `getKubectlDescribe`; **fixes the resolver bug** where the kube client was built with an empty kubeconfig, ignoring the user's active context |
| GET | `/api/system/kubernetes/controllers/status/stream` | SSE; replaces `subscribeMesheryControllersStatus` |

## Highlights

**Server-side change detection in the controllers stream.** The legacy
GraphQL resolver emitted every tick if `newStatus != prev.Status || version != prev.Version`.
The new SSE handler uses `reflect.DeepEqual` on the full struct so the
diff survives future field additions, batches all changed
`(connection, controller)` pairs into a single SSE frame per tick, and
moves the lodash `_.isEqual` dedupe out of the UI hot path.

**Uses `sse.Stream` from #19393.** A producer goroutine ticks every 5
seconds, polls each requested connection's controller handlers,
computes the diff, and pushes batched updates onto a buffered channel;
`sse.Stream` owns headers, heartbeat, and write/flush cadence.

**Connection-tracker singleton.** Moved `connectionTrackerSingleton`
semantics into `model.ConnectionTrackerSingleton` (exported var). The
resolver still holds its own local copy (untouched per the "don't
touch resolvers" rule); both go away together when the resolvers are
deleted in the teardown PR.

**Operator-status handler lookup.** The resolver reads from
`ctx.Value(MesheryControllerHandlersKey)`, but that key is never
populated anywhere in the codebase — it's effectively dead-code that
nil-derefs in practice. The new handler looks up the controller via
the state-machine tracker keyed by connection ID, matching the
working pattern in `getMeshsyncStatus` / `getNatsStatus`.

**Resync body shape.** Accepts proper JSON booleans
(`{"reSync":true,"clearDb":false,"hardReset":false}`) instead of the
legacy string-enum (`"true"`/`"false"`).

**Broadcasts dropped on the REST path.** Resolver's `r.Broadcast.Submit`
calls existed only to drive GraphQL subscriptions; REST/SSE consumers
don't need them. Every other side effect is preserved faithfully.

## Test plan
- [x] `go build ./...` clean
- [x] `go vet ./...` clean
- [x] `go test ./handlers/...` PASS (2.9s)
- [x] `go test ./internal/graphql/model/... ./router/... ./models/... ./machines/kubernetes/...` PASS
- [x] One pre-existing failure (`TestFetchKubernetesVersion` in `helpers/`) reproduces on unmodified master; requires a live cluster at 127.0.0.1:6443
- [x] `golangci-lint run ./handlers/...`: only pre-existing `QF1012` warnings in `component_generator_helper.go`; new code is lint-clean

## Stats
+1,051 / -2 across 8 files. 5 new handler files; minor edits to `models/handlers.go`, `router/server.go`, `internal/graphql/model/helpers.go`.

---

> ⚠️ **Schemas-canonical refactor follow-up:** This PR introduces locally-defined RTK Query hooks / Redux reducer changes / Go handler types that should originate from `meshery/schemas` (canonical OpenAPI source). Landing as-is per maintainer direction to keep the GraphQL→SSE migration on schedule. Tracking refactor: #19418.