### PR TITLE
feat(meshmodel): add AWS ElastiCache ReplicationGroup relationships to Kubernetes Deployment and Pod

### DIFF
--- a/server/meshmodel/aws-elasticache-controller/v1.3.5/v1.0.0/relationships/edge-non-binding-reference-replicationgroup-deployment.json
+++ b/server/meshmodel/aws-elasticache-controller/v1.3.5/v1.0.0/relationships/edge-non-binding-reference-replicationgroup-deployment.json
@@ -1,0 +1,96 @@
+{
+  "id": "00000000-0000-0000-0000-000000000000",
+  "evaluationQuery": "",
+  "kind": "edge",
+  "metadata": {
+    "description": "An edge relationship between an AWS ElastiCache ReplicationGroup and a Kubernetes Deployment, representing a Deployment whose containers reference the ReplicationGroup.",
+    "styles": {
+      "primaryColor": "",
+      "svgColor": "",
+      "svgWhite": ""
+    },
+    "isAnnotation": false
+  },
+  "model": {
+    "version": "v1.3.5",
+    "name": "aws-elasticache-controller",
+    "displayName": "AWS ElastiCache",
+    "id": "00000000-0000-0000-0000-000000000000",
+    "registrant": {
+      "kind": "github"
+    }
+  },
+  "schemaVersion": "relationships.meshery.io/v1beta3",
+  "selectors": [
+    {
+      "allow": {
+        "from": [
+          {
+            "id": null,
+            "kind": "ReplicationGroup",
+            "match": {},
+            "match_strategy_matrix": null,
+            "model": {
+              "version": "v1.3.5",
+              "name": "aws-elasticache-controller",
+              "displayName": "AWS ElastiCache",
+              "id": "00000000-0000-0000-0000-000000000000",
+              "registrant": {
+                "kind": "github"
+              }
+            },
+            "patch": {
+              "patchStrategy": "replace",
+              "mutatorRef": [
+                [
+                  "configuration",
+                  "metadata",
+                  "name"
+                ]
+              ]
+            }
+          }
+        ],
+        "to": [
+          {
+            "id": null,
+            "kind": "Deployment",
+            "match": {},
+            "match_strategy_matrix": null,
+            "model": {
+              "version": "*",
+              "name": "kubernetes",
+              "displayName": "Kubernetes",
+              "id": "00000000-0000-0000-0000-000000000000",
+              "registrant": {
+                "kind": "github"
+              }
+            },
+            "patch": {
+              "patchStrategy": "replace",
+              "mutatedRef": [
+                [
+                  "configuration",
+                  "spec",
+                  "template",
+                  "spec",
+                  "containers",
+                  "_",
+                  "env"
+                ]
+              ]
+            }
+          }
+        ]
+      },
+      "deny": {
+        "from": [],
+        "to": []
+      }
+    }
+  ],
+  "subType": "reference",
+  "status": "enabled",
+  "type": "non-binding",
+  "version": "v1.0.0"
+}

--- a/server/meshmodel/aws-elasticache-controller/v1.3.5/v1.0.0/relationships/edge-non-binding-reference-replicationgroup-deployment.json
+++ b/server/meshmodel/aws-elasticache-controller/v1.3.5/v1.0.0/relationships/edge-non-binding-reference-replicationgroup-deployment.json
@@ -12,15 +12,18 @@
     "isAnnotation": false
   },
   "model": {
-    "version": "v1.3.5",
+    "version": "",
     "name": "aws-elasticache-controller",
     "displayName": "AWS ElastiCache",
     "id": "00000000-0000-0000-0000-000000000000",
     "registrant": {
       "kind": "github"
+    },
+    "model": {
+      "version": "v1.3.5"
     }
   },
