### PR TITLE
[Docs] Display catalog designs on model pages

### DIFF
--- a/docs/assets/scss/_integration.scss
+++ b/docs/assets/scss/_integration.scss
@@ -45,7 +45,7 @@
 
 h6.integration > a {
   color: var(--brand-color-primary);
-  & :hover {
+  &:hover {
     color: var(--brand-color-secondary);
   }
 }

--- a/docs/assets/scss/_integration.scss
+++ b/docs/assets/scss/_integration.scss
@@ -49,3 +49,136 @@ h6.integration > a {
     color: var(--brand-color-secondary);
   }
 }
+
+// Related Designs Section
+
+.related-designs-section {
+  margin-top: 2rem;
+}
+
+.related-designs-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+  margin-bottom: 1.25rem;
+
+  h3 {
+    margin: 0;
+  }
+}
+
+.catalog-cta-link {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.25rem;
+  padding: 0.4rem 1rem;
+  border-radius: 0.5rem;
+  background: var(--brand-color-primary);
+  color: #fff !important;
+  font-size: 0.875rem;
+  font-weight: 600;
+  text-decoration: none;
+  transition: background 0.2s ease, transform 0.15s ease;
+  white-space: nowrap;
+
+  &:hover {
+    background: var(--brand-color-secondary);
+    transform: translateY(-1px);
+    text-decoration: none;
+  }
+}
+
+.designs-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(200px, 1fr));
+  gap: 1.25rem;
+
+  @media (max-width: 480px) {
+    grid-template-columns: 1fr 1fr;
+  }
+
+  @media (max-width: 320px) {
+    grid-template-columns: 1fr;
+  }
+}
+
+.design-card {
+  display: flex;
+  flex-direction: column;
+  background-color: var(--background-models);
+  border-radius: 0.85rem;
+  overflow: hidden;
+  text-decoration: none;
+  box-shadow: var(--box-shadow-primary-light);
+  transition: transform 0.18s ease, box-shadow 0.18s ease;
+
+  &:hover {
+    transform: translateY(-3px);
+    box-shadow: var(--box-shadow-primary);
+    text-decoration: none;
+  }
+
+  &__img-wrap {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    padding: 1rem;
+    background: var(--color-primary-medium);
+    min-height: 100px;
+
+    img {
+      max-height: 80px;
+      max-width: 100%;
+      object-fit: contain;
+    }
+  }
+
+  &__body {
+    display: flex;
+    flex-direction: column;
+    gap: 0.25rem;
+    padding: 0.75rem 1rem;
+  }
+
+  &__name {
+    font-size: 0.875rem;
+    font-weight: 600;
+    color: var(--color-secondary-dark);
+    line-height: 1.3;
+    word-break: break-word;
+  }
+
+  &__author {
+    font-size: 0.75rem;
+    color: var(--color-grey-dark);
+  }
+
+  &__type {
+    display: inline-block;
+    margin-top: 0.25rem;
+    padding: 0.15rem 0.5rem;
+    border-radius: 0.3rem;
+    background: var(--brand-color-primary);
+    color: #fff;
+    font-size: 0.7rem;
+    font-weight: 600;
+    text-transform: capitalize;
+    width: fit-content;
+  }
+}
+
+.related-designs-empty {
+  color: var(--color-grey-dark);
+  font-size: 0.9rem;
+  margin: 0.5rem 0;
+
+  a {
+    color: var(--brand-color-primary);
+
+    &:hover {
+      color: var(--brand-color-secondary);
+    }
+  }
+}

--- a/docs/layouts/models/single.html
+++ b/docs/layouts/models/single.html
@@ -47,7 +47,7 @@
     <!-- Related Designs -->
     {{ $tech := "" }}
     {{ with .Params.docURL }}
-        {{ $tech = path.Base (strings.TrimSuffix "/" .) }}
+        {{ $tech = path.Base (strings.TrimSuffix "/" .) | lower }}
     {{ end }}
     {{ $matchedDesigns := slice }}
     {{ if $tech }}
@@ -101,10 +101,14 @@
                target="_blank"
                rel="noopener noreferrer">
                 <div class="design-card__img-wrap">
-                    {{ if .image }}
-                    <img src="{{ .image }}" alt="{{ .name }} thumbnail" loading="lazy" />
+                    {{ $designImage := .image }}
+                    {{ if and $designImage (hasPrefix $designImage "/") }}
+                        {{ $designImage = printf "https://meshery.io%s" $designImage }}
+                    {{ end }}
+                    {{ if $designImage }}
+                    <img src="{{ $designImage }}" alt="{{ .name }} thumbnail" loading="lazy" />
                     {{ else }}
-                    <img src="/assets/images/logos/service-mesh-pattern.svg" alt="{{ .name }} thumbnail" loading="lazy" />
+                    <img src="https://meshery.io/assets/images/logos/service-mesh-pattern.svg" alt="{{ .name }} thumbnail" loading="lazy" />
                     {{ end }}
                 </div>
                 <div class="design-card__body">

--- a/docs/layouts/models/single.html
+++ b/docs/layouts/models/single.html
@@ -44,10 +44,13 @@
     {{ partialCached "integration/models-components.html" . }}
     {{ partialCached "integration/meshery-registry.html" . }}
 
