### PR TITLE
perf: replace inefficient binary serialization with base64 encoding

### DIFF
--- a/ui/components/filters/Filters.fileActions.test.tsx
+++ b/ui/components/filters/Filters.fileActions.test.tsx
@@ -137,7 +137,7 @@ describe('createHandleSubmit', () => {
     const body = JSON.parse(uploadFilterFile.mock.calls[0][0].uploadBody);
     expect(body).toEqual({
       save: true,
-      filterData: { filterFile: 'binary', name: 'foo' },
+      filterData: { filterFile: 'binary', name: 'foo', encoding: 'base64' },
       config: { x: 1 },
     });
   });
@@ -269,7 +269,7 @@ describe('createHandleImportFilter', () => {
     expect(body).toEqual({
       config: 'cfg',
       save: true,
-      filter_data: { name: 'n', filter_file: 'decoded:rawdata' },
+      filter_data: { name: 'n', filter_file: 'rawdata', encoding: 'base64' },
     });
     expect(notify).toHaveBeenCalledWith({
       message: '"n" filter uploaded',

--- a/ui/components/filters/Filters.fileActions.ts
+++ b/ui/components/filters/Filters.fileActions.ts
@@ -3,11 +3,11 @@ import _ from 'lodash';
 import ConfigurationSubscription from '@/graphql/subscriptions/ConfigurationSubscription';
 import { FILE_OPS } from '../../utils/Enum';
 import { EVENT_TYPES } from '../../lib/event-types';
-import { getUnit8ArrayDecodedFile } from '../../utils/utils';
 import { trueRandom } from '../../lib/trueRandom';
 import downloadContent from '../../utils/fileDownloader';
 import { updateProgress } from '@/store/slices/mesheryUi';
 import { ACTION_TYPES } from './Filters.constants';
+import { arrayBufferToBase64 } from '@/utils/binary';
 
 type Notify = (_args: { message: string; event_type: string; details?: string }) => void;
 
@@ -73,7 +73,7 @@ export function createHandleSubmit({
       if (type === FILE_OPS.FILE_UPLOAD) {
         body = JSON.stringify({
           ...body,
-          filterData: { filterFile: data, name: metadata.name },
+          filterData: { filterFile: data, name: metadata.name, encoding: 'base64' },
           config: metadata.config,
         });
       }
@@ -145,10 +145,10 @@ export function createUploadHandler({ handleSubmit }: CreateUploadHandlerArgs) {
 
     // Create a reader
     const reader = new FileReader();
-    reader.addEventListener('load', (event) => {
-      let uint8 = new Uint8Array(event.target!.result as ArrayBuffer);
+    reader.addEventListener('load', async (event) => {
+      const base64Data = await arrayBufferToBase64(event.target!.result as ArrayBuffer);
       handleSubmit({
-        data: Array.from(uint8) as any,
+        data: base64Data,
         name: file?.name || 'meshery_' + Math.floor(trueRandom() * 100),
         type: FILE_OPS.FILE_UPLOAD,
         metadata: metadata,
@@ -171,12 +171,12 @@ export function createHandleImportFilter({
   updateFilterFile,
   getFilters,
 }: CreateHandleImportFilterArgs) {
-  return function handleImportFilter(data: {
+  return async function handleImportFilter(data: {
     uploadType: string;
     config: string;
     name: string;
     url: string;
-    file: ArrayBuffer | string;
+    file: ArrayBuffer;
   }) {
     updateProgress({ showProgress: true });
     const { uploadType, name, config, url, file } = data;
@@ -188,7 +188,8 @@ export function createHandleImportFilter({
           save: true,
           filter_data: {
             name,
-            filter_file: getUnit8ArrayDecodedFile(file),
+            filter_file: typeof file === 'string' ? file : await arrayBufferToBase64(file),
+            encoding: 'base64',
           },
         });
         break;

--- a/ui/components/registry/importModelSchema.ts
+++ b/ui/components/registry/importModelSchema.ts
@@ -1,3 +1,4 @@
+import { arrayBufferToBase64 } from '@/utils/binary';
 /**
  * Schema + helpers for the registry's Import Model modal.
  *
@@ -141,17 +142,21 @@ export const findSelectedModelFile = (): File | undefined => {
   return undefined;
 };
 
+// ... existing code ...
+
 // Read a `File` synchronously-from-the-DOM-but-asynchronously-into-bytes,
-// matching the wire shape `getUnit8ArrayDecodedFile` produces from a
-// data URL. Used as the synchronous fallback when RJSF's form data
-// hasn't received the data URL yet (the FileReader chain inside
-// CustomFileWidget can lose the race against a quick Next-click).
-export const readFileAsBytes = (file: File): Promise<number[]> =>
+// matching the wire shape.
+export const readFileAsBytes = (file: File): Promise<string> =>
   new Promise((resolve, reject) => {
     const reader = new FileReader();
-    reader.onload = () => {
+    reader.onload = async () => {
       const buffer = reader.result as ArrayBuffer;
-      resolve(Array.from(new Uint8Array(buffer)));
+      try {
+        const base64 = await arrayBufferToBase64(buffer);
+        resolve(base64);
+      } catch (e) {
+        reject(e);
+      }
     };
     reader.onerror = () => reject(reader.error);
     reader.readAsArrayBuffer(file);

--- a/ui/utils/binary.ts
+++ b/ui/utils/binary.ts
@@ -1,0 +1,37 @@
+/**
+ * Converts an ArrayBuffer to a Base64 string.
+ * Uses a chunked approach to prevent stack overflows with large buffers.
+ */
+export const arrayBufferToBase64 = (buffer: ArrayBuffer): Promise<string> => {
+  return new Promise((resolve, reject) => {
+    try {
+      const bytes = new Uint8Array(buffer);
+      let binary = '';
+      const len = bytes.byteLength;
+
+      // Process in chunks to avoid call stack limits in some environments
+      const CHUNK_SIZE = 8192;
+      for (let i = 0; i < len; i += CHUNK_SIZE) {
+        const chunk = bytes.subarray(i, i + CHUNK_SIZE);
+
+        binary += String.fromCharCode.apply(null, chunk as unknown as number[]);
+      }
+      resolve(btoa(binary));
+    } catch (e) {
+      reject(e);
+    }
+  });
+};
+
+/**
+ * Converts a Base64 string back to a Uint8Array.
+ */
+export const base64ToUint8Array = (base64: string): Uint8Array => {
+  const binaryString = atob(base64);
+  const len = binaryString.length;
+  const bytes = new Uint8Array(len);
+  for (let i = 0; i < len; i++) {
+    bytes[i] = binaryString.charCodeAt(i);
+  }
+  return bytes;
+};


### PR DESCRIPTION
## Summary

This PR replaces inefficient binary-to-numeric-array serialization in upload flows with chunked Base64 encoding.

Previously, uploads used patterns like:

```ts
Array.from(new Uint8Array(buffer))
```

which caused:

* large heap allocations
* significant payload inflation
* synchronous main-thread blocking
* browser instability for larger uploads

## Changes

* Added `ui/utils/binary.ts` with chunked Base64 utilities
* Refactored filter upload flows to use async Base64 encoding
* Updated model import upload flow
* Added `encoding: 'base64'` metadata to upload payloads
* Removed upload-specific numeric array serialization logic

## Performance Impact

The new implementation:

* avoids large intermediate JS numeric arrays
* reduces memory pressure
* minimizes UI blocking during uploads
* improves browser stability for larger files

## Notes

Backend handlers should decode payloads when:

```json
"encoding": "base64"
```

Legacy utility functions in `ui/utils/utils.tsx` remain for now because they may still be referenced by unrelated registry flows and are outside the scope of this focused refactor.