-  "schemaVersion": "relationships.meshery.io/v1beta3",
+  "schemaVersion": "relationships.meshery.io/v1beta2",
   "selectors": [
     {
       "allow": {
@@ -31,12 +34,15 @@
             "match": {},
             "match_strategy_matrix": null,
             "model": {
-              "version": "v1.3.5",
+              "version": "",
               "name": "aws-elasticache-controller",
               "displayName": "AWS ElastiCache",
               "id": "00000000-0000-0000-0000-000000000000",
               "registrant": {
                 "kind": "github"
+              },
+              "model": {
+                "version": ""
               }
             },
             "patch": {
@@ -64,6 +70,9 @@
               "id": "00000000-0000-0000-0000-000000000000",
               "registrant": {
                 "kind": "github"
+              },
+              "model": {
+                "version": ""
               }
             },
             "patch": {

--- a/server/meshmodel/aws-elasticache-controller/v1.3.5/v1.0.0/relationships/edge-non-binding-reference-replicationgroup-pod.json
+++ b/server/meshmodel/aws-elasticache-controller/v1.3.5/v1.0.0/relationships/edge-non-binding-reference-replicationgroup-pod.json
@@ -1,0 +1,94 @@
+{
+  "id": "00000000-0000-0000-0000-000000000000",
+  "evaluationQuery": "",
+  "kind": "edge",
+  "metadata": {
+    "description": "An edge relationship between an AWS ElastiCache ReplicationGroup and a Kubernetes Pod, representing a Pod whose containers reference the ReplicationGroup.",
+    "styles": {
+      "primaryColor": "",
+      "svgColor": "",
+      "svgWhite": ""
+    },
+    "isAnnotation": false
+  },
+  "model": {
+    "version": "v1.3.5",
+    "name": "aws-elasticache-controller",
+    "displayName": "AWS ElastiCache",
+    "id": "00000000-0000-0000-0000-000000000000",
+    "registrant": {
+      "kind": "github"
+    }
+  },
+  "schemaVersion": "relationships.meshery.io/v1beta3",
+  "selectors": [
+    {
+      "allow": {
+        "from": [
+          {
+            "id": null,
+            "kind": "ReplicationGroup",
+            "match": {},
+            "match_strategy_matrix": null,
+            "model": {
+              "version": "v1.3.5",
+              "name": "aws-elasticache-controller",
+              "displayName": "AWS ElastiCache",
+              "id": "00000000-0000-0000-0000-000000000000",
+              "registrant": {
+                "kind": "github"
+              }
+            },
+            "patch": {
+              "patchStrategy": "replace",
+              "mutatorRef": [
+                [
+                  "configuration",
+                  "metadata",
+                  "name"
+                ]
+              ]
+            }
+          }
+        ],
+        "to": [
+          {
+            "id": null,
+            "kind": "Pod",
+            "match": {},
+            "match_strategy_matrix": null,
+            "model": {
+              "version": "*",
+              "name": "kubernetes",
+              "displayName": "Kubernetes",
+              "id": "00000000-0000-0000-0000-000000000000",
+              "registrant": {
+                "kind": "github"
+              }
+            },
+            "patch": {
+              "patchStrategy": "replace",
+              "mutatedRef": [
+                [
+                  "configuration",
+                  "spec",
+                  "containers",
+                  "_",
+                  "env"
+                ]
+              ]
+            }
+          }
+        ]
+      },
+      "deny": {
+        "from": [],
+        "to": []
+      }
+    }
+  ],
+  "subType": "reference",
+  "status": "enabled",
+  "type": "non-binding",
+  "version": "v1.0.0"
+}

--- a/server/meshmodel/aws-elasticache-controller/v1.3.5/v1.0.0/relationships/edge-non-binding-reference-replicationgroup-pod.json
+++ b/server/meshmodel/aws-elasticache-controller/v1.3.5/v1.0.0/relationships/edge-non-binding-reference-replicationgroup-pod.json
@@ -12,15 +12,18 @@
     "isAnnotation": false
   },
   "model": {
-    "version": "v1.3.5",
+    "version": "",
     "name": "aws-elasticache-controller",
     "displayName": "AWS ElastiCache",
     "id": "00000000-0000-0000-0000-000000000000",
     "registrant": {
       "kind": "github"
+    },
+    "model": {
+      "version": "v1.3.5"
     }
   },
-  "schemaVersion": "relationships.meshery.io/v1beta3",
+  "schemaVersion": "relationships.meshery.io/v1beta2",
   "selectors": [
     {
       "allow": {
@@ -31,12 +34,15 @@
             "match": {},
             "match_strategy_matrix": null,
             "model": {
-              "version": "v1.3.5",
+              "version": "",
               "name": "aws-elasticache-controller",
               "displayName": "AWS ElastiCache",
               "id": "00000000-0000-0000-0000-000000000000",
               "registrant": {
                 "kind": "github"
+              },
+              "model": {
+                "version": ""
               }
             },
             "patch": {
@@ -64,6 +70,9 @@
               "id": "00000000-0000-0000-0000-000000000000",
               "registrant": {
                 "kind": "github"
+              },
+              "model": {
+                "version": ""
               }
             },
             "patch": {


### PR DESCRIPTION
## Description

Adds edge non-binding reference relationships for AWS ElastiCache to Kubernetes workloads, completing the **data layer pattern** alongside PR #19502 (RDS DBInstance).

**ElastiCache (aws-elasticache-controller v1.3.5):**
- `ReplicationGroup → Deployment` — models a Deployment whose containers connect to the ElastiCache Redis cluster
- `ReplicationGroup → Pod` — models a Pod whose containers connect to the ElastiCache Redis cluster

ElastiCache + RDS together form the most common AWS data layer pattern: RDS for persistence, ElastiCache for caching. Having both in the Meshery registry means platform engineers can accurately model this pattern end to end.

Relates to #14794
<img width="320" height="294" alt="Screenshot 2026-05-29 at 10 49 10 AM" src="https://github.com/user-attachments/assets/07ffdcca-817a-4d8a-8da7-06a12d964390" />