### PR TITLE
fix(mesheryctl): use canonical path in --config flag for docs generation

### DIFF
--- a/mesheryctl/internal/cli/root/root.go
+++ b/mesheryctl/internal/cli/root/root.go
@@ -109,6 +109,10 @@ func init() {
 	cobra.OnInitialize(initConfig)
 
 	RootCmd.PersistentFlags().StringVar(&cfgFile, "config", utils.DefaultConfigPath, "path to config file")
+	// Use the canonical tilde form in generated docs so the runner's home dir is never embedded.
+	if f := RootCmd.PersistentFlags().Lookup("config"); f != nil {
+		f.DefValue = "~/.meshery/config.yaml"
+	}
 
 	// Preparing for an "edge" channel
 	// RootCmd.PersistentFlags().StringVar(&cfgFile, "edge", "", "flag to run Meshery as edge (one-time)")


### PR DESCRIPTION
## Summary

The generated CLI reference docs were embedding the GitHub Actions runner's ephemeral home directory (`/home/runner/.meshery/config.yaml`) in every command's **Options** section, because `flags.PrintDefaults()` includes the actual default value of each flag.

Fix: after registering the `--config` flag in `root.go`, immediately override `DefValue` to the canonical tilde form:

```go
if f := RootCmd.PersistentFlags().Lookup("config"); f != nil {
    f.DefValue = "~/.meshery/config.yaml"
}
```

- **Runtime behaviour is unchanged** - the flag still resolves to `utils.DefaultConfigPath` (the real expanded path) at startup.
- **Docs output changes** - `flags.PrintDefaults()` now prints `~/.meshery/config.yaml` instead of the runner-specific absolute path.

Fixes #19419

## Test plan

- [ ] Run `cd mesheryctl && make docs` locally - verify no absolute home path appears in the generated markdown under `docs/content/en/reference/mesheryctl`
- [ ] Run `mesheryctl --help` - verify the `--config` flag still shows and functions correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)