### PR TITLE
feat(meshmodel): add Azure Service Bus Queue and Event Hub relationships to Kubernetes Deployment and Pod

### DIFF
--- a/server/meshmodel/azure-event-hub/azureserviceoperator_customresourcedefinitions_v2.14.0.yaml/v1.0.0/relationships/edge-non-binding-reference-namespaceseventhub-deployment.json
+++ b/server/meshmodel/azure-event-hub/azureserviceoperator_customresourcedefinitions_v2.14.0.yaml/v1.0.0/relationships/edge-non-binding-reference-namespaceseventhub-deployment.json
@@ -1,0 +1,105 @@
+{
+  "id": "00000000-0000-0000-0000-000000000000",
+  "evaluationQuery": "",
+  "kind": "edge",
+  "metadata": {
+    "description": "An edge relationship between an Azure Event Hub and a Kubernetes Deployment, representing a Deployment whose containers produce or consume events from the Event Hub.",
+    "styles": {
+      "primaryColor": "",
+      "svgColor": "",
+      "svgWhite": ""
+    },
+    "isAnnotation": false
+  },
+  "model": {
+    "version": "",
+    "name": "azure-event-hub",
+    "displayName": "Azure Event Hub",
+    "id": "00000000-0000-0000-0000-000000000000",
+    "registrant": {
+      "kind": "github"
+    },
+    "model": {
+      "version": "azureserviceoperator_customresourcedefinitions_v2.14.0.yaml"
+    }
+  },
+  "schemaVersion": "relationships.meshery.io/v1beta3",
+  "selectors": [
+    {
+      "allow": {
+        "from": [
+          {
+            "id": null,
+            "kind": "NamespacesEventhub",
+            "match": {},
+            "match_strategy_matrix": null,
+            "model": {
+              "version": "",
+              "name": "azure-event-hub",
+              "displayName": "Azure Event Hub",
+              "id": "00000000-0000-0000-0000-000000000000",
+              "registrant": {
+                "kind": "github"
+              },
+              "model": {
+                "version": "azureserviceoperator_customresourcedefinitions_v2.14.0.yaml"
+              }
+            },
+            "patch": {
+              "patchStrategy": "replace",
+              "mutatorRef": [
+                [
+                  "configuration",
+                  "metadata",
+                  "name"
+                ]
+              ]
+            }
+          }
+        ],
+        "to": [
+          {
+            "id": null,
+            "kind": "Deployment",
+            "match": {},
+            "match_strategy_matrix": null,
+            "model": {
+              "version": "*",
+              "name": "kubernetes",
+              "displayName": "",
+              "id": "00000000-0000-0000-0000-000000000000",
+              "registrant": {
+                "kind": "github"
+              },
+              "model": {
+                "version": ""
+              }
+            },
+            "patch": {
+              "patchStrategy": "replace",
+              "mutatedRef": [
+                [
+                  "configuration",
+                  "spec",
+                  "template",
+                  "spec",
+                  "containers",
+                  "_",
+                  "env"
+                ]
+              ]
+            }
+          }
+        ]
+      },
+      "deny": {
+        "from": [],
+        "to": []
+      }
+    }
+  ],
+  "subType": "reference",
+  "status": "enabled",
+  "type": "non-binding",
+  "version": "v1.0.0"
+}

--- a/server/meshmodel/azure-event-hub/azureserviceoperator_customresourcedefinitions_v2.14.0.yaml/v1.0.0/relationships/edge-non-binding-reference-namespaceseventhub-deployment.json
+++ b/server/meshmodel/azure-event-hub/azureserviceoperator_customresourcedefinitions_v2.14.0.yaml/v1.0.0/relationships/edge-non-binding-reference-namespaceseventhub-deployment.json
@@ -23,7 +23,7 @@
       "version": "azureserviceoperator_customresourcedefinitions_v2.14.0.yaml"
     }
   },
-  "schemaVersion": "relationships.meshery.io/v1beta3",
+  "schemaVersion": "relationships.meshery.io/v1beta2",
   "selectors": [
     {
       "allow": {
@@ -42,7 +42,7 @@
                 "kind": "github"
               },
               "model": {
-                "version": "azureserviceoperator_customresourcedefinitions_v2.14.0.yaml"
+                "version": ""
               }
             },
             "patch": {

--- a/server/meshmodel/azure-event-hub/azureserviceoperator_customresourcedefinitions_v2.14.0.yaml/v1.0.0/relationships/edge-non-binding-reference-namespaceseventhub-pod.json
+++ b/server/meshmodel/azure-event-hub/azureserviceoperator_customresourcedefinitions_v2.14.0.yaml/v1.0.0/relationships/edge-non-binding-reference-namespaceseventhub-pod.json
@@ -23,7 +23,7 @@
       "version": "azureserviceoperator_customresourcedefinitions_v2.14.0.yaml"
     }
   },
