### PR TITLE
[Server] Fix silent config corruption on YAML parse failure in validate.go

### DIFF
--- a/server/helpers/component_info.json
+++ b/server/helpers/component_info.json
@@ -1,5 +1,5 @@
 {
   "name": "meshery-server",
   "type": "component",
-  "next_error_code": 1430
+  "next_error_code": 1432
 }

--- a/server/models/pattern/stages/error.go
+++ b/server/models/pattern/stages/error.go
@@ -4,8 +4,13 @@ import "github.com/meshery/meshkit/errors"
 
 const (
 	ErrResolveReferenceCode = "meshery-server-1361"
+	ErrYAMLUnmarshalCode    = "meshery-server-1431"
 )
 
 func ErrResolveReference(err error) error {
 	return errors.New(ErrResolveReferenceCode, errors.Alert, []string{}, []string{err.Error()}, []string{}, []string{})
+}
+
+func ErrYAMLUnmarshal(err error) error {
+	return errors.New(ErrYAMLUnmarshalCode, errors.Alert, []string{"failed to parse YAML configuration"}, []string{err.Error()}, []string{"malformed YAML in component configuration"}, []string{"verify the YAML syntax in your design configuration"})
 }

--- a/server/models/pattern/stages/validate.go
+++ b/server/models/pattern/stages/validate.go
@@ -55,8 +55,13 @@ func hydrateComponentWithOriginalType(compType string, spec interface{}) error {
 
 func formatValue(path string, val map[string]interface{}) error {
 	updatedValue := make(map[string]interface{})
-	byt, _ := val[path].(string)
-	_ = yaml.Unmarshal([]byte(byt), &updatedValue)
+	byt, ok := val[path].(string)
+	if !ok {
+		return nil
+	}
+	if err := yaml.Unmarshal([]byte(byt), &updatedValue); err != nil {
+		return ErrYAMLUnmarshal(err)
+	}
 	val[path] = updatedValue
 	return nil
 }


### PR DESCRIPTION
The formatValue function in the pattern validation stage silently discarded YAML unmarshal errors, overwriting user configuration data with an empty map on parse failure. This caused irrecoverable data loss with no user feedback.

- Added ErrYAMLUnmarshal error code (meshery-server-1431) to stages error.go using meshkit error patterns
- Updated formatValue to check and propagate YAML unmarshal errors instead of swallowing them

Fixes #19670

