### PR TITLE
docs: describe maintainer assignments explicitly

### DIFF
--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -29,7 +29,7 @@ The Meshery project consists of multiple repositories. Each repository is subjec
 
 ### Who are Maintainers?
 
-The current maintainers of a repo can be found in [MAINTAINERS.md](./MAINTAINERS.md) file of the repo.
+The current maintainers for all Meshery repositories and their respective directories can be found in the central [MAINTAINERS.md](https://github.com/meshery/meshery/blob/master/MAINTAINERS.md) file in the `meshery/meshery` repository.
 
 Maintainers are individuals that have demonstrated their dedication the betterment of the project and dedication to Maintainers are empowered to review, approve, merge, close issues and pull requests. Maintainers are empowered to make releases. These individuals are most experience with the given project (or specific repo) and are expected to lead its growth and improvement. Adding and removing maintainers for a given repo is the responsibility of the existing maintainer team for that repo and therefore does not require approval from the steering committee.
 
@@ -53,7 +53,7 @@ The process of nominating and voting for maintainers involves the following step
 
 This process ensures that new maintainers are selected in a transparent and democratic way, with input from the entire community. It also helps maintain the health and sustainability of the project by ensuring that those who take on leadership roles are committed to its success and have the support of their peers.
 
-Maintainers will be added to the GitHub @meshery/maintainers team, and made a GitHub maintainer of that team. They will be given write permission to the Meshery GitHub repository <https://github.com/meshery/meshery> repo.
+Maintainer rights are granted by adding users to specific GitHub teams for each repository and/or directory they are responsible for. They will be given write permission to their respective Meshery GitHub repositories.
 
 ### Maintainer Responsibilities
 

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -1,61 +1,61 @@
 ### CLI Maintainers
 
-| Name                    | GitHub            | Affiliation |
-| ----------------------- | ----------------- | ----------- |
-| [Hussaina Begum](https://meshery.io/community/members/hussaina-begum)          | @hexxdump          | VMware      |
-| [Aadhitya Amarendiran](https://meshery.io/community/members/aadhitya-amarendiran)    | @alphaX86          | Citi        |
-| [Jerod Culpepper](https://meshery.io/community/members/jerod-culpepper)         | @cpepper96         | SAIC        |
-| [Antonette Caldwell](https://meshery.io/community/members/antonette-caldwell)      | @acald-creator     | Acquia      |
-| [Matthieu Evrin](https://meshery.io/community/members/matthieu-evrin)          | @lekaf974          | Moneris     |
+| Name                    | GitHub            | Affiliation | Repository / Directory |
+| ----------------------- | ----------------- | ----------- | ---------------------- |
+| [Hussaina Begum](https://meshery.io/community/members/hussaina-begum)          | @hexxdump          | VMware      | `meshery/meshery/mesheryctl` |
+| [Aadhitya Amarendiran](https://meshery.io/community/members/aadhitya-amarendiran)    | @alphaX86          | Citi        | `meshery/meshery/mesheryctl` |
+| [Jerod Culpepper](https://meshery.io/community/members/jerod-culpepper)         | @cpepper96         | SAIC        | `meshery/meshery/mesheryctl` |
+| [Antonette Caldwell](https://meshery.io/community/members/antonette-caldwell)      | @acald-creator     | Acquia      | `meshery/meshery/mesheryctl` |
+| [Matthieu Evrin](https://meshery.io/community/members/matthieu-evrin)          | @lekaf974          | Moneris     | `meshery/meshery/mesheryctl` |
 
 ### UI Maintainers
 
-| Name                | GitHub                 | Affiliation |
-| ------------------- | ---------------------- | --------------|
-| [Nikhil Ladha](https://meshery.io/community/members/nikhil-ladha)        | @Nikhil-Ladha           | Red Hat       |
-| [Antonette Caldwell](https://meshery.io/community/members/antonette-caldwell)  | @acald-creator          | Acquia        |
-| [Aabid Sofi](https://meshery.io/community/members/aabid-sofi)          | @aabidsofi19            | Layer5        |
-| [Yash Sharma](https://meshery.io/community/members/yash-sharma)         | @Yashsharma1911         | Digital Ocean |
-| [Sudhanshu Dasgupta](https://meshery.io/community/members/sudhanshu-dasgupta)  | @sudhanshutech          | SafeDep       |
-| [Ian Whitney](https://meshery.io/community/members/ian-whitney) | @ianrwhitney | Intuit |
+| Name                | GitHub                 | Affiliation | Repository / Directory |
+| ------------------- | ---------------------- | --------------| ---------------------- |
+| [Nikhil Ladha](https://meshery.io/community/members/nikhil-ladha)        | @Nikhil-Ladha           | Red Hat       | `meshery/meshery/ui` |
+| [Antonette Caldwell](https://meshery.io/community/members/antonette-caldwell)  | @acald-creator          | Acquia        | `meshery/meshery/ui` |
+| [Aabid Sofi](https://meshery.io/community/members/aabid-sofi)          | @aabidsofi19            | Layer5        | `meshery/meshery/ui` |
+| [Yash Sharma](https://meshery.io/community/members/yash-sharma)         | @Yashsharma1911         | Digital Ocean | `meshery/meshery/ui` |
+| [Sudhanshu Dasgupta](https://meshery.io/community/members/sudhanshu-dasgupta)  | @sudhanshutech          | SafeDep       | `meshery/meshery/ui` |
+| [Ian Whitney](https://meshery.io/community/members/ian-whitney) | @ianrwhitney | Intuit | `meshery/meshery/ui` |
 
 ### Adapter Maintainers
 
-| Name                | GitHub        | Affiliation |
-| ------------------- | ------------- | ----------- |
-| [Aisuko Li](https://meshery.io/community/members/aisuko)           | @aisuko        | RMIT        |
-| [Dheeraj Gedam](https://meshery.io/community/members/dheeraj-gedam)        | @dheerajng     | Citrix      |
-| [Haim Helman](https://meshery.io/community/members/haim-helman)         | @thehh1974     | VMware      |
-| [Hussaina Begum](https://meshery.io/community/members/hussaina-begum)      | @hexxdump      | VMware      |
-| [Ashish Tiwari](https://meshery.io/community/members/ashish-tiwari)       | @revolyssup    | API7        |
-| [Michael Gfeller](https://meshery.io/community/members/michael-gfeller)     | @mgfeller      | Computas AS |
-| [Antonette Caldwell](https://meshery.io/community/members/antonette-caldwell)  | @acald-creator | Acquia      |
+| Name                | GitHub        | Affiliation | Repository / Directory |
+| ------------------- | ------------- | ----------- | ---------------------- |
+| [Aisuko Li](https://meshery.io/community/members/aisuko)           | @aisuko        | RMIT        | `meshery-extensions/meshery-istio`, `meshery-extensions/meshery-linkerd`, `meshery-extensions/meshery-consul`, `meshery-extensions/meshery-kuma`, `meshery-extensions/meshery-nsm`, `meshery-extensions/meshery-nginx-sm`, `meshery-extensions/meshery-app-mesh`, `meshery-extensions/meshery-cilium`, `meshery-extensions/meshery-traefik-mesh` |
+| [Dheeraj Gedam](https://meshery.io/community/members/dheeraj-gedam)        | @dheerajng     | Citrix      | `meshery-extensions/meshery-istio`, `meshery-extensions/meshery-linkerd`, `meshery-extensions/meshery-consul`, `meshery-extensions/meshery-kuma`, `meshery-extensions/meshery-nsm`, `meshery-extensions/meshery-nginx-sm`, `meshery-extensions/meshery-app-mesh`, `meshery-extensions/meshery-cilium`, `meshery-extensions/meshery-traefik-mesh` |
+| [Haim Helman](https://meshery.io/community/members/haim-helman)         | @thehh1974     | VMware      | `meshery-extensions/meshery-istio`, `meshery-extensions/meshery-linkerd`, `meshery-extensions/meshery-consul`, `meshery-extensions/meshery-kuma`, `meshery-extensions/meshery-nsm`, `meshery-extensions/meshery-nginx-sm`, `meshery-extensions/meshery-app-mesh`, `meshery-extensions/meshery-cilium`, `meshery-extensions/meshery-traefik-mesh` |
+| [Hussaina Begum](https://meshery.io/community/members/hussaina-begum)      | @hexxdump      | VMware      | `meshery-extensions/meshery-istio`, `meshery-extensions/meshery-linkerd`, `meshery-extensions/meshery-consul`, `meshery-extensions/meshery-kuma`, `meshery-extensions/meshery-nsm`, `meshery-extensions/meshery-nginx-sm`, `meshery-extensions/meshery-app-mesh`, `meshery-extensions/meshery-cilium`, `meshery-extensions/meshery-traefik-mesh` |
+| [Ashish Tiwari](https://meshery.io/community/members/ashish-tiwari)       | @revolyssup    | API7        | `meshery-extensions/meshery-istio`, `meshery-extensions/meshery-linkerd`, `meshery-extensions/meshery-consul`, `meshery-extensions/meshery-kuma`, `meshery-extensions/meshery-nsm`, `meshery-extensions/meshery-nginx-sm`, `meshery-extensions/meshery-app-mesh`, `meshery-extensions/meshery-cilium`, `meshery-extensions/meshery-traefik-mesh` |
+| [Michael Gfeller](https://meshery.io/community/members/michael-gfeller)     | @mgfeller      | Computas AS | `meshery-extensions/meshery-istio`, `meshery-extensions/meshery-linkerd`, `meshery-extensions/meshery-consul`, `meshery-extensions/meshery-kuma`, `meshery-extensions/meshery-nsm`, `meshery-extensions/meshery-nginx-sm`, `meshery-extensions/meshery-app-mesh`, `meshery-extensions/meshery-cilium`, `meshery-extensions/meshery-traefik-mesh` |
+| [Antonette Caldwell](https://meshery.io/community/members/antonette-caldwell)  | @acald-creator | Acquia      | `meshery-extensions/meshery-istio`, `meshery-extensions/meshery-linkerd`, `meshery-extensions/meshery-consul`, `meshery-extensions/meshery-kuma`, `meshery-extensions/meshery-nsm`, `meshery-extensions/meshery-nginx-sm`, `meshery-extensions/meshery-app-mesh`, `meshery-extensions/meshery-cilium`, `meshery-extensions/meshery-traefik-mesh` |
 
 ### CI / Build & Release Maintainers
 
-| Name                  | GitHub             | Affiliation |
-| --------------------- | ------------------ | ----------- |
-| [Sangram Rath](https://meshery.io/community/members/sangram-rath)          | @sangramrath        | OD10        |
-| [Ian Whitney](https://meshery.io/community/members/ian-whitney) | @ianrwhitney | Intuit |
+| Name                  | GitHub             | Affiliation | Repository / Directory |
+| --------------------- | ------------------ | ----------- | ---------------------- |
+| [Sangram Rath](https://meshery.io/community/members/sangram-rath)          | @sangramrath        | OD10        | `meshery/meshery/.github` |
+| [Ian Whitney](https://meshery.io/community/members/ian-whitney) | @ianrwhitney | Intuit | `meshery/meshery/.github` |
 
 ### Docs Maintainers
 
-| Name              | GitHub          | Affiliation |
-| ----------------- | --------------- | ----------- |
-| [Adithya Krishna](https://meshery.io/community/members/adithya-krishna)   | @adithyaakrishna | Red Hat     |
-| [Lee Calcote](https://meshery.io/community/members/lee-calcote)       | @leecalcote      | Layer5      |
-| [Mia Grenell](https://meshery.io/community/members/mia-grenell)       | @miacycle        | USyd        |
+| Name              | GitHub          | Affiliation | Repository / Directory |
+| ----------------- | --------------- | ----------- | ---------------------- |
+| [Adithya Krishna](https://meshery.io/community/members/adithya-krishna)   | @adithyaakrishna | Red Hat     | `meshery/meshery/docs` |
+| [Lee Calcote](https://meshery.io/community/members/lee-calcote)       | @leecalcote      | Layer5      | `meshery/meshery/docs` |
+| [Mia Grenell](https://meshery.io/community/members/mia-grenell)       | @miacycle        | USyd        | `meshery/meshery/docs` |
 
 ### Site Maintainers
 
-| Name                    | GitHub       | Affiliation    |
-| ----------------------  | -----------  | -------------- |
-| [Nikhil Ladha](https://meshery.io/community/members/nikhil-ladha)            | @Nikhil-Ladha | Red Hat        |
-| [Aaditya Narayan Subedy](https://meshery.io/community/members/aaditya-narayan-subedy)  | @asubedy      | Fast Retailing |
+| Name                    | GitHub       | Affiliation    | Repository / Directory |
+| ----------------------  | -----------  | -------------- | ---------------------- |
+| [Nikhil Ladha](https://meshery.io/community/members/nikhil-ladha)            | @Nikhil-Ladha | Red Hat        | `meshery/meshery.io` |
+| [Aaditya Narayan Subedy](https://meshery.io/community/members/aaditya-narayan-subedy)  | @asubedy      | Fast Retailing | `meshery/meshery.io` |
 
 ### Meshery Extensions Maintainers
 
-| Name                    | GitHub         | Affiliation    |
-| ----------------------  | -------------- | -------------- |
-| [Ijeoma Eti](https://meshery.io/community/members/eti-ijeoma)              | @Aijeyomah      | Manufactured   |
-| [Pranav Singh](https://meshery.io/community/members/pranav-singh)            | @theBeginner86  | Intel          |
+| Name                    | GitHub         | Affiliation    | Repository / Directory |
+| ----------------------  | -------------- | -------------- | ---------------------- |
+| [Ijeoma Eti](https://meshery.io/community/members/eti-ijeoma)              | @Aijeyomah      | Manufactured   | `meshery/meshery-extensions` |
+| [Pranav Singh](https://meshery.io/community/members/pranav-singh)            | @theBeginner86  | Intel          | `meshery/meshery-extensions` |


### PR DESCRIPTION
Fixes #19447.

- Updated GOVERNANCE.md to state that maintainers for all Meshery repositories are listed in the central MAINTAINERS.md file.
- Updated GOVERNANCE.md to clarify that maintainer rights are granted via GitHub teams.
- Added a `Repository / Directory` column to tables in MAINTAINERS.md to explicitly map maintainers to their specific repositories and directories.