### PR TITLE
Profile navigation to new tab

### DIFF
--- a/ui/components/User.test.tsx
+++ b/ui/components/User.test.tsx
@@ -254,8 +254,8 @@ describe('User component', () => {
     render(<UserProvider />);
 
     await user.click(screen.getByTestId('icon-button-avatar'));
-    expect(notify).toHaveBeenCalledWith({
-      message: 'Profile URL not available. Please try again later.',
-    });
+    await waitFor(() => expect(notify).toHaveBeenCalled());
+    const [payload] = notify.mock.calls[0];
+    expect(payload.message).toBe('Profile URL not available. Please try again later.');
   });
 });

--- a/ui/components/User.test.tsx
+++ b/ui/components/User.test.tsx
@@ -207,8 +207,11 @@ describe('User component', () => {
     expect(payload.details).toBe('oops');
   });
 
-  it('navigates to the profile URL when the avatar is clicked', async () => {
+  it('opens profile URL in a new tab when avatar is clicked', async () => {
     const user = userEvent.setup();
+    const mockOpen = vi.fn();
+    window.open = mockOpen;
+
     mockGetUserQuery = {
       data: { status: 'authenticated' },
       isSuccess: true,
@@ -228,7 +231,11 @@ describe('User component', () => {
     await waitFor(() => expect(ExtensionPointSchemaValidator).toHaveBeenCalledWith('account'));
 
     await user.click(screen.getByTestId('icon-button-avatar'));
-    expect(window.location.href).toContain('https://cloud.test/profile');
+    expect(mockOpen).toHaveBeenCalledWith(
+      'https://cloud.test/profile',
+      '_blank',
+      'noopener,noreferrer',
+    );
   });
 
   it('does not redirect when no profile URL is present', async () => {
@@ -239,12 +246,16 @@ describe('User component', () => {
       isError: false,
       error: undefined,
     };
+    // no extensions.account → profileUrl will be undefined
+    mockProviderCapabilities = {
+      providerUrl: 'https://provider.test',
+    };
 
-    const startingHref = window.location.href;
     render(<UserProvider />);
 
     await user.click(screen.getByTestId('icon-button-avatar'));
-    // window.location.href should still be the same since profileUrl is undefined
-    expect(window.location.href).toBe(startingHref);
+    expect(notify).toHaveBeenCalledWith({
+      message: 'Profile URL not available. Please try again later.',
+    });
   });
 });

--- a/ui/components/User.test.tsx
+++ b/ui/components/User.test.tsx
@@ -238,7 +238,7 @@ describe('User component', () => {
     );
   });
 
-  it('does not redirect when no profile URL is present', async () => {
+  it('shows a warning when no profile URL is present', async () => {
     const user = userEvent.setup();
     mockGetUserQuery = {
       data: { status: 'authenticated' },

--- a/ui/components/User.tsx
+++ b/ui/components/User.tsx
@@ -37,7 +37,7 @@ const User = (props) => {
       return;
     }
     notify({
-      message: 'Profile URL not available. Please try again later.',
+      message: 'Please log in to access this profile',
       event_type: EVENT_TYPES.WARNING,
     });
   };

--- a/ui/components/User.tsx
+++ b/ui/components/User.tsx
@@ -33,9 +33,13 @@ const User = (props) => {
   const goToProfile = () => {
     const profileUrl = getProfileUrl();
     if (profileUrl) {
-      window.location = profileUrl;
+      window.open(profileUrl, '_blank', 'noopener,noreferrer');
       return;
     }
+    notify({
+      message: 'Profile URL not available. Please try again later.',
+      event_type: EVENT_TYPES.WARNING,
+    });
   };
 
   useEffect(() => {


### PR DESCRIPTION
**Notes for Reviewers**

- This PR fixes #17148 

-  Opened profile URL in a new tab instead of redirecting in the same tab, so users no longer lose their active Meshery Playground workspace or unsaved configuration when accessing their profile.


**[Signed commits](https://github.com/meshery/meshery/blob/master/CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [x] Yes, I signed my commits.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Profile links now open in a new browser tab/window instead of navigating away from the current page.
  * Added/updated warning behavior when a profile URL isn’t available.
* **Tests**
  * Updated avatar click tests to verify the new-tab behavior and the missing-URL warning.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->