### PR TITLE
fix(ui): clear setTimeout on unmount in AnimatedMeshPattern

### DIFF
--- a/ui/components/shared/LoadingState/Animations/AnimatedMeshPattern.tsx
+++ b/ui/components/shared/LoadingState/Animations/AnimatedMeshPattern.tsx
@@ -15,15 +15,15 @@ const AnimatedMeshPattern = (props: React.SVGAttributes<SVGSVGElement>) => {
   const [isActive, setIsActive] = useState(true);
   const theme = useTheme();
   useEffect(() => {
-    setTimeout(() => {
-      setIsActive(false);
-    }, 100);
+    const id = window.setTimeout(() => setIsActive(false), 100);
+    return () => window.clearTimeout(id);
   }, []);
 
   useEffect(() => {
-    setTimeout(() => {
-      setIsActive(!isActive);
+    const id = window.setTimeout(() => {
+      setIsActive((prev) => !prev);
     }, 2000);
+    return () => window.clearTimeout(id);
   }, [isActive]);
 
   return (


### PR DESCRIPTION
## Description

Fixes #19647

## Problem
Two `setTimeout` calls inside `useEffect` hooks in 
`AnimatedMeshPattern.tsx` had no cleanup function. When the component 
unmounts before the timers fire, `setIsActive` is called on an unmounted 
component causing React warnings and memory leaks.

## Root Cause
`useEffect` hooks scheduled `setTimeout` but returned no cleanup so 
`clearTimeout` was never called on unmount.

## Solution
- Stored `setTimeout` return value in variable `id`
- Returned `clearTimeout(id)` as cleanup from both effects
- Used functional `setState` (`prev => !prev`) in second effect 
  to avoid stale closure

## Changes
- `ui/components/shared/LoadingState/Animations/AnimatedMeshPattern.tsx`