### PR TITLE
[mesheryctl] Fix config path shown in generated docs

### DIFF
--- a/docs/content/en/reference/mesheryctl/adapter/_index.md
+++ b/docs/content/en/reference/mesheryctl/adapter/_index.md
@@ -27,7 +27,7 @@ Provisioning, configuration, and on-going operational management of cloud and cl
 
 <pre class='codeblock-pre'>
 <div class='codeblock'>
-      --config string   path to config file (default "/home/runner/.meshery/config.yaml")
+      --config string   path to config file (default "~/.meshery/config.yaml")
   -v, --verbose         verbose output
 
 </div>

--- a/docs/content/en/reference/mesheryctl/adapter/deploy.md
+++ b/docs/content/en/reference/mesheryctl/adapter/deploy.md
@@ -76,7 +76,7 @@ mesheryctl adapter deploy linkerd --watch
 
 <pre class='codeblock-pre'>
 <div class='codeblock'>
-      --config string   path to config file (default "/home/runner/.meshery/config.yaml")
+      --config string   path to config file (default "~/.meshery/config.yaml")
   -v, --verbose         verbose output
 
 </div>

--- a/docs/content/en/reference/mesheryctl/adapter/remove.md
+++ b/docs/content/en/reference/mesheryctl/adapter/remove.md
@@ -58,7 +58,7 @@ mesheryctl adapter remove linkerd --namespace linkerd-ns
 
 <pre class='codeblock-pre'>
 <div class='codeblock'>
-      --config string   path to config file (default "/home/runner/.meshery/config.yaml")
+      --config string   path to config file (default "~/.meshery/config.yaml")
   -t, --token string    Path to token for authenticating to Meshery API
   -v, --verbose         verbose output
 

--- a/docs/content/en/reference/mesheryctl/adapter/validate.md
+++ b/docs/content/en/reference/mesheryctl/adapter/validate.md
@@ -54,7 +54,7 @@ mesheryctl adapter validate istio --adapter meshery-istio --spec smi
 
 <pre class='codeblock-pre'>
 <div class='codeblock'>
-      --config string   path to config file (default "/home/runner/.meshery/config.yaml")
+      --config string   path to config file (default "~/.meshery/config.yaml")
   -v, --verbose         verbose output
 
 </div>

--- a/docs/content/en/reference/mesheryctl/completion.md
+++ b/docs/content/en/reference/mesheryctl/completion.md
@@ -123,7 +123,7 @@ mesheryctl completion fish > ~/.config/fish/completions/mesheryctl.fish
 
 <pre class='codeblock-pre'>
 <div class='codeblock'>
-      --config string   path to config file (default "/home/runner/.meshery/config.yaml")
+      --config string   path to config file (default "~/.meshery/config.yaml")
   -v, --verbose         verbose output
 
 </div>

--- a/docs/content/en/reference/mesheryctl/component/_index.md
+++ b/docs/content/en/reference/mesheryctl/component/_index.md
@@ -68,7 +68,7 @@ mesheryctl component view [component-name | component-id]
 
 <pre class='codeblock-pre'>
 <div class='codeblock'>
-      --config string   path to config file (default "/home/runner/.meshery/config.yaml")
+      --config string   path to config file (default "~/.meshery/config.yaml")
   -v, --verbose         verbose output
 
 </div>

--- a/docs/content/en/reference/mesheryctl/component/list.md
+++ b/docs/content/en/reference/mesheryctl/component/list.md
@@ -70,7 +70,7 @@ mesheryctl component list --count
 
 <pre class='codeblock-pre'>
 <div class='codeblock'>
-      --config string   path to config file (default "/home/runner/.meshery/config.yaml")
+      --config string   path to config file (default "~/.meshery/config.yaml")
   -v, --verbose         verbose output
 
 </div>

--- a/docs/content/en/reference/mesheryctl/component/search.md
+++ b/docs/content/en/reference/mesheryctl/component/search.md
@@ -61,7 +61,7 @@ mesheryctl component search [query-text] [--page 1]
 
 <pre class='codeblock-pre'>
 <div class='codeblock'>
-      --config string   path to config file (default "/home/runner/.meshery/config.yaml")
+      --config string   path to config file (default "~/.meshery/config.yaml")
   -v, --verbose         verbose output
 
 </div>

--- a/docs/content/en/reference/mesheryctl/component/view.md
+++ b/docs/content/en/reference/mesheryctl/component/view.md
@@ -61,7 +61,7 @@ mesheryctl component view [component-name | component-id] -o [json|yaml] --save
 
 <pre class='codeblock-pre'>
 <div class='codeblock'>
-      --config string   path to config file (default "/home/runner/.meshery/config.yaml")
+      --config string   path to config file (default "~/.meshery/config.yaml")
   -v, --verbose         verbose output
 
 </div>

--- a/docs/content/en/reference/mesheryctl/connection/_index.md
+++ b/docs/content/en/reference/mesheryctl/connection/_index.md
@@ -96,7 +96,7 @@ mesheryctl connection delete [connection_id]
 
 <pre class='codeblock-pre'>
 <div class='codeblock'>
-      --config string   path to config file (default "/home/runner/.meshery/config.yaml")
+      --config string   path to config file (default "~/.meshery/config.yaml")
   -v, --verbose         verbose output
 
 </div>

--- a/docs/content/en/reference/mesheryctl/connection/create.md
+++ b/docs/content/en/reference/mesheryctl/connection/create.md
@@ -73,7 +73,7 @@ mesheryctl connection create --type gke --token auth.json
 
 <pre class='codeblock-pre'>
 <div class='codeblock'>
-      --config string   path to config file (default "/home/runner/.meshery/config.yaml")
+      --config string   path to config file (default "~/.meshery/config.yaml")
   -v, --verbose         verbose output
 
 </div>

--- a/docs/content/en/reference/mesheryctl/connection/delete.md
+++ b/docs/content/en/reference/mesheryctl/connection/delete.md
@@ -42,7 +42,7 @@ mesheryctl connection delete [connection_id]
 
 <pre class='codeblock-pre'>
 <div class='codeblock'>
-      --config string   path to config file (default "/home/runner/.meshery/config.yaml")
+      --config string   path to config file (default "~/.meshery/config.yaml")
   -v, --verbose         verbose output
 
 </div>

--- a/docs/content/en/reference/mesheryctl/connection/list.md
+++ b/docs/content/en/reference/mesheryctl/connection/list.md
@@ -80,7 +80,7 @@ mesheryctl connection list --count
 
 <pre class='codeblock-pre'>
 <div class='codeblock'>
-      --config string   path to config file (default "/home/runner/.meshery/config.yaml")
+      --config string   path to config file (default "~/.meshery/config.yaml")
   -v, --verbose         verbose output
 
 </div>

--- a/docs/content/en/reference/mesheryctl/connection/view.md
+++ b/docs/content/en/reference/mesheryctl/connection/view.md
@@ -61,7 +61,7 @@ mesheryctl connection view [connection-name|connection-id] --output-format json 
 
 <pre class='codeblock-pre'>
 <div class='codeblock'>
-      --config string   path to config file (default "/home/runner/.meshery/config.yaml")
+      --config string   path to config file (default "~/.meshery/config.yaml")
   -v, --verbose         verbose output
 
 </div>

--- a/docs/content/en/reference/mesheryctl/design/_index.md
+++ b/docs/content/en/reference/mesheryctl/design/_index.md
@@ -68,7 +68,7 @@ mesheryctl design list
 
 <pre class='codeblock-pre'>
 <div class='codeblock'>
