### PR TITLE
chore: update e2e test workflow to use correct artifact name

### DIFF
--- a/.github/workflows/comment-e2e-test.yml
+++ b/.github/workflows/comment-e2e-test.yml
@@ -2,7 +2,6 @@ name: E2E Report on Pull Request Comment
 on:
   workflow_run:
     workflows: [
-      'Meshery UI and Server',
       'Meshery UI and Server PR Build',
       'Meshery Build And Test'
     ]
@@ -21,7 +20,7 @@ jobs:
     - name: Download e2e test report artifact
       uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16 # v4.1.8
       with:
-        name: e2e-test-reporter
+        name: e2e-test-report
         github-token: ${{ secrets.MESHERY_CI }}
         run-id: ${{ github.event.workflow_run.id }}
     - name: Retrieve PR Number


### PR DESCRIPTION
Looks like there may be a type in the download with the artifact name when the workflow was being deconstructed. I also removed the workflow Meshery UI and Server as this will be deprecated soon. This is currently only triggered on push to master.  


<img width="335" height="358" alt="image" src="https://github.com/user-attachments/assets/30a365fa-8369-4707-b262-7f411e031c7d" />
