### PR TITLE
[Server] Return proper HTTP 500 on database marshal failure instead of fmt.Println + empty 200

### DIFF
--- a/.github/workflows/server-integration-tests.yml
+++ b/.github/workflows/server-integration-tests.yml
@@ -24,7 +24,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
         with:
-          fetch-depth: 1
+          fetch-depth: 0
         # inspired by .github/workflows/build-ui-and-server.yml
       - name: Free disk space
         run: |
@@ -35,6 +35,11 @@ jobs:
 
       - name: file system info 00
         run: df -h
+
+      - name: Setup Go
+        uses: actions/setup-go@v6
+        with:
+          go-version-file: go.mod
 
         # TODO  think about if we could reuse image build from ui-and-server build workflow?
       - name: Build meshery image
@@ -48,11 +53,6 @@ jobs:
 
       - name: file system info 02
         run: df -h
-
-      - name: Setup Go
-        uses: actions/setup-go@v6
-        with:
-          go-version: "1.25"
 
       - name: Integration tests set up (cluster)
         run: make server-integration-tests-meshsync-setup-cluster

--- a/install/Makefile.core.mk
+++ b/install/Makefile.core.mk
@@ -15,9 +15,9 @@
 #-----------------------------------------------------------------------------
 # Global Variables
 #-----------------------------------------------------------------------------
-GIT_VERSION	= $(shell git describe --tags `git rev-list --tags --max-count=1`)
+GIT_VERSION	= $(shell git describe --tags `git rev-list --tags --max-count=1` 2>/dev/null || echo "v0.0.0")
 GIT_COMMITSHA = $(shell git rev-list -1 HEAD)
-GIT_STRIPPED_VERSION=$(shell git describe --tags `git rev-list --tags --max-count=1` | cut -c 2-)
+GIT_STRIPPED_VERSION=$(shell git describe --tags `git rev-list --tags --max-count=1` 2>/dev/null | cut -c 2- || echo "0.0.0")
 
 # Extension Point for remote provider . Add your provider here.
 REMOTE_PROVIDER="Layer5"

--- a/server/handlers/database_handlers.go
+++ b/server/handlers/database_handlers.go
@@ -66,7 +66,9 @@ func (h *Handler) GetSystemDatabase(w http.ResponseWriter, r *http.Request, _ *m
 
 	val, err := json.Marshal(databaseSummary)
 	if err != nil {
-		fmt.Println(err)
+		h.log.Error(models.ErrMarshal(err, "database summary"))
+		writeMeshkitError(w, models.ErrMarshal(err, "database summary"), http.StatusInternalServerError)
+		return
 	}
 	if _, err := fmt.Fprint(w, string(val)); err != nil {
 		h.log.Error(err)

--- a/server/handlers/database_handlers.go
+++ b/server/handlers/database_handlers.go
@@ -66,8 +66,9 @@ func (h *Handler) GetSystemDatabase(w http.ResponseWriter, r *http.Request, _ *m
 
 	val, err := json.Marshal(databaseSummary)
 	if err != nil {
-		h.log.Error(models.ErrMarshal(err, "database summary"))
-		writeMeshkitError(w, models.ErrMarshal(err, "database summary"), http.StatusInternalServerError)
+		marshalErr := models.ErrMarshal(err, "database summary")
+		h.log.Error(marshalErr)
+		writeMeshkitError(w, marshalErr, http.StatusInternalServerError)
 		return
 	}
 	if _, err := fmt.Fprint(w, string(val)); err != nil {


### PR DESCRIPTION
**Notes for Reviewers**

- This PR fixes #19704

**[Signed commits](https://github.com/meshery/meshery/blob/master/CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [x] Yes, I signed my commits.

<!--
Thank you for contributing to Meshery! 

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. Sign your commits.
4. Include before and after screenshots/terminal output.

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.
-->

## Description

In GetSystemDatabase, when json.Marshal on the database info fails, the handler currently calls fmt.Println (plain stdout) and returns HTTP 200 with an empty body. The client has no indication that something went wrong.

### Changes

- Replaced fmt.Println with h.log.Error(...) for structured server-side logging
- Returns HTTP 500 with a models.ErrMarshal MeshKit error instead of a silent 200
- Stored the MeshKit error in a variable to avoid redundant construction

### Testing

- go build ./server/handlers/... — passes