-      --config string   path to config file (default "/home/runner/.meshery/config.yaml")
+      --config string   path to config file (default "~/.meshery/config.yaml")
   -v, --verbose         verbose output
 
 </div>

--- a/docs/content/en/reference/mesheryctl/design/apply.md
+++ b/docs/content/en/reference/mesheryctl/design/apply.md
@@ -52,7 +52,7 @@ mesheryctl design apply [design-name]
 
 <pre class='codeblock-pre'>
 <div class='codeblock'>
-      --config string   path to config file (default "/home/runner/.meshery/config.yaml")
+      --config string   path to config file (default "~/.meshery/config.yaml")
   -t, --token string    Path to token file default from current context
   -v, --verbose         verbose output
 

--- a/docs/content/en/reference/mesheryctl/design/delete.md
+++ b/docs/content/en/reference/mesheryctl/design/delete.md
@@ -43,7 +43,7 @@ mesheryctl design delete [file | URL]
 
 <pre class='codeblock-pre'>
 <div class='codeblock'>
-      --config string   path to config file (default "/home/runner/.meshery/config.yaml")
+      --config string   path to config file (default "~/.meshery/config.yaml")
   -t, --token string    Path to token file default from current context
   -v, --verbose         verbose output
 

--- a/docs/content/en/reference/mesheryctl/design/deploy.md
+++ b/docs/content/en/reference/mesheryctl/design/deploy.md
@@ -45,7 +45,7 @@ mesheryctl design deploy -f [filepath] -s [source type]
 
 <pre class='codeblock-pre'>
 <div class='codeblock'>
-      --config string   path to config file (default "/home/runner/.meshery/config.yaml")
+      --config string   path to config file (default "~/.meshery/config.yaml")
   -t, --token string    Path to token file default from current context
   -v, --verbose         verbose output
 

--- a/docs/content/en/reference/mesheryctl/design/export.md
+++ b/docs/content/en/reference/mesheryctl/design/export.md
@@ -72,7 +72,7 @@ mesheryctl design export [pattern-name | ID] --type [design-type] --output ./exp
 
 <pre class='codeblock-pre'>
 <div class='codeblock'>
-      --config string   path to config file (default "/home/runner/.meshery/config.yaml")
+      --config string   path to config file (default "~/.meshery/config.yaml")
   -t, --token string    Path to token file default from current context
   -v, --verbose         verbose output
 

--- a/docs/content/en/reference/mesheryctl/design/import.md
+++ b/docs/content/en/reference/mesheryctl/design/import.md
@@ -74,7 +74,7 @@ mesheryctl design import -f design.yml -s "Kubernetes Manifest" -n design-name
 
 <pre class='codeblock-pre'>
 <div class='codeblock'>
-      --config string   path to config file (default "/home/runner/.meshery/config.yaml")
+      --config string   path to config file (default "~/.meshery/config.yaml")
   -t, --token string    Path to token file default from current context
   -v, --verbose         verbose output
 

--- a/docs/content/en/reference/mesheryctl/design/list.md
+++ b/docs/content/en/reference/mesheryctl/design/list.md
@@ -79,7 +79,7 @@ mesheryctl design list --count
 
 <pre class='codeblock-pre'>
 <div class='codeblock'>
-      --config string   path to config file (default "/home/runner/.meshery/config.yaml")
+      --config string   path to config file (default "~/.meshery/config.yaml")
   -t, --token string    Path to token file default from current context
 
 </div>

--- a/docs/content/en/reference/mesheryctl/design/undeploy.md
+++ b/docs/content/en/reference/mesheryctl/design/undeploy.md
@@ -43,7 +43,7 @@ mesheryctl design undeploy -f [filepath]
 
 <pre class='codeblock-pre'>
 <div class='codeblock'>
-      --config string   path to config file (default "/home/runner/.meshery/config.yaml")
+      --config string   path to config file (default "~/.meshery/config.yaml")
   -t, --token string    Path to token file default from current context
   -v, --verbose         verbose output
 

--- a/docs/content/en/reference/mesheryctl/design/view.md
+++ b/docs/content/en/reference/mesheryctl/design/view.md
@@ -44,7 +44,7 @@ mesheryctl design view [design-name | ID]
 
 <pre class='codeblock-pre'>
 <div class='codeblock'>
-      --config string   path to config file (default "/home/runner/.meshery/config.yaml")
+      --config string   path to config file (default "~/.meshery/config.yaml")
   -t, --token string    Path to token file default from current context
   -v, --verbose         verbose output
 

--- a/docs/content/en/reference/mesheryctl/environment/_index.md
+++ b/docs/content/en/reference/mesheryctl/environment/_index.md
@@ -67,7 +67,7 @@ mesheryctl environment view --orgId [orgId]
 
 <pre class='codeblock-pre'>
 <div class='codeblock'>
-      --config string   path to config file (default "/home/runner/.meshery/config.yaml")
+      --config string   path to config file (default "~/.meshery/config.yaml")
   -v, --verbose         verbose output
 
 </div>

