### PR TITLE
fix(notification): initialize current_view filter to unread to prevent stale events flashing

### DIFF
--- a/ui/store/slices/__tests__/events.test.ts
+++ b/ui/store/slices/__tests__/events.test.ts
@@ -4,6 +4,7 @@ import eventsReducer, {
   setEvents,
   toggleNotificationCenter,
   closeNotificationCenter,
+  selectIsEventVisible,
 } from '../events';
 
 const makeEvent = (overrides = {}) => ({
@@ -65,5 +66,15 @@ describe('events slice', () => {
     state = eventsReducer(state, closeNotificationCenter());
     expect(state.isNotificationCenterOpen).toBe(false);
     expect(state.current_view.page).toBe(0);
+  });
+
+  it('initial current_view filter hides read events before first fetch', () => {
+    let state = eventsReducer(undefined, { type: 'unknown' });
+    state = eventsReducer(state, pushEvent(makeEvent({ id: 'r1', status: 'read' })));
+    state = eventsReducer(state, pushEvent(makeEvent({ id: 'u1', status: 'unread' })));
+
+    const storeShape = { events: state };
+    expect(selectIsEventVisible(storeShape, 'r1')).toBe(false);
+    expect(selectIsEventVisible(storeShape, 'u1')).toBe(true);
   });
 });

--- a/ui/store/slices/events.ts
+++ b/ui/store/slices/events.ts
@@ -6,7 +6,7 @@ const initialState = {
     page: 0,
     pagesize: 10,
     filters: {
-      initial: true,
+      status: STATUS.UNREAD,
     },
     has_more: true,
   },


### PR DESCRIPTION
## Description

Fixes #16239

### Root Cause

The notification center opened showing a "status: unread" chip but could briefly display read notifications (wrong set). The cause was in `ui/store/slices/events.ts`:

```ts
current_view: {
  filters: {
    initial: true,   // <-- undefined status
  },
  ...
}
```

The `selectIsEventVisible` selector gates each notification card's visibility:

```ts
const shouldBeInCurrentFilteredView = currentFilters.status
  ? currentFilters.status == event.status
  : true;           // <-- no status filter = show everything
```

Because `filters.initial = true` has no `status` key, the selector returned `true` for **all** events in the Redux entity store, including any previously-seen read notifications. This caused a brief flash of read events before the initial `loadEvents` API call returned and set `current_view.filters = {status: 'unread'}`.

Meanwhile the `view_to_fetch_on_open` was already correctly set to `{status: STATUS.UNREAD}`, creating an inconsistency.

### Fix

Initialize `current_view.filters` to `{status: STATUS.UNREAD}` to match `view_to_fetch_on_open`. Now `selectIsEventVisible` immediately applies the unread filter, so any cached read events in the entity store are invisible from the first render.

```ts
current_view: {
  filters: {
    status: STATUS.UNREAD,   // consistent with view_to_fetch_on_open
  },
  ...
}
```

`closeNotificationCenter` resets `current_view = initialState.current_view`, so the fix propagates correctly on close/reopen.

### Test Added

A new unit test in `events.test.ts` verifies that a freshly initialized store immediately hides `status: 'read'` events and shows `status: 'unread'` events without waiting for an API response.

### Testing

- Open notification center: only unread notifications appear from the first render.
- Existing tests: `toggleNotificationCenter`, `closeNotificationCenter`, `pushEvent` all still pass.