### PR TITLE
 Fix discard button error background

### DIFF
--- a/ui/components/shared/Modal/UnsavedChangesModal.tsx
+++ b/ui/components/shared/Modal/UnsavedChangesModal.tsx
@@ -26,7 +26,12 @@ const ActionsRow = styled('div')({
 });
 
 const DiscardButton = styled(ModalButtonPrimary)(({ theme }) => ({
-  background: theme.palette.background.error.default,
+  '&&': {
+    backgroundColor: theme.palette.background.error.default,
+    '&:hover': {
+      backgroundColor: theme.palette.background.error.default,
+    },
+  },
 }));
 
 export interface UnsavedChangesModalProps {

--- a/ui/components/shared/Modal/UnsavedChangesModal.tsx
+++ b/ui/components/shared/Modal/UnsavedChangesModal.tsx
@@ -29,7 +29,7 @@ const DiscardButton = styled(ModalButtonPrimary)(({ theme }) => ({
   '&&': {
     backgroundColor: theme.palette.background.error.default,
     '&:hover': {
-      backgroundColor: theme.palette.background.error.default,
+      backgroundColor: theme.palette.background.error.hover,
     },
   },
 }));


### PR DESCRIPTION

**Root Cause:** `DiscardButton` extends `ModalButtonPrimary`, whose primary and hover background styles override the discard button’s custom background.

**Fix:** Override `backgroundColor` for the discard button and its hover state with higher selector specificity.

| Before | After |
|--------|-------|
| <img width="380" height="180" alt="Before" src="https://github.com/user-attachments/assets/5aeb3e1f-26e5-405c-a19e-0fff9599ca9f" /> | <img width="380" height="180" alt="After" src="https://github.com/user-attachments/assets/044eacf1-0cc8-4f10-a4d0-196f58443bb3" /> |


**[Signed commits](https://github.com/meshery/meshery/blob/master/CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [x] Yes, I signed my commits.

<!--
Thank you for contributing to Meshery! 

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. Sign your commits.
4. Include before and after screenshots/terminal output.

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.
-->
