### PR TITLE
Disable Publishing categories and tags page

### DIFF
--- a/docs/assets/scss/_td-content.scss
+++ b/docs/assets/scss/_td-content.scss
@@ -24,6 +24,25 @@
     color: var(--color-grey-medium);                 
   }  
 
+  .related-reading {
+    margin-top: 1.2rem;
+
+    h2 {
+      margin-bottom: 1rem;
+    }
+
+    ul {
+      gap: 0;
+      padding-inline-start: 1.6rem;
+    }
+
+    li {
+      line-height: 1.35rem !important;
+      margin: 0 0 0.35rem;
+      padding: 0.1rem 0.25rem !important;
+    }
+  }
+
   @media (max-width: 320px) {
     & > h1 {
       font-size: 1.5rem;

--- a/docs/content/en/installation/kubernetes/eks.md
+++ b/docs/content/en/installation/kubernetes/eks.md
@@ -1,6 +1,6 @@
 ---
 title: EKS
-category: [kubernetes]
+categories: [kubernetes]
 aliases:
 - /installation/platforms/eks
 display_title: false

--- a/docs/content/en/installation/linux-mac/_index.md
+++ b/docs/content/en/installation/linux-mac/_index.md
@@ -20,7 +20,6 @@ To set up and run Meshery on Linux or macOS, you will need to install `mesheryct
 
 {{% mesheryctl/installation-bash %}}
 
-# Related Reading
 
 ## Meshery CLI Guides
 

--- a/docs/content/en/installation/windows/scoop.md
+++ b/docs/content/en/installation/windows/scoop.md
@@ -11,8 +11,6 @@ description: Install Meshery CLI on Windows with Scoop
 
 {{% mesheryctl/installation-scoop %}}
 
-# Related Reading
-
 ## Mesheryctl Guides
 
 Guides to using Meshery's various features and components.

--- a/docs/content/en/project/contributing/contributing-server-events.md
+++ b/docs/content/en/project/contributing/contributing-server-events.md
@@ -1,7 +1,7 @@
 ---
 title: Contributing to Meshery Server Events
 description: Guide is to help backend contributors send server events using Golang.
-category: [contributing]
+categories: [contributing]
 ---
 
 Meshery incorporates an internal events publication mechanism that provides users with real-time updates on the processes occurring within the Meshery server when interacting with its endpoints. It ensures that users are kept in the loop regarding the ongoing activities within the API, and guides users towards future steps to resolve issues. This guide will provide step-by-step instructions on sending events from the server, including when to trigger events and what information to include.

--- a/docs/content/en/project/contributing/contributing-ui-sistent.md
+++ b/docs/content/en/project/contributing/contributing-ui-sistent.md
@@ -1,7 +1,7 @@
 ---
 title: Contributing to Meshery UI - Sistent
 description: How to contribute to the Meshery's web-based UI using sistent design system.
-category: [contributing]
+categories: [contributing]
 ---
 
 <div class="prereqs"><p><strong style="font-size: 20px;">Prerequisite Reading</strong></p>

--- a/docs/content/en/project/contributing/contributing-ui-tests.md
+++ b/docs/content/en/project/contributing/contributing-ui-tests.md
@@ -1,7 +1,7 @@
 ---
 title: Contributing to Meshery UI End-to-End Tests
 description: How to contribute to end-to-end testing in Meshery UI using Playwright.
-category: [contributing]
+categories: [contributing]
 ---
 
 To automate functional integration and end-to-end testing Meshery uses [Playwright](https://playwright.dev/) as one of the tools to automate browser testing. End-to-end tests run with each pull request to ensure that the changes do not break the existing functionality.
@@ -191,4 +191,3 @@ To filter and view only UI-related tests using the Sheet Views feature:
 2. Choose the pre-defined view labeled "UI"
 
 ![Meshery Test Plan Screenshot](/project/contributing/images/meshery-test-plan-v0.8.0-ui.png)
-

--- a/docs/content/en/project/contributing/meshery-windows.md
+++ b/docs/content/en/project/contributing/meshery-windows.md
@@ -1,7 +1,7 @@
 ---
 title: Setting up Meshery Development Environment on Windows
 description: How to set up Meshery Development Environment on Windows
-category: [contributing]
+categories: [contributing]
 --- 
 
 You can use one of the following three approaches to setup a Meshery development environment in Windows:

--- a/docs/go.mod
+++ b/docs/go.mod
@@ -1,8 +1,9 @@
-module github.com/layer5io/docs
+module github.com/meshery/meshery/docs
 
 go 1.25.5
 
 require (
 	github.com/google/docsy v0.15.0 // indirect
 	github.com/google/docsy/dependencies v0.7.2 // indirect
+	github.com/layer5io/docs v0.0.0-20260526140853-c48776ad0daf // indirect
 )

--- a/docs/go.sum
+++ b/docs/go.sum
@@ -4,5 +4,7 @@ github.com/google/docsy v0.15.0 h1:MNJ1nrE2ZuweXlUNaegTo/UbSKZJu+WMczahfZaxosI=
 github.com/google/docsy v0.15.0/go.mod h1:1Fj1W1O3esZh7IBQ8XAYtxtg10udBXuGI89+LUQc1AU=
 github.com/google/docsy/dependencies v0.7.2 h1:+t5ufoADQAj4XneFphz4A+UU0ICAxmNaRHVWtMYXPSI=
 github.com/google/docsy/dependencies v0.7.2/go.mod h1:gihhs5gmgeO+wuoay4FwOzob+jYJVyQbNaQOh788lD4=
+github.com/layer5io/docs v0.0.0-20260526140853-c48776ad0daf h1:9hETuEkGDDUYlDiXBOOcx4vDpkco9b8KyguBMbd/Zgc=
+github.com/layer5io/docs v0.0.0-20260526140853-c48776ad0daf/go.mod h1:679C+zRDJw9BXEUsxi1zzVy2OX7pS8EPeS6HLkzKhEA=
 github.com/twbs/bootstrap v5.2.3+incompatible/go.mod h1:fZTSrkpSf0/HkL0IIJzvVspTt1r9zuf7XlZau8kpcY0=
 github.com/twbs/bootstrap v5.3.8+incompatible/go.mod h1:fZTSrkpSf0/HkL0IIJzvVspTt1r9zuf7XlZau8kpcY0=

--- a/docs/hugo.toml
+++ b/docs/hugo.toml
@@ -207,6 +207,13 @@ enable = false
   [[module.imports]]
     path = "github.com/google/docsy/dependencies"
     disable = false
+  [[module.imports]]
+    path = "github.com/layer5io/docs"
+    disable = false
+    ignoreConfig = true
+    [[module.imports.mounts]]
+      source = "layouts/partials/related-reading.html"
+      target = "layouts/partials/related-reading.html"
   [[module.mounts]]
     source = "static"
     target = "static"

--- a/docs/hugo.toml
+++ b/docs/hugo.toml
@@ -21,8 +21,7 @@ ignoreFiles = ["^meetings/.*", "^notes/.*", "^integrations/.*" ]
 # Will give values to .Lastmod etc.
 enableGitInfo = true
 
-# Comment out to enable taxonomies in Docsy
-# disableKinds = ["taxonomy", "term"]
+# Keep taxonomy metadata available to templates, but do not publish taxonomy listing pages.
 
 # You can add your own taxonomies
 [taxonomies]
@@ -99,8 +98,8 @@ As a self-service engineering platform, Meshery enables collaborative design and
 [outputs]
   home = ["HTML", "RSS", "SITEMAP"]
   section = ["HTML", "RSS"]
-  taxonomy = ["HTML", "RSS"]
-  term = ["HTML", "RSS"]
+  taxonomy = []
+  term = []
 
 [sitemap]
   changefreq = "daily"

--- a/docs/layouts/_default/baseof.html
+++ b/docs/layouts/_default/baseof.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html lang="{{ .Site.Language.Lang }}" class="no-js">
   <head>
-    {{ partialCached "head.html" (dict "Title" .Title "Description" .Params.abstract "Site" .Site) .RelPermalink }}
+    {{ partialCached "head.html" (dict "Title" .Title "Description" .Params.abstract "Kind" .Kind "Permalink" .Permalink "Site" .Site) .RelPermalink }} 
     {{ partialCached "header.html" . .RelPermalink }}
     <script src="https://cdn.jsdelivr.net/npm/clipboard@1/dist/clipboard.min.js"></script>
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.0/css/all.min.css">

--- a/docs/layouts/_default/baseof.html
+++ b/docs/layouts/_default/baseof.html
@@ -81,6 +81,9 @@
             <h1>{{ .Title }}</h1>
           {{ end }}
           {{ block "main" . }}{{ end }}
+          <div class="related-reading">
+            {{ partial "related-reading.html" . -}}
+          </div>
         </div>
         {{ if or .IsPage .IsSection }}
           {{ partial "pagination.html" . }}

--- a/docs/layouts/_default/baseof.html
+++ b/docs/layouts/_default/baseof.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html lang="{{ .Site.Language.Lang }}" class="no-js">
   <head>
-    {{ partialCached "head.html" (dict "Title" .Title "Description" .Params.abstract "Kind" .Kind "Permalink" .Permalink "Site" .Site) .RelPermalink }} 
+    {{ partial "head.html" (dict "Title" .Title "Description" .Params.abstract "Kind" .Kind "Permalink" .Permalink "Site" .Site) }}
     {{ partialCached "header.html" . .RelPermalink }}
     <script src="https://cdn.jsdelivr.net/npm/clipboard@1/dist/clipboard.min.js"></script>
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.0/css/all.min.css">

--- a/docs/layouts/partials/head.html
+++ b/docs/layouts/partials/head.html
@@ -11,6 +11,10 @@
   <meta name="robots" content="index, follow" />
   {{- end }}
 
+  {{- if eq .Kind "404" }}
+  <base href="{{ .Site.BaseURL }}" />
+  {{- end }}
+
   <link
     rel="alternate"
     type="application/rss+xml"


### PR DESCRIPTION
**Notes for Reviewers**

Related PR https://github.com/layer5io/docs/pull/1065

- Remove publishing of /categories and /tags page
#### Why categories and tags are relevant?
- Upon Adding the Related reading component it check the categories and tags and assigns a relevant weight to it, of which 6 of the items get's displayed in the end of the page.  This PR https://github.com/layer5io/docs/pull/1065 adds that behaviour in layer5 docs, and we do want the same behaviour in Meshery docs, so it imports the layer5io/docs as go module and use the shared partial.


**[Signed commits](https://github.com/meshery/meshery/blob/master/CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [x] Yes, I signed my commits.

<!--
Thank you for contributing to Meshery! 

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. Sign your commits.
4. Include before and after screenshots/terminal output.

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.
-->
