### PR TITLE
add(relationships): add hierarchical relationships for karpenter model

### DIFF
--- a/server/meshmodel/karpenter/1.0.0/v1.0.0/relationships/hierarchical-parent-inventory-ab1c2.json
+++ b/server/meshmodel/karpenter/1.0.0/v1.0.0/relationships/hierarchical-parent-inventory-ab1c2.json
@@ -1,0 +1,43 @@
+{
+  "schemaVersion": "core.meshery.io/v1beta1",
+  "version": "v1.0.0",
+  "kind": "hierarchical",
+  "type": "parent",
+  "subType": "inventory",
+  "metadata": {
+    "description": "A Karpenter NodeClaim that references a NodePool as its source."
+  },
+  "model": {
+    "name": "karpenter"
+  },
+  "id": "00000000-0000-0000-0000-000000000000",
+  "selectors": [
+    {
+      "allow": {
+        "from": [
+          {
+            "kind": "NodeClaim",
+            "model": "karpenter",
+            "patch": {
+              "patchStrategy": "replace",
+              "mutatorRef": [["configuration", "spec", "nodePoolName"]],
+              "description": "NodeClaim references the NodePool as its source."
+            }
+          }
+        ],
+        "to": [
+          {
+            "kind": "NodePool",
+            "model": "karpenter",
+            "patch": {
+              "patchStrategy": "replace",
+              "mutatedRef": [["displayName"]],
+              "description": "NodePool is the source for the NodeClaim."
+            }
+          }
+        ]
+      },
+      "deny": {}
+    }
+  ]
+}

