### PR TITLE
Added a paragraph that tells about the openness and vendor neutrality…

### DIFF
--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -4,7 +4,9 @@ This document defines governance policies for the Meshery project.
 
 Anyone can become a Meshery contributor simply by contributing to the project, with code, documentation or other means. As with all Meshery community members, contributors are expected to follow the [Code of Conduct](./CODE_OF_CONDUCT.md).
 
-Meshery is a vendor-neutral project. Project blogs and announcements do not favor or advertise any specific vendor, and vendor participation rules across Slack and social media are applied equally to all. Community meetings, code, and documentation are hosted on neutral platforms such as CNCF Zoom and GitHub. No single vendor controls the project's features or roadmap, and architectural decisions are made openly with equal opportunity for community input, and no vendor may block reasonable contributions from other organizations. No single organization holds sole decision-making authority; leadership is open to any contributor regardless of employer or affiliation, and unresolved conflicts may be escalated to the [CNCF TOC](https://github.com/cncf/toc).
+Meshery is a vendor-neutral project. Project blogs and announcements do not favor or advertise any specific vendor, and vendor participation rules across Slack and social media are applied equally to all. Community meetings, code, and documentation are hosted on neutral platforms such as CNCF Zoom and GitHub.
+
+No single vendor controls the project's features or roadmap. Architectural decisions are made openly with equal opportunity for community input, and no vendor may block reasonable contributions from other organizations. No single organization holds sole decision-making authority; leadership is open to any contributor regardless of employer or affiliation, and unresolved conflicts may be escalated to the [CNCF TOC](https://github.com/cncf/toc).
 
 ## Contributors
 

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -4,6 +4,8 @@ This document defines governance policies for the Meshery project.
 
 Anyone can become a Meshery contributor simply by contributing to the project, with code, documentation or other means. As with all Meshery community members, contributors are expected to follow the [Code of Conduct](./CODE_OF_CONDUCT.md).
 
+Meshery is a vendor-neutral project. Project blogs and announcements do not favor or advertise any specific vendor, and vendor participation rules across Slack and social media are applied equally to all. Community meetings, code, and documentation are hosted on neutral platforms such as CNCF Zoom and GitHub. No single vendor controls the project's features or roadmap, and architectural decisions are made openly with equal opportunity for community input, and no vendor may block reasonable contributions from other organizations. No single organization holds sole decision-making authority; leadership is open to any contributor regardless of employer or affiliation, and unresolved conflicts may be escalated to the [CNCF TOC](https://github.com/cncf/toc).
+
 ## Contributors
 
 GitHub organization members are people who have `triage` access to all repos in the organization. Community members who wish to become members of the organization should meet the following requirements, which are open to the discretion of the steering committee:


### PR DESCRIPTION

**Notes for Reviewers**

- This PR addresses this issue #19461 
- It adds a paragraph about the openness and vendor neutrality of Meshery to the GOVERNANCE doc.

**[Signed commits](https://github.com/meshery/meshery/blob/master/CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [x] Yes, I signed my commits.