### PR TITLE
fix(auth): cookie-lifecycle gaps — PSL parity + cross-domain logout clearance

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -522,6 +522,26 @@ directly with Meshery Server APIs and can manage local Docker containers or Kube
 - **Remote Providers**: Implement authentication, preferences, and sync logic externally.
 - **Example**: Meshery Cloud provider integrates via HTTPS/gRPC.
 
+#### Auth-cookie lifecycle (CDA-aware)
+
+When Meshery Server bridges a login through Meshery Cloud's Custom Domain
+Authentication (CDA), the browser may end up with auth cookies on several
+host scopes: the Meshery Server's own host, the cloud canonical scope
+(e.g. `.layer5.io`), and the BYOC custom-domain scope (e.g. `.meshery.io`
+or an off-eTLD apex). A one-scope logout would leave the other scopes'
+cookies in place and a subsequent navigation could silently
+re-authenticate the browser.
+
+`LogoutHandler` in `server/handlers/common_handlers.go` calls the helpers
+in `server/handlers/auth_cookie_clear.go` to emit a Set-Cookie clearance
+on every host scope the server knows about — the current request's host,
+its PSL-derived eTLD+1, and every configured remote provider's host plus
+eTLD+1. Any code that derives an eTLD+1 (for setting or clearing a
+Domain-scoped cookie, for redirect-target validation, etc.) MUST use
+`golang.org/x/net/publicsuffix.EffectiveTLDPlusOne`; a naive
+`strings.SplitN(host, ".", 2)[1]` resolves `example.co.uk` to `co.uk`,
+which is a public suffix and yields a cookie that the browser rejects.
+
 ### Adapters (gRPC)
 
 - **Protocol**: Defined in `server/meshes/meshops.proto`.

