### PR TITLE
Resolved `make site` failure

### DIFF
--- a/docs/Makefile
+++ b/docs/Makefile
@@ -20,7 +20,7 @@ setup:
 
 ## Run docs.meshery.io on your local machine with draft and future content enabled.
 site: check-go
-	hugo server -D -F
+	npx hugo server -D -F
 
 ## Build docs.meshery.io on your local machine.
 build:


### PR DESCRIPTION

**Notes for Reviewers**

This PR fixes https://github.com/meshery/meshery/issues/19363

* Replaced `hugo server -D -F` with `npx hugo server -D -F`

**[Signed commits](https://github.com/meshery/meshery/blob/master/CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [x] Yes, I signed my commits.

