### PR TITLE
[server] init subscriber slices with len=0 in helper constructors

### DIFF
--- a/server/models/configuration_helper.go
+++ b/server/models/configuration_helper.go
@@ -15,9 +15,9 @@ type ConfigurationChannel struct {
 
 func NewConfigurationHelper() *ConfigurationChannel {
 	return &ConfigurationChannel{
-		ApplicationsChannel: make([]chan struct{}, 10),
-		PatternsChannel:     make([]chan struct{}, 10),
-		FiltersChannel:      make([]chan struct{}, 10),
+		ApplicationsChannel: make([]chan struct{}, 0),
+		PatternsChannel:     make([]chan struct{}, 0),
+		FiltersChannel:      make([]chan struct{}, 0),
 	}
 }
 

--- a/server/models/meshmodel/helper.go
+++ b/server/models/meshmodel/helper.go
@@ -13,7 +13,7 @@ type SummaryChannel struct {
 
 func NewSummaryHelper() *SummaryChannel {
 	return &SummaryChannel{
-		channel: make([]chan struct{}, 10),
+		channel: make([]chan struct{}, 0),
 	}
 }
 


### PR DESCRIPTION

Fixes #19581.

`NewConfigurationHelper` (`server/models/configuration_helper.go:14-20`) and `NewSummaryHelper` (`server/models/meshmodel/helper.go:12-16`) initialise their subscriber slices with `make([]chan struct{}, 10)`. The slice has length 10 of zero-value (nil) channels before any subscriber appends. `Subscribe*` then appends real subscribers onto the slice, so iteration in `Publish*` walks 10 nil entries first and the real subscribers after.

Sending to a nil channel blocks forever. The pre-existing `utils.IsClosed` guard short-circuited on nil channels (explicit `if ch == nil { return true }`), but the same helper also drains buffered channels of any queued value (`case <-ch: return true`), which is bug #17011's root cause.

### Change

Switch to `make([]chan struct{}, 0)` so `Subscribe*` grows the slice with real channels only.

```go
// server/models/configuration_helper.go
func NewConfigurationHelper() *ConfigurationChannel {
    return &ConfigurationChannel{
        ApplicationsChannel: make([]chan struct{}, 0),
        PatternsChannel:     make([]chan struct{}, 0),
        FiltersChannel:      make([]chan struct{}, 0),
    }
}

// server/models/meshmodel/helper.go
func NewSummaryHelper() *SummaryChannel {
    return &SummaryChannel{
        channel: make([]chan struct{}, 0),
    }
}
```

Matches the existing pattern in `NewDashboardK8sResourcesHelper` (`server/models/dashboard_k8s_resources.go:14`) and `NewContextHelper` (`server/models/k8scontext_helper.go:14`), both of which already use length-zero slices.

### Why a separate PR

The `IsClosed` cleanup chain (#19572 → #19580 → #19585) replaces the broken gate. After that chain lands, the publishers no longer block on nil slots (they hit the `default` branch of the non-blocking select), but they still silently iterate ten no-op slots per publish. Fixing the root cause at construction is independent and correct on master too.

**[Signed commits](https://github.com/meshery/meshery/blob/master/CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [x] Yes, I signed my commits.