### PR TITLE
[UI] Fix Next.js build imports and builder deps

### DIFF
--- a/install/docker/Dockerfile
+++ b/install/docker/Dockerfile
@@ -17,13 +17,13 @@ RUN apk add --no-cache libc6-compat
 WORKDIR /app
 COPY ui/package.json ui/package-lock.json ./
 ENV HUSKY=0
-RUN npm ci --omit=dev --legacy-peer-deps --ignore-scripts
+RUN npm ci --legacy-peer-deps --ignore-scripts
 
 FROM base-node AS meshery-ui-provider-deps
 RUN apk add --no-cache libc6-compat
 WORKDIR /app
 COPY provider-ui/package.json provider-ui/package-lock.json ./
-RUN npm ci --omit=dev --legacy-peer-deps
+RUN npm ci --legacy-peer-deps
 
 # Build NextJS Application
 FROM base-node AS meshery-ui-builder

--- a/install/docker/testing/Dockerfile
+++ b/install/docker/testing/Dockerfile
@@ -18,7 +18,7 @@ WORKDIR /app
 
 COPY ui/package.json ui/package-lock.json ./
 ENV HUSKY=0
-RUN npm ci --omit=dev --legacy-peer-deps --ignore-scripts
+RUN npm ci --legacy-peer-deps --ignore-scripts
 
 FROM base-node AS ui-builder
 WORKDIR /app
@@ -37,7 +37,7 @@ RUN apk add --no-cache libc6-compat
 WORKDIR /app
 # Install dependencies based on the preferred package manager
 COPY provider-ui/package.json provider-ui/package-lock.json ./
-RUN npm ci --omit=dev --legacy-peer-deps
+RUN npm ci --legacy-peer-deps
 
 FROM base-node AS ui-provider-builder
 WORKDIR /app

--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -107,6 +107,7 @@
         "@testing-library/jest-dom": "^6.9.1",
         "@testing-library/react": "^16.3.2",
         "@testing-library/user-event": "^14.6.1",
+        "@types/node": "^25.9.1",
         "@vitejs/plugin-react": "^6.0.2",
         "@vitest/coverage-v8": "^4.1.7",
         "allure-playwright": "^3.9.0",

--- a/ui/package.json
+++ b/ui/package.json
@@ -133,6 +133,7 @@
     "@testing-library/jest-dom": "^6.9.1",
     "@testing-library/react": "^16.3.2",
     "@testing-library/user-event": "^14.6.1",
+    "@types/node": "^25.9.1",
     "@vitejs/plugin-react": "^6.0.2",
     "@vitest/coverage-v8": "^4.1.7",
     "allure-playwright": "^3.9.0",

--- a/ui/pages/configuration/catalog.tsx
+++ b/ui/pages/configuration/catalog.tsx
@@ -2,8 +2,8 @@ import React from 'react';
 import { VISIBILITY } from '../../utils/Enum';
 import CAN from '@/utils/can';
 import { keys } from '@/utils/permission_constants';
-import DefaultError from '@/components/General/error-404';
-import MesheryPatterns from '@/components/MesheryPatterns/MesheryPatterns';
+import DefaultError from '@/components/general/error-404/index';
+import MesheryPatterns from '@/components/designs/patterns/MesheryPatterns';
 import { MesheryPage } from '@/components/MesheryPage';
 
 function CatalogPage() {

--- a/ui/pages/configuration/designs/configurator.tsx
+++ b/ui/pages/configuration/designs/configurator.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import DesignConfigurator from '../../../components/configuratorComponents/MeshModel';
+import DesignConfigurator from '@/components/designs/configurator/MeshModel';
 import { MesheryPage } from '@/components/MesheryPage';
 
 function DesignConfiguratorPage() {

--- a/ui/pages/configuration/designs/index.tsx
+++ b/ui/pages/configuration/designs/index.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import MesheryPatterns from '../../../components/MesheryPatterns/MesheryPatterns';
+import MesheryPatterns from '@/components/designs/patterns/MesheryPatterns';
 import { MesheryPage } from '@/components/MesheryPage';
 
 function Patterns() {

--- a/ui/pages/configuration/filters.tsx
+++ b/ui/pages/configuration/filters.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import MesheryFilters from '../../components/MesheryFilters/Filters';
+import MesheryFilters from '@/components/filters/Filters';
 import { MesheryPage, PageContainer } from '../../components/MesheryPage';
 
 function NewFilters() {

--- a/ui/pages/index.tsx
+++ b/ui/pages/index.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import Dashboard from '../components/Dashboard';
+import Dashboard from '@/components/dashboard';
 import { MesheryPage } from '../components/MesheryPage';
 
 function Index() {

--- a/ui/pages/management/environments.tsx
+++ b/ui/pages/management/environments.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { EnvironmentComponent } from '../../components/Lifecycle';
+import { EnvironmentComponent } from '@/components/lifecycle';
 import { MesheryPage, PageContainer } from '../../components/MesheryPage';
 
 const Environments = () => (

--- a/ui/pages/management/workspaces.tsx
+++ b/ui/pages/management/workspaces.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { WorkspacesComponent } from '../../components/Lifecycle';
+import { WorkspacesComponent } from '@/components/lifecycle';
 import { MesheryPage, PageContainer } from '../../components/MesheryPage';
 
 const Workspaces = () => (

--- a/ui/pages/performance/index.tsx
+++ b/ui/pages/performance/index.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import MesheryPerformanceComponent from '../../components/Performance/Dashboard';
+import MesheryPerformanceComponent from '@/components/performance/Dashboard';
 import { MesheryPage } from '../../components/MesheryPage';
 
 function Performance() {

--- a/ui/pages/performance/profiles.tsx
+++ b/ui/pages/performance/profiles.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import PerformanceProfiles from '../../components/Performance/PerformanceProfiles';
+import PerformanceProfiles from '@/components/performance/PerformanceProfiles';
 import { MesheryPage } from '../../components/MesheryPage';
 
 function Results() {

--- a/ui/pages/settings/index.tsx
+++ b/ui/pages/settings/index.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import MesherySettings from '../../components/Settings/MesherySettings';
+import MesherySettings from '@/components/settings/MesherySettings';
 import { MesheryPage } from '../../components/MesheryPage';
 
 function Settings() {

--- a/ui/pages/user/preferences.tsx
+++ b/ui/pages/user/preferences.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import UserPreferences from '../../components/UserPreferences';
+import UserPreferences from '@/components/user-preferences';
 import { useSelector } from 'react-redux';
 import { useGetUserPrefWithContextQuery } from '@/rtk-query/user';
 import { MesheryPage } from '../../components/MesheryPage';


### PR DESCRIPTION
## Summary
- update stale UI page imports to the current component locations
- install build-time dependencies in the UI Docker builder stages so Next.js can run TypeScript checks during production builds
- add `@types/node` to the UI devDependencies used by the build

## Testing
- `cd ui && npm run build`
- `cd ui && npm run lint`