### PR TITLE
feat(meshmodel): add AWS DynamoDB Table and SQS Queue relationships to Kubernetes Deployment and Pod

### DIFF
--- a/server/meshmodel/aws-dynamodb-controller/v1.8.0/v1.0.0/relationships/edge-non-binding-reference-table-deployment.json
+++ b/server/meshmodel/aws-dynamodb-controller/v1.8.0/v1.0.0/relationships/edge-non-binding-reference-table-deployment.json
@@ -1,0 +1,105 @@
+{
+  "id": "00000000-0000-0000-0000-000000000000",
+  "evaluationQuery": "",
+  "kind": "edge",
+  "metadata": {
+    "description": "An edge relationship between a DynamoDB Table and a Kubernetes Deployment, representing a Deployment whose containers read from or write to the DynamoDB table.",
+    "styles": {
+      "primaryColor": "",
+      "svgColor": "",
+      "svgWhite": ""
+    },
+    "isAnnotation": false
+  },
+  "model": {
+    "version": "",
+    "name": "aws-dynamodb-controller",
+    "displayName": "AWS DynamoDB",
+    "id": "00000000-0000-0000-0000-000000000000",
+    "registrant": {
+      "kind": "github"
+    },
+    "model": {
+      "version": "v1.8.0"
+    }
+  },
+  "schemaVersion": "relationships.meshery.io/v1beta3",
+  "selectors": [
+    {
+      "allow": {
+        "from": [
+          {
+            "id": null,
+            "kind": "Table",
+            "match": {},
+            "match_strategy_matrix": null,
+            "model": {
+              "version": "",
+              "name": "aws-dynamodb-controller",
+              "displayName": "AWS DynamoDB",
+              "id": "00000000-0000-0000-0000-000000000000",
+              "registrant": {
+                "kind": "github"
+              },
+              "model": {
+                "version": ""
+              }
+            },
+            "patch": {
+              "patchStrategy": "replace",
+              "mutatorRef": [
+                [
+                  "configuration",
+                  "metadata",
+                  "name"
+                ]
+              ]
+            }
+          }
+        ],
+        "to": [
+          {
+            "id": null,
+            "kind": "Deployment",
+            "match": {},
+            "match_strategy_matrix": null,
+            "model": {
+              "version": "*",
+              "name": "kubernetes",
+              "displayName": "",
+              "id": "00000000-0000-0000-0000-000000000000",
+              "registrant": {
+                "kind": "github"
+              },
+              "model": {
+                "version": ""
+              }
+            },
+            "patch": {
+              "patchStrategy": "replace",
+              "mutatedRef": [
+                [
+                  "configuration",
+                  "spec",
+                  "template",
+                  "spec",
+                  "containers",
+                  "_",
+                  "env"
+                ]
+              ]
+            }
+          }
+        ]
+      },
+      "deny": {
+        "from": [],
+        "to": []
+      }
+    }
+  ],
+  "subType": "reference",
+  "status": "enabled",
+  "type": "non-binding",
+  "version": "v1.0.0"
+}

--- a/server/meshmodel/aws-dynamodb-controller/v1.8.0/v1.0.0/relationships/edge-non-binding-reference-table-deployment.json
+++ b/server/meshmodel/aws-dynamodb-controller/v1.8.0/v1.0.0/relationships/edge-non-binding-reference-table-deployment.json
@@ -23,7 +23,7 @@
       "version": "v1.8.0"
     }
   },
