### PR TITLE
docs: add REST API related reading heading

### DIFF
--- a/docs/content/en/reference/rest-apis/_index.md
+++ b/docs/content/en/reference/rest-apis/_index.md
@@ -10,6 +10,8 @@ aliases:
 
 Meshery's REST API specifications are now maintained and published from the [meshery/schemas](https://github.com/meshery/schemas) repository.
 
+### Related Reading
+
 - Published schemas: [schemas.meshery.io](https://schemas.meshery.io/)
 - Source repository: [github.com/meshery/schemas](https://github.com/meshery/schemas)
 - Contributor guide: [Schema-Driven Development](https://docs.meshery.io/project/contributing/contributing-schemas)

--- a/docs/content/en/reference/rest-apis/_index.md
+++ b/docs/content/en/reference/rest-apis/_index.md
@@ -10,8 +10,6 @@ aliases:
 
 Meshery's REST API specifications are now maintained and published from the [meshery/schemas](https://github.com/meshery/schemas) repository.
 
-### Related Reading
-
 - Published schemas: [schemas.meshery.io](https://schemas.meshery.io/)
 - Source repository: [github.com/meshery/schemas](https://github.com/meshery/schemas)
 - Contributor guide: [Schema-Driven Development](https://docs.meshery.io/project/contributing/contributing-schemas)
@@ -89,5 +87,7 @@ Using curl, you can access Meshery's REST API by executing this command:
 </details>
 
 ## Endpoints
+
+### Related Reading
 
 See the published Meshery OpenAPI bundles in [meshery/schemas](https://github.com/meshery/schemas) for the authoritative REST API definitions.


### PR DESCRIPTION
﻿Closes #19422

## Summary
- Add a `Related Reading` heading above the Meshery schemas links in the REST API reference page.
- Keep the existing schemas, source repository, and contributor guide links unchanged.

## Impact
This makes the meshery/schemas references easier to scan in the REST API section without changing generated API content or endpoint behavior.

## Validation
- `git diff --check` -> passed
- `npm ci` -> failed twice while downloading `hugo_extended_0.157.0_windows-amd64.zip` from GitHub releases with `Gateway Time-out`
- `npx --yes markdownlint-cli2 "docs/content/en/reference/rest-apis/_index.md"` -> failed on existing long-line/inline-HTML warnings in this page