### PR TITLE
ci: add additional workflows for E2E report on pull request comment

### DIFF
--- a/.github/workflows/comment-e2e-test.yml
+++ b/.github/workflows/comment-e2e-test.yml
@@ -1,7 +1,11 @@
 name: E2E Report on Pull Request Comment
 on:
   workflow_run:
-    workflows: ['Meshery UI and Server']
+    workflows: [
+      'Meshery UI and Server',
+      'Meshery UI and Server PR Build',
+      'Meshery Build And Test'
+    ]
     types: [completed]
   
 permissions:


### PR DESCRIPTION
**Notes for Reviewers**
The e2e test report was not posting. This is d/t the name change as we are decomposing and cleaningup workflows. I added the new names to this workflow and will delete after the workflows get cleaned up. 