### PR TITLE
fix: use ErrBuildOCIImg for OCI image build error in ExportModel

### DIFF
--- a/server/handlers/component_handler.go
+++ b/server/handlers/component_handler.go
@@ -1418,8 +1418,8 @@ func (h *Handler) ExportModel(rw http.ResponseWriter, r *http.Request) {
 	if fileTypes == "oci" {
 		img, err := meshkitOci.BuildImage(modelDir)
 		if err != nil {
-			h.log.Error(err)
-			writeMeshkitError(rw, ErrExportModel(err, "OCI image build"), http.StatusInternalServerError)
+			h.log.Error(ErrBuildOCIImg(err))
+			writeMeshkitError(rw, ErrBuildOCIImg(err), http.StatusInternalServerError)
 			return
 		}
 

--- a/server/handlers/component_handler.go
+++ b/server/handlers/component_handler.go
@@ -1418,8 +1418,9 @@ func (h *Handler) ExportModel(rw http.ResponseWriter, r *http.Request) {
 	if fileTypes == "oci" {
 		img, err := meshkitOci.BuildImage(modelDir)
 		if err != nil {
-			h.log.Error(ErrBuildOCIImg(err))
-			writeMeshkitError(rw, ErrBuildOCIImg(err), http.StatusInternalServerError)
+			buildErr := ErrBuildOCIImg(err)
+			h.log.Error(buildErr)
+			writeMeshkitError(rw, buildErr, http.StatusInternalServerError)
 			return
 		}
 


### PR DESCRIPTION
## Summary

In `ExportModel`, the OCI image build failure was logged with a raw `err` and reported via the generic `ErrExportModel` wrapper. This PR replaces both with `ErrBuildOCIImg(err)`, the purpose-built structured error that already carries specific diagnostic hints (corrupted source directory, insufficient permissions) and the correct error code.

Fixes #19424

## Test plan

- [ ] Export a model with `file_type=oci` and trigger a build failure (e.g. by pointing at an empty directory) - verify the response and server log both show the structured `ErrBuildOCIImg` error message with actionable hints

🤖 Generated with [Claude Code](https://claude.com/claude-code)