### PR TITLE
[Models] Add VirtualNetworksSubnet relationships for Azure FlexibleServer resources

### DIFF
--- a/server/meshmodel/azure-db-for-mysql/azureserviceoperator_customresourcedefinitions_v2.13.0.yaml/v1.0.0/relationships/edge-non-binding-reference-rmkda.json
+++ b/server/meshmodel/azure-db-for-mysql/azureserviceoperator_customresourcedefinitions_v2.13.0.yaml/v1.0.0/relationships/edge-non-binding-reference-rmkda.json
@@ -1,0 +1,113 @@
+{
+  "id": "00000000-0000-0000-0000-000000000000",
+  "evaluationQuery": "",
+  "kind": "edge",
+  "metadata": {
+    "description": "",
+    "isAnnotation": false,
+    "styles": {
+      "primaryColor": "",
+      "svgColor": "",
+      "svgWhite": ""
+    }
+  },
+  "model": {
+    "displayName": "",
+    "id": "00000000-0000-0000-0000-000000000000",
+    "model": {
+      "version": "azureserviceoperator_customresourcedefinitions_v2.13.0.yaml"
+    },
+    "name": "azure-db-for-mysql",
+    "registrant": {
+      "kind": ""
+    },
+    "version": ""
+  },
+  "schemaVersion": "relationships.meshery.io/v1beta2",
+  "selectors": [
+    {
+      "allow": {
+        "from": [
+          {
+            "id": null,
+            "kind": "FlexibleServer",
+            "match_strategy_matrix": null,
+            "model": {
+              "displayName": "",
+              "id": "00000000-0000-0000-0000-000000000000",
+              "model": {
+                "version": ""
+              },
+              "name": "azure-db-for-mysql",
+              "registrant": {
+                "kind": "github"
+              },
+              "version": ""
+            },
+            "patch": {
+              "mutatedRef": [
+                [
+                  "configuration",
+                  "spec",
+                  "network",
+                  "delegatedSubnetResourceReference",
+                  "group"
+                ],
+                [
+                  "configuration",
+                  "spec",
+                  "network",
+                  "delegatedSubnetResourceReference",
+                  "kind"
+                ],
+                [
+                  "configuration",
+                  "spec",
+                  "network",
+                  "delegatedSubnetResourceReference",
+                  "name"
+                ]
+              ],
+              "patchStrategy": "replace"
+            }
+          }
+        ],
+        "to": [
+          {
+            "id": null,
+            "kind": "VirtualNetworksSubnet",
+            "match_strategy_matrix": null,
+            "model": {
+              "displayName": "",
+              "id": "00000000-0000-0000-0000-000000000000",
+              "model": {
+                "version": ""
+              },
+              "name": "azure-network",
+              "registrant": {
+                "kind": "github"
+              },
+              "version": ""
+            },
+            "patch": {
+              "mutatorRef": [
+                ["configuration", "group"],
+                ["configuration", "kind"],
+                ["configuration", "spec", "name"]
+              ],
+              "patchStrategy": "replace"
+            }
+          }
+        ]
+      },
+      "deny": {
+        "from": [],
+        "to": []
+      }
+    }
+  ],
+  "subType": "reference",
+  "status": "enabled",
+  "type": "non-binding",
+  "version": "v1.0.0"
+}

