### PR TITLE
feat(meshmodel): add AWS Secrets Manager Secret relationships to Kubernetes Deployment and Pod

### DIFF
--- a/server/meshmodel/aws-secretsmanager-controller/v1.2.4/v1.0.0/relationships/edge-non-binding-reference-secret-deployment.json
+++ b/server/meshmodel/aws-secretsmanager-controller/v1.2.4/v1.0.0/relationships/edge-non-binding-reference-secret-deployment.json
@@ -1,0 +1,99 @@
+{
+  "id": "00000000-0000-0000-0000-000000000000",
+  "evaluationQuery": "",
+  "kind": "edge",
+  "metadata": {
+    "description": "An edge relationship between an AWS Secrets Manager Secret and a Kubernetes Deployment, representing a Deployment whose containers reference the Secret.",
+    "styles": {
+      "primaryColor": "",
+      "svgColor": "",
+      "svgWhite": ""
+    },
+    "isAnnotation": false
+  },
+  "model": {
+    "version": "v1.2.4",
+    "name": "aws-secretsmanager-controller",
+    "displayName": "AWS Secrets Manager",
+    "id": "00000000-0000-0000-0000-000000000000",
+    "registrant": {
+      "kind": "github"
+    }
+  },
+  "schemaVersion": "relationships.meshery.io/v1beta3",
+  "selectors": [
+    {
+      "allow": {
+        "from": [
+          {
+            "id": null,
+            "kind": "Secret",
+            "match": {},
+            "match_strategy_matrix": null,
+            "model": {
+              "version": "v1.2.4",
+              "name": "aws-secretsmanager-controller",
+              "displayName": "AWS Secrets Manager",
+              "id": "00000000-0000-0000-0000-000000000000",
+              "registrant": {
+                "kind": "github"
+              }
+            },
+            "patch": {
+              "patchStrategy": "replace",
+              "mutatorRef": [
+                [
+                  "configuration",
+                  "metadata",
+                  "name"
+                ]
+              ]
+            }
+          }
+        ],
+        "to": [
+          {
+            "id": null,
+            "kind": "Deployment",
+            "match": {},
+            "match_strategy_matrix": null,
+            "model": {
+              "version": "*",
+              "name": "kubernetes",
+              "displayName": "Kubernetes",
+              "id": "00000000-0000-0000-0000-000000000000",
+              "registrant": {
+                "kind": "github"
+              }
+            },
+            "patch": {
+              "patchStrategy": "replace",
+              "mutatedRef": [
+                [
+                  "configuration",
+                  "spec",
+                  "template",
+                  "spec",
+                  "containers",
+                  "_",
+                  "envFrom",
+                  "_",
+                  "secretRef",
+                  "name"
+                ]
+              ]
+            }
+          }
+        ]
+      },
+      "deny": {
+        "from": [],
+        "to": []
+      }
+    }
+  ],
+  "subType": "reference",
+  "status": "enabled",
+  "type": "non-binding",
+  "version": "v1.0.0"
+}

--- a/server/meshmodel/aws-secretsmanager-controller/v1.2.4/v1.0.0/relationships/edge-non-binding-reference-secret-deployment.json
+++ b/server/meshmodel/aws-secretsmanager-controller/v1.2.4/v1.0.0/relationships/edge-non-binding-reference-secret-deployment.json
@@ -12,15 +12,18 @@
     "isAnnotation": false
   },
   "model": {
-    "version": "v1.2.4",
+    "version": "",
     "name": "aws-secretsmanager-controller",
     "displayName": "AWS Secrets Manager",
     "id": "00000000-0000-0000-0000-000000000000",
     "registrant": {
       "kind": "github"
+    },
+    "model": {
+      "version": "v1.2.4"
     }
   },
