### PR TITLE
[Server] Refactor workspace/environment handlers to use httputil.WriteJSONBytes

### DIFF
--- a/.github/workflows/server-integration-tests.yml
+++ b/.github/workflows/server-integration-tests.yml
@@ -24,7 +24,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
         with:
-          fetch-depth: 1
+          fetch-depth: 0
         # inspired by .github/workflows/build-ui-and-server.yml
       - name: Free disk space
         run: |
@@ -35,6 +35,11 @@ jobs:
 
       - name: file system info 00
         run: df -h
+
+      - name: Setup Go
+        uses: actions/setup-go@v6
+        with:
+          go-version-file: go.mod
 
         # TODO  think about if we could reuse image build from ui-and-server build workflow?
       - name: Build meshery image
@@ -48,11 +53,6 @@ jobs:
 
       - name: file system info 02
         run: df -h
-
-      - name: Setup Go
-        uses: actions/setup-go@v6
-        with:
-          go-version: "1.25"
 
       - name: Integration tests set up (cluster)
         run: make server-integration-tests-meshsync-setup-cluster

--- a/install/Makefile.core.mk
+++ b/install/Makefile.core.mk
@@ -15,9 +15,9 @@
 #-----------------------------------------------------------------------------
 # Global Variables
 #-----------------------------------------------------------------------------
-GIT_VERSION	= $(shell git describe --tags `git rev-list --tags --max-count=1`)
+GIT_VERSION	= $(shell git describe --tags `git rev-list --tags --max-count=1` 2>/dev/null || echo "v0.0.0")
 GIT_COMMITSHA = $(shell git rev-list -1 HEAD)
-GIT_STRIPPED_VERSION=$(shell git describe --tags `git rev-list --tags --max-count=1` | cut -c 2-)
+GIT_STRIPPED_VERSION=$(shell git describe --tags `git rev-list --tags --max-count=1` 2>/dev/null | cut -c 2- || echo "0.0.0")
 
 # Extension Point for remote provider . Add your provider here.
 REMOTE_PROVIDER="Layer5"

--- a/server/handlers/environments_handlers.go
+++ b/server/handlers/environments_handlers.go
@@ -76,10 +76,7 @@ func (h *Handler) GetEnvironments(w http.ResponseWriter, req *http.Request, _ *m
 		return
 	}
 