--- a/go.mod
+++ b/go.mod
@@ -68,6 +68,7 @@ require (
 	github.com/vmihailenco/taskq/v3 v3.2.9
 	go.opentelemetry.io/contrib/instrumentation/github.com/gorilla/mux/otelmux v0.64.0
 	go.opentelemetry.io/otel/sdk v1.43.0
+	golang.org/x/net v0.53.0
 	golang.org/x/oauth2 v0.36.0
 	golang.org/x/text v0.36.0
 	gonum.org/v1/gonum v0.17.0
@@ -403,7 +404,6 @@ require (
 	golang.org/x/crypto v0.50.0 // indirect
 	golang.org/x/crypto/x509roots/fallback v0.0.0-20250406160420-959f8f3db0fb // indirect
 	golang.org/x/exp v0.0.0-20260410095643-746e56fc9e2f // indirect
-	golang.org/x/net v0.53.0 // indirect
 	golang.org/x/sync v0.20.0 // indirect
 	golang.org/x/sys v0.43.0 // indirect
 	golang.org/x/term v0.42.0 // indirect

--- a/server/handlers/auth_cookie_clear.go
+++ b/server/handlers/auth_cookie_clear.go
@@ -1,0 +1,191 @@
+// Package handlers : CDA cookie-lifecycle helpers.
+//
+// This file owns the cross-scope auth-cookie clearance used by LogoutHandler.
+// It pairs with the symmetric clearance on the Meshery Cloud side: when a user
+// logs out from a Meshery Server (e.g. playground.meshery.io) that bridges
+// auth through Cloud's per-org Custom Domain Authentication (CDA), cookies
+// could have been set on multiple host scopes:
+//
+//   - The Meshery Server's own host (no Domain attribute).
+//   - The Meshery Cloud canonical scope (.layer5.io).
+//   - A custom-domain BYOC scope (e.g. .meshery.io, or an off-eTLD apex like
+//     example.com).
+//
+// A one-scope logout leaves the other scopes' cookies in place, and the next
+// auth-required request can pick them back up and re-authenticate the
+// browser against a provider the user thought they'd left. We mirror what
+// meshery-cloud does on its side and iterate every host scope the server
+// knows about, emitting a Set-Cookie clearance for each.
+//
+// The eTLD+1 derivation uses golang.org/x/net/publicsuffix (the PSL) so that
+// hosts like foo.example.co.uk resolve to example.co.uk rather than co.uk.
+// A naive strings.SplitN("example.co.uk", ".", 2)[1] returns "co.uk" — which
+// is a public suffix, so any cookie scoped to it would be rejected by the
+// browser as a "public suffix domain" anyway. The PSL path is the only
+// correct way to do this in Go.
+package handlers
+
+import (
+	"net"
+	"net/http"
+	"net/url"
+	"strings"
+
+	"golang.org/x/net/publicsuffix"
+)
+
+// cookieScope represents one host scope at which a Set-Cookie clearance
+// should be emitted. An empty Domain means "no Domain attribute" — the
+// clearance applies only to the request's exact host.
+type cookieScope struct {
+	// Domain is the value placed in the Set-Cookie Domain attribute. An
+	// empty string means "omit the Domain attribute entirely", which
+	// targets the current host only.
+	Domain string
+}
+
+// hostFromRequest returns the bare hostname (no port) of the incoming
+// request. It prefers r.Host (which Go populates from the Host header) and
+// strips an optional port suffix. Falls back to an empty string when the
+// host is not parseable; callers must treat the empty result as "no host
+// scope known" and skip Domain attachment.
+func hostFromRequest(r *http.Request) string {
+	if r == nil {
+		return ""
+	}
+	host := r.Host
+	if host == "" {
+		return ""
+	}
+	if h, _, err := net.SplitHostPort(host); err == nil {
+		return h
+	}
+	return host
+}
+
+// hostFromURL returns the bare hostname for a configured provider URL.
+// Returns empty string if the URL cannot be parsed.
+func hostFromURL(raw string) string {
+	if strings.TrimSpace(raw) == "" {
+		return ""
+	}
+	parsed, err := url.Parse(raw)
+	if err != nil {
+		return ""
+	}
+	return parsed.Hostname()
+}
+
+// effectiveTLDPlusOne returns the PSL-derived eTLD+1 for host (e.g.
+// "foo.bar.example.co.uk" -> "example.co.uk"). It returns the empty string
+// for IP literals, hosts that ARE a public suffix, single-label hosts like
+// "localhost", and any input the PSL rejects. Callers must treat the empty
+// result as "no cross-host clearance possible at this scope" and skip
+// emitting a Domain-scoped Set-Cookie.
+//
+// We never want to set Domain=co.uk or Domain=localhost on a cookie: the
+// browser will silently drop the attribute (public-suffix rule) or — worse
+// for development — pin the cookie to a single label that overlaps with
+// every dev project on the same machine.
+func effectiveTLDPlusOne(host string) string {
+	host = strings.TrimSpace(host)
+	if host == "" {
+		return ""
+	}
+	// Public-suffix lookup is undefined for IP literals; bail out early.
+	if ip := net.ParseIP(host); ip != nil {
+		return ""
+	}
+	// Reject hosts without at least one dot — a single label is either
+	// "localhost" or a development hostname that cannot host a
+	// cross-subdomain cookie regardless of PSL behavior.
+	if !strings.Contains(host, ".") {
+		return ""
+	}
+	etld1, err := publicsuffix.EffectiveTLDPlusOne(host)
+	if err != nil {
+		return ""
+	}
+	return etld1
+}
+
+// authCookieScopes returns the ordered, deduplicated list of host scopes
+// at which auth cookies should be cleared on logout.
+//
+// The order is: (1) the current request's host (no Domain attribute), then
+// (2) the current host's PSL-derived eTLD+1, then (3) for each configured
+// remote provider URL the same pair (bare host + eTLD+1). Duplicates are
+// dropped to avoid emitting redundant Set-Cookie headers.
+//
+// Empty scope.Domain values are preserved in the list — they signal "emit
+// the no-Domain clearance once". Callers must handle that case explicitly.
+func authCookieScopes(requestHost string, providerURLs []string) []cookieScope {
+	scopes := []cookieScope{}
+	seen := map[string]struct{}{}
+
+	addDomain := func(domain string) {
+		domain = strings.TrimSpace(strings.ToLower(domain))
+		if domain == "" {
+			return
+		}
+		if _, ok := seen[domain]; ok {
+			return
+		}
+		seen[domain] = struct{}{}
+		scopes = append(scopes, cookieScope{Domain: domain})
+	}
+
+	// (1) Always emit the no-Domain clearance first. This targets the
+	// current host exactly and is what the legacy single-scope logout
+	// already did — we never want to regress that case.
+	scopes = append(scopes, cookieScope{Domain: ""})
+
+	// (2) Current host's eTLD+1.
+	if requestHost != "" {
+		addDomain(effectiveTLDPlusOne(requestHost))
+	}
+
+	// (3) For each configured provider URL, add both the bare host
+	// (as a Domain-scoped clearance, which targets that exact host
+	// from the browser's perspective) and its eTLD+1. The bare-host
+	// entry covers the case where the provider sets a cookie without
+	// a Domain attribute on its own host; the eTLD+1 entry covers
+	// cookies set with Domain=.example.com on a sibling subdomain.
+	for _, raw := range providerURLs {
+		host := hostFromURL(raw)
+		if host == "" {
+			continue
+		}
+		// Avoid re-adding the current host as a Domain-scoped
+		// clearance — the no-Domain entry above already covers it,
+		// and emitting Domain=<current-host> on the same response
+		// is redundant.
+		if !strings.EqualFold(host, requestHost) {
+			addDomain(host)
+		}
+		addDomain(effectiveTLDPlusOne(host))
+	}
+
+	return scopes
+}
+
+// clearAuthCookies emits a Set-Cookie header for every (cookieName, scope)
+// combination, with MaxAge=-1 to request immediate browser-side deletion.
+// Callers should pass the scopes returned by authCookieScopes.
+func clearAuthCookies(w http.ResponseWriter, cookieNames []string, scopes []cookieScope) {
+	for _, name := range cookieNames {
+		if strings.TrimSpace(name) == "" {
+			continue
+		}
+		for _, s := range scopes {
+			http.SetCookie(w, &http.Cookie{
+				Name:     name,
+				Value:    "",
+				Path:     "/",
+				Domain:   s.Domain,
+				HttpOnly: true,
+				MaxAge:   -1,
+			})
+		}
+	}
+}

--- a/server/handlers/auth_cookie_clear_test.go
+++ b/server/handlers/auth_cookie_clear_test.go
@@ -1,0 +1,433 @@
+package handlers
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"sort"
+	"strings"
+	"testing"
+
+	"github.com/gofrs/uuid"
+	"github.com/meshery/meshery/server/models"
+)
+
+func TestEffectiveTLDPlusOne_PSLParity(t *testing.T) {
+	cases := []struct {
+		name string
+		host string
+		want string
+	}{
+		{
+			name: "single dot eTLD",
+			host: "foo.example.com",
+			want: "example.com",
+		},
+		{
+			name: "deeper subdomain on single eTLD",
+			host: "a.b.c.example.com",
+			want: "example.com",
+		},
+		// The PSL case that a naive strings.SplitN(host, ".", 2)[1]
+		// gets wrong: "example.co.uk" would yield "co.uk", which is a
+		// public suffix — and any cookie scoped there would be
+		// rejected by the browser as a public-suffix domain.
+		{
+			name: "multi-label public suffix .co.uk",
+			host: "foo.example.co.uk",
+			want: "example.co.uk",
+		},
+		{
+			name: "multi-label public suffix .com.au",
+			host: "deep.sub.example.com.au",
+			want: "example.com.au",
+		},
+		// IP literals must NOT be treated as cross-host scopes. Returning
+		// an empty string here is the signal to callers to skip the
+		// Domain-scoped clearance.
+		{
+			name: "IPv4 literal returns empty",
+			host: "127.0.0.1",
+			want: "",
+		},
+		{
+			name: "IPv6 literal returns empty",
+			host: "::1",
+			want: "",
+		},
+		// "localhost" is a single label — no cross-subdomain cookie is
+		// even possible, and Domain=localhost has surprising semantics.
+		{
+			name: "localhost single label returns empty",
+			host: "localhost",
+			want: "",
+		},
+		// A host that IS itself a public suffix has no eTLD+1; reject it.
+		{
+			name: "bare public suffix returns empty",
+			host: "co.uk",
+			want: "",
+		},
+		{
+			name: "empty input returns empty",
+			host: "",
+			want: "",
+		},
+		{
+			name: "whitespace-only input returns empty",
+			host: "   ",
+			want: "",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := effectiveTLDPlusOne(tc.host)
+			if got != tc.want {
+				t.Fatalf("effectiveTLDPlusOne(%q) = %q, want %q", tc.host, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestAuthCookieScopes(t *testing.T) {
+	cases := []struct {
+		name         string
+		requestHost  string
+		providerURLs []string
+		// wantDomains is the expected SORTED set of non-empty Domain
+		// values. We always expect at least one entry with empty
+		// Domain ("no Domain attribute"), and we check that separately.
+		wantDomains []string
+	}{
+		{
+			name:        "playground -> cloud (canonical scope)",
+			requestHost: "playground.meshery.io",
+			providerURLs: []string{
+				"https://cloud.layer5.io",
+			},
+			wantDomains: []string{
+				"cloud.layer5.io", // bare host
+				"layer5.io",       // eTLD+1 of cloud.layer5.io
+				"meshery.io",      // eTLD+1 of playground.meshery.io
+			},
+		},
+		{
+			name:        "self-hosted localhost with cloud provider — no eTLD+1 for current host",
+			requestHost: "localhost",
+			providerURLs: []string{
+				"https://cloud.layer5.io",
+			},
+			wantDomains: []string{
+				"cloud.layer5.io",
+				"layer5.io",
+			},
+		},
+		{
+			name:        "BYOC custom-domain provider",
+			requestHost: "playground.meshery.io",
+			providerURLs: []string{
+				"https://cloud.example.co.uk",
+			},
+			wantDomains: []string{
+				"cloud.example.co.uk", // bare host
+				"example.co.uk",       // PSL-correct eTLD+1
+				"meshery.io",          // request host eTLD+1
+			},
+		},
+		{
+			name:        "multiple providers deduped",
+			requestHost: "playground.meshery.io",
+			providerURLs: []string{
+				"https://cloud.layer5.io",
+				"https://cloud.layer5.io", // exact dup
+				"https://other.layer5.io", // shares eTLD+1
+			},
+			wantDomains: []string{
+				"cloud.layer5.io",
+				"layer5.io",
+				"meshery.io",
+				"other.layer5.io",
+			},
+		},
+		{
+			name:         "no providers, current host eTLD+1 still emitted",
+			requestHost:  "app.example.com",
+			providerURLs: nil,
+			wantDomains:  []string{"example.com"},
+		},
+		{
+			name:        "current host equals provider host — no redundant Domain entry for current host",
+			requestHost: "cloud.layer5.io",
+			providerURLs: []string{
+				"https://cloud.layer5.io",
+			},
+			wantDomains: []string{
+				// "cloud.layer5.io" is NOT here: it's the request
+				// host and the no-Domain entry already covers it.
+				"layer5.io",
+			},
+		},
+		{
+			name:         "ip-literal request host, no providers",
+			requestHost:  "127.0.0.1",
+			providerURLs: nil,
+			wantDomains:  []string{},
+		},
+		{
+			name:        "malformed provider URL skipped",
+			requestHost: "playground.meshery.io",
+			providerURLs: []string{
+				"::::not-a-url",
+				"",
+				"   ",
+				"https://cloud.layer5.io",
+			},
+			wantDomains: []string{
+				"cloud.layer5.io",
+				"layer5.io",
+				"meshery.io",
+			},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			scopes := authCookieScopes(tc.requestHost, tc.providerURLs)
+
+			// 1. The first scope must always be the no-Domain
+			// clearance — that's the back-compat guarantee.
+			if len(scopes) == 0 || scopes[0].Domain != "" {
+				t.Fatalf("expected first scope to be no-Domain, got %+v", scopes)
+			}
+
+			// 2. Collect non-empty Domains and compare as a set.
+			var gotDomains []string
+			seen := map[string]struct{}{}
+			for _, s := range scopes[1:] {
+				if s.Domain == "" {
+					t.Errorf("unexpected duplicate no-Domain entry in scopes: %+v", scopes)
+					continue
+				}
+				if _, dup := seen[s.Domain]; dup {
+					t.Errorf("duplicate Domain %q in scopes: %+v", s.Domain, scopes)
+				}
+				seen[s.Domain] = struct{}{}
+				gotDomains = append(gotDomains, s.Domain)
+			}
+			sort.Strings(gotDomains)
+			want := append([]string(nil), tc.wantDomains...)
+			sort.Strings(want)
+			if !equalStringSlices(gotDomains, want) {
+				t.Fatalf("Domain set mismatch:\ngot:  %v\nwant: %v", gotDomains, want)
+			}
+		})
+	}
+}
+
+func equalStringSlices(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}
+
+func TestClearAuthCookies_EmitsAllScopes(t *testing.T) {
+	w := httptest.NewRecorder()
+	cookieNames := []string{"token", "session_cookie", "meshery-provider"}
+	scopes := []cookieScope{
+		{Domain: ""},             // no Domain
+		{Domain: "layer5.io"},    // PSL-correct eTLD+1
+		{Domain: "meshery.io"},   // BYOC eTLD+1
+		{Domain: "cloud.layer5.io"},
+	}
+
+	clearAuthCookies(w, cookieNames, scopes)
+
+	resp := w.Result()
+	t.Cleanup(func() { _ = resp.Body.Close() })
+	setCookies := resp.Header.Values("Set-Cookie")
+	if len(setCookies) != len(cookieNames)*len(scopes) {
+		t.Fatalf("expected %d Set-Cookie headers, got %d: %v", len(cookieNames)*len(scopes), len(setCookies), setCookies)
+	}
+
+	// For each (cookieName, scope) pair, assert exactly one matching
+	// Set-Cookie header that's a clearance (Max-Age=0 from MaxAge=-1) and
+	// that the Domain attribute is set correctly (or absent).
+	for _, name := range cookieNames {
+		for _, s := range scopes {
+			matches := 0
+			for _, c := range setCookies {
+				if !strings.HasPrefix(c, name+"=") {
+					continue
+				}
+				domainAttr := extractCookieAttr(c, "Domain")
+				if !strings.EqualFold(domainAttr, s.Domain) {
+					continue
+				}
+				if !strings.Contains(c, "Max-Age=0") {
+					t.Errorf("Set-Cookie for %q@%q should be a clearance (Max-Age=0), got %q", name, s.Domain, c)
+				}
+				matches++
+			}
+			if matches != 1 {
+				t.Errorf("expected exactly one Set-Cookie for (%q, Domain=%q), got %d (headers=%v)", name, s.Domain, matches, setCookies)
+			}
+		}
+	}
+}
+
+// extractCookieAttr returns the value of the given attribute in a
+// Set-Cookie header, or empty string if absent. Case-insensitive on the
+// attribute name, as is RFC 6265 standard.
+func extractCookieAttr(setCookie, attr string) string {
+	parts := strings.Split(setCookie, ";")
+	for _, p := range parts[1:] {
+		p = strings.TrimSpace(p)
+		eq := strings.IndexByte(p, '=')
+		if eq < 0 {
+			continue
+		}
+		if strings.EqualFold(p[:eq], attr) {
+			return p[eq+1:]
+		}
+	}
+	return ""
+}
+
+// logoutSpyProvider is a minimal Provider implementation used to exercise
+// LogoutHandler without standing up a real persister or remote-provider
+// chain. It embeds DefaultLocalProvider so we inherit all method
+// implementations we don't need to override.
+type logoutSpyProvider struct {
+	*models.DefaultLocalProvider
+	providerURL string
+	name        string
+}
+
+func (p *logoutSpyProvider) Name() string             { return p.name }
+func (p *logoutSpyProvider) GetProviderURL() string   { return p.providerURL }
+func (p *logoutSpyProvider) Logout(_ http.ResponseWriter, _ *http.Request) error { return nil }
+
+// DeleteCapabilitiesForUser short-circuits the embedded persister so the
+// test doesn't need to stand up a real DB. LogoutHandler ignores the
+// return value anyway, so a no-op is fine.
+func (p *logoutSpyProvider) DeleteCapabilitiesForUser(_ string) error { return nil }
+
+// TestLogoutHandler_ClearsAcrossAllProviderScopes asserts the headline CDA
+// cookie-lifecycle invariant: when a user logs out, the response carries
+// Set-Cookie clearances on every host scope a CDA flow might have set
+// cookies on — current host, current host eTLD+1 (PSL-correct), and
+// each configured remote provider's host + eTLD+1.
+func TestLogoutHandler_ClearsAcrossAllProviderScopes(t *testing.T) {
+	local := &models.DefaultLocalProvider{}
+	local.Initialize()
+	cloudProv := &logoutSpyProvider{DefaultLocalProvider: local, providerURL: "https://cloud.layer5.io", name: "Cloud"}
+	byocProv := &logoutSpyProvider{DefaultLocalProvider: local, providerURL: "https://cloud.example.co.uk", name: "BYOC"}
+
+	providers := map[string]models.Provider{
+		"Cloud": cloudProv,
+		"BYOC":  byocProv,
+	}
+	h := newTestHandler(t, providers, "")
+
+	req := httptest.NewRequest(http.MethodGet, "/api/user/logout", nil)
+	req.Host = "playground.meshery.io"
+	rec := httptest.NewRecorder()
+
+	user := &models.User{ID: uuid.Must(uuid.FromString("11111111-1111-1111-1111-111111111111"))}
+	h.LogoutHandler(rec, req, user, cloudProv)
+
+	resp := rec.Result()
+	t.Cleanup(func() { _ = resp.Body.Close() })
+
+	if resp.StatusCode != http.StatusFound {
+		t.Fatalf("expected logout redirect (302), got %d", resp.StatusCode)
+	}
+
+	setCookies := resp.Header.Values("Set-Cookie")
+	if len(setCookies) == 0 {
+		t.Fatal("expected logout to emit Set-Cookie clearances, got none")
+	}
+
+	// The three cookie names we expect on every scope.
+	expectedNames := []string{"meshery-provider", "token", "session_cookie"}
+
+	// The expected NON-EMPTY Domain scopes — a clearance with no Domain
+	// attribute is also expected but tested separately.
+	expectedDomains := []string{
+		"cloud.layer5.io",     // bare provider host
+		"layer5.io",           // cloud eTLD+1
+		"cloud.example.co.uk", // BYOC bare provider host
+		"example.co.uk",       // PSL-correct BYOC eTLD+1 (NOT co.uk!)
+		"meshery.io",          // request host eTLD+1
+	}
+
+	for _, name := range expectedNames {
+		// Bare/no-Domain clearance.
+		if !findClearanceCookie(setCookies, name, "") {
+			t.Errorf("missing no-Domain clearance for cookie %q (headers=%v)", name, setCookies)
+		}
+		for _, dom := range expectedDomains {
+			if !findClearanceCookie(setCookies, name, dom) {
+				t.Errorf("missing clearance for cookie %q on Domain=%q (headers=%v)", name, dom, setCookies)
+			}
+		}
+	}
+
+	// Specifically assert that NO clearance was emitted for Domain=co.uk —
+	// that's the Gap A regression we're guarding against.
+	for _, c := range setCookies {
+		if strings.EqualFold(strings.TrimSpace(extractCookieAttr(c, "Domain")), "co.uk") {
+			t.Fatalf("PSL parity violated: Set-Cookie emitted at Domain=co.uk: %q", c)
+		}
+	}
+}
+
+// findClearanceCookie reports whether setCookies contains a Set-Cookie
+// header with the given name, Domain (empty string = no Domain attribute),
+// and a clearance Max-Age of 0.
+func findClearanceCookie(setCookies []string, name, domain string) bool {
+	for _, c := range setCookies {
+		if !strings.HasPrefix(c, name+"=") {
+			continue
+		}
+		got := extractCookieAttr(c, "Domain")
+		if !strings.EqualFold(strings.TrimSpace(got), strings.TrimSpace(domain)) {
+			continue
+		}
+		if !strings.Contains(c, "Max-Age=0") {
+			continue
+		}
+		return true
+	}
+	return false
+}
+
+func TestHostFromRequest(t *testing.T) {
+	cases := []struct {
+		name     string
+		hostHdr  string
+		want     string
+	}{
+		{name: "bare host", hostHdr: "playground.meshery.io", want: "playground.meshery.io"},
+		{name: "host:port", hostHdr: "localhost:9081", want: "localhost"},
+		{name: "ipv4:port", hostHdr: "127.0.0.1:9081", want: "127.0.0.1"},
+		{name: "ipv6:port", hostHdr: "[::1]:9081", want: "::1"},
+		{name: "empty host header", hostHdr: "", want: ""},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			req := httptest.NewRequest(http.MethodGet, "/", nil)
+			req.Host = tc.hostHdr
+			got := hostFromRequest(req)
+			if got != tc.want {
+				t.Fatalf("hostFromRequest(host=%q) = %q, want %q", tc.hostHdr, got, tc.want)
+			}
+		})
+	}
+}

--- a/server/handlers/common_handlers.go
+++ b/server/handlers/common_handlers.go
@@ -24,25 +24,42 @@ func (h *Handler) LoginHandler(w http.ResponseWriter, r *http.Request, p models.
 }
 
 // LogoutHandler destroys the session and redirects to home.
+//
+// CDA cookie-lifecycle: this server may bridge auth through a Meshery Cloud
+// custom-domain (e.g. cloud.meshery.io -> .meshery.io) that sets cookies at
+// a Domain scope different from the Meshery Server's own host. A
+// one-scope logout would leave those sibling-domain cookies in place and a
+// subsequent navigation could silently re-authenticate the browser. We
+// iterate every host scope the server knows about — the current host,
+// its PSL-derived eTLD+1, and every configured remote provider's host +
+// eTLD+1 — and emit a Set-Cookie clearance for each. See
+// auth_cookie_clear.go for the scope-resolution logic and the rationale
+// for using golang.org/x/net/publicsuffix instead of a naive dot split.
 func (h *Handler) LogoutHandler(w http.ResponseWriter, req *http.Request, user *models.User, p models.Provider) {
 	if req.Method != http.MethodGet {
 		w.WriteHeader(http.StatusNotFound)
 		return
 	}
-	// Clear all Meshery cookies to ensure complete logout
-	for _, cookieName := range []string{
+	// Clear all Meshery cookies to ensure complete logout — across every
+	// host scope a CDA flow might have set them on.
+	cookieNames := []string{
 		h.config.ProviderCookieName,
 		models.TokenCookieName,
 		models.ProviderSessionCookieName,
-	} {
-		http.SetCookie(w, &http.Cookie{
-			Name:     cookieName,
-			Value:    "",
-			Path:     "/",
-			HttpOnly: true,
-			MaxAge:   -1,
-		})
 	}
+	providerURLs := []string{}
+	if h.config != nil {
+		for _, prov := range h.config.Providers {
+			if prov == nil {
+				continue
+			}
+			if u := prov.GetProviderURL(); u != "" {
+				providerURLs = append(providerURLs, u)
+			}
+		}
+	}
+	scopes := authCookieScopes(hostFromRequest(req), providerURLs)
+	clearAuthCookies(w, cookieNames, scopes)
 	_ = p.DeleteCapabilitiesForUser(user.ID.String())
 	err := p.Logout(w, req)
 	if err != nil {


### PR DESCRIPTION
## Summary

Symmetric counterpart to the parallel cookie-lifecycle fix in `layer5io/meshery-cloud` (see prior context: layer5io/meshery-cloud#4570 fixing the same class of issue on the Cloud side). Both repos participate in the CDA (Custom Domain Authentication) auth-cookie lifecycle and need symmetric handling on logout — clearing on only one host scope leaves stale cookies on the others that can silently re-authenticate the browser.

## Two gaps addressed

### Gap A — PSL parity

Any code on the Meshery Server side that derives an eTLD+1 (for setting or clearing a Domain-scoped cookie, for redirect-target validation, etc.) must use `golang.org/x/net/publicsuffix.EffectiveTLDPlusOne` rather than a naive `strings.SplitN(host, ".", 2)[1]`. The naive form returns `co.uk` for `example.co.uk` — a public suffix — and any cookie scoped there would be rejected by the browser.

Pre-fix audit: the Meshery Server code never previously computed an eTLD+1 anywhere in the auth path (no `Domain:` field was set on any of the existing `http.Cookie` literals — see `server/handlers/common_handlers.go`, `server/models/remote_auth.go`, `server/models/remote_provider.go`, `server/handlers/provider_handler.go`, `server/router/server.go`). PSL parity was therefore moot until we needed Domain-scoped clearances for Gap B; this PR introduces the helper that does the eTLD+1 derivation using the PSL, in `server/handlers/auth_cookie_clear.go`.

### Gap B — cross-domain cookie clearing on logout

The previous `LogoutHandler` (in `server/handlers/common_handlers.go`) emitted a single set of Set-Cookie clearances with no `Domain` attribute, covering only the current host. With CDA, a user authenticated against a Meshery Server (e.g. `playground.meshery.io`) that bridges through `cloud.layer5.io` (or a custom-domain BYOC scope like `cloud.example.co.uk`) could end up with auth cookies on:

- The Meshery Server's own host
- The cloud canonical scope (`.layer5.io`)
- A BYOC custom-domain scope (`.meshery.io`, `.example.co.uk`, …)

A one-scope logout leaves the sibling-domain cookies in place and a subsequent navigation can silently re-authenticate the browser.

## Implementation

- **`server/handlers/auth_cookie_clear.go` (new)** — Owns the cross-scope cookie clearance logic:
  - `effectiveTLDPlusOne(host)` wraps `publicsuffix.EffectiveTLDPlusOne` with PSL-correct semantics and short-circuits on IP literals, single-label hosts (`localhost`), and bare public suffixes (which have no eTLD+1 to clear at).
  - `authCookieScopes(requestHost, providerURLs)` returns the deduplicated ordered list of host scopes: the no-Domain entry (current host, back-compat preserved), the current host's eTLD+1, and every configured remote provider's host + eTLD+1.
  - `clearAuthCookies(w, names, scopes)` emits a `MaxAge=-1` clearance per (cookie, scope) pair.

- **`server/handlers/common_handlers.go`** — `LogoutHandler` now iterates `h.config.Providers` to harvest every configured `RemoteProviderURL`, calls `authCookieScopes` with the request's host, and emits clearances on every resulting scope.

- **`go.mod`** — `golang.org/x/net` promoted from indirect to direct (we now consume `publicsuffix` ourselves).

- **`AGENTS.md`** — Brief subsection under "Provider Plugins" documenting the cookie-lifecycle invariant and the PSL-only-via-`x/net/publicsuffix` rule so future contributors don't reintroduce a naive dot-split.

## Tests

- `TestEffectiveTLDPlusOne_PSLParity` — Multi-label public suffixes (`.co.uk`, `.com.au`), IP literals (v4 + v6), `localhost`, bare public suffix, empty/whitespace.
- `TestAuthCookieScopes` — Playground → cloud, self-hosted localhost → cloud (no eTLD+1 for the current host), BYOC custom-domain provider on `.co.uk` (PSL-correct → `example.co.uk` not `co.uk`), dedup across multiple providers, malformed provider URL skipped, request host equals provider host → no redundant Domain entry.
- `TestClearAuthCookies_EmitsAllScopes` — Asserts one Set-Cookie per (name, scope) pair with `Max-Age=0`.
- `TestHostFromRequest` — Bare host, host:port, IPv4:port, IPv6:port, empty.
- `TestLogoutHandler_ClearsAcrossAllProviderScopes` — End-to-end via `LogoutHandler` with two providers (canonical `.layer5.io` + BYOC `.example.co.uk`), asserting clearances on every host scope AND explicitly rejecting any `Set-Cookie` emitted at `Domain=co.uk` — the Gap A regression guard.

## Verification

| Command | Result |
| --- | --- |
| `go vet ./...` | clean |
| `go build ./...` | clean |
| `go test -count=1 ./server/...` | passes including the new tests |

## Test plan

- [ ] CI: `go vet`, `go build`, `go test` on `./server/...` pass.
- [ ] Manual smoke: a logout from `playground.meshery.io` (or any Meshery Server with a configured Cloud provider) emits `Set-Cookie` clearances for the three auth cookies on every host scope — the current host (no Domain), the current host's eTLD+1, and every configured provider's host + eTLD+1.
- [ ] Manual smoke under a BYOC custom-domain provider whose host falls under a multi-label public suffix (e.g. `.co.uk`): the clearance targets `example.co.uk`, never `co.uk`.

## References

- Sister PR on the Cloud side: layer5io/meshery-cloud#4570 (and the broader cookie-lifecycle work tracked there)
- `golang.org/x/net/publicsuffix` — PSL implementation in the standard ecosystem