### PR TITLE
[server] Fix Broadcast races and value-copy clobber in event_broadcast

### DIFF
--- a/server/models/event_broadcast.go
+++ b/server/models/event_broadcast.go
@@ -3,14 +3,12 @@ package models
 import (
 	"sync"
 
-	"github.com/meshery/meshery/server/helpers/utils"
 	"github.com/meshery/schemas/models/core"
-	"github.com/sirupsen/logrus"
 )
 
 type clients struct {
 	listeners []chan interface{}
-	mu        *sync.Mutex
+	mu        sync.Mutex
 }
 
 type Broadcast struct {
@@ -19,63 +17,53 @@ type Broadcast struct {
 }
 
 func (c *Broadcast) Subscribe(id core.Uuid) (chan interface{}, func()) {
-	clientMap, err := c.clients.LoadOrStore(id, clients{mu: &sync.Mutex{}})
-	if err {
-		logrus.Infof("Client for id %s does not exist in clients map", id)
-	}
+	actual, _ := c.clients.LoadOrStore(id, &clients{})
+	cc := actual.(*clients)
+
 	ch := make(chan interface{}, 1)
-	connectedClient, err := clientMap.(clients)
 
-	if err {
-		logrus.Infof("Client for id %s is not connected. Attempting to connect to client %s.", id, id)
-	}
+	cc.mu.Lock()
+	cc.listeners = append(cc.listeners, ch)
+	cc.mu.Unlock()
 
-	connectedClient.mu.Lock()
-	connectedClient.listeners = append(connectedClient.listeners, ch)
-	connectedClient.mu.Unlock()
-
-	c.clients.Store(id, connectedClient)
 	unsubscribe := func() {
-		cclient, ok := c.clients.Load(id)
-		var client clients
-		if ok {
-			client, ok = cclient.(clients)
-			if !ok {
-				return
-			}
+		v, ok := c.clients.Load(id)
+		if !ok {
+			return
 		}
-		client.mu.Lock()
-		defer client.mu.Unlock()
+		cc := v.(*clients)
 
-		listeners := client.listeners
-		updatedListeners := []chan interface{}{}
-		for _, client := range listeners {
-			if client == ch {
-				close(client)
-				// break
-			} else {
-				updatedListeners = append(updatedListeners, client)
+		cc.mu.Lock()
+		updated := make([]chan interface{}, 0, len(cc.listeners))
+		for _, l := range cc.listeners {
+			if l != ch {
+				updated = append(updated, l)
 			}
 		}
-		client.listeners = updatedListeners
-		c.clients.Store(id, client)
+		cc.listeners = updated
+		cc.mu.Unlock()
+
+		close(ch)
 	}
 	return ch, unsubscribe
 }
 
 func (c *Broadcast) Publish(id core.Uuid, data interface{}) {
-	clientMap, ok := c.clients.Load(id)
+	v, ok := c.clients.Load(id)
+	if !ok {
+		return
+	}
+	cc, ok := v.(*clients)
 	if !ok {
 		return
 	}
 
-	clientToPublish, ok := clientMap.(clients)
-	if !ok {
-		return
-	}
-	for _, client := range clientToPublish.listeners {
-		if !utils.IsClosed(client) {
-			client <- data
+	cc.mu.Lock()
+	defer cc.mu.Unlock()
+	for _, client := range cc.listeners {
+		select {
+		case client <- data:
+		default:
 		}
 	}
 }

--- a/server/models/event_broadcast.go
+++ b/server/models/event_broadcast.go
@@ -31,19 +31,27 @@ func (c *Broadcast) Subscribe(id core.Uuid) (chan interface{}, func()) {
 		if !ok {
 			return
 		}
-		cc := v.(*clients)
+		cc, ok := v.(*clients)
+		if !ok {
+			return
+		}
 
 		cc.mu.Lock()
+		found := false
 		updated := make([]chan interface{}, 0, len(cc.listeners))
 		for _, l := range cc.listeners {
-			if l != ch {
-				updated = append(updated, l)
+			if l == ch {
+				found = true
+				continue
 			}
+			updated = append(updated, l)
 		}
 		cc.listeners = updated
 		cc.mu.Unlock()
 
-		close(ch)
+		if found {
+			close(ch)
+		}
 	}
 	return ch, unsubscribe
 }

--- a/server/models/event_broadcast.go
+++ b/server/models/event_broadcast.go
@@ -56,6 +56,11 @@ func (c *Broadcast) Subscribe(id core.Uuid) (chan interface{}, func()) {
 	return ch, unsubscribe
 }
 
+// Publish delivers data to every subscriber for id. Delivery is
+// best-effort: each listener channel has a buffer of 1, and a non-blocking
+// send is used so a slow subscriber cannot block other subscribers or the
+// publisher. If the listener buffer is full, the event is dropped for that
+// subscriber.
 func (c *Broadcast) Publish(id core.Uuid, data interface{}) {
 	v, ok := c.clients.Load(id)
 	if !ok {

--- a/server/models/event_broadcast_test.go
+++ b/server/models/event_broadcast_test.go
@@ -6,7 +6,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/google/uuid"
+	"github.com/gofrs/uuid"
 )
 
 // TestBroadcast_MultipleSubscribersSameID asserts that two Subscribe calls
@@ -15,7 +15,7 @@ import (
 // first subscriber's listener slice entry.
 func TestBroadcast_MultipleSubscribersSameID(t *testing.T) {
 	b := NewBroadcaster("test")
-	id := uuid.New()
+	id := uuid.Must(uuid.NewV4())
 
 	ch1, unsub1 := b.Subscribe(id)
 	ch2, unsub2 := b.Subscribe(id)
@@ -41,7 +41,7 @@ func TestBroadcast_MultipleSubscribersSameID(t *testing.T) {
 // close-of-closed-channel.
 func TestBroadcast_DoubleUnsubscribe(t *testing.T) {
 	b := NewBroadcaster("test")
-	id := uuid.New()
+	id := uuid.Must(uuid.NewV4())
 
 	_, unsub := b.Subscribe(id)
 	unsub()
@@ -61,7 +61,7 @@ func TestBroadcast_DoubleUnsubscribe(t *testing.T) {
 // unsubscribe.
 func TestBroadcast_ConcurrentPublishUnsubscribe(t *testing.T) {
 	b := NewBroadcaster("test")
-	id := uuid.New()
+	id := uuid.Must(uuid.NewV4())
 
 	const subscribers = 50
 	const publishesPerSubscriber = 10
@@ -108,4 +108,34 @@ func TestBroadcast_ConcurrentPublishUnsubscribe(t *testing.T) {
 	<-bgDone
 
 	t.Logf("background publishes: %d", bgPublishes.Load())
+}
+
+// TestBroadcast_BestEffortDeliveryWhenBufferFull locks in the documented
+// behaviour of Publish: each subscriber's channel has buffer 1, and a
+// second publish before the subscriber drains the first is dropped
+// rather than blocking or panicking.
+func TestBroadcast_BestEffortDeliveryWhenBufferFull(t *testing.T) {
+	b := NewBroadcaster("test")
+	id := uuid.Must(uuid.NewV4())
+
+	ch, unsub := b.Subscribe(id)
+	defer unsub()
+
+	b.Publish(id, "first")
+	b.Publish(id, "dropped")
+
+	select {
+	case v := <-ch:
+		if v != "first" {
+			t.Errorf("got %v, want first", v)
+		}
+	case <-time.After(100 * time.Millisecond):
+		t.Fatal("expected first event in buffer")
+	}
+
+	select {
+	case v := <-ch:
+		t.Errorf("expected no second event, got %v", v)
+	case <-time.After(50 * time.Millisecond):
+	}
 }

--- a/server/models/event_broadcast_test.go
+++ b/server/models/event_broadcast_test.go
@@ -1,0 +1,111 @@
+package models
+
+import (
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+)
+
+// TestBroadcast_MultipleSubscribersSameID asserts that two Subscribe calls
+// for the same id both receive the published event. This regresses the
+// value-copy clobber bug where the second Subscribe could overwrite the
+// first subscriber's listener slice entry.
+func TestBroadcast_MultipleSubscribersSameID(t *testing.T) {
+	b := NewBroadcaster("test")
+	id := uuid.New()
+
+	ch1, unsub1 := b.Subscribe(id)
+	ch2, unsub2 := b.Subscribe(id)
+	defer unsub1()
+	defer unsub2()
+
+	b.Publish(id, "hello")
+
+	for i, ch := range []chan interface{}{ch1, ch2} {
+		select {
+		case v := <-ch:
+			if v != "hello" {
+				t.Errorf("subscriber %d got %v, want hello", i, v)
+			}
+		case <-time.After(200 * time.Millisecond):
+			t.Errorf("subscriber %d timed out waiting for event", i)
+		}
+	}
+}
+
+// TestBroadcast_DoubleUnsubscribe asserts that calling the returned
+// unsubscribe function twice is a no-op rather than a panic on
+// close-of-closed-channel.
+func TestBroadcast_DoubleUnsubscribe(t *testing.T) {
+	b := NewBroadcaster("test")
+	id := uuid.New()
+
+	_, unsub := b.Subscribe(id)
+	unsub()
+
+	defer func() {
+		if r := recover(); r != nil {
+			t.Errorf("second unsubscribe panicked: %v", r)
+		}
+	}()
+	unsub()
+}
+
+// TestBroadcast_ConcurrentPublishUnsubscribe runs many goroutines that
+// subscribe, publish, and unsubscribe on the same id while a background
+// publisher hammers the same id. Under -race this exercises both the
+// listener slice serialization and the close-after-unlock ordering in
+// unsubscribe.
+func TestBroadcast_ConcurrentPublishUnsubscribe(t *testing.T) {
+	b := NewBroadcaster("test")
+	id := uuid.New()
+
+	const subscribers = 50
+	const publishesPerSubscriber = 10
+
+	var wg sync.WaitGroup
+	for i := 0; i < subscribers; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			ch, unsub := b.Subscribe(id)
+			// Drain in the background so publishes do not stall on a full buffer.
+			drainDone := make(chan struct{})
+			go func() {
+				for range ch {
+				}
+				close(drainDone)
+			}()
+			for j := 0; j < publishesPerSubscriber; j++ {
+				b.Publish(id, j)
+			}
+			unsub()
+			<-drainDone
+		}()
+	}
+
+	var bgPublishes atomic.Int64
+	stop := make(chan struct{})
+	bgDone := make(chan struct{})
+	go func() {
+		defer close(bgDone)
+		for {
+			select {
+			case <-stop:
+				return
+			default:
+			}
+			b.Publish(id, "bg")
+			bgPublishes.Add(1)
+		}
+	}()
+
+	wg.Wait()
+	close(stop)
+	<-bgDone
+
+	t.Logf("background publishes: %d", bgPublishes.Load())
+}


### PR DESCRIPTION

Fixes #17011

### Context and prior art

This PR addresses #17011 (server panic on event broadcaster races, open since 2026-01-18). PR #17013 (Ady0333) was approved and had its merge conflict resolved by @leecalcote, but two E2E tests failed and the author self-closed it on 2026-03-18 without follow-up. The issue is still assigned to @Ady0333 but has had no activity in over four months; happy to hand back or split the work if they want to pick it up again.

### Three concurrency bugs in `server/models/event_broadcast.go`

1. `utils.IsClosed` (`server/helpers/utils/utils.go:151`) does `case <-ch: return true` and drains a queued event from a buffered, still-open channel. The Publish gate at the old `event_broadcast.go:77` then reports the channel closed and drops the send. Events silently lost on bursty subscribers.

2. `Subscribe` stored `clients` by value in `sync.Map` and re-`Store`'d a local copy after appending to `listeners`. The `*sync.Mutex` was shared, but the slice header was not, so two racing subscribers for the same id could both read the same pre-append header and last-writer-wins on `Store`, losing one subscriber. PR #17013 did not address this bug.

3. `Publish` iterated `listeners` with no lock while `unsubscribe` closed the channel mid-iteration; concurrent unsubscribe + publish could send on a closed channel and panic (this is the panic the issue's stack trace shows).

### Fix

- Store `*clients` in the `sync.Map` so the mutex actually protects the slice header. Eliminates the value-copy clobber.
- Embed `sync.Mutex` directly in `clients` (no longer a pointer; the struct is no longer copied).
- In `Publish`, hold `cc.mu` and use a non-blocking `select { case client <- data: default: }`. Drops the `IsClosed` gate, which is wrong for buffered channels.
- In `unsubscribe`, rebuild `listeners` without `ch` under `mu`, release the lock, then `close(ch)`. Publish either runs before the rebuild (sees the listener, sends safely under lock) or after (slice no longer contains ch), never racing the `close`.

### Delta versus PR #17013

- #17013 used `defer recover()` around each send to catch send-on-closed-channel panics. This works but adds per-send overhead and treats the symptom rather than the root cause. This PR makes the race impossible by serializing Publish iteration with the unsubscribe slice rebuild and closing only after the listener is removed.
- #17013 snapshotted listeners under lock then sent outside the lock. This PR sends under the lock with a non-blocking select, which avoids the snapshot allocation. Since the inner send is constant-time (default branch), holding the lock across iteration is bounded.
- #17013 did not change `Subscribe` or the `clients` struct. This PR fixes the value-copy lost-update bug there as well.

Diff keeps the `Broadcast.Subscribe` / `Broadcast.Publish` public API identical.

### Follow-ups (separate issue, not this PR)

The remaining `utils.IsClosed` callers have the same drop-an-event bug:

- `server/models/k8scontext_helper.go:46`
- `server/models/dashboard_k8s_resources.go:29`
- `server/models/meshmodel/helper.go:28`
- `server/models/configuration_helper.go:32, 46, 60`

`IsClosed` itself should be removed or replaced with a non-blocking send pattern. Left in place here to keep the diff scoped to the broadcaster.

### Verification

- `gofmt` clean on the changed file.
- Manual review: every `clients` access in `Subscribe`, `Publish`, and `unsubscribe` is now under `cc.mu`; `close(ch)` happens strictly after the listener is removed from the slice.
- E2E test stability was the prior blocker on #17013; would appreciate a maintainer ack to re-run the suite against this version since the failures may have been environmental.

**Notes for Reviewers**

- This PR fixes #17011

**[Signed commits](https://github.com/meshery/meshery/blob/master/CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [x] Yes, I signed my commits.