### PR TITLE
[UI] Fix InfoOutlinedIcon import alias in MesheryTreeView

### DIFF
--- a/ui/components/registry/MesheryTreeView.tsx
+++ b/ui/components/registry/MesheryTreeView.tsx
@@ -5,7 +5,7 @@ import {
   Switch,
   CircularProgress,
   Typography,
-  InfoOutlinedIcon,
+  InfoOutlined as InfoOutlinedIcon,
 } from '@sistent/sistent';
 import { MODELS, COMPONENTS, RELATIONSHIPS, REGISTRANTS } from '../../constants/navigator';
 import SearchBar from '@/utils/custom-search';

--- a/ui/components/registry/MesheryTreeView.tsx
+++ b/ui/components/registry/MesheryTreeView.tsx
@@ -5,7 +5,7 @@ import {
   Switch,
   CircularProgress,
   Typography,
-  InfoOutlined as InfoOutlinedIcon,
+  InfoOutlined,
 } from '@sistent/sistent';
 import { MODELS, COMPONENTS, RELATIONSHIPS, REGISTRANTS } from '../../constants/navigator';
 import SearchBar from '@/utils/custom-search';
@@ -281,7 +281,7 @@ const MesheryTreeView = React.memo(
                     sx={{ margin: '0rem', padding: '0rem' }}
                   >
                     <IconButton>
-                      <InfoOutlinedIcon height={20} width={20} />
+                      <InfoOutlined height={20} width={20} />
                     </IconButton>
                   </CustomTextTooltip>
                 </>


### PR DESCRIPTION
**Note for reviewers**

The Registry/Models page crashes because InfoOutlinedIcon is imported from @sistent/sistent, but the package exports it as InfoOutlined. This resolves to undefined, causing a React runtime error. Fixed by aliasing the import correctly.

<img width="1783" height="996" alt="Screenshot 2026-05-16 at 7 59 07 PM" src="https://github.com/user-attachments/assets/6e6874bd-e3ba-48e7-9424-24bd718b2c92" />

**[Signed commits](https://github.com/meshery/meshery/blob/master/CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [x] Yes, I signed my commits.

<!--
Thank you for contributing to Meshery! 

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. Sign your commits.
4. Include before and after screenshots/terminal output.

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.
-->
