### PR TITLE
[Server] Rename matchLabels policy to tag

### DIFF
--- a/server/policies/engine.go
+++ b/server/policies/engine.go
@@ -24,7 +24,7 @@ func NewGoEngine(log Logger) *GoEngine {
 	return &GoEngine{
 		log: log,
 		policies: []RelationshipPolicy{
-			&MatchLabelsPolicy{},
+			&TagPolicy{},
 			&AliasPolicy{},
 			&EdgeNonBindingPolicy{},
 			&EdgeBindingPolicy{},

--- a/server/policies/engine_test.go
+++ b/server/policies/engine_test.go
@@ -137,7 +137,7 @@ func TestPolicyImplication(t *testing.T) {
 		&HierarchicalParentChildPolicy{},
 		&EdgeNonBindingPolicy{},
 		&AliasPolicy{},
-		&MatchLabelsPolicy{},
+		&TagPolicy{},
 	}
 
 	tests := []struct {
@@ -634,11 +634,11 @@ func TestAliasIsInvalidStatusMatrix(t *testing.T) {
 	}
 }
 
-// MatchLabelsPolicy must produce identical relationship UUIDs across runs for
+// TagPolicy must produce identical relationship UUIDs across runs for
 // the same input. Pre-fix, sibling identification leaked Go map iteration order
 // (groupMap range) and pointer addresses (fmt.Sprintf("%v", selectorSetItem))
 // into the generated IDs.
-func TestMatchLabelsPolicyIdentificationIsDeterministic(t *testing.T) {
+func TestTagPolicyIdentificationIsDeterministic(t *testing.T) {
 	pod := func(idHex string) *component.ComponentDefinition {
 		c := &component.ComponentDefinition{
 			Component: component.Component{Kind: "Pod"},
@@ -670,11 +670,11 @@ func TestMatchLabelsPolicyIdentificationIsDeterministic(t *testing.T) {
 	}
 
 	design := makePatternFile([]*component.ComponentDefinition{podA, podB, podC}, nil)
-	p := &MatchLabelsPolicy{}
+	p := &TagPolicy{}
 
 	first := p.IdentifyRelationship(makeRel(), design)
 	if len(first) == 0 {
-		t.Fatal("expected at least one matchlabels relationship")
+		t.Fatal("expected at least one tag relationship")
 	}
 	for i := 0; i < 5; i++ {
 		again := p.IdentifyRelationship(makeRel(), design)

--- a/server/policies/identify_bench_test.go
+++ b/server/policies/identify_bench_test.go
@@ -9,11 +9,11 @@ import (
 	"github.com/meshery/schemas/models/v1beta1/pattern"
 )
 
-// buildMatchlabelsBenchFixture returns n Pods sharing label values across a
-// small number of groups so identifyMatchlabels has nontrivial bucketing work.
+// buildTagsBenchFixture returns n Pods sharing label values across a
+// small number of groups so identifyTags has nontrivial bucketing work.
 // Each pod has two labels (app, version) whose values come from a small pool,
 // producing several non-trivial groups regardless of n.
-func buildMatchlabelsBenchFixture(n int) (*pattern.PatternFile, *relationship.RelationshipDefinition) {
+func buildTagsBenchFixture(n int) (*pattern.PatternFile, *relationship.RelationshipDefinition) {
 	comps := make([]*component.ComponentDefinition, 0, n)
 	groups := n/5 + 1
 	for i := 0; i < n; i++ {
@@ -46,20 +46,20 @@ func buildMatchlabelsBenchFixture(n int) (*pattern.PatternFile, *relationship.Re
 			},
 		},
 	}
-	relDef.ID = staticUUID("rel-matchlabels-bench")
+	relDef.ID = staticUUID("rel-tags-bench")
 
 	return &pattern.PatternFile{Components: comps}, relDef
 }
 
-// BenchmarkIdentifyMatchlabels measures identifyMatchlabels as the component
+// BenchmarkIdentifyTags measures identifyTags as the component
 // count grows, so the perf delta from the O(N²·F) → O(N·F) rewrite is visible.
-func BenchmarkIdentifyMatchlabels(b *testing.B) {
+func BenchmarkIdentifyTags(b *testing.B) {
 	for _, n := range []int{10, 50, 200} {
-		design, relDef := buildMatchlabelsBenchFixture(n)
+		design, relDef := buildTagsBenchFixture(n)
 		b.Run(fmt.Sprintf("N=%d", n), func(b *testing.B) {
 			b.ReportAllocs()
 			for i := 0; i < b.N; i++ {
-				_ = identifyMatchlabels(design, relDef)
+				_ = identifyTags(design, relDef)
 			}
 		})
 	}

--- a/server/policies/policy_tag.go
+++ b/server/policies/policy_tag.go
@@ -10,51 +10,57 @@ import (
 	"github.com/meshery/schemas/models/v1beta1/pattern"
 )
 
-// MatchLabelsPolicy handles sibling match-label relationships.
-type MatchLabelsPolicy struct{}
+// TagPolicy handles sibling relationships that group components sharing an
+// equal-valued configuration field. Despite the historical "matchLabels" name
+// (Kubernetes terminology), the grouping is not restricted to metadata.labels;
+// it applies to any equal-valued config field referenced by the selector.
+type TagPolicy struct{}
 
-const maxMatchLabels = 20
+const maxTags = 20
 
-func (p *MatchLabelsPolicy) Identifier() string {
+func (p *TagPolicy) Identifier() string {
+	// Wire identifier shared with the Rego engine (matchlabels-policy.rego) and
+	// used as a staticUUID seed, so it stays stable until renamed in
+	// meshery/schemas. See meshery/meshery#19149 (3).
 	return "sibling_match_labels_policy"
 }
 
-func (p *MatchLabelsPolicy) IsImplicatedBy(rel *relationship.RelationshipDefinition) bool {
+func (p *TagPolicy) IsImplicatedBy(rel *relationship.RelationshipDefinition) bool {
 	return strings.EqualFold(rel.RelationshipType, "sibling")
 }
 
-func (p *MatchLabelsPolicy) IsInvalid(rel *relationship.RelationshipDefinition, design *pattern.PatternFile) bool {
+func (p *TagPolicy) IsInvalid(rel *relationship.RelationshipDefinition, design *pattern.PatternFile) bool {
 	return p.IsImplicatedBy(rel)
 }
 
-func (p *MatchLabelsPolicy) AlreadyExists(rel *relationship.RelationshipDefinition, design *pattern.PatternFile) bool {
+func (p *TagPolicy) AlreadyExists(rel *relationship.RelationshipDefinition, design *pattern.PatternFile) bool {
 	return relationshipAlreadyExists(design, rel)
 }
 
-func (p *MatchLabelsPolicy) IdentifyRelationship(relDef *relationship.RelationshipDefinition, design *pattern.PatternFile) []*relationship.RelationshipDefinition {
-	return identifyMatchlabelRelationships(relDef, design)
+func (p *TagPolicy) IdentifyRelationship(relDef *relationship.RelationshipDefinition, design *pattern.PatternFile) []*relationship.RelationshipDefinition {
+	return identifyTagRelationships(relDef, design)
 }
 
-func (p *MatchLabelsPolicy) SideEffects(rel *relationship.RelationshipDefinition, design *pattern.PatternFile) []PolicyAction {
+func (p *TagPolicy) SideEffects(rel *relationship.RelationshipDefinition, design *pattern.PatternFile) []PolicyAction {
 	return nil
 }
 
-// matchLabelGroup represents a group of components sharing a label field+value.
-type matchLabelGroup struct {
+// tagGroup represents a group of components sharing a config field+value.
+type tagGroup struct {
 	Field      string
 	Value      interface{}
 	Components []*component.ComponentDefinition
 }
 
-// identifyMatchlabels finds all matching label groups in the design.
+// identifyTags finds all groups of components sharing an equal-valued config field.
 //
 // Single-pass bucketing: each component contributes its (field, value) pairs to
 // shared buckets once, instead of re-scanning all (comp, other) pairs. Reduces
 // the dominating cost from O(N²·F) to O(N·F) where N = components and F =
 // average label fields per component. Output groups are byte-identical to the
-// previous double-loop implementation on symmetric matchlabels fixtures, which
-// is the only shape this policy is exercised against.
-func identifyMatchlabels(design *pattern.PatternFile, relDef *relationship.RelationshipDefinition) []matchLabelGroup {
+// previous double-loop implementation on symmetric fixtures, which is the only
+// shape this policy is exercised against.
+func identifyTags(design *pattern.PatternFile, relDef *relationship.RelationshipDefinition) []tagGroup {
 	type bucketKey struct {
 		field, valueKey string
 	}
@@ -117,7 +123,7 @@ func identifyMatchlabels(design *pattern.PatternFile, relDef *relationship.Relat
 	}
 
 	// Iterate buckets in sorted key order so the output (and the truncation
-	// when len > maxMatchLabels) is stable across runs. Key ordering matches
+	// when len > maxTags) is stable across runs. Key ordering matches
 	// the previous `fmt.Sprintf("%s=%v", field, value)` lexicographic sort.
 	sortedKeys := make([]bucketKey, 0, len(buckets))
 	for k := range buckets {
@@ -130,7 +136,7 @@ func identifyMatchlabels(design *pattern.PatternFile, relDef *relationship.Relat
 		return sortedKeys[i].valueKey < sortedKeys[j].valueKey
 	})
 
-	groups := make([]matchLabelGroup, 0, len(sortedKeys))
+	groups := make([]tagGroup, 0, len(sortedKeys))
 	for _, k := range sortedKeys {
 		b := buckets[k]
 		if !b.hasFrom || !b.hasTo {
@@ -139,21 +145,21 @@ func identifyMatchlabels(design *pattern.PatternFile, relDef *relationship.Relat
 		if len(b.components) < 2 {
 			continue
 		}
-		groups = append(groups, matchLabelGroup{
+		groups = append(groups, tagGroup{
 			Field:      b.field,
 			Value:      b.value,
 			Components: b.components,
 		})
 	}
-	if len(groups) > maxMatchLabels {
-		groups = groups[:maxMatchLabels]
+	if len(groups) > maxTags {
+		groups = groups[:maxTags]
 	}
 	return groups
 }
 
-// identifyMatchlabelRelationships creates relationship definitions from matchlabel groups.
-func identifyMatchlabelRelationships(relDef *relationship.RelationshipDefinition, design *pattern.PatternFile) []*relationship.RelationshipDefinition {
-	groups := identifyMatchlabels(design, relDef)
+// identifyTagRelationships creates relationship definitions from tag groups.
+func identifyTagRelationships(relDef *relationship.RelationshipDefinition, design *pattern.PatternFile) []*relationship.RelationshipDefinition {
+	groups := identifyTags(design, relDef)
 
 	var identified []*relationship.RelationshipDefinition
 	seen := make(map[string]bool)


### PR DESCRIPTION
Fixes follow-up (3) in #19149.

`matchLabels` is Kubernetes terminology, but the policy groups components by any equal-valued configuration field, not just `metadata.labels`. Rename the Go-internal symbols to `tag` to reflect what the policy actually does.

## Changes

- `policy_matchlabels.go` -> `policy_tag.go`: `MatchLabelsPolicy` -> `TagPolicy`, `identifyMatchlabels` -> `identifyTags`, `identifyMatchlabelRelationships` -> `identifyTagRelationships`, `matchLabelGroup` -> `tagGroup`, `maxMatchLabels` -> `maxTags`.
- `engine.go`, `engine_test.go`, `identify_bench_test.go`: update references and the benchmark (`BenchmarkIdentifyTags`) to the new names.

The wire identifier `sibling_match_labels_policy` is kept: it is shared with the Rego engine (`matchlabels-policy.rego`) and seeds `staticUUID`, so renaming it would change generated relationship UUIDs. That rename is deferred until coordinated with meshery/schemas, per the issue. The `sibling` relationship type and the OPA-comparison vocabulary in `catalog_alignment_test.go` are likewise left untouched.

No behavior change; `go test ./server/policies/...` stays green.

**[Signed commits](https://github.com/meshery/meshery/blob/master/CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [x] Yes, I signed my commits.