--- a/server/meshmodel/karpenter/1.0.0/v1.0.0/relationships/hierarchical-parent-inventory-ab1c2.json
+++ b/server/meshmodel/karpenter/1.0.0/v1.0.0/relationships/hierarchical-parent-inventory-ab1c2.json
@@ -1,99 +1,107 @@
 {
-  "id": "00000000-0000-0000-0000-000000000000",
-  "evaluationQuery": "",
-  "kind": "hierarchical",
-  "metadata": {
-    "description": "",
-    "isAnnotation": false,
-    "styles": {
-      "primaryColor": "",
-      "svgColor": "",
-      "svgWhite": ""
-    }
-  },
-  "model": {
-    "displayName": "",
-    "id": "00000000-0000-0000-0000-000000000000",
-    "model": {
-      "version": "1.0.0"
-    },
-    "name": "karpenter",
-    "registrant": {
-      "kind": ""
-    },
-    "version": ""
-  },
-  "schemaVersion": "relationships.meshery.io/v1beta2",
-  "selectors": [
-    {
-      "allow": {
-        "from": [
-          {
-            "id": null,
-            "kind": "NodePool",
-            "match": {},
-            "match_strategy_matrix": null,
-            "model": {
-              "displayName": "",
-              "id": "00000000-0000-0000-0000-000000000000",
-              "model": {
-                "version": ""
+    "id":  "00000000-0000-0000-0000-000000000000",
+    "evaluationQuery":  "",
+    "kind":  "hierarchical",
+    "metadata":  {
+                     "description":  "",
+                     "isAnnotation":  false,
+                     "styles":  {
+                                    "primaryColor":  "",
+                                    "svgColor":  "",
+                                    "svgWhite":  ""
+                                }
+                 },
+    "model":  {
+                  "displayName":  "",
+                  "id":  "00000000-0000-0000-0000-000000000000",
+                  "model":  {
+                                "version":  "1.0.0"
+                            },
+                  "name":  "karpenter",
+                  "registrant":  {
+                                     "kind":  ""
+                                 },
+                  "version":  ""
               },
-              "name": "karpenter",
-              "registrant": {
-                "kind": "github"
-              },
-              "version": ""
-            },
-            "patch": {
-              "mutatedRef": [
-                [
-                  "displayName"
-                ]
-              ],
-              "patchStrategy": "replace"
-            }
-          }
-        ],
-        "to": [
-          {
-            "id": null,
-            "kind": "NodeClaim",
-            "match": {},
-            "match_strategy_matrix": null,
-            "model": {
-              "displayName": "",
-              "id": "00000000-0000-0000-0000-000000000000",
-              "model": {
-                "version": ""
-              },
-              "name": "karpenter",
-              "registrant": {
-                "kind": "github"
-              },
-              "version": ""
-            },
-            "patch": {
-              "mutatorRef": [
-                [
-                  "configuration",
-                  "spec",
-                  "nodePoolName"
-                ]
-              ],
-              "patchStrategy": "replace"
-            }
-          }
-        ]
-      },
-      "deny": {
-        "from": [],
-        "to": []
-      }
-    }
-  ],
-  "subType": "inventory",
-  "status": "enabled",
-  "type": "parent",
-  "version": "v1.0.0"
+    "schemaVersion":  "relationships.meshery.io/v1beta2",
+    "selectors":  [
+                      {
+                          "allow":  {
+                                        "from":  [
+                                                     {
+                                                         "id":  null,
+                                                         "kind":  "NodeClaim",
+                                                         "match":  {
+
+                                                                   },
+                                                         "match_strategy_matrix":  null,
+                                                         "model":  {
+                                                                       "displayName":  "",
+                                                                       "id":  "00000000-0000-0000-0000-000000000000",
+                                                                       "model":  {
+                                                                                     "version":  ""
+                                                                                 },
+                                                                       "name":  "karpenter",
+                                                                       "registrant":  {
+                                                                                          "kind":  "github"
+                                                                                      },
+                                                                       "version":  ""
+                                                                   },
+                                                         "patch":  {
+                                                                       "mutatorRef":  [
+                                                                                          [
+                                                                                              "configuration",
+                                                                                              "spec",
+                                                                                              "nodePoolName"
+                                                                                          ]
+                                                                                      ],
+                                                                       "patchStrategy":  "replace"
+                                                                   }
+                                                     }
+                                                 ],
+                                        "to":  [
+                                                   {
+                                                       "id":  null,
+                                                       "kind":  "NodePool",
+                                                       "match":  {
+
+                                                                 },
+                                                       "match_strategy_matrix":  null,
+                                                       "model":  {
+                                                                     "displayName":  "",
+                                                                     "id":  "00000000-0000-0000-0000-000000000000",
+                                                                     "model":  {
+                                                                                   "version":  ""
+                                                                               },
+                                                                     "name":  "karpenter",
+                                                                     "registrant":  {
+                                                                                        "kind":  "github"
+                                                                                    },
+                                                                     "version":  ""
+                                                                 },
+                                                       "patch":  {
+                                                                     "mutatedRef":  [
+                                                                                        [
+                                                                                            "displayName"
+                                                                                        ]
+                                                                                    ],
+                                                                     "patchStrategy":  "replace"
+                                                                 }
+                                                   }
+                                               ]
+                                    },
+                          "deny":  {
+                                       "from":  [
+
+                                                ],
+                                       "to":  [
+
+                                              ]
+                                   }
+                      }
+                  ],
+    "subType":  "inventory",
+    "status":  "enabled",
+    "type":  "parent",
+    "version":  "v1.0.0"
 }

--- a/server/meshmodel/karpenter/1.0.0/v1.0.0/relationships/hierarchical-parent-inventory-ab1c2.json
+++ b/server/meshmodel/karpenter/1.0.0/v1.0.0/relationships/hierarchical-parent-inventory-ab1c2.json
@@ -1,43 +1,99 @@
 {
-  "schemaVersion": "core.meshery.io/v1beta1",
-  "version": "v1.0.0",
+  "id": "00000000-0000-0000-0000-000000000000",
+  "evaluationQuery": "",
   "kind": "hierarchical",
-  "type": "parent",
-  "subType": "inventory",
   "metadata": {
-    "description": "A Karpenter NodeClaim that references a NodePool as its source."
+    "description": "",
+    "isAnnotation": false,
+    "styles": {
+      "primaryColor": "",
+      "svgColor": "",
+      "svgWhite": ""
+    }
   },
   "model": {
-    "name": "karpenter"
+    "displayName": "",
+    "id": "00000000-0000-0000-0000-000000000000",
+    "model": {
+      "version": "1.0.0"
+    },
+    "name": "karpenter",
+    "registrant": {
+      "kind": ""
+    },
+    "version": ""
   },
-  "id": "00000000-0000-0000-0000-000000000000",
+  "schemaVersion": "relationships.meshery.io/v1beta2",
   "selectors": [
     {
       "allow": {
         "from": [
           {
-            "kind": "NodeClaim",
-            "model": "karpenter",
+            "id": null,
+            "kind": "NodePool",
+            "match": {},
+            "match_strategy_matrix": null,
+            "model": {
+              "displayName": "",
+              "id": "00000000-0000-0000-0000-000000000000",
+              "model": {
+                "version": ""
+              },
+              "name": "karpenter",
+              "registrant": {
+                "kind": "github"
+              },
+              "version": ""
+            },
             "patch": {
-              "patchStrategy": "replace",
-              "mutatorRef": [["configuration", "spec", "nodePoolName"]],
-              "description": "NodeClaim references the NodePool as its source."
+              "mutatedRef": [
+                [
+                  "displayName"
+                ]
+              ],
+              "patchStrategy": "replace"
             }
           }
         ],
         "to": [
           {
-            "kind": "NodePool",
-            "model": "karpenter",
+            "id": null,
+            "kind": "NodeClaim",
+            "match": {},
+            "match_strategy_matrix": null,
+            "model": {
+              "displayName": "",
+              "id": "00000000-0000-0000-0000-000000000000",
+              "model": {
+                "version": ""
+              },
+              "name": "karpenter",
+              "registrant": {
+                "kind": "github"
+              },
+              "version": ""
+            },
             "patch": {
-              "patchStrategy": "replace",
-              "mutatedRef": [["displayName"]],
-              "description": "NodePool is the source for the NodeClaim."
+              "mutatorRef": [
+                [
+                  "configuration",
+                  "spec",
+                  "nodePoolName"
+                ]
+              ],
+              "patchStrategy": "replace"
             }
           }
         ]
       },
-      "deny": {}
+      "deny": {
+        "from": [],
+        "to": []
+      }
     }
-  ]
+  ],
+  "subType": "inventory",
+  "status": "enabled",
+  "type": "parent",
+  "version": "v1.0.0"
 }

