### PR TITLE
fix: cluster count issue

### DIFF
--- a/server/internal/graphql/resolver/kubernetes.go
+++ b/server/internal/graphql/resolver/kubernetes.go
@@ -221,11 +221,36 @@ func (r *Resolver) getK8sContexts(ctx context.Context, provider models.Provider,
 	if err != nil {
 		return nil, err
 	}
-	var k8sContext model.K8sContextsPage
-	err = json.Unmarshal(resp, &k8sContext)
+	k8sContext, err := decodeK8sContextsPage(resp)
 	if err != nil {
 		obj := "k8s context"
 		return nil, models.ErrEncoding(err, obj)
 	}
-	return &k8sContext, nil
+	return k8sContext, nil
+}
+
+func decodeK8sContextsPage(resp []byte) (*model.K8sContextsPage, error) {
+	var page struct {
+		TotalCount       *int                `json:"totalCount"`
+		TotalCountLegacy *int                `json:"total_count"`
+		Contexts         []*model.K8sContext `json:"contexts"`
+	}
+	if err := json.Unmarshal(resp, &page); err != nil {
+		return nil, err
+	}
+
+	totalCount := 0
+	switch {
+	case page.TotalCount != nil:
+		totalCount = *page.TotalCount
+	case page.TotalCountLegacy != nil:
+		totalCount = *page.TotalCountLegacy
+	case len(page.Contexts) > 0:
+		totalCount = len(page.Contexts)
+	}
+
+	return &model.K8sContextsPage{
+		TotalCount: totalCount,
+		Contexts:   page.Contexts,
+	}, nil
 }


### PR DESCRIPTION
**Notes for Reviewers**
Fixed the cluster count bug in the GraphQL Kubernetes context path.

The issue was that the resolver decoded provider responses into a model that only accepted total_count, while the local/remote provider path often emits totalCount. That made the subscription send 0 to the top bar even when contexts were present.

Now decodes both totalCount and total_count, and falls back to contexts.length if the count is missing.

Fix Kubernetes cluster count in top navigation

The GraphQL Kubernetes context resolver was unmarshaling provider responses directly into `K8sContextsPage`, whose JSON tag expects `total_count`. Provider responses may return canonical `totalCount`, causing the resolver to drop the count and send `0` to the UI even when clusters were connected.

This change decodes both `totalCount` and `total_count`, with a fallback to the number of returned contexts, so the top-bar Kubernetes badge reflects the actual connected cluster count.


### before 
<img width="375" height="263" alt="Screenshot From 2026-05-25 02-01-38" src="https://github.com/user-attachments/assets/50bea2bc-3c83-42ad-8f51-6c73dadec561" />


### after

https://github.com/user-attachments/assets/829481aa-e35f-4bba-98b1-d1a29676b09a


- This PR fixes #

**[Signed commits](https://github.com/meshery/meshery/blob/master/CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [x] Yes, I signed my commits.

<!--
Thank you for contributing to Meshery! 

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. Sign your commits.
4. Include before and after screenshots/terminal output.

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.
-->
