### PR TITLE
[Server] Batch adapter event streaming

### DIFF
--- a/server/handlers/events_streamer.go
+++ b/server/handlers/events_streamer.go
@@ -39,6 +39,16 @@ func defaultSubscribeToEventStream(eb *_events.EventStreamer, ch chan interface{
 // traffic; the timeout keeps the handler from waiting on an idle publisher.
 const eventStreamDrainTimeout = 100 * time.Millisecond
 
+const (
+	adapterEventStreamBatchSize   = 50
+	adapterEventStreamBatchWindow = 250 * time.Millisecond
+)
+
+type adapterEventStreamResult struct {
+	event *meshes.EventsResponse
+	err   error
+}
+
 type eventStatusPayload struct {
 	Status    string       `json:"status"`
 	StatusIDs []*core.Uuid `json:"ids"`
@@ -464,6 +474,122 @@ func listenForCoreEvents(ctx context.Context, eb *_events.EventStreamer, resp ch
 		}
 	}
 }
+
+func receiveAdapterEvents(ctx context.Context, streamClient meshes.MeshService_StreamEventsClient) <-chan adapterEventStreamResult {
+	eventResults := make(chan adapterEventStreamResult)
+	go func() {
+		defer close(eventResults)
+		for {
+			event, err := streamClient.Recv()
+			select {
+			case eventResults <- adapterEventStreamResult{event: event, err: err}:
+			case <-ctx.Done():
+				return
+			}
+			if err != nil {
+				return
+			}
+		}
+	}()
+
+	return eventResults
+}
+
+func forwardAdapterEventBatches(ctx context.Context, eventResults <-chan adapterEventStreamResult, respChan chan<- []byte, log logger.Handler, batchSize int, batchWindow time.Duration, onEvent func(*meshes.EventsResponse)) {
+	if batchSize <= 0 {
+		batchSize = adapterEventStreamBatchSize
+	}
+	if batchWindow <= 0 {
+		batchWindow = adapterEventStreamBatchWindow
+	}
+
+	batch := make([]*meshes.EventsResponse, 0, batchSize)
+	var batchTimer *time.Timer
+	var batchTimerC <-chan time.Time
+
+	stopBatchTimer := func() {
+		if batchTimer == nil {
+			return
+		}
+		if !batchTimer.Stop() {
+			select {
+			case <-batchTimer.C:
+			default:
+			}
+		}
+		batchTimer = nil
+		batchTimerC = nil
+	}
+	defer stopBatchTimer()
+
+	startBatchTimer := func() {
+		if batchTimer != nil {
+			return
+		}
+		batchTimer = time.NewTimer(batchWindow)
+		batchTimerC = batchTimer.C
+	}
+
+	flushBatch := func() bool {
+		if len(batch) == 0 {
+			stopBatchTimer()
+			return true
+		}
+
+		data, err := json.Marshal(batch)
+		if err != nil {
+			log.Error(models.ErrMarshal(err, "adapter event batch"))
+			return false
+		}
+
+		if !sendStreamEvent(ctx, respChan, data) {
+			return false
+		}
+
+		batch = batch[:0]
+		stopBatchTimer()
+		return true
+	}
+
+	for {
+		select {
+		case result, ok := <-eventResults:
+			if !ok {
+				flushBatch()
+				return
+			}
+			if result.err != nil {
+				log.Error(ErrStreamClient(result.err))
+				flushBatch()
+				return
+			}
+			if result.event == nil {
+				continue
+			}
+
+			if onEvent != nil {
+				onEvent(result.event)
+			}
+
+			batch = append(batch, result.event)
+			if len(batch) == 1 {
+				startBatchTimer()
+			}
+			if len(batch) >= batchSize && !flushBatch() {
+				return
+			}
+		case <-batchTimerC:
+			batchTimer = nil
+			batchTimerC = nil
+			if !flushBatch() {
+				return
+			}
+		case <-ctx.Done():
+			return
+		}
+	}
+}
+
 func listenForAdapterEvents(ctx context.Context, mClient *meshes.MeshClient, respChan chan []byte, log logger.Handler, p models.Provider, ec *models.Broadcast, systemID core.Uuid, userID string) {
 	log.Debug("Received a stream client...")
 	token, _ := ctx.Value(models.TokenCtxKey).(string)
@@ -476,17 +602,9 @@ func listenForAdapterEvents(ctx context.Context, mClient *meshes.MeshClient, res
 		return
 	}
 
-	for {
+	eventResults := receiveAdapterEvents(ctx, streamClient)
+	forwardAdapterEventBatches(ctx, eventResults, respChan, log, adapterEventStreamBatchSize, adapterEventStreamBatchWindow, func(event *meshes.EventsResponse) {
 		log.Debug("Waiting to receive events.")
-		event, err := streamClient.Recv()
-		if err != nil {
-			if err == io.EOF {
-				log.Error(ErrStreamClient(err))
-				return
-			}
-			log.Error(ErrStreamClient(err))
-			return
-		}
 		// log.Debugf("received an event: %+#v", event)
 		log.Debug("Received an event.")
 		eventType := event.EventType.String()
@@ -506,16 +624,7 @@ func listenForAdapterEvents(ctx context.Context, mClient *meshes.MeshClient, res
 		_event := eventBuilder.Build()
 		_ = p.PersistEvent(*_event, token)
 		ec.Publish(userUUID, _event)
-
-		data, err := json.Marshal(event)
-		if err != nil {
-			log.Error(models.ErrMarshal(err, "event"))
-			return
-		}
-		if !sendStreamEvent(ctx, respChan, data) {
-			return
-		}
-	}
+	})
 }
 
 func closeAdapterConnections(localMeshAdaptersLock *sync.Mutex, localMeshAdapters map[string]*meshes.MeshClient) map[string]*meshes.MeshClient {

--- a/server/handlers/events_streamer.go
+++ b/server/handlers/events_streamer.go
@@ -40,6 +40,11 @@ func defaultSubscribeToEventStream(eb *_events.EventStreamer, ch chan interface{
 const eventStreamDrainTimeout = 100 * time.Millisecond
 
 const (
+	// Adapter streams can emit very high-volume bursts during MeshSync. Sending
+	// each event individually means a 1,000-event burst becomes 1,000 SSE writes
+	// and 1,000 downstream UI update opportunities. Batching 50 at a time turns
+	// the same burst into about 20 SSE writes, while the 250ms window caps the
+	// added latency for smaller trickles at a quarter second.
 	adapterEventStreamBatchSize   = 50
 	adapterEventStreamBatchWindow = 250 * time.Millisecond
 )

--- a/server/handlers/events_streamer_test.go
+++ b/server/handlers/events_streamer_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"sync"
 	"sync/atomic"
 	"testing"
@@ -271,6 +272,35 @@ func TestForwardAdapterEventBatches_FlushesOnStreamClose(t *testing.T) {
 	}
 
 	waitForSignal(t, done, "stream-close forwarder shutdown")
+}
+
+func TestForwardAdapterEventBatches_FlushesPendingBatchOnStreamError(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	log := newTestLogger(t)
+	eventResults := make(chan adapterEventStreamResult)
+	respChan := make(chan []byte, 1)
+	done := make(chan struct{})
+
+	go func() {
+		forwardAdapterEventBatches(ctx, eventResults, respChan, log, 50, time.Hour, nil)
+		close(done)
+	}()
+
+	eventResults <- adapterEventStreamResult{event: &meshes.EventsResponse{Summary: "pending-before-error"}}
+	eventResults <- adapterEventStreamResult{err: errors.New("adapter stream failed")}
+
+	payload := waitForPayload(t, respChan, "stream-error flush")
+	events := decodeAdapterEventBatch(t, payload)
+	if len(events) != 1 {
+		t.Fatalf("expected 1 event in error batch, got %d", len(events))
+	}
+	if events[0].Summary != "pending-before-error" {
+		t.Fatalf("expected pending event summary, got %q", events[0].Summary)
+	}
+
+	waitForSignal(t, done, "stream-error forwarder shutdown")
 }
 
 func TestWriteEventStream_StopsOnContextCancellation(t *testing.T) {

--- a/server/handlers/events_streamer_test.go
+++ b/server/handlers/events_streamer_test.go
@@ -200,10 +200,10 @@ func TestForwardAdapterEventBatches_FlushesAtBatchSize(t *testing.T) {
 	if len(events) != 3 {
 		t.Fatalf("expected 3 events in batch, got %d", len(events))
 	}
-	for i, event := range events {
+	for i := range events {
 		expected := "event-" + string(rune('1'+i))
-		if event.Summary != expected {
-			t.Fatalf("expected event %d summary %q, got %q", i, expected, event.Summary)
+		if events[i].Summary != expected {
+			t.Fatalf("expected event %d summary %q, got %q", i, expected, events[i].Summary)
 		}
 	}
 	if processed.Load() != 3 {

--- a/server/handlers/events_streamer_test.go
+++ b/server/handlers/events_streamer_test.go
@@ -3,6 +3,7 @@ package handlers
 import (
 	"bytes"
 	"context"
+	"encoding/json"
 	"sync"
 	"sync/atomic"
 	"testing"
@@ -92,6 +93,17 @@ func waitForPayload(t *testing.T, ch <-chan []byte, name string) []byte {
 	panic("unreachable")
 }
 
+func decodeAdapterEventBatch(t *testing.T, payload []byte) []meshes.EventsResponse {
+	t.Helper()
+
+	var events []meshes.EventsResponse
+	if err := json.Unmarshal(payload, &events); err != nil {
+		t.Fatalf("failed to unmarshal adapter event batch %s: %v", payload, err)
+	}
+
+	return events
+}
+
 func assertNoPayload(t *testing.T, ch <-chan []byte, name string) {
 	t.Helper()
 
@@ -160,6 +172,105 @@ func TestSendStreamEvent(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestForwardAdapterEventBatches_FlushesAtBatchSize(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	log := newTestLogger(t)
+	eventResults := make(chan adapterEventStreamResult)
+	respChan := make(chan []byte, 1)
+	done := make(chan struct{})
+	var processed atomic.Int32
+
+	go func() {
+		forwardAdapterEventBatches(ctx, eventResults, respChan, log, 3, time.Hour, func(event *meshes.EventsResponse) {
+			processed.Add(1)
+		})
+		close(done)
+	}()
+
+	eventResults <- adapterEventStreamResult{event: &meshes.EventsResponse{Summary: "event-1"}}
+	eventResults <- adapterEventStreamResult{event: &meshes.EventsResponse{Summary: "event-2"}}
+	eventResults <- adapterEventStreamResult{event: &meshes.EventsResponse{Summary: "event-3"}}
+
+	payload := waitForPayload(t, respChan, "batch-size flush")
+	events := decodeAdapterEventBatch(t, payload)
+	if len(events) != 3 {
+		t.Fatalf("expected 3 events in batch, got %d", len(events))
+	}
+	for i, event := range events {
+		expected := "event-" + string(rune('1'+i))
+		if event.Summary != expected {
+			t.Fatalf("expected event %d summary %q, got %q", i, expected, event.Summary)
+		}
+	}
+	if processed.Load() != 3 {
+		t.Fatalf("expected callback to process 3 events, got %d", processed.Load())
+	}
+
+	cancel()
+	waitForSignal(t, done, "batch-size forwarder shutdown")
+}
+
+func TestForwardAdapterEventBatches_FlushesAfterWindow(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	log := newTestLogger(t)
+	eventResults := make(chan adapterEventStreamResult)
+	respChan := make(chan []byte, 1)
+	done := make(chan struct{})
+
+	go func() {
+		forwardAdapterEventBatches(ctx, eventResults, respChan, log, 50, 20*time.Millisecond, nil)
+		close(done)
+	}()
+
+	eventResults <- adapterEventStreamResult{event: &meshes.EventsResponse{Summary: "windowed-event"}}
+
+	payload := waitForPayload(t, respChan, "batch-window flush")
+	events := decodeAdapterEventBatch(t, payload)
+	if len(events) != 1 {
+		t.Fatalf("expected 1 event in timed batch, got %d", len(events))
+	}
+	if events[0].Summary != "windowed-event" {
+		t.Fatalf("expected timed event summary, got %q", events[0].Summary)
+	}
+
+	cancel()
+	waitForSignal(t, done, "batch-window forwarder shutdown")
+}
+
+func TestForwardAdapterEventBatches_FlushesOnStreamClose(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	log := newTestLogger(t)
+	eventResults := make(chan adapterEventStreamResult)
+	respChan := make(chan []byte, 1)
+	done := make(chan struct{})
+
+	go func() {
+		forwardAdapterEventBatches(ctx, eventResults, respChan, log, 50, time.Hour, nil)
+		close(done)
+	}()
+
+	eventResults <- adapterEventStreamResult{event: &meshes.EventsResponse{Summary: "stream-close-1"}}
+	eventResults <- adapterEventStreamResult{event: &meshes.EventsResponse{Summary: "stream-close-2"}}
+	close(eventResults)
+
+	payload := waitForPayload(t, respChan, "stream-close flush")
+	events := decodeAdapterEventBatch(t, payload)
+	if len(events) != 2 {
+		t.Fatalf("expected 2 events in close batch, got %d", len(events))
+	}
+	if events[0].Summary != "stream-close-1" || events[1].Summary != "stream-close-2" {
+		t.Fatalf("unexpected stream-close event order: %#v", events)
+	}
+
+	waitForSignal(t, done, "stream-close forwarder shutdown")
 }
 
 func TestWriteEventStream_StopsOnContextCancellation(t *testing.T) {

--- a/ui/machines/__tests__/index.test.ts
+++ b/ui/machines/__tests__/index.test.ts
@@ -18,7 +18,7 @@ vi.mock('@/graphql/subscriptions/EventsSubscription', () => ({
   default: () => ({ dispose: vi.fn() }),
 }));
 vi.mock('../../store', () => ({ store: { dispatch: vi.fn() } }));
-vi.mock('@/store/slices/events', () => ({ pushEvent: vi.fn() }));
+vi.mock('@/store/slices/events', () => ({ pushEvent: vi.fn(), pushEvents: vi.fn() }));
 vi.mock('../../rtk-query', () => ({ api: { util: { invalidateTags: vi.fn() } } }));
 vi.mock('@/rtk-query/notificationCenter', () => ({ PROVIDER_TAGS: { EVENT: 'Event' } }));
 vi.mock('@/components/layout/NotificationCenter/constants', () => ({

--- a/ui/machines/__tests__/operationsCenter.test.ts
+++ b/ui/machines/__tests__/operationsCenter.test.ts
@@ -191,6 +191,10 @@ describe('operationsCenter machine', () => {
 
   it('forwards subscription event batches into the machine via the next callback', () => {
     const { actor } = startActor();
+    const seen: unknown[] = [];
+    actor.on('*', (event) => {
+      seen.push(event);
+    });
     const eventBatch = [
       { id: 'live-1', description: 'streamed one', severity: 'warning' },
       { id: 'live-2', description: 'streamed two', severity: 'informational' },
@@ -198,6 +202,11 @@ describe('operationsCenter machine', () => {
     subscriptionState.onEvent?.({ events: eventBatch });
     expect(pushEvents).toHaveBeenCalledWith(eventBatch);
     expect(pushEvent).not.toHaveBeenCalled();
+    const emitted = seen.find(
+      (e: { type?: string }) => e?.type === OPERATION_CENTER_EVENTS.EVENT_RECEIVED_FROM_SERVER,
+    ) as { data?: { event?: unknown } } | undefined;
+    expect(emitted?.data?.event).toEqual(eventBatch);
+    expect(Array.isArray(emitted?.data?.event)).toBe(true);
     actor.stop();
   });
 

--- a/ui/machines/__tests__/operationsCenter.test.ts
+++ b/ui/machines/__tests__/operationsCenter.test.ts
@@ -7,7 +7,7 @@ import { createActor } from 'xstate';
 // NotificationCenter constants so we can drive events and assert side
 // effects.
 
-type EventCallback = (result: { event?: unknown }) => void;
+type EventCallback = (result: { event?: unknown; events?: unknown[] }) => void;
 type ErrorCallback = (err: unknown) => void;
 
 const hoisted = vi.hoisted(() => ({
@@ -18,10 +18,12 @@ const hoisted = vi.hoisted(() => ({
   },
   dispatch: vi.fn(),
   pushEvent: vi.fn((p: unknown) => ({ type: 'events/pushEvent', payload: p })),
+  pushEvents: vi.fn((p: unknown) => ({ type: 'events/pushEvents', payload: p })),
 }));
 const subscriptionState = hoisted.subscriptionState;
 const dispatch = hoisted.dispatch;
 const pushEvent = hoisted.pushEvent;
+const pushEvents = hoisted.pushEvents;
 
 vi.mock('@/graphql/subscriptions/EventsSubscription', () => ({
   default: (next: EventCallback, error: ErrorCallback) => {
@@ -37,6 +39,7 @@ vi.mock('../../store', () => ({
 
 vi.mock('@/store/slices/events', () => ({
   pushEvent: (p: unknown) => hoisted.pushEvent(p),
+  pushEvents: (p: unknown) => hoisted.pushEvents(p),
 }));
 
 vi.mock('../../rtk-query', () => ({
@@ -68,6 +71,7 @@ describe('operationsCenter machine', () => {
   beforeEach(() => {
     dispatch.mockClear();
     pushEvent.mockClear();
+    pushEvents.mockClear();
     subscriptionState.dispose.mockClear();
     subscriptionState.onEvent = undefined;
     subscriptionState.onError = undefined;
@@ -79,6 +83,43 @@ describe('operationsCenter machine', () => {
     expect(snap.value).toBe('idle');
     expect(subscriptionState.onEvent).toBeTypeOf('function');
     expect(subscriptionState.onError).toBeTypeOf('function');
+    actor.stop();
+  });
+
+  it('stores received event batches in redux and sends one batch notifier', () => {
+    const { actor, notify } = startActor();
+
+    const eventBatch = [
+      {
+        id: 'evt-1',
+        description: 'A thing happened',
+        severity: 'informational',
+        createdAt: '2025-01-01T00:00:00Z',
+      },
+      {
+        id: 'evt-2',
+        description: 'A bad thing happened',
+        severity: 'error',
+        createdAt: '2025-01-01T00:00:01Z',
+      },
+    ];
+
+    actor.send({
+      type: OPERATION_CENTER_EVENTS.EVENT_RECEIVED_FROM_SERVER,
+      data: { event: eventBatch },
+    });
+
+    expect(pushEvent).not.toHaveBeenCalled();
+    expect(pushEvents).toHaveBeenCalledWith(eventBatch);
+    expect(dispatch).toHaveBeenCalledWith({ type: 'events/pushEvents', payload: eventBatch });
+    expect(notify).toHaveBeenCalledTimes(1);
+    expect(notify).toHaveBeenCalledWith({
+      message: '2 events received',
+      event_type: 'error',
+      id: 'evt-2',
+      showInNotificationCenter: true,
+    });
+
     actor.stop();
   });
 
@@ -145,6 +186,18 @@ describe('operationsCenter machine', () => {
     const event = { id: 'live', description: 'streamed', severity: 'warning' };
     subscriptionState.onEvent?.({ event });
     expect(pushEvent).toHaveBeenCalledWith(event);
+    actor.stop();
+  });
+
+  it('forwards subscription event batches into the machine via the next callback', () => {
+    const { actor } = startActor();
+    const eventBatch = [
+      { id: 'live-1', description: 'streamed one', severity: 'warning' },
+      { id: 'live-2', description: 'streamed two', severity: 'informational' },
+    ];
+    subscriptionState.onEvent?.({ events: eventBatch });
+    expect(pushEvents).toHaveBeenCalledWith(eventBatch);
+    expect(pushEvent).not.toHaveBeenCalled();
     actor.stop();
   });
 

--- a/ui/machines/operationsCenter.ts
+++ b/ui/machines/operationsCenter.ts
@@ -2,13 +2,55 @@ import { SEVERITY_TO_NOTIFICATION_TYPE_MAPPING } from '@/components/layout/Notif
 import subscribeEvents from '@/graphql/subscriptions/EventsSubscription';
 import { emit, fromCallback, setup, spawnChild, stopChild } from 'xstate';
 import { store } from '../store';
-import { pushEvent } from '@/store/slices/events';
+import { pushEvent, pushEvents } from '@/store/slices/events';
 import { api as mesheryApi } from '../rtk-query';
 import { PROVIDER_TAGS } from '@/rtk-query/notificationCenter';
+
+const SEVERITY_RANK = {
+  error: 4,
+  warning: 3,
+  success: 2,
+  informational: 1,
+  info: 1,
+};
+
 export const OPERATION_CENTER_EVENTS = {
   EVENT_RECEIVED_FROM_SERVER: 'EVENT_RECEIVED_FROM_SERVER',
   ERROR_OCCURRED_IN_SUBSCRIPTION: 'ERROR_OCCURRED_IN_SUBSCRIPTION',
 };
+
+const normalizeServerEvents = (payload) => {
+  if (!payload) {
+    return [];
+  }
+  if (Array.isArray(payload)) {
+    return payload.filter(Boolean);
+  }
+
+  const hasEventEnvelope =
+    Object.prototype.hasOwnProperty.call(payload, 'events') ||
+    Object.prototype.hasOwnProperty.call(payload, 'event');
+  const eventsPayload = hasEventEnvelope ? (payload.events ?? payload.event) : payload;
+  if (Array.isArray(eventsPayload)) {
+    return eventsPayload.filter(Boolean);
+  }
+  return eventsPayload && Object.keys(eventsPayload).length > 0 ? [eventsPayload] : [];
+};
+
+const getRepresentativeEvent = (events) => {
+  return events.reduce((selected, event) => {
+    const selectedRank = SEVERITY_RANK[selected?.severity] || 0;
+    const eventRank = SEVERITY_RANK[event?.severity] || 0;
+    if (eventRank > selectedRank) {
+      return event;
+    }
+    if (eventRank === selectedRank && event?.createdAt && selected?.createdAt) {
+      return event.createdAt > selected.createdAt ? event : selected;
+    }
+    return selected;
+  }, events[0]);
+};
+
 const events = {
   eventReceivedFromServer: (event) => ({
     type: OPERATION_CENTER_EVENTS.EVENT_RECEIVED_FROM_SERVER,
@@ -28,7 +70,8 @@ const subscriptionActor = fromCallback(({ sendBack }) => {
   const subscription = subscribeEvents(
     (result) => {
       try {
-        if (!result.event) {
+        const receivedEvents = normalizeServerEvents(result);
+        if (receivedEvents.length === 0) {
           console.error('Invalid event received', result);
           return;
         }
@@ -36,7 +79,11 @@ const subscriptionActor = fromCallback(({ sendBack }) => {
         // GraphQL Event payload (canonical camelCase) is consumed as-is by
         // downstream UI; meshkit Event JSON tags also flipped to camelCase in
         // v1.0.7 so the REST /api/system/events list endpoint matches.
-        sendBack(events.eventReceivedFromServer(result.event));
+        sendBack(
+          events.eventReceivedFromServer(
+            receivedEvents.length === 1 ? receivedEvents[0] : receivedEvents,
+          ),
+        );
       } catch (error) {
         console.error('[operationsCenter] An error occurred in processing event', error);
       }
@@ -58,15 +105,29 @@ export const operationsCenterActor = setup({
       id: 'subscriptionActor',
     }),
     storeInRedux: ({ event }) => {
-      store.dispatch(pushEvent(event.data.event));
+      const receivedEvents = normalizeServerEvents(event.data);
+      if (receivedEvents.length === 1) {
+        store.dispatch(pushEvent(receivedEvents[0]));
+        return;
+      }
+      if (receivedEvents.length > 1) {
+        store.dispatch(pushEvents(receivedEvents));
+      }
     },
     invalidateRtk: () => {
       store.dispatch(mesheryApi.util.invalidateTags([PROVIDER_TAGS.EVENT]));
     },
     notifyUI: ({ context, event }) => {
-      const validatedEvent = event.data.event;
+      const receivedEvents = normalizeServerEvents(event.data);
+      if (receivedEvents.length === 0) {
+        return;
+      }
+      const validatedEvent = getRepresentativeEvent(receivedEvents);
       context.notify({
-        message: validatedEvent.description,
+        message:
+          receivedEvents.length === 1
+            ? validatedEvent.description
+            : `${receivedEvents.length} events received`,
         event_type: SEVERITY_TO_NOTIFICATION_TYPE_MAPPING[validatedEvent.severity],
         id: validatedEvent.id,
         showInNotificationCenter: true,

--- a/ui/store/slices/__tests__/events.test.ts
+++ b/ui/store/slices/__tests__/events.test.ts
@@ -1,6 +1,18 @@
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, vi } from 'vitest';
+
+vi.mock('../../../components/layout/NotificationCenter/constants', () => ({
+  SEVERITY: {
+    INFO: 'informational',
+  },
+  STATUS: {
+    READ: 'read',
+    UNREAD: 'unread',
+  },
+}));
+
 import eventsReducer, {
   pushEvent,
+  pushEvents,
   setEvents,
   toggleNotificationCenter,
   closeNotificationCenter,
@@ -36,6 +48,24 @@ describe('events slice', () => {
     const state = eventsReducer(initial, pushEvent(event));
     expect(state.entities['evt-1'].severity).toBe('warning');
     expect(state.entities['evt-1'].status).toBe('read');
+  });
+
+  it('pushEvents adds a batch and trims severity and status', () => {
+    const initial = eventsReducer(undefined, { type: 'unknown' });
+    const state = eventsReducer(
+      initial,
+      pushEvents([
+        makeEvent({ id: 'evt-1', severity: '  warning  ', status: '  read  ' }),
+        makeEvent({ id: 'evt-2', severity: '', status: '' }),
+      ]),
+    );
+
+    expect(state.ids).toContain('evt-1');
+    expect(state.ids).toContain('evt-2');
+    expect(state.entities['evt-1'].severity).toBe('warning');
+    expect(state.entities['evt-1'].status).toBe('read');
+    expect(state.entities['evt-2'].severity).toBe('informational');
+    expect(state.entities['evt-2'].status).toBe('unread');
   });
 
   it('setEvents replaces all events', () => {

--- a/ui/store/slices/events.ts
+++ b/ui/store/slices/events.ts
@@ -32,6 +32,12 @@ const defaultEventProperties = {
   status: STATUS.UNREAD,
 };
 
+const normalizeEvent = (event) => ({
+  ...event,
+  severity: event?.severity?.trim() || defaultEventProperties.severity,
+  status: event?.status?.trim() || defaultEventProperties.status,
+});
+
 const eventsEntityAdapter = createEntityAdapter({
   selectId: (event) => event.id,
   //sort based on createdAt timestamp(utc)
@@ -61,16 +67,15 @@ export const eventsSlice = createSlice({
 
     pushEvents: (state, action) => {
       // state.events = [...state.events, ...action.payload]
-      eventsEntityAdapter.addMany(state, action.payload);
-      state.current_view.has_more = action.payload.length == 0 ? false : true;
+      const events = Array.isArray(action.payload)
+        ? action.payload.filter(Boolean).map(normalizeEvent)
+        : [];
+      eventsEntityAdapter.addMany(state, events);
+      state.current_view.has_more = events.length == 0 ? false : true;
     },
 
     pushEvent: (state, action) => {
-      const event = {
-        ...action.payload,
-        severity: action.payload?.severity?.trim() || defaultEventProperties.severity,
-        status: action.payload?.status?.trim() || defaultEventProperties.status,
-      };
+      const event = normalizeEvent(action.payload);
       eventsEntityAdapter.addOne(state, event);
       // state.events = [event, ...state.events]
     },


### PR DESCRIPTION
**Notes for Reviewers**

- This PR fixes #18680
## Description

This PR batches adapter event delivery from `listenForAdapterEvents` to reduce the number of small SSE flushes emitted during
high-volume operations like MeshSync cluster syncs.

Adapter events are now buffered and flushed downstream when either:
- the batch reaches 50 events, or
- 250ms elapses after the first buffered event.

The UI event handling path now accepts both single events and event arrays, dispatches batched events with `pushEvents`, and
shows one compact notification for a batch instead of one notification per event.

## Event Batching Strategy and Latency Impact

Adapter event streaming now batches events before forwarding them downstream. A batch is flushed when
either:

- `50` events have accumulated, or
- `250ms` has elapsed since the first buffered event.

This keeps live-event latency bounded while reducing SSE/message churn during high-volume MeshSync bursts.
For example, a 1,000-event burst previously produced 1,000 downstream writes/update opportunities; with a
batch size of 50, that drops to about 20 batched messages. During lower-volume live updates, the first event
in a batch waits at most 250ms before being forwarded, and burst traffic flushes sooner when the batch
fills.

Validation performed:

- Server tests cover flush-on-batch-size, flush-on-window, flush-on-stream-close, and flush-on-stream-error.
- UI tests cover batched subscription events being stored in Redux and emitted back to parent consumers as
an array.
- Focused checks passed:
  - `go test ./server/handlers`
  - `npm --prefix ui test -- machines/__tests__/operationsCenter.test.ts --reporter verbose`

## Changes

- Added interval/size-based batching for adapter SSE event payloads.
- Preserved per-event persistence and `EventBroadcaster.Publish` behavior.
- Updated NotificationCenter event handling to normalize single-event and array payloads.
- Updated `pushEvents` to normalize event defaults consistently with `pushEvent`.
- Added focused Go and UI tests for batching and batched event handling.

## Before

Adapter events were flushed one-by-one as separate SSE messages:

  ```txt
data: {"summary":"event 1"}
data: {"summary":"event 2"}
data: {"summary":"event 3"}
```
  This could create excessive network traffic and UI re-render pressure during large MeshSync operations.

## After

  Adapter events are flushed as batches:
```txt
data: [{"summary":"event 1"},{"summary":"event 2"},{"summary":"event 3"}]
```
  The UI handles the array payload and emits one compact notification for the batch.

 ## Test
```txt
machines/__tests__/operationsCenter.test.ts > operationsCenter machine > boots into idle after init and spawns the subscription actor 3ms
 ✓ machines/__tests__/operationsCenter.test.ts > operationsCenter machine > stores received event batches in redux and sends one batch notifier 2ms
 ✓ machines/__tests__/operationsCenter.test.ts > operationsCenter machine > exposes the canonical event constants 0ms
 ✓ machines/__tests__/operationsCenter.test.ts > operationsCenter machine > stores received events in redux and triggers the notifier 1ms
 ✓ machines/__tests__/operationsCenter.test.ts > operationsCenter machine > emits received events back to the parent for consumers 1ms
 ✓ machines/__tests__/operationsCenter.test.ts > operationsCenter machine > forwards subscription stream events into the machine via the next callback 1ms
 ✓ machines/__tests__/operationsCenter.test.ts > operationsCenter machine > forwards subscription event batches into the machine via the next callback 0ms
 ✓ machines/__tests__/operationsCenter.test.ts > operationsCenter machine > ignores stream callbacks without an event payload but logs 0ms
 ✓ machines/__tests__/operationsCenter.test.ts > operationsCenter machine > respawns the subscription actor on ERROR_OCCURRED_IN_SUBSCRIPTION 1ms
stdout | store/slices/__tests__/events.test.ts > events slice > toggleNotificationCenter toggles open state
Toggling notification center state { type: 'events/toggleNotificationCenter', payload: undefined }
Toggling notification center state { type: 'events/toggleNotificationCenter', payload: undefined }

stdout | store/slices/__tests__/events.test.ts > events slice > closeNotificationCenter resets view state
Toggling notification center state { type: 'events/toggleNotificationCenter', payload: undefined }

 ✓ store/slices/__tests__/events.test.ts > events slice > returns initial state 1ms
 ✓ store/slices/__tests__/events.test.ts > events slice > pushEvent adds a single event 1ms
 ✓ store/slices/__tests__/events.test.ts > events slice > pushEvent trims severity and status 0ms
 ✓ store/slices/__tests__/events.test.ts > events slice > pushEvents adds a batch and trims severity and status 9ms
 ✓ store/slices/__tests__/events.test.ts > events slice > setEvents replaces all events 1ms
 ✓ store/slices/__tests__/events.test.ts > events slice > toggleNotificationCenter toggles open state 1ms
 ✓ store/slices/__tests__/events.test.ts > events slice > closeNotificationCenter resets view state 0ms

 Test Files  2 passed (2)
      Tests  16 passed (16)
   Start at  12:18:41
   Duration  992ms (transform 108ms, setup 158ms, import 87ms, tests 24ms, environment 1.43s)
```

**[Signed commits](https://github.com/meshery/meshery/blob/master/CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [x] Yes, I signed my commits.

<!--
Thank you for contributing to Meshery! 

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. Sign your commits.
4. Include before and after screenshots/terminal output.

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.
-->
