### PR TITLE
[CI] Reconcile playground Deployment env from manifest on every release

### DIFF
--- a/.github/workflows/cncf-playground-deploy-meshery.yaml
+++ b/.github/workflows/cncf-playground-deploy-meshery.yaml
@@ -14,17 +14,42 @@ jobs:
     cncf-playground-rollout:
         name: Update Meshery on CNCF playground
         if: github.repository == 'meshery/meshery'
-        runs-on: ubuntu-24.04 
+        runs-on: ubuntu-24.04
         steps:
-        - name: Pull latest images and restart containers
+        - name: Reconcile env from manifest, then roll image forward
           uses: appleboy/ssh-action@master
+          env:
+              MANIFEST_REF: ${{ github.sha }}
           with:
               host: ${{ secrets.OCI_BASTION_HOST }}
               username: ${{ secrets.OCI_BASTION_USERNAME }}
               key: ${{ secrets.OCI_BASTION_KEY }}
+              envs: MANIFEST_REF
               script: |
+                set -euo pipefail
                 kubectl config use-context prod
+                # Fetch the canonical Deployment spec at the exact commit being
+                # deployed, so the env applied to the cluster always matches the
+                # release. Pinning to ${MANIFEST_REF} (github.sha) keeps replays
+                # of an older release reproducible too.
+                MANIFEST_URL="https://raw.githubusercontent.com/meshery/meshery/${MANIFEST_REF}/install/playground/kubernetes/playground-deployment.yaml"
+                MANIFEST_FILE="$(mktemp)"
+                trap 'rm -f "$MANIFEST_FILE"' EXIT
+                curl -fsSL "$MANIFEST_URL" -o "$MANIFEST_FILE"
+                # Reconcile the spec (env vars, probes, volumes) from the canonical
+                # manifest before rolling the image. Without this, every release
+                # inherits whatever was last hand-edited on the cluster - which is
+                # how the live pod lost PROVIDER=Meshery and stopped pre-selecting
+                # the provider on playground.meshery.io after the server-side
+                # auto-select gate was tightened.
+                kubectl -n meshery apply -f "$MANIFEST_FILE"
+                # set image runs after apply so the release tag wins over the
+                # bootstrap tag pinned in the manifest. Both updates land in the
+                # same rollout because the controller coalesces consecutive spec
+                # changes before the new ReplicaSet is fully scaled.
                 kubectl -n meshery set image deployment/playground meshery=${{ inputs.image }}
+                kubectl -n meshery rollout status deployment/playground --timeout=5m
 
 # Verify
-# kubectl get deployment playground -n meshery-o custom-columns=NAME:.metadata.name,IMAGE:.spec.template.spec.containers[*].image --no-headers
+# kubectl get deployment playground -n meshery -o custom-columns=NAME:.metadata.name,IMAGE:.spec.template.spec.containers[*].image --no-headers
+# kubectl get deployment playground -n meshery -o jsonpath='{.spec.template.spec.containers[?(@.name=="meshery")].env}' | jq

--- a/install/playground/readme.md
+++ b/install/playground/readme.md
@@ -12,9 +12,11 @@ with `kubectl -n meshery apply -f kubernetes/playground-deployment.yaml`.
 
 Provider configuration is set there: the playground offers only the **Meshery** provider
 (`PROVIDER_BASE_URLS=https://cloud.meshery.io`) and pre-selects it on load
-(`PROVIDER=Meshery`). Releases update only the container image via
-`.github/workflows/cncf-playground-deploy-meshery.yaml` (`kubectl set image`); they do not
-reconcile env, so changes to provider configuration must be applied from the manifest above.
+(`PROVIDER=Meshery`). Releases reconcile the spec from this manifest and then roll the
+container image forward via `.github/workflows/cncf-playground-deploy-meshery.yaml`
+(`kubectl apply` then `kubectl set image`), so env changes ride in with the next release.
+Out-of-band edits on the cluster will be overwritten on the next deploy - put the change
+in this manifest instead.
 
 _The bare-metal/Equinix notes below describe an earlier topology and are retained for reference._
 


### PR DESCRIPTION
## Symptom
After recent Meshery releases shipped to `playground.meshery.io`, the "Meshery" provider is no longer pre-selected. Users land on the provider-chooser instead of being bounced through `/user/login`.

## Root cause
Two changes landed out of order.

1. **2026-04-29 - PR #19006 (`0b497440b2d`) tightened `ProviderUIHandler`'s auto-select gate** in `server/handlers/provider_handler.go:163`. Previously `PlaygroundBuild=true` alone entered the auto-select branch (and wrote an empty `meshery-provider=` cookie when `PROVIDER` was unset, producing the `/user/login` <-> `/provider` loop). After this PR, auto-select requires `PROVIDER` to be set AND registered in `h.config.Providers`. With `PLAYGROUND=true` and `PROVIDER` unset, the handler now falls through to the chooser and logs:
   > `PLAYGROUND=true but PROVIDER env var is unset on this deployment; serving the provider-selection UI instead of looping...`

2. **2026-05-22 - `5e0fc411afa` added the canonical Deployment manifest to the repo.** Its commit message confirmed the live CNCF Deployment had been hand-maintained and had drifted ("served the wrong `PROVIDER_BASE_URLS`"). The manifest in the repo is correct (`PROVIDER=Meshery` at line 53), but the release workflow at `.github/workflows/cncf-playground-deploy-meshery.yaml` only ran `kubectl set image` and never reconciled env. So the manifest in git has never reached the cluster.

Net: the running pod is missing `PROVIDER=Meshery`, which used to be tolerable (`PLAYGROUND` alone was enough) and now isn't.

## Fix
- **`cncf-playground-deploy-meshery.yaml`**: fetch the canonical manifest at the exact `github.sha` being deployed, `kubectl apply` it to reconcile env, then `kubectl set image` to roll the release tag forward, then `rollout status` to fail loudly if the pod can't come up. Pinning the manifest fetch to `github.sha` keeps replays of older releases reproducible.
- **`install/playground/readme.md`**: document that releases now reconcile spec from the manifest, so out-of-band cluster edits will be overwritten on the next deploy.

The first deploy after this lands will reset env to the manifest on the live cluster. The bootstrap image tag pinned in the manifest is immediately overwritten by `set image` in the same step, so there is no period during which an older image is served.

### One-shot reconciliation for the live cluster (before this PR ships)

To repair `playground.meshery.io` immediately without waiting for the next release, run from the bastion:

\`\`\`bash
kubectl config use-context prod
curl -fsSL https://raw.githubusercontent.com/meshery/meshery/master/install/playground/kubernetes/playground-deployment.yaml -o /tmp/playground-deployment.yaml
CURRENT_IMAGE=\$(kubectl -n meshery get deployment/playground -o jsonpath='{.spec.template.spec.containers[?(@.name=="meshery")].image}')
kubectl -n meshery apply -f /tmp/playground-deployment.yaml
kubectl -n meshery set image deployment/playground meshery=\${CURRENT_IMAGE}
kubectl -n meshery rollout status deployment/playground --timeout=5m
\`\`\`

