### PR TITLE
[Docs] Displace Kanvas and Layer5 from Kubernetes tutorial pages

### DIFF
--- a/docs/content/en/guides/tutorials/kubernetes/exploring-kubernetes-cronjobs.md
+++ b/docs/content/en/guides/tutorials/kubernetes/exploring-kubernetes-cronjobs.md
@@ -56,7 +56,7 @@ To deploy a web application on Meshery, follow these steps:
 
 <!-- 
 
-Convey to user that Kanvas Designs are auto-saved. 
+Convey to user that Designs are auto-saved. 
 
 -->
 
@@ -67,15 +67,15 @@ Convey to user that Kanvas Designs are auto-saved.
 
 <!--
 
-Show user how to do this using Kanvas Designer to drag and drop components and configure them.
+Show user how to do this using Meshery Design Configurator to drag and drop components and configure them.
 
 -->
 
-1. Open the Kanvas tab located in the left panel.
-2. Upon opening Kanvas, ensure that you are on the Design tab, which can be found at the top center of the canvas.
+1. Open the Designer tab located in the left panel.
+2. Upon opening the Designer, ensure that you are on the Design tab, which can be found at the top center of the canvas.
 3. Navigate to the Design option located in the top menu of the left panel. Using the search bar, type in the name of your app, which in this instance is the Minecraft App.
 4. Once your app appears in the list, click on it to upload the design file onto the canvas.
-[![Navigate Kanvas](/guides/tutorials/images/navigate-kanvas.png)](/guides/tutorials/images/navigate-kanvas.png)
+[![Navigate Designer](/guides/tutorials/images/navigate-kanvas.png)](/guides/tutorials/images/navigate-kanvas.png)
 5. Locate the control panel at the bottom of the canvas and choose the Kubernetes option.
 6. Using the search bar, enter "Cron Job" and click on the corresponding icon to display it on the canvas.
 [![Select CronJob item](/guides/tutorials/images/select-cronjob.png)](/guides/tutorials/images/select-cronjob.png)
@@ -95,7 +95,7 @@ Show user how to do this using Kanvas Designer to drag and drop components and c
 #### 4. **Verifying CronJob Execution:**
    - Monitor the execution of the CronJob and verify that backups are created at the specified intervals.
 
-To view the resources created for the CronJob, we will utilize the Visualize tab of the Kanvas. A view will be created with necessary filters to display the relevant resources.
+To view the resources created for the CronJob, we will utilize the Visualize tab of the Meshery Dashboard. A view will be created with necessary filters to display the relevant resources.
 
    1. Ensure that you are on the Visualize tab, located at the top center of the canvas.
    2. Give the view a name.
@@ -107,7 +107,7 @@ To view the resources created for the CronJob, we will utilize the Visualize tab
 
 <!-- 
 
-Show user how to use Views and filters in Kanvas Visualizer.
+Show user how to use Views and filters in Meshery Dashboard.
 
 -->
 
@@ -129,11 +129,11 @@ Show user how to use Views and filters in Kanvas Visualizer.
         [![Vizualize CronJob](/guides/tutorials/images/scale.png)](/guides/tutorials/images/scale.png)
 
    7.  Save Changes:
-        After verifying the adjustments, save the changes made to the CronJob settings within the Kanvas Designer interface to ensure they are retained for future reference.
+        After verifying the adjustments, save the changes made to the CronJob settings within the Meshery Design Configurator interface to ensure they are retained for future reference.
         [![Save CronJob](/guides/tutorials/images/save.png)](/guides/tutorials/images/save.png)
 <!-- 
 
-Show user how to use Designs and components in Kanvas Designer.
+Show user how to use Designs and components in Meshery Design Configurator.
 
 -->
 
@@ -148,11 +148,11 @@ Use Meshery Playground to visualize the changes and observe the impact on the sc
     Click on the CronJob component to open the tooltip. This action will enable access to the delete icon. Click to delete the CronJob.
     [![Save CronJob](/guides/tutorials/images/delete.png)](/guides/tutorials/images/delete.png)
 3. Save Changes:
-    After deleting the CronJob, save the changes made within the Kanvas Designer interface to reflect the cleanup.
+    After deleting the CronJob, save the changes made within the Meshery Design Configurator interface to reflect the cleanup.
     [![Save CronJob](/guides/tutorials/images/save-app.png)](/guides/tutorials/images/save-app.png)
 <!-- 
 
-Show user how to use Designs and components in Kanvas Designer.
+Show user how to use Designs and components in Meshery Design Configurator.
 
 -->
 
