### PR TITLE
[Perf] Add Docker BuildKit cache mounts for Go module and build cache in Dockerfile

### DIFF
--- a/install/docker/Dockerfile
+++ b/install/docker/Dockerfile
@@ -6,8 +6,20 @@ ARG RELEASE_CHANNEL
 
 RUN adduser --disabled-login appuser
 WORKDIR /github.com/meshery/meshery
+
+# Cache Go module downloads across builds so a new dependency only
+# fetches what's missing instead of redownloading everything.
+RUN --mount=type=cache,target=/go/pkg/mod \
+    --mount=type=cache,target=/root/.cache/go-build \
+    cd server/cmd && \
+    GOPROXY=https://proxy.golang.org GOSUMDB=off go mod download
 ADD . .
-RUN go clean -modcache; cd server; cd cmd; GOPROXY=https://proxy.golang.org GOSUMDB=off go build -ldflags="-w -s -X main.globalTokenForAnonymousResults=$TOKEN -X main.version=$GIT_VERSION -X main.commitsha=$GIT_COMMITSHA -X main.releasechannel=$RELEASE_CHANNEL" -tags draft -a -o /meshery .
+RUN --mount=type=cache,target=/go/pkg/mod \
+    --mount=type=cache,target=/root/.cache/go-build \
+    cd server/cmd && \
+    GOPROXY=https://proxy.golang.org GOSUMDB=off go build \
+    -ldflags="-w -s -X main.globalTokenForAnonymousResults=$TOKEN -X main.version=$GIT_VERSION -X main.commitsha=$GIT_COMMITSHA -X main.releasechannel=$RELEASE_CHANNEL" \
+    -tags draft -o /meshery .
 
 FROM node:22-alpine AS base-node
 

--- a/install/docker/Dockerfile
+++ b/install/docker/Dockerfile
@@ -9,9 +9,8 @@ WORKDIR /github.com/meshery/meshery
 
 # Cache Go module downloads across builds so a new dependency only
 # fetches what's missing instead of redownloading everything.
+COPY go.mod go.sum ./
 RUN --mount=type=cache,target=/go/pkg/mod \
-    --mount=type=cache,target=/root/.cache/go-build \
-    cd server/cmd && \
     GOPROXY=https://proxy.golang.org GOSUMDB=off go mod download
 ADD . .
 RUN --mount=type=cache,target=/go/pkg/mod \


### PR DESCRIPTION
**Notes for Reviewers**

- This PR fixes #19703

**[Signed commits](https://github.com/meshery/meshery/blob/master/CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [x] Yes, I signed my commits.

<!--
Thank you for contributing to Meshery! 

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. Sign your commits.
4. Include before and after screenshots/terminal output.

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.
-->

## Description

The Go build stage in install/docker/Dockerfile currently runs go clean -modcache (defeats module caching) and compiles with -a (forces full rebuilds). This makes repeated docker build runs unnecessarily slow.

### Changes

- Replaced go clean -modcache && go build -a with plain go build
- Added COPY go.mod go.sum ./ before go mod download so the module cache actually works
- Added --mount=type=cache,target=/go/pkg/mod to persist the Go module cache across builds
- Added --mount=type=cache,target=/root/.cache/go-build to persist the Go build cache across builds

### Benefits

- Subsequent docker build runs reuse cached modules and compiled objects instead of redownloading everything
- CI builds benefit even more when agents share a common cache volume

### Testing

- docker build completes successfully
- First build: full compilation (cache miss)
- Subsequent builds: near-instant when Go sources are unchanged
