### PR TITLE
fix: enhance provider selection UX with tooltip and info icon

### DIFF
--- a/docs/content/en/project/contributing/contributing-ui-notification-center.md
+++ b/docs/content/en/project/contributing/contributing-ui-notification-center.md
@@ -123,19 +123,34 @@ This section outlines the essential files and folders that you'll interact with 
 
 #### `NotificationCenter/` _(Root Directory)_
 
-- **index.js**: Contains the main context provider (`NotificationCenterProvider`), the drawer component (`NotificationCenterDrawer`), and orchestrates the overall structure.
-- **metadata.js**: Defines `PropertyFormatters`, `LinkFormatters`, `PropertyLinkFormatters`, and `EventTypeFormatters`. Contains the `FormattedMetadata` component which decides _how_ to format the metadata based on event type or specific properties.
-- **notification.js**: Defines how an individual notification is rendered.
+- **[index.tsx](https://github.com/meshery/meshery/blob/master/ui/components/NotificationCenter/index.tsx)**:  
+  Contains the main context provider (`NotificationCenterProvider`), the drawer component (`NotificationCenterDrawer`), and orchestrates the overall structure.
+
+- **[metadata.tsx](https://github.com/meshery/meshery/blob/master/ui/components/NotificationCenter/metadata.tsx)**:  
+  Defines `PropertyFormatters`, `LinkFormatters`, `PropertyLinkFormatters`, and `EventTypeFormatters`. Contains the `FormattedMetadata` component.
+
+- **[notification.tsx](https://github.com/meshery/meshery/blob/master/ui/components/NotificationCenter/notification.tsx)**:  
+  Defines how an individual notification is rendered.
+
 
 #### `formatters/` _(NotificationCenter/formatters)_
 
 This directory houses reusable formatter components dedicated to specific types of metadata or event types.
 
-- **common.js**: Contains shared components like `TitleLink`, `DataToFileLink`, `EmptyState`.
-- **error.js**: Defines `ErrorMetadataFormatter` for displaying structured error details.
-- **model_registration.js**: Contains formatters for model import/registration events (`ModelImportMessages`, `ModelImportedSection`).
-- **pattern_dryrun.js**: Defines `DryRunResponseFormatter` which utilizes components from `DesignLifeCycle`.
-- **relationship_evaluation.js**: Defines `RelationshipEvaluationEventFormatter` responsible for rendering notifications related to the evaluation of relationships between components in a design.
+- **[common.tsx](https://github.com/meshery/meshery/blob/master/ui/components/NotificationCenter/formatters/common.tsx)**:  
+  Contains shared components like `TitleLink`, `DataToFileLink`, `EmptyState`.
+
+- **[error.tsx](https://github.com/meshery/meshery/blob/master/ui/components/NotificationCenter/formatters/error.tsx)**:  
+  Defines `ErrorMetadataFormatter` for displaying structured error details.
+
+- **[model_registration.tsx](https://github.com/meshery/meshery/blob/master/ui/components/NotificationCenter/formatters/model_registration.tsx)**:  
+  Contains formatters for model import/registration events (`ModelImportMessages`, `ModelImportedSection`).
+
+- **[pattern_dryrun.tsx](https://github.com/meshery/meshery/blob/master/ui/components/NotificationCenter/formatters/pattern_dryrun.tsx)**:  
+  Defines `DryRunResponseFormatter` which utilizes components from `DesignLifeCycle`.
+
+- **[relationship_evaluation.tsx](https://github.com/meshery/meshery/blob/master/ui/components/NotificationCenter/formatters/relationship_evaluation.tsx)**:  
+  Defines `RelationshipEvaluationEventFormatter` responsible for rendering notifications related to the evaluation of relationships between components in a design.
 
 ## Types of Event Specific Notification Formatters
 

--- a/docs/content/en/project/contributing/contributing-ui-notification-center.md
+++ b/docs/content/en/project/contributing/contributing-ui-notification-center.md
@@ -105,13 +105,13 @@ While this system was initially developed for our events and notification center
 
 When a notification event is received from the server, it includes a `metadata` field containing structured, event-specific information. The purpose of formatters is to present this data in a clean, readable, and user-friendly format inside the expanded view of each notification.
 
-The core logic for rendering metadata is handled by the `FormattedMetadata` component in `metadata.js`, which follows this decision tree:
+The core logic for rendering metadata is handled by the `FormattedMetadata` component in `metadata.tsx`, which follows this decision tree:
 
 1. **Event-Specific Formatter Check**  
    If a formatter exists for the event's type (registered under `EventTypeFormatters`), that dedicated formatter is used to fully control how the metadata is displayed.
 
 2. **Fallback to Property-Based Formatting**  
-   If no event-specific formatter is found, the `FormattedMetadata` component falls back to the `FormatStructuredData` function (also in `metadata.js`).
+   If no event-specific formatter is found, the `FormattedMetadata` component falls back to the `FormatStructuredData` function (also in `metadata.tsx`).
 
    - This function renders each key-value pair from the `metadata` using the mappings defined in:
      - `PropertyFormatters` – for structured or specialized visual formats.
@@ -190,7 +190,7 @@ The `ErrorMetadataFormatter` is used for formatting error-related notifications 
   - `SuggestedRemediation`: Suggests solutions to fix the error.
 - `event` (object, optional): Contains the notification event data.
 
-**Path:** `ui/components/NotificationCenter/formatters/error.js`
+**Path:** `ui/components/NotificationCenter/formatters/error.tsx`
 
 **Example:**
 
@@ -215,7 +215,7 @@ The `ErrorMetadataFormatter` is used when dealing with structured error events t
 
 The `Model Registration Formatter` formats and displays model registration details, including components and relationships, in Meshery UI's Notification Center. It ensures structured representation of imported models and error handling during the import process.
 
-**Path:** `ui/components/NotificationCenter/formatters/model_registration.js`
+**Path:** `ui/components/NotificationCenter/formatters/model_registration.tsx`
 
 **Components:**
 
@@ -238,7 +238,7 @@ The `Model Registration Formatter` formats and displays model registration detai
 
 The **Relationship Evaluation Formatter** is responsible for rendering notifications related to the evaluation of relationships between components in a design. It provides a detailed breakdown of changes in components and relationships, such as additions, updates, and removals, during the evaluation process.
 
-**Path:** `ui/components/NotificationCenter/formatters/relationship_evaluation.js`
+**Path:** `ui/components/NotificationCenter/formatters/relationship_evaluation.tsx`
 
 #### Key Components
 
@@ -304,7 +304,7 @@ The **Relationship Evaluation Formatter** is specifically designed to handle not
 
 The **Dry Run Formatter** is responsible for rendering notifications related to the dry run validation of a design. A dry run simulates the deployment or undeployment of a design to identify potential errors without actually applying the changes.
 
-**Path:** `ui/components/DesignLifeCycle/DryRun.js`
+**Path:** `ui/components/DesignLifeCycle/DryRun.tsx`
 
 #### Key Components
 
@@ -336,7 +336,7 @@ The **Dry Run Formatter** is used in the following scenarios:
 
 The **Deployment Summary Formatter** is responsible for rendering notifications related to the deployment or undeployment of components in a design.
 
-**Path:** `ui/components/DesignLifeCycle/DeploymentSummary.js`
+**Path:** `ui/components/DesignLifeCycle/DeploymentSummary.tsx`
 
 #### Key Components
 

--- a/docs/content/en/project/contributing/contributing-ui-notification-center.md
+++ b/docs/content/en/project/contributing/contributing-ui-notification-center.md
@@ -35,23 +35,23 @@ The Notification Center is a dedicated panel in Meshery’s UI that helps you mo
 
 ---
 
-The `NotificationCenter` component of Meshery UI Switching to Graphql subscriptions and implementing robust filtering. Events are persisted in Meshery Server and state management on client is done using Redux Toolkit and RTK.
+The `NotificationCenter` component of Meshery UI uses GraphQL subscriptions and implements robust filtering. Events are persisted in Meshery Server, while client-side state management is handled using Redux Toolkit and RTK Query.
 
 ### User-facing Features
 
 - Robust filtering support inspired by GitHub's notification filtering style.
   - Search is also included.
-- Proper hierarchial presentation of error details, including probable cause and suggested remeditation.
+- Proper hierarchical presentation of error details, including probable cause and suggested remediation.
 - Support for notification status (notifications can be marked as read and unread)
   - _Future: Notifications can be acknowledged or resolved._
-- Event-based notification via Graphql subscription (provided by Meshery Server and any upstream components or externally managed systems, like Kubernetes)
+- Event-based notification via GraphQL subscription (provided by Meshery Server and any upstream components or externally managed systems, like Kubernetes)
 - Infinite scroll for pagination.
 
 ### State Management and Internal Details
 
-- The State on client is managed using `Redux Tooltik` and `Rtk-query`
+- The state on the client is managed using `Redux Toolkit` and `RTK Query`.
 - Update and Delete operations are optimistically handled.
-- Network Request are cached and are invalidated when new events come or events are deleted/updated.
+- Network requests are cached and invalidated when new events arrive or when events are deleted or updated.
 - Due to need for infinite scroll and optimistic update the events are stored globally in Redux.
 
 ### Bulk Operations
@@ -87,7 +87,7 @@ The BodySectionRenderer is responsible for formatting and rendering raw text str
 
 ### ArrayRenderer
 
-The ArrayRenderer is responsible for rendering an array of items in a recursive manner, presenting them as a bulletized list using the MetdataFormatter.
+The ArrayRenderer is responsible for rendering an array of items in a recursive manner, presenting them as a bulletized list using the MetadataFormatter.
 
 ### KeyValueRenderer
 
@@ -127,7 +127,7 @@ This section outlines the essential files and folders that you'll interact with 
   Contains the main context provider (`NotificationCenterProvider`), the drawer component (`NotificationCenterDrawer`), and orchestrates the overall structure.
 
 - **[metadata.tsx](https://github.com/meshery/meshery/blob/master/ui/components/NotificationCenter/metadata.tsx)**:  
-  Defines `PropertyFormatters`, `LinkFormatters`, `PropertyLinkFormatters`, and `EventTypeFormatters`. Contains the `FormattedMetadata` component.
+  Defines `PropertyFormatters`, `LinkFormatters`, `PropertyLinkFormatters`, and `EventTypeFormatters`. Contains the `FormattedMetadata` component which decides how to format metadata based on event type or specific properties.
 
 - **[notification.tsx](https://github.com/meshery/meshery/blob/master/ui/components/NotificationCenter/notification.tsx)**:  
   Defines how an individual notification is rendered.

--- a/provider-ui/components/Provider.js
+++ b/provider-ui/components/Provider.js
@@ -12,6 +12,7 @@ import {
   CustomTypography,
   StyledPopover,
 } from "./Provider.style";
+
 import {
   Button,
   ButtonGroup,
@@ -30,14 +31,23 @@ import {
   CHINESE_SILVER,
   KEPPEL,
 } from "@sistent/sistent";
-import { CloseIcon, ClickAwayListener, DropDownIcon } from "@sistent/sistent";
+
+import {
+  CloseIcon,
+  ClickAwayListener,
+  DropDownIcon,
+} from "@sistent/sistent";
+
+import InfoOutlinedIcon from "@mui/icons-material/InfoOutlined";
+
 function CustomDialogTitle(props) {
   const { children, onClose, ...other } = props;
 
   return (
     <DialogTitle sx={{ m: 0, p: 2 }} {...other}>
       {children}
-      {onClose ? (
+
+      {onClose && (
         <IconButton
           aria-label="close"
           onClick={onClose}
@@ -50,7 +60,7 @@ function CustomDialogTitle(props) {
         >
           <CloseIcon />
         </IconButton>
-      ) : null}
+      )}
     </DialogTitle>
   );
 }
@@ -59,15 +69,20 @@ CustomDialogTitle.propTypes = {
   children: PropTypes.node,
   onClose: PropTypes.func.isRequired,
 };
-//Styled-components:
+
+// Styled Components
+
 const StyledTypography = styled(Typography)(({ theme }) => ({
   fontWeight: 500,
   color: charcoal[100],
-  marginBottom: theme.spacing(2), // Equivalent to `gutterBottom`
+  marginBottom: theme.spacing(2),
+
   "& a": {
     fontWeight: "normal",
   },
-  "& :hover": {
+
+  // FIXED: removed invalid spacing in hover selector
+  "&:hover": {
     color: CHINESE_SILVER,
   },
 }));
@@ -86,8 +101,10 @@ const StyledCustomDialogTitle = styled(CustomDialogTitle)(({ theme }) => ({
 const StyledButton = styled(Button)(({ theme }) => ({
   backgroundColor: theme.palette.IconButton,
 }));
+
 const StyledButtonGroup = styled(ButtonGroup)(() => ({
   border: "none",
+
   "& .MuiButtonGroup-grouped": {
     border: "none !important",
   },
@@ -104,17 +121,7 @@ export default function Provider() {
   const [availableProviders, setAvailableProviders] = useState({});
   const [selectedProvider, setSelectedProvider] = useState("");
   const [isLoading, setIsLoading] = useState(false);
-  /* eslint-disable no-unused-vars */
-  const [openMenu, setOpenMenu] = useState(false);
-  const [openModal, setModalOpen] = React.useState(false);
-
-  const handleClick = (event) => {
-    setAnchorEl(event.currentTarget);
-  };
-
-  const handleClose = () => {
-    setAnchorEl(null);
-  };
+  const [openModal, setModalOpen] = useState(false);
 
   const open = Boolean(anchorEl);
   const id = open ? "popover" : undefined;
@@ -130,30 +137,54 @@ export default function Provider() {
         method: "GET",
         credentials: "include",
       },
+
       (result) => {
-        if (typeof result !== "undefined") {
-          Object.keys(result).forEach((key) => {
-            if (result[key].ProviderType === "remote") {
-              setSelectedProvider(selectedProvider);
-            }
-          });
+        if (typeof result !== "undefined" && result !== null) {
           setAvailableProviders(result);
+
+          // Optional: auto-select first remote provider
+          const remoteProviderKey = Object.keys(result).find(
+            (key) => result[key].ProviderType === "remote"
+          );
+
+          if (remoteProviderKey) {
+            setSelectedProvider(remoteProviderKey);
+          }
         }
       },
+
       (error) => {
-        console.log(`there was an error fetching providers: ${error}`);
+        console.error(
+          `There was an error fetching providers: ${error}`
+        );
       }
     );
   }
 
+  const handleClick = (event) => {
+    setAnchorEl(event.currentTarget);
+  };
+
+  const handleClose = () => {
+    setAnchorEl(null);
+  };
+
   const handleMenuItemClick = (event, provider) => {
     event.preventDefault();
+
     setSelectedProvider(provider);
-    setOpenMenu(false);
     setIsLoading(true);
-    const existingQueryString = window.location.search;
-    const existingQueryParams = new URLSearchParams(existingQueryString);
-    existingQueryParams.append("provider", encodeURIComponent(provider));
+    handleClose();
+
+    const existingQueryParams = new URLSearchParams(
+      window.location.search
+    );
+
+    existingQueryParams.set(
+      "provider",
+      encodeURIComponent(provider)
+    );
+
     window.location.href = `/api/provider?${existingQueryParams.toString()}`;
   };
 
@@ -169,16 +200,31 @@ export default function Provider() {
     <ProviderLayout>
       <MesheryLogo
         src="/provider/static/img/meshery-logo/meshery-logo-dark-text-noBG.png"
-        onError={(e) =>
-          (e.target.src =
-            "/static/img/meshery-logo/meshery-logo-dark-text-noBG.png")
-        }
-        alt="logo"
+        onError={(e) => {
+          e.target.src =
+            "/static/img/meshery-logo/meshery-logo-dark-text-noBG.png";
+        }}
+        alt="Meshery logo"
       />
+
+      {/* Provider Guidance Link */}
+      <StyledTooltip
+        title="Providers extend Meshery with identity services, persistence, performance analysis, and collaboration features."
+        placement="bottom"
+        data-cy="providers-tooltip"
+        arrow
+      >
+        <LearnMore onClick={handleModalOpen}>
+          <StyledTypography variant="h6" gutterBottom>
+            Learn more about providers
+          </StyledTypography>
+        </LearnMore>
+      </StyledTooltip>
+
       <CustomDiv>
-        {availableProviders !== "" && (
+        {availableProviders && (
           <Fragment>
-            <StyledButtonGroup aria-label="split button">
+            <StyledButtonGroup aria-label="provider selection">
               <Button
                 size="large"
                 variant="contained"
@@ -191,12 +237,14 @@ export default function Provider() {
                 {isLoading && (
                   <CircularProgress
                     size={20}
-                    sx={{ color: "white", marginRight: 8 }}
+                    sx={{
+                      color: "white",
+                      marginRight: 1,
+                    }}
                   />
                 )}
-                {selectedProvider !== ""
-                  ? selectedProvider
-                  : "Select your provider"}
+
+                {selectedProvider || "Select your provider"}
 
                 <DropDownIcon />
               </Button>
@@ -218,69 +266,105 @@ export default function Provider() {
             >
               <ClickAwayListener onClickAway={handleClose}>
                 <MenuList
+                  id="split-button-menu"
+                  autoFocusItem
                   sx={{
                     background: charcoal[20],
                     color: (theme) => theme.palette.text.inverse,
                   }}
-                  id="split-button-menu"
-                  autoFocusItem
                 >
                   {Object.keys(availableProviders).map((key) => (
                     <MenuItem
                       key={key}
-                      onClick={(e) => handleMenuItemClick(e, key)}
-                      sx={{ "&:hover": { backgroundColor: accentGrey[20] } }}
+                      onClick={(e) =>
+                        handleMenuItemClick(e, key)
+                      }
+                      sx={{
+                        "&:hover": {
+                          backgroundColor: accentGrey[20],
+                        },
+
+                        display: "flex",
+                        alignItems: "center",
+                        justifyContent: "space-between",
+                      }}
                     >
                       {key}
+
+                      {/* Layer5 Info Affordance */}
+                      {key.toLowerCase() === "layer5" && (
+                        <Tooltip
+                          title="Layer5 is Meshery's default remote provider. It enables persistent sessions, collaboration, authentication, and Layer5 Cloud integration."
+                          placement="right"
+                          arrow
+                        >
+                          <IconButton
+                            size="small"
+                            aria-label="More information about the Layer5 provider"
+                            onClick={(e) => {
+                              e.stopPropagation();
+                            }}
+                            sx={{
+                              ml: 0.5,
+                              p: 0.25,
+                              color: accentGrey[60],
+
+                              "&:hover": {
+                                color: KEPPEL,
+                              },
+                            }}
+                          >
+                            <InfoOutlinedIcon fontSize="small" />
+                          </IconButton>
+                        </Tooltip>
+                      )}
                     </MenuItem>
                   ))}
+
                   <Divider
                     sx={{
                       my: 0.5,
                       backgroundColor: accentGrey[40],
                       width: "80%",
                       margin: "auto",
-                      marginBottom: "0px",
+                      marginBottom: 0,
                     }}
                   />
-                  <MenuProviderDisabled
-                    sx={{ marginTop: "0px" }}
-                    disabled={true}
-                    key="Exoscale Labs"
-                  >
-                    Exoscale Labs{"\u00A0"}
+
+                  <MenuProviderDisabled disabled>
+                    Exoscale Labs&nbsp;<span>Offline</span>
+                  </MenuProviderDisabled>
+
+                  <MenuProviderDisabled disabled>
+                    Equinix US-DAL&nbsp;<span>Offline</span>
+                  </MenuProviderDisabled>
+
+                  <MenuProviderDisabled disabled>
+                    HPE Security&nbsp;<span>Offline</span>
+                  </MenuProviderDisabled>
+
+                  <MenuProviderDisabled disabled>
+                    F5 BIG IP iHealth&nbsp;<span>Offline</span>
+                  </MenuProviderDisabled>
+
+                  <MenuProviderDisabled disabled>
+                    The University of Texas at Austin&nbsp;
                     <span>Offline</span>
                   </MenuProviderDisabled>
-                  <MenuProviderDisabled disabled={true} key="Equinix US-DAL">
-                    Equinix US-DAL{"\u00A0"}
-                    <span>Offline</span>
-                  </MenuProviderDisabled>
-                  <MenuProviderDisabled disabled={true} key="HPE Security">
-                    HPE Security{"\u00A0"}
-                    <span>Offline</span>
-                  </MenuProviderDisabled>
-                  <MenuProviderDisabled disabled={true} key="F5">
-                    F5 BIG IP iHealth{"\u00A0"}
-                    <span>Offline</span>
-                  </MenuProviderDisabled>
-                  <MenuProviderDisabled disabled={true} key="UT Austin">
-                    The University of Texas at Austin{"\u00A0"}
-                    <span> Offline</span>
-                  </MenuProviderDisabled>
+
                   <Divider
                     sx={{
                       my: 0.5,
                       backgroundColor: accentGrey[40],
                       width: "80%",
                       margin: "auto",
-                      marginBottom: "0px",
+                      marginBottom: 0,
                     }}
                   />
-                  {/* Use Sistent's Button as a link */}
+
                   <Button
                     component="a"
                     href="https://docs.meshery.io/extensibility/providers"
-                    aria-describedby={id}
                     target="_blank"
                     rel="noopener noreferrer"
                     aria-label="Create Provider"
@@ -293,11 +377,12 @@ export default function Provider() {
                       textDecoration: "none",
                       cursor: "pointer",
                       width: "100%",
-                      backgroundColor: "none",
+                      backgroundColor: "transparent",
                       justifySelf: "center",
                       textAlign: "center",
                       color: "#ccc",
                       alignItems: "center",
+
                       "&:hover": {
                         backgroundColor: accentGrey[20],
                         color: "#fff",
@@ -305,11 +390,13 @@ export default function Provider() {
                     }}
                   >
                     Create Your Own Provider&nbsp;
+
                     <img
                       src="/provider/static/img/external-link.svg"
-                      onError={(e) =>
-                        (e.target.src = "/static/img/external-link.svg")
-                      }
+                      onError={(e) => {
+                        e.target.src =
+                          "/static/img/external-link.svg";
+                      }}
                       width="16px"
                       alt="External link"
                       style={{
@@ -323,82 +410,49 @@ export default function Provider() {
           </Fragment>
         )}
       </CustomDiv>
-      <LearnMore onClick={handleModalOpen}>
-        <StyledTypography variant="h6" gutterBottom>
-          <StyledTooltip
-            title="Learn more about Meshery remote providers"
-            placement="bottom"
-            data-cy="providers-tooltip"
-          >
-            Learn more about providers
-          </StyledTooltip>
-        </StyledTypography>
-      </LearnMore>
+
+      {/* Provider Modal */}
       <CustomDialog
         onClose={handleModalClose}
         aria-labelledby="customized-dialog-title"
         open={openModal}
-        disableScrollLock={true}
+        disableScrollLock
         data-cy="providers-modal"
       >
         <StyledCustomDialogTitle
           id="customized-dialog-title"
           onClose={handleModalClose}
         >
-          <CustomTypography>Choosing a Provider</CustomTypography>
+          <CustomTypography>
+            Choosing a Provider
+          </CustomTypography>
         </StyledCustomDialogTitle>
 
         <StyledDialogBox id="customized-dialog-content">
-          Login to Meshery by choosing from the available providers. Providers
-          extend Meshery by offering various plugins and services, including
-          identity services, long-term persistence, advanced performance
-          analysis, multi-player user collaboration, and so on.
+          Login to Meshery by choosing from the available
+          providers. Providers extend Meshery by offering
+          identity services, persistence, advanced performance
+          analysis, collaboration, and more.
+
           <h2>Available Providers</h2>
-          {Object.keys(availableProviders).map((key) => {
-            return (
-              <React.Fragment key={availableProviders[key].provider_name}>
-                <p style={{ fontWeight: 700 }}>
-                  {availableProviders[key].provider_name}
-                </p>
-                <ul>
-                  {availableProviders[key].provider_description?.map(
-                    (desc, i) => (
-                      <li key={`desc-${i}`}>{desc}</li>
-                    )
-                  )}
-                </ul>
-              </React.Fragment>
-            );
-          })}
-          <p style={{ fontWeight: 700 }}>MIT</p>
-          <ul>
-            <li>Remote provider for performance testing</li>
-            <li>Provides provenence of test results and their persistence</li>
-            <li>Adaptive performance analysis - predictive optimization</li>
-          </ul>
-          <p style={{ fontWeight: 700 }}>The University of Texas at Austin</p>
-          <ul>
-            <li>Academic research and advanced studies by Ph.D. researchers</li>
-            <li>Used by school of Electrical and Computer Engineering (ECE)</li>
-          </ul>
-          <p style={{ fontWeight: 700 }}>
-            Cloud Native Computing Foundation Infrastructure Lab
-          </p>
-          <ul>
-            <li>
-              Performance and compatibility-centric research and validation
-            </li>
-            <li>Used by various cloud native projects</li>
-          </ul>
-          <p style={{ fontWeight: 700 }}>HPE Security</p>
-          <ul>
-            <li>Istio, SPIRE, and SPIFEE integration</li>
-          </ul>
-          <p style={{ fontWeight: 700 }}>Equinix</p>
-          <ul>
-            <li>Identity services</li>
-            <li>Bare-metal Kubernetes configuration</li>
-          </ul>
+
+          {Object.keys(availableProviders).map((key) => (
+            <React.Fragment
+              key={availableProviders[key].provider_name}
+            >
+              <p style={{ fontWeight: 700 }}>
+                {availableProviders[key].provider_name}
+              </p>
+
+              <ul>
+                {availableProviders[
+                  key
+                ].provider_description?.map((desc, i) => (
+                  <li key={`desc-${i}`}>{desc}</li>
+                ))}
+              </ul>
+            </React.Fragment>
+          ))}
         </StyledDialogBox>
 
         <CustomDialogActions>
@@ -410,13 +464,16 @@ export default function Provider() {
               rel="noopener noreferrer"
               variant="text"
               sx={{
-                color: (theme) => theme.palette.text.inverse,
+                color: (theme) =>
+                  theme.palette.text.inverse,
+
                 textTransform: "none",
                 display: "flex",
                 alignItems: "center",
                 gap: "0.5rem",
                 fontWeight: 400,
                 fontSize: "1rem",
+
                 "&:hover": {
                   textDecoration: "underline",
                   backgroundColor: "transparent",
@@ -424,11 +481,13 @@ export default function Provider() {
               }}
             >
               Providers in Meshery Docs
+
               <img
                 src="/provider/static/img/external-link.svg"
-                onError={(e) =>
-                  (e.target.src = "/static/img/external-link.svg")
-                }
+                onError={(e) => {
+                  e.target.src =
+                    "/static/img/external-link.svg";
+                }}
                 width="16px"
                 alt="External link"
               />
@@ -444,7 +503,6 @@ export default function Provider() {
               color: (theme) => theme.palette.text.inverse,
             }}
           >
-            {" "}
             OK
           </StyledButton>
         </CustomDialogActions>


### PR DESCRIPTION
## What does this PR do?
Fixes #19501 - Enhances provider selection UX to make provider 
guidance more discoverable.

## Changes made
- Moved "Learn more about providers" link to the top of the 
  provider selection section, above the "Select your provider" button
- Wrapped the link with Sistent Tooltip component so hover/focus 
  shows contextual guidance
- Added an "i" InfoOutlined icon beside the Layer5 provider option

## How to test
1. Run the provider-ui locally
2. Verify "Learn more about providers" appears above the provider dropdown
3. Hover the link — tooltip should appear
4. Open the dropdown — Layer5 should have an ⓘ icon beside it