### PR TITLE
[Tests] Use Meshery as the remote provider in e2e tests

### DIFF
--- a/.github/workflows/mesheryctl-e2e.yaml
+++ b/.github/workflows/mesheryctl-e2e.yaml
@@ -190,13 +190,13 @@ jobs:
               components: []
               channel: stable
               version: latest
-              provider: Layer5
+              provider: Meshery
           current-context: local
           tokens:
             - location: auth.json
               name: default
           EOF
-          echo '{ "meshery-provider": "Layer5", "token": null }' | jq -c '.token = env.PROVIDER_TOKEN' > "$HOME/.meshery/auth.json"
+          echo '{ "meshery-provider": "Meshery", "token": null }' | jq -c '.token = env.PROVIDER_TOKEN' > "$HOME/.meshery/auth.json"
           cp "$HOME/.meshery/auth.json" "$RUNNER_TEMP/auth.json"
           chmod 600 "$RUNNER_TEMP/auth.json"
           make build
@@ -284,13 +284,13 @@ jobs:
               components: []
               channel: stable
               version: latest
-              provider: Layer5
+              provider: Meshery
           current-context: local
           tokens:
             - location: auth.json
               name: default
           EOF
-          echo '{ "meshery-provider": "Layer5", "token": null }' | jq -c '.token = env.PROVIDER_TOKEN' > "$HOME/.meshery/auth.json"
+          echo '{ "meshery-provider": "Meshery", "token": null }' | jq -c '.token = env.PROVIDER_TOKEN' > "$HOME/.meshery/auth.json"
           cp "$HOME/.meshery/auth.json" "$RUNNER_TEMP/auth.json"
           chmod 600 "$RUNNER_TEMP/auth.json"
           make build