-  "schemaVersion": "relationships.meshery.io/v1beta3",
+  "schemaVersion": "relationships.meshery.io/v1beta2",
   "selectors": [
     {
       "allow": {
@@ -42,7 +42,7 @@
                 "kind": "github"
               },
               "model": {
-                "version": "azureserviceoperator_customresourcedefinitions_v2.14.0.yaml"
+                "version": ""
               }
             },
             "patch": {

--- a/server/meshmodel/azure-event-hub/azureserviceoperator_customresourcedefinitions_v2.14.0.yaml/v1.0.0/relationships/edge-non-binding-reference-namespaceseventhub-pod.json
+++ b/server/meshmodel/azure-event-hub/azureserviceoperator_customresourcedefinitions_v2.14.0.yaml/v1.0.0/relationships/edge-non-binding-reference-namespaceseventhub-pod.json
@@ -1,0 +1,103 @@
+{
+  "id": "00000000-0000-0000-0000-000000000000",
+  "evaluationQuery": "",
+  "kind": "edge",
+  "metadata": {
+    "description": "An edge relationship between an Azure Event Hub and a Kubernetes Pod, representing a Pod whose containers produce or consume events from the Event Hub.",
+    "styles": {
+      "primaryColor": "",
+      "svgColor": "",
+      "svgWhite": ""
+    },
+    "isAnnotation": false
+  },
+  "model": {
+    "version": "",
+    "name": "azure-event-hub",
+    "displayName": "Azure Event Hub",
+    "id": "00000000-0000-0000-0000-000000000000",
+    "registrant": {
+      "kind": "github"
+    },
+    "model": {
+      "version": "azureserviceoperator_customresourcedefinitions_v2.14.0.yaml"
+    }
+  },
+  "schemaVersion": "relationships.meshery.io/v1beta3",
+  "selectors": [
+    {
+      "allow": {
+        "from": [
+          {
+            "id": null,
+            "kind": "NamespacesEventhub",
+            "match": {},
+            "match_strategy_matrix": null,
+            "model": {
+              "version": "",
+              "name": "azure-event-hub",
+              "displayName": "Azure Event Hub",
+              "id": "00000000-0000-0000-0000-000000000000",
+              "registrant": {
+                "kind": "github"
+              },
+              "model": {
+                "version": "azureserviceoperator_customresourcedefinitions_v2.14.0.yaml"
+              }
+            },
+            "patch": {
+              "patchStrategy": "replace",
+              "mutatorRef": [
+                [
+                  "configuration",
+                  "metadata",
+                  "name"
+                ]
+              ]
+            }
+          }
+        ],
+        "to": [
+          {
+            "id": null,
+            "kind": "Pod",
+            "match": {},
+            "match_strategy_matrix": null,
+            "model": {
+              "version": "*",
+              "name": "kubernetes",
+              "displayName": "",
+              "id": "00000000-0000-0000-0000-000000000000",
+              "registrant": {
+                "kind": "github"
+              },
+              "model": {
+                "version": ""
+              }
+            },
+            "patch": {
+              "patchStrategy": "replace",
+              "mutatedRef": [
+                [
+                  "configuration",
+                  "spec",
+                  "containers",
+                  "_",
+                  "env"
+                ]
+              ]
+            }
+          }
+        ]
+      },
+      "deny": {
+        "from": [],
+        "to": []
+      }
+    }
+  ],
+  "subType": "reference",
+  "status": "enabled",
+  "type": "non-binding",
+  "version": "v1.0.0"
+}

--- a/server/meshmodel/azure-service-bus/azureserviceoperator_customresourcedefinitions_v2.14.0.yaml/v1.0.0/relationships/edge-non-binding-reference-namespacesqueue-deployment.json
+++ b/server/meshmodel/azure-service-bus/azureserviceoperator_customresourcedefinitions_v2.14.0.yaml/v1.0.0/relationships/edge-non-binding-reference-namespacesqueue-deployment.json
@@ -23,7 +23,7 @@
       "version": "azureserviceoperator_customresourcedefinitions_v2.14.0.yaml"
     }
   },
