### PR TITLE
[Docs] Update community name reference in docs

### DIFF
--- a/docs/content/en/guides/troubleshooting/enabling-extensions-locally.md
+++ b/docs/content/en/guides/troubleshooting/enabling-extensions-locally.md
@@ -56,5 +56,5 @@ Given that you cannot build the extension from source, a solution typically requ
 While you can attempt to experiment by manually testing different versions of packages from the [meshery-extensions-packages](https://github.com/layer5labs/meshery-extensions-packages) repository, this trial-and-error method is not guaranteed to work.
 
 The most reliable path forward is to:
-- **Seek assistance:** Ask for guidance in the [Layer5 community](/project/community).
+- **Seek assistance:** Ask for guidance in the [Meshery community](/project/community).
 - **Check for requirements:** To check access requirements or find maintainers, consult the [community handbook](https://meshery.io/community).


### PR DESCRIPTION
Fixes the link display text on `guides/troubleshooting/enabling-extensions-locally.md` line 59 — the link already pointed to `/project/community` (correct), but the visible text read "Layer5 community" instead of "Meshery community".

Followup to #19403 and #19406.

