### PR TITLE
[CI] Fix stable release workflow warnings

### DIFF
--- a/.github/workflows/build-and-release-dde.yml
+++ b/.github/workflows/build-and-release-dde.yml
@@ -1,6 +1,22 @@
 name: Docker Extension for Meshery
 on:
   workflow_call:
+    inputs:
+      release-ver:
+        description: "Stable Release Version"
+        required: false
+        type: string
+        default: "v"
+      stripped-release-ver:
+        description: "Stripped Stable Release Version"
+        required: false
+        type: string
+        default: ""
+      release-channel:
+        description: "Release Channel"
+        required: false
+        type: string
+        default: "edge"
   # push:
   #   tags:
   #     - "v*"
@@ -20,9 +36,9 @@ on:
         default: "edge"
 
 env:
-  GIT_VERSION: ${{github.event.inputs.release-ver}}
-  GIT_STRIPPED_VERSION: ${{github.event.inputs.stripped-release-ver}}
-  RELEASE_CHANNEL: ${{github.event.inputs.release-channel}}
+  GIT_VERSION: ${{ inputs.release-ver }}
+  GIT_STRIPPED_VERSION: ${{ inputs.stripped-release-ver }}
+  RELEASE_CHANNEL: ${{ inputs.release-channel }}
   GIT_TAG: ${{ github.event.release.tag_name }}
 
 jobs:
@@ -30,11 +46,11 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - run: |
-          echo "Dispatched GIT_VERSION: ${{github.event.inputs.release-ver}}"
-          echo " Dispatched GIT_STRIPPED_VERSION: ${{github.event.inputs.stripped-release-ver}}"
-          echo "Env RELEASE_CHANNEL: ${{env.RELEASE_CHANNEL}}"
-          echo "Env GIT_VERSION: ${{env.GIT_VERSION}}"
-          echo "Env GIT_STRIPPED_VERSION: ${{env.GIT_STRIPPED_VERSION}}"
+          echo "Dispatched GIT_VERSION: ${{ inputs.release-ver }}"
+          echo "Dispatched GIT_STRIPPED_VERSION: ${{ inputs.stripped-release-ver }}"
+          echo "Env RELEASE_CHANNEL: ${{ env.RELEASE_CHANNEL }}"
+          echo "Env GIT_VERSION: ${{ env.GIT_VERSION }}"
+          echo "Env GIT_STRIPPED_VERSION: ${{ env.GIT_STRIPPED_VERSION }}"
           echo "Env GIT_TAG: ${{ github.event.release.tag_name }}"
 
   docker-extension:
@@ -43,7 +59,7 @@ jobs:
       - name: Checkout 🛎️ repo
         uses: actions/checkout@v6
       - name: Identify Release Values
-        if: "${{ github.event.inputs.release-ver}} != 'v' }}"
+        if: ${{ github.event_name != 'workflow_dispatch' || inputs.release-ver == 'v' }}
         run: |
           # GIT_TAG=`git symbolic-ref HEAD`
           if [[ ${GITHUB_REF} = refs/tags* ]]
@@ -79,7 +95,7 @@ jobs:
             type=raw,value=${{env.RELEASE_CHANNEL}}-latest
             type=raw,value=${{env.RELEASE_CHANNEL}}-${{env.GIT_VERSION}},enable=${{ startsWith(github.ref, 'refs/tags/v') }}
       - name: Login to DockerHub
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}

--- a/.github/workflows/build-and-release-stable.yml
+++ b/.github/workflows/build-and-release-stable.yml
@@ -26,7 +26,7 @@ jobs:
           sudo rm -rf /var/lib/apt/lists/*
           docker system prune -af
       - name: Login to DockerHub
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}

--- a/.github/workflows/helm-chart-releaser.yml
+++ b/.github/workflows/helm-chart-releaser.yml
@@ -40,7 +40,7 @@ jobs:
       run: helm lint install/kubernetes/helm/meshery-operator --with-subcharts
   release-chart:
     runs-on: ubuntu-24.04
-    if: ${{ github.event_name != 'pull_request' }} && ${{ github.ref == 'refs/heads/master' }}
+    if: ${{ github.event_name != 'pull_request' }}
     steps:
       - uses: actions/checkout@master
       - name: set env


### PR DESCRIPTION
## Summary
- fix the malformed reusable-workflow condition in the Docker extension release workflow
- fix the helm chart releaser job condition so the stable workflow no longer inherits a syntax warning
- bump docker/login-action to v4 in the stable release path to remove the Node 20 deprecation warning

## Validation
- actionlint -ignore 'shellcheck reported issue' .github/workflows/build-and-release-stable.yml .github/workflows/build-and-release-dde.yml .github/workflows/helm-chart-releaser.yml