--- a/mesheryctl/pkg/utils/helpers_test.go
+++ b/mesheryctl/pkg/utils/helpers_test.go
@@ -34,7 +34,6 @@ func TestIsLocalProvider(t *testing.T) {
 		{"None", true}, // legacy alias
 		{"NONE", true},
 		{"Meshery", false},
-		{"Layer5", false},
 		{"", false},
 	}
 	for _, c := range cases {

--- a/mesheryctl/tests/e2e/000-prerequisites/00-config.bats
+++ b/mesheryctl/tests/e2e/000-prerequisites/00-config.bats
@@ -11,20 +11,20 @@ setup() {
     assert_exists "$MESHERY_CONFIG_FILE_PATH"
 }
 
-@test "meshery config.yaml provider is Layer5" {
+@test "meshery config.yaml provider is Meshery" {
     run yq '.contexts.local.provider' "$MESHERY_CONFIG_FILE_PATH"
     assert_success
 
-    assert_output  --partial "Layer5"
+    assert_output  --partial "Meshery"
 }
 
 @test "meshery auth.json file as been created" {
     assert_exists "$MESHERY_AUTH_FILE"
 }
 
-@test "meshery auth.json file meshery provider is Layer5" {
+@test "meshery auth.json file meshery provider is Meshery" {
     run jq '."meshery-provider"' "$MESHERY_AUTH_FILE"
     assert_success
 
-    assert_output "\"Layer5\""
+    assert_output "\"Meshery\""
 }

--- a/mesheryctl/tests/e2e/setup_suite.bash
+++ b/mesheryctl/tests/e2e/setup_suite.bash
@@ -11,15 +11,15 @@ create_meshery_config_folder() {
 
 # Generate auth file to communicate with meshery server
 create_auth_file() {
-    echo "start: authentication configuration" 
-    echo '{ "meshery-provider": "Layer5", "token": null }' | jq -c '.token = "'$MESHERY_PROVIDER_TOKEN'"' > "$MESHERY_AUTH_FILE"
+    echo "start: authentication configuration"
+    echo '{ "meshery-provider": "Meshery", "token": null }' | jq -c '.token = "'$MESHERY_PROVIDER_TOKEN'"' > "$MESHERY_AUTH_FILE"
     echo "done: authentication configuration"
 }
 
-set_context_to_layer5() {
-    echo "start: set context to Layer5"
-    yq -i '.contexts.local.provider = "Layer5"' "$MESHERY_CONFIG_FILE_PATH"
-    echo "done: set context to Layer5"
+set_context_to_meshery() {
+    echo "start: set context to Meshery"
+    yq -i '.contexts.local.provider = "Meshery"' "$MESHERY_CONFIG_FILE_PATH"
+    echo "done: set context to Meshery"
 }
 
 
@@ -38,8 +38,8 @@ main() {
     export TEMP_DATA_DIR=$TEMP_DATA_DIR
 
     create_meshery_config_folder
-    create_auth_file 
-    set_context_to_layer5
+    create_auth_file
+    set_context_to_meshery
 
     echo -e "### done: Test environment setup ###\n"
 }

--- a/ui/tests/e2e/.env.example
+++ b/ui/tests/e2e/.env.example
@@ -38,7 +38,7 @@ PROVIDER_TOKEN=
 # ------------------------------------------------------------------------------
 
 # Default provider to use for tests
-# Valid values: Local, Meshery, Layer5
+# Valid values: Local, Meshery
 # Default: Local
 MESHERY_PROVIDER=Local
 

--- a/ui/tests/e2e/pages/LoginPage.js
+++ b/ui/tests/e2e/pages/LoginPage.js
@@ -17,7 +17,7 @@ export class LoginPage {
     await this.page.goto('/login');
   }
 
-  async loginWithToken(token, baseURL, provider = 'Layer5') {
+  async loginWithToken(token, baseURL, provider = 'Meshery') {
     if (!token) {
       throw new Error('Token is required for token-based authentication');
     }

--- a/ui/tests/e2e/remote.setup.js
+++ b/ui/tests/e2e/remote.setup.js
@@ -6,7 +6,6 @@ import { ENV } from './env';
 const PROVIDERS = {
   LOCAL: 'Local',
   MESHERY: 'Meshery',
-  LAYER5: 'Layer5',
   // Extension Point: Add other providers as needed
 };
 


### PR DESCRIPTION
## Summary

Switches Playwright UI tests and mesheryctl BATS / Go tests from the legacy `Layer5` provider name to `Meshery`, so the remote provider exercised by the test suites matches the current Meshery Cloud naming.

## Changes

**Playwright UI tests (`ui/tests/e2e/`)**
- `.env.example`: drop `Layer5` from the documented `MESHERY_PROVIDER` valid values.
- `remote.setup.js`: remove the unused `LAYER5` entry from the `PROVIDERS` map.
- `pages/LoginPage.js`: default `loginWithToken` provider parameter to `Meshery`.

**mesheryctl BATS e2e tests (`mesheryctl/tests/e2e/`)**
- `setup_suite.bash`: write `Meshery` into `auth.json` and `config.yaml`, and rename `set_context_to_layer5` → `set_context_to_meshery`.
- `000-prerequisites/00-config.bats`: assert that `config.yaml` and `auth.json` carry the `Meshery` provider.

**mesheryctl Go tests (`mesheryctl/pkg/utils/`)**
- `helpers_test.go`: drop the `Layer5` row from `TestIsLocalProvider` table (the equivalent `Meshery` row already covers the remote-provider negative case).

**CI workflow (`.github/workflows/mesheryctl-e2e.yaml`)**
- Seed the same `Meshery` provider into both the manual and scheduled e2e jobs' `config.yaml` and `auth.json` fixtures, so the workflow matches the test expectations.

## Test plan

- [ ] `go test ./mesheryctl/pkg/utils/ -run TestIsLocalProvider` passes
- [ ] mesheryctl BATS e2e suite passes against a Meshery instance configured with the Meshery remote provider
- [ ] Playwright `chromium-meshery-provider` project authenticates and runs end-to-end against a Meshery server with `MESHERY_PROVIDER=Meshery`
- [ ] CI mesheryctl-e2e workflow (manual + scheduled jobs) initializes meshery with the Meshery provider

---
_Generated by [Claude Code](https://claude.ai/code/session_01TJLB9PieeyNY8K4w5dGiK8)_