### PR TITLE
Added prerequisites section to Quick Start guide

### DIFF
--- a/docs/content/en/installation/quick-start/index.md
+++ b/docs/content/en/installation/quick-start/index.md
@@ -34,6 +34,16 @@ If you are on a macOS or Linux system, you can download, install, and run both `
   <div class="clipboardjs">curl -L https://meshery.io/install | PLATFORM=kubernetes bash -</div>
   </div>
 </pre>
+<br/>
+
+If you are on Windows, you can install `mesheryctl` using <a href="https://scoop.sh">Scoop</a> and start Meshery by executing:
+
+<pre class="codeblock-pre">
+  <div class="codeblock">
+  <div class="clipboardjs">scoop install mesheryctl
+mesheryctl system start</div>
+  </div>
+</pre>
 
 {{% alert color="info" title="Meshery CLI" %}}
 Meshery's command line interface, <code>mesheryctl</code>, can be installed in <a href='{{< ref "installation/mesheryctl/_index.md" >}}'>various ways</a>. In addition to <a href='{{< ref "installation/mesheryctl/linux-mac/bash.md" >}}'>Bash</a>, you can also use <a href='{{< ref "installation/mesheryctl/linux-mac/brew.md" >}}'>Brew</a> or <a href='{{< ref "installation/mesheryctl/windows/scoop.md" >}}'>Scoop</a> to install <code>mesheryctl</code>. Alternatively, <code>mesheryctl</code> is also available via <a href='https://github.com/meshery/meshery/releases/latest'>direct download</a>.


### PR DESCRIPTION
**Notes for Reviewers**

- This PR fixes #19362 
- Added a Prerequisites section listing macOS/Linux, Docker or a Kubernetes cluster, and curl/bash as requirements, with a redirect for Windows users.
- Split the install command into two labeled variants (`PLATFORM=docker` for first-timers, `PLATFORM=kubernetes` for existing clusters)

**[Signed commits](https://github.com/meshery/meshery/blob/master/CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [x] Yes, I signed my commits.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added Windows installation instructions to the Quick Start guide.
  * Documented how to install `mesheryctl` using Scoop.
  * Added instructions for starting Meshery with `mesheryctl system start`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->