### PR TITLE
fix: batch-load connection environments to eliminate N+1 queries

### DIFF
--- a/server/models/connection_persister.go
+++ b/server/models/connection_persister.go
@@ -65,18 +65,40 @@ func (cp *ConnectionPersister) GetConnections(search, order string, page, pageSi
 	query.Table("connections").Count(&count)
 	Paginate(uint(page), uint(pageSize))(query).Find(&connectionsFetched)
 
-	for _, connectionFetched := range connectionsFetched {
-		// Declare a fresh slice per iteration so GORM's Find(&slice)
-		// populates a distinct underlying array for each connection. If
-		// the slice were hoisted out of the loop, all connections would
-		// end up sharing the same header and subsequent iterations would
-		// clobber earlier results.
-		environmentsFetched := []*environments.EnvironmentData{}
-		cp.DB.Table("environment_connection_mappings").Joins("LEFT JOIN environments ON environments.id = environment_connection_mappings.environment_id").Select("environments.*").
-			Where("connection_id = ?", connectionFetched.ID).
-			Find(&environmentsFetched)
+	// Batch-load environments for all connections on the page in a single
+	// query rather than issuing one query per connection (N+1 problem).
+	if len(connectionsFetched) > 0 {
+		connectionIDs := make([]core.Uuid, len(connectionsFetched))
+		for i, conn := range connectionsFetched {
+			connectionIDs[i] = conn.ID
+		}
 
-		connectionFetched.Environments = environmentsFetched
+		// envWithConnID augments EnvironmentData with the join-table's
+		// connection_id so we can group results after scanning.
+		type envWithConnID struct {
+			environments.EnvironmentData
+			ConnectionID core.Uuid `gorm:"column:connection_id"`
+		}
+
+		var envMappings []envWithConnID
+		cp.DB.Table("environment_connection_mappings").
+			Joins("LEFT JOIN environments ON environments.id = environment_connection_mappings.environment_id").
+			Select("environments.*, environment_connection_mappings.connection_id").
+			Where("environment_connection_mappings.connection_id IN ?", connectionIDs).
+			Find(&envMappings)
+
+		envsByConnID := make(map[core.Uuid][]*environments.EnvironmentData)
+		for i := range envMappings {
+			connID := envMappings[i].ConnectionID
+			envsByConnID[connID] = append(envsByConnID[connID], &envMappings[i].EnvironmentData)
+		}
+
+		for _, conn := range connectionsFetched {
+			conn.Environments = envsByConnID[conn.ID]
+			if conn.Environments == nil {
+				conn.Environments = []*environments.EnvironmentData{}
+			}
+		}
 	}
 	statusSummary, err := cp.getConnectionsStatusSummary()
 	if err != nil {

--- a/server/models/connection_persister.go
+++ b/server/models/connection_persister.go
@@ -81,11 +81,13 @@ func (cp *ConnectionPersister) GetConnections(search, order string, page, pageSi
 		}
 
 		var envMappings []envWithConnID
-		cp.DB.Table("environment_connection_mappings").
+		if err := cp.DB.Table("environment_connection_mappings").
 			Joins("LEFT JOIN environments ON environments.id = environment_connection_mappings.environment_id").
 			Select("environments.*, environment_connection_mappings.connection_id").
 			Where("environment_connection_mappings.connection_id IN ?", connectionIDs).
-			Find(&envMappings)
+			Find(&envMappings).Error; err != nil {
+			return nil, fmt.Errorf("error fetching environments for connections: %v", err)
+		}
 
 		envsByConnID := make(map[core.Uuid][]*environments.EnvironmentData)
 		for i := range envMappings {


### PR DESCRIPTION
## Summary

- `GetConnections` was issuing one separate DB query per connection to fetch its associated environments, producing up to 101 round-trips for a full page of 100 connections (the N+1 problem).
- Replace the per-connection loop with a single `JOIN` query scoped to all connection IDs on the page via an `IN` clause, then group results in-memory by connection ID.
- Reduces environment loading from O(N) queries to one query regardless of page size.

## Details

**Before** (`connection_persister.go`):
```go
for _, connectionFetched := range connectionsFetched {
    environmentsFetched := []*environments.EnvironmentData{}
    cp.DB.Table("environment_connection_mappings").
        Joins("LEFT JOIN environments ON ...").
        Select("environments.*").
        Where("connection_id = ?", connectionFetched.ID).  // one query per connection
        Find(&environmentsFetched)
    connectionFetched.Environments = environmentsFetched
}
```

**After**:
```go
// One query for all connections on the page
cp.DB.Table("environment_connection_mappings").
    Joins("LEFT JOIN environments ON ...").
    Select("environments.*, environment_connection_mappings.connection_id").
    Where("environment_connection_mappings.connection_id IN ?", connectionIDs).
    Find(&envMappings)

// Group in-memory and assign
for _, conn := range connectionsFetched {
    conn.Environments = envsByConnID[conn.ID]
}
```

## Test plan

- [ ] List connections via `GET /api/environments/connections` and verify environments are populated per connection
- [ ] Verify behavior with connections that belong to multiple environments
- [ ] Verify behavior with connections that belong to no environment (should return empty slice, not nil)
- [ ] Check DB query count drops from N+1 to 2 when listing a full page
