### PR TITLE
[system] Fix out-of-bounds panic when selecting context in setToken()

### DIFF
--- a/mesheryctl/internal/cli/root/system/config.go
+++ b/mesheryctl/internal/cli/root/system/config.go
@@ -397,6 +397,17 @@ func setToken() error {
 		if err != nil {
 			return ErrSetCurrentContext(fmt.Errorf("error reading input: %s", err.Error()))
 		}
+		
+		// check if the choice is less than 1, so wait that's bad
+		if choice < 1 {
+			return ErrSetCurrentContext(fmt.Errorf("invalid choice... cant be less than 1"))
+		}
+		// also check if choice is bigger than the length of contexts
+		maxLen := len(contexts)
+		if choice > maxLen {
+			return ErrSetCurrentContext(fmt.Errorf("invalid choice... cant be greater than max length"))
+		}
+
 		choosenCtx = contexts[choice-1]
 	}
 

--- a/mesheryctl/internal/cli/root/system/config.go
+++ b/mesheryctl/internal/cli/root/system/config.go
@@ -397,15 +397,10 @@ func setToken() error {
 		if err != nil {
 			return ErrSetCurrentContext(fmt.Errorf("error reading input: %s", err.Error()))
 		}
-		
-		// check if the choice is less than 1, so wait that's bad
-		if choice < 1 {
-			return ErrSetCurrentContext(fmt.Errorf("invalid choice... cant be less than 1"))
-		}
-		// also check if choice is bigger than the length of contexts
-		maxLen := len(contexts)
-		if choice > maxLen {
-			return ErrSetCurrentContext(fmt.Errorf("invalid choice... cant be greater than max length"))
+
+		// validate choice is in valid range
+		if choice < 1 || choice > len(contexts) {
+			return ErrSetCurrentContext(fmt.Errorf("invalid choice: must be between 1 and %d", len(contexts)))
 		}
 
 		choosenCtx = contexts[choice-1]


### PR DESCRIPTION
Summary:

This patch prevents a runtime panic in [setToken()](https://musical-goldfish-xj64w955q4jcvpqw.github.dev/) by validating interactive user input before indexing the [contexts](https://musical-goldfish-xj64w955q4jcvpqw.github.dev/) slice. If the user provides an out-of-range number (e.g., 0, negative, or greater than the number of available contexts), the command now returns a clear error instead of crashing.
Background:

[setToken()](https://musical-goldfish-xj64w955q4jcvpqw.github.dev/) previously read a numeric choice from stdin and immediately used [contexts[choice-1]](https://musical-goldfish-xj64w955q4jcvpqw.github.dev/) without bounds checking. Invalid input could trigger a Go "index out of range" panic and terminate the CLI process. This is a stability and UX issue for users working with multiple contexts.
Changes:

Validate the parsed integer choice with explicit checks:
ensure [choice >= 1](https://musical-goldfish-xj64w955q4jcvpqw.github.dev/)
ensure [choice <= len(contexts)](https://musical-goldfish-xj64w955q4jcvpqw.github.dev/)
Return a descriptive error via existing error helpers when the choice is invalid.

File modified:
[config.go:379-400](https://musical-goldfish-xj64w955q4jcvpqw.github.dev/)
Behavior:

On invalid input, the CLI exits gracefully with a user-facing error message describing valid input range rather than panicking.
No change to normal flows when a valid context number is provided.
Testing:

Ran go test --short workspaces. for the [mesheryctl](https://musical-goldfish-xj64w955q4jcvpqw.github.dev/) module. Existing unrelated failures in the connections package pre-existed and are unaffected by this change; tests covering system passed locally.
Manual verification: when prompted to select a context, entering an out-of-range number now produces a clear error and no panic.
Impact & Risk:

Low risk: change is localized to [setToken()](https://musical-goldfish-xj64w955q4jcvpqw.github.dev/) input handling and only adds defensive validation.
Backwards compatibility: unchanged for valid inputs and scripting where --context flags are used; interactive behavior is improved.
Notes for reviewers: