### PR TITLE
[UI]: Fix broken radio buttons and silent form submission failure in Import Model dialog

### DIFF
--- a/ui/components/registry/ImportModelModal.tsx
+++ b/ui/components/registry/ImportModelModal.tsx
@@ -118,13 +118,13 @@ const CustomRadioWidget = (props: CustomRadioWidgetProps) => {
 
   return (
     <FormControl component="fieldset">
-      <Typography fontWeight={'bold'} fontSize={'1rem'}>
+      <Typography fontWeight={'bold'} fontSize={'1rem'} sx={{ marginBottom: '0.5rem' }}>
         {label}
       </Typography>
       <RadioGroup
         value={value}
         onChange={(e) => onChange(e.target.value)}
-        sx={{ marginBottom: '0.5rem' }}
+        aria-label="Upload Method"
       >
         {enumOptions.map((option, index) => (
           <FormControlLabel

--- a/ui/components/registry/ImportModelModal.tsx
+++ b/ui/components/registry/ImportModelModal.tsx
@@ -121,11 +121,7 @@ const CustomRadioWidget = (props: CustomRadioWidgetProps) => {
       <Typography fontWeight={'bold'} fontSize={'1rem'} sx={{ marginBottom: '0.5rem' }}>
         {label}
       </Typography>
-      <RadioGroup
-        value={value}
-        onChange={(e) => onChange(e.target.value)}
-        aria-label="Upload Method"
-      >
+      <RadioGroup value={value} onChange={(e) => onChange(e.target.value)} aria-label={label}>
         {enumOptions.map((option, index) => (
           <FormControlLabel
             key={option.value}

--- a/ui/components/registry/ImportModelModal.tsx
+++ b/ui/components/registry/ImportModelModal.tsx
@@ -118,14 +118,14 @@ const CustomRadioWidget = (props: CustomRadioWidgetProps) => {
 
   return (
     <FormControl component="fieldset">
+      <Typography fontWeight={'bold'} fontSize={'1rem'}>
+        {label}
+      </Typography>
       <RadioGroup
         value={value}
         onChange={(e) => onChange(e.target.value)}
-        sx={{ marginTop: '-1.7rem', marginLeft: '-1rem' }}
+        sx={{ marginBottom: '0.5rem' }}
       >
-        <Typography fontWeight={'bold'} fontSize={'1rem'}>
-          {label}
-        </Typography>
         {enumOptions.map((option, index) => (
           <FormControlLabel
             key={option.value}


### PR DESCRIPTION
**Notes for Reviewers**
- This PR fixes #19246

**Changes Made**
- Removed negative margins (`marginTop: '-1.7rem'`, `marginLeft: '-1rem'`) from `RadioGroup` which were causing radio button circles to appear broken/incomplete due to paint boundary clipping.
- Added `style={{ marginBottom: '0.5rem' }} to the Typography component to adjust the position of the Upload Method label.
- Moved the Typography component above the RadioGroup component
-  I have also mentioned in the PR heading to include Fix silent form submission failure in Import Modal dialog, based on the suggestion mentioned in this comment: https://github.com/meshery/meshery/pull/19261#issuecomment-4437299080

**Root Cause**
The negative margins on `RadioGroup` were shifting the component outside its paint bounds. On initial render, the radio circles and label were clipped. Browser repaints triggered by MUI's built-in hover styles accidentally revealed the content, creating an inconsistent hover-dependent UI.

**[Signed commits](https://github.com/meshery/meshery/blob/master/CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [x] Yes, I signed my commits.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Improved spacing and layout for radio-group headers and containers in the model import dialog.
  * Adjusted label styling and removed prior margin overrides for a cleaner presentation.
* **Accessibility**
  * Added descriptive `aria-label` text to the radio group to better support assistive technologies.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->