--- a/server/meshmodel/karpenter/1.0.0/v1.0.0/relationships/hierarchical-parent-inventory-de3f4.json
+++ b/server/meshmodel/karpenter/1.0.0/v1.0.0/relationships/hierarchical-parent-inventory-de3f4.json
@@ -1,43 +1,102 @@
 {
-  "schemaVersion": "core.meshery.io/v1beta1",
-  "version": "v1.0.0",
+  "id": "00000000-0000-0000-0000-000000000000",
+  "evaluationQuery": "",
   "kind": "hierarchical",
-  "type": "parent",
-  "subType": "inventory",
   "metadata": {
-    "description": "A Karpenter NodePool that references an OCINodeClass for node configuration."
+    "description": "",
+    "isAnnotation": false,
+    "styles": {
+      "primaryColor": "",
+      "svgColor": "",
+      "svgWhite": ""
+    }
   },
   "model": {
-    "name": "karpenter"
+    "displayName": "",
+    "id": "00000000-0000-0000-0000-000000000000",
+    "model": {
+      "version": "1.0.0"
+    },
+    "name": "karpenter",
+    "registrant": {
+      "kind": ""
+    },
+    "version": ""
   },
-  "id": "00000000-0000-0000-0000-000000000000",
+  "schemaVersion": "relationships.meshery.io/v1beta2",
   "selectors": [
     {
       "allow": {
         "from": [
           {
-            "kind": "NodePool",
-            "model": "karpenter",
+            "id": null,
+            "kind": "OCINodeClass",
+            "match": {},
+            "match_strategy_matrix": null,
+            "model": {
+              "displayName": "",
+              "id": "00000000-0000-0000-0000-000000000000",
+              "model": {
+                "version": ""
+              },
+              "name": "karpenter",
+              "registrant": {
+                "kind": "github"
+              },
+              "version": ""
+            },
             "patch": {
-              "patchStrategy": "replace",
-              "mutatorRef": [["configuration", "spec", "template", "spec", "nodeClassRef", "name"]],
-              "description": "NodePool references the OCINodeClass for node configuration."
+              "mutatedRef": [
+                [
+                  "displayName"
+                ]
+              ],
+              "patchStrategy": "replace"
             }
           }
         ],
         "to": [
           {
-            "kind": "OCINodeClass",
-            "model": "karpenter",
+            "id": null,
+            "kind": "NodePool",
+            "match": {},
+            "match_strategy_matrix": null,
+            "model": {
+              "displayName": "",
+              "id": "00000000-0000-0000-0000-000000000000",
+              "model": {
+                "version": ""
+              },
+              "name": "karpenter",
+              "registrant": {
+                "kind": "github"
+              },
+              "version": ""
+            },
             "patch": {
-              "patchStrategy": "replace",
-              "mutatedRef": [["displayName"]],
-              "description": "OCINodeClass provides node configuration for the NodePool."
+              "mutatorRef": [
+                [
+                  "configuration",
+                  "spec",
+                  "template",
+                  "spec",
+                  "nodeClassRef",
+                  "name"
+                ]
+              ],
+              "patchStrategy": "replace"
             }
           }
         ]
       },
-      "deny": {}
+      "deny": {
+        "from": [],
+        "to": []
+      }
     }
-  ]
+  ],
+  "subType": "inventory",
+  "status": "enabled",
+  "type": "parent",
+  "version": "v1.0.0"
 }

