### PR TITLE
[Server] Return JSON success bodies from event mutation handlers

### DIFF
--- a/server/handlers/events_streamer.go
+++ b/server/handlers/events_streamer.go
@@ -165,6 +165,7 @@ func (h *Handler) UpdateEventStatus(w http.ResponseWriter, req *http.Request, pr
 		return
 	}
 
+	writeJSONMessage(w, map[string]string{"message": "Event status updated"}, http.StatusOK)
 }
 
 func (h *Handler) BulkUpdateEventStatus(w http.ResponseWriter, req *http.Request, prefObj *models.Preference, user *models.User, provider models.Provider) {
@@ -191,6 +192,7 @@ func (h *Handler) BulkUpdateEventStatus(w http.ResponseWriter, req *http.Request
 		return
 	}
 
+	writeJSONMessage(w, map[string]string{"message": "Event statuses updated"}, http.StatusOK)
 }
 
 func (h *Handler) BulkDeleteEvent(w http.ResponseWriter, req *http.Request, prefObj *models.Preference, user *models.User, provider models.Provider) {
@@ -215,6 +217,8 @@ func (h *Handler) BulkDeleteEvent(w http.ResponseWriter, req *http.Request, pref
 		writeMeshkitError(w, _err, http.StatusInternalServerError)
 		return
 	}
+
+	writeJSONMessage(w, map[string]string{"message": "Events deleted"}, http.StatusOK)
 }
 
 func (h *Handler) DeleteEvent(w http.ResponseWriter, req *http.Request, prefObj *models.Preference, user *models.User, provider models.Provider) {
@@ -228,6 +232,8 @@ func (h *Handler) DeleteEvent(w http.ResponseWriter, req *http.Request, prefObj 
 		writeMeshkitError(w, _err, http.StatusInternalServerError)
 		return
 	}
+
+	writeJSONMessage(w, map[string]string{"message": "Event deleted"}, http.StatusOK)
 }
 
 func getEventFilter(req *http.Request) (*events.EventsFilter, error) {

--- a/server/handlers/events_streamer.go
+++ b/server/handlers/events_streamer.go
@@ -165,7 +165,11 @@ func (h *Handler) UpdateEventStatus(w http.ResponseWriter, req *http.Request, pr
 		return
 	}
 
-	writeJSONMessage(w, map[string]string{"message": "Event status updated"}, http.StatusOK)
+	writeJSONMessage(w, map[string]interface{}{
+		"message": "Event status updated",
+		"eventId": eventID,
+		"status":  status,
+	}, http.StatusOK)
 }
 
 func (h *Handler) BulkUpdateEventStatus(w http.ResponseWriter, req *http.Request, prefObj *models.Preference, user *models.User, provider models.Provider) {
@@ -192,7 +196,10 @@ func (h *Handler) BulkUpdateEventStatus(w http.ResponseWriter, req *http.Request
 		return
 	}
 
-	writeJSONMessage(w, map[string]string{"message": "Event statuses updated"}, http.StatusOK)
+	writeJSONMessage(w, map[string]interface{}{
+		"message": "Event statuses updated",
+		"updated": reqBody.StatusIDs,
+	}, http.StatusOK)
 }
 
 func (h *Handler) BulkDeleteEvent(w http.ResponseWriter, req *http.Request, prefObj *models.Preference, user *models.User, provider models.Provider) {
@@ -218,7 +225,10 @@ func (h *Handler) BulkDeleteEvent(w http.ResponseWriter, req *http.Request, pref
 		return
 	}
 
-	writeJSONMessage(w, map[string]string{"message": "Events deleted"}, http.StatusOK)
+	writeJSONMessage(w, map[string]interface{}{
+		"message": "Events deleted",
+		"deleted": reqBody.IDs,
+	}, http.StatusOK)
 }
 
 func (h *Handler) DeleteEvent(w http.ResponseWriter, req *http.Request, prefObj *models.Preference, user *models.User, provider models.Provider) {
@@ -233,7 +243,7 @@ func (h *Handler) DeleteEvent(w http.ResponseWriter, req *http.Request, prefObj 
 		return
 	}
 
-	writeJSONMessage(w, map[string]string{"message": "Event deleted"}, http.StatusOK)
+	w.WriteHeader(http.StatusNoContent)
 }
 
 func getEventFilter(req *http.Request) (*events.EventsFilter, error) {


### PR DESCRIPTION
**Notes for Reviewers**

- This PR fixes #19707

**[Signed commits](https://github.com/meshery/meshery/blob/master/CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [x] Yes, I signed my commits.

<!--
Thank you for contributing to Meshery! 

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. Sign your commits.
4. Include before and after screenshots/terminal output.

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.
-->

## Description

Four event mutation handlers — UpdateEventStatus, BulkUpdateEventStatus, BulkDeleteEvent, and DeleteEvent — return a bare HTTP 200 with no body (or write nothing to the response writer). The frontend RTK Query expects a JSON body on success, causing response-dispatching issues.

### Response shapes (aligned with v1beta3 event schema)

| Handler | Status | Response body |
|---------|--------|--------------|
| UpdateEventStatus | 200 | `{"message", "eventId", "status"}` |
| BulkUpdateEventStatus | 200 | `{"message", "updated": [UUID]}` |
| BulkDeleteEvent | 200 | `{"message", "deleted": [UUID]}` |
| DeleteEvent | **204** | No body |

The response schemas are defined in `meshery/schemas` at `schemas/constructs/v1beta3/event/api.yml`.

### Changes

All four handlers now write a JSON response body on success via the existing writeJSONMessage helper. DeleteEvent returns 204 No Content per the OpenAPI contract.

### Testing

- go build ./server/handlers/... — passes
- go vet ./server/handlers/ — no issues
