### PR TITLE
[ui] Merge controller-status diffs instead of wholesale-replacing

### DIFF
--- a/ui/store/slices/__tests__/mesheryUi.test.ts
+++ b/ui/store/slices/__tests__/mesheryUi.test.ts
@@ -40,6 +40,7 @@ import mesheryUiReducer, {
   toggleDrawer,
   toggleCatalogContent,
   setControllerState,
+  clearControllerState,
   updateExtensionType,
   updateProviderCapabilities,
   setConnectionMetadata,
@@ -151,10 +152,60 @@ describe('mesheryUi slice', () => {
     expect(state.catalogVisibility).toBe(false);
   });
 
-  it('setControllerState updates controllerState', () => {
+  it('setControllerState wholesale-replaces for non-array payloads (legacy callers)', () => {
     let state = mesheryUiReducer(undefined, { type: 'init' } as any);
     state = mesheryUiReducer(state, setControllerState({ controllerState: { ok: true } }));
     expect(state.controllerState).toEqual({ ok: true });
+  });
+
+  it('setControllerState merges array payloads by (connectionID, controller) key', () => {
+    let state = mesheryUiReducer(undefined, { type: 'init' } as any);
+
+    // Initial seed from the SSE stream — full snapshot of two connections.
+    state = mesheryUiReducer(
+      state,
+      setControllerState({
+        controllerState: [
+          { connectionID: 'c1', controller: 'operator', status: 'ENABLED', version: 'v1' },
+          { connectionID: 'c1', controller: 'meshsync', status: 'ENABLED', version: 'v1' },
+          { connectionID: 'c2', controller: 'operator', status: 'ENABLED', version: 'v1' },
+        ],
+      }),
+    );
+    expect(state.controllerState).toHaveLength(3);
+
+    // Diff tick — only c1/operator changed. The other two entries must
+    // survive: this is the regression a wholesale replace would cause.
+    state = mesheryUiReducer(
+      state,
+      setControllerState({
+        controllerState: [
+          { connectionID: 'c1', controller: 'operator', status: 'DISABLED', version: 'v2' },
+        ],
+      }),
+    );
+    expect(state.controllerState).toHaveLength(3);
+    const updated = (state.controllerState as Array<Record<string, unknown>>).find(
+      (item) => item.connectionID === 'c1' && item.controller === 'operator',
+    );
+    expect(updated).toMatchObject({ status: 'DISABLED', version: 'v2' });
+    const untouched = (state.controllerState as Array<Record<string, unknown>>).find(
+      (item) => item.connectionID === 'c2' && item.controller === 'operator',
+    );
+    expect(untouched).toMatchObject({ status: 'ENABLED', version: 'v1' });
+  });
+
+  it('clearControllerState resets controllerState to null', () => {
+    let state = mesheryUiReducer(undefined, { type: 'init' } as any);
+    state = mesheryUiReducer(
+      state,
+      setControllerState({
+        controllerState: [{ connectionID: 'c1', controller: 'operator', status: 'ENABLED' }],
+      }),
+    );
+    expect(state.controllerState).not.toBeNull();
+    state = mesheryUiReducer(state, clearControllerState());
+    expect(state.controllerState).toBeNull();
   });
 
   it('updateExtensionType updates extensionType', () => {

--- a/ui/store/slices/mesheryUi.ts
+++ b/ui/store/slices/mesheryUi.ts
@@ -62,8 +62,44 @@ const coreSlice = createSlice({
     toggleCatalogContent: (state, action) => {
       state.catalogVisibility = action.payload.catalogVisibility;
     },
+    // mergeControllerState upserts incoming controller-status entries keyed by
+    // (connectionID, controller). Pre-SSE, the GraphQL resolver emitted the
+    // entire controller set on every tick, so the legacy setControllerState
+    // could wholesale-replace state without losing data. The new SSE endpoint
+    // emits only DIFFS after the initial seed (server-side change detection
+    // moved out of the UI hot path), so a wholesale replace would drop the
+    // status of every controller not mentioned in the latest tick. Merge by
+    // composite key preserves the unchanged controllers and only updates the
+    // ones the server signalled changed.
+    //
+    // For non-array payloads (legacy callers, error paths), fall back to the
+    // wholesale-replace behavior to avoid surprising existing consumers.
     setControllerState: (state, action) => {
-      state.controllerState = action.payload.controllerState;
+      const incoming = action.payload?.controllerState;
+      if (!Array.isArray(incoming)) {
+        state.controllerState = incoming;
+        return;
+      }
+      const existing = Array.isArray(state.controllerState) ? state.controllerState : [];
+      const byKey = new Map();
+      for (const item of existing) {
+        if (item && typeof item === 'object') {
+          byKey.set(`${item.connectionID}|${item.controller}`, item);
+        }
+      }
+      for (const item of incoming) {
+        if (item && typeof item === 'object') {
+          byKey.set(`${item.connectionID}|${item.controller}`, item);
+        }
+      }
+      state.controllerState = Array.from(byKey.values());
+    },
+    // clearControllerState resets the slice to its empty form. The SSE
+    // subscription dispatches this before rebinding to a new connection set
+    // so the diff-merge in setControllerState doesn't carry stale entries
+    // from the previous set forward.
+    clearControllerState: (state) => {
+      state.controllerState = null;
     },
     updateExtensionType: (state, action) => {
       state.extensionType = action.payload.extensionType;
@@ -102,6 +138,7 @@ export const {
   toggleDrawer,
   toggleCatalogContent,
   setControllerState,
+  clearControllerState,
   setMeshsyncSubscription,
   updateExtensionType,
   updateProviderCapabilities,


### PR DESCRIPTION
## Summary
Companion fix for the GraphQL→SSE migration. The new
`/api/system/kubernetes/controllers/status/stream` handler in #19397
moved change-detection server-side and now emits **diffs only** after
the initial seed. The existing `setControllerState` reducer is a
wholesale replace, which silently drops the status of every controller
not mentioned in the latest diff.

Two changes to the `mesheryUi` slice:

1. **`setControllerState` is now a merge for array payloads.** Incoming
   entries are upserted by composite key `(connectionID, controller)`,
   so a tick that says \"only c1/operator changed\" no longer wipes out
   c1/meshsync, c2/operator, etc. Non-array payloads still
   wholesale-replace, preserving the legacy-caller contract.
2. **New `clearControllerState` action.** The SSE subscription will
   dispatch this before rebinding to a new connection set so removed
   connections don't linger in the merged state. (Wiring the dispatch
   into `_app.tsx` is a follow-up once #19395 + #19400 land — calling
   it ahead of time would dispatch against a reducer that doesn't yet
   exist on those branches.)

## Why a standalone PR
This was flagged in review of the teardown PR #19400 (comment
PRRC_kwDOCWQXL87BWUdw):
> The previous GraphQL implementation used an explicit mergeFn to
> reconcile updates with existing state. If the new SSE endpoint sends
> deltas (individual controller updates) rather than full state
> snapshots, this will overwrite the entire controller state and lose
> data for other active connections.

Landing the reducer change in #19400 would have mixed a touchy
behavior change into a 30,000-line teardown. Isolating it here keeps
review tractable and lets the controllers slice get its own attention.

## Test plan
- [x] `npx vitest run store/slices/__tests__/mesheryUi.test.ts` — 27 pass (added 3 tests: non-array replace, array merge across seed+diff, clearControllerState reset)
- [x] `npx tsc --noEmit` clean

## Base
Targets `feature/graphql-to-sse-migration` like the other PRs in this
series. Independent of all other stacked PRs — no rebase coupling.

---

> ⚠️ **Schemas-canonical refactor follow-up:** This PR introduces locally-defined RTK Query hooks / Redux reducer changes / Go handler types that should originate from `meshery/schemas` (canonical OpenAPI source). Landing as-is per maintainer direction to keep the GraphQL→SSE migration on schedule. Tracking refactor: #19418.