@@ -163,13 +163,13 @@ Show user how to use Designs and components in Kanvas Designer.
 
   
 1. Save Your Scenario:
-   - Click the save option in Kanvas Designer and give your scenario a descriptive name.
+   - Click the save option in Meshery Design Configurator and give your scenario a descriptive name.
 
 2. Make Design Public:
    - Toggle the visibility of your design to "Public" to allow others to view it.
 
 3. Share Your Design:
-   - Copy the shareable link or invite collaborators directly from Kanvas Designer.
+   - Copy the shareable link or invite collaborators directly from Meshery Design Configurator.
 
 4. Invite Friends to Collaborate:
    - Share the link with friends or collaborators to enable collaboration on your design.
@@ -182,7 +182,7 @@ Show user how to use Designs and components in Kanvas Designer.
 
 <!-- 
 
-Show user how to make Design public and share with other users in Kanvas Designer.
+Show user how to make Design public and share with other users in Meshery Design Configurator.
 
 -->
 

--- a/docs/content/en/guides/tutorials/kubernetes/kubernetes-configmaps-secrets.md
+++ b/docs/content/en/guides/tutorials/kubernetes/kubernetes-configmaps-secrets.md
@@ -35,9 +35,7 @@ Learn how to create and manage _Kubernetes ConfigMaps and Secrets_ within the co
 ### Access Meshery Playground
 
 - Log in to the [Meshery Playground](http://playground.meshery.io/) using your credentials. On successful login, you should be at the dashboard. Press the **X** on the _Where do you want to start?_ popup to close it (if required).
-- Click **Kanvas** in the navigation menu to navigate to _Kanvas_.
-
-> **_NOTE:_** Kanvas is still in beta.
+- Click **Designer** in the navigation menu to navigate to the _Meshery Design Configurator_.
 
 ### Clone the starter design
 

--- a/docs/content/en/guides/tutorials/kubernetes/kubernetes-deployments.md
+++ b/docs/content/en/guides/tutorials/kubernetes/kubernetes-deployments.md
@@ -33,15 +33,13 @@ Learn how to create, manage, and explore _Kubernetes Deployments_ within the con
 #### Access Meshery Playground
 
 - Log in to the [Meshery Playground](https://playground.meshery.io) using your credentials. On successful login, you should be at the dashboard. Press the **X** on the _Where do you want to start?_ popup to close it (if required).
-- Click **Kanvas** from the left menu to navigate to the _Kanvas_ design page.
+- Click **Designer** from the left menu to navigate to the _Meshery Design Configurator_ page.
 
   ![](/guides/tutorials/images/kubernetes-deployments/2025-02-27_16-59.png)
 
-> **_NOTE:_** Kanvas is still in beta.
-
 #### Create a Deployment
 
-1. In the _Kanvas Design_ page, start by renaming the design to a name of your choice for easier identification later.
+1. In the _Design_ page, start by renaming the design to a name of your choice for easier identification later.
     ![](/guides/tutorials/images/kubernetes-deployments/2025-02-27_17-03.png)
 2. From the floating dock below, click the **Kubernetes** icon and then click **Deployment** from the list. This will create the _Deployment_ component on the design canvas. 
     ![](/guides/tutorials/images/kubernetes-deployments/2025-02-27_17-16.png)
@@ -87,7 +85,7 @@ You should see a few alerts on the bottom right about the deployment.
 
 #### Viewing and Operating the Deployment
 
-To view and perform operations on the resources deployed, i.e. the _Deployment_ in this exmaple, we will use the **Operate** functionality of _Kanvas_. You can open the design in _Operate_ mode during the _Deploy_ workflow or later by click the **Operate** tab. It will load the deployed resources in _Operate_ view similar to the screenshot below.
+To view and perform operations on the resources deployed, i.e. the _Deployment_ in this exmaple, we will use the **Operate** functionality of _Meshery Dashboard_. You can open the design in _Operate_ mode during the _Deploy_ workflow or later by click the **Operate** tab. It will load the deployed resources in _Operate_ view similar to the screenshot below.
 ![](/guides/tutorials/images/kubernetes-deployments/2025-02-28_15-03.png)
 
 You can click on any of the resources to view various details and actions applicable to them. For example, click on the _Deployment_ i.e. `deployment-bl` in this case (shown with a green border in the image below), to view deployment details such as _Age_, _Kind_, _Pods_, _Replicas_, _Namespace_ etc. 

--- a/docs/content/en/guides/tutorials/kubernetes/kubernetes-pods.md
+++ b/docs/content/en/guides/tutorials/kubernetes/kubernetes-pods.md
@@ -33,13 +33,11 @@ Learn how to create, manage, and explore _Kubernetes Pods and Services_ within t
 #### Access Meshery Playground
 
 - Log in to the [Meshery Playground](https://play.meshery.io) using your credentials. On successful login, you should be at the dashboard. Press the **X** on the _Where do you want to start?_ popup to close it (if required).
-- Click **Explore** in the Cloud Native Playground tile to navigate to _Kanvas_.
-
-> **_NOTE:_** Kanvas is still in beta.
+- Click **Explore** in the Cloud Native Playground tile to navigate to the _Meshery Design Configurator_.
 
 #### Create a simple stand-alone Pod
 
-1. In the Kanvas screen, rename the design from _Untitled Design_ to a name of choice. This helps in identifying the design later easily.
+1. In the design screen, rename the design from _Untitled Design_ to a name of choice. This helps in identifying the design later easily.
 2. Click **Components** tab.
 3. Search for **Pod** in the list of components.
     ![](/guides/tutorials/images/kubernetes-pods/2024-02-22_18-20.png)
@@ -84,7 +82,7 @@ You should see a few alerts on the bottom right about the deployment.
 
 #### Visualizing the Pod
 
-To view the resources deployed we will use the **Visualize** section of the _Kanvas_. A view is created with necessary filters to show the relevant resources.
+To view the resources deployed we will use the **Visualize** section of the _Meshery Dashboard_. A view is created with necessary filters to show the relevant resources.
 
 1.  Click **Visualize** to begin.
 2.  Give the view a name (rename).

--- a/docs/content/en/guides/tutorials/kubernetes/kubernetes-request-flow.md
+++ b/docs/content/en/guides/tutorials/kubernetes/kubernetes-request-flow.md
@@ -1,6 +1,6 @@
 ---
 title: Kubernetes Request Flow – A Visual Guide
-description: A visual walkthrough of how user requests flow through Kubernetes components using Meshery Kanvas.
+description: A visual walkthrough of how user requests flow through Kubernetes components using Meshery Design Configurator.
 model: kubernetes
 params:
   kind: deployments
@@ -8,7 +8,7 @@ categories: [tutorials]
 aliases: 
 - /guides/tutorials/kubernetes-request-flow
 ---
-In this tutorial, we will explore the exact journey a request takes inside a Kubernetes cluster from the moment a user hits "Enter" in their browser, to the moment a response is sent back. We will understand the fundamental data path of a request - from the user to the container, using a **diagram built in Meshery Kanvas**.
+In this tutorial, we will explore the exact journey a request takes inside a Kubernetes cluster from the moment a user hits "Enter" in their browser, to the moment a response is sent back. We will understand the fundamental data path of a request - from the user to the container, using a **diagram built in Meshery Design Configurator**.
 
 > **_Note:_** This tutorial is completely visual and beginner-friendly. No YAML or CLI is required.
 
@@ -32,19 +32,19 @@ This is a common real-world pattern seen in microservices architectures and back
 
 ### Objective
 
- We will visually explore how all the kubernetes components come together using Meshery Kanvas, and learn how this understanding can simplify debugging and designing applications.
+ We will visually explore how all the kubernetes components come together using Meshery Design Configurator, and learn how this understanding can simplify debugging and designing applications.
 
 
-## Walkthrough in Meshery Kanvas
+## Walkthrough in Meshery Design Configurator
 
 ### Accessing the Visual Guide Design
 
 - Start by opening the prebuilt design from here:
-  [![Kubernetes Flow Diagram](/guides/tutorials/images/kubernetes-request-flow/k8s-request-flow.png)](https://kanvas.new/extension/meshmap?mode=design&design=629b6039-ebb3-4bd8-9b1b-19184fade225)
+  [![Kubernetes Flow Diagram](/guides/tutorials/images/kubernetes-request-flow/k8s-request-flow.png)](https://playground.meshery.io)
 
->  Click the image above to open the interactive design in Meshery Kanvas.
+>  Click the image above to open the interactive design in Meshery Design Configurator.
 
-- Once inside Kanvas, we will see a complete layout of how a request flows through the Kubernetes architecture. We are going to understand what’s happening in this architecture.
+- Once inside the Meshery Design Configurator, we will see a complete layout of how a request flows through the Kubernetes architecture. We are going to understand what’s happening in this architecture.
 - If it looks a bit overwhelming at first, zoom in/out or drag around the canvas to get comfortable with the layout.
 
 
@@ -98,7 +98,7 @@ Think of this request path as the backbone of your Kubernetes understanding. Eve
 
 ### Operate This Flow
 
-- If we want to go beyond just “viewing” the flow, we can switch to **Meshery Kanvas → Operate Mode** to interact with real Kubernetes clusters. 
+- If we want to go beyond just "viewing" the flow, we can switch to **Meshery Dashboard → Operate Mode** to interact with real Kubernetes clusters. 
 This lets us:
 
 - Swap containers inside Pods
@@ -110,14 +110,14 @@ All of this happens visually, without having to write or apply any YAML.
 
 ## Want to Try Building It Yourself?
 
-If we want to recreate this flow from scratch, we can drag and drop the same components inside Meshery Kanvas → Design Mode. It’s a great way to test our understanding and see how things fit together.
+If we want to recreate this flow from scratch, we can drag and drop the same components inside Meshery Design Configurator. It's a great way to test our understanding and see how things fit together.
 
 
 ### Diagram Screenshot
 
 [![Kubernetes Flow Diagram](/guides/tutorials/images/kubernetes-request-flow/k8s-request-flow.png)](/guides/tutorials/images/kubernetes-request-flow/k8s-request-flow.png)
 
-> Note: You can design this yourself using the components in Meshery Kanvas.
+> Note: You can design this yourself using the components in Meshery Design Configurator.
 
 
 ## Conclusion

--- a/docs/content/en/guides/tutorials/kubernetes/kubernetes-services.md
+++ b/docs/content/en/guides/tutorials/kubernetes/kubernetes-services.md
@@ -34,16 +34,14 @@ Learn how to create, manage, and explore _Kubernetes Services_ to expose applica
 #### Access Meshery Playground
 - Log in to the [Meshery Playground](https://playground.meshery.io/) using your credentials.  
 - On successful login, you should be at the dashboard.
-- Click **Kanvas** from the left menu to navigate to the [_Kanvas_ design](https://kanvas.new/extension/meshmap) page.
+- Click **Designer** from the left menu to navigate to the _Meshery Design Configurator_ page.
 
   ![](/guides/tutorials/images/kubernetes-deployments/2025-02-27_16-59.png)
-
-> **_NOTE:_** Kanvas is still in beta.
 
 
 #### Create a Deployment
 
-1. In the _Kanvas Design_ page, start by renaming the design to a name of your choice for easier identification later.
+1. In the _Design_ page, start by renaming the design to a name of your choice for easier identification later.
 
     ![](/guides/tutorials/images/kubernetes-services/2025-09-04_02.png)
 
@@ -183,7 +181,7 @@ To remove all the resources you created in this tutorial: in Design mode, go to 
 
 Congratulations! You've successfully completed the lab on exploring Kubernetes Services with Meshery Playground. You created and deployed a sample application, then exposed it with different Service types (ClusterIP, NodePort, LoadBalancer).
 
-Continue exploring more scenarios in the Meshery Kanvas to enhance your skills.
+Continue exploring more scenarios in the Meshery Playground to enhance your skills.
 
 
 ---


### PR DESCRIPTION
## Description

Per project policy, Kanvas is an extension (not core Meshery) and Layer5 is a vendor — neither belongs in core platform documentation. This PR displaces Kanvas/Layer5 branded vocabulary from the `guides/tutorials/kubernetes/` tutorial files.

## Changes

Applied the canonical replacement vocabulary table to all six files:

| Source phrase | Replacement |
|---|---|
| `Kanvas` / `Meshery Kanvas` (UI prose) | `Meshery Design Configurator` |
| `Kanvas Designer` | `Meshery Design Configurator` |
| `Kanvas Visualizer` / Visualize tab of Kanvas | `Meshery Dashboard` |
| `Kanvas → Operate Mode` | `Meshery Dashboard → Operate Mode` |
| `Click Kanvas in left menu` | `Click Designer in the left menu` |
| `kanvas.new/...` URLs | `https://playground.meshery.io` |

Additionally removed `> NOTE: Kanvas is still in beta` notices and updated inline comments.

### Files changed
- `kubernetes-request-flow.md`
- `exploring-kubernetes-cronjobs.md`
- `kubernetes-pods.md`
- `kubernetes-configmaps-secrets.md`
- `kubernetes-deployments.md`
- `kubernetes-services.md`

## Testing

Verified with `grep -i kanvas` — only remaining match is the image filename `navigate-kanvas.png` (file on disk; image rename is tracked separately).