### PR TITLE
[Docs] Displace vendor references from remaining tutorial pages

### DIFF
--- a/docs/content/en/guides/tutorials/aws/deploy-aws-ec2-instances-with-meshery.md
+++ b/docs/content/en/guides/tutorials/aws/deploy-aws-ec2-instances-with-meshery.md
@@ -13,9 +13,9 @@ aliases:
 
 Meshery is a powerful multi-cloud management platform that enables you to configure, deploy, and manage AWS resources, such as EC2 instances. In order to manage AWS resources, Meshery uses [AWS Controllers for Kubernetes (ACK)](https://aws.amazon.com/blogs/containers/aws-controllers-for-kubernetes-ack/). ACK facilitates the bridge between Kubernetes and AWS services, enabling Meshery to manage AWS resources and Meshery enabling you to benefit from the enhanced experience that Meshery and its extensions offer.
 
-Meshery has a number of extensions, adapters, and plugins. In this tutorial, we will use the [Kanvas](/extensions/kanvas) extension to provide an intuitive, visual experience for configuring and deploying an AWS EC2 instance. Among other aspects, Kanvas provides an alternative to command-line tools like `kubectl` by offering infrastructure as design. Once you connect your Kubernetes cluster to Meshery, you can configure, deploy, and manage AWS resources directly from the Kanvas interface, making deployments more intuitive and collaborative 
+Meshery has a number of extensions, adapters, and plugins. In this tutorial, we will use the Meshery Design Configurator to provide an intuitive, visual experience for configuring and deploying an AWS EC2 instance. Among other aspects, the Design Configurator provides an alternative to command-line tools like `kubectl` by offering infrastructure as design. Once you connect your Kubernetes cluster to Meshery, you can configure, deploy, and manage AWS resources directly from the Meshery UI, making deployments more intuitive and collaborative 
 
-In this guide, you’ll explore how to deploy AWS resources, including setup and architecture details. This guide also covers how to access pre-configured designs from [Meshery Catalog](https://meshery.io/catalog) and demonstrates how to visualize deployed resources using Kanvas' operator mode, offering a comprehensive understanding of AWS resource management.
+In this guide, you'll explore how to deploy AWS resources, including setup and architecture details. This guide also covers how to access pre-configured designs from [Meshery Catalog](https://meshery.io/catalog) and demonstrates how to visualize deployed resources using Meshery Dashboard's operator mode, offering a comprehensive understanding of AWS resource management.
 
 ### Prerequisites
 
@@ -68,7 +68,7 @@ For this guide, the `in-cluster deployment` method is used.  Follow this [setup 
 
 In this section, you will set up the EC2 controller and configure it to connect to your AWS account. This process involves creating a Kubernetes secret that contains your AWS access keys and configuring the controller pod to consume this secret. While these configurations are already included in our designs, the steps will be demonstrated for clarity.
 
-1. **Clone the EC2 Controller Design**: Start by [cloning the EC2 controller design](https://meshery.io/catalog/deployment/ec2-controller-design-8f7e1431-3885-4ebf-9ef7-d2ec64bd4eb5.html) from the catalog. To do this, click on **Clone** on the catalog page. Once cloned, open the design in the playground, and you will see it displayed on the Kanvas.
+1. **Clone the EC2 Controller Design**: Start by [cloning the EC2 controller design](https://meshery.io/catalog/deployment/ec2-controller-design-8f7e1431-3885-4ebf-9ef7-d2ec64bd4eb5.html) from the catalog. To do this, click on **Clone** on the catalog page. Once cloned, open the design in the playground, and you will see it displayed on the canvas.
 
     ![EC2 Controller Chart](/guides/tutorials/images/aws-controllers/controller-chart.png)
 
@@ -110,9 +110,9 @@ While this step is already handled in the design, but it's worth clarifying how 
 
 After configuring your design, the next step is deployment. To learn more about deploying your designs in Meshery, see [Deploying Meshery Designs](https://cloud.meshery.io/academy/learning-paths/11111111-1111-1111-1111-111111111111/mastering-meshery/introduction-to-meshery?chapter=deploying-meshery-designs). To deploy the resources, follow these steps:
 
-1. Click the **Actions** button at the top of the Kanvas and click **Deploy**.
+1. Click the **Actions** button at the top of the canvas and click **Deploy**.
 
-1. Once the deployment is complete, click **Open in Visualizer** to switch to Operator mode and see a pre-filtered view of your just deployed resources in the cluster. Alternatively, you can click *Operate* at the top of the Kanvas to enter Operater mode.
+1. Once the deployment is complete, click **Open in Visualizer** to switch to Operator mode and see a pre-filtered view of your just deployed resources in the cluster. Alternatively, you can click *Operate* at the top to enter Operator mode.
 
     ![Operator Mode](/guides/tutorials/images/aws-controllers/controller-operator-mode.png)
 
@@ -136,7 +136,7 @@ This step involves deploying all the necessary resources to create the VPC and o
 
 1. Start by [cloning the design](https://cloud.meshery.io/catalog/content/catalog/vpc-workflow-design-50cac19e-209c-4acf-b91c-4784281db033) from the catalog.
 
-2. Once cloned, open the design in the playground, and you will see it displayed on the Kanvas.
+2. Once cloned, open the design in the playground, and you will see it displayed on the canvas.
 
 3. You can adjust CIDR blocks, region, and other parameters as needed through the configuration tab. This design is configured to be deployed in the `us-east-1` region.
 
@@ -156,4 +156,4 @@ With the VPC and networking resources set up, deploy the EC2 instances within th
 
 ### Conclusion
 
-This guide covered the steps to deploy and manage EC2 instances using Meshery. It demonstrated how to leverage pre-configured catalog designs, configure and deploy resources, set up the controller and necessary secrets, configure VPC networking resources, and ultimately deploy the EC2 instances. It also showed how to visualize Kubernetes resources using Kanvas's operator mode. This process highlights the ease of managing AWS resources visually through Meshery’s Kanvas interface, eliminating the need for CLI commands.
+This guide covered the steps to deploy and manage EC2 instances using Meshery. It demonstrated how to leverage pre-configured catalog designs, configure and deploy resources, set up the controller and necessary secrets, configure VPC networking resources, and ultimately deploy the EC2 instances. It also showed how to visualize Kubernetes resources using Meshery Dashboard's operator mode. This process highlights the ease of managing AWS resources visually through Meshery's UI, eliminating the need for CLI commands.

--- a/docs/content/en/guides/tutorials/azure/deploy-azure-storage-account-with-meshery.md
+++ b/docs/content/en/guides/tutorials/azure/deploy-azure-storage-account-with-meshery.md
@@ -107,7 +107,7 @@ Azure Service Operator requires a Kubernetes secret with your Azure identity:
 
 ### 4. Design and Deploy an Azure Storage Account
 
-1. In the Meshery UI, navigate to **Kanvas**.
+1. In the Meshery UI, navigate to **Designer**.
 2. Click **Catalog**, filter by **Azure**, and select the **StorageAccount** design.
 3. Click **Clone** to add it to your canvas.
 4. Configure the following properties:
@@ -134,7 +134,7 @@ You have successfully:
 * Connected your Kubernetes cluster to Meshery
 * Installed the Azure Service Operator (Meshery managed CRDs)
 * Created a Kubernetes secret for Azure credentials
-* Designed and deployed an Azure Storage Account using Meshery’s Kanvas
+* Designed and deployed an Azure Storage Account using Meshery's Design Configurator
 
 ---
 

--- a/docs/content/en/guides/tutorials/kubernetes/deploy-apache-cassandra-with-statefulset.md
+++ b/docs/content/en/guides/tutorials/kubernetes/deploy-apache-cassandra-with-statefulset.md
@@ -46,7 +46,7 @@ These YAML files contain the Cassandra Service and Cassandra StatefulSet manifes
 
 1. Log in to the [Meshery Playground](https://play.meshery.io/) using your credentials. On successful login, you should be at the dashboard. Press the **X** on the _Where do you want to start?_ popup to close it (if required).
 
-2. Click **Explore** in the Cloud Native Playground tile to navigate to _MeshMap_
+2. Click **Explore** in the Cloud Native Playground tile to navigate to the _Meshery Design Configurator_
 
 #### Import the Files to Meshery Playground
 
@@ -95,7 +95,7 @@ To merge the Service deployment design with the StatefulSet deployment design:
 
 #### Visualizing the Deployed Resources
 
-To view the resources deployed we will use the Visualize section of the _MeshMap_. In this section, you can apply filters to display the specific resources you want to see.
+To view the resources deployed we will use the Visualize section of the _Meshery Dashboard_. In this section, you can apply filters to display the specific resources you want to see.
 
 1. Move to the Visualize tab.
 2. Click the filter icon and choose the appropriate filters

--- a/docs/content/en/guides/tutorials/kubernetes/deploy-php-redis.md
+++ b/docs/content/en/guides/tutorials/kubernetes/deploy-php-redis.md
@@ -50,7 +50,7 @@ These YAML files contain the Service definitions and Deployment configurations f
 
 1. Log in to the [Meshery Playground](https://play.meshery.io) using your credentials. On successful login, you should be at the dashboard. Press the **X** on the _Where do you want to start?_ popup to close it (if required).
 
-2. Click **Explore** in the Cloud Native Playground tile to navigate to _MeshMap_
+2. Click **Explore** in the Cloud Native Playground tile to navigate to the _Meshery Design Configurator_
 
 
 #### Import the Files to Meshery Playground

--- a/docs/content/en/guides/tutorials/kubernetes/wordpress-mysql-persistentvolume.md
+++ b/docs/content/en/guides/tutorials/kubernetes/wordpress-mysql-persistentvolume.md
@@ -48,7 +48,7 @@ These YAML files contain the Service definitions, Persistent Volume Claims, and 
 
 1. Log in to the [Meshery Playground](https://play.meshery.io) using your credentials. On successful login, you should be at the dashboard. Press the **X** on the _Where do you want to start?_ popup to close it (if required).
 
-2. Click **Explore** in the Cloud Native Playground tile to navigate to _Kanvas_
+2. Click **Explore** in the Cloud Native Playground tile to navigate to the _Meshery Design Configurator_
 
 #### Import the Files to Meshery Playground
 
@@ -212,7 +212,7 @@ This functionality aids in visualizing the relationships between various resourc
 
 #### Visualizing the Deployed Resources
 
-To view the resources deployed we will use the Visualize section of the _Kanvas_. In this section, you can apply filters to display the specific resources you want to see.
+To view the resources deployed we will use the Visualize section of the _Meshery Dashboard_. In this section, you can apply filters to display the specific resources you want to see.
 
 1. Move to the Visualize tab.
 2. Click the filter icon and choose the appropriate filters

--- a/docs/content/en/guides/tutorials/wordpress/embedding-meshery-design-in-wordpress.md
+++ b/docs/content/en/guides/tutorials/wordpress/embedding-meshery-design-in-wordpress.md
@@ -11,9 +11,9 @@ aliases:
 
 ### Introduction
 
-In this tutorial, we will learn how to embed a **Meshery Design** in a WordPress post using the **Embed** option in **Kanvas**.
+In this tutorial, we will learn how to embed a **Meshery Design** in a WordPress post using the **Embed** option in **Meshery Design Configurator**.
 
-This tutorial assumes that you have created a design or have an existing one. If not, you can use one of the numerous public designs available in **Kanvas** for this tutorial.
+This tutorial assumes that you have created a design or have an existing one. If not, you can use one of the numerous public designs available in **Meshery Design Configurator** for this tutorial.
 
 1. Expand the **Designs** menu on the left.
    
@@ -43,7 +43,7 @@ This tutorial assumes that you have created a design or have an existing one. If
 
    ![Copy URL](/guides/tutorials/images/embedding-design-in-wordpress/add-custom-html.png)
 
-8. Paste the following CSS code as it is, followed by the **Embed Code** copied from **Kanvas**. Update the script source value to the URL copied from WordPress.  
+8. Paste the following CSS code as it is, followed by the **Embed Code** copied from **Meshery Design Configurator**. Update the script source value to the URL copied from WordPress.  
    ```
    <style>
      .embed-design-container {
@@ -74,7 +74,7 @@ This tutorial assumes that you have created a design or have an existing one. If
        background-color: gray;
     }
     </style>
-    <!-- Learn more at https://docs.layer5.io/meshmap/designer/export-designs/#exporting-as-embedding -->
+    <!-- Learn more at https://docs.meshery.io/guides/tutorials/wordpress/embedding-meshery-design-in-wordpress -->
     <div id="embedded-design-a1376b51-d2c4-4ef8-8337-6dc2c24fa939"></div>
     <script src="https://yourwordpressdomain/wp-content/uploads/2025/01/embedded-design-tutorial-exploring-kubernetes-pod.js" type="module" ></script>
     ```


### PR DESCRIPTION
Extend vocabulary replacement to all remaining tutorial subdirectories: kubernetes/ (wordpress-mysql, cassandra, php-redis), wordpress/, azure/, and aws/.

Changes applied per the canonical replacement table:
- 'Kanvas' / 'MeshMap' (navigate prose) → 'Meshery Design Configurator'
- 'Kanvas Designer' / 'Kanvas' (UI labels) → 'Meshery Design Configurator'
- 'Kanvas Visualizer' / 'Visualize section of Kanvas/MeshMap' → 'Meshery Dashboard'
- 'on the Kanvas' → 'on the canvas'
- 'top of the Kanvas' → 'top of the canvas'
- 'Kanvas interface' → 'Meshery UI'
- [Kanvas](/extensions/kanvas) extension link → plain prose
- 'Kanvas's/Kanvas' operator mode → 'Meshery Dashboard's operator mode'
- docs.layer5.io comment URL → docs.meshery.io equivalent

Files changed:
- kubernetes/wordpress-mysql-persistentvolume.md
- kubernetes/deploy-apache-cassandra-with-statefulset.md
- kubernetes/deploy-php-redis.md
- wordpress/embedding-meshery-design-in-wordpress.md
- azure/deploy-azure-storage-account-with-meshery.md
- aws/deploy-aws-ec2-instances-with-meshery.md

**Notes for Reviewers**

- This PR fixes #

**[Signed commits](https://github.com/meshery/meshery/blob/master/CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [ ] Yes, I signed my commits.

<!--
Thank you for contributing to Meshery! 

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. Sign your commits.
4. Include before and after screenshots/terminal output.

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.
-->