-	w.Header().Set("Content-Type", "application/json")
-	if _, err := fmt.Fprint(w, string(resp)); err != nil {
-		h.log.Error(err)
-	}
+	writeJSONBytes(w, resp, http.StatusOK)
 }
 
 func (h *Handler) GetEnvironmentByIDHandler(w http.ResponseWriter, r *http.Request, _ *models.Preference, _ *models.User, provider models.Provider) {
@@ -98,10 +95,7 @@ func (h *Handler) GetEnvironmentByIDHandler(w http.ResponseWriter, r *http.Reque
 		return
 	}
 
-	w.Header().Set("Content-Type", "application/json")
-	if _, err := fmt.Fprint(w, string(resp)); err != nil {
-		h.log.Error(err)
-	}
+	writeJSONBytes(w, resp, http.StatusOK)
 }
 
 func (h *Handler) SaveEnvironment(w http.ResponseWriter, req *http.Request, _ *models.Preference, user *models.User, provider models.Provider) {
@@ -133,11 +127,7 @@ func (h *Handler) SaveEnvironment(w http.ResponseWriter, req *http.Request, _ *m
 	description := fmt.Sprintf("Environment %s created.", environment.Name)
 
 	h.log.Info(description)
-	w.Header().Set("Content-Type", "application/json")
-	w.WriteHeader(http.StatusCreated)
-	if _, err := fmt.Fprint(w, string(resp)); err != nil {
-		h.log.Error(err)
-	}
+	writeJSONBytes(w, resp, http.StatusCreated)
 }
 
 func (h *Handler) DeleteEnvironmentHandler(w http.ResponseWriter, r *http.Request, _ *models.Preference, _ *models.User, provider models.Provider) {
@@ -149,10 +139,7 @@ func (h *Handler) DeleteEnvironmentHandler(w http.ResponseWriter, r *http.Reques
 		return
 	}
 
-	w.Header().Set("Content-Type", "application/json")
-	if _, err := fmt.Fprint(w, string(resp)); err != nil {
-		h.log.Error(err)
-	}
+	writeJSONBytes(w, resp, http.StatusOK)
 }
 
 func (h *Handler) UpdateEnvironmentHandler(w http.ResponseWriter, req *http.Request, _ *models.Preference, user *models.User, provider models.Provider) {
@@ -191,14 +178,7 @@ func (h *Handler) UpdateEnvironmentHandler(w http.ResponseWriter, req *http.Requ
 	description := fmt.Sprintf("Environment %s updated.", environment.Name)
 	h.log.Info(description)
 
-	w.Header().Set("Content-Type", "application/json")
-	w.WriteHeader(http.StatusOK)
-	_, err = w.Write(respJSON)
-	if err != nil {
-		h.log.Error(ErrGetResult(err))
-		// Headers already committed; log only. Writing another body would corrupt the stream.
-		return
-	}
+	writeJSONBytes(w, respJSON, http.StatusOK)
 }
 
 func (h *Handler) AddConnectionToEnvironmentHandler(w http.ResponseWriter, r *http.Request, _ *models.Preference, _ *models.User, provider models.Provider) {
@@ -211,10 +191,7 @@ func (h *Handler) AddConnectionToEnvironmentHandler(w http.ResponseWriter, r *ht
 		return
 	}
 
-	w.Header().Set("Content-Type", "application/json")
-	if _, err := fmt.Fprint(w, string(resp)); err != nil {
-		h.log.Error(err)
-	}
+	writeJSONBytes(w, resp, http.StatusOK)
 }
 
 func (h *Handler) RemoveConnectionFromEnvironmentHandler(w http.ResponseWriter, r *http.Request, _ *models.Preference, _ *models.User, provider models.Provider) {
@@ -227,10 +204,7 @@ func (h *Handler) RemoveConnectionFromEnvironmentHandler(w http.ResponseWriter, 
 		return
 	}
 
-	w.Header().Set("Content-Type", "application/json")
-	if _, err := fmt.Fprint(w, string(resp)); err != nil {
-		h.log.Error(err)
-	}
+	writeJSONBytes(w, resp, http.StatusOK)
 }
 
 func (h *Handler) GetConnectionsOfEnvironmentHandler(w http.ResponseWriter, r *http.Request, _ *models.Preference, _ *models.User, provider models.Provider) {
@@ -242,8 +216,5 @@ func (h *Handler) GetConnectionsOfEnvironmentHandler(w http.ResponseWriter, r *h
 		writeMeshkitError(w, ErrGetResult(err), http.StatusInternalServerError)
 		return
 	}
-	w.Header().Set("Content-Type", "application/json")
-	if _, err := fmt.Fprint(w, string(resp)); err != nil {
-		h.log.Error(err)
-	}
+	writeJSONBytes(w, resp, http.StatusOK)
 }

--- a/server/handlers/utils.go
+++ b/server/handlers/utils.go
@@ -50,6 +50,10 @@ func writeJSONEmptyObject(w http.ResponseWriter, status int) {
 	httputil.WriteJSONEmptyObject(w, status)
 }
 
+func writeJSONBytes(w http.ResponseWriter, data []byte, status int) {
+	httputil.WriteJSONBytes(w, data, status)
+}
+
 const (
 	defaultPageSize = 25
 	queryParamTrue  = "true"

--- a/server/handlers/workspace_handlers.go
+++ b/server/handlers/workspace_handlers.go
@@ -107,10 +107,7 @@ func (h *Handler) GetWorkspacesHandler(w http.ResponseWriter, req *http.Request,
 		return
 	}
 
-	w.Header().Set("Content-Type", "application/json")
-	if _, err := w.Write(resp); err != nil {
-		h.log.Error(err)
-	}
+	writeJSONBytes(w, resp, http.StatusOK)
 }
 
 func (h *Handler) GetWorkspaceByIdHandler(w http.ResponseWriter, r *http.Request, _ *models.Preference, _ *models.User, provider models.Provider) {
@@ -135,10 +132,7 @@ func (h *Handler) GetWorkspaceByIdHandler(w http.ResponseWriter, r *http.Request
 		return
 	}
 
-	w.Header().Set("Content-Type", "application/json")
-	if _, err := w.Write(resp); err != nil {
-		h.log.Error(err)
-	}
+	writeJSONBytes(w, resp, http.StatusOK)
 }
 
 func (h *Handler) SaveWorkspaceHandler(w http.ResponseWriter, req *http.Request, _ *models.Preference, user *models.User, provider models.Provider) {
@@ -170,11 +164,7 @@ func (h *Handler) SaveWorkspaceHandler(w http.ResponseWriter, req *http.Request,
 	description := fmt.Sprintf("Workspace %s created.", workspace.Name)
 
 	h.log.Info(description)
-	w.WriteHeader(http.StatusCreated)
-	w.Header().Set("Content-Type", "application/json")
-	if _, err := w.Write(bf); err != nil {
-		h.log.Error(err)
-	}
+	writeJSONBytes(w, bf, http.StatusCreated)
 }
 
 func (h *Handler) DeleteWorkspaceHandler(w http.ResponseWriter, r *http.Request, _ *models.Preference, _ *models.User, provider models.Provider) {
@@ -186,10 +176,7 @@ func (h *Handler) DeleteWorkspaceHandler(w http.ResponseWriter, r *http.Request,
 		return
 	}
 
-	w.Header().Set("Content-Type", "application/json")
-	if _, err := w.Write(resp); err != nil {
-		h.log.Error(err)
-	}
+	writeJSONBytes(w, resp, http.StatusOK)
 }
 
 func (h *Handler) UpdateWorkspaceHandler(w http.ResponseWriter, req *http.Request, _ *models.Preference, user *models.User, provider models.Provider) {
@@ -228,14 +215,7 @@ func (h *Handler) UpdateWorkspaceHandler(w http.ResponseWriter, req *http.Reques
 	description := fmt.Sprintf("Workspace %s updated.", resp.Name)
 	h.log.Info(description)
 
-	w.Header().Set("Content-Type", "application/json")
-	w.WriteHeader(http.StatusOK)
-	_, err = w.Write(respJSON)
-	if err != nil {
-		h.log.Error(ErrGetResult(err))
-		// Headers already committed; log only. Writing another body would corrupt the stream.
-		return
-	}
+	writeJSONBytes(w, respJSON, http.StatusOK)
 }
 
 func (h *Handler) GetEnvironmentsOfWorkspaceHandler(w http.ResponseWriter, req *http.Request, _ *models.Preference, _ *models.User, provider models.Provider) {
@@ -248,10 +228,7 @@ func (h *Handler) GetEnvironmentsOfWorkspaceHandler(w http.ResponseWriter, req *
 		return
 	}
 
-	w.Header().Set("Content-Type", "application/json")
-	if _, err := w.Write(resp); err != nil {
-		h.log.Error(err)
-	}
+	writeJSONBytes(w, resp, http.StatusOK)
 }
 
 func (h *Handler) GetDesignsOfWorkspaceHandler(w http.ResponseWriter, req *http.Request, _ *models.Preference, _ *models.User, provider models.Provider) {
@@ -264,10 +241,7 @@ func (h *Handler) GetDesignsOfWorkspaceHandler(w http.ResponseWriter, req *http.
 		return
 	}
 
-	w.Header().Set("Content-Type", "application/json")
-	if _, err := w.Write(resp); err != nil {
-		h.log.Error(err)
-	}
+	writeJSONBytes(w, resp, http.StatusOK)
 }
 
 func (h *Handler) AddEnvironmentToWorkspaceHandler(w http.ResponseWriter, req *http.Request, _ *models.Preference, _ *models.User, provider models.Provider) {
@@ -279,10 +253,7 @@ func (h *Handler) AddEnvironmentToWorkspaceHandler(w http.ResponseWriter, req *h
 		writeMeshkitError(w, ErrGetResult(err), http.StatusInternalServerError)
 		return
 	}
-	w.Header().Set("Content-Type", "application/json")
-	if _, err := w.Write(resp); err != nil {
-		h.log.Error(err)
-	}
+	writeJSONBytes(w, resp, http.StatusOK)
 }
 
 func (h *Handler) RemoveEnvironmentFromWorkspaceHandler(w http.ResponseWriter, req *http.Request, _ *models.Preference, _ *models.User, provider models.Provider) {
@@ -294,10 +265,7 @@ func (h *Handler) RemoveEnvironmentFromWorkspaceHandler(w http.ResponseWriter, r
 		writeMeshkitError(w, ErrGetResult(err), http.StatusInternalServerError)
 		return
 	}
-	w.Header().Set("Content-Type", "application/json")
-	if _, err := w.Write(resp); err != nil {
-		h.log.Error(err)
-	}
+	writeJSONBytes(w, resp, http.StatusOK)
 }
 
 func (h *Handler) AddDesignToWorkspaceHandler(w http.ResponseWriter, req *http.Request, _ *models.Preference, _ *models.User, provider models.Provider) {
@@ -309,10 +277,7 @@ func (h *Handler) AddDesignToWorkspaceHandler(w http.ResponseWriter, req *http.R
 		writeMeshkitError(w, ErrGetResult(err), http.StatusInternalServerError)
 		return
 	}
-	w.Header().Set("Content-Type", "application/json")
-	if _, err := w.Write(resp); err != nil {
-		h.log.Error(err)
-	}
+	writeJSONBytes(w, resp, http.StatusOK)
 }
 
 func (h *Handler) RemoveDesignFromWorkspaceHandler(w http.ResponseWriter, req *http.Request, _ *models.Preference, _ *models.User, provider models.Provider) {
@@ -324,10 +289,7 @@ func (h *Handler) RemoveDesignFromWorkspaceHandler(w http.ResponseWriter, req *h
 		writeMeshkitError(w, ErrGetResult(err), http.StatusInternalServerError)
 		return
 	}
-	w.Header().Set("Content-Type", "application/json")
-	if _, err := w.Write(resp); err != nil {
-		h.log.Error(err)
-	}
+	writeJSONBytes(w, resp, http.StatusOK)
 }
 
 func (h *Handler) GetViewsOfWorkspaceHandler(w http.ResponseWriter, req *http.Request, _ *models.Preference, _ *models.User, provider models.Provider) {
@@ -339,10 +301,7 @@ func (h *Handler) GetViewsOfWorkspaceHandler(w http.ResponseWriter, req *http.Re
 		writeMeshkitError(w, ErrGetResult(err), http.StatusInternalServerError)
 		return
 	}
-	w.Header().Set("Content-Type", "application/json")
-	if _, err := w.Write(resp); err != nil {
-		h.log.Error(err)
-	}
+	writeJSONBytes(w, resp, http.StatusOK)
 }
 
 func (h *Handler) AddViewToWorkspaceHandler(w http.ResponseWriter, req *http.Request, _ *models.Preference, _ *models.User, provider models.Provider) {
@@ -354,10 +313,7 @@ func (h *Handler) AddViewToWorkspaceHandler(w http.ResponseWriter, req *http.Req
 		writeMeshkitError(w, ErrGetResult(err), http.StatusInternalServerError)
 		return
 	}
-	w.Header().Set("Content-Type", "application/json")
-	if _, err := w.Write(resp); err != nil {
-		h.log.Error(err)
-	}
+	writeJSONBytes(w, resp, http.StatusOK)
 }
 
 func (h *Handler) RemoveViewFromWorkspaceHandler(w http.ResponseWriter, req *http.Request, _ *models.Preference, _ *models.User, provider models.Provider) {
@@ -369,10 +325,7 @@ func (h *Handler) RemoveViewFromWorkspaceHandler(w http.ResponseWriter, req *htt
 		writeMeshkitError(w, ErrGetResult(err), http.StatusInternalServerError)
 		return
 	}
-	w.Header().Set("Content-Type", "application/json")
-	if _, err := w.Write(resp); err != nil {
-		h.log.Error(err)
-	}
+	writeJSONBytes(w, resp, http.StatusOK)
 }
 
 func (h *Handler) GetTeamsOfWorkspaceHandler(w http.ResponseWriter, req *http.Request, _ *models.Preference, _ *models.User, provider models.Provider) {
@@ -384,10 +337,7 @@ func (h *Handler) GetTeamsOfWorkspaceHandler(w http.ResponseWriter, req *http.Re
 		writeMeshkitError(w, ErrGetResult(err), http.StatusInternalServerError)
 		return
 	}
-	w.Header().Set("Content-Type", "application/json")
-	if _, err := w.Write(resp); err != nil {
-		h.log.Error(err)
-	}
+	writeJSONBytes(w, resp, http.StatusOK)
 }
 
 func (h *Handler) AddTeamToWorkspaceHandler(w http.ResponseWriter, req *http.Request, _ *models.Preference, _ *models.User, provider models.Provider) {
@@ -399,10 +349,7 @@ func (h *Handler) AddTeamToWorkspaceHandler(w http.ResponseWriter, req *http.Req
 		writeMeshkitError(w, ErrGetResult(err), http.StatusInternalServerError)
 		return
 	}
-	w.Header().Set("Content-Type", "application/json")
-	if _, err := w.Write(resp); err != nil {
-		h.log.Error(err)
-	}
+	writeJSONBytes(w, resp, http.StatusOK)
 }
 
 func (h *Handler) RemoveTeamFromWorkspaceHandler(w http.ResponseWriter, req *http.Request, _ *models.Preference, _ *models.User, provider models.Provider) {
@@ -414,8 +361,5 @@ func (h *Handler) RemoveTeamFromWorkspaceHandler(w http.ResponseWriter, req *htt
 		writeMeshkitError(w, ErrGetResult(err), http.StatusInternalServerError)
 		return
 	}
-	w.Header().Set("Content-Type", "application/json")
-	if _, err := w.Write(resp); err != nil {
-		h.log.Error(err)
-	}
+	writeJSONBytes(w, resp, http.StatusOK)
 }

--- a/server/models/httputil/httputil.go
+++ b/server/models/httputil/httputil.go
@@ -141,6 +141,9 @@ func WriteJSONEmptyObject(w http.ResponseWriter, status int) {
 }
 
 // WriteJSONBytes writes pre-encoded JSON bytes with the given status code.
+// Unlike WriteJSONMessage which would marshal the data a second time (causing
+// double-encoding for already-serialized payloads), this helper writes the bytes
+// directly after setting the correct Content-Type header and status code.
 // Use this when the payload is already serialized (e.g. returned from a
 // provider method) to avoid the unnecessary marshal-then-unmarshal cycle of
 // decoding and re-encoding through WriteJSONMessage.

--- a/server/models/httputil/httputil.go
+++ b/server/models/httputil/httputil.go
@@ -139,3 +139,14 @@ func WriteJSONEmptyObject(w http.ResponseWriter, status int) {
 	w.WriteHeader(status)
 	_, _ = w.Write([]byte("{}"))
 }
+
+// WriteJSONBytes writes pre-encoded JSON bytes with the given status code.
+// Use this when the payload is already serialized (e.g. returned from a
+// provider method) to avoid the unnecessary marshal-then-unmarshal cycle of
+// decoding and re-encoding through WriteJSONMessage.
+func WriteJSONBytes(w http.ResponseWriter, data []byte, status int) {
+	w.Header().Set("Content-Type", "application/json; charset=utf-8")
+	w.Header().Set("X-Content-Type-Options", "nosniff")
+	w.WriteHeader(status)
+	_, _ = w.Write(data)
+}


### PR DESCRIPTION
**Notes for Reviewers**

- This PR fixes #19705

**[Signed commits](https://github.com/meshery/meshery/blob/master/CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [x] Yes, I signed my commits.

<!--
Thank you for contributing to Meshery! 

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. Sign your commits.
4. Include before and after screenshots/terminal output.

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.
-->

## Description

Workspace and environment handlers contain roughly 25 manual response-writing blocks that independently set Content-Type, call WriteHeader, and write raw bytes. This pattern is repetitive and makes it easy to miss headers.

### Changes

- Added WriteJSONBytes to server/models/httputil/httputil.go for pre-encoded JSON payloads
- Added writeJSONBytes wrapper in server/handlers/utils.go for consistent internal access
- Replaced 15 manual Header.Set+Write blocks in workspace_handlers.go with canonical writeJSONBytes calls
- Replaced 8 manual Header.Set+Fprint/Write blocks in environments_handlers.go with canonical writeJSONBytes calls
- Status codes preserved: http.StatusOK for reads and deletes, http.StatusCreated for creates

### Testing

- go build ./server/handlers/... — passes
- No behavioral changes — all response content and headers identical
