### PR TITLE
[server] Replace remaining broken utils.IsClosed gates with non-blocking sends

### DIFF
--- a/server/models/configuration_helper.go
+++ b/server/models/configuration_helper.go
@@ -2,8 +2,6 @@ package models
 
 import (
 	"sync"
-
-	"github.com/meshery/meshery/server/helpers/utils"
 )
 
 type ConfigurationChannel struct {
@@ -29,8 +27,9 @@ func (c *ConfigurationChannel) SubscribeApplications(ch chan struct{}) {
 
 func (c *ConfigurationChannel) PublishApplications() {
 	for _, ch := range c.ApplicationsChannel {
-		if !utils.IsClosed(ch) {
-			ch <- struct{}{}
+		select {
+		case ch <- struct{}{}:
+		default:
 		}
 	}
 }
@@ -43,8 +42,9 @@ func (c *ConfigurationChannel) SubscribePatterns(ch chan struct{}) {
 
 func (c *ConfigurationChannel) PublishPatterns() {
 	for _, ch := range c.PatternsChannel {
-		if !utils.IsClosed(ch) {
-			ch <- struct{}{}
+		select {
+		case ch <- struct{}{}:
+		default:
 		}
 	}
 }
@@ -57,8 +57,9 @@ func (c *ConfigurationChannel) SubscribeFilters(ch chan struct{}) {
 
 func (c *ConfigurationChannel) PublishFilters() {
 	for _, ch := range c.FiltersChannel {
-		if !utils.IsClosed(ch) {
-			ch <- struct{}{}
+		select {
+		case ch <- struct{}{}:
+		default:
 		}
 	}
 }

--- a/server/models/configuration_helper.go
+++ b/server/models/configuration_helper.go
@@ -26,7 +26,12 @@ func (c *ConfigurationChannel) SubscribeApplications(ch chan struct{}) {
 }
 
 func (c *ConfigurationChannel) PublishApplications() {
-	for _, ch := range c.ApplicationsChannel {
+	c.mx.Lock()
+	subscribers := make([]chan struct{}, len(c.ApplicationsChannel))
+	copy(subscribers, c.ApplicationsChannel)
+	c.mx.Unlock()
+
+	for _, ch := range subscribers {
 		select {
 		case ch <- struct{}{}:
 		default:
@@ -41,7 +46,12 @@ func (c *ConfigurationChannel) SubscribePatterns(ch chan struct{}) {
 }
 
 func (c *ConfigurationChannel) PublishPatterns() {
-	for _, ch := range c.PatternsChannel {
+	c.mx.Lock()
+	subscribers := make([]chan struct{}, len(c.PatternsChannel))
+	copy(subscribers, c.PatternsChannel)
+	c.mx.Unlock()
+
+	for _, ch := range subscribers {
 		select {
 		case ch <- struct{}{}:
 		default:
@@ -56,7 +66,12 @@ func (c *ConfigurationChannel) SubscribeFilters(ch chan struct{}) {
 }
 
 func (c *ConfigurationChannel) PublishFilters() {
-	for _, ch := range c.FiltersChannel {
+	c.mx.Lock()
+	subscribers := make([]chan struct{}, len(c.FiltersChannel))
+	copy(subscribers, c.FiltersChannel)
+	c.mx.Unlock()
+
+	for _, ch := range subscribers {
 		select {
 		case ch <- struct{}{}:
 		default:

--- a/server/models/dashboard_k8s_resources.go
+++ b/server/models/dashboard_k8s_resources.go
@@ -23,7 +23,12 @@ func (d *DashboardK8sResourcesChan) SubscribeDashbordK8Resources(ch chan struct{
 }
 
 func (d *DashboardK8sResourcesChan) PublishDashboardK8sResources() {
-	for _, ch := range d.ResourcesChan {
+	d.mx.Lock()
+	subscribers := make([]chan struct{}, len(d.ResourcesChan))
+	copy(subscribers, d.ResourcesChan)
+	d.mx.Unlock()
+
+	for _, ch := range subscribers {
 		select {
 		case ch <- struct{}{}:
 		default:

--- a/server/models/dashboard_k8s_resources.go
+++ b/server/models/dashboard_k8s_resources.go
@@ -2,8 +2,6 @@ package models
 
 import (
 	"sync"
-
-	"github.com/meshery/meshery/server/helpers/utils"
 )
 
 type DashboardK8sResourcesChan struct {
@@ -26,8 +24,9 @@ func (d *DashboardK8sResourcesChan) SubscribeDashbordK8Resources(ch chan struct{
 
 func (d *DashboardK8sResourcesChan) PublishDashboardK8sResources() {
 	for _, ch := range d.ResourcesChan {
-		if !utils.IsClosed(ch) {
-			ch <- struct{}{}
+		select {
+		case ch <- struct{}{}:
+		default:
 		}
 	}
 }

--- a/server/models/k8scontext_helper.go
+++ b/server/models/k8scontext_helper.go
@@ -2,8 +2,6 @@ package models
 
 import (
 	"sync"
-
-	"github.com/meshery/meshery/server/helpers/utils"
 )
 
 type K8scontextChan struct {
@@ -43,11 +41,9 @@ func (k *K8scontextChan) PublishContext() {
 	k.mx.Unlock()
 
 	for _, ch := range subscribers {
-		if !utils.IsClosed(ch) {
-			select {
-			case ch <- struct{}{}:
-			default:
-			}
+		select {
+		case ch <- struct{}{}:
+		default:
 		}
 	}
 }

--- a/server/models/meshmodel/helper.go
+++ b/server/models/meshmodel/helper.go
@@ -22,7 +22,12 @@ func (c *SummaryChannel) Subscribe(ch chan struct{}) {
 }
 
 func (c *SummaryChannel) Publish() {
-	for _, ch := range c.channel {
+	c.mx.Lock()
+	subscribers := make([]chan struct{}, len(c.channel))
+	copy(subscribers, c.channel)
+	c.mx.Unlock()
+
+	for _, ch := range subscribers {
 		select {
 		case ch <- struct{}{}:
 		default:

--- a/server/models/meshmodel/helper.go
+++ b/server/models/meshmodel/helper.go
@@ -2,8 +2,6 @@ package meshmodel
 
 import (
 	"sync"
-
-	"github.com/meshery/meshery/server/helpers/utils"
 )
 
 type SummaryChannel struct {
@@ -25,8 +23,9 @@ func (c *SummaryChannel) Subscribe(ch chan struct{}) {
 
 func (c *SummaryChannel) Publish() {
 	for _, ch := range c.channel {
-		if !utils.IsClosed(ch) {
-			ch <- struct{}{}
+		select {
+		case ch <- struct{}{}:
+		default:
 		}
 	}
 }


### PR DESCRIPTION
The `IsClosed[K]` helper at `server/helpers/utils/utils.go:151` does `case <-ch: return true` on the passed channel. For a buffered channel that is open but has a queued value, the receive branch fires and the value is dropped. The `Publish*` helpers that use it as a gate then report the channel closed and skip the send, so events are silently lost.

This is the follow-up I flagged in #19572 for the remaining five `utils.IsClosed` callers outside `event_broadcast.go`.

### Changes

- `server/models/configuration_helper.go`: `PublishApplications`, `PublishPatterns`, `PublishFilters`
- `server/models/dashboard_k8s_resources.go`: `PublishDashboardK8sResources`
- `server/models/meshmodel/helper.go`: `SummaryChannel.Publish`
- `server/models/k8scontext_helper.go`: `PublishContext` (the inner select was already non-blocking; only the redundant `IsClosed` gate is removed)

Each gate is replaced with:

```go
for _, ch := range listeners {
    select {
    case ch <- struct{}{}:
    default:
    }
}
```

`utils.IsClosed` itself is left in place because `event_broadcast.go` still references it on master. Removal will be a follow-up once #19572 merges and no callers remain.

### Why non-blocking

None of these four helper types expose an unsubscribe path that calls `close(ch)`. Subscribers register a channel and are responsible for their own channel lifecycle, so a send on a closed channel would still panic; that case is not introduced by this PR and is not supported by these helpers either before or after. The non-blocking select preserves the previous "best-effort delivery" intent, handles slow subscribers without blocking the publisher or other subscribers, and avoids the buffered-channel drain bug entirely.

**[Signed commits](https://github.com/meshery/meshery/blob/master/CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [x] Yes, I signed my commits.