### PR TITLE
fix(ui): resolve invalid save icon import in performance preferences

### DIFF
--- a/ui/components/settings/MesherySettingsPerformanceComponent.tsx
+++ b/ui/components/settings/MesherySettingsPerformanceComponent.tsx
@@ -17,7 +17,7 @@ import {
   Autocomplete,
   NoSsr,
   Radio,
-  SaveOutlinedIcon,
+  SaveIcon,
 } from '@sistent/sistent';
 import { useGetLoadTestPrefsQuery, useUpdateLoadTestPrefsMutation } from '@/rtk-query/user';
 import { useSelector, useDispatch } from 'react-redux';
@@ -246,7 +246,7 @@ const MesherySettingsPerformanceComponent = () => {
               onClick={handleSubmit}
               disabled={isSaving}
             >
-              <SaveOutlinedIcon style={{ marginRight: '3px' }} />
+              <SaveIcon style={{ marginRight: '3px' }} />
               {isSaving ? <CircularProgress size={30} /> : 'Save'}
             </Button>
           </div>

--- a/ui/components/settings/MesherySettingsPerformanceComponent.tsx
+++ b/ui/components/settings/MesherySettingsPerformanceComponent.tsx
@@ -246,7 +246,7 @@ const MesherySettingsPerformanceComponent = () => {
               onClick={handleSubmit}
               disabled={isSaving}
             >
-              <SaveIcon style={{ marginRight: '3px' }} />
+{!isSaving && <SaveIcon style={{ marginRight: '3px' }} />}
               {isSaving ? <CircularProgress size={30} /> : 'Save'}
             </Button>
           </div>


### PR DESCRIPTION
**Notes for Reviewers**

Fixes a runtime error in the Performance Preferences page caused by importing `SaveOutlinedIcon` from `@sistent/sistent`.

`SaveOutlinedIcon` is not exported by Sistent, causing the component to render `undefined` and triggering a React runtime error (`Element type is invalid`).

This PR replaces the invalid import with the exported `SaveIcon` component from Sistent.

## Changes

* Replaced `SaveOutlinedIcon` with `SaveIcon`
* Verified Performance Preferences page renders correctly
* Verified preferences save flow works successfully

- This PR fixes #14694 

**[Signed commits](https://github.com/meshery/meshery/blob/master/CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [X] Yes, I signed my commits.

<!--
Thank you for contributing to Meshery! 

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. Sign your commits.
4. Include before and after screenshots/terminal output.

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.
-->
