### PR TITLE
feat(meshmodel): add AWS EventBridge EventBus relationships to Kubernetes Deployment and Pod

### DIFF
--- a/server/meshmodel/aws-eventbridge-controller/v1.2.3/v1.0.0/relationships/edge-non-binding-reference-eventbus-deployment.json
+++ b/server/meshmodel/aws-eventbridge-controller/v1.2.3/v1.0.0/relationships/edge-non-binding-reference-eventbus-deployment.json
@@ -12,15 +12,18 @@
     "isAnnotation": false
   },
   "model": {
-    "version": "v1.2.3",
+    "version": "",
     "name": "aws-eventbridge-controller",
     "displayName": "AWS EventBridge",
     "id": "00000000-0000-0000-0000-000000000000",
     "registrant": {
       "kind": "github"
+    },
+    "model": {
+      "version": "v1.2.3"
     }
   },
-  "schemaVersion": "relationships.meshery.io/v1beta3",
+  "schemaVersion": "relationships.meshery.io/v1beta2",
   "selectors": [
     {
       "allow": {
@@ -31,12 +34,15 @@
             "match": {},
             "match_strategy_matrix": null,
             "model": {
-              "version": "v1.2.3",
+              "version": "",
               "name": "aws-eventbridge-controller",
               "displayName": "AWS EventBridge",
               "id": "00000000-0000-0000-0000-000000000000",
               "registrant": {
                 "kind": "github"
+              },
+              "model": {
+                "version": ""
               }
             },
             "patch": {
@@ -64,6 +70,9 @@
               "id": "00000000-0000-0000-0000-000000000000",
               "registrant": {
                 "kind": "github"
+              },
+              "model": {
+                "version": ""
               }
             },
             "patch": {

--- a/server/meshmodel/aws-eventbridge-controller/v1.2.3/v1.0.0/relationships/edge-non-binding-reference-eventbus-deployment.json
+++ b/server/meshmodel/aws-eventbridge-controller/v1.2.3/v1.0.0/relationships/edge-non-binding-reference-eventbus-deployment.json
@@ -30,36 +30,6 @@
         "from": [
           {
             "id": null,
-            "kind": "EventBus",
-            "match": {},
-            "match_strategy_matrix": null,
-            "model": {
-              "version": "",
-              "name": "aws-eventbridge-controller",
-              "displayName": "AWS EventBridge",
-              "id": "00000000-0000-0000-0000-000000000000",
-              "registrant": {
-                "kind": "github"
-              },
-              "model": {
-                "version": ""
-              }
-            },
-            "patch": {
-              "patchStrategy": "replace",
-              "mutatorRef": [
-                [
-                  "configuration",
-                  "metadata",
-                  "name"
-                ]
-              ]
-            }
-          }
-        ],
-        "to": [
-          {
-            "id": null,
             "kind": "Deployment",
             "match": {},
             "match_strategy_matrix": null,
@@ -86,6 +56,36 @@
                   "containers",
                   "_",
                   "env"
+                ]
+              ]
+            }
+          }
+        ],
+        "to": [
+          {
+            "id": null,
+            "kind": "EventBus",
+            "match": {},
+            "match_strategy_matrix": null,
+            "model": {
+              "version": "",
+              "name": "aws-eventbridge-controller",
+              "displayName": "AWS EventBridge",
+              "id": "00000000-0000-0000-0000-000000000000",
+              "registrant": {
+                "kind": "github"
+              },
+              "model": {
+                "version": ""
+              }
+            },
+            "patch": {
+              "patchStrategy": "replace",
+              "mutatorRef": [
+                [
+                  "configuration",
+                  "metadata",
+                  "name"
                 ]
               ]
             }

--- a/server/meshmodel/aws-eventbridge-controller/v1.2.3/v1.0.0/relationships/edge-non-binding-reference-eventbus-deployment.json
+++ b/server/meshmodel/aws-eventbridge-controller/v1.2.3/v1.0.0/relationships/edge-non-binding-reference-eventbus-deployment.json
@@ -1,0 +1,96 @@
+{
+  "id": "00000000-0000-0000-0000-000000000000",
+  "evaluationQuery": "",
+  "kind": "edge",
+  "metadata": {
+    "description": "An edge relationship between an AWS EventBridge EventBus and a Kubernetes Deployment, representing a Deployment whose containers interact with the EventBus.",
+    "styles": {
+      "primaryColor": "",
+      "svgColor": "",
+      "svgWhite": ""
+    },
+    "isAnnotation": false
+  },
+  "model": {
+    "version": "v1.2.3",
+    "name": "aws-eventbridge-controller",
+    "displayName": "AWS EventBridge",
+    "id": "00000000-0000-0000-0000-000000000000",
+    "registrant": {
+      "kind": "github"
+    }
+  },
+  "schemaVersion": "relationships.meshery.io/v1beta3",
+  "selectors": [
+    {
+      "allow": {
+        "from": [
+          {
+            "id": null,
+            "kind": "EventBus",
+            "match": {},
+            "match_strategy_matrix": null,
+            "model": {
+              "version": "v1.2.3",
+              "name": "aws-eventbridge-controller",
+              "displayName": "AWS EventBridge",
+              "id": "00000000-0000-0000-0000-000000000000",
+              "registrant": {
+                "kind": "github"
+              }
+            },
+            "patch": {
+              "patchStrategy": "replace",
+              "mutatorRef": [
+                [
+                  "configuration",
+                  "metadata",
+                  "name"
+                ]
+              ]
+            }
+          }
+        ],
+        "to": [
+          {
+            "id": null,
+            "kind": "Deployment",
+            "match": {},
+            "match_strategy_matrix": null,
+            "model": {
+              "version": "*",
+              "name": "kubernetes",
+              "displayName": "Kubernetes",
+              "id": "00000000-0000-0000-0000-000000000000",
+              "registrant": {
+                "kind": "github"
+              }
+            },
+            "patch": {
+              "patchStrategy": "replace",
+              "mutatedRef": [
+                [
+                  "configuration",
+                  "spec",
+                  "template",
+                  "spec",
+                  "containers",
+                  "_",
+                  "env"
+                ]
+              ]
+            }
+          }
+        ]
+      },
+      "deny": {
+        "from": [],
+        "to": []
+      }
+    }
+  ],
+  "subType": "reference",
+  "status": "enabled",
+  "type": "non-binding",
+  "version": "v1.0.0"
+}

--- a/server/meshmodel/aws-eventbridge-controller/v1.2.3/v1.0.0/relationships/edge-non-binding-reference-eventbus-pod.json
+++ b/server/meshmodel/aws-eventbridge-controller/v1.2.3/v1.0.0/relationships/edge-non-binding-reference-eventbus-pod.json
@@ -12,15 +12,18 @@
     "isAnnotation": false
   },
   "model": {
-    "version": "v1.2.3",
+    "version": "",
     "name": "aws-eventbridge-controller",
     "displayName": "AWS EventBridge",
     "id": "00000000-0000-0000-0000-000000000000",
     "registrant": {
       "kind": "github"
+    },
+    "model": {
+      "version": "v1.2.3"
     }
   },
-  "schemaVersion": "relationships.meshery.io/v1beta3",
+  "schemaVersion": "relationships.meshery.io/v1beta2",
   "selectors": [
     {
       "allow": {
@@ -31,12 +34,15 @@
             "match": {},
             "match_strategy_matrix": null,
             "model": {
-              "version": "v1.2.3",
+              "version": "",
               "name": "aws-eventbridge-controller",
               "displayName": "AWS EventBridge",
               "id": "00000000-0000-0000-0000-000000000000",
               "registrant": {
                 "kind": "github"
+              },
+              "model": {
+                "version": ""
               }
             },
             "patch": {
@@ -64,6 +70,9 @@
               "id": "00000000-0000-0000-0000-000000000000",
               "registrant": {
                 "kind": "github"
+              },
+              "model": {
+                "version": ""
               }
             },
             "patch": {

--- a/server/meshmodel/aws-eventbridge-controller/v1.2.3/v1.0.0/relationships/edge-non-binding-reference-eventbus-pod.json
+++ b/server/meshmodel/aws-eventbridge-controller/v1.2.3/v1.0.0/relationships/edge-non-binding-reference-eventbus-pod.json
@@ -30,36 +30,6 @@
         "from": [
           {
             "id": null,
-            "kind": "EventBus",
-            "match": {},
-            "match_strategy_matrix": null,
-            "model": {
-              "version": "",
-              "name": "aws-eventbridge-controller",
-              "displayName": "AWS EventBridge",
-              "id": "00000000-0000-0000-0000-000000000000",
-              "registrant": {
-                "kind": "github"
-              },
-              "model": {
-                "version": ""
-              }
-            },
-            "patch": {
-              "patchStrategy": "replace",
-              "mutatorRef": [
-                [
-                  "configuration",
-                  "metadata",
-                  "name"
-                ]
-              ]
-            }
-          }
-        ],
-        "to": [
-          {
-            "id": null,
             "kind": "Pod",
             "match": {},
             "match_strategy_matrix": null,
@@ -84,6 +54,36 @@
                   "containers",
                   "_",
                   "env"
+                ]
+              ]
+            }
+          }
+        ],
+        "to": [
+          {
+            "id": null,
+            "kind": "EventBus",
+            "match": {},
+            "match_strategy_matrix": null,
+            "model": {
+              "version": "",
+              "name": "aws-eventbridge-controller",
+              "displayName": "AWS EventBridge",
+              "id": "00000000-0000-0000-0000-000000000000",
+              "registrant": {
+                "kind": "github"
+              },
+              "model": {
+                "version": ""
+              }
+            },
+            "patch": {
+              "patchStrategy": "replace",
+              "mutatorRef": [
+                [
+                  "configuration",
+                  "metadata",
+                  "name"
                 ]
               ]
             }

--- a/server/meshmodel/aws-eventbridge-controller/v1.2.3/v1.0.0/relationships/edge-non-binding-reference-eventbus-pod.json
+++ b/server/meshmodel/aws-eventbridge-controller/v1.2.3/v1.0.0/relationships/edge-non-binding-reference-eventbus-pod.json
@@ -1,0 +1,94 @@
+{
+  "id": "00000000-0000-0000-0000-000000000000",
+  "evaluationQuery": "",
+  "kind": "edge",
+  "metadata": {
+    "description": "An edge relationship between an AWS EventBridge EventBus and a Kubernetes Pod, representing a Pod whose containers interact with the EventBus.",
+    "styles": {
+      "primaryColor": "",
+      "svgColor": "",
+      "svgWhite": ""
+    },
+    "isAnnotation": false
+  },
+  "model": {
+    "version": "v1.2.3",
+    "name": "aws-eventbridge-controller",
+    "displayName": "AWS EventBridge",
+    "id": "00000000-0000-0000-0000-000000000000",
+    "registrant": {
+      "kind": "github"
+    }
+  },
+  "schemaVersion": "relationships.meshery.io/v1beta3",
+  "selectors": [
+    {
+      "allow": {
+        "from": [
+          {
+            "id": null,
+            "kind": "EventBus",
+            "match": {},
+            "match_strategy_matrix": null,
+            "model": {
+              "version": "v1.2.3",
+              "name": "aws-eventbridge-controller",
+              "displayName": "AWS EventBridge",
+              "id": "00000000-0000-0000-0000-000000000000",
+              "registrant": {
+                "kind": "github"
+              }
+            },
+            "patch": {
+              "patchStrategy": "replace",
+              "mutatorRef": [
+                [
+                  "configuration",
+                  "metadata",
+                  "name"
+                ]
+              ]
+            }
+          }
+        ],
+        "to": [
+          {
+            "id": null,
+            "kind": "Pod",
+            "match": {},
+            "match_strategy_matrix": null,
+            "model": {
+              "version": "*",
+              "name": "kubernetes",
+              "displayName": "Kubernetes",
+              "id": "00000000-0000-0000-0000-000000000000",
+              "registrant": {
+                "kind": "github"
+              }
+            },
+            "patch": {
+              "patchStrategy": "replace",
+              "mutatedRef": [
+                [
+                  "configuration",
+                  "spec",
+                  "containers",
+                  "_",
+                  "env"
+                ]
+              ]
+            }
+          }
+        ]
+      },
+      "deny": {
+        "from": [],
+        "to": []
+      }
+    }
+  ],
+  "subType": "reference",
+  "status": "enabled",
+  "type": "non-binding",
+  "version": "v1.0.0"
+}


### PR DESCRIPTION
## Description

Adds edge non-binding reference relationships for AWS EventBridge to Kubernetes workloads.

**EventBridge (aws-eventbridge-controller v1.2.3):**
- `EventBus → Deployment` — models a Deployment whose containers publish to or consume events from an EventBridge event bus
- `EventBus → Pod` — models a Pod whose containers interact with the EventBridge event bus

EventBridge is the central event routing layer in modern AWS serverless architectures — it connects Lambda functions, SQS queues, SNS topics, and external SaaS sources. With Lambda (#19502), SQS (#19490), and SNS (#19507) already contributed, EventBridge completes the missing router that ties these services into a full event-driven architecture modelable in Meshery.

Relates to #14794
Happy to update the Meshery Integrations spreadsheet once this is merged.

## Checklist
- [x] Follows existing relationship schema (`relationships.meshery.io/v1beta2`)
- [x] registrant.kind set to github (AWS ACK controller hosted on GitHub)
- [x] from selector patch ref uses metadata.name
- [x] DCO signed off

## Note on Kanvas screenshot
The canvas shows 4 reference edges (2 × `EventBus → Deployment`, 2 × `EventBus → Pod`) due to a known Kanvas relationship evaluator behavior: the `aws-eventbridge-controller` model has 13 versions present in the registry, and the evaluator matches the same relationship definition more than once per component instance across those versions. The registry confirms only **2** reference relationship definitions exist for `EventBus` — one to `Deployment` and one to `Pod`. The relationship files are correct and the duplication is a Kanvas-side evaluation artifact, not a defect in this PR.

<img width="451" height="340" alt="Screenshot 2026-05-29 at 11 09 13 AM" src="https://github.com/user-attachments/assets/a6d62dc5-a6e4-436a-b13f-8811496a8447" />
