### PR TITLE
[UI] Load connection types dynamically from registry instead of hardcoding

### DIFF
--- a/ui/components/connections/meshSync/Stepper/StepperContent.test.tsx
+++ b/ui/components/connections/meshSync/Stepper/StepperContent.test.tsx
@@ -344,7 +344,7 @@ describe('SelectConnection component', () => {
     render(<SelectConnection setSharedData={mockSetSharedData} handleNext={mockHandleNext} />);
 
     expect(mockUseGetComponentsQuery).toHaveBeenCalledWith({
-      params: { pagesize: 'all', search: 'Connection' },
+      params: { pagesize: 'all', search: 'Connection', trim: true },
     });
   });
 });

--- a/ui/components/connections/meshSync/Stepper/StepperContent.test.tsx
+++ b/ui/components/connections/meshSync/Stepper/StepperContent.test.tsx
@@ -8,6 +8,7 @@
  */
 import React from 'react';
 import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import { describe, expect, it, vi, beforeEach } from 'vitest';
 import { deriveConnectionTypes } from './StepperContent';
 
@@ -217,6 +218,21 @@ describe('SelectConnection component', () => {
     expect(screen.getByText(/failed to load connection types/i)).toBeInTheDocument();
   });
 
+  it('renders cached connection types even if a refetch fails (isError is true)', () => {
+    mockUseGetComponentsQuery.mockReturnValue({
+      data: {
+        components: [{ component: { kind: 'PrometheusConnection' } }],
+      },
+      isLoading: false,
+      isError: true,
+    });
+
+    render(<SelectConnection setSharedData={mockSetSharedData} handleNext={mockHandleNext} />);
+
+    expect(screen.queryByText(/failed to load connection types/i)).not.toBeInTheDocument();
+    expect(screen.getByTestId('option-Prometheus Connection')).toBeInTheDocument();
+  });
+
   it('shows an empty state when no connection types are available', () => {
     mockUseGetComponentsQuery.mockReturnValue({
       data: { components: [] },
@@ -248,6 +264,8 @@ describe('SelectConnection component', () => {
   });
 
   it('passes stable kind (not a sliced label) to the registration payload', async () => {
+    const user = userEvent.setup();
+
     // RTK Query mutations return an object with an `.unwrap()` method.
     mockRegisterConnection.mockReturnValue({
       unwrap: () =>
@@ -267,7 +285,7 @@ describe('SelectConnection component', () => {
 
     render(<SelectConnection setSharedData={mockSetSharedData} handleNext={mockHandleNext} />);
 
-    screen.getByTestId('option-Prometheus Connection').click();
+    await user.click(screen.getByTestId('option-Prometheus Connection'));
 
     await waitFor(() => {
       expect(mockRegisterConnection).toHaveBeenCalledWith({

--- a/ui/components/connections/meshSync/Stepper/StepperContent.test.tsx
+++ b/ui/components/connections/meshSync/Stepper/StepperContent.test.tsx
@@ -1,0 +1,332 @@
+/**
+ * Tests for the dynamic connection type registration flow in StepperContent.
+ *
+ * Covers:
+ * - deriveConnectionTypes: pure unit tests (no rendering needed)
+ * - SelectConnection component: dynamic rendering, loading/error/empty states,
+ *   stable kind passed to registration, no hardcoded list
+ */
+import React from 'react';
+import { render, screen, waitFor } from '@testing-library/react';
+import { describe, expect, it, vi, beforeEach } from 'vitest';
+import { deriveConnectionTypes } from './StepperContent';
+
+// ---------------------------------------------------------------------------
+// Unit tests for deriveConnectionTypes (pure function, no mocks needed)
+// ---------------------------------------------------------------------------
+
+describe('deriveConnectionTypes', () => {
+  it('returns an empty array for empty input', () => {
+    expect(deriveConnectionTypes([])).toEqual([]);
+  });
+
+  it('returns an empty array for null/undefined input', () => {
+    expect(deriveConnectionTypes(null as any)).toEqual([]);
+    expect(deriveConnectionTypes(undefined as any)).toEqual([]);
+  });
+
+  it('filters out components whose kind does not end with "Connection"', () => {
+    const components = [
+      { component: { kind: 'PrometheusCredential' } },
+      { component: { kind: 'SomeRandomComponent' } },
+      { component: { kind: 'GrafanaCredential' } },
+    ];
+    expect(deriveConnectionTypes(components)).toEqual([]);
+  });
+
+  it('extracts kind by removing the "Connection" suffix — not by slicing a label', () => {
+    const components = [{ component: { kind: 'PrometheusConnection' } }];
+    const result = deriveConnectionTypes(components);
+    expect(result).toHaveLength(1);
+    expect(result[0].kind).toBe('Prometheus');
+    expect(result[0].label).toBe('Prometheus Connection');
+  });
+
+  it('handles multiple connection types correctly', () => {
+    const components = [
+      { component: { kind: 'PrometheusConnection' } },
+      { component: { kind: 'GrafanaConnection' } },
+      { component: { kind: 'PrometheusCredential' } }, // should be filtered out
+    ];
+    const result = deriveConnectionTypes(components);
+    expect(result).toHaveLength(2);
+    expect(result.map((r) => r.kind)).toEqual(['Prometheus', 'Grafana']);
+    expect(result.map((r) => r.label)).toEqual(['Prometheus Connection', 'Grafana Connection']);
+  });
+
+  it('deduplicates components with the same kind', () => {
+    const components = [
+      { component: { kind: 'PrometheusConnection' } },
+      { component: { kind: 'PrometheusConnection' } }, // duplicate
+    ];
+    const result = deriveConnectionTypes(components);
+    expect(result).toHaveLength(1);
+    expect(result[0].kind).toBe('Prometheus');
+  });
+
+  it('handles components with missing or null kind gracefully', () => {
+    const components = [
+      { component: { kind: null as any } },
+      { component: {} },
+      {},
+      { component: { kind: 'GrafanaConnection' } },
+    ];
+    const result = deriveConnectionTypes(components);
+    expect(result).toHaveLength(1);
+    expect(result[0].kind).toBe('Grafana');
+  });
+
+  it('automatically includes newly registered {Kind}Connection schemas', () => {
+    // Simulates a new "Jaeger" connection type being registered in the backend
+    // without any frontend code change.
+    const components = [
+      { component: { kind: 'PrometheusConnection' } },
+      { component: { kind: 'GrafanaConnection' } },
+      { component: { kind: 'JaegerConnection' } }, // newly registered
+    ];
+    const result = deriveConnectionTypes(components);
+    expect(result.map((r) => r.kind)).toContain('Jaeger');
+    expect(result.map((r) => r.label)).toContain('Jaeger Connection');
+  });
+
+  it('does NOT derive kind by splitting on spaces in the label', () => {
+    // Ensures the implementation uses suffix removal, not indexOf(' ')
+    const components = [{ component: { kind: 'PrometheusConnection' } }];
+    const result = deriveConnectionTypes(components);
+    // If kind were derived by label.slice(0, label.indexOf(' ')), it would be
+    // empty string because "PrometheusConnection" has no space. The correct
+    // implementation returns "Prometheus".
+    expect(result[0].kind).toBe('Prometheus');
+    expect(result[0].kind).not.toBe('');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Component tests for SelectConnection
+// ---------------------------------------------------------------------------
+
+// Mock RTK query hooks
+const mockUseGetComponentsQuery = vi.fn();
+const mockUseVerifyAndRegisterConnectionMutation = vi.fn();
+
+vi.mock('@/rtk-query/meshModel', () => ({
+  useGetComponentsQuery: (...args) => mockUseGetComponentsQuery(...args),
+}));
+
+vi.mock('@/rtk-query/connection', () => ({
+  useVerifyAndRegisterConnectionMutation: () => mockUseVerifyAndRegisterConnectionMutation(),
+  useConnectToConnectionMutation: () => [vi.fn(), {}],
+}));
+
+vi.mock('@/rtk-query/credentials', () => ({
+  useGetCredentialsQuery: () => ({ data: { credentials: [] } }),
+}));
+
+vi.mock('@/components/shared/FormFields/rjsf-utils/common', () => ({
+  selectCompSchema: (enums: string[]) => ({
+    properties: {
+      selectedConnectionType: {
+        enum: enums,
+        type: 'string',
+        title: 'test',
+        uniqueItems: true,
+        'x-rjsf-grid-area': 12,
+        description: 'test',
+      },
+    },
+    required: ['selectedConnectionType'],
+    type: 'object',
+  }),
+}));
+
+vi.mock('../../../meshery-mesh-interface/PatternService/RJSF_wrapper', () => ({
+  default: ({ jsonSchema, onChange }) => (
+    <div data-testid="rjsf-wrapper">
+      {jsonSchema?.properties?.selectedConnectionType?.enum?.map((label: string) => (
+        <button
+          key={label}
+          data-testid={`option-${label}`}
+          onClick={() => onChange({ selectedConnectionType: label })}
+        >
+          {label}
+        </button>
+      ))}
+    </div>
+  ),
+}));
+
+vi.mock('./StepperContentWrapper', () => ({
+  default: ({ children }) => <div data-testid="stepper-content">{children}</div>,
+}));
+
+vi.mock('../../../../utils/utils', () => ({
+  JsonParse: (v) => v,
+  randomPatternNameGenerator: () => 'test-name',
+}));
+
+vi.mock('@sistent/sistent', () => ({
+  Typography: ({ children, color }) => (
+    <span data-testid="typography" data-color={color}>
+      {children}
+    </span>
+  ),
+  Checkbox: () => <input type="checkbox" />,
+  MenuItem: ({ children }) => <div>{children}</div>,
+  ListItemText: ({ primary }) => <span>{primary}</span>,
+  Select: ({ children }) => <div>{children}</div>,
+  FormControl: ({ children }) => <div>{children}</div>,
+  InputLabel: ({ children }) => <label>{children}</label>,
+  OutlinedInput: () => <input />,
+  Box: ({ children }) => <div>{children}</div>,
+}));
+
+// Import after mocks are set up
+const { SelectConnection } = await import('./StepperContent');
+
+describe('SelectConnection component', () => {
+  const mockHandleNext = vi.fn();
+  const mockSetSharedData = vi.fn();
+  const mockRegisterConnection = vi.fn();
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockUseVerifyAndRegisterConnectionMutation.mockReturnValue([mockRegisterConnection, {}]);
+  });
+
+  it('shows a loading state while fetching connection types', () => {
+    mockUseGetComponentsQuery.mockReturnValue({
+      data: undefined,
+      isLoading: true,
+      isError: false,
+    });
+
+    render(<SelectConnection setSharedData={mockSetSharedData} handleNext={mockHandleNext} />);
+
+    expect(screen.getByText(/loading available connection types/i)).toBeInTheDocument();
+  });
+
+  it('shows an error state when the fetch fails', () => {
+    mockUseGetComponentsQuery.mockReturnValue({
+      data: undefined,
+      isLoading: false,
+      isError: true,
+    });
+
+    render(<SelectConnection setSharedData={mockSetSharedData} handleNext={mockHandleNext} />);
+
+    expect(screen.getByText(/failed to load connection types/i)).toBeInTheDocument();
+  });
+
+  it('shows an empty state when no connection types are available', () => {
+    mockUseGetComponentsQuery.mockReturnValue({
+      data: { components: [] },
+      isLoading: false,
+      isError: false,
+    });
+
+    render(<SelectConnection setSharedData={mockSetSharedData} handleNext={mockHandleNext} />);
+
+    expect(screen.getByText(/no connection types are currently available/i)).toBeInTheDocument();
+  });
+
+  it('renders connection types dynamically from registry data', () => {
+    mockUseGetComponentsQuery.mockReturnValue({
+      data: {
+        components: [
+          { component: { kind: 'PrometheusConnection' } },
+          { component: { kind: 'GrafanaConnection' } },
+        ],
+      },
+      isLoading: false,
+      isError: false,
+    });
+
+    render(<SelectConnection setSharedData={mockSetSharedData} handleNext={mockHandleNext} />);
+
+    expect(screen.getByTestId('option-Prometheus Connection')).toBeInTheDocument();
+    expect(screen.getByTestId('option-Grafana Connection')).toBeInTheDocument();
+  });
+
+  it('passes stable kind (not a sliced label) to the registration payload', async () => {
+    // RTK Query mutations return an object with an `.unwrap()` method.
+    mockRegisterConnection.mockReturnValue({
+      unwrap: () =>
+        Promise.resolve({
+          connection: { schema: '{}', id: 'conn-1' },
+          credential: { schema: '{}' },
+        }),
+    });
+
+    mockUseGetComponentsQuery.mockReturnValue({
+      data: {
+        components: [{ component: { kind: 'PrometheusConnection' } }],
+      },
+      isLoading: false,
+      isError: false,
+    });
+
+    render(<SelectConnection setSharedData={mockSetSharedData} handleNext={mockHandleNext} />);
+
+    screen.getByTestId('option-Prometheus Connection').click();
+
+    await waitFor(() => {
+      expect(mockRegisterConnection).toHaveBeenCalledWith({
+        body: {
+          kind: 'Prometheus', // stable kind, NOT "Prometheus Connection" or a sliced label
+          status: 'initialize',
+        },
+      });
+    });
+  });
+
+  it('automatically renders a newly registered connection type without frontend changes', () => {
+    // Simulates Jaeger being registered in the backend registry
+    mockUseGetComponentsQuery.mockReturnValue({
+      data: {
+        components: [
+          { component: { kind: 'PrometheusConnection' } },
+          { component: { kind: 'GrafanaConnection' } },
+          { component: { kind: 'JaegerConnection' } }, // new — no frontend change needed
+        ],
+      },
+      isLoading: false,
+      isError: false,
+    });
+
+    render(<SelectConnection setSharedData={mockSetSharedData} handleNext={mockHandleNext} />);
+
+    expect(screen.getByTestId('option-Jaeger Connection')).toBeInTheDocument();
+  });
+
+  it('does not render non-connection components (e.g. credentials)', () => {
+    mockUseGetComponentsQuery.mockReturnValue({
+      data: {
+        components: [
+          { component: { kind: 'PrometheusConnection' } },
+          { component: { kind: 'PrometheusCredential' } }, // should NOT appear
+        ],
+      },
+      isLoading: false,
+      isError: false,
+    });
+
+    render(<SelectConnection setSharedData={mockSetSharedData} handleNext={mockHandleNext} />);
+
+    expect(screen.getByTestId('option-Prometheus Connection')).toBeInTheDocument();
+    expect(screen.queryByTestId('option-PrometheusCredential')).not.toBeInTheDocument();
+  });
+
+  it('queries the components API with the correct search param', () => {
+    mockUseGetComponentsQuery.mockReturnValue({
+      data: { components: [] },
+      isLoading: false,
+      isError: false,
+    });
+
+    render(<SelectConnection setSharedData={mockSetSharedData} handleNext={mockHandleNext} />);
+
+    expect(mockUseGetComponentsQuery).toHaveBeenCalledWith({
+      params: { pagesize: 'all', search: 'Connection' },
+    });
+  });
+});

--- a/ui/components/connections/meshSync/Stepper/StepperContent.tsx
+++ b/ui/components/connections/meshSync/Stepper/StepperContent.tsx
@@ -85,7 +85,7 @@ export const SelectConnection = ({ setSharedData, handleNext }) => {
     isLoading: isLoadingComponents,
     isError: isComponentsError,
   } = useGetComponentsQuery({
-    params: { pagesize: 'all', search: CONNECTION_COMPONENT_SUFFIX },
+    params: { pagesize: 'all', search: CONNECTION_COMPONENT_SUFFIX, trim: true },
   });
 
   const connectionTypes: ConnectionType[] = useMemo(

--- a/ui/components/connections/meshSync/Stepper/StepperContent.tsx
+++ b/ui/components/connections/meshSync/Stepper/StepperContent.tsx
@@ -99,8 +99,8 @@ export const SelectConnection = ({ setSharedData, handleNext }) => {
     () =>
       selectCompSchema(
         connectionTypes.map((ct) => ct.label),
-        'Select one of the available Connection type',
-        'Select type of Connection to register',
+        'Select one of the available connection types',
+        'Select the type of connection to register',
         'selectedConnectionType',
       ),
     [connectionTypes],
@@ -160,7 +160,7 @@ export const SelectConnection = ({ setSharedData, handleNext }) => {
     );
   }
 
-  if (isComponentsError) {
+  if (isComponentsError && connectionTypes.length === 0) {
     return (
       <StepperContent {...SelectConnectionTypeContent} handleCallback={handleCallback}>
         <Typography variant="body2" color="error">

--- a/ui/components/connections/meshSync/Stepper/StepperContent.tsx
+++ b/ui/components/connections/meshSync/Stepper/StepperContent.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useRef, useState } from 'react';
+import React, { useEffect, useMemo, useRef, useState } from 'react';
 import {
   Checkbox,
   MenuItem,
@@ -27,31 +27,97 @@ import {
   useVerifyAndRegisterConnectionMutation,
 } from '@/rtk-query/connection';
 import { useGetCredentialsQuery } from '@/rtk-query/credentials';
+import { useGetComponentsQuery } from '@/rtk-query/meshModel';
 
-const CONNECTION_TYPES = ['Prometheus Connection', 'Grafana Connection'];
+/**
+ * Represents a single registerable connection type derived from the registry.
+ */
+interface ConnectionType {
+  /** The stable kind value sent to the backend, e.g. "Prometheus" */
+  kind: string;
+  /** The human-readable label shown in the UI, e.g. "Prometheus Connection" */
+  label: string;
+}
 
-const schema = selectCompSchema(
-  CONNECTION_TYPES,
-  'Select one of the available Connection type',
-  'Select type of Connection to register',
-  'selectedConnectionType',
-);
+/** Suffix that all registerable connection component names end with in the registry. */
+const CONNECTION_COMPONENT_SUFFIX = 'Connection';
+
+/**
+ * Derives a stable list of ConnectionType objects from raw registry component data.
+ * Filters to components whose name ends exactly with "Connection", then extracts
+ * the kind by removing that suffix — never by slicing a display label.
+ */
+export const deriveConnectionTypes = (
+  components: { component?: { kind?: string } }[],
+): ConnectionType[] => {
+  if (!Array.isArray(components)) return [];
+
+  const seen = new Set<string>();
+  const result: ConnectionType[] = [];
+
+  for (const comp of components) {
+    const name = comp?.component?.kind ?? '';
+    if (!name.endsWith(CONNECTION_COMPONENT_SUFFIX)) continue;
+
+    // Extract kind by removing the suffix — stable, not derived from a display label.
+    const kind = name.slice(0, name.length - CONNECTION_COMPONENT_SUFFIX.length);
+    if (!kind || seen.has(kind)) continue;
+
+    seen.add(kind);
+    result.push({
+      kind,
+      label: `${kind} Connection`,
+    });
+  }
+
+  return result;
+};
+
 export const SelectConnection = ({ setSharedData, handleNext }) => {
   const formRef = useRef();
   const [registerConnection] = useVerifyAndRegisterConnectionMutation();
 
-  const handleRegisterConnection = async (componentName) => {
+  // Fetch all components whose name contains "Connection" from the registry.
+  // The search param narrows the result set server-side; client-side filtering
+  // then ensures we only keep names that end exactly with "Connection".
+  const {
+    data: componentsData,
+    isLoading: isLoadingComponents,
+    isError: isComponentsError,
+  } = useGetComponentsQuery({
+    params: { pagesize: 'all', search: CONNECTION_COMPONENT_SUFFIX },
+  });
+
+  const connectionTypes: ConnectionType[] = useMemo(
+    () => deriveConnectionTypes(componentsData?.components ?? []),
+    [componentsData],
+  );
+
+  // Build the RJSF enum from display labels. The label is only used for display;
+  // kind is looked up from connectionTypes when the user makes a selection.
+  const schema = useMemo(
+    () =>
+      selectCompSchema(
+        connectionTypes.map((ct) => ct.label),
+        'Select one of the available Connection type',
+        'Select type of Connection to register',
+        'selectedConnectionType',
+      ),
+    [connectionTypes],
+  );
+
+  const handleRegisterConnection = async (kind: string) => {
     try {
       const payload = {
         body: {
-          kind: componentName,
+          kind,
           status: 'initialize',
         },
       };
 
       const result = await registerConnection(payload).unwrap();
 
-      let schemaObj = {
+      const schemaObj = {
         connection: JsonParse(result?.connection?.schema),
         credential: JsonParse(result?.credential?.schema),
       };
@@ -60,7 +126,7 @@ export const SelectConnection = ({ setSharedData, handleNext }) => {
         ...prevState,
         connection: result,
         schemas: schemaObj,
-        kind: componentName.toLowerCase(),
+        kind: kind.toLowerCase(),
       }));
 
       handleNext();
@@ -74,15 +140,43 @@ export const SelectConnection = ({ setSharedData, handleNext }) => {
   };
 
   const handleChange = (data) => {
-    if (data.selectedConnectionType) {
-      const selectedConnectionType = data.selectedConnectionType;
-      // The selectedConnectionType is the concatentaion of connectionType, ' ' and 'Connection' suffix.
-      // Therefore, when initiating connection we are removing ' ' and suffix so that correct schema is retrieved.
-      handleRegisterConnection(
-        selectedConnectionType?.slice(0, selectedConnectionType.indexOf(' ')),
-      );
+    if (!data.selectedConnectionType) return;
+
+    const selectedLabel: string = data.selectedConnectionType;
+
+    // Look up the stable kind from the registry-derived list.
+    // Never derive kind by slicing the display label.
+    const match = connectionTypes.find((ct) => ct.label === selectedLabel);
+    if (match) {
+      handleRegisterConnection(match.kind);
     }
   };
+
+  if (isLoadingComponents) {
+    return (
+      <StepperContent {...SelectConnectionTypeContent} handleCallback={handleCallback}>
+        <Typography variant="body2">Loading available connection types…</Typography>
+      </StepperContent>
+    );
+  }
+
+  if (isComponentsError) {
+    return (
+      <StepperContent {...SelectConnectionTypeContent} handleCallback={handleCallback}>
+        <Typography variant="body2" color="error">
+          Failed to load connection types. Please try again.
+        </Typography>
+      </StepperContent>
+    );
+  }
+
+  if (connectionTypes.length === 0) {
+    return (
+      <StepperContent {...SelectConnectionTypeContent} handleCallback={handleCallback}>
+        <Typography variant="body2">No connection types are currently available.</Typography>
+      </StepperContent>
+    );
+  }
 
   return (
     <StepperContent {...SelectConnectionTypeContent} handleCallback={handleCallback}>


### PR DESCRIPTION
## Related Issue

Closes #19477

## Summary

This PR removes the hardcoded connection registration types (`Prometheus Connection` and `Grafana Connection`) and replaces them with a schema-driven implementation powered by registry-backed component data.

The registration flow now dynamically derives available `{Kind}Connection` components from registry schemas, allowing newly registered connection types to automatically appear in the UI without requiring additional frontend updates.

## Changes Made

- Removed hardcoded `CONNECTION_TYPES` array from `StepperContent.tsx`
- Added dynamic fetching of connection component schemas using existing registry-backed queries
- Implemented filtering for `{Kind}Connection` component definitions
- Added stable `{ kind, label }` mapping instead of deriving kind values from display strings
- Added loading, error, and empty states for improved UX
- Added utility handling for deduplication and dropdown rendering
- Added/updated unit tests covering:
  - schema parsing
  - dropdown generation
  - empty states
  - edge cases

## Why This Change

Previously, the frontend required manual updates whenever a new connection type was introduced, despite the backend already supporting schema-driven registration flows dynamically.

This implementation closes that extensibility gap and aligns the UI with the backend registry-driven architecture.

## Validation

- Verified existing Prometheus registration flow
- Verified existing Grafana registration flow
- Verified dynamically discovered connection types render correctly
- Verified registration payload preserves stable `kind` values
- Verified tests pass successfully