-  "schemaVersion": "relationships.meshery.io/v1beta3",
+  "schemaVersion": "relationships.meshery.io/v1beta2",
   "selectors": [
     {
       "allow": {
@@ -31,12 +34,15 @@
             "match": {},
             "match_strategy_matrix": null,
             "model": {
-              "version": "v1.2.4",
+              "version": "",
               "name": "aws-secretsmanager-controller",
               "displayName": "AWS Secrets Manager",
               "id": "00000000-0000-0000-0000-000000000000",
               "registrant": {
                 "kind": "github"
+              },
+              "model": {
+                "version": ""
               }
             },
             "patch": {
@@ -64,6 +70,9 @@
               "id": "00000000-0000-0000-0000-000000000000",
               "registrant": {
                 "kind": "github"
+              },
+              "model": {
+                "version": ""
               }
             },
             "patch": {

--- a/server/meshmodel/aws-secretsmanager-controller/v1.2.4/v1.0.0/relationships/edge-non-binding-reference-secret-pod.json
+++ b/server/meshmodel/aws-secretsmanager-controller/v1.2.4/v1.0.0/relationships/edge-non-binding-reference-secret-pod.json
@@ -12,15 +12,18 @@
     "isAnnotation": false
   },
   "model": {
-    "version": "v1.2.4",
+    "version": "",
     "name": "aws-secretsmanager-controller",
     "displayName": "AWS Secrets Manager",
     "id": "00000000-0000-0000-0000-000000000000",
     "registrant": {
       "kind": "github"
+    },
+    "model": {
+      "version": "v1.2.4"
     }
   },
-  "schemaVersion": "relationships.meshery.io/v1beta3",
+  "schemaVersion": "relationships.meshery.io/v1beta2",
   "selectors": [
     {
       "allow": {
@@ -31,12 +34,15 @@
             "match": {},
             "match_strategy_matrix": null,
             "model": {
-              "version": "v1.2.4",
+              "version": "",
               "name": "aws-secretsmanager-controller",
               "displayName": "AWS Secrets Manager",
               "id": "00000000-0000-0000-0000-000000000000",
               "registrant": {
                 "kind": "github"
+              },
+              "model": {
+                "version": ""
               }
             },
             "patch": {
@@ -64,6 +70,9 @@
               "id": "00000000-0000-0000-0000-000000000000",
               "registrant": {
                 "kind": "github"
+              },
+              "model": {
+                "version": ""
               }
             },
             "patch": {

--- a/server/meshmodel/aws-secretsmanager-controller/v1.2.4/v1.0.0/relationships/edge-non-binding-reference-secret-pod.json
+++ b/server/meshmodel/aws-secretsmanager-controller/v1.2.4/v1.0.0/relationships/edge-non-binding-reference-secret-pod.json
@@ -1,0 +1,97 @@
+{
+  "id": "00000000-0000-0000-0000-000000000000",
+  "evaluationQuery": "",
+  "kind": "edge",
+  "metadata": {
+    "description": "An edge relationship between an AWS Secrets Manager Secret and a Kubernetes Pod, representing a Pod whose containers reference the Secret.",
+    "styles": {
+      "primaryColor": "",
+      "svgColor": "",
+      "svgWhite": ""
+    },
+    "isAnnotation": false
+  },
+  "model": {
+    "version": "v1.2.4",
+    "name": "aws-secretsmanager-controller",
+    "displayName": "AWS Secrets Manager",
+    "id": "00000000-0000-0000-0000-000000000000",
+    "registrant": {
+      "kind": "github"
+    }
+  },
+  "schemaVersion": "relationships.meshery.io/v1beta3",
+  "selectors": [
+    {
+      "allow": {
+        "from": [
+          {
+            "id": null,
+            "kind": "Secret",
+            "match": {},
+            "match_strategy_matrix": null,
+            "model": {
+              "version": "v1.2.4",
+              "name": "aws-secretsmanager-controller",
+              "displayName": "AWS Secrets Manager",
+              "id": "00000000-0000-0000-0000-000000000000",
+              "registrant": {
+                "kind": "github"
+              }
+            },
+            "patch": {
+              "patchStrategy": "replace",
+              "mutatorRef": [
+                [
+                  "configuration",
+                  "metadata",
+                  "name"
+                ]
+              ]
+            }
+          }
+        ],
+        "to": [
+          {
+            "id": null,
+            "kind": "Pod",
+            "match": {},
+            "match_strategy_matrix": null,
+            "model": {
+              "version": "*",
+              "name": "kubernetes",
+              "displayName": "Kubernetes",
+              "id": "00000000-0000-0000-0000-000000000000",
+              "registrant": {
+                "kind": "github"
+              }
+            },
+            "patch": {
+              "patchStrategy": "replace",
+              "mutatedRef": [
+                [
+                  "configuration",
+                  "spec",
+                  "containers",
+                  "_",
+                  "envFrom",
+                  "_",
+                  "secretRef",
+                  "name"
+                ]
+              ]
+            }
+          }
+        ]
+      },
+      "deny": {
+        "from": [],
+        "to": []
+      }
+    }
+  ],
+  "subType": "reference",
+  "status": "enabled",
+  "type": "non-binding",
+  "version": "v1.0.0"
+}


### PR DESCRIPTION
## Description

Adds edge non-binding reference relationships for AWS Secrets Manager to Kubernetes workloads, completing the **serverless security pattern** alongside PR #19502 (Lambda Function).

**Secrets Manager (aws-secretsmanager-controller v1.2.4):**
- `Secret → Deployment` — models a Deployment whose containers retrieve credentials or configuration from Secrets Manager
- `Secret → Pod` — models a Pod whose containers retrieve credentials or configuration from Secrets Manager

Lambda + Secrets Manager is the standard pattern for serverless functions that need database credentials or API keys without hardcoding them. Having both in the registry enables accurate modeling of secure serverless architectures.

Relates to #14794

<img width="546" height="351" alt="Screenshot 2026-05-29 at 11 01 02 AM" src="https://github.com/user-attachments/assets/cb0a5329-d42d-49e5-9525-68fd31369787" />
