### PR TITLE
[mesheryctl] fix: add timeout to latest version check HTTP client

### DIFF
--- a/mesheryctl/pkg/utils/latest_version.go
+++ b/mesheryctl/pkg/utils/latest_version.go
@@ -5,6 +5,7 @@ import (
 	"io"
 	"net/http"
 	"strings"
+	"time"
 )
 
 func GetLatestVersionForMesheryctl() (string, error) {
@@ -14,7 +15,9 @@ func GetLatestVersionForMesheryctl() (string, error) {
 		return "", err
 	}
 
-	client := http.Client{}
+	client := http.Client{
+		Timeout: 5 * time.Second,
+	}
 
 	resp, err := client.Do(req)
 	if err != nil {


### PR DESCRIPTION
### What does this PR do?
Resolves #19223

This PR addresses the issue where `mesheryctl` commands (such as `version`, `system start`, and `system update`) hang indefinitely when `docs.meshery.io` is slow or unreachable. It introduces a bounded `5 * time.Second` timeout on the HTTP client used to check the latest version, ensuring the CLI fails fast and runs gracefully under poor network conditions.

### Changes Made

#### mesheryctl:
- **`mesheryctl/pkg/utils/latest_version.go`**: 
  - Imported the standard library `"time"` package.
  - Initialized the `http.Client` with a `Timeout` of `5 * time.Second` in `GetLatestVersionForMesheryctl()`.

### Testing
- Verified successful local compilation using:
  `$env:CGO_ENABLED="0"; go build ./...`
- Manually verified timeout behavior by temporarily pointing the docs releases URL to a non-routable IP (`http://10.255.255.1`) and measuring execution time:
  `Measure-Command { .\mesheryctl.exe version }`
  - **Result**: The command successfully timed out and exited gracefully after exactly **5.05 seconds** instead of hanging indefinitely.

### Checklist
- [x] Yes, I signed my commits.
</pre>