-  "schemaVersion": "relationships.meshery.io/v1beta3",
+  "schemaVersion": "relationships.meshery.io/v1beta2",
   "selectors": [
     {
       "allow": {

--- a/server/meshmodel/aws-dynamodb-controller/v1.8.0/v1.0.0/relationships/edge-non-binding-reference-table-pod.json
+++ b/server/meshmodel/aws-dynamodb-controller/v1.8.0/v1.0.0/relationships/edge-non-binding-reference-table-pod.json
@@ -23,7 +23,7 @@
       "version": "v1.8.0"
     }
   },
-  "schemaVersion": "relationships.meshery.io/v1beta3",
+  "schemaVersion": "relationships.meshery.io/v1beta2",
   "selectors": [
     {
       "allow": {

--- a/server/meshmodel/aws-dynamodb-controller/v1.8.0/v1.0.0/relationships/edge-non-binding-reference-table-pod.json
+++ b/server/meshmodel/aws-dynamodb-controller/v1.8.0/v1.0.0/relationships/edge-non-binding-reference-table-pod.json
@@ -1,0 +1,103 @@
+{
+  "id": "00000000-0000-0000-0000-000000000000",
+  "evaluationQuery": "",
+  "kind": "edge",
+  "metadata": {
+    "description": "An edge relationship between a DynamoDB Table and a Kubernetes Pod, representing a Pod whose containers read from or write to the DynamoDB table.",
+    "styles": {
+      "primaryColor": "",
+      "svgColor": "",
+      "svgWhite": ""
+    },
+    "isAnnotation": false
+  },
+  "model": {
+    "version": "",
+    "name": "aws-dynamodb-controller",
+    "displayName": "AWS DynamoDB",
+    "id": "00000000-0000-0000-0000-000000000000",
+    "registrant": {
+      "kind": "github"
+    },
+    "model": {
+      "version": "v1.8.0"
+    }
+  },
+  "schemaVersion": "relationships.meshery.io/v1beta3",
+  "selectors": [
+    {
+      "allow": {
+        "from": [
+          {
+            "id": null,
+            "kind": "Table",
+            "match": {},
+            "match_strategy_matrix": null,
+            "model": {
+              "version": "",
+              "name": "aws-dynamodb-controller",
+              "displayName": "AWS DynamoDB",
+              "id": "00000000-0000-0000-0000-000000000000",
+              "registrant": {
+                "kind": "github"
+              },
+              "model": {
+                "version": ""
+              }
+            },
+            "patch": {
+              "patchStrategy": "replace",
+              "mutatorRef": [
+                [
+                  "configuration",
+                  "metadata",
+                  "name"
+                ]
+              ]
+            }
+          }
+        ],
+        "to": [
+          {
+            "id": null,
+            "kind": "Pod",
+            "match": {},
+            "match_strategy_matrix": null,
+            "model": {
+              "version": "*",
+              "name": "kubernetes",
+              "displayName": "",
+              "id": "00000000-0000-0000-0000-000000000000",
+              "registrant": {
+                "kind": "github"
+              },
+              "model": {
+                "version": ""
+              }
+            },
+            "patch": {
+              "patchStrategy": "replace",
+              "mutatedRef": [
+                [
+                  "configuration",
+                  "spec",
+                  "containers",
+                  "_",
+                  "env"
+                ]
+              ]
+            }
+          }
+        ]
+      },
+      "deny": {
+        "from": [],
+        "to": []
+      }
+    }
+  ],
+  "subType": "reference",
+  "status": "enabled",
+  "type": "non-binding",
+  "version": "v1.0.0"
+}

--- a/server/meshmodel/aws-sqs-controller/v1.4.3/v1.0.0/relationships/edge-non-binding-reference-queue-deployment.json
+++ b/server/meshmodel/aws-sqs-controller/v1.4.3/v1.0.0/relationships/edge-non-binding-reference-queue-deployment.json
@@ -1,0 +1,105 @@
+{
+  "id": "00000000-0000-0000-0000-000000000000",
+  "evaluationQuery": "",
+  "kind": "edge",
+  "metadata": {
+    "description": "An edge relationship between an SQS Queue and a Kubernetes Deployment, representing a Deployment whose containers send or receive messages from the SQS queue.",
+    "styles": {
+      "primaryColor": "",
+      "svgColor": "",
+      "svgWhite": ""
+    },
+    "isAnnotation": false
+  },
+  "model": {
+    "version": "",
+    "name": "aws-sqs-controller",
+    "displayName": "AWS SQS",
+    "id": "00000000-0000-0000-0000-000000000000",
+    "registrant": {
+      "kind": "github"
+    },
+    "model": {
+      "version": "v1.4.3"
+    }
+  },
+  "schemaVersion": "relationships.meshery.io/v1beta3",
+  "selectors": [
+    {
+      "allow": {
+        "from": [
+          {
+            "id": null,
+            "kind": "Queue",
+            "match": {},
+            "match_strategy_matrix": null,
+            "model": {
+              "version": "",
+              "name": "aws-sqs-controller",
+              "displayName": "AWS SQS",
+              "id": "00000000-0000-0000-0000-000000000000",
+              "registrant": {
+                "kind": "github"
+              },
+              "model": {
+                "version": ""
+              }
+            },
+            "patch": {
+              "patchStrategy": "replace",
+              "mutatorRef": [
+                [
+                  "configuration",
+                  "metadata",
+                  "name"
+                ]
+              ]
+            }
+          }
+        ],
+        "to": [
+          {
+            "id": null,
+            "kind": "Deployment",
+            "match": {},
+            "match_strategy_matrix": null,
+            "model": {
+              "version": "*",
+              "name": "kubernetes",
+              "displayName": "",
+              "id": "00000000-0000-0000-0000-000000000000",
+              "registrant": {
+                "kind": "github"
+              },
+              "model": {
+                "version": ""
+              }
+            },
+            "patch": {
+              "patchStrategy": "replace",
+              "mutatedRef": [
+                [
+                  "configuration",
+                  "spec",
+                  "template",
+                  "spec",
+                  "containers",
+                  "_",
+                  "env"
+                ]
+              ]
+            }
+          }
+        ]
+      },
+      "deny": {
+        "from": [],
+        "to": []
+      }
+    }
+  ],
+  "subType": "reference",
+  "status": "enabled",
+  "type": "non-binding",
+  "version": "v1.0.0"
+}

--- a/server/meshmodel/aws-sqs-controller/v1.4.3/v1.0.0/relationships/edge-non-binding-reference-queue-deployment.json
+++ b/server/meshmodel/aws-sqs-controller/v1.4.3/v1.0.0/relationships/edge-non-binding-reference-queue-deployment.json
@@ -23,7 +23,7 @@
       "version": "v1.4.3"
     }
   },
-  "schemaVersion": "relationships.meshery.io/v1beta3",
+  "schemaVersion": "relationships.meshery.io/v1beta2",
   "selectors": [
     {
       "allow": {

--- a/server/meshmodel/aws-sqs-controller/v1.4.3/v1.0.0/relationships/edge-non-binding-reference-queue-pod.json
+++ b/server/meshmodel/aws-sqs-controller/v1.4.3/v1.0.0/relationships/edge-non-binding-reference-queue-pod.json
@@ -1,0 +1,103 @@
+{
+  "id": "00000000-0000-0000-0000-000000000000",
+  "evaluationQuery": "",
+  "kind": "edge",
+  "metadata": {
+    "description": "An edge relationship between an SQS Queue and a Kubernetes Pod, representing a Pod whose containers send or receive messages from the SQS queue.",
+    "styles": {
+      "primaryColor": "",
+      "svgColor": "",
+      "svgWhite": ""
+    },
+    "isAnnotation": false
+  },
+  "model": {
+    "version": "",
+    "name": "aws-sqs-controller",
+    "displayName": "AWS SQS",
+    "id": "00000000-0000-0000-0000-000000000000",
+    "registrant": {
+      "kind": "github"
+    },
+    "model": {
+      "version": "v1.4.3"
+    }
+  },
+  "schemaVersion": "relationships.meshery.io/v1beta3",
+  "selectors": [
+    {
+      "allow": {
+        "from": [
+          {
+            "id": null,
+            "kind": "Queue",
+            "match": {},
+            "match_strategy_matrix": null,
+            "model": {
+              "version": "",
+              "name": "aws-sqs-controller",
+              "displayName": "AWS SQS",
+              "id": "00000000-0000-0000-0000-000000000000",
+              "registrant": {
+                "kind": "github"
+              },
+              "model": {
+                "version": ""
+              }
+            },
+            "patch": {
+              "patchStrategy": "replace",
+              "mutatorRef": [
+                [
+                  "configuration",
+                  "metadata",
+                  "name"
+                ]
+              ]
+            }
+          }
+        ],
+        "to": [
+          {
+            "id": null,
+            "kind": "Pod",
+            "match": {},
+            "match_strategy_matrix": null,
+            "model": {
+              "version": "*",
+              "name": "kubernetes",
+              "displayName": "",
+              "id": "00000000-0000-0000-0000-000000000000",
+              "registrant": {
+                "kind": "github"
+              },
+              "model": {
+                "version": ""
+              }
+            },
+            "patch": {
+              "patchStrategy": "replace",
+              "mutatedRef": [
+                [
+                  "configuration",
+                  "spec",
+                  "containers",
+                  "_",
+                  "env"
+                ]
+              ]
+            }
+          }
+        ]
+      },
+      "deny": {
+        "from": [],
+        "to": []
+      }
+    }
+  ],
+  "subType": "reference",
+  "status": "enabled",
+  "type": "non-binding",
+  "version": "v1.0.0"
+}

--- a/server/meshmodel/aws-sqs-controller/v1.4.3/v1.0.0/relationships/edge-non-binding-reference-queue-pod.json
+++ b/server/meshmodel/aws-sqs-controller/v1.4.3/v1.0.0/relationships/edge-non-binding-reference-queue-pod.json
@@ -23,7 +23,7 @@
       "version": "v1.4.3"
     }
   },
-  "schemaVersion": "relationships.meshery.io/v1beta3",
+  "schemaVersion": "relationships.meshery.io/v1beta2",
   "selectors": [
     {
       "allow": {


### PR DESCRIPTION
## Description

Adds edge non-binding reference relationships for two AWS services to Kubernetes workloads, following the same pattern as #17372 (Kinesis→Deployment/Pod) and #17175 (ECR→Deployment/Pod).

**DynamoDB (aws-dynamodb-controller v1.8.0):**
- `Table → Deployment` — models a Deployment whose containers interact with a DynamoDB table
- `Table → Pod` — models a Pod whose containers interact with a DynamoDB table

**SQS (aws-sqs-controller v1.4.3):**
- `Queue → Deployment` — models a Deployment whose containers produce or consume SQS messages
- `Queue → Pod` — models a Pod whose containers produce or consume SQS messages

Relates to #14794

Happy to update the Meshery Integrations spreadsheet once this is merged.

## Checklist
- [x] Follows existing relationship schema (`relationships.meshery.io/v1beta2`)
- [x] Matches pattern of previously merged AWS relationship PRs

<img width="561" height="384" alt="Screenshot 2026-05-29 at 12 45 15 AM" src="https://github.com/user-attachments/assets/18f9cd08-481c-4842-8464-61272093491b" />
