### PR TITLE
[Docs] Remove Meshery UI references outside extensions docs

### DIFF
--- a/docs/content/en/reference/mesheryctl/system/dashboard.md
+++ b/docs/content/en/reference/mesheryctl/system/dashboard.md
@@ -7,7 +7,7 @@ subcommand: dashboard
 
 # mesheryctl system dashboard
 
-Open Meshery UI in browser.
+Open the Meshery dashboard in browser.
 
 <pre class='codeblock-pre'>
 <div class='codeblock'>
@@ -18,7 +18,7 @@ mesheryctl system dashboard [flags]
 
 ## Examples
 
-Open Meshery UI in browser
+Open the Meshery dashboard in browser
 <pre class='codeblock-pre'>
 <div class='codeblock'>
 mesheryctl system dashboard
@@ -26,7 +26,7 @@ mesheryctl system dashboard
 </div>
 </pre> 
 
-Open Meshery UI in browser and use port-forwarding (if default port is taken already)
+Open the Meshery dashboard in browser and use port-forwarding (if default port is taken already)
 <pre class='codeblock-pre'>
 <div class='codeblock'>
 mesheryctl system dashboard --port-forward
@@ -34,7 +34,7 @@ mesheryctl system dashboard --port-forward
 </div>
 </pre> 
 
-Open Meshery UI in browser and use port-forwarding, listen on port 9081 locally, forwarding traffic to meshery server in the pod
+Open the Meshery dashboard in browser and use port-forwarding, listen on port 9081 locally, forwarding traffic to meshery server in the pod
 <pre class='codeblock-pre'>
 <div class='codeblock'>
 mesheryctl system dashboard --port-forward -p 9081
@@ -42,7 +42,7 @@ mesheryctl system dashboard --port-forward -p 9081
 </div>
 </pre> 
 
-(optional) skip opening of MesheryUI in browser.
+(optional) skip opening of the Meshery dashboard in browser.
 <pre class='codeblock-pre'>
 <div class='codeblock'>
 mesheryctl system dashboard --skip-browser
@@ -52,7 +52,7 @@ mesheryctl system dashboard --skip-browser
 
 <pre class='codeblock-pre'>
 <div class='codeblock'>
-Note: Meshery's web-based user interface is embedded in Meshery Server and is available as soon as Meshery starts. The location and port that Meshery UI is exposed varies depending upon your mode of deployment. See accessing \"Meshery UI\" for additional deployment-specific options: https://docs.meshery.io/installation/accessing-meshery-ui.
+Note: Meshery's web-based user interface is embedded in Meshery Server and is available as soon as Meshery starts. The location and port where the Meshery dashboard is exposed varies depending upon your mode of deployment. See accessing the Meshery dashboard for additional deployment-specific options: https://docs.meshery.io/installation/accessing-meshery-ui.
 
 </div>
 </pre> 
@@ -63,9 +63,8 @@ Note: Meshery's web-based user interface is embedded in Meshery Server and is av
 <div class='codeblock'>
   -h, --help           help for dashboard
   -p, --port int       (optional) Local port that is not in use from which traffic is to be forwarded to the server running inside the Pod. (default 9081)
-      --port-forward   (optional) Use port forwarding to access Meshery UI
-      --skip-browser   (optional) skip opening of MesheryUI in browser.
-
+      --port-forward   (optional) Use port forwarding to access the Meshery dashboard
+      --skip-browser   (optional) skip opening of the Meshery dashboard in browser.
 </div>
 </pre>
 

--- a/docs/content/en/reference/rest-apis/_index.md
+++ b/docs/content/en/reference/rest-apis/_index.md
@@ -20,7 +20,7 @@ Each of Meshery's APIs is subject to Meshery's authentication and authorization 
   <summary>Authentication</summary>
   Requests to any of the API endpoints must be authenticated and include a valid JWT access token in the HTTP headers. The type of authentication is determined by the selected <a href='/extensibility/providers'>Providers</a>. Use of the Local Provider, "None", puts Meshery into single-user mode and uses minimal, intentionally insecure authentication.
 
-  {{% alert color="dark" title="What are authentication tokens?" %}}Meshery authentication tokens allow users or systems to authenticate with Meshery Server via either its two clients, <a href='/reference/mesheryctl'>Meshery CLI</a> and <a href='/extensibility/api#how-to-get-your-token'>Meshery UI</a>, or its two APIs: <a href='/reference/rest-apis'>REST</a> or <a href='/reference/graphql-apis'>GraphQL</a>. <p>Meshery's authentication token system provides secure access to Meshery's management features.</p>{{% /alert %}}
+  {{% alert color="dark" title="What are authentication tokens?" %}}Meshery authentication tokens allow users or systems to authenticate with Meshery Server via either its two clients, <a href='/reference/mesheryctl'>Meshery CLI</a> and <a href='/extensibility/api#how-to-get-your-token'>Meshery dashboard</a>, or its two APIs: <a href='/reference/rest-apis'>REST</a> or <a href='/reference/graphql-apis'>GraphQL</a>. <p>Meshery's authentication token system provides secure access to Meshery's management features.</p>{{% /alert %}}
 </details>
 
 ### How to get your token
@@ -28,9 +28,9 @@ Each of Meshery's APIs is subject to Meshery's authentication and authorization 
 There are two ways to get your authentication token:
 
 <details>
-  <summary>Meshery UI</summary>
+  <summary>Meshery dashboard</summary>
 
-Using Meshery UI, you can get a copy of your authentication token by following these steps:
+Using the Meshery dashboard, you can get a copy of your authentication token by following these steps:
 <br/>
 
 1. Log into Meshery by selecting your identity provider of choice (typically found at <code style="


### PR DESCRIPTION
## Description

This PR removes references to "Meshery UI" outside of extension-related documentation to align terminology and documentation structure.

### Changes

* Updated Meshery dashboard references in mesheryctl documentation
* Updated REST API documentation references
* Preserved existing URLs and API paths where applicable

This change follows maintainer guidance in #19610.
