### PR TITLE
fix(workflow): set explicit ref on cross-repo workflow dispatch

### DIFF
--- a/.github/workflows/notify-providers.yaml
+++ b/.github/workflows/notify-providers.yaml
@@ -22,6 +22,7 @@ jobs:
         workflow: Build and Release Extensions
         repo: meshery-extensions/meshery-extensions-packages
         token: ${{ secrets.GH_ACCESS_TOKEN }}
+        ref: master
         inputs: '{"version": "master"}'
     - name: Set release tag
       if: github.event_name != 'pull_request' && startsWith(github.ref, 'refs/tags/') && success()
@@ -34,4 +35,5 @@ jobs:
         workflow: Build and Release Extensions
         repo: meshery-extensions/meshery-extensions-packages
         token: ${{ secrets.GH_ACCESS_TOKEN }}
+        ref: master
         inputs: '{"version": "${{ steps.vars.outputs.tag }}"}'


### PR DESCRIPTION
## Symptom

`Notify Remote Providers` has failed on every tag push since `v1.0.30` (2026-05-26):

```
No ref found for: refs/tags/v1.0.33
```

Most recent failing run: https://github.com/meshery/meshery/actions/runs/26558860608

## Root cause

Commit b97345cd851b ("security: pin external workflow/action references to commit SHAs") pinned `benc-uk/workflow-dispatch` from the floating `@v1` to the immutable SHA for v1.3.2. v1.3.2's `action.yaml` declares a default for the `ref` input:

```yaml
ref:
  description: 'The reference can be a branch, tag, or a commit SHA'
  required: false
  default: ${{ github.head_ref || github.ref }}
```

Since `ref` was never set explicitly in `notify-providers.yaml`, the action now forwards meshery/meshery's tag ref (`refs/tags/v1.0.33`) as the dispatch ref to `meshery-extensions/meshery-extensions-packages`. That tag does not exist in the target repo, so the `POST /repos/{owner}/{repo}/actions/workflows/{id}/dispatches` call returns 404.

The floating `@v1` build had no such default - it omitted `ref` from the API call, which let GitHub fall back to the target repo's default branch. Pinning to a newer minor changed behavior silently.

## Fix

Set `ref: master` explicitly on both `workflow-dispatch` steps (release and edge). `master` is the default branch of `meshery-extensions/meshery-extensions-packages` (verified via API). The dispatch ref is now independent of whatever ref triggered the notify workflow, which is the correct semantics for cross-repo dispatch - the dispatcher repo's tag has no meaning in the target repo.

## Test plan

- [x] Verified `benc-uk/workflow-dispatch@v1.3.2`'s `action.yaml` defines a default for `ref` that did not exist on the older floating `@v1`.
- [x] Verified `meshery-extensions/meshery-extensions-packages` default branch is `master`.
- [x] Reviewed all `benc-uk/workflow-dispatch` usages in `.github/` - only this file uses it.
- [ ] On merge, next `v*` tag push should successfully dispatch `Build and Release Extensions` in the target repo.

## Watch for

- The `on:` block of this workflow has its `branches:` filter commented out, so the "edge" dispatch step is currently dead code (the workflow only fires on tag pushes). Pre-existing - flagging for separate follow-up if edge builds were intended to fire on master pushes.
- Any future cross-repo `benc-uk/workflow-dispatch` usage in this repo must set `ref:` explicitly to avoid repeating this failure mode.