### PR TITLE
chore(deps): bump meshery/schemas to v1.3.1

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -50,7 +50,7 @@ require (
 	github.com/meshery/meshery-operator v0.8.11
 	github.com/meshery/meshkit v1.0.8
 	github.com/meshery/meshsync v1.0.0
-	github.com/meshery/schemas v1.2.23
+	github.com/meshery/schemas v1.3.1
 	github.com/nsf/termbox-go v1.1.1
 	github.com/oapi-codegen/runtime v1.4.0
 	github.com/olekukonko/tablewriter v1.1.4

--- a/go.sum
+++ b/go.sum
@@ -704,8 +704,8 @@ github.com/meshery/meshkit v1.0.8 h1:cdpSSdwZKV5n4Uh/T1yBbPfJVf0EZClqIn9S8CzDdv8
 github.com/meshery/meshkit v1.0.8/go.mod h1:YQbXQtWnsvv2kt8nlCU6eJPjj5qWDf3heiLgbtZjKF0=
 github.com/meshery/meshsync v1.0.0 h1:BIHEVG4BDjqOnSd3vBt9B4IfWJNTfMRAgdwLroBcCfY=
 github.com/meshery/meshsync v1.0.0/go.mod h1:mFsPXkZRiCSuk5DhxBTrkWdlo6peItRBUoIEEQCovIg=
-github.com/meshery/schemas v1.2.23 h1:MlgkYSMbhUKPrCeAPkDCY0SvJCRX12t6lnsPVeEnQbQ=
-github.com/meshery/schemas v1.2.23/go.mod h1:JS5V0zTEHbP5I4VZw0mttkY09+0UnFK6qFt33PqK3aY=
+github.com/meshery/schemas v1.3.1 h1:nJCQO1rac9q+9SGVkRxkQCbOEJkkRzkSFiCvLz3Mn9k=
+github.com/meshery/schemas v1.3.1/go.mod h1:JS5V0zTEHbP5I4VZw0mttkY09+0UnFK6qFt33PqK3aY=
 github.com/miekg/dns v1.1.57 h1:Jzi7ApEIzwEPLHWRcafCN9LZSBbqQpxjt/wpgvg7wcM=
 github.com/miekg/dns v1.1.57/go.mod h1:uqRjCRUuEAA6qsOiJvDd+CFo/vW+y5WR6SNmHE55hZk=
 github.com/miekg/pkcs11 v1.0.2/go.mod h1:XsNlhZGX73bx86s2hdc/FuaLm2CPZJemRLMA+WTFxgs=

--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -21,7 +21,7 @@
         "@emotion/react": "^11.14.0",
         "@emotion/server": "^11.11.0",
         "@emotion/styled": "^11.14.1",
-        "@meshery/schemas": "^1.2.22",
+        "@meshery/schemas": "^1.3.1",
         "@microlink/react-json-view": "^1.31.20",
         "@mui/icons-material": "^9.0.1",
         "@mui/material": "^9.0.1",
@@ -2088,9 +2088,9 @@
       "license": "MIT"
     },
     "node_modules/@meshery/schemas": {
-      "version": "1.2.22",
-      "resolved": "https://registry.npmjs.org/@meshery/schemas/-/schemas-1.2.22.tgz",
-      "integrity": "sha512-PHje1ucZ9d/bjBvqsdOomnUpYB9G3c6k/RtPJ7R9CpP0H46OD80B7yLMWtSq0BJxH/NGdakWvgHAbUQOOyvesg==",
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/@meshery/schemas/-/schemas-1.3.1.tgz",
+      "integrity": "sha512-AB1o5VjKG6Sh8qOgYQt5QiDhUBmumyAbYSZWMyTKq9WvI0fSdaEwq5h62yrQ00OLUQ31+6FxbjMSx1c6XQZT7g==",
       "license": "ISC",
       "peerDependencies": {
         "@reduxjs/toolkit": "^2.8.1",

--- a/ui/package.json
+++ b/ui/package.json
@@ -48,7 +48,7 @@
     "@emotion/react": "^11.14.0",
     "@emotion/server": "^11.11.0",
     "@emotion/styled": "^11.14.1",
-    "@meshery/schemas": "^1.2.22",
+    "@meshery/schemas": "^1.3.1",
     "@microlink/react-json-view": "^1.31.20",
     "@mui/icons-material": "^9.0.1",
     "@mui/material": "^9.0.1",


### PR DESCRIPTION
## Summary

Bumps `github.com/meshery/schemas` (Go) and `@meshery/schemas` (npm) from v1.2.x to v1.3.1.

Picks up the product-neutral `CURRENT_ORG_KEY` rename in the upstream schemas package:

- `Layer5-Current-Orgid` -> `X-Current-Orgid`
- `Layer5-Current-Org-Name` -> `X-Current-Org-Name`
- `Layer5-Program` -> `X-Program`

Meshery server consumes `CURRENT_ORG_KEY` via the canonical `@meshery/schemas` re-exports; no source change is required in this repo.

## Lockstep cluster

- [`meshery/schemas` v1.3.1](https://github.com/meshery/schemas/releases/tag/v1.3.1) - published
- `meshery/meshery-cloud` - merged ([PR #5403](https://github.com/layer5io/meshery-cloud/pull/5403))
- `layer5io/sistent` - [PR #1587](https://github.com/layer5io/sistent/pull/1587)
- `layer5labs/meshery-extensions` - follow-up

## Test plan

- [x] `go build ./...`: clean
- [x] `npm install` in `ui/`: clean (registers @meshery/schemas@1.3.1)
- [ ] CI checks via this PR's workflow