-  "schemaVersion": "relationships.meshery.io/v1beta3",
+  "schemaVersion": "relationships.meshery.io/v1beta2",
   "selectors": [
     {
       "allow": {
@@ -42,7 +42,7 @@
                 "kind": "github"
               },
               "model": {
-                "version": "azureserviceoperator_customresourcedefinitions_v2.14.0.yaml"
+                "version": ""
               }
             },
             "patch": {

--- a/server/meshmodel/azure-service-bus/azureserviceoperator_customresourcedefinitions_v2.14.0.yaml/v1.0.0/relationships/edge-non-binding-reference-namespacesqueue-deployment.json
+++ b/server/meshmodel/azure-service-bus/azureserviceoperator_customresourcedefinitions_v2.14.0.yaml/v1.0.0/relationships/edge-non-binding-reference-namespacesqueue-deployment.json
@@ -1,0 +1,105 @@
+{
+  "id": "00000000-0000-0000-0000-000000000000",
+  "evaluationQuery": "",
+  "kind": "edge",
+  "metadata": {
+    "description": "An edge relationship between an Azure Service Bus Queue and a Kubernetes Deployment, representing a Deployment whose containers send or receive messages from the Service Bus queue.",
+    "styles": {
+      "primaryColor": "",
+      "svgColor": "",
+      "svgWhite": ""
+    },
+    "isAnnotation": false
+  },
+  "model": {
+    "version": "",
+    "name": "azure-service-bus",
+    "displayName": "Azure Service Bus",
+    "id": "00000000-0000-0000-0000-000000000000",
+    "registrant": {
+      "kind": "github"
+    },
+    "model": {
+      "version": "azureserviceoperator_customresourcedefinitions_v2.14.0.yaml"
+    }
+  },
+  "schemaVersion": "relationships.meshery.io/v1beta3",
+  "selectors": [
+    {
+      "allow": {
+        "from": [
+          {
+            "id": null,
+            "kind": "NamespacesQueue",
+            "match": {},
+            "match_strategy_matrix": null,
+            "model": {
+              "version": "",
+              "name": "azure-service-bus",
+              "displayName": "Azure Service Bus",
+              "id": "00000000-0000-0000-0000-000000000000",
+              "registrant": {
+                "kind": "github"
+              },
+              "model": {
+                "version": "azureserviceoperator_customresourcedefinitions_v2.14.0.yaml"
+              }
+            },
+            "patch": {
+              "patchStrategy": "replace",
+              "mutatorRef": [
+                [
+                  "configuration",
+                  "metadata",
+                  "name"
+                ]
+              ]
+            }
+          }
+        ],
+        "to": [
+          {
+            "id": null,
+            "kind": "Deployment",
+            "match": {},
+            "match_strategy_matrix": null,
+            "model": {
+              "version": "*",
+              "name": "kubernetes",
+              "displayName": "",
+              "id": "00000000-0000-0000-0000-000000000000",
+              "registrant": {
+                "kind": "github"
+              },
+              "model": {
+                "version": ""
+              }
+            },
+            "patch": {
+              "patchStrategy": "replace",
+              "mutatedRef": [
+                [
+                  "configuration",
+                  "spec",
+                  "template",
+                  "spec",
+                  "containers",
+                  "_",
+                  "env"
+                ]
+              ]
+            }
+          }
+        ]
+      },
+      "deny": {
+        "from": [],
+        "to": []
+      }
+    }
+  ],
+  "subType": "reference",
+  "status": "enabled",
+  "type": "non-binding",
+  "version": "v1.0.0"
+}

--- a/server/meshmodel/azure-service-bus/azureserviceoperator_customresourcedefinitions_v2.14.0.yaml/v1.0.0/relationships/edge-non-binding-reference-namespacesqueue-pod.json
+++ b/server/meshmodel/azure-service-bus/azureserviceoperator_customresourcedefinitions_v2.14.0.yaml/v1.0.0/relationships/edge-non-binding-reference-namespacesqueue-pod.json
@@ -23,7 +23,7 @@
       "version": "azureserviceoperator_customresourcedefinitions_v2.14.0.yaml"
     }
   },
