### PR TITLE
[UI] Harden E2E dashboard navigation

### DIFF
--- a/ui/tests/e2e/connections.spec.ts
+++ b/ui/tests/e2e/connections.spec.ts
@@ -1,6 +1,7 @@
 import { expect, Page, Response } from '@playwright/test';
 import { test } from './fixtures/project';
 import { ENV } from './env';
+import { DashboardPage } from './pages/DashboardPage';
 import { waitForSnackBar } from './utils/waitForSnackBar';
 
 // Define the shape of the transition test objects
@@ -47,11 +48,12 @@ const transitionTests: TransitionTest[] = [
 
 test.describe.serial('Connection Management Tests', () => {
   test.beforeEach(async ({ page }) => {
+    const dashboardPage = new DashboardPage(page);
+    await dashboardPage.navigateToDashboard();
     const initialConnectionsRes = waitForConnectionsApiResponse(page);
-    await page.goto('/management/connections', { waitUntil: 'domcontentloaded' });
+    await dashboardPage.navigateToConnections();
     await page.waitForURL(/\/management\/connections/);
     await initialConnectionsRes;
-    await page.waitForLoadState('networkidle');
     await expect(page.getByTestId('ConnectionTable-search')).toBeVisible();
   });
 

--- a/ui/tests/e2e/models.spec.ts
+++ b/ui/tests/e2e/models.spec.ts
@@ -1,5 +1,6 @@
 import { test, expect } from '@playwright/test';
 import path from 'path';
+import { DashboardPage } from './pages/DashboardPage';
 
 // Strongly typed inline to avoid JS linter false positives
 const model: {
@@ -38,10 +39,10 @@ const model_import: {
 
 test.describe.serial('Model Workflow Tests', () => {
   test.beforeEach(async ({ page }) => {
-    await page.goto('/settings', { waitUntil: 'domcontentloaded' });
-    await page.waitForURL(/\/settings/);
-    await page.waitForLoadState('networkidle');
-    await expect(page.getByTestId('settings-tab-registry')).toBeVisible();
+    const dashboardPage = new DashboardPage(page);
+    await dashboardPage.navigateToDashboard();
+    await dashboardPage.navigateToSettings();
+    await expect(page.getByTestId('settings-tab-registry')).toBeVisible({ timeout: 120000 });
     await page.getByTestId('settings-tab-registry').click();
   });
 

--- a/ui/tests/e2e/pages/DashboardPage.js
+++ b/ui/tests/e2e/pages/DashboardPage.js
@@ -1,3 +1,5 @@
+import { expect } from '@playwright/test';
+
 const LEFT_NAV = {
   DASHBOARD: {
     name: 'Dashboard',
@@ -51,16 +53,22 @@ export class DashboardPage {
   }
 
   async navigateToMenu(navItem) {
-    await this.page.getByTestId(navItem).click();
+    const menuItem = this.page.getByTestId(navItem);
+    await expect(menuItem).toBeVisible({ timeout: 120000 });
+    await menuItem.click();
   }
 
   async navigateToSubMenuItem(parentItem, childItem) {
     await this.navigateToMenu(parentItem);
-    await this.navigateToMenu(childItem);
+    const submenuItem = this.page.getByTestId(childItem);
+    await expect(submenuItem).toBeVisible({ timeout: 120000 });
+    await submenuItem.click();
   }
 
   async navigateToDashboard() {
-    await this.page.goto(LEFT_NAV.DASHBOARD.path);
+    await this.page.goto(LEFT_NAV.DASHBOARD.path, { waitUntil: 'domcontentloaded' });
+    await expect(this.navigationPanel).toBeVisible({ timeout: 120000 });
+    await expect(this.headerMenu).toBeVisible({ timeout: 120000 });
   }
 
   async navigateToPerformance() {
@@ -115,8 +123,11 @@ export class DashboardPage {
   }
 
   async navigateToHeaderItem(navItem) {
+    await expect(this.headerMenu).toBeVisible({ timeout: 120000 });
     await this.headerMenu.click();
-    await this.page.getByTestId(navItem).click();
+    const headerItem = this.page.getByTestId(navItem);
+    await expect(headerItem).toBeVisible({ timeout: 120000 });
+    await headerItem.click();
   }
 
   async navigateToSettings() {

--- a/ui/tests/e2e/pages/ExtensionsPage.js
+++ b/ui/tests/e2e/pages/ExtensionsPage.js
@@ -1,4 +1,5 @@
 import { expect } from '@playwright/test';
+import { DashboardPage } from './DashboardPage';
 
 export class ExtensionsPage {
   constructor(page) {
@@ -23,9 +24,9 @@ export class ExtensionsPage {
   }
 
   async goto() {
-    await this.page.goto('/extensions', { waitUntil: 'domcontentloaded' });
-    await this.page.waitForURL(/\/extensions/);
-    await this.page.waitForLoadState('networkidle');
+    const dashboardPage = new DashboardPage(this.page);
+    await dashboardPage.navigateToDashboard();
+    await dashboardPage.navigateToExtensions();
   }
 
   async verifyPerformanceAnalysisDetails() {

--- a/ui/tests/e2e/performance.spec.ts
+++ b/ui/tests/e2e/performance.spec.ts
@@ -1,4 +1,5 @@
 import { expect, test, Page } from '@playwright/test';
+import { DashboardPage } from './pages/DashboardPage';
 
 const SETTINGS_TABS: string[] = [
   'settings-tab-adapters',
@@ -24,9 +25,9 @@ const COMMON_UI_ELEMENTS: string[] = [
 
 test.describe('Performance Section Tests', () => {
   test.beforeEach(async ({ page }: { page: Page }) => {
-    await page.goto('/performance', { waitUntil: 'domcontentloaded' });
-    await page.waitForURL(/\/performance/);
-    await page.waitForLoadState('networkidle');
+    const dashboardPage = new DashboardPage(page);
+    await dashboardPage.navigateToDashboard();
+    await dashboardPage.navigateToPerformance();
   });
 
   test('Common UI elements', async ({ page }: { page: Page }) => {


### PR DESCRIPTION
## Summary
- harden dashboard-driven E2E navigation with explicit shell and menu visibility waits
- keep extensions, performance, models, and connections specs on the authenticated dashboard path
- reduce CI-only sidebar/header timing flakiness seen after #19686 merged

## Notes
- follow-up to #19686, which merged before the remaining E2E-only fix could be validated
- contains only commit 901a28ec17bf on top of current master