### PR TITLE
chore(ui): drop @ts-nocheck from Relay-generated files

### DIFF
--- a/ui/graphql/mutations/__generated__/AdapterStatusMutation.graphql.ts
+++ b/ui/graphql/mutations/__generated__/AdapterStatusMutation.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<b4a6749ab9275b430386aab0f45b65b1>>
+ * @generated SignedSource<<ed1ec0402fa8b4861339501488a3e28e>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -8,7 +8,7 @@
 /* eslint-disable */
 
 import { ConcreteRequest } from 'relay-runtime';
-export type Status = "CONNECTED" | "DISABLED" | "ENABLED" | "PROCESSING" | "UNKNOWN";
+export type Status = "CONNECTED" | "DISABLED" | "ENABLED" | "PROCESSING" | "UNKNOWN" | "%future added value";
 export type AdapterStatusInput = {
   adapter: string;
   targetPort: string;

--- a/ui/graphql/mutations/__generated__/AdapterStatusMutation.graphql.ts
+++ b/ui/graphql/mutations/__generated__/AdapterStatusMutation.graphql.ts
@@ -1,15 +1,14 @@
 /**
- * @generated SignedSource<<ed1ec0402fa8b4861339501488a3e28e>>
+ * @generated SignedSource<<b4a6749ab9275b430386aab0f45b65b1>>
  * @lightSyntaxTransform
  * @nogrep
  */
 
 /* tslint:disable */
 /* eslint-disable */
-// @ts-nocheck
 
 import { ConcreteRequest } from 'relay-runtime';
-export type Status = "CONNECTED" | "DISABLED" | "ENABLED" | "PROCESSING" | "UNKNOWN" | "%future added value";
+export type Status = "CONNECTED" | "DISABLED" | "ENABLED" | "PROCESSING" | "UNKNOWN";
 export type AdapterStatusInput = {
   adapter: string;
   targetPort: string;

--- a/ui/graphql/mutations/__generated__/OperatorStatusMutation.graphql.ts
+++ b/ui/graphql/mutations/__generated__/OperatorStatusMutation.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<2b36fe46181a41c113b770b00d9865b3>>
+ * @generated SignedSource<<0dd9419c0a7558919b38722c00dfcffc>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -8,7 +8,7 @@
 /* eslint-disable */
 
 import { ConcreteRequest } from 'relay-runtime';
-export type Status = "CONNECTED" | "DISABLED" | "ENABLED" | "PROCESSING" | "UNKNOWN";
+export type Status = "CONNECTED" | "DISABLED" | "ENABLED" | "PROCESSING" | "UNKNOWN" | "%future added value";
 export type OperatorStatusInput = {
   contextID: string;
   targetStatus: Status;

--- a/ui/graphql/mutations/__generated__/OperatorStatusMutation.graphql.ts
+++ b/ui/graphql/mutations/__generated__/OperatorStatusMutation.graphql.ts
@@ -1,15 +1,14 @@
 /**
- * @generated SignedSource<<0dd9419c0a7558919b38722c00dfcffc>>
+ * @generated SignedSource<<2b36fe46181a41c113b770b00d9865b3>>
  * @lightSyntaxTransform
  * @nogrep
  */
 
 /* tslint:disable */
 /* eslint-disable */
-// @ts-nocheck
 
 import { ConcreteRequest } from 'relay-runtime';
-export type Status = "CONNECTED" | "DISABLED" | "ENABLED" | "PROCESSING" | "UNKNOWN" | "%future added value";
+export type Status = "CONNECTED" | "DISABLED" | "ENABLED" | "PROCESSING" | "UNKNOWN";
 export type OperatorStatusInput = {
   contextID: string;
   targetStatus: Status;

--- a/ui/graphql/queries/__generated__/AddonsStatusQuery.graphql.ts
+++ b/ui/graphql/queries/__generated__/AddonsStatusQuery.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<0d72a55bcf757e9a518626678ee44bb3>>
+ * @generated SignedSource<<f39d23088d57dc8c3b41374519736d28>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -8,7 +8,7 @@
 /* eslint-disable */
 
 import { ConcreteRequest } from 'relay-runtime';
-export type MeshType = "ALL_MESH" | "APP_MESH" | "CILIUM_SERVICE_MESH" | "CITRIX_SERVICE_MESH" | "CONSUL" | "INVALID_MESH" | "ISTIO" | "KUMA" | "LINKERD" | "NETWORK_SERVICE_MESH" | "NGINX_SERVICE_MESH" | "OCTARINE" | "OPEN_SERVICE_MESH" | "TANZU" | "TRAEFIK_MESH";
+export type MeshType = "ALL_MESH" | "APP_MESH" | "CILIUM_SERVICE_MESH" | "CITRIX_SERVICE_MESH" | "CONSUL" | "INVALID_MESH" | "ISTIO" | "KUMA" | "LINKERD" | "NETWORK_SERVICE_MESH" | "NGINX_SERVICE_MESH" | "OCTARINE" | "OPEN_SERVICE_MESH" | "TANZU" | "TRAEFIK_MESH" | "%future added value";
 export type ServiceMeshFilter = {
   k8sClusterIDs?: ReadonlyArray<string> | null | undefined;
   type?: MeshType | null | undefined;

--- a/ui/graphql/queries/__generated__/AddonsStatusQuery.graphql.ts
+++ b/ui/graphql/queries/__generated__/AddonsStatusQuery.graphql.ts
@@ -1,15 +1,14 @@
 /**
- * @generated SignedSource<<f39d23088d57dc8c3b41374519736d28>>
+ * @generated SignedSource<<0d72a55bcf757e9a518626678ee44bb3>>
  * @lightSyntaxTransform
  * @nogrep
  */
 
 /* tslint:disable */
 /* eslint-disable */
-// @ts-nocheck
 
 import { ConcreteRequest } from 'relay-runtime';
-export type MeshType = "ALL_MESH" | "APP_MESH" | "CILIUM_SERVICE_MESH" | "CITRIX_SERVICE_MESH" | "CONSUL" | "INVALID_MESH" | "ISTIO" | "KUMA" | "LINKERD" | "NETWORK_SERVICE_MESH" | "NGINX_SERVICE_MESH" | "OCTARINE" | "OPEN_SERVICE_MESH" | "TANZU" | "TRAEFIK_MESH" | "%future added value";
+export type MeshType = "ALL_MESH" | "APP_MESH" | "CILIUM_SERVICE_MESH" | "CITRIX_SERVICE_MESH" | "CONSUL" | "INVALID_MESH" | "ISTIO" | "KUMA" | "LINKERD" | "NETWORK_SERVICE_MESH" | "NGINX_SERVICE_MESH" | "OCTARINE" | "OPEN_SERVICE_MESH" | "TANZU" | "TRAEFIK_MESH";
 export type ServiceMeshFilter = {
   k8sClusterIDs?: ReadonlyArray<string> | null | undefined;
   type?: MeshType | null | undefined;

--- a/ui/graphql/queries/__generated__/CatalogFilterQuery.graphql.ts
+++ b/ui/graphql/queries/__generated__/CatalogFilterQuery.graphql.ts
@@ -6,7 +6,6 @@
 
 /* tslint:disable */
 /* eslint-disable */
-// @ts-nocheck
 
 import { ConcreteRequest } from 'relay-runtime';
 export type CatalogSelector = {

--- a/ui/graphql/queries/__generated__/CatalogPatternQuery.graphql.ts
+++ b/ui/graphql/queries/__generated__/CatalogPatternQuery.graphql.ts
@@ -6,7 +6,6 @@
 
 /* tslint:disable */
 /* eslint-disable */
-// @ts-nocheck
 
 import { ConcreteRequest } from 'relay-runtime';
 export type CatalogSelector = {

--- a/ui/graphql/queries/__generated__/ControlPlanesQuery.graphql.ts
+++ b/ui/graphql/queries/__generated__/ControlPlanesQuery.graphql.ts
@@ -1,15 +1,14 @@
 /**
- * @generated SignedSource<<0aa783078586045b165f63f176d2f220>>
+ * @generated SignedSource<<92c9b993c9fb0364f2d2ddc1895c675d>>
  * @lightSyntaxTransform
  * @nogrep
  */
 
 /* tslint:disable */
 /* eslint-disable */
-// @ts-nocheck
 
 import { ConcreteRequest } from 'relay-runtime';
-export type MeshType = "ALL_MESH" | "APP_MESH" | "CILIUM_SERVICE_MESH" | "CITRIX_SERVICE_MESH" | "CONSUL" | "INVALID_MESH" | "ISTIO" | "KUMA" | "LINKERD" | "NETWORK_SERVICE_MESH" | "NGINX_SERVICE_MESH" | "OCTARINE" | "OPEN_SERVICE_MESH" | "TANZU" | "TRAEFIK_MESH" | "%future added value";
+export type MeshType = "ALL_MESH" | "APP_MESH" | "CILIUM_SERVICE_MESH" | "CITRIX_SERVICE_MESH" | "CONSUL" | "INVALID_MESH" | "ISTIO" | "KUMA" | "LINKERD" | "NETWORK_SERVICE_MESH" | "NGINX_SERVICE_MESH" | "OCTARINE" | "OPEN_SERVICE_MESH" | "TANZU" | "TRAEFIK_MESH";
 export type ServiceMeshFilter = {
   k8sClusterIDs?: ReadonlyArray<string> | null | undefined;
   type?: MeshType | null | undefined;

--- a/ui/graphql/queries/__generated__/ControlPlanesQuery.graphql.ts
+++ b/ui/graphql/queries/__generated__/ControlPlanesQuery.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<92c9b993c9fb0364f2d2ddc1895c675d>>
+ * @generated SignedSource<<0aa783078586045b165f63f176d2f220>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -8,7 +8,7 @@
 /* eslint-disable */
 
 import { ConcreteRequest } from 'relay-runtime';
-export type MeshType = "ALL_MESH" | "APP_MESH" | "CILIUM_SERVICE_MESH" | "CITRIX_SERVICE_MESH" | "CONSUL" | "INVALID_MESH" | "ISTIO" | "KUMA" | "LINKERD" | "NETWORK_SERVICE_MESH" | "NGINX_SERVICE_MESH" | "OCTARINE" | "OPEN_SERVICE_MESH" | "TANZU" | "TRAEFIK_MESH";
+export type MeshType = "ALL_MESH" | "APP_MESH" | "CILIUM_SERVICE_MESH" | "CITRIX_SERVICE_MESH" | "CONSUL" | "INVALID_MESH" | "ISTIO" | "KUMA" | "LINKERD" | "NETWORK_SERVICE_MESH" | "NGINX_SERVICE_MESH" | "OCTARINE" | "OPEN_SERVICE_MESH" | "TANZU" | "TRAEFIK_MESH" | "%future added value";
 export type ServiceMeshFilter = {
   k8sClusterIDs?: ReadonlyArray<string> | null | undefined;
   type?: MeshType | null | undefined;

--- a/ui/graphql/queries/__generated__/DataPlanesQuery.graphql.ts
+++ b/ui/graphql/queries/__generated__/DataPlanesQuery.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<96ce61ba3d6337c00f5d9bfcfe2d3aa0>>
+ * @generated SignedSource<<f9852dade3787a060e19fd82c12208b0>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -8,7 +8,7 @@
 /* eslint-disable */
 
 import { ConcreteRequest } from 'relay-runtime';
-export type MeshType = "ALL_MESH" | "APP_MESH" | "CILIUM_SERVICE_MESH" | "CITRIX_SERVICE_MESH" | "CONSUL" | "INVALID_MESH" | "ISTIO" | "KUMA" | "LINKERD" | "NETWORK_SERVICE_MESH" | "NGINX_SERVICE_MESH" | "OCTARINE" | "OPEN_SERVICE_MESH" | "TANZU" | "TRAEFIK_MESH";
+export type MeshType = "ALL_MESH" | "APP_MESH" | "CILIUM_SERVICE_MESH" | "CITRIX_SERVICE_MESH" | "CONSUL" | "INVALID_MESH" | "ISTIO" | "KUMA" | "LINKERD" | "NETWORK_SERVICE_MESH" | "NGINX_SERVICE_MESH" | "OCTARINE" | "OPEN_SERVICE_MESH" | "TANZU" | "TRAEFIK_MESH" | "%future added value";
 export type ServiceMeshFilter = {
   k8sClusterIDs?: ReadonlyArray<string> | null | undefined;
   type?: MeshType | null | undefined;

--- a/ui/graphql/queries/__generated__/DataPlanesQuery.graphql.ts
+++ b/ui/graphql/queries/__generated__/DataPlanesQuery.graphql.ts
@@ -1,15 +1,14 @@
 /**
- * @generated SignedSource<<f9852dade3787a060e19fd82c12208b0>>
+ * @generated SignedSource<<96ce61ba3d6337c00f5d9bfcfe2d3aa0>>
  * @lightSyntaxTransform
  * @nogrep
  */
 
 /* tslint:disable */
 /* eslint-disable */
-// @ts-nocheck
 
 import { ConcreteRequest } from 'relay-runtime';
-export type MeshType = "ALL_MESH" | "APP_MESH" | "CILIUM_SERVICE_MESH" | "CITRIX_SERVICE_MESH" | "CONSUL" | "INVALID_MESH" | "ISTIO" | "KUMA" | "LINKERD" | "NETWORK_SERVICE_MESH" | "NGINX_SERVICE_MESH" | "OCTARINE" | "OPEN_SERVICE_MESH" | "TANZU" | "TRAEFIK_MESH" | "%future added value";
+export type MeshType = "ALL_MESH" | "APP_MESH" | "CILIUM_SERVICE_MESH" | "CITRIX_SERVICE_MESH" | "CONSUL" | "INVALID_MESH" | "ISTIO" | "KUMA" | "LINKERD" | "NETWORK_SERVICE_MESH" | "NGINX_SERVICE_MESH" | "OCTARINE" | "OPEN_SERVICE_MESH" | "TANZU" | "TRAEFIK_MESH";
 export type ServiceMeshFilter = {
   k8sClusterIDs?: ReadonlyArray<string> | null | undefined;
   type?: MeshType | null | undefined;

--- a/ui/graphql/queries/__generated__/FetchAllResultsQuery.graphql.ts
+++ b/ui/graphql/queries/__generated__/FetchAllResultsQuery.graphql.ts
@@ -6,7 +6,6 @@
 
 /* tslint:disable */
 /* eslint-disable */
-// @ts-nocheck
 
 import { ConcreteRequest } from 'relay-runtime';
 export type PageFilter = {

--- a/ui/graphql/queries/__generated__/MeshsyncStatusQuery.graphql.ts
+++ b/ui/graphql/queries/__generated__/MeshsyncStatusQuery.graphql.ts
@@ -1,15 +1,14 @@
 /**
- * @generated SignedSource<<cd252b762f4c91a7b1ee54846a2eb9fd>>
+ * @generated SignedSource<<f13e56c4cf444ab7fd139348002c4e88>>
  * @lightSyntaxTransform
  * @nogrep
  */
 
 /* tslint:disable */
 /* eslint-disable */
-// @ts-nocheck
 
 import { ConcreteRequest } from 'relay-runtime';
-export type Status = "CONNECTED" | "DISABLED" | "ENABLED" | "PROCESSING" | "UNKNOWN" | "%future added value";
+export type Status = "CONNECTED" | "DISABLED" | "ENABLED" | "PROCESSING" | "UNKNOWN";
 export type MeshsyncStatusQuery$variables = {
   connectionID: string;
 };

--- a/ui/graphql/queries/__generated__/MeshsyncStatusQuery.graphql.ts
+++ b/ui/graphql/queries/__generated__/MeshsyncStatusQuery.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<f13e56c4cf444ab7fd139348002c4e88>>
+ * @generated SignedSource<<cd252b762f4c91a7b1ee54846a2eb9fd>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -8,7 +8,7 @@
 /* eslint-disable */
 
 import { ConcreteRequest } from 'relay-runtime';
-export type Status = "CONNECTED" | "DISABLED" | "ENABLED" | "PROCESSING" | "UNKNOWN";
+export type Status = "CONNECTED" | "DISABLED" | "ENABLED" | "PROCESSING" | "UNKNOWN" | "%future added value";
 export type MeshsyncStatusQuery$variables = {
   connectionID: string;
 };

--- a/ui/graphql/queries/__generated__/NamespaceQuery.graphql.ts
+++ b/ui/graphql/queries/__generated__/NamespaceQuery.graphql.ts
@@ -6,7 +6,6 @@
 
 /* tslint:disable */
 /* eslint-disable */
-// @ts-nocheck
 
 import { ConcreteRequest } from 'relay-runtime';
 export type NamespaceQuery$variables = {

--- a/ui/graphql/queries/__generated__/NatsStatusQuery.graphql.ts
+++ b/ui/graphql/queries/__generated__/NatsStatusQuery.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<c3a746f897b6e7bd63ab1139cf90a092>>
+ * @generated SignedSource<<ab8619d4497e08066a968ab897a59fa1>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -8,7 +8,7 @@
 /* eslint-disable */
 
 import { ConcreteRequest } from 'relay-runtime';
-export type Status = "CONNECTED" | "DISABLED" | "ENABLED" | "PROCESSING" | "UNKNOWN";
+export type Status = "CONNECTED" | "DISABLED" | "ENABLED" | "PROCESSING" | "UNKNOWN" | "%future added value";
 export type NatsStatusQuery$variables = {
   connectionID: string;
 };

--- a/ui/graphql/queries/__generated__/NatsStatusQuery.graphql.ts
+++ b/ui/graphql/queries/__generated__/NatsStatusQuery.graphql.ts
@@ -1,15 +1,14 @@
 /**
- * @generated SignedSource<<ab8619d4497e08066a968ab897a59fa1>>
+ * @generated SignedSource<<c3a746f897b6e7bd63ab1139cf90a092>>
  * @lightSyntaxTransform
  * @nogrep
  */
 
 /* tslint:disable */
 /* eslint-disable */
-// @ts-nocheck
 
 import { ConcreteRequest } from 'relay-runtime';
-export type Status = "CONNECTED" | "DISABLED" | "ENABLED" | "PROCESSING" | "UNKNOWN" | "%future added value";
+export type Status = "CONNECTED" | "DISABLED" | "ENABLED" | "PROCESSING" | "UNKNOWN";
 export type NatsStatusQuery$variables = {
   connectionID: string;
 };

--- a/ui/graphql/queries/__generated__/OperatorStatusQuery.graphql.ts
+++ b/ui/graphql/queries/__generated__/OperatorStatusQuery.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<113d49e98bcc343e127a7bbee3273c0f>>
+ * @generated SignedSource<<af9b90fa300571b33bcd5c7f70347fcd>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -8,8 +8,8 @@
 /* eslint-disable */
 
 import { ConcreteRequest } from 'relay-runtime';
-export type MesheryController = "BROKER" | "MESHSYNC" | "OPERATOR";
-export type MesheryControllerStatus = "CONNECTED" | "DEPLOYED" | "DEPLOYING" | "ENABLED" | "NOTDEPLOYED" | "RUNNING" | "UNDEPLOYED" | "UNKOWN";
+export type MesheryController = "BROKER" | "MESHSYNC" | "OPERATOR" | "%future added value";
+export type MesheryControllerStatus = "CONNECTED" | "DEPLOYED" | "DEPLOYING" | "ENABLED" | "NOTDEPLOYED" | "RUNNING" | "UNDEPLOYED" | "UNKOWN" | "%future added value";
 export type OperatorStatusQuery$variables = {
   connectionID: string;
 };

--- a/ui/graphql/queries/__generated__/OperatorStatusQuery.graphql.ts
+++ b/ui/graphql/queries/__generated__/OperatorStatusQuery.graphql.ts
@@ -1,16 +1,15 @@
 /**
- * @generated SignedSource<<af9b90fa300571b33bcd5c7f70347fcd>>
+ * @generated SignedSource<<113d49e98bcc343e127a7bbee3273c0f>>
  * @lightSyntaxTransform
  * @nogrep
  */
 
 /* tslint:disable */
 /* eslint-disable */
-// @ts-nocheck
 
 import { ConcreteRequest } from 'relay-runtime';
-export type MesheryController = "BROKER" | "MESHSYNC" | "OPERATOR" | "%future added value";
-export type MesheryControllerStatus = "CONNECTED" | "DEPLOYED" | "DEPLOYING" | "ENABLED" | "NOTDEPLOYED" | "RUNNING" | "UNDEPLOYED" | "UNKOWN" | "%future added value";
+export type MesheryController = "BROKER" | "MESHSYNC" | "OPERATOR";
+export type MesheryControllerStatus = "CONNECTED" | "DEPLOYED" | "DEPLOYING" | "ENABLED" | "NOTDEPLOYED" | "RUNNING" | "UNDEPLOYED" | "UNKOWN";
 export type OperatorStatusQuery$variables = {
   connectionID: string;
 };

--- a/ui/graphql/queries/__generated__/PerformanceProfilesQuery.graphql.ts
+++ b/ui/graphql/queries/__generated__/PerformanceProfilesQuery.graphql.ts
@@ -6,7 +6,6 @@
 
 /* tslint:disable */
 /* eslint-disable */
-// @ts-nocheck
 
 import { ConcreteRequest } from 'relay-runtime';
 export type PageFilter = {

--- a/ui/graphql/queries/__generated__/PerformanceResultQuery.graphql.ts
+++ b/ui/graphql/queries/__generated__/PerformanceResultQuery.graphql.ts
@@ -6,7 +6,6 @@
 
 /* tslint:disable */
 /* eslint-disable */
-// @ts-nocheck
 
 import { ConcreteRequest } from 'relay-runtime';
 export type PageFilter = {

--- a/ui/graphql/queries/__generated__/ResetDatabaseQuery.graphql.ts
+++ b/ui/graphql/queries/__generated__/ResetDatabaseQuery.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<34a404dcc13560d31f1435df147e1abc>>
+ * @generated SignedSource<<0315f8c654f92713d4952b2f465c4149>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -8,7 +8,7 @@
 /* eslint-disable */
 
 import { ConcreteRequest } from 'relay-runtime';
-export type Status = "CONNECTED" | "DISABLED" | "ENABLED" | "PROCESSING" | "UNKNOWN";
+export type Status = "CONNECTED" | "DISABLED" | "ENABLED" | "PROCESSING" | "UNKNOWN" | "%future added value";
 export type ReSyncActions = {
   ReSync: string;
   clearDB: string;

--- a/ui/graphql/queries/__generated__/ResetDatabaseQuery.graphql.ts
+++ b/ui/graphql/queries/__generated__/ResetDatabaseQuery.graphql.ts
@@ -1,15 +1,14 @@
 /**
- * @generated SignedSource<<0315f8c654f92713d4952b2f465c4149>>
+ * @generated SignedSource<<34a404dcc13560d31f1435df147e1abc>>
  * @lightSyntaxTransform
  * @nogrep
  */
 
 /* tslint:disable */
 /* eslint-disable */
-// @ts-nocheck
 
 import { ConcreteRequest } from 'relay-runtime';
-export type Status = "CONNECTED" | "DISABLED" | "ENABLED" | "PROCESSING" | "UNKNOWN" | "%future added value";
+export type Status = "CONNECTED" | "DISABLED" | "ENABLED" | "PROCESSING" | "UNKNOWN";
 export type ReSyncActions = {
   ReSync: string;
   clearDB: string;

--- a/ui/graphql/queries/__generated__/TelemetryComponentsQuery.graphql.ts
+++ b/ui/graphql/queries/__generated__/TelemetryComponentsQuery.graphql.ts
@@ -6,7 +6,6 @@
 
 /* tslint:disable */
 /* eslint-disable */
-// @ts-nocheck
 
 import { ConcreteRequest } from 'relay-runtime';
 export type TelemetryComponentsQuery$variables = {

--- a/ui/graphql/subscriptions/__generated__/ClusterResourcesSubscription.graphql.ts
+++ b/ui/graphql/subscriptions/__generated__/ClusterResourcesSubscription.graphql.ts
@@ -6,7 +6,6 @@
 
 /* tslint:disable */
 /* eslint-disable */
-// @ts-nocheck
 
 import { ConcreteRequest } from 'relay-runtime';
 export type ClusterResourcesSubscription$variables = {

--- a/ui/graphql/subscriptions/__generated__/ConfigurationSubscription.graphql.ts
+++ b/ui/graphql/subscriptions/__generated__/ConfigurationSubscription.graphql.ts
@@ -6,7 +6,6 @@
 
 /* tslint:disable */
 /* eslint-disable */
-// @ts-nocheck
 
 import { ConcreteRequest } from 'relay-runtime';
 export type PageFilter = {

--- a/ui/graphql/subscriptions/__generated__/EventsSubscription.graphql.ts
+++ b/ui/graphql/subscriptions/__generated__/EventsSubscription.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<46d4c7f18d4c40ee15da94dbfdef2921>>
+ * @generated SignedSource<<64a6e2242e655d185ae16b2fb0efa9fb>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -8,7 +8,7 @@
 /* eslint-disable */
 
 import { ConcreteRequest } from 'relay-runtime';
-export type Severity = "alert" | "critical" | "debug" | "emergency" | "error" | "informational" | "warning";
+export type Severity = "alert" | "critical" | "debug" | "emergency" | "error" | "informational" | "warning" | "%future added value";
 export type EventsSubscription$variables = Record<PropertyKey, never>;
 export type EventsSubscription$data = {
   readonly event: {

--- a/ui/graphql/subscriptions/__generated__/EventsSubscription.graphql.ts
+++ b/ui/graphql/subscriptions/__generated__/EventsSubscription.graphql.ts
@@ -1,15 +1,14 @@
 /**
- * @generated SignedSource<<64a6e2242e655d185ae16b2fb0efa9fb>>
+ * @generated SignedSource<<46d4c7f18d4c40ee15da94dbfdef2921>>
  * @lightSyntaxTransform
  * @nogrep
  */
 
 /* tslint:disable */
 /* eslint-disable */
-// @ts-nocheck
 
 import { ConcreteRequest } from 'relay-runtime';
-export type Severity = "alert" | "critical" | "debug" | "emergency" | "error" | "informational" | "warning" | "%future added value";
+export type Severity = "alert" | "critical" | "debug" | "emergency" | "error" | "informational" | "warning";
 export type EventsSubscription$variables = Record<PropertyKey, never>;
 export type EventsSubscription$data = {
   readonly event: {

--- a/ui/graphql/subscriptions/__generated__/K8sContextSubscription.graphql.ts
+++ b/ui/graphql/subscriptions/__generated__/K8sContextSubscription.graphql.ts
@@ -6,7 +6,6 @@
 
 /* tslint:disable */
 /* eslint-disable */
-// @ts-nocheck
 
 import { ConcreteRequest } from 'relay-runtime';
 export type PageFilter = {

--- a/ui/graphql/subscriptions/__generated__/MesheryControllersStatusSubscription.graphql.ts
+++ b/ui/graphql/subscriptions/__generated__/MesheryControllersStatusSubscription.graphql.ts
@@ -1,16 +1,15 @@
 /**
- * @generated SignedSource<<3d0a5f39aed11ffb58ed017a5e4aa0a1>>
+ * @generated SignedSource<<07c7cf8f0ec61c47994e16e18c8aad46>>
  * @lightSyntaxTransform
  * @nogrep
  */
 
 /* tslint:disable */
 /* eslint-disable */
-// @ts-nocheck
 
 import { ConcreteRequest } from 'relay-runtime';
-export type MesheryController = "BROKER" | "MESHSYNC" | "OPERATOR" | "%future added value";
-export type MesheryControllerStatus = "CONNECTED" | "DEPLOYED" | "DEPLOYING" | "ENABLED" | "NOTDEPLOYED" | "RUNNING" | "UNDEPLOYED" | "UNKOWN" | "%future added value";
+export type MesheryController = "BROKER" | "MESHSYNC" | "OPERATOR";
+export type MesheryControllerStatus = "CONNECTED" | "DEPLOYED" | "DEPLOYING" | "ENABLED" | "NOTDEPLOYED" | "RUNNING" | "UNDEPLOYED" | "UNKOWN";
 export type MesheryControllersStatusSubscription$variables = {
   connectionIDs?: ReadonlyArray<string> | null | undefined;
 };

--- a/ui/graphql/subscriptions/__generated__/MesheryControllersStatusSubscription.graphql.ts
+++ b/ui/graphql/subscriptions/__generated__/MesheryControllersStatusSubscription.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<07c7cf8f0ec61c47994e16e18c8aad46>>
+ * @generated SignedSource<<3d0a5f39aed11ffb58ed017a5e4aa0a1>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -8,8 +8,8 @@
 /* eslint-disable */
 
 import { ConcreteRequest } from 'relay-runtime';
-export type MesheryController = "BROKER" | "MESHSYNC" | "OPERATOR";
-export type MesheryControllerStatus = "CONNECTED" | "DEPLOYED" | "DEPLOYING" | "ENABLED" | "NOTDEPLOYED" | "RUNNING" | "UNDEPLOYED" | "UNKOWN";
+export type MesheryController = "BROKER" | "MESHSYNC" | "OPERATOR" | "%future added value";
+export type MesheryControllerStatus = "CONNECTED" | "DEPLOYED" | "DEPLOYING" | "ENABLED" | "NOTDEPLOYED" | "RUNNING" | "UNDEPLOYED" | "UNKOWN" | "%future added value";
 export type MesheryControllersStatusSubscription$variables = {
   connectionIDs?: ReadonlyArray<string> | null | undefined;
 };

--- a/ui/graphql/subscriptions/__generated__/PerformanceProfilesSubscription.graphql.ts
+++ b/ui/graphql/subscriptions/__generated__/PerformanceProfilesSubscription.graphql.ts
@@ -6,7 +6,6 @@
 
 /* tslint:disable */
 /* eslint-disable */
-// @ts-nocheck
 
 import { ConcreteRequest } from 'relay-runtime';
 export type PageFilter = {

--- a/ui/graphql/subscriptions/__generated__/PerformanceResultSubscription.graphql.ts
+++ b/ui/graphql/subscriptions/__generated__/PerformanceResultSubscription.graphql.ts
@@ -6,7 +6,6 @@
 
 /* tslint:disable */
 /* eslint-disable */
-// @ts-nocheck
 
 import { ConcreteRequest } from 'relay-runtime';
 export type PageFilter = {

--- a/ui/package.json
+++ b/ui/package.json
@@ -22,7 +22,7 @@
     "test": "vitest run",
     "test:watch": "vitest",
     "test:coverage": "vitest run --coverage",
-    "relay": "relay-compiler",
+    "relay": "relay-compiler && node scripts/relay-strip-ts-nocheck.js",
     "prepare": "cd .. && { [ -e .git ] && husky ui/.husky || true; }",
     "postinstall": "patch-package",
     "clean": "rm -rf .next,out",

--- a/ui/relay.config.js
+++ b/ui/relay.config.js
@@ -8,7 +8,4 @@ module.exports = {
   language: 'typescript',
   src: './',
   schema: '../server/internal/graphql/schema/schema.graphql',
-  // Remove the "%future added value" catch-all from generated enum unions.
-  // Without it the generated TS is fully type-safe and does not need @ts-nocheck.
-  noFutureProofEnums: true,
 };

--- a/ui/relay.config.js
+++ b/ui/relay.config.js
@@ -8,4 +8,7 @@ module.exports = {
   language: 'typescript',
   src: './',
   schema: '../server/internal/graphql/schema/schema.graphql',
+  // Remove the "%future added value" catch-all from generated enum unions.
+  // Without it the generated TS is fully type-safe and does not need @ts-nocheck.
+  noFutureProofEnums: true,
 };

--- a/ui/scripts/relay-strip-ts-nocheck.js
+++ b/ui/scripts/relay-strip-ts-nocheck.js
@@ -1,0 +1,32 @@
+#!/usr/bin/env node
+/**
+ * Post-processes Relay-generated TypeScript artifacts to remove the
+ * // @ts-nocheck directive that relay-compiler v20 unconditionally emits.
+ *
+ * The generated code is valid TypeScript without the directive, so this step
+ * is safe and survives strict-mode tsc checks.  Run automatically as part of
+ * `npm run relay` so that the suppression never re-appears on rebuild.
+ */
+
+const fs = require('fs');
+const path = require('path');
+const { globSync } = require('glob');
+
+const generatedGlob = 'graphql/{queries,mutations,subscriptions}/__generated__/*.graphql.ts';
+const files = globSync(generatedGlob, { cwd: path.join(__dirname, '..') });
+
+let changed = 0;
+for (const rel of files) {
+  const abs = path.join(__dirname, '..', rel);
+  const original = fs.readFileSync(abs, 'utf8');
+  // Remove the @ts-nocheck line (relay-compiler emits it on its own line)
+  const patched = original.replace(/^\/\/ @ts-nocheck\n/m, '');
+  if (patched !== original) {
+    fs.writeFileSync(abs, patched, 'utf8');
+    changed++;
+  }
+}
+
+console.log(
+  `relay-strip-ts-nocheck: removed @ts-nocheck from ${changed}/${files.length} generated file(s).`,
+);

--- a/ui/scripts/relay-strip-ts-nocheck.js
+++ b/ui/scripts/relay-strip-ts-nocheck.js
@@ -8,19 +8,22 @@
  * `npm run relay` so that the suppression never re-appears on rebuild.
  */
 
-const fs = require('fs');
-const path = require('path');
-const { globSync } = require('glob');
+const { globSync } = require('node:fs');
+const fs = require('node:fs');
+const path = require('node:path');
 
-const generatedGlob = 'graphql/{queries,mutations,subscriptions}/__generated__/*.graphql.ts';
-const files = globSync(generatedGlob, { cwd: path.join(__dirname, '..') });
+// Match all __generated__ directories under ui/ (excludes node_modules automatically)
+const files = globSync('**/__generated__/*.graphql.ts', {
+  cwd: path.join(__dirname, '..'),
+  exclude: ['**/node_modules/**'],
+});
 
 let changed = 0;
 for (const rel of files) {
   const abs = path.join(__dirname, '..', rel);
   const original = fs.readFileSync(abs, 'utf8');
-  // Remove the @ts-nocheck line (relay-compiler emits it on its own line)
-  const patched = original.replace(/^\/\/ @ts-nocheck\n/m, '');
+  // Remove the @ts-nocheck line; handle both LF and CRLF line endings
+  const patched = original.replace(/^\/\/ @ts-nocheck\r?\n/m, '');
   if (patched !== original) {
     fs.writeFileSync(abs, patched, 'utf8');
     changed++;


### PR DESCRIPTION
## Summary

- **What changed**: `// @ts-nocheck` is removed from all 23 Relay-generated TypeScript artifacts in `ui/graphql/{queries,mutations,subscriptions}/__generated__/`. The fix is in the codegen pipeline, not in the generated files directly, so it survives every `npm run relay` rebuild.
- **Why now**: A recent cleanup dropped `@ts-nocheck` from 109 hand-written component files. The generated files were intentionally deferred because hand-editing them is futile — the compiler rewrites them on the next build.

## What was changed and why

### `ui/relay.config.js` — `noFutureProofEnums: true`

relay-compiler v20.1.1 (the latest release) hardcodes `// @ts-nocheck` into every TypeScript artifact it emits; there is no first-class config flag to suppress the directive. Investigation showed the primary source of theoretical unsoundness was the `"%future added value"` catch-all appended to every enum union (e.g. `MeshType`). Setting `noFutureProofEnums: true` removes that entry, making the generated types exact and fully compatible with the project's `strictNullChecks` + `exactOptionalPropertyTypes` settings.

### `ui/scripts/relay-strip-ts-nocheck.js` — new post-process script

Because the compiler still emits the directive even with `noFutureProofEnums`, a lightweight Node script strips the `// @ts-nocheck` line from every `__generated__/*.graphql.ts` file immediately after codegen. This is intentionally minimal — it only touches that one line, leaves every other generated comment intact, and is idempotent (safe to run even when the compiler changes its output).

### `ui/package.json` — relay script updated

```
"relay": "relay-compiler && node scripts/relay-strip-ts-nocheck.js"
```

The post-process step is wired into `npm run relay`, so the directive is automatically removed on every rebuild. No manual intervention required.

### Regenerated artifacts (23 files)

All 23 files in `graphql/{queries,mutations,subscriptions}/__generated__/` were regenerated. The only diff per file is:
1. Removal of `// @ts-nocheck`
2. Removal of `"%future added value"` from enum union types (effect of `noFutureProofEnums`)

## Verification

- `grep -rln '@ts-nocheck' ui/graphql/**/__generated__/` → no output (0 files)
- `npm run lint` → exits 0
- `npx tsc --noEmit -p ui/tsconfig.json` → exits 0


---
_Generated by [Claude Code](https://claude.ai/code/session_01VmVsFvHyRag1wdW6Ybv1dM)_