### PR TITLE
fix(server): detach goroutine context in NotifySmOfConnectionStatusChange

### DIFF
--- a/server/handlers/connections_handlers.go
+++ b/server/handlers/connections_handlers.go
@@ -467,7 +467,7 @@ func (h *Handler) UpdateConnectionById(w http.ResponseWriter, req *http.Request,
 	w.WriteHeader(http.StatusOK)
 }
 
-func (h *Handler) NotifySmOfConnectionStatusChange(context context.Context, userID core.Uuid, provider models.Provider, token string, connection *connections.ConnectionPayload) (events.Event, error) {
+func (h *Handler) NotifySmOfConnectionStatusChange(ctx context.Context, userID core.Uuid, provider models.Provider, token string, connection *connections.ConnectionPayload) (events.Event, error) {
 	connectionID := connection.ID
 
 	eventBuilder := events.NewEvent().ActedUpon(connectionID).FromUser(userID).FromSystem(*h.SystemID).WithCategory("connection").WithAction("update")
@@ -503,7 +503,7 @@ func (h *Handler) NotifySmOfConnectionStatusChange(context context.Context, user
 
 		inst, err := helpers.InitializeMachineWithContext(
 			machineCtx,
-			context,
+			ctx,
 			connectionID,
 			userID,
 			smInstanceTracker,
@@ -520,9 +520,11 @@ func (h *Handler) NotifySmOfConnectionStatusChange(context context.Context, user
 			})
 			return *eventBuilder.Build(), err
 		}
-
+		// detach from the http request lifecycle so that the goroutine isn't cancelled when
+		// the handler returns, while preserving context values (e.g. TokenCtxKey) that downstream calls depend on.
+		detachedCtx := context.WithoutCancel(ctx)
 		go func(inst *machines.StateMachine, status connections.ConnectionStatus) {
-			event, err := inst.SendEvent(context, machines.EventType(helpers.StatusToEvent(status)), nil)
+			event, err := inst.SendEvent(detachedCtx, machines.EventType(helpers.StatusToEvent(status)), nil)
 			if err != nil {
 				h.log.Error(err)
 				_ = provider.PersistEvent(*event, token)


### PR DESCRIPTION
**Notes for Reviewers**

- This PR fixes #
The goroutine in `NotifySmOfConnectionStatusChange `captured the HTTP request context, which is cancelled when the handler returns. This caused `SendEvent `to receive a cancelled `context `and broadcast a false error event to the UI, producing error toasts after successful connection state transitions.
Use `context.WithoutCancel` to detach from the request lifecycle while preserving context values (e.g. TokenCtxKey) that downstream calls depend on.

Fixes #19721 

**[Signed commits](https://github.com/meshery/meshery/blob/master/CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [x] Yes, I signed my commits.

<!--
Thank you for contributing to Meshery! 

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. Sign your commits.
4. Include before and after screenshots/terminal output.

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.
-->