--- a/server/meshmodel/karpenter/1.0.0/v1.0.0/relationships/hierarchical-parent-inventory-de3f4.json
+++ b/server/meshmodel/karpenter/1.0.0/v1.0.0/relationships/hierarchical-parent-inventory-de3f4.json
@@ -1,102 +1,110 @@
 {
-  "id": "00000000-0000-0000-0000-000000000000",
-  "evaluationQuery": "",
-  "kind": "hierarchical",
-  "metadata": {
-    "description": "",
-    "isAnnotation": false,
-    "styles": {
-      "primaryColor": "",
-      "svgColor": "",
-      "svgWhite": ""
-    }
-  },
-  "model": {
-    "displayName": "",
-    "id": "00000000-0000-0000-0000-000000000000",
-    "model": {
-      "version": "1.0.0"
-    },
-    "name": "karpenter",
-    "registrant": {
-      "kind": ""
-    },
-    "version": ""
-  },
-  "schemaVersion": "relationships.meshery.io/v1beta2",
-  "selectors": [
-    {
-      "allow": {
-        "from": [
-          {
-            "id": null,
-            "kind": "OCINodeClass",
-            "match": {},
-            "match_strategy_matrix": null,
-            "model": {
-              "displayName": "",
-              "id": "00000000-0000-0000-0000-000000000000",
-              "model": {
-                "version": ""
+    "id":  "00000000-0000-0000-0000-000000000000",
+    "evaluationQuery":  "",
+    "kind":  "hierarchical",
+    "metadata":  {
+                     "description":  "",
+                     "isAnnotation":  false,
+                     "styles":  {
+                                    "primaryColor":  "",
+                                    "svgColor":  "",
+                                    "svgWhite":  ""
+                                }
+                 },
+    "model":  {
+                  "displayName":  "",
+                  "id":  "00000000-0000-0000-0000-000000000000",
+                  "model":  {
+                                "version":  "1.0.0"
+                            },
+                  "name":  "karpenter",
+                  "registrant":  {
+                                     "kind":  ""
+                                 },
+                  "version":  ""
               },
-              "name": "karpenter",
-              "registrant": {
-                "kind": "github"
-              },
-              "version": ""
-            },
-            "patch": {
-              "mutatedRef": [
-                [
-                  "displayName"
-                ]
-              ],
-              "patchStrategy": "replace"
-            }
-          }
-        ],
-        "to": [
-          {
-            "id": null,
-            "kind": "NodePool",
-            "match": {},
-            "match_strategy_matrix": null,
-            "model": {
-              "displayName": "",
-              "id": "00000000-0000-0000-0000-000000000000",
-              "model": {
-                "version": ""
-              },
-              "name": "karpenter",
-              "registrant": {
-                "kind": "github"
-              },
-              "version": ""
-            },
-            "patch": {
-              "mutatorRef": [
-                [
-                  "configuration",
-                  "spec",
-                  "template",
-                  "spec",
-                  "nodeClassRef",
-                  "name"
-                ]
-              ],
-              "patchStrategy": "replace"
-            }
-          }
-        ]
-      },
-      "deny": {
-        "from": [],
-        "to": []
-      }
-    }
-  ],
-  "subType": "inventory",
-  "status": "enabled",
-  "type": "parent",
-  "version": "v1.0.0"
+    "schemaVersion":  "relationships.meshery.io/v1beta2",
+    "selectors":  [
+                      {
+                          "allow":  {
+                                        "from":  [
+                                                     {
+                                                         "id":  null,
+                                                         "kind":  "NodePool",
+                                                         "match":  {
+
+                                                                   },
+                                                         "match_strategy_matrix":  null,
+                                                         "model":  {
+                                                                       "displayName":  "",
+                                                                       "id":  "00000000-0000-0000-0000-000000000000",
+                                                                       "model":  {
+                                                                                     "version":  ""
+                                                                                 },
+                                                                       "name":  "karpenter",
+                                                                       "registrant":  {
+                                                                                          "kind":  "github"
+                                                                                      },
+                                                                       "version":  ""
+                                                                   },
+                                                         "patch":  {
+                                                                       "mutatorRef":  [
+                                                                                          [
+                                                                                              "configuration",
+                                                                                              "spec",
+                                                                                              "template",
+                                                                                              "spec",
+                                                                                              "nodeClassRef",
+                                                                                              "name"
+                                                                                          ]
+                                                                                      ],
+                                                                       "patchStrategy":  "replace"
+                                                                   }
+                                                     }
+                                                 ],
+                                        "to":  [
+                                                   {
+                                                       "id":  null,
+                                                       "kind":  "OCINodeClass",
+                                                       "match":  {
+
+                                                                 },
+                                                       "match_strategy_matrix":  null,
+                                                       "model":  {
+                                                                     "displayName":  "",
+                                                                     "id":  "00000000-0000-0000-0000-000000000000",
+                                                                     "model":  {
+                                                                                   "version":  ""
+                                                                               },
+                                                                     "name":  "karpenter",
+                                                                     "registrant":  {
+                                                                                        "kind":  "github"
+                                                                                    },
+                                                                     "version":  ""
+                                                                 },
+                                                       "patch":  {
+                                                                     "mutatedRef":  [
+                                                                                        [
+                                                                                            "displayName"
+                                                                                        ]
+                                                                                    ],
+                                                                     "patchStrategy":  "replace"
+                                                                 }
+                                                   }
+                                               ]
+                                    },
+                          "deny":  {
+                                       "from":  [
+
+                                                ],
+                                       "to":  [
+
+                                              ]
+                                   }
+                      }
+                  ],
+    "subType":  "inventory",
+    "status":  "enabled",
+    "type":  "parent",
+    "version":  "v1.0.0"
 }

--- a/server/meshmodel/karpenter/1.0.0/v1.0.0/relationships/hierarchical-parent-inventory-de3f4.json
+++ b/server/meshmodel/karpenter/1.0.0/v1.0.0/relationships/hierarchical-parent-inventory-de3f4.json
@@ -1,0 +1,43 @@
+{
+  "schemaVersion": "core.meshery.io/v1beta1",
+  "version": "v1.0.0",
+  "kind": "hierarchical",
+  "type": "parent",
+  "subType": "inventory",
+  "metadata": {
+    "description": "A Karpenter NodePool that references an OCINodeClass for node configuration."
+  },
+  "model": {
+    "name": "karpenter"
+  },
+  "id": "00000000-0000-0000-0000-000000000000",
+  "selectors": [
+    {
+      "allow": {
+        "from": [
+          {
+            "kind": "NodePool",
+            "model": "karpenter",
+            "patch": {
+              "patchStrategy": "replace",
+              "mutatorRef": [["configuration", "spec", "template", "spec", "nodeClassRef", "name"]],
+              "description": "NodePool references the OCINodeClass for node configuration."
+            }
+          }
+        ],
+        "to": [
+          {
+            "kind": "OCINodeClass",
+            "model": "karpenter",
+            "patch": {
+              "patchStrategy": "replace",
+              "mutatedRef": [["displayName"]],
+              "description": "OCINodeClass provides node configuration for the NodePool."
+            }
+          }
+        ]
+      },
+      "deny": {}
+    }
+  ]
+}


### PR DESCRIPTION
Fixes #19746

## Description
Added hierarchical parent-inventory relationships for the Karpenter model (v1.0.0):

- NodeClaim → NodePool: A NodeClaim references a NodePool via `spec.nodePoolName`
- NodePool → OCINodeClass: A NodePool references an OCINodeClass via `spec.template.spec.nodeClassRef.name`

These relationships enable visual parent-child grouping in Kanvas, allowing users to see how Karpenter resources depend on each other.