--- a/server/meshmodel/azure-db-for-mysql/azureserviceoperator_customresourcedefinitions_v2.14.0.yaml/v1.0.0/relationships/edge-non-binding-reference-rmkda.json
+++ b/server/meshmodel/azure-db-for-mysql/azureserviceoperator_customresourcedefinitions_v2.14.0.yaml/v1.0.0/relationships/edge-non-binding-reference-rmkda.json
@@ -1,0 +1,113 @@
+{
+  "id": "00000000-0000-0000-0000-000000000000",
+  "evaluationQuery": "",
+  "kind": "edge",
+  "metadata": {
+    "description": "",
+    "isAnnotation": false,
+    "styles": {
+      "primaryColor": "",
+      "svgColor": "",
+      "svgWhite": ""
+    }
+  },
+  "model": {
+    "displayName": "",
+    "id": "00000000-0000-0000-0000-000000000000",
+    "model": {
+      "version": "azureserviceoperator_customresourcedefinitions_v2.14.0.yaml"
+    },
+    "name": "azure-db-for-mysql",
+    "registrant": {
+      "kind": ""
+    },
+    "version": ""
+  },
+  "schemaVersion": "relationships.meshery.io/v1beta2",
+  "selectors": [
+    {
+      "allow": {
+        "from": [
+          {
+            "id": null,
+            "kind": "FlexibleServer",
+            "match_strategy_matrix": null,
+            "model": {
+              "displayName": "",
+              "id": "00000000-0000-0000-0000-000000000000",
+              "model": {
+                "version": ""
+              },
+              "name": "azure-db-for-mysql",
+              "registrant": {
+                "kind": "github"
+              },
+              "version": ""
+            },
+            "patch": {
+              "mutatedRef": [
+                [
+                  "configuration",
+                  "spec",
+                  "network",
+                  "delegatedSubnetResourceReference",
+                  "group"
+                ],
+                [
+                  "configuration",
+                  "spec",
+                  "network",
+                  "delegatedSubnetResourceReference",
+                  "kind"
+                ],
+                [
+                  "configuration",
+                  "spec",
+                  "network",
+                  "delegatedSubnetResourceReference",
+                  "name"
+                ]
+              ],
+              "patchStrategy": "replace"
+            }
+          }
+        ],
+        "to": [
+          {
+            "id": null,
+            "kind": "VirtualNetworksSubnet",
+            "match_strategy_matrix": null,
+            "model": {
+              "displayName": "",
+              "id": "00000000-0000-0000-0000-000000000000",
+              "model": {
+                "version": ""
+              },
+              "name": "azure-network",
+              "registrant": {
+                "kind": "github"
+              },
+              "version": ""
+            },
+            "patch": {
+              "mutatorRef": [
+                ["configuration", "group"],
+                ["configuration", "kind"],
+                ["configuration", "spec", "name"]
+              ],
+              "patchStrategy": "replace"
+            }
+          }
+        ]
+      },
+      "deny": {
+        "from": [],
+        "to": []
+      }
+    }
+  ],
+  "subType": "reference",
+  "status": "enabled",
+  "type": "non-binding",
+  "version": "v1.0.0"
+}

--- a/server/meshmodel/azure-db-for-postgresql/azureserviceoperator_customresourcedefinitions_v2.13.0.yaml/v1.0.0/relationships/edge-non-binding-reference-qxjzt.json
+++ b/server/meshmodel/azure-db-for-postgresql/azureserviceoperator_customresourcedefinitions_v2.13.0.yaml/v1.0.0/relationships/edge-non-binding-reference-qxjzt.json
@@ -1,0 +1,113 @@
+{
+  "id": "00000000-0000-0000-0000-000000000000",
+  "evaluationQuery": "",
+  "kind": "edge",
+  "metadata": {
+    "description": "",
+    "isAnnotation": false,
+    "styles": {
+      "primaryColor": "",
+      "svgColor": "",
+      "svgWhite": ""
+    }
+  },
+  "model": {
+    "displayName": "",
+    "id": "00000000-0000-0000-0000-000000000000",
+    "model": {
+      "version": "azureserviceoperator_customresourcedefinitions_v2.13.0.yaml"
+    },
+    "name": "azure-db-for-postgresql",
+    "registrant": {
+      "kind": ""
+    },
+    "version": ""
+  },
+  "schemaVersion": "relationships.meshery.io/v1beta2",
+  "selectors": [
+    {
+      "allow": {
+        "from": [
+          {
+            "id": null,
+            "kind": "FlexibleServer",
+            "match_strategy_matrix": null,
+            "model": {
+              "displayName": "",
+              "id": "00000000-0000-0000-0000-000000000000",
+              "model": {
+                "version": ""
+              },
+              "name": "azure-db-for-postgresql",
+              "registrant": {
+                "kind": "github"
+              },
+              "version": ""
+            },
+            "patch": {
+              "mutatedRef": [
+                [
+                  "configuration",
+                  "spec",
+                  "network",
+                  "delegatedSubnetResourceReference",
+                  "group"
+                ],
+                [
+                  "configuration",
+                  "spec",
+                  "network",
+                  "delegatedSubnetResourceReference",
+                  "kind"
+                ],
+                [
+                  "configuration",
+                  "spec",
+                  "network",
+                  "delegatedSubnetResourceReference",
+                  "name"
+                ]
+              ],
+              "patchStrategy": "replace"
+            }
+          }
+        ],
+        "to": [
+          {
+            "id": null,
+            "kind": "VirtualNetworksSubnet",
+            "match_strategy_matrix": null,
+            "model": {
+              "displayName": "",
+              "id": "00000000-0000-0000-0000-000000000000",
+              "model": {
+                "version": ""
+              },
+              "name": "azure-network",
+              "registrant": {
+                "kind": "github"
+              },
+              "version": ""
+            },
+            "patch": {
+              "mutatorRef": [
+                ["configuration", "group"],
+                ["configuration", "kind"],
+                ["configuration", "spec", "name"]
+              ],
+              "patchStrategy": "replace"
+            }
+          }
+        ]
+      },
+      "deny": {
+        "from": [],
+        "to": []
+      }
+    }
+  ],
+  "subType": "reference",
+  "status": "enabled",
+  "type": "non-binding",
+  "version": "v1.0.0"
+}

