### PR TITLE
feat(meshmodel): add AWS SNS Topic relationships to Kubernetes Deployment and Pod

### DIFF
--- a/server/meshmodel/aws-sns-controller/v1.4.4/v1.0.0/relationships/edge-non-binding-reference-topic-deployment.json
+++ b/server/meshmodel/aws-sns-controller/v1.4.4/v1.0.0/relationships/edge-non-binding-reference-topic-deployment.json
@@ -12,15 +12,18 @@
     "isAnnotation": false
   },
   "model": {
-    "version": "v1.4.4",
+    "version": "",
     "name": "aws-sns-controller",
     "displayName": "AWS SNS",
     "id": "00000000-0000-0000-0000-000000000000",
     "registrant": {
       "kind": "github"
+    },
+    "model": {
+      "version": "v1.4.4"
     }
   },
-  "schemaVersion": "relationships.meshery.io/v1beta3",
+  "schemaVersion": "relationships.meshery.io/v1beta2",
   "selectors": [
     {
       "allow": {
@@ -31,12 +34,15 @@
             "match": {},
             "match_strategy_matrix": null,
             "model": {
-              "version": "v1.4.4",
+              "version": "",
               "name": "aws-sns-controller",
               "displayName": "AWS SNS",
               "id": "00000000-0000-0000-0000-000000000000",
               "registrant": {
                 "kind": "github"
+              },
+              "model": {
+                "version": ""
               }
             },
             "patch": {
@@ -64,6 +70,9 @@
               "id": "00000000-0000-0000-0000-000000000000",
               "registrant": {
                 "kind": "github"
+              },
+              "model": {
+                "version": ""
               }
             },
             "patch": {

--- a/server/meshmodel/aws-sns-controller/v1.4.4/v1.0.0/relationships/edge-non-binding-reference-topic-deployment.json
+++ b/server/meshmodel/aws-sns-controller/v1.4.4/v1.0.0/relationships/edge-non-binding-reference-topic-deployment.json
@@ -1,0 +1,96 @@
+{
+  "id": "00000000-0000-0000-0000-000000000000",
+  "evaluationQuery": "",
+  "kind": "edge",
+  "metadata": {
+    "description": "An edge relationship between an AWS SNS Topic and a Kubernetes Deployment, representing a Deployment whose containers reference the Topic.",
+    "styles": {
+      "primaryColor": "",
+      "svgColor": "",
+      "svgWhite": ""
+    },
+    "isAnnotation": false
+  },
+  "model": {
+    "version": "v1.4.4",
+    "name": "aws-sns-controller",
+    "displayName": "AWS SNS",
+    "id": "00000000-0000-0000-0000-000000000000",
+    "registrant": {
+      "kind": "github"
+    }
+  },
+  "schemaVersion": "relationships.meshery.io/v1beta3",
+  "selectors": [
+    {
+      "allow": {
+        "from": [
+          {
+            "id": null,
+            "kind": "Topic",
+            "match": {},
+            "match_strategy_matrix": null,
+            "model": {
+              "version": "v1.4.4",
+              "name": "aws-sns-controller",
+              "displayName": "AWS SNS",
+              "id": "00000000-0000-0000-0000-000000000000",
+              "registrant": {
+                "kind": "github"
+              }
+            },
+            "patch": {
+              "patchStrategy": "replace",
+              "mutatorRef": [
+                [
+                  "configuration",
+                  "metadata",
+                  "name"
+                ]
+              ]
+            }
+          }
+        ],
+        "to": [
+          {
+            "id": null,
+            "kind": "Deployment",
+            "match": {},
+            "match_strategy_matrix": null,
+            "model": {
+              "version": "*",
+              "name": "kubernetes",
+              "displayName": "Kubernetes",
+              "id": "00000000-0000-0000-0000-000000000000",
+              "registrant": {
+                "kind": "github"
+              }
+            },
+            "patch": {
+              "patchStrategy": "replace",
+              "mutatedRef": [
+                [
+                  "configuration",
+                  "spec",
+                  "template",
+                  "spec",
+                  "containers",
+                  "_",
+                  "env"
+                ]
+              ]
+            }
+          }
+        ]
+      },
+      "deny": {
+        "from": [],
+        "to": []
+      }
+    }
+  ],
+  "subType": "reference",
+  "status": "enabled",
+  "type": "non-binding",
+  "version": "v1.0.0"
+}

--- a/server/meshmodel/aws-sns-controller/v1.4.4/v1.0.0/relationships/edge-non-binding-reference-topic-pod.json
+++ b/server/meshmodel/aws-sns-controller/v1.4.4/v1.0.0/relationships/edge-non-binding-reference-topic-pod.json
@@ -12,15 +12,18 @@
     "isAnnotation": false
   },
   "model": {
-    "version": "v1.4.4",
+    "version": "",
     "name": "aws-sns-controller",
     "displayName": "AWS SNS",
     "id": "00000000-0000-0000-0000-000000000000",
     "registrant": {
       "kind": "github"
+    },
+    "model": {
+      "version": "v1.4.4"
     }
   },
-  "schemaVersion": "relationships.meshery.io/v1beta3",
+  "schemaVersion": "relationships.meshery.io/v1beta2",
   "selectors": [
     {
       "allow": {
@@ -31,12 +34,15 @@
             "match": {},
             "match_strategy_matrix": null,
             "model": {
-              "version": "v1.4.4",
+              "version": "",
               "name": "aws-sns-controller",
               "displayName": "AWS SNS",
               "id": "00000000-0000-0000-0000-000000000000",
               "registrant": {
                 "kind": "github"
+              },
+              "model": {
+                "version": ""
               }
             },
             "patch": {
@@ -64,6 +70,9 @@
               "id": "00000000-0000-0000-0000-000000000000",
               "registrant": {
                 "kind": "github"
+              },
+              "model": {
+                "version": ""
               }
             },
             "patch": {

--- a/server/meshmodel/aws-sns-controller/v1.4.4/v1.0.0/relationships/edge-non-binding-reference-topic-pod.json
+++ b/server/meshmodel/aws-sns-controller/v1.4.4/v1.0.0/relationships/edge-non-binding-reference-topic-pod.json
@@ -1,0 +1,94 @@
+{
+  "id": "00000000-0000-0000-0000-000000000000",
+  "evaluationQuery": "",
+  "kind": "edge",
+  "metadata": {
+    "description": "An edge relationship between an AWS SNS Topic and a Kubernetes Pod, representing a Pod whose containers reference the Topic.",
+    "styles": {
+      "primaryColor": "",
+      "svgColor": "",
+      "svgWhite": ""
+    },
+    "isAnnotation": false
+  },
+  "model": {
+    "version": "v1.4.4",
+    "name": "aws-sns-controller",
+    "displayName": "AWS SNS",
+    "id": "00000000-0000-0000-0000-000000000000",
+    "registrant": {
+      "kind": "github"
+    }
+  },
+  "schemaVersion": "relationships.meshery.io/v1beta3",
+  "selectors": [
+    {
+      "allow": {
+        "from": [
+          {
+            "id": null,
+            "kind": "Topic",
+            "match": {},
+            "match_strategy_matrix": null,
+            "model": {
+              "version": "v1.4.4",
+              "name": "aws-sns-controller",
+              "displayName": "AWS SNS",
+              "id": "00000000-0000-0000-0000-000000000000",
+              "registrant": {
+                "kind": "github"
+              }
+            },
+            "patch": {
+              "patchStrategy": "replace",
+              "mutatorRef": [
+                [
+                  "configuration",
+                  "metadata",
+                  "name"
+                ]
+              ]
+            }
+          }
+        ],
+        "to": [
+          {
+            "id": null,
+            "kind": "Pod",
+            "match": {},
+            "match_strategy_matrix": null,
+            "model": {
+              "version": "*",
+              "name": "kubernetes",
+              "displayName": "Kubernetes",
+              "id": "00000000-0000-0000-0000-000000000000",
+              "registrant": {
+                "kind": "github"
+              }
+            },
+            "patch": {
+              "patchStrategy": "replace",
+              "mutatedRef": [
+                [
+                  "configuration",
+                  "spec",
+                  "containers",
+                  "_",
+                  "env"
+                ]
+              ]
+            }
+          }
+        ]
+      },
+      "deny": {
+        "from": [],
+        "to": []
+      }
+    }
+  ],
+  "subType": "reference",
+  "status": "enabled",
+  "type": "non-binding",
+  "version": "v1.0.0"
+}


### PR DESCRIPTION
## Description

Adds edge non-binding reference relationships for AWS SNS to Kubernetes workloads, completing the **event-driven pattern** alongside PR #19490 (SQS Queue).

**SNS (aws-sns-controller v1.4.4):**
- `Topic → Deployment` — models a Deployment whose containers publish to or subscribe to the SNS topic
- `Topic → Pod` — models a Pod whose containers publish to or subscribe to the SNS topic

SNS + SQS together form the canonical AWS event-driven fanout pattern: SNS as the publisher, SQS as the subscriber queues. Having both in the registry makes this pattern fully modelable in Meshery.

Relates to #14794

<img width="293" height="292" alt="Screenshot 2026-05-29 at 10 54 58 AM" src="https://github.com/user-attachments/assets/78dee9e7-984f-4751-bca1-ab0d328a4dcd" />

