### PR TITLE
[docs] Add "What's Next?" section to Quick Start guide

### DIFF
--- a/docs/content/en/installation/quick-start/index.md
+++ b/docs/content/en/installation/quick-start/index.md
@@ -90,6 +90,22 @@ You may now proceed to manage any cloud native infrastructure supported by Meshe
   <img class="center" style="width:min(100%,650px);" src="./images/meshery-designs.png" />
 </a>
 
+## What's Next?
+
+Now that Meshery is running, here are a few suggested next steps:
+
+* 🎮 Explore the **[Cloud Native Playground](https://play.meshery.io)** to try Meshery in a pre-configured environment.
+* 📐 Create your first design using **[Kanvas](/extensions/kanvas)**, Meshery's visual designer for cloud native infrastructure.
+* 🔍 Explore your connected infrastructure and resources from the Meshery dashboard, or learn more about **[Managing Kubernetes Clusters](/installation/kubernetes)**.
+* 📚 Continue learning with the tutorials below or explore Meshery's **[Core Concepts](/concepts/logical)** and **[Architecture](/concepts/architecture)**.
+* 🤝 Join the **[Meshery Community](https://slack.meshery.io)** to ask questions, share feedback, and connect with other users and contributors.
+* 🛠️ Interested in contributing? Start with the **[Contributor Guides](/project/contributing)**.
+
+{{% alert color="info" title="Need help?" %}}
+If you run into any issues, see the **[Troubleshooting Guides](/guides/troubleshooting/installation)** or ask for help in the Meshery community.
+{{% /alert %}}
+
+
 ## Explore Tutorials
 
 🧑‍🔬 Explore these tutorials to learn how to use Meshery for collaboratively managing infrastructure.

--- a/docs/content/en/installation/quick-start/index.md
+++ b/docs/content/en/installation/quick-start/index.md
@@ -105,7 +105,6 @@ Now that Meshery is running, here are a few suggested next steps:
 If you run into any issues, see the **[Troubleshooting Guides](/guides/troubleshooting/installation)** or ask for help in the Meshery community.
 {{% /alert %}}
 
-
 ## Explore Tutorials
 
 🧑‍🔬 Explore these tutorials to learn how to use Meshery for collaboratively managing infrastructure.


### PR DESCRIPTION
### Summary

This PR adds a new **"What's Next?"** section to the Quick Start guide.

The section highlights useful next steps after installing Meshery, such as exploring the Cloud Native Playground, creating designs with Kanvas, learning core concepts, joining the community, and finding contributor resources. This helps new users and contributors discover relevant resources more easily and continue exploring Meshery after completing the initial setup.

### Testing

* Verified links and formatting locally.
* Confirmed the new section renders correctly in the documentation site.

**Signed commits**

* [x] Yes, I signed my commits.
