### PR TITLE
[CI] Harden PR E2E workflow and model creation timeouts

### DIFF
--- a/.github/workflows/test-e2e-pr.yml
+++ b/.github/workflows/test-e2e-pr.yml
@@ -67,6 +67,21 @@ jobs:
             --name meshery \
             meshery-server:ci
 
+      - name: Wait for Meshery server
+        run: |
+          set -euo pipefail
+          for attempt in $(seq 1 60); do
+            if curl -sf "http://localhost:9081/api/system/version" >/dev/null; then
+              echo "Meshery ready after attempt ${attempt}"
+              exit 0
+            fi
+            echo "Waiting for Meshery (attempt ${attempt}/60)..."
+            sleep 5
+          done
+          echo "Meshery did not become ready in time; last container logs:"
+          docker logs meshery 2>&1 | tail -200 || true
+          exit 1
+
       - name: Install Playwright
         run: make ui-setup-ci
 

--- a/ui/tests/e2e/models.spec.ts
+++ b/ui/tests/e2e/models.spec.ts
@@ -2,6 +2,12 @@ import { test, expect } from '@playwright/test';
 import path from 'path';
 import { DashboardPage } from './pages/DashboardPage';
 
+/** CI runners are slower (Docker, shared CPU); wizard steps and Git-backed generation need more headroom. */
+const isCI = !!process.env.CI;
+const UI_STEP_TIMEOUT_MS = isCI ? 120_000 : 60_000;
+const MODEL_GENERATE_VISIBLE_MS = isCI ? 300_000 : 180_000;
+const CREATE_MODEL_TEST_TIMEOUT_MS = isCI ? 420_000 : 240_000;
+
 // Strongly typed inline to avoid JS linter false positives
 const model: {
   MODEL_URL: string;
@@ -49,7 +55,7 @@ test.describe.serial('Model Workflow Tests', () => {
     // Model generation downloads from GitHub and can be very slow in CI.
     // test.slow() triples the default timeout (60s → 180s).
     test.slow();
-    test.setTimeout(240_000);
+    test.setTimeout(CREATE_MODEL_TEST_TIMEOUT_MS);
 
     await page.getByTestId('TabBar-Button-CreateModel').click();
 
@@ -58,17 +64,31 @@ test.describe.serial('Model Workflow Tests', () => {
 
     await page.getByTestId('UrlStepper-Button-Next').click();
 
-    await expect(page.getByTestId('UrlStepper-Select-Category')).toBeVisible();
-    await expect(page.getByTestId('UrlStepper-Select-Subcategory')).toBeVisible();
+    await expect(page.getByTestId('UrlStepper-Select-Category')).toBeVisible({
+      timeout: UI_STEP_TIMEOUT_MS,
+    });
+    await expect(page.getByTestId('UrlStepper-Select-Subcategory')).toBeVisible({
+      timeout: UI_STEP_TIMEOUT_MS,
+    });
 
     await page.getByTestId('UrlStepper-Button-Next').click();
 
-    await expect(page.getByTestId('UrlStepper-Select-Logo-Dark-Theme')).toBeVisible();
-    await expect(page.getByTestId('UrlStepper-Select-Logo-Light-Theme')).toBeVisible();
+    await expect(page.getByTestId('UrlStepper-Select-Logo-Dark-Theme')).toBeVisible({
+      timeout: UI_STEP_TIMEOUT_MS,
+    });
+    await expect(page.getByTestId('UrlStepper-Select-Logo-Light-Theme')).toBeVisible({
+      timeout: UI_STEP_TIMEOUT_MS,
+    });
 
-    await expect(page.getByTestId('UrlStepper-Select-Primary-Color')).toBeVisible();
-    await expect(page.getByTestId('UrlStepper-Select-Secondary-Color')).toBeVisible();
-    await expect(page.getByTestId('UrlStepper-Select-Shape')).toBeVisible();
+    await expect(page.getByTestId('UrlStepper-Select-Primary-Color')).toBeVisible({
+      timeout: UI_STEP_TIMEOUT_MS,
+    });
+    await expect(page.getByTestId('UrlStepper-Select-Secondary-Color')).toBeVisible({
+      timeout: UI_STEP_TIMEOUT_MS,
+    });
+    await expect(page.getByTestId('UrlStepper-Select-Shape')).toBeVisible({
+      timeout: UI_STEP_TIMEOUT_MS,
+    });
 
     await page.getByTestId('UrlStepper-Button-Next').click();
 
@@ -84,8 +104,10 @@ test.describe.serial('Model Workflow Tests', () => {
     // Model generation fetches from GitHub — wait with extended timeout
     await expect(
       page.getByTestId(`ModelImportedSection-ModelHeader-${model.MODEL_NAME}`),
-    ).toBeVisible({ timeout: 180_000 });
-    await expect(page.getByTestId('ModelImportMessages-Wrapper')).toBeVisible();
+    ).toBeVisible({ timeout: MODEL_GENERATE_VISIBLE_MS });
+    await expect(page.getByTestId('ModelImportMessages-Wrapper')).toBeVisible({
+      timeout: UI_STEP_TIMEOUT_MS,
+    });
 
     await page.getByTestId('UrlStepper-Button-Finish').click();
   });
@@ -115,8 +137,10 @@ test.describe.serial('Model Workflow Tests', () => {
 
     await expect(
       page.getByTestId(`ModelImportedSection-ModelHeader-${model_import.MODEL_NAME}`),
-    ).toBeVisible();
-    await expect(page.getByTestId('ModelImportMessages-Wrapper')).toBeVisible();
+    ).toBeVisible({ timeout: UI_STEP_TIMEOUT_MS });
+    await expect(page.getByTestId('ModelImportMessages-Wrapper')).toBeVisible({
+      timeout: UI_STEP_TIMEOUT_MS,
+    });
     await page.getByRole('button', { name: 'Finish' }).click();
   });
 
@@ -131,8 +155,10 @@ test.describe.serial('Model Workflow Tests', () => {
 
     await expect(
       page.getByTestId(`ModelImportedSection-ModelHeader-${model_import.MODEL_NAME}`),
-    ).toBeVisible();
-    await expect(page.getByTestId('ModelImportMessages-Wrapper')).toBeVisible();
+    ).toBeVisible({ timeout: UI_STEP_TIMEOUT_MS });
+    await expect(page.getByTestId('ModelImportMessages-Wrapper')).toBeVisible({
+      timeout: UI_STEP_TIMEOUT_MS,
+    });
     await page.getByRole('button', { name: 'Finish' }).click();
   });
 
@@ -154,8 +180,10 @@ test.describe.serial('Model Workflow Tests', () => {
       page.getByTestId(
         `ModelImportedSection-ModelHeader-${model_import.MODEL_CSV_IMPORT.Model_Name}`,
       ),
-    ).toBeVisible();
-    await expect(page.getByTestId('ModelImportMessages-Wrapper')).toBeVisible();
+    ).toBeVisible({ timeout: UI_STEP_TIMEOUT_MS });
+    await expect(page.getByTestId('ModelImportMessages-Wrapper')).toBeVisible({
+      timeout: UI_STEP_TIMEOUT_MS,
+    });
     await page.getByRole('button', { name: 'Finish' }).click();
   });
 });


### PR DESCRIPTION
## Problem
The reusable PR E2E job (`test-e2e-pr.yml`) starts Meshery in Docker and immediately installs/runs Playwright, with no guarantee the API is accepting traffic. Separately, `Model Workflow Tests` often hit the default **60s** `expect` timeout on wizard steps while Git-backed model generation can exceed the previous **180s** budget on slow CI runners—showing up as failures on unrelated PRs (e.g. Meshery UI and Server PR Build → E2E Tests).

## Solution
- **Workflow:** After `docker run`, poll `GET http://localhost:9081/api/system/version` (up to ~5 minutes, 5s interval); on failure, print the last container logs.
- **Playwright:** When `CI` is set, increase timeouts for the create-model wizard, the post-generate model header wait, the overall create-model test budget, and the import-flow `ModelImportedSection` / message wrapper expects.

## Notes
- No production server or UI behavior change for end users; CI and test timing only.
- After merge, rebase/merge `master` into open PRs that were failing this job to pick up the fix.