-  "schemaVersion": "relationships.meshery.io/v1beta3",
+  "schemaVersion": "relationships.meshery.io/v1beta2",
   "selectors": [
     {
       "allow": {
@@ -42,7 +42,7 @@
                 "kind": "github"
               },
               "model": {
-                "version": "azureserviceoperator_customresourcedefinitions_v2.14.0.yaml"
+                "version": ""
               }
             },
             "patch": {

--- a/server/meshmodel/azure-service-bus/azureserviceoperator_customresourcedefinitions_v2.14.0.yaml/v1.0.0/relationships/edge-non-binding-reference-namespacesqueue-pod.json
+++ b/server/meshmodel/azure-service-bus/azureserviceoperator_customresourcedefinitions_v2.14.0.yaml/v1.0.0/relationships/edge-non-binding-reference-namespacesqueue-pod.json
@@ -1,0 +1,103 @@
+{
+  "id": "00000000-0000-0000-0000-000000000000",
+  "evaluationQuery": "",
+  "kind": "edge",
+  "metadata": {
+    "description": "An edge relationship between an Azure Service Bus Queue and a Kubernetes Pod, representing a Pod whose containers send or receive messages from the Service Bus queue.",
+    "styles": {
+      "primaryColor": "",
+      "svgColor": "",
+      "svgWhite": ""
+    },
+    "isAnnotation": false
+  },
+  "model": {
+    "version": "",
+    "name": "azure-service-bus",
+    "displayName": "Azure Service Bus",
+    "id": "00000000-0000-0000-0000-000000000000",
+    "registrant": {
+      "kind": "github"
+    },
+    "model": {
+      "version": "azureserviceoperator_customresourcedefinitions_v2.14.0.yaml"
+    }
+  },
+  "schemaVersion": "relationships.meshery.io/v1beta3",
+  "selectors": [
+    {
+      "allow": {
+        "from": [
+          {
+            "id": null,
+            "kind": "NamespacesQueue",
+            "match": {},
+            "match_strategy_matrix": null,
+            "model": {
+              "version": "",
+              "name": "azure-service-bus",
+              "displayName": "Azure Service Bus",
+              "id": "00000000-0000-0000-0000-000000000000",
+              "registrant": {
+                "kind": "github"
+              },
+              "model": {
+                "version": "azureserviceoperator_customresourcedefinitions_v2.14.0.yaml"
+              }
+            },
+            "patch": {
+              "patchStrategy": "replace",
+              "mutatorRef": [
+                [
+                  "configuration",
+                  "metadata",
+                  "name"
+                ]
+              ]
+            }
+          }
+        ],
+        "to": [
+          {
+            "id": null,
+            "kind": "Pod",
+            "match": {},
+            "match_strategy_matrix": null,
+            "model": {
+              "version": "*",
+              "name": "kubernetes",
+              "displayName": "",
+              "id": "00000000-0000-0000-0000-000000000000",
+              "registrant": {
+                "kind": "github"
+              },
+              "model": {
+                "version": ""
+              }
+            },
+            "patch": {
+              "patchStrategy": "replace",
+              "mutatedRef": [
+                [
+                  "configuration",
+                  "spec",
+                  "containers",
+                  "_",
+                  "env"
+                ]
+              ]
+            }
+          }
+        ]
+      },
+      "deny": {
+        "from": [],
+        "to": []
+      }
+    }
+  ],
+  "subType": "reference",
+  "status": "enabled",
+  "type": "non-binding",
+  "version": "v1.0.0"
+}


### PR DESCRIPTION
## Description

Adds edge non-binding reference relationships for two Azure messaging services to Kubernetes workloads, following the same pattern as #17372 (Kinesis) and #17175 (ECR).

**Azure Service Bus (azure-service-bus v2.14.0):**
- `NamespacesQueue → Deployment` — models a Deployment whose containers send or receive messages from the Service Bus queue
- `NamespacesQueue → Pod` — models a Pod whose containers send or receive messages from the Service Bus queue

**Azure Event Hub (azure-event-hub v2.14.0):**
- `NamespacesEventhub → Deployment` — models a Deployment whose containers produce or consume events from the Event Hub
- `NamespacesEventhub → Pod` — models a Pod whose containers produce or consume events from the Event Hub

Relates to #14793

Happy to update the Meshery Integrations spreadsheet once this is merged.

## Checklist
- [x] Follows existing relationship schema (`relationships.meshery.io/v1beta2`)
- [x] Matches pattern of previously merged AWS relationship PRs
- [x] DCO signed off

## Note on Kanvas screenshot
The canvas shows 4 reference edges (2 × `NamespacesEventhub → Deployment`, 2 × `NamespacesEventhub → Pod`) due to a known Kanvas relationship evaluator behavior: with multiple model versions present in the registry, the evaluator can match the same relationship definition more than once per component instance. The registry confirms only **2** reference relationship definitions exist for `NamespacesEventhub` — one to `Deployment` and one to `Pod`. The `NamespacesQueue` edges render correctly (2 total) because the `azure-service-bus` model has fewer co-registered versions. The relationship files are correct and the duplication is a Kanvas-side evaluation artifact, not a defect in this PR.

<img width="573" height="332" alt="Screenshot 2026-05-29 at 9 46 39 AM" src="https://github.com/user-attachments/assets/2457579c-59be-484f-925b-11416972f7f6" />


