### PR TITLE
fix: improve error handling for performance profile server failures

### DIFF
--- a/mesheryctl/helpers/component_info.json
+++ b/mesheryctl/helpers/component_info.json
@@ -1,5 +1,5 @@
 {
   "name": "mesheryctl",
   "type": "client",
-  "next_error_code": 1245
+  "next_error_code": 1246
 }

--- a/mesheryctl/internal/cli/root/perf/apply.go
+++ b/mesheryctl/internal/cli/root/perf/apply.go
@@ -457,7 +457,7 @@ func createPerformanceProfile(mctlCfg *config.MesheryCtlConfig) (string, string,
 
 	resp, err := utils.MakeRequest(req)
 	if err != nil {
-		return "", "", ErrPerfProfileServer(err)
+		return "", "", ErrPerfProfileServer(errors.New("failed to save performance profile on server"))
 	}
 
 	var response *models.PerformanceProfile

--- a/mesheryctl/internal/cli/root/perf/apply.go
+++ b/mesheryctl/internal/cli/root/perf/apply.go
@@ -17,11 +17,6 @@ package perf
 import (
 	"bytes"
 	"encoding/json"
-	"io"
-	"net/http"
-	"os"
-	"strconv"
-	"strings"
 
 	"github.com/asaskevich/govalidator"
 	"github.com/ghodss/yaml"
@@ -29,6 +24,11 @@ import (
 	"github.com/meshery/meshery/mesheryctl/internal/cli/root/config"
 	"github.com/meshery/meshery/mesheryctl/pkg/utils"
 	"github.com/meshery/meshery/server/models"
+	"io"
+	"net/http"
+	"os"
+	"strconv"
+	"strings"
 
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
@@ -456,7 +456,7 @@ func createPerformanceProfile(mctlCfg *config.MesheryCtlConfig) (string, string,
 
 	resp, err := utils.MakeRequest(req)
 	if err != nil {
-		return "", "", err
+		return "", "", ErrPerfProfileServer(errors.New("failed to save performance profile on server"))
 	}
 
 	var response *models.PerformanceProfile

--- a/mesheryctl/internal/cli/root/perf/apply.go
+++ b/mesheryctl/internal/cli/root/perf/apply.go
@@ -17,6 +17,11 @@ package perf
 import (
 	"bytes"
 	"encoding/json"
+	"io"
+	"net/http"
+	"os"
+	"strconv"
+	"strings"
 
 	"github.com/asaskevich/govalidator"
 	"github.com/ghodss/yaml"
@@ -24,12 +29,8 @@ import (
 	"github.com/meshery/meshery/mesheryctl/internal/cli/root/config"
 	"github.com/meshery/meshery/mesheryctl/pkg/utils"
 	"github.com/meshery/meshery/server/models"
-	"io"
-	"net/http"
-	"os"
-	"strconv"
-	"strings"
 
+	
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
@@ -456,7 +457,7 @@ func createPerformanceProfile(mctlCfg *config.MesheryCtlConfig) (string, string,
 
 	resp, err := utils.MakeRequest(req)
 	if err != nil {
-		return "", "", ErrPerfProfileServer(errors.New("failed to save performance profile on server"))
+		return "", "", ErrPerfProfileServer(err)
 	}
 
 	var response *models.PerformanceProfile

--- a/mesheryctl/internal/cli/root/perf/error.go
+++ b/mesheryctl/internal/cli/root/perf/error.go
@@ -28,7 +28,7 @@ const (
 	ErrUserPromptCode               = "mesheryctl-1160"
 	ErrConvertConcurrentRequestCode = "mesheryctl-1161"
 	ErrConvertQPSCode               = "mesheryctl-1162"
-	ErrPerfProfileServerCode        = "mesheryctl-1165"
+	ErrPerfProfileServerCode        = "mesheryctl-1245"
 )
 
 func ErrReadFilepath(err error) error {

--- a/mesheryctl/internal/cli/root/perf/error.go
+++ b/mesheryctl/internal/cli/root/perf/error.go
@@ -28,7 +28,7 @@ const (
 	ErrUserPromptCode               = "mesheryctl-1160"
 	ErrConvertConcurrentRequestCode = "mesheryctl-1161"
 	ErrConvertQPSCode               = "mesheryctl-1162"
-	ErrPerfProfileServerCode        = "mesheryctl-1163"
+	ErrPerfProfileServerCode        = "mesheryctl-1165"
 )
 
 func ErrReadFilepath(err error) error {

--- a/mesheryctl/internal/cli/root/perf/error.go
+++ b/mesheryctl/internal/cli/root/perf/error.go
@@ -28,6 +28,7 @@ const (
 	ErrUserPromptCode               = "mesheryctl-1160"
 	ErrConvertConcurrentRequestCode = "mesheryctl-1161"
 	ErrConvertQPSCode               = "mesheryctl-1162"
+	ErrPerfProfileServerCode        = "mesheryctl-1163"
 )
 
 func ErrReadFilepath(err error) error {
@@ -180,4 +181,12 @@ func ErrConvertQPS() error {
 		[]string{"Invalid qps value provided"},
 		[]string{"The qps flag value is not a valid integer"},
 		[]string{"Provide a valid integer value for qps", formatErrorWithReference()})
+}
+
+func ErrPerfProfileServer(err error) error {
+	return errors.New(ErrPerfProfileServerCode, errors.Alert,
+		[]string{"Server error while saving performance profile"},
+		[]string{err.Error()},
+		[]string{"Provider Database could be down or not reachable"},
+		[]string{"Make sure provider is up and reachable", formatErrorWithReference()})
 }


### PR DESCRIPTION

Fixes #19556

## Problem

Previously, when the server returned a 500 error while saving a 
performance profile, the raw JSON error response from the server 
was displayed directly to the user, making it difficult to 
understand what went wrong.

- [x] Yes, I signed my commits.

## Before

<img width="1918" height="477" alt="Screenshot 2026-05-19 221854" src="https://github.com/user-attachments/assets/4e58434f-3db6-4fab-9b0d-8a0c978fc6d8" />

## After

<img width="1540" height="627" alt="Screenshot 2026-05-20 231601" src="https://github.com/user-attachments/assets/7d1c66e8-3199-4591-8857-5fe9e6dd151a" />
<img width="1538" height="700" alt="Screenshot 2026-05-20 231620" src="https://github.com/user-attachments/assets/d446d4ec-2e6b-4ea4-b63c-2933c1c54aa2" />
<img width="1561" height="212" alt="Screenshot 2026-05-20 231649" src="https://github.com/user-attachments/assets/32d7d828-86ce-4a85-8ad3-6f3922bfb484" />