-    <section>
-        <h3 id="related-designs-header">Designs containing {{ .Title }}</h3>
-        {{ $tech := path.Base (strings.TrimSuffix "/" .Params.docURL) }}
-        <ul>
+    <!-- Related Designs -->
+    {{ $tech := "" }}
+    {{ with .Params.docURL }}
+        {{ $tech = path.Base (strings.TrimSuffix "/" .) }}
+    {{ end }}
+    {{ $matchedDesigns := slice }}
+    {{ if $tech }}
         {{ $catalogRoot := "catalog" }}
         {{ range readDir $catalogRoot }}
             {{ if .IsDir }}
@@ -62,18 +65,65 @@
                             {{ $meta := transform.Unmarshal (index $parts 1) }}
                             {{ $compatibility := index $meta "compatibility" }}
                             {{ if and $compatibility (in $compatibility $tech) }}
-            <li class="design-link">
-                <a href="https://meshery.io/catalog/{{ $catalogType }}/{{ replace (index $meta "name") "." "-" | urlize }}-{{ index $meta "patternId" }}" target="_blank">
-                    {{ index $meta "name" }}
-                </a>
-            </li>
+                                {{ $matchedDesigns = $matchedDesigns | append (dict
+                                    "name"      (index $meta "name")
+                                    "patternId" (index $meta "patternId")
+                                    "type"      $catalogType
+                                    "image"     (index $meta "image")
+                                    "userName"  (index $meta "userName")
+                                ) }}
                             {{ end }}
                         {{ end }}
                     {{ end }}
                 {{ end }}
             {{ end }}
         {{ end }}
-    </ul>
+    {{ end }}
+
+    <section class="related-designs-section">
+        <div class="related-designs-header">
+            <h3>Designs containing {{ .Title }}</h3>
+            {{ if gt (len $matchedDesigns) 0 }}
+            <a class="catalog-cta-link"
+               href="https://meshery.io/catalog?search={{ $tech | urlize }}"
+               target="_blank"
+               rel="noopener noreferrer">
+                View all in Catalog &rarr;
+            </a>
+            {{ end }}
+        </div>
+
+        {{ if gt (len $matchedDesigns) 0 }}
+        <div class="designs-grid">
+            {{ range $matchedDesigns }}
+            <a class="design-card"
+               href="https://meshery.io/catalog/{{ .type }}/{{ replace .name "." "-" | urlize }}-{{ .patternId }}"
+               target="_blank"
+               rel="noopener noreferrer">
+                <div class="design-card__img-wrap">
+                    {{ if .image }}
+                    <img src="{{ .image }}" alt="{{ .name }} thumbnail" loading="lazy" />
+                    {{ else }}
+                    <img src="/assets/images/logos/service-mesh-pattern.svg" alt="{{ .name }} thumbnail" loading="lazy" />
+                    {{ end }}
+                </div>
+                <div class="design-card__body">
+                    <span class="design-card__name">{{ .name }}</span>
+                    {{ if .userName }}
+                    <span class="design-card__author">by {{ .userName }}</span>
+                    {{ end }}
+                    <span class="design-card__type">{{ .type }}</span>
+                </div>
+            </a>
+            {{ end }}
+        </div>
+        {{ else }}
+        <p class="related-designs-empty">
+            No catalog designs currently reference this model.
+            <a href="https://meshery.io/catalog" target="_blank" rel="noopener noreferrer">Browse the catalog</a>
+            to discover or contribute designs.
+        </p>
+        {{ end }}
     </section>
 
     <!-- Related Tutorials -->
@@ -143,11 +193,6 @@
         image.onerror = null;
         image.src = '{{ .Params.image }}';
     }
-    const designLinks = document.querySelectorAll('.design-link');
-    if (designLinks.length === 0) {
-        document.getElementById('related-designs-header').style.display = 'none';
-    }
-
     const relatedTutorials = document.querySelectorAll(".tutorial-link");
     if (relatedTutorials.length === 0) {
         document.getElementById("related-tutorials-header").style.display = "none";


### PR DESCRIPTION
## What does this PR do?

Closes #18959

Enhances model pages by surfacing related catalog designs directly on each page.

## Changes

- Added a responsive card grid to `docs/layouts/models/single.html` displaying designs that reference the model via their `compatibility` field
- Each card shows the design thumbnail, author, and type badge with a direct catalog link
- Added a **"View all in Catalog →"** CTA linking to filtered catalog results (`meshery.io/catalog?search=<model-slug>`)
- Added graceful empty-state handling when no related designs exist
- Guarded against models missing `docURL` frontmatter (prevents template errors)
- Removed the JS DOM hack that hid the header — empty state is now handled server-side in Hugo
- Added supporting responsive and dark-mode compatible styles in `docs/assets/scss/_integration.scss` using existing CSS variables

## Testing

```bash
cd docs && hugo --minify
# Exit 0, zero template errors
```

Verified card URL construction against live catalog (HTTP 200 confirmed).

## Before / After

- **Before:** Plain unstyled bullet list with no CTA; header hidden via JS DOM counting hack
- **After:** Responsive card grid with thumbnails, metadata, catalog CTA, and server-side empty state