--- a/server/meshmodel/azure-db-for-postgresql/azureserviceoperator_customresourcedefinitions_v2.14.0.yaml/v1.0.0/relationships/edge-non-binding-reference-qxjzt.json
+++ b/server/meshmodel/azure-db-for-postgresql/azureserviceoperator_customresourcedefinitions_v2.14.0.yaml/v1.0.0/relationships/edge-non-binding-reference-qxjzt.json
@@ -1,0 +1,113 @@
+{
+  "id": "00000000-0000-0000-0000-000000000000",
+  "evaluationQuery": "",
+  "kind": "edge",
+  "metadata": {
+    "description": "",
+    "isAnnotation": false,
+    "styles": {
+      "primaryColor": "",
+      "svgColor": "",
+      "svgWhite": ""
+    }
+  },
+  "model": {
+    "displayName": "",
+    "id": "00000000-0000-0000-0000-000000000000",
+    "model": {
+      "version": "azureserviceoperator_customresourcedefinitions_v2.14.0.yaml"
+    },
+    "name": "azure-db-for-postgresql",
+    "registrant": {
+      "kind": ""
+    },
+    "version": ""
+  },
+  "schemaVersion": "relationships.meshery.io/v1beta2",
+  "selectors": [
+    {
+      "allow": {
+        "from": [
+          {
+            "id": null,
+            "kind": "FlexibleServer",
+            "match_strategy_matrix": null,
+            "model": {
+              "displayName": "",
+              "id": "00000000-0000-0000-0000-000000000000",
+              "model": {
+                "version": ""
+              },
+              "name": "azure-db-for-postgresql",
+              "registrant": {
+                "kind": "github"
+              },
+              "version": ""
+            },
+            "patch": {
+              "mutatedRef": [
+                [
+                  "configuration",
+                  "spec",
+                  "network",
+                  "delegatedSubnetResourceReference",
+                  "group"
+                ],
+                [
+                  "configuration",
+                  "spec",
+                  "network",
+                  "delegatedSubnetResourceReference",
+                  "kind"
+                ],
+                [
+                  "configuration",
+                  "spec",
+                  "network",
+                  "delegatedSubnetResourceReference",
+                  "name"
+                ]
+              ],
+              "patchStrategy": "replace"
+            }
+          }
+        ],
+        "to": [
+          {
+            "id": null,
+            "kind": "VirtualNetworksSubnet",
+            "match_strategy_matrix": null,
+            "model": {
+              "displayName": "",
+              "id": "00000000-0000-0000-0000-000000000000",
+              "model": {
+                "version": ""
+              },
+              "name": "azure-network",
+              "registrant": {
+                "kind": "github"
+              },
+              "version": ""
+            },
+            "patch": {
+              "mutatorRef": [
+                ["configuration", "group"],
+                ["configuration", "kind"],
+                ["configuration", "spec", "name"]
+              ],
+              "patchStrategy": "replace"
+            }
+          }
+        ]
+      },
+      "deny": {
+        "from": [],
+        "to": []
+      }
+    }
+  ],
+  "subType": "reference",
+  "status": "enabled",
+  "type": "non-binding",
+  "version": "v1.0.0"
+}


### PR DESCRIPTION
**Notes for Reviewers**

- Related to #14793

### Summary

This PR adds reference relationships between Azure FlexibleServer resources and VirtualNetworksSubnet resources.

Added relationships for:

- Azure Database for PostgreSQL FlexibleServer → VirtualNetworksSubnet
- Azure Database for MySQL FlexibleServer → VirtualNetworksSubnet

The relationships were added for ASO v2.13.0 and v2.14.0.

### Validation

- Verified that `delegatedSubnetResourceReference` exists in the FlexibleServer schemas.
- Checked existing Azure subnet relationships to avoid duplicate relationship definitions.
- Validated all new relationship JSON files.
- Verified the relationship visually in Kanvas.

### Screenshot

<img width="2879" height="1530" alt="Screenshot 2026-06-02 001357" src="https://github.com/user-attachments/assets/8c0fcee9-ff6d-4213-af4f-8401ecfe48fa" />
<img width="1129" height="748" alt="Screenshot 2026-06-02 001407" src="https://github.com/user-attachments/assets/96b50771-4382-41f8-97a2-49e530cf1081" />


**[Signed commits](https://github.com/meshery/meshery/blob/master/CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [x] Yes, I signed my commits.