### PR TITLE
feat(meshmodel): add AWS RDS DBInstance and Lambda Function relationships to Kubernetes Deployment and Pod

### DIFF
--- a/server/meshmodel/aws-lambda-controller/v1.12.2/v1.0.0/relationships/edge-non-binding-reference-function-deployment.json
+++ b/server/meshmodel/aws-lambda-controller/v1.12.2/v1.0.0/relationships/edge-non-binding-reference-function-deployment.json
@@ -4,23 +4,26 @@
   "kind": "edge",
   "metadata": {
     "description": "An edge relationship between a Lambda Function and a Kubernetes Deployment, representing a Deployment whose containers invoke or are triggered by the Lambda function.",
+    "isAnnotation": false,
     "styles": {
       "primaryColor": "",
       "svgColor": "",
       "svgWhite": ""
-    },
-    "isAnnotation": false
-  },
-  "model": {
-    "version": "v1.12.2",
-    "name": "aws-lambda-controller",
-    "displayName": "AWS Lambda",
-    "id": "00000000-0000-0000-0000-000000000000",
-    "registrant": {
-      "kind": "github"
     }
   },
-  "schemaVersion": "relationships.meshery.io/v1beta3",
+  "model": {
+    "displayName": "AWS Lambda",
+    "id": "00000000-0000-0000-0000-000000000000",
+    "model": {
+      "version": "v1.12.2"
+    },
+    "name": "aws-lambda-controller",
+    "registrant": {
+      "kind": "github"
+    },
+    "version": ""
+  },
+  "schemaVersion": "relationships.meshery.io/v1beta2",
   "selectors": [
     {
       "allow": {
@@ -31,13 +34,16 @@
             "match": {},
             "match_strategy_matrix": null,
             "model": {
-              "version": "v1.12.2",
-              "name": "aws-lambda-controller",
               "displayName": "AWS Lambda",
               "id": "00000000-0000-0000-0000-000000000000",
+              "model": {
+                "version": ""
+              },
+              "name": "aws-lambda-controller",
               "registrant": {
                 "kind": "github"
-              }
+              },
+              "version": ""
             },
             "patch": {
               "patchStrategy": "replace",
@@ -58,13 +64,16 @@
             "match": {},
             "match_strategy_matrix": null,
             "model": {
-              "version": "*",
-              "name": "kubernetes",
               "displayName": "Kubernetes",
               "id": "00000000-0000-0000-0000-000000000000",
+              "model": {
+                "version": ""
+              },
+              "name": "kubernetes",
               "registrant": {
                 "kind": "github"
-              }
+              },
+              "version": "*"
             },
             "patch": {
               "patchStrategy": "replace",

--- a/server/meshmodel/aws-lambda-controller/v1.12.2/v1.0.0/relationships/edge-non-binding-reference-function-deployment.json
+++ b/server/meshmodel/aws-lambda-controller/v1.12.2/v1.0.0/relationships/edge-non-binding-reference-function-deployment.json
@@ -1,0 +1,96 @@
+{
+  "id": "00000000-0000-0000-0000-000000000000",
+  "evaluationQuery": "",
+  "kind": "edge",
+  "metadata": {
+    "description": "An edge relationship between a Lambda Function and a Kubernetes Deployment, representing a Deployment whose containers invoke or are triggered by the Lambda function.",
+    "styles": {
+      "primaryColor": "",
+      "svgColor": "",
+      "svgWhite": ""
+    },
+    "isAnnotation": false
+  },
+  "model": {
+    "version": "v1.12.2",
+    "name": "aws-lambda-controller",
+    "displayName": "AWS Lambda",
+    "id": "00000000-0000-0000-0000-000000000000",
+    "registrant": {
+      "kind": "github"
+    }
+  },
+  "schemaVersion": "relationships.meshery.io/v1beta3",
+  "selectors": [
+    {
+      "allow": {
+        "from": [
+          {
+            "id": null,
+            "kind": "Function",
+            "match": {},
+            "match_strategy_matrix": null,
+            "model": {
+              "version": "v1.12.2",
+              "name": "aws-lambda-controller",
+              "displayName": "AWS Lambda",
+              "id": "00000000-0000-0000-0000-000000000000",
+              "registrant": {
+                "kind": "github"
+              }
+            },
+            "patch": {
+              "patchStrategy": "replace",
+              "mutatorRef": [
+                [
+                  "configuration",
+                  "metadata",
+                  "name"
+                ]
+              ]
+            }
+          }
+        ],
+        "to": [
+          {
+            "id": null,
+            "kind": "Deployment",
+            "match": {},
+            "match_strategy_matrix": null,
+            "model": {
+              "version": "*",
+              "name": "kubernetes",
+              "displayName": "Kubernetes",
+              "id": "00000000-0000-0000-0000-000000000000",
+              "registrant": {
+                "kind": "github"
+              }
+            },
+            "patch": {
+              "patchStrategy": "replace",
+              "mutatedRef": [
+                [
+                  "configuration",
+                  "spec",
+                  "template",
+                  "spec",
+                  "containers",
+                  "_",
+                  "env"
+                ]
+              ]
+            }
+          }
+        ]
+      },
+      "deny": {
+        "from": [],
+        "to": []
+      }
+    }
+  ],
+  "subType": "reference",
+  "status": "enabled",
+  "type": "non-binding",
+  "version": "v1.0.0"
+}

--- a/server/meshmodel/aws-lambda-controller/v1.12.2/v1.0.0/relationships/edge-non-binding-reference-function-pod.json
+++ b/server/meshmodel/aws-lambda-controller/v1.12.2/v1.0.0/relationships/edge-non-binding-reference-function-pod.json
@@ -1,0 +1,94 @@
+{
+  "id": "00000000-0000-0000-0000-000000000000",
+  "evaluationQuery": "",
+  "kind": "edge",
+  "metadata": {
+    "description": "An edge relationship between a Lambda Function and a Kubernetes Pod, representing a Pod whose containers invoke or are triggered by the Lambda function.",
+    "styles": {
+      "primaryColor": "",
+      "svgColor": "",
+      "svgWhite": ""
+    },
+    "isAnnotation": false
+  },
+  "model": {
+    "version": "v1.12.2",
+    "name": "aws-lambda-controller",
+    "displayName": "AWS Lambda",
+    "id": "00000000-0000-0000-0000-000000000000",
+    "registrant": {
+      "kind": "github"
+    }
+  },
+  "schemaVersion": "relationships.meshery.io/v1beta3",
+  "selectors": [
+    {
+      "allow": {
+        "from": [
+          {
+            "id": null,
+            "kind": "Function",
+            "match": {},
+            "match_strategy_matrix": null,
+            "model": {
+              "version": "v1.12.2",
+              "name": "aws-lambda-controller",
+              "displayName": "AWS Lambda",
+              "id": "00000000-0000-0000-0000-000000000000",
+              "registrant": {
+                "kind": "github"
+              }
+            },
+            "patch": {
+              "patchStrategy": "replace",
+              "mutatorRef": [
+                [
+                  "configuration",
+                  "metadata",
+                  "name"
+                ]
+              ]
+            }
+          }
+        ],
+        "to": [
+          {
+            "id": null,
+            "kind": "Pod",
+            "match": {},
+            "match_strategy_matrix": null,
+            "model": {
+              "version": "*",
+              "name": "kubernetes",
+              "displayName": "Kubernetes",
+              "id": "00000000-0000-0000-0000-000000000000",
+              "registrant": {
+                "kind": "github"
+              }
+            },
+            "patch": {
+              "patchStrategy": "replace",
+              "mutatedRef": [
+                [
+                  "configuration",
+                  "spec",
+                  "containers",
+                  "_",
+                  "env"
+                ]
+              ]
+            }
+          }
+        ]
+      },
+      "deny": {
+        "from": [],
+        "to": []
+      }
+    }
+  ],
+  "subType": "reference",
+  "status": "enabled",
+  "type": "non-binding",
+  "version": "v1.0.0"
+}

--- a/server/meshmodel/aws-lambda-controller/v1.12.2/v1.0.0/relationships/edge-non-binding-reference-function-pod.json
+++ b/server/meshmodel/aws-lambda-controller/v1.12.2/v1.0.0/relationships/edge-non-binding-reference-function-pod.json
@@ -4,23 +4,26 @@
   "kind": "edge",
   "metadata": {
     "description": "An edge relationship between a Lambda Function and a Kubernetes Pod, representing a Pod whose containers invoke or are triggered by the Lambda function.",
+    "isAnnotation": false,
     "styles": {
       "primaryColor": "",
       "svgColor": "",
       "svgWhite": ""
-    },
-    "isAnnotation": false
-  },
-  "model": {
-    "version": "v1.12.2",
-    "name": "aws-lambda-controller",
-    "displayName": "AWS Lambda",
-    "id": "00000000-0000-0000-0000-000000000000",
-    "registrant": {
-      "kind": "github"
     }
   },
-  "schemaVersion": "relationships.meshery.io/v1beta3",
+  "model": {
+    "displayName": "AWS Lambda",
+    "id": "00000000-0000-0000-0000-000000000000",
+    "model": {
+      "version": "v1.12.2"
+    },
+    "name": "aws-lambda-controller",
+    "registrant": {
+      "kind": "github"
+    },
+    "version": ""
+  },
+  "schemaVersion": "relationships.meshery.io/v1beta2",
   "selectors": [
     {
       "allow": {
@@ -31,13 +34,16 @@
             "match": {},
             "match_strategy_matrix": null,
             "model": {
-              "version": "v1.12.2",
-              "name": "aws-lambda-controller",
               "displayName": "AWS Lambda",
               "id": "00000000-0000-0000-0000-000000000000",
+              "model": {
+                "version": ""
+              },
+              "name": "aws-lambda-controller",
               "registrant": {
                 "kind": "github"
-              }
+              },
+              "version": ""
             },
             "patch": {
               "patchStrategy": "replace",
@@ -58,13 +64,16 @@
             "match": {},
             "match_strategy_matrix": null,
             "model": {
-              "version": "*",
-              "name": "kubernetes",
               "displayName": "Kubernetes",
               "id": "00000000-0000-0000-0000-000000000000",
+              "model": {
+                "version": ""
+              },
+              "name": "kubernetes",
               "registrant": {
                 "kind": "github"
-              }
+              },
+              "version": "*"
             },
             "patch": {
               "patchStrategy": "replace",

--- a/server/meshmodel/aws-rds-controller/v1.7.12/v1.0.0/relationships/edge-non-binding-reference-dbinstance-deployment.json
+++ b/server/meshmodel/aws-rds-controller/v1.7.12/v1.0.0/relationships/edge-non-binding-reference-dbinstance-deployment.json
@@ -1,0 +1,96 @@
+{
+  "id": "00000000-0000-0000-0000-000000000000",
+  "evaluationQuery": "",
+  "kind": "edge",
+  "metadata": {
+    "description": "An edge relationship between an RDS DBInstance and a Kubernetes Deployment, representing a Deployment whose containers connect to the RDS database instance.",
+    "styles": {
+      "primaryColor": "",
+      "svgColor": "",
+      "svgWhite": ""
+    },
+    "isAnnotation": false
+  },
+  "model": {
+    "version": "v1.7.12",
+    "name": "aws-rds-controller",
+    "displayName": "AWS RDS",
+    "id": "00000000-0000-0000-0000-000000000000",
+    "registrant": {
+      "kind": "github"
+    }
+  },
+  "schemaVersion": "relationships.meshery.io/v1beta3",
+  "selectors": [
+    {
+      "allow": {
+        "from": [
+          {
+            "id": null,
+            "kind": "DBInstance",
+            "match": {},
+            "match_strategy_matrix": null,
+            "model": {
+              "version": "v1.7.12",
+              "name": "aws-rds-controller",
+              "displayName": "AWS RDS",
+              "id": "00000000-0000-0000-0000-000000000000",
+              "registrant": {
+                "kind": "github"
+              }
+            },
+            "patch": {
+              "patchStrategy": "replace",
+              "mutatorRef": [
+                [
+                  "configuration",
+                  "metadata",
+                  "name"
+                ]
+              ]
+            }
+          }
+        ],
+        "to": [
+          {
+            "id": null,
+            "kind": "Deployment",
+            "match": {},
+            "match_strategy_matrix": null,
+            "model": {
+              "version": "*",
+              "name": "kubernetes",
+              "displayName": "Kubernetes",
+              "id": "00000000-0000-0000-0000-000000000000",
+              "registrant": {
+                "kind": "github"
+              }
+            },
+            "patch": {
+              "patchStrategy": "replace",
+              "mutatedRef": [
+                [
+                  "configuration",
+                  "spec",
+                  "template",
+                  "spec",
+                  "containers",
+                  "_",
+                  "env"
+                ]
+              ]
+            }
+          }
+        ]
+      },
+      "deny": {
+        "from": [],
+        "to": []
+      }
+    }
+  ],
+  "subType": "reference",
+  "status": "enabled",
+  "type": "non-binding",
+  "version": "v1.0.0"
+}

--- a/server/meshmodel/aws-rds-controller/v1.7.12/v1.0.0/relationships/edge-non-binding-reference-dbinstance-deployment.json
+++ b/server/meshmodel/aws-rds-controller/v1.7.12/v1.0.0/relationships/edge-non-binding-reference-dbinstance-deployment.json
@@ -4,23 +4,26 @@
   "kind": "edge",
   "metadata": {
     "description": "An edge relationship between an RDS DBInstance and a Kubernetes Deployment, representing a Deployment whose containers connect to the RDS database instance.",
+    "isAnnotation": false,
     "styles": {
       "primaryColor": "",
       "svgColor": "",
       "svgWhite": ""
-    },
-    "isAnnotation": false
-  },
-  "model": {
-    "version": "v1.7.12",
-    "name": "aws-rds-controller",
-    "displayName": "AWS RDS",
-    "id": "00000000-0000-0000-0000-000000000000",
-    "registrant": {
-      "kind": "github"
     }
   },
-  "schemaVersion": "relationships.meshery.io/v1beta3",
+  "model": {
+    "displayName": "AWS RDS",
+    "id": "00000000-0000-0000-0000-000000000000",
+    "model": {
+      "version": "v1.7.12"
+    },
+    "name": "aws-rds-controller",
+    "registrant": {
+      "kind": "github"
+    },
+    "version": ""
+  },
+  "schemaVersion": "relationships.meshery.io/v1beta2",
   "selectors": [
     {
       "allow": {
@@ -31,13 +34,16 @@
             "match": {},
             "match_strategy_matrix": null,
             "model": {
-              "version": "v1.7.12",
-              "name": "aws-rds-controller",
               "displayName": "AWS RDS",
               "id": "00000000-0000-0000-0000-000000000000",
+              "model": {
+                "version": ""
+              },
+              "name": "aws-rds-controller",
               "registrant": {
                 "kind": "github"
-              }
+              },
+              "version": ""
             },
             "patch": {
               "patchStrategy": "replace",
@@ -58,13 +64,16 @@
             "match": {},
             "match_strategy_matrix": null,
             "model": {
-              "version": "*",
-              "name": "kubernetes",
               "displayName": "Kubernetes",
               "id": "00000000-0000-0000-0000-000000000000",
+              "model": {
+                "version": ""
+              },
+              "name": "kubernetes",
               "registrant": {
                 "kind": "github"
-              }
+              },
+              "version": "*"
             },
             "patch": {
               "patchStrategy": "replace",

--- a/server/meshmodel/aws-rds-controller/v1.7.12/v1.0.0/relationships/edge-non-binding-reference-dbinstance-pod.json
+++ b/server/meshmodel/aws-rds-controller/v1.7.12/v1.0.0/relationships/edge-non-binding-reference-dbinstance-pod.json
@@ -1,0 +1,94 @@
+{
+  "id": "00000000-0000-0000-0000-000000000000",
+  "evaluationQuery": "",
+  "kind": "edge",
+  "metadata": {
+    "description": "An edge relationship between an RDS DBInstance and a Kubernetes Pod, representing a Pod whose containers connect to the RDS database instance.",
+    "styles": {
+      "primaryColor": "",
+      "svgColor": "",
+      "svgWhite": ""
+    },
+    "isAnnotation": false
+  },
+  "model": {
+    "version": "v1.7.12",
+    "name": "aws-rds-controller",
+    "displayName": "AWS RDS",
+    "id": "00000000-0000-0000-0000-000000000000",
+    "registrant": {
+      "kind": "github"
+    }
+  },
+  "schemaVersion": "relationships.meshery.io/v1beta3",
+  "selectors": [
+    {
+      "allow": {
+        "from": [
+          {
+            "id": null,
+            "kind": "DBInstance",
+            "match": {},
+            "match_strategy_matrix": null,
+            "model": {
+              "version": "v1.7.12",
+              "name": "aws-rds-controller",
+              "displayName": "AWS RDS",
+              "id": "00000000-0000-0000-0000-000000000000",
+              "registrant": {
+                "kind": "github"
+              }
+            },
+            "patch": {
+              "patchStrategy": "replace",
+              "mutatorRef": [
+                [
+                  "configuration",
+                  "metadata",
+                  "name"
+                ]
+              ]
+            }
+          }
+        ],
+        "to": [
+          {
+            "id": null,
+            "kind": "Pod",
+            "match": {},
+            "match_strategy_matrix": null,
+            "model": {
+              "version": "*",
+              "name": "kubernetes",
+              "displayName": "Kubernetes",
+              "id": "00000000-0000-0000-0000-000000000000",
+              "registrant": {
+                "kind": "github"
+              }
+            },
+            "patch": {
+              "patchStrategy": "replace",
+              "mutatedRef": [
+                [
+                  "configuration",
+                  "spec",
+                  "containers",
+                  "_",
+                  "env"
+                ]
+              ]
+            }
+          }
+        ]
+      },
+      "deny": {
+        "from": [],
+        "to": []
+      }
+    }
+  ],
+  "subType": "reference",
+  "status": "enabled",
+  "type": "non-binding",
+  "version": "v1.0.0"
+}

--- a/server/meshmodel/aws-rds-controller/v1.7.12/v1.0.0/relationships/edge-non-binding-reference-dbinstance-pod.json
+++ b/server/meshmodel/aws-rds-controller/v1.7.12/v1.0.0/relationships/edge-non-binding-reference-dbinstance-pod.json
@@ -4,23 +4,26 @@
   "kind": "edge",
   "metadata": {
     "description": "An edge relationship between an RDS DBInstance and a Kubernetes Pod, representing a Pod whose containers connect to the RDS database instance.",
+    "isAnnotation": false,
     "styles": {
       "primaryColor": "",
       "svgColor": "",
       "svgWhite": ""
-    },
-    "isAnnotation": false
-  },
-  "model": {
-    "version": "v1.7.12",
-    "name": "aws-rds-controller",
-    "displayName": "AWS RDS",
-    "id": "00000000-0000-0000-0000-000000000000",
-    "registrant": {
-      "kind": "github"
     }
   },
-  "schemaVersion": "relationships.meshery.io/v1beta3",
+  "model": {
+    "displayName": "AWS RDS",
+    "id": "00000000-0000-0000-0000-000000000000",
+    "model": {
+      "version": "v1.7.12"
+    },
+    "name": "aws-rds-controller",
+    "registrant": {
+      "kind": "github"
+    },
+    "version": ""
+  },
+  "schemaVersion": "relationships.meshery.io/v1beta2",
   "selectors": [
     {
       "allow": {
@@ -31,13 +34,16 @@
             "match": {},
             "match_strategy_matrix": null,
             "model": {
-              "version": "v1.7.12",
-              "name": "aws-rds-controller",
               "displayName": "AWS RDS",
               "id": "00000000-0000-0000-0000-000000000000",
+              "model": {
+                "version": ""
+              },
+              "name": "aws-rds-controller",
               "registrant": {
                 "kind": "github"
-              }
+              },
+              "version": ""
             },
             "patch": {
               "patchStrategy": "replace",
@@ -58,13 +64,16 @@
             "match": {},
             "match_strategy_matrix": null,
             "model": {
-              "version": "*",
-              "name": "kubernetes",
               "displayName": "Kubernetes",
               "id": "00000000-0000-0000-0000-000000000000",
+              "model": {
+                "version": ""
+              },
+              "name": "kubernetes",
               "registrant": {
                 "kind": "github"
-              }
+              },
+              "version": "*"
             },
             "patch": {
               "patchStrategy": "replace",


### PR DESCRIPTION
## Description

Adds edge non-binding reference relationships for two additional AWS services to Kubernetes workloads, continuing the pattern established in #19490 (DynamoDB + SQS), #17372 (Kinesis), and #17175 (ECR).

**RDS (aws-rds-controller v1.7.12):**
- `DBInstance → Deployment` — models a Deployment whose containers connect to the RDS database instance
- `DBInstance → Pod` — models a Pod whose containers connect to the RDS database instance

**Lambda (aws-lambda-controller v1.12.2):**
- `Function → Deployment` — models a Deployment whose containers invoke or are triggered by the Lambda function
- `Function → Pod` — models a Pod whose containers invoke or are triggered by the Lambda function

Relates to #14794

Happy to update the Meshery Integrations spreadsheet once this is merged.

## Checklist
- [x] Follows existing relationship schema (`relationships.meshery.io/v1beta2`)
- [x] registrant.kind set to github (AWS ACK controllers hosted on GitHub)
- [x] displayName populated
- [x] from selector patch ref uses metadata.name
- [x] DCO signed off
<img width="644" height="361" alt="Screenshot 2026-05-29 at 9 28 47 AM" src="https://github.com/user-attachments/assets/b7945665-2cff-4d8c-a014-bdcb62b8bf34" />