--- a/docs/content/en/reference/mesheryctl/environment/create.md
+++ b/docs/content/en/reference/mesheryctl/environment/create.md
@@ -46,7 +46,7 @@ mesheryctl environment create --orgId [orgId] --name [name] --description [descr
 
 <pre class='codeblock-pre'>
 <div class='codeblock'>
-      --config string   path to config file (default "/home/runner/.meshery/config.yaml")
+      --config string   path to config file (default "~/.meshery/config.yaml")
   -v, --verbose         verbose output
 
 </div>

--- a/docs/content/en/reference/mesheryctl/environment/delete.md
+++ b/docs/content/en/reference/mesheryctl/environment/delete.md
@@ -43,7 +43,7 @@ mesheryctl environment delete [environmentId]
 
 <pre class='codeblock-pre'>
 <div class='codeblock'>
-      --config string   path to config file (default "/home/runner/.meshery/config.yaml")
+      --config string   path to config file (default "~/.meshery/config.yaml")
   -v, --verbose         verbose output
 
 </div>

--- a/docs/content/en/reference/mesheryctl/environment/list.md
+++ b/docs/content/en/reference/mesheryctl/environment/list.md
@@ -71,7 +71,7 @@ mesheryctl environment list --orgId [orgId] --pagesize [pagesize]
 
 <pre class='codeblock-pre'>
 <div class='codeblock'>
-      --config string   path to config file (default "/home/runner/.meshery/config.yaml")
+      --config string   path to config file (default "~/.meshery/config.yaml")
   -v, --verbose         verbose output
 
 </div>

--- a/docs/content/en/reference/mesheryctl/environment/view.md
+++ b/docs/content/en/reference/mesheryctl/environment/view.md
@@ -46,7 +46,7 @@ mesheryctl environment view --orgId [orgId]
 
 <pre class='codeblock-pre'>
 <div class='codeblock'>
-      --config string   path to config file (default "/home/runner/.meshery/config.yaml")
+      --config string   path to config file (default "~/.meshery/config.yaml")
   -v, --verbose         verbose output
 
 </div>

--- a/docs/content/en/reference/mesheryctl/exp.md
+++ b/docs/content/en/reference/mesheryctl/exp.md
@@ -32,7 +32,7 @@ mesheryctl exp [flags]
 
 <pre class='codeblock-pre'>
 <div class='codeblock'>
-      --config string   path to config file (default "/home/runner/.meshery/config.yaml")
+      --config string   path to config file (default "~/.meshery/config.yaml")
   -v, --verbose         verbose output
 
 </div>

--- a/docs/content/en/reference/mesheryctl/filter/_index.md
+++ b/docs/content/en/reference/mesheryctl/filter/_index.md
@@ -44,7 +44,7 @@ mesheryctl filter [subcommands]
 
 <pre class='codeblock-pre'>
 <div class='codeblock'>
-      --config string   path to config file (default "/home/runner/.meshery/config.yaml")
+      --config string   path to config file (default "~/.meshery/config.yaml")
   -v, --verbose         verbose output
 
 </div>

--- a/docs/content/en/reference/mesheryctl/filter/delete.md
+++ b/docs/content/en/reference/mesheryctl/filter/delete.md
@@ -43,7 +43,7 @@ mesheryctl filter delete [filter-name | ID]
 
 <pre class='codeblock-pre'>
 <div class='codeblock'>
-      --config string   path to config file (default "/home/runner/.meshery/config.yaml")
+      --config string   path to config file (default "~/.meshery/config.yaml")
   -t, --token string    Path to token file default from current context
   -v, --verbose         verbose output
 

--- a/docs/content/en/reference/mesheryctl/filter/import.md
+++ b/docs/content/en/reference/mesheryctl/filter/import.md
@@ -70,7 +70,7 @@ mesheryctl filter import /path/to/filter.wasm --name [string]
 
 <pre class='codeblock-pre'>
 <div class='codeblock'>
-      --config string   path to config file (default "/home/runner/.meshery/config.yaml")
+      --config string   path to config file (default "~/.meshery/config.yaml")
   -t, --token string    Path to token file default from current context
   -v, --verbose         verbose output
 

--- a/docs/content/en/reference/mesheryctl/filter/list.md
+++ b/docs/content/en/reference/mesheryctl/filter/list.md
@@ -60,7 +60,7 @@ mesheryctl filter list 'Test Filter' (maximum 25 filters)
 
 <pre class='codeblock-pre'>
 <div class='codeblock'>
-      --config string   path to config file (default "/home/runner/.meshery/config.yaml")
+      --config string   path to config file (default "~/.meshery/config.yaml")
   -t, --token string    Path to token file default from current context
 
 </div>

--- a/docs/content/en/reference/mesheryctl/filter/view.md
+++ b/docs/content/en/reference/mesheryctl/filter/view.md
@@ -85,7 +85,7 @@ mesheryctl filter view "filter name"
 
 <pre class='codeblock-pre'>
 <div class='codeblock'>
-      --config string   path to config file (default "/home/runner/.meshery/config.yaml")
+      --config string   path to config file (default "~/.meshery/config.yaml")
   -t, --token string    Path to token file default from current context
   -v, --verbose         verbose output
 

--- a/docs/content/en/reference/mesheryctl/model/_index.md
+++ b/docs/content/en/reference/mesheryctl/model/_index.md
@@ -131,7 +131,7 @@ mesheryctl model build [model-name]/[model-version]
 
 <pre class='codeblock-pre'>
 <div class='codeblock'>
-      --config string   path to config file (default "/home/runner/.meshery/config.yaml")
+      --config string   path to config file (default "~/.meshery/config.yaml")
   -v, --verbose         verbose output
 
 </div>

--- a/docs/content/en/reference/mesheryctl/model/build.md
+++ b/docs/content/en/reference/mesheryctl/model/build.md
@@ -60,7 +60,7 @@ mesheryctl model build [model-name]/[model-version]
 
 <pre class='codeblock-pre'>
 <div class='codeblock'>
-      --config string   path to config file (default "/home/runner/.meshery/config.yaml")
+      --config string   path to config file (default "~/.meshery/config.yaml")
   -v, --verbose         verbose output
 
 </div>

--- a/docs/content/en/reference/mesheryctl/model/delete.md
+++ b/docs/content/en/reference/mesheryctl/model/delete.md
@@ -51,7 +51,7 @@ mesheryctl model delete [model-name]
 
 <pre class='codeblock-pre'>
 <div class='codeblock'>
-      --config string   path to config file (default "/home/runner/.meshery/config.yaml")
+      --config string   path to config file (default "~/.meshery/config.yaml")
   -v, --verbose         verbose output
 
 </div>

--- a/docs/content/en/reference/mesheryctl/model/export.md
+++ b/docs/content/en/reference/mesheryctl/model/export.md
@@ -82,7 +82,7 @@ mesheryctl model export [model-name] --version [version (ex: v0.7.3)]
 
 <pre class='codeblock-pre'>
 <div class='codeblock'>
-      --config string   path to config file (default "/home/runner/.meshery/config.yaml")
+      --config string   path to config file (default "~/.meshery/config.yaml")
   -v, --verbose         verbose output
 
 </div>

--- a/docs/content/en/reference/mesheryctl/model/generate.md
+++ b/docs/content/en/reference/mesheryctl/model/generate.md
@@ -62,7 +62,7 @@ mesheryctl model generate --f [URL] -t [path-to-template.json] -r
 
 <pre class='codeblock-pre'>
 <div class='codeblock'>
-      --config string   path to config file (default "/home/runner/.meshery/config.yaml")
+      --config string   path to config file (default "~/.meshery/config.yaml")
   -v, --verbose         verbose output
 
 </div>

--- a/docs/content/en/reference/mesheryctl/model/import.md
+++ b/docs/content/en/reference/mesheryctl/model/import.md
@@ -84,7 +84,7 @@ mesheryctl model import --file [path-to-csv-directory]
 
 <pre class='codeblock-pre'>
 <div class='codeblock'>
-      --config string   path to config file (default "/home/runner/.meshery/config.yaml")
+      --config string   path to config file (default "~/.meshery/config.yaml")
   -v, --verbose         verbose output
 
 </div>

--- a/docs/content/en/reference/mesheryctl/model/init.md
+++ b/docs/content/en/reference/mesheryctl/model/init.md
@@ -77,7 +77,7 @@ mesheryctl model init [model-name] --output-format [json|yaml|csv] (default is j
 
 <pre class='codeblock-pre'>
 <div class='codeblock'>
-      --config string   path to config file (default "/home/runner/.meshery/config.yaml")
+      --config string   path to config file (default "~/.meshery/config.yaml")
   -v, --verbose         verbose output
 
 </div>

--- a/docs/content/en/reference/mesheryctl/model/list.md
+++ b/docs/content/en/reference/mesheryctl/model/list.md
@@ -69,7 +69,7 @@ mesheryctl model list --count
 
 <pre class='codeblock-pre'>
 <div class='codeblock'>
-      --config string   path to config file (default "/home/runner/.meshery/config.yaml")
+      --config string   path to config file (default "~/.meshery/config.yaml")
   -v, --verbose         verbose output
 
 </div>

--- a/docs/content/en/reference/mesheryctl/model/search.md
+++ b/docs/content/en/reference/mesheryctl/model/search.md
@@ -61,7 +61,7 @@ mesheryctl model search [query-text] --pagesize [pagesize-number]
 
 <pre class='codeblock-pre'>
 <div class='codeblock'>
-      --config string   path to config file (default "/home/runner/.meshery/config.yaml")
+      --config string   path to config file (default "~/.meshery/config.yaml")
   -v, --verbose         verbose output
 
 </div>

--- a/docs/content/en/reference/mesheryctl/model/view.md
+++ b/docs/content/en/reference/mesheryctl/model/view.md
@@ -61,7 +61,7 @@ mesheryctl model view [model-name] --output-format [json|yaml] --save
 
 <pre class='codeblock-pre'>
 <div class='codeblock'>
-      --config string   path to config file (default "/home/runner/.meshery/config.yaml")
+      --config string   path to config file (default "~/.meshery/config.yaml")
   -v, --verbose         verbose output
 
 </div>

--- a/docs/content/en/reference/mesheryctl/organization/_index.md
+++ b/docs/content/en/reference/mesheryctl/organization/_index.md
@@ -52,7 +52,7 @@ mesheryctl organization list
 
 <pre class='codeblock-pre'>
 <div class='codeblock'>
-      --config string   path to config file (default "/home/runner/.meshery/config.yaml")
+      --config string   path to config file (default "~/.meshery/config.yaml")
   -v, --verbose         verbose output
 
 </div>

--- a/docs/content/en/reference/mesheryctl/organization/list.md
+++ b/docs/content/en/reference/mesheryctl/organization/list.md
@@ -62,7 +62,7 @@ mesheryctl organization list --count
 
 <pre class='codeblock-pre'>
 <div class='codeblock'>
-      --config string   path to config file (default "/home/runner/.meshery/config.yaml")
+      --config string   path to config file (default "~/.meshery/config.yaml")
   -v, --verbose         verbose output
 
 </div>

--- a/docs/content/en/reference/mesheryctl/perf/_index.md
+++ b/docs/content/en/reference/mesheryctl/perf/_index.md
@@ -77,7 +77,7 @@ mesheryctl perf result -o yaml
 
 <pre class='codeblock-pre'>
 <div class='codeblock'>
-      --config string   path to config file (default "/home/runner/.meshery/config.yaml")
+      --config string   path to config file (default "~/.meshery/config.yaml")
   -v, --verbose         verbose output
 
 </div>

--- a/docs/content/en/reference/mesheryctl/perf/apply.md
+++ b/docs/content/en/reference/mesheryctl/perf/apply.md
@@ -159,7 +159,7 @@ mesheryctl perf apply meshery-profile-new --url "https://google.com" --load-gene
 
 <pre class='codeblock-pre'>
 <div class='codeblock'>
-      --config string          path to config file (default "/home/runner/.meshery/config.yaml")
+      --config string          path to config file (default "~/.meshery/config.yaml")
   -o, --output-format string   (optional) format to display in [json|yaml]
   -t, --token string           (required) Path to meshery auth config
   -v, --verbose                verbose output

--- a/docs/content/en/reference/mesheryctl/perf/profile.md
+++ b/docs/content/en/reference/mesheryctl/perf/profile.md
@@ -60,7 +60,7 @@ mesheryctl perf profile test --view
 
 <pre class='codeblock-pre'>
 <div class='codeblock'>
-      --config string          path to config file (default "/home/runner/.meshery/config.yaml")
+      --config string          path to config file (default "~/.meshery/config.yaml")
   -o, --output-format string   (optional) format to display in [json|yaml]
   -t, --token string           (required) Path to meshery auth config
   -v, --verbose                verbose output

--- a/docs/content/en/reference/mesheryctl/perf/result.md
+++ b/docs/content/en/reference/mesheryctl/perf/result.md
@@ -60,7 +60,7 @@ mesheryctl perf result saturday-profile --view
 
 <pre class='codeblock-pre'>
 <div class='codeblock'>
-      --config string          path to config file (default "/home/runner/.meshery/config.yaml")
+      --config string          path to config file (default "~/.meshery/config.yaml")
   -o, --output-format string   (optional) format to display in [json|yaml]
   -t, --token string           (required) Path to meshery auth config
   -v, --verbose                verbose output

--- a/docs/content/en/reference/mesheryctl/registry/_index.md
+++ b/docs/content/en/reference/mesheryctl/registry/_index.md
@@ -42,7 +42,7 @@ mesheryctl registry [subcommand]
 
 <pre class='codeblock-pre'>
 <div class='codeblock'>
-      --config string   path to config file (default "/home/runner/.meshery/config.yaml")
+      --config string   path to config file (default "~/.meshery/config.yaml")
   -v, --verbose         verbose output
 
 </div>

--- a/docs/content/en/reference/mesheryctl/registry/generate.md
+++ b/docs/content/en/reference/mesheryctl/registry/generate.md
@@ -103,7 +103,7 @@ mesheryctl registry generate --spreadsheet-id "1DZHnzxYWOlJ69Oguz4LkRVTFM79kC2tu
 
 <pre class='codeblock-pre'>
 <div class='codeblock'>
-      --config string   path to config file (default "/home/runner/.meshery/config.yaml")
+      --config string   path to config file (default "~/.meshery/config.yaml")
   -v, --verbose         verbose output
 
 </div>

--- a/docs/content/en/reference/mesheryctl/registry/publish.md
+++ b/docs/content/en/reference/mesheryctl/registry/publish.md
@@ -99,7 +99,7 @@ mesheryctl registry publish website "$CRED" 1DZHnzxYWOlJ69Oguz4LkRVTFM79kC2tuvdw
 
 <pre class='codeblock-pre'>
 <div class='codeblock'>
-      --config string   path to config file (default "/home/runner/.meshery/config.yaml")
+      --config string   path to config file (default "~/.meshery/config.yaml")
   -v, --verbose         verbose output
 
 </div>

--- a/docs/content/en/reference/mesheryctl/registry/update.md
+++ b/docs/content/en/reference/mesheryctl/registry/update.md
@@ -63,7 +63,7 @@ mesheryctl registry update --spreadsheet-id 1DZHnzxYWOlJ69Oguz4LkRVTFM79kC2tuvdw
 
 <pre class='codeblock-pre'>
 <div class='codeblock'>
-      --config string   path to config file (default "/home/runner/.meshery/config.yaml")
+      --config string   path to config file (default "~/.meshery/config.yaml")
   -v, --verbose         verbose output
 
 </div>

--- a/docs/content/en/reference/mesheryctl/relationship/_index.md
+++ b/docs/content/en/reference/mesheryctl/relationship/_index.md
@@ -77,7 +77,7 @@ mesheryctl relationship view [model-name]
 
 <pre class='codeblock-pre'>
 <div class='codeblock'>
-      --config string   path to config file (default "/home/runner/.meshery/config.yaml")
+      --config string   path to config file (default "~/.meshery/config.yaml")
   -v, --verbose         verbose output
 
 </div>

--- a/docs/content/en/reference/mesheryctl/relationship/generate.md
+++ b/docs/content/en/reference/mesheryctl/relationship/generate.md
@@ -44,7 +44,7 @@ mesheryctl relationship generate --spreadsheet-id [Spreadsheet ID] --spreadsheet
 
 <pre class='codeblock-pre'>
 <div class='codeblock'>
-      --config string   path to config file (default "/home/runner/.meshery/config.yaml")
+      --config string   path to config file (default "~/.meshery/config.yaml")
   -v, --verbose         verbose output
 
 </div>

--- a/docs/content/en/reference/mesheryctl/relationship/list.md
+++ b/docs/content/en/reference/mesheryctl/relationship/list.md
@@ -69,7 +69,7 @@ mesheryctl relationship list --count
 
 <pre class='codeblock-pre'>
 <div class='codeblock'>
-      --config string   path to config file (default "/home/runner/.meshery/config.yaml")
+      --config string   path to config file (default "~/.meshery/config.yaml")
   -v, --verbose         verbose output
 
 </div>

--- a/docs/content/en/reference/mesheryctl/relationship/search.md
+++ b/docs/content/en/reference/mesheryctl/relationship/search.md
@@ -55,7 +55,7 @@ mesheryctl relationship search [--kind <kind>] [--page <int>]
 
 <pre class='codeblock-pre'>
 <div class='codeblock'>
-      --config string   path to config file (default "/home/runner/.meshery/config.yaml")
+      --config string   path to config file (default "~/.meshery/config.yaml")
   -v, --verbose         verbose output
 
 </div>

--- a/docs/content/en/reference/mesheryctl/relationship/view.md
+++ b/docs/content/en/reference/mesheryctl/relationship/view.md
@@ -60,7 +60,7 @@ mesheryctl relationship view [model-name] --output-format json --save
 
 <pre class='codeblock-pre'>
 <div class='codeblock'>
-      --config string   path to config file (default "/home/runner/.meshery/config.yaml")
+      --config string   path to config file (default "~/.meshery/config.yaml")
   -v, --verbose         verbose output
 
 </div>

--- a/docs/content/en/reference/mesheryctl/system/_index.md
+++ b/docs/content/en/reference/mesheryctl/system/_index.md
@@ -34,7 +34,7 @@ mesheryctl system [flags]
 
 <pre class='codeblock-pre'>
 <div class='codeblock'>
-      --config string   path to config file (default "/home/runner/.meshery/config.yaml")
+      --config string   path to config file (default "~/.meshery/config.yaml")
   -v, --verbose         verbose output
 
 </div>

--- a/docs/content/en/reference/mesheryctl/system/channel/_index.md
+++ b/docs/content/en/reference/mesheryctl/system/channel/_index.md
@@ -75,7 +75,7 @@ mesheryctl system channel switch [stable|stable-version|edge|edge-version]
 
 <pre class='codeblock-pre'>
 <div class='codeblock'>
-      --config string    path to config file (default "/home/runner/.meshery/config.yaml")
+      --config string    path to config file (default "~/.meshery/config.yaml")
   -c, --context string   (optional) temporarily change the current context.
   -v, --verbose          verbose output
   -y, --yes              (optional) assume yes for user interactive prompts.

--- a/docs/content/en/reference/mesheryctl/system/channel/set.md
+++ b/docs/content/en/reference/mesheryctl/system/channel/set.md
@@ -43,7 +43,7 @@ mesheryctl system channel set [stable|stable-version|edge|edge-version]
 
 <pre class='codeblock-pre'>
 <div class='codeblock'>
-      --config string    path to config file (default "/home/runner/.meshery/config.yaml")
+      --config string    path to config file (default "~/.meshery/config.yaml")
   -c, --context string   (optional) temporarily change the current context.
   -v, --verbose          verbose output
   -y, --yes              (optional) assume yes for user interactive prompts.

--- a/docs/content/en/reference/mesheryctl/system/channel/switch.md
+++ b/docs/content/en/reference/mesheryctl/system/channel/switch.md
@@ -43,7 +43,7 @@ mesheryctl system channel switch [stable|stable-version|edge|edge-version]
 
 <pre class='codeblock-pre'>
 <div class='codeblock'>
-      --config string    path to config file (default "/home/runner/.meshery/config.yaml")
+      --config string    path to config file (default "~/.meshery/config.yaml")
   -c, --context string   (optional) temporarily change the current context.
   -v, --verbose          verbose output
   -y, --yes              (optional) assume yes for user interactive prompts.

--- a/docs/content/en/reference/mesheryctl/system/channel/view.md
+++ b/docs/content/en/reference/mesheryctl/system/channel/view.md
@@ -52,7 +52,7 @@ mesheryctl system channel view --all
 
 <pre class='codeblock-pre'>
 <div class='codeblock'>
-      --config string    path to config file (default "/home/runner/.meshery/config.yaml")
+      --config string    path to config file (default "~/.meshery/config.yaml")
   -c, --context string   (optional) temporarily change the current context.
   -v, --verbose          verbose output
   -y, --yes              (optional) assume yes for user interactive prompts.

--- a/docs/content/en/reference/mesheryctl/system/check.md
+++ b/docs/content/en/reference/mesheryctl/system/check.md
@@ -96,7 +96,7 @@ mesheryctl system check --operator
 
 <pre class='codeblock-pre'>
 <div class='codeblock'>
-      --config string    path to config file (default "/home/runner/.meshery/config.yaml")
+      --config string    path to config file (default "~/.meshery/config.yaml")
   -c, --context string   (optional) temporarily change the current context.
   -v, --verbose          verbose output
   -y, --yes              (optional) assume yes for user interactive prompts.

--- a/docs/content/en/reference/mesheryctl/system/context/_index.md
+++ b/docs/content/en/reference/mesheryctl/system/context/_index.md
@@ -44,7 +44,7 @@ mesheryctl system context
 
 <pre class='codeblock-pre'>
 <div class='codeblock'>
-      --config string   path to config file (default "/home/runner/.meshery/config.yaml")
+      --config string   path to config file (default "~/.meshery/config.yaml")
   -v, --verbose         verbose output
   -y, --yes             (optional) assume yes for user interactive prompts.
 

--- a/docs/content/en/reference/mesheryctl/system/context/create.md
+++ b/docs/content/en/reference/mesheryctl/system/context/create.md
@@ -56,7 +56,7 @@ mesheryctl system context create [context-name] --components [meshery-nsm] --pla
 
 <pre class='codeblock-pre'>
 <div class='codeblock'>
-      --config string    path to config file (default "/home/runner/.meshery/config.yaml")
+      --config string    path to config file (default "~/.meshery/config.yaml")
   -c, --context string   (optional) temporarily change the current context.
   -v, --verbose          verbose output
   -y, --yes              (optional) assume yes for user interactive prompts.

--- a/docs/content/en/reference/mesheryctl/system/context/delete.md
+++ b/docs/content/en/reference/mesheryctl/system/context/delete.md
@@ -44,7 +44,7 @@ mesheryctl system context delete [context name]
 
 <pre class='codeblock-pre'>
 <div class='codeblock'>
-      --config string    path to config file (default "/home/runner/.meshery/config.yaml")
+      --config string    path to config file (default "~/.meshery/config.yaml")
   -c, --context string   (optional) temporarily change the current context.
   -v, --verbose          verbose output
   -y, --yes              (optional) assume yes for user interactive prompts.

--- a/docs/content/en/reference/mesheryctl/system/context/list.md
+++ b/docs/content/en/reference/mesheryctl/system/context/list.md
@@ -43,7 +43,7 @@ mesheryctl system context list
 
 <pre class='codeblock-pre'>
 <div class='codeblock'>
-      --config string    path to config file (default "/home/runner/.meshery/config.yaml")
+      --config string    path to config file (default "~/.meshery/config.yaml")
   -c, --context string   (optional) temporarily change the current context.
   -v, --verbose          verbose output
   -y, --yes              (optional) assume yes for user interactive prompts.

--- a/docs/content/en/reference/mesheryctl/system/context/switch.md
+++ b/docs/content/en/reference/mesheryctl/system/context/switch.md
@@ -43,7 +43,7 @@ mesheryctl system context switch sample
 
 <pre class='codeblock-pre'>
 <div class='codeblock'>
-      --config string    path to config file (default "/home/runner/.meshery/config.yaml")
+      --config string    path to config file (default "~/.meshery/config.yaml")
   -c, --context string   (optional) temporarily change the current context.
   -v, --verbose          verbose output
   -y, --yes              (optional) assume yes for user interactive prompts.

--- a/docs/content/en/reference/mesheryctl/system/context/view.md
+++ b/docs/content/en/reference/mesheryctl/system/context/view.md
@@ -78,7 +78,7 @@ mesheryctl system context view --all
 
 <pre class='codeblock-pre'>
 <div class='codeblock'>
-      --config string   path to config file (default "/home/runner/.meshery/config.yaml")
+      --config string   path to config file (default "~/.meshery/config.yaml")
   -v, --verbose         verbose output
   -y, --yes             (optional) assume yes for user interactive prompts.
 

--- a/docs/content/en/reference/mesheryctl/system/dashboard.md
+++ b/docs/content/en/reference/mesheryctl/system/dashboard.md
@@ -73,7 +73,7 @@ Note: Meshery's web-based user interface is embedded in Meshery Server and is av
 
 <pre class='codeblock-pre'>
 <div class='codeblock'>
-      --config string    path to config file (default "/home/runner/.meshery/config.yaml")
+      --config string    path to config file (default "~/.meshery/config.yaml")
   -c, --context string   (optional) temporarily change the current context.
   -v, --verbose          verbose output
   -y, --yes              (optional) assume yes for user interactive prompts.

--- a/docs/content/en/reference/mesheryctl/system/delete.md
+++ b/docs/content/en/reference/mesheryctl/system/delete.md
@@ -50,7 +50,7 @@ mesheryctl system delete -y
 
 <pre class='codeblock-pre'>
 <div class='codeblock'>
-      --config string    path to config file (default "/home/runner/.meshery/config.yaml")
+      --config string    path to config file (default "~/.meshery/config.yaml")
   -c, --context string   (optional) temporarily change the current context.
   -v, --verbose          verbose output
   -y, --yes              (optional) assume yes for user interactive prompts.

--- a/docs/content/en/reference/mesheryctl/system/login.md
+++ b/docs/content/en/reference/mesheryctl/system/login.md
@@ -54,7 +54,7 @@ mesheryctl system login -p Meshery
 
 <pre class='codeblock-pre'>
 <div class='codeblock'>
-      --config string    path to config file (default "/home/runner/.meshery/config.yaml")
+      --config string    path to config file (default "~/.meshery/config.yaml")
   -c, --context string   (optional) temporarily change the current context.
   -v, --verbose          verbose output
   -y, --yes              (optional) assume yes for user interactive prompts.

--- a/docs/content/en/reference/mesheryctl/system/logout.md
+++ b/docs/content/en/reference/mesheryctl/system/logout.md
@@ -45,7 +45,7 @@ mesheryctl system logout
 
 <pre class='codeblock-pre'>
 <div class='codeblock'>
-      --config string    path to config file (default "/home/runner/.meshery/config.yaml")
+      --config string    path to config file (default "~/.meshery/config.yaml")
   -c, --context string   (optional) temporarily change the current context.
   -v, --verbose          verbose output
   -y, --yes              (optional) assume yes for user interactive prompts.

--- a/docs/content/en/reference/mesheryctl/system/logs.md
+++ b/docs/content/en/reference/mesheryctl/system/logs.md
@@ -60,7 +60,7 @@ mesheryctl system logs meshery-istio
 
 <pre class='codeblock-pre'>
 <div class='codeblock'>
-      --config string    path to config file (default "/home/runner/.meshery/config.yaml")
+      --config string    path to config file (default "~/.meshery/config.yaml")
   -c, --context string   (optional) temporarily change the current context.
   -v, --verbose          verbose output
   -y, --yes              (optional) assume yes for user interactive prompts.

--- a/docs/content/en/reference/mesheryctl/system/provider/_index.md
+++ b/docs/content/en/reference/mesheryctl/system/provider/_index.md
@@ -74,7 +74,7 @@ mesheryctl system provider reset
 
 <pre class='codeblock-pre'>
 <div class='codeblock'>
-      --config string    path to config file (default "/home/runner/.meshery/config.yaml")
+      --config string    path to config file (default "~/.meshery/config.yaml")
   -c, --context string   (optional) temporarily change the current context.
   -v, --verbose          verbose output
   -y, --yes              (optional) assume yes for user interactive prompts.

--- a/docs/content/en/reference/mesheryctl/system/provider/list.md
+++ b/docs/content/en/reference/mesheryctl/system/provider/list.md
@@ -42,7 +42,7 @@ mesheryctl system provider list
 
 <pre class='codeblock-pre'>
 <div class='codeblock'>
-      --config string    path to config file (default "/home/runner/.meshery/config.yaml")
+      --config string    path to config file (default "~/.meshery/config.yaml")
   -c, --context string   (optional) temporarily change the current context.
   -v, --verbose          verbose output
   -y, --yes              (optional) assume yes for user interactive prompts.

--- a/docs/content/en/reference/mesheryctl/system/provider/reset.md
+++ b/docs/content/en/reference/mesheryctl/system/provider/reset.md
@@ -42,7 +42,7 @@ mesheryctl system provider reset
 
 <pre class='codeblock-pre'>
 <div class='codeblock'>
-      --config string    path to config file (default "/home/runner/.meshery/config.yaml")
+      --config string    path to config file (default "~/.meshery/config.yaml")
   -c, --context string   (optional) temporarily change the current context.
   -v, --verbose          verbose output
   -y, --yes              (optional) assume yes for user interactive prompts.

--- a/docs/content/en/reference/mesheryctl/system/provider/set.md
+++ b/docs/content/en/reference/mesheryctl/system/provider/set.md
@@ -43,7 +43,7 @@ mesheryctl system provider set [provider]
 
 <pre class='codeblock-pre'>
 <div class='codeblock'>
-      --config string    path to config file (default "/home/runner/.meshery/config.yaml")
+      --config string    path to config file (default "~/.meshery/config.yaml")
   -c, --context string   (optional) temporarily change the current context.
   -v, --verbose          verbose output
   -y, --yes              (optional) assume yes for user interactive prompts.

--- a/docs/content/en/reference/mesheryctl/system/provider/switch.md
+++ b/docs/content/en/reference/mesheryctl/system/provider/switch.md
@@ -42,7 +42,7 @@ mesheryctl system provider switch [provider]
 
 <pre class='codeblock-pre'>
 <div class='codeblock'>
-      --config string    path to config file (default "/home/runner/.meshery/config.yaml")
+      --config string    path to config file (default "~/.meshery/config.yaml")
   -c, --context string   (optional) temporarily change the current context.
   -v, --verbose          verbose output
   -y, --yes              (optional) assume yes for user interactive prompts.

--- a/docs/content/en/reference/mesheryctl/system/provider/view.md
+++ b/docs/content/en/reference/mesheryctl/system/provider/view.md
@@ -43,7 +43,7 @@ mesheryctl system provider view
 
 <pre class='codeblock-pre'>
 <div class='codeblock'>
-      --config string    path to config file (default "/home/runner/.meshery/config.yaml")
+      --config string    path to config file (default "~/.meshery/config.yaml")
   -c, --context string   (optional) temporarily change the current context.
   -v, --verbose          verbose output
   -y, --yes              (optional) assume yes for user interactive prompts.

--- a/docs/content/en/reference/mesheryctl/system/reset.md
+++ b/docs/content/en/reference/mesheryctl/system/reset.md
@@ -43,7 +43,7 @@ mesheryctl system reset
 
 <pre class='codeblock-pre'>
 <div class='codeblock'>
-      --config string    path to config file (default "/home/runner/.meshery/config.yaml")
+      --config string    path to config file (default "~/.meshery/config.yaml")
   -c, --context string   (optional) temporarily change the current context.
   -v, --verbose          verbose output
   -y, --yes              (optional) assume yes for user interactive prompts.

--- a/docs/content/en/reference/mesheryctl/system/restart.md
+++ b/docs/content/en/reference/mesheryctl/system/restart.md
@@ -53,7 +53,7 @@ mesheryctl system restart --skip-update
 
 <pre class='codeblock-pre'>
 <div class='codeblock'>
-      --config string    path to config file (default "/home/runner/.meshery/config.yaml")
+      --config string    path to config file (default "~/.meshery/config.yaml")
   -c, --context string   (optional) temporarily change the current context.
   -v, --verbose          verbose output
   -y, --yes              (optional) assume yes for user interactive prompts.

--- a/docs/content/en/reference/mesheryctl/system/start.md
+++ b/docs/content/en/reference/mesheryctl/system/start.md
@@ -87,7 +87,7 @@ mesheryctl system start --provider Meshery
 
 <pre class='codeblock-pre'>
 <div class='codeblock'>
-      --config string    path to config file (default "/home/runner/.meshery/config.yaml")
+      --config string    path to config file (default "~/.meshery/config.yaml")
   -c, --context string   (optional) temporarily change the current context.
   -v, --verbose          verbose output
   -y, --yes              (optional) assume yes for user interactive prompts.

--- a/docs/content/en/reference/mesheryctl/system/status.md
+++ b/docs/content/en/reference/mesheryctl/system/status.md
@@ -51,7 +51,7 @@ mesheryctl system status --verbose
 
 <pre class='codeblock-pre'>
 <div class='codeblock'>
-      --config string    path to config file (default "/home/runner/.meshery/config.yaml")
+      --config string    path to config file (default "~/.meshery/config.yaml")
   -c, --context string   (optional) temporarily change the current context.
   -y, --yes              (optional) assume yes for user interactive prompts.
 

--- a/docs/content/en/reference/mesheryctl/system/stop.md
+++ b/docs/content/en/reference/mesheryctl/system/stop.md
@@ -69,7 +69,7 @@ mesheryctl system stop --force
 
 <pre class='codeblock-pre'>
 <div class='codeblock'>
-      --config string    path to config file (default "/home/runner/.meshery/config.yaml")
+      --config string    path to config file (default "~/.meshery/config.yaml")
   -c, --context string   (optional) temporarily change the current context.
   -v, --verbose          verbose output
   -y, --yes              (optional) assume yes for user interactive prompts.

--- a/docs/content/en/reference/mesheryctl/system/token/_index.md
+++ b/docs/content/en/reference/mesheryctl/system/token/_index.md
@@ -33,7 +33,7 @@ mesheryctl system token [flags]
 
 <pre class='codeblock-pre'>
 <div class='codeblock'>
-      --config string    path to config file (default "/home/runner/.meshery/config.yaml")
+      --config string    path to config file (default "~/.meshery/config.yaml")
   -c, --context string   (optional) temporarily change the current context.
   -v, --verbose          verbose output
   -y, --yes              (optional) assume yes for user interactive prompts.

--- a/docs/content/en/reference/mesheryctl/system/token/create.md
+++ b/docs/content/en/reference/mesheryctl/system/token/create.md
@@ -57,7 +57,7 @@ mesheryctl system token create [token-name] -f [token-path] --set
 
 <pre class='codeblock-pre'>
 <div class='codeblock'>
-      --config string    path to config file (default "/home/runner/.meshery/config.yaml")
+      --config string    path to config file (default "~/.meshery/config.yaml")
   -c, --context string   (optional) temporarily change the current context.
   -v, --verbose          verbose output
   -y, --yes              (optional) assume yes for user interactive prompts.

--- a/docs/content/en/reference/mesheryctl/system/token/delete.md
+++ b/docs/content/en/reference/mesheryctl/system/token/delete.md
@@ -41,7 +41,7 @@ mesheryctl system token delete [token-name]
 
 <pre class='codeblock-pre'>
 <div class='codeblock'>
-      --config string    path to config file (default "/home/runner/.meshery/config.yaml")
+      --config string    path to config file (default "~/.meshery/config.yaml")
   -c, --context string   (optional) temporarily change the current context.
   -v, --verbose          verbose output
   -y, --yes              (optional) assume yes for user interactive prompts.

--- a/docs/content/en/reference/mesheryctl/system/token/list.md
+++ b/docs/content/en/reference/mesheryctl/system/token/list.md
@@ -41,7 +41,7 @@ mesheryctl system token list
 
 <pre class='codeblock-pre'>
 <div class='codeblock'>
-      --config string    path to config file (default "/home/runner/.meshery/config.yaml")
+      --config string    path to config file (default "~/.meshery/config.yaml")
   -c, --context string   (optional) temporarily change the current context.
   -v, --verbose          verbose output
   -y, --yes              (optional) assume yes for user interactive prompts.

--- a/docs/content/en/reference/mesheryctl/system/token/set.md
+++ b/docs/content/en/reference/mesheryctl/system/token/set.md
@@ -42,7 +42,7 @@ mesheryctl system token set [token-name]
 
 <pre class='codeblock-pre'>
 <div class='codeblock'>
-      --config string   path to config file (default "/home/runner/.meshery/config.yaml")
+      --config string   path to config file (default "~/.meshery/config.yaml")
   -v, --verbose         verbose output
   -y, --yes             (optional) assume yes for user interactive prompts.
 

--- a/docs/content/en/reference/mesheryctl/system/token/view.md
+++ b/docs/content/en/reference/mesheryctl/system/token/view.md
@@ -49,7 +49,7 @@ mesheryctl system token view (show token of current context)
 
 <pre class='codeblock-pre'>
 <div class='codeblock'>
-      --config string    path to config file (default "/home/runner/.meshery/config.yaml")
+      --config string    path to config file (default "~/.meshery/config.yaml")
   -c, --context string   (optional) temporarily change the current context.
   -v, --verbose          verbose output
   -y, --yes              (optional) assume yes for user interactive prompts.

--- a/docs/content/en/reference/mesheryctl/system/update.md
+++ b/docs/content/en/reference/mesheryctl/system/update.md
@@ -51,7 +51,7 @@ mesheryctl system update --skip-reset
 
 <pre class='codeblock-pre'>
 <div class='codeblock'>
-      --config string    path to config file (default "/home/runner/.meshery/config.yaml")
+      --config string    path to config file (default "~/.meshery/config.yaml")
   -c, --context string   (optional) temporarily change the current context.
   -v, --verbose          verbose output
   -y, --yes              (optional) assume yes for user interactive prompts.

--- a/docs/content/en/reference/mesheryctl/version.md
+++ b/docs/content/en/reference/mesheryctl/version.md
@@ -42,7 +42,7 @@ mesheryctl version
 
 <pre class='codeblock-pre'>
 <div class='codeblock'>
-      --config string   path to config file (default "/home/runner/.meshery/config.yaml")
+      --config string   path to config file (default "~/.meshery/config.yaml")
   -v, --verbose         verbose output
 
 </div>

--- a/docs/content/en/reference/mesheryctl/workspace/_index.md
+++ b/docs/content/en/reference/mesheryctl/workspace/_index.md
@@ -52,7 +52,7 @@ mesheryctl workspace create --orgId [orgId] --name [name] --description [descrip
 
 <pre class='codeblock-pre'>
 <div class='codeblock'>
-      --config string   path to config file (default "/home/runner/.meshery/config.yaml")
+      --config string   path to config file (default "~/.meshery/config.yaml")
   -v, --verbose         verbose output
 
 </div>

--- a/docs/content/en/reference/mesheryctl/workspace/create.md
+++ b/docs/content/en/reference/mesheryctl/workspace/create.md
@@ -46,7 +46,7 @@ mesheryctl workspace create --orgId [orgId] --name [name] --description [descrip
 
 <pre class='codeblock-pre'>
 <div class='codeblock'>
-      --config string   path to config file (default "/home/runner/.meshery/config.yaml")
+      --config string   path to config file (default "~/.meshery/config.yaml")
   -v, --verbose         verbose output
 
 </div>

--- a/docs/content/en/reference/mesheryctl/workspace/list.md
+++ b/docs/content/en/reference/mesheryctl/workspace/list.md
@@ -63,7 +63,7 @@ mesheryctl workspace list --orgId [orgId] --count
 
 <pre class='codeblock-pre'>
 <div class='codeblock'>
-      --config string   path to config file (default "/home/runner/.meshery/config.yaml")
+      --config string   path to config file (default "~/.meshery/config.yaml")
   -v, --verbose         verbose output
 
 </div>

--- a/docs/content/en/reference/mesheryctl/workspace/view.md
+++ b/docs/content/en/reference/mesheryctl/workspace/view.md
@@ -70,7 +70,7 @@ mesheryctl workspace view [workspace-id] --orgId [orgId] --output-format json --
 
 <pre class='codeblock-pre'>
 <div class='codeblock'>
-      --config string   path to config file (default "/home/runner/.meshery/config.yaml")
+      --config string   path to config file (default "~/.meshery/config.yaml")
   -v, --verbose         verbose output
 
 </div>

--- a/mesheryctl/internal/cli/root/root.go
+++ b/mesheryctl/internal/cli/root/root.go
@@ -108,7 +108,7 @@ func init() {
 	cobra.OnInitialize(setupLogger)
 	cobra.OnInitialize(initConfig)
 
-	RootCmd.PersistentFlags().StringVar(&cfgFile, "config", "~/.meshery/config.yaml", "path to config file")
+    RootCmd.PersistentFlags().StringVar(&cfgFile, "config", "~/.meshery/config.yaml", "path to config file")
 	// Preparing for an "edge" channel
 	// RootCmd.PersistentFlags().StringVar(&cfgFile, "edge", "", "flag to run Meshery as edge (one-time)")
 
@@ -164,7 +164,7 @@ const configFlagPlaceholder = "~/.meshery/config.yaml"
 // initConfig reads in config file and ENV variables if set.
 func initConfig() {
 	if cfgFile == configFlagPlaceholder {
-		cfgFile = utils.DefaultConfigPath
+    cfgFile = utils.DefaultConfigPath
 	}
 	utils.CfgFile = cfgFile
 	// initialize the path to the kubeconfig file

--- a/mesheryctl/internal/cli/root/root.go
+++ b/mesheryctl/internal/cli/root/root.go
@@ -108,7 +108,7 @@ func init() {
 	cobra.OnInitialize(setupLogger)
 	cobra.OnInitialize(initConfig)
 
-    RootCmd.PersistentFlags().StringVar(&cfgFile, "config", "~/.meshery/config.yaml", "path to config file")
+	RootCmd.PersistentFlags().StringVar(&cfgFile, "config", "~/.meshery/config.yaml", "path to config file")
 	// Preparing for an "edge" channel
 	// RootCmd.PersistentFlags().StringVar(&cfgFile, "edge", "", "flag to run Meshery as edge (one-time)")
 
@@ -164,7 +164,7 @@ const configFlagPlaceholder = "~/.meshery/config.yaml"
 // initConfig reads in config file and ENV variables if set.
 func initConfig() {
 	if cfgFile == configFlagPlaceholder {
-    cfgFile = utils.DefaultConfigPath
+		cfgFile = utils.DefaultConfigPath
 	}
 	utils.CfgFile = cfgFile
 	// initialize the path to the kubeconfig file

--- a/mesheryctl/internal/cli/root/root.go
+++ b/mesheryctl/internal/cli/root/root.go
@@ -108,8 +108,7 @@ func init() {
 	cobra.OnInitialize(setupLogger)
 	cobra.OnInitialize(initConfig)
 
-	RootCmd.PersistentFlags().StringVar(&cfgFile, "config", utils.DefaultConfigPath, "path to config file")
-
+    RootCmd.PersistentFlags().StringVar(&cfgFile, "config", "~/.meshery/config.yaml", "path to config file")
 	// Preparing for an "edge" channel
 	// RootCmd.PersistentFlags().StringVar(&cfgFile, "edge", "", "flag to run Meshery as edge (one-time)")
 
@@ -160,8 +159,13 @@ func TreePath() *cobra.Command {
 	return RootCmd
 }
 
+const configFlagPlaceholder = "~/.meshery/config.yaml"
+
 // initConfig reads in config file and ENV variables if set.
 func initConfig() {
+	if cfgFile == configFlagPlaceholder {
+    cfgFile = utils.DefaultConfigPath
+	}
 	utils.CfgFile = cfgFile
 	// initialize the path to the kubeconfig file
 	utils.SetKubeConfig()


### PR DESCRIPTION
## Description

Fixes #19419

This PR prevents generated Meshery CLI documentation from embedding environment-specific runner paths in the `--config` flag help output.

## Root Cause

During self-documentation generation (`make docs`), the GitHub Actions runner resolves:

```text
utils.DefaultConfigPath -> /home/runner/.meshery/config.yaml
```

This occurred because `utils.SetFileLocation()` resolved the absolute home directory before the Cobra `--config` flag was registered. The resolved path was then used directly as the flag default:

```go
RootCmd.PersistentFlags().StringVar(&cfgFile, "config", utils.DefaultConfigPath, "path to config file")
```

Cobra later rendered this literal value into generated markdown/help output, causing docs to contain CI-specific paths such as:

```text
(default "/home/runner/.meshery/config.yaml")
```

## Changes Made

### Updated `--config` flag default

Replaced the resolved absolute path with a human-readable placeholder:

```go
RootCmd.PersistentFlags().StringVar(
    &cfgFile,
    "config",
    "~/.meshery/config.yaml",
    "path to config file",
)
```

This ensures generated documentation consistently displays:

```text
~/.meshery/config.yaml
```

instead of environment-specific paths.

### Added runtime placeholder resolution

Added:

```go
const configFlagPlaceholder = "~/.meshery/config.yaml"
```

and resolved it during runtime initialization:

```go
if cfgFile == configFlagPlaceholder {
    cfgFile = utils.DefaultConfigPath
}
```

This preserves existing runtime behavior by converting the placeholder back into the actual resolved config path before filesystem operations occur.

## Result

* Generated docs no longer embed `/home/runner/...`
* Runtime behavior remains unchanged
* Explicit `--config <path>` values are unaffected
* Existing tests remain unaffected

## Files Changed

* `mesheryctl/internal/cli/root/root.go`

## Validation Performed

### Before

<img width="1920" height="1020" alt="Screenshot 2026-05-23 152504" src="https://github.com/user-attachments/assets/19546aca-446f-4a0e-87f7-e36904e13814" />


### After
<img width="1920" height="1020" alt="Screenshot 2026-05-23 152347" src="https://github.com/user-attachments/assets/e5890288-781d-48e1-b5b4-d572bf22b13c" />


Validated locally using:

```bash
go run ./mesheryctl/cmd/mesheryctl --help
```

Verified output now shows:

```text
(default "~/.meshery/config.yaml")
```

instead of environment-specific runner paths.

## Checklist

* [x] Runtime behavior preserved
* [x] Generated docs output verified
* [x] DCO signed off
