### PR TITLE
add(relationships): add hierarchical relationships for stackgres-operator model

### DIFF
--- a/server/meshmodel/stackgres-operator/1.18.8/v1.0.0/relationships/hierarchical-parent-inventory-ab1c2.json
+++ b/server/meshmodel/stackgres-operator/1.18.8/v1.0.0/relationships/hierarchical-parent-inventory-ab1c2.json
@@ -1,89 +1,107 @@
 {
-  "id": "00000000-0000-0000-0000-000000000000",
-  "evaluationQuery": "",
-  "kind": "hierarchical",
-  "metadata": {
-    "description": "",
-    "isAnnotation": false,
-    "styles": {
-      "primaryColor": "",
-      "svgColor": "",
-      "svgWhite": ""
-    }
-  },
-  "model": {
-    "displayName": "",
-    "id": "00000000-0000-0000-0000-000000000000",
-    "model": {
-      "version": "1.18.8"
-    },
-    "name": "stackgres-operator",
-    "registrant": {
-      "kind": ""
-    },
-    "version": ""
-  },
-  "schemaVersion": "relationships.meshery.io/v1beta2",
-  "selectors": [
-    {
-      "allow": {
-        "from": [
-          {
-            "id": null,
-            "kind": "SGCluster",
-            "match": {},
-            "match_strategy_matrix": null,
-            "model": {
-              "displayName": "",
-              "id": "00000000-0000-0000-0000-000000000000",
-              "model": {
-                "version": ""
+    "id":  "00000000-0000-0000-0000-000000000000",
+    "evaluationQuery":  "",
+    "kind":  "hierarchical",
+    "metadata":  {
+                     "description":  "",
+                     "isAnnotation":  false,
+                     "styles":  {
+                                    "primaryColor":  "",
+                                    "svgColor":  "",
+                                    "svgWhite":  ""
+                                }
+                 },
+    "model":  {
+                  "displayName":  "",
+                  "id":  "00000000-0000-0000-0000-000000000000",
+                  "model":  {
+                                "version":  "1.18.8"
+                            },
+                  "name":  "stackgres-operator",
+                  "registrant":  {
+                                     "kind":  ""
+                                 },
+                  "version":  ""
               },
-              "name": "stackgres-operator",
-              "registrant": {
-                "kind": "github"
-              },
-              "version": ""
-            },
-            "patch": {
-              "mutatorRef": [["displayName"]],
-              "patchStrategy": "replace"
-            }
-          }
-        ],
-        "to": [
-          {
-            "id": null,
-            "kind": "SGBackup",
-            "match": {},
-            "match_strategy_matrix": null,
-            "model": {
-              "displayName": "",
-              "id": "00000000-0000-0000-0000-000000000000",
-              "model": {
-                "version": ""
-              },
-              "name": "stackgres-operator",
-              "registrant": {
-                "kind": "github"
-              },
-              "version": ""
-            },
-            "patch": {
-              "mutatedRef": [["configuration", "spec", "sgCluster"]],
-              "patchStrategy": "replace"
-            }
-          }
-        ]
-      },
-      "deny": {
-        "from": [],
-        "to": []
-      }
-    }
-  ],
-  "subType": "inventory",
-  "status": "enabled",
-  "type": "parent",
-  "version": "v1.0.0"
+    "schemaVersion":  "relationships.meshery.io/v1beta2",
+    "selectors":  [
+                      {
+                          "allow":  {
+                                        "from":  [
+                                                     {
+                                                         "id":  null,
+                                                         "kind":  "SGBackup",
+                                                         "match":  {
+
+                                                                   },
+                                                         "match_strategy_matrix":  null,
+                                                         "model":  {
+                                                                       "displayName":  "",
+                                                                       "id":  "00000000-0000-0000-0000-000000000000",
+                                                                       "model":  {
+                                                                                     "version":  ""
+                                                                                 },
+                                                                       "name":  "stackgres-operator",
+                                                                       "registrant":  {
+                                                                                          "kind":  "github"
+                                                                                      },
+                                                                       "version":  ""
+                                                                   },
+                                                         "patch":  {
+                                                                       "mutatedRef":  [
+                                                                                          [
+                                                                                              "configuration",
+                                                                                              "spec",
+                                                                                              "sgCluster"
+                                                                                          ]
+                                                                                      ],
+                                                                       "patchStrategy":  "replace"
+                                                                   }
+                                                     }
+                                                 ],
+                                        "to":  [
+                                                   {
+                                                       "id":  null,
+                                                       "kind":  "SGCluster",
+                                                       "match":  {
+
+                                                                 },
+                                                       "match_strategy_matrix":  null,
+                                                       "model":  {
+                                                                     "displayName":  "",
+                                                                     "id":  "00000000-0000-0000-0000-000000000000",
+                                                                     "model":  {
+                                                                                   "version":  ""
+                                                                               },
+                                                                     "name":  "stackgres-operator",
+                                                                     "registrant":  {
+                                                                                        "kind":  "github"
+                                                                                    },
+                                                                     "version":  ""
+                                                                 },
+                                                       "patch":  {
+                                                                     "mutatorRef":  [
+                                                                                        [
+                                                                                            "displayName"
+                                                                                        ]
+                                                                                    ],
+                                                                     "patchStrategy":  "replace"
+                                                                 }
+                                                   }
+                                               ]
+                                    },
+                          "deny":  {
+                                       "from":  [
+
+                                                ],
+                                       "to":  [
+
+                                              ]
+                                   }
+                      }
+                  ],
+    "subType":  "inventory",
+    "status":  "enabled",
+    "type":  "parent",
+    "version":  "v1.0.0"
 }

--- a/server/meshmodel/stackgres-operator/1.18.8/v1.0.0/relationships/hierarchical-parent-inventory-ab1c2.json
+++ b/server/meshmodel/stackgres-operator/1.18.8/v1.0.0/relationships/hierarchical-parent-inventory-ab1c2.json
@@ -1,0 +1,89 @@
+{
+  "id": "00000000-0000-0000-0000-000000000000",
+  "evaluationQuery": "",
+  "kind": "hierarchical",
+  "metadata": {
+    "description": "",
+    "isAnnotation": false,
+    "styles": {
+      "primaryColor": "",
+      "svgColor": "",
+      "svgWhite": ""
+    }
+  },
+  "model": {
+    "displayName": "",
+    "id": "00000000-0000-0000-0000-000000000000",
+    "model": {
+      "version": "1.18.8"
+    },
+    "name": "stackgres-operator",
+    "registrant": {
+      "kind": ""
+    },
+    "version": ""
+  },
+  "schemaVersion": "relationships.meshery.io/v1beta2",
+  "selectors": [
+    {
+      "allow": {
+        "from": [
+          {
+            "id": null,
+            "kind": "SGCluster",
+            "match": {},
+            "match_strategy_matrix": null,
+            "model": {
+              "displayName": "",
+              "id": "00000000-0000-0000-0000-000000000000",
+              "model": {
+                "version": ""
+              },
+              "name": "stackgres-operator",
+              "registrant": {
+                "kind": "github"
+              },
+              "version": ""
+            },
+            "patch": {
+              "mutatorRef": [["displayName"]],
+              "patchStrategy": "replace"
+            }
+          }
+        ],
+        "to": [
+          {
+            "id": null,
+            "kind": "SGBackup",
+            "match": {},
+            "match_strategy_matrix": null,
+            "model": {
+              "displayName": "",
+              "id": "00000000-0000-0000-0000-000000000000",
+              "model": {
+                "version": ""
+              },
+              "name": "stackgres-operator",
+              "registrant": {
+                "kind": "github"
+              },
+              "version": ""
+            },
+            "patch": {
+              "mutatedRef": [["configuration", "spec", "sgCluster"]],
+              "patchStrategy": "replace"
+            }
+          }
+        ]
+      },
+      "deny": {
+        "from": [],
+        "to": []
+      }
+    }
+  ],
+  "subType": "inventory",
+  "status": "enabled",
+  "type": "parent",
+  "version": "v1.0.0"
+}

--- a/server/meshmodel/stackgres-operator/1.18.8/v1.0.0/relationships/hierarchical-parent-inventory-de3f4.json
+++ b/server/meshmodel/stackgres-operator/1.18.8/v1.0.0/relationships/hierarchical-parent-inventory-de3f4.json
@@ -1,89 +1,107 @@
 {
-  "id": "00000000-0000-0000-0000-000000000000",
-  "evaluationQuery": "",
-  "kind": "hierarchical",
-  "metadata": {
-    "description": "",
-    "isAnnotation": false,
-    "styles": {
-      "primaryColor": "",
-      "svgColor": "",
-      "svgWhite": ""
-    }
-  },
-  "model": {
-    "displayName": "",
-    "id": "00000000-0000-0000-0000-000000000000",
-    "model": {
-      "version": "1.18.8"
-    },
-    "name": "stackgres-operator",
-    "registrant": {
-      "kind": ""
-    },
-    "version": ""
-  },
-  "schemaVersion": "relationships.meshery.io/v1beta2",
-  "selectors": [
-    {
-      "allow": {
-        "from": [
-          {
-            "id": null,
-            "kind": "SGCluster",
-            "match": {},
-            "match_strategy_matrix": null,
-            "model": {
-              "displayName": "",
-              "id": "00000000-0000-0000-0000-000000000000",
-              "model": {
-                "version": ""
+    "id":  "00000000-0000-0000-0000-000000000000",
+    "evaluationQuery":  "",
+    "kind":  "hierarchical",
+    "metadata":  {
+                     "description":  "",
+                     "isAnnotation":  false,
+                     "styles":  {
+                                    "primaryColor":  "",
+                                    "svgColor":  "",
+                                    "svgWhite":  ""
+                                }
+                 },
+    "model":  {
+                  "displayName":  "",
+                  "id":  "00000000-0000-0000-0000-000000000000",
+                  "model":  {
+                                "version":  "1.18.8"
+                            },
+                  "name":  "stackgres-operator",
+                  "registrant":  {
+                                     "kind":  ""
+                                 },
+                  "version":  ""
               },
-              "name": "stackgres-operator",
-              "registrant": {
-                "kind": "github"
-              },
-              "version": ""
-            },
-            "patch": {
-              "mutatorRef": [["displayName"]],
-              "patchStrategy": "replace"
-            }
-          }
-        ],
-        "to": [
-          {
-            "id": null,
-            "kind": "SGDbOps",
-            "match": {},
-            "match_strategy_matrix": null,
-            "model": {
-              "displayName": "",
-              "id": "00000000-0000-0000-0000-000000000000",
-              "model": {
-                "version": ""
-              },
-              "name": "stackgres-operator",
-              "registrant": {
-                "kind": "github"
-              },
-              "version": ""
-            },
-            "patch": {
-              "mutatedRef": [["configuration", "spec", "sgCluster"]],
-              "patchStrategy": "replace"
-            }
-          }
-        ]
-      },
-      "deny": {
-        "from": [],
-        "to": []
-      }
-    }
-  ],
-  "subType": "inventory",
-  "status": "enabled",
-  "type": "parent",
-  "version": "v1.0.0"
+    "schemaVersion":  "relationships.meshery.io/v1beta2",
+    "selectors":  [
+                      {
+                          "allow":  {
+                                        "from":  [
+                                                     {
+                                                         "id":  null,
+                                                         "kind":  "SGDbOps",
+                                                         "match":  {
+
+                                                                   },
+                                                         "match_strategy_matrix":  null,
+                                                         "model":  {
+                                                                       "displayName":  "",
+                                                                       "id":  "00000000-0000-0000-0000-000000000000",
+                                                                       "model":  {
+                                                                                     "version":  ""
+                                                                                 },
+                                                                       "name":  "stackgres-operator",
+                                                                       "registrant":  {
+                                                                                          "kind":  "github"
+                                                                                      },
+                                                                       "version":  ""
+                                                                   },
+                                                         "patch":  {
+                                                                       "mutatedRef":  [
+                                                                                          [
+                                                                                              "configuration",
+                                                                                              "spec",
+                                                                                              "sgCluster"
+                                                                                          ]
+                                                                                      ],
+                                                                       "patchStrategy":  "replace"
+                                                                   }
+                                                     }
+                                                 ],
+                                        "to":  [
+                                                   {
+                                                       "id":  null,
+                                                       "kind":  "SGCluster",
+                                                       "match":  {
+
+                                                                 },
+                                                       "match_strategy_matrix":  null,
+                                                       "model":  {
+                                                                     "displayName":  "",
+                                                                     "id":  "00000000-0000-0000-0000-000000000000",
+                                                                     "model":  {
+                                                                                   "version":  ""
+                                                                               },
+                                                                     "name":  "stackgres-operator",
+                                                                     "registrant":  {
+                                                                                        "kind":  "github"
+                                                                                    },
+                                                                     "version":  ""
+                                                                 },
+                                                       "patch":  {
+                                                                     "mutatorRef":  [
+                                                                                        [
+                                                                                            "displayName"
+                                                                                        ]
+                                                                                    ],
+                                                                     "patchStrategy":  "replace"
+                                                                 }
+                                                   }
+                                               ]
+                                    },
+                          "deny":  {
+                                       "from":  [
+
+                                                ],
+                                       "to":  [
+
+                                              ]
+                                   }
+                      }
+                  ],
+    "subType":  "inventory",
+    "status":  "enabled",
+    "type":  "parent",
+    "version":  "v1.0.0"
 }

--- a/server/meshmodel/stackgres-operator/1.18.8/v1.0.0/relationships/hierarchical-parent-inventory-de3f4.json
+++ b/server/meshmodel/stackgres-operator/1.18.8/v1.0.0/relationships/hierarchical-parent-inventory-de3f4.json
@@ -1,0 +1,89 @@
+{
+  "id": "00000000-0000-0000-0000-000000000000",
+  "evaluationQuery": "",
+  "kind": "hierarchical",
+  "metadata": {
+    "description": "",
+    "isAnnotation": false,
+    "styles": {
+      "primaryColor": "",
+      "svgColor": "",
+      "svgWhite": ""
+    }
+  },
+  "model": {
+    "displayName": "",
+    "id": "00000000-0000-0000-0000-000000000000",
+    "model": {
+      "version": "1.18.8"
+    },
+    "name": "stackgres-operator",
+    "registrant": {
+      "kind": ""
+    },
+    "version": ""
+  },
+  "schemaVersion": "relationships.meshery.io/v1beta2",
+  "selectors": [
+    {
+      "allow": {
+        "from": [
+          {
+            "id": null,
+            "kind": "SGCluster",
+            "match": {},
+            "match_strategy_matrix": null,
+            "model": {
+              "displayName": "",
+              "id": "00000000-0000-0000-0000-000000000000",
+              "model": {
+                "version": ""
+              },
+              "name": "stackgres-operator",
+              "registrant": {
+                "kind": "github"
+              },
+              "version": ""
+            },
+            "patch": {
+              "mutatorRef": [["displayName"]],
+              "patchStrategy": "replace"
+            }
+          }
+        ],
+        "to": [
+          {
+            "id": null,
+            "kind": "SGDbOps",
+            "match": {},
+            "match_strategy_matrix": null,
+            "model": {
+              "displayName": "",
+              "id": "00000000-0000-0000-0000-000000000000",
+              "model": {
+                "version": ""
+              },
+              "name": "stackgres-operator",
+              "registrant": {
+                "kind": "github"
+              },
+              "version": ""
+            },
+            "patch": {
+              "mutatedRef": [["configuration", "spec", "sgCluster"]],
+              "patchStrategy": "replace"
+            }
+          }
+        ]
+      },
+      "deny": {
+        "from": [],
+        "to": []
+      }
+    }
+  ],
+  "subType": "inventory",
+  "status": "enabled",
+  "type": "parent",
+  "version": "v1.0.0"
+}

--- a/server/meshmodel/stackgres-operator/1.18.8/v1.0.0/relationships/hierarchical-parent-inventory-gh5i6.json
+++ b/server/meshmodel/stackgres-operator/1.18.8/v1.0.0/relationships/hierarchical-parent-inventory-gh5i6.json
@@ -1,0 +1,89 @@
+{
+  "id": "00000000-0000-0000-0000-000000000000",
+  "evaluationQuery": "",
+  "kind": "hierarchical",
+  "metadata": {
+    "description": "",
+    "isAnnotation": false,
+    "styles": {
+      "primaryColor": "",
+      "svgColor": "",
+      "svgWhite": ""
+    }
+  },
+  "model": {
+    "displayName": "",
+    "id": "00000000-0000-0000-0000-000000000000",
+    "model": {
+      "version": "1.18.8"
+    },
+    "name": "stackgres-operator",
+    "registrant": {
+      "kind": ""
+    },
+    "version": ""
+  },
+  "schemaVersion": "relationships.meshery.io/v1beta2",
+  "selectors": [
+    {
+      "allow": {
+        "from": [
+          {
+            "id": null,
+            "kind": "SGInstanceProfile",
+            "match": {},
+            "match_strategy_matrix": null,
+            "model": {
+              "displayName": "",
+              "id": "00000000-0000-0000-0000-000000000000",
+              "model": {
+                "version": ""
+              },
+              "name": "stackgres-operator",
+              "registrant": {
+                "kind": "github"
+              },
+              "version": ""
+            },
+            "patch": {
+              "mutatorRef": [["displayName"]],
+              "patchStrategy": "replace"
+            }
+          }
+        ],
+        "to": [
+          {
+            "id": null,
+            "kind": "SGCluster",
+            "match": {},
+            "match_strategy_matrix": null,
+            "model": {
+              "displayName": "",
+              "id": "00000000-0000-0000-0000-000000000000",
+              "model": {
+                "version": ""
+              },
+              "name": "stackgres-operator",
+              "registrant": {
+                "kind": "github"
+              },
+              "version": ""
+            },
+            "patch": {
+              "mutatedRef": [["configuration", "spec", "sgInstanceProfile"]],
+              "patchStrategy": "replace"
+            }
+          }
+        ]
+      },
+      "deny": {
+        "from": [],
+        "to": []
+      }
+    }
+  ],
+  "subType": "inventory",
+  "status": "enabled",
+  "type": "parent",
+  "version": "v1.0.0"
+}

--- a/server/meshmodel/stackgres-operator/1.18.8/v1.0.0/relationships/hierarchical-parent-inventory-gh5i6.json
+++ b/server/meshmodel/stackgres-operator/1.18.8/v1.0.0/relationships/hierarchical-parent-inventory-gh5i6.json
@@ -1,89 +1,107 @@
 {
-  "id": "00000000-0000-0000-0000-000000000000",
-  "evaluationQuery": "",
-  "kind": "hierarchical",
-  "metadata": {
-    "description": "",
-    "isAnnotation": false,
-    "styles": {
-      "primaryColor": "",
-      "svgColor": "",
-      "svgWhite": ""
-    }
-  },
-  "model": {
-    "displayName": "",
-    "id": "00000000-0000-0000-0000-000000000000",
-    "model": {
-      "version": "1.18.8"
-    },
-    "name": "stackgres-operator",
-    "registrant": {
-      "kind": ""
-    },
-    "version": ""
-  },
-  "schemaVersion": "relationships.meshery.io/v1beta2",
-  "selectors": [
-    {
-      "allow": {
-        "from": [
-          {
-            "id": null,
-            "kind": "SGInstanceProfile",
-            "match": {},
-            "match_strategy_matrix": null,
-            "model": {
-              "displayName": "",
-              "id": "00000000-0000-0000-0000-000000000000",
-              "model": {
-                "version": ""
+    "id":  "00000000-0000-0000-0000-000000000000",
+    "evaluationQuery":  "",
+    "kind":  "hierarchical",
+    "metadata":  {
+                     "description":  "",
+                     "isAnnotation":  false,
+                     "styles":  {
+                                    "primaryColor":  "",
+                                    "svgColor":  "",
+                                    "svgWhite":  ""
+                                }
+                 },
+    "model":  {
+                  "displayName":  "",
+                  "id":  "00000000-0000-0000-0000-000000000000",
+                  "model":  {
+                                "version":  "1.18.8"
+                            },
+                  "name":  "stackgres-operator",
+                  "registrant":  {
+                                     "kind":  ""
+                                 },
+                  "version":  ""
               },
-              "name": "stackgres-operator",
-              "registrant": {
-                "kind": "github"
-              },
-              "version": ""
-            },
-            "patch": {
-              "mutatorRef": [["displayName"]],
-              "patchStrategy": "replace"
-            }
-          }
-        ],
-        "to": [
-          {
-            "id": null,
-            "kind": "SGCluster",
-            "match": {},
-            "match_strategy_matrix": null,
-            "model": {
-              "displayName": "",
-              "id": "00000000-0000-0000-0000-000000000000",
-              "model": {
-                "version": ""
-              },
-              "name": "stackgres-operator",
-              "registrant": {
-                "kind": "github"
-              },
-              "version": ""
-            },
-            "patch": {
-              "mutatedRef": [["configuration", "spec", "sgInstanceProfile"]],
-              "patchStrategy": "replace"
-            }
-          }
-        ]
-      },
-      "deny": {
-        "from": [],
-        "to": []
-      }
-    }
-  ],
-  "subType": "inventory",
-  "status": "enabled",
-  "type": "parent",
-  "version": "v1.0.0"
+    "schemaVersion":  "relationships.meshery.io/v1beta2",
+    "selectors":  [
+                      {
+                          "allow":  {
+                                        "from":  [
+                                                     {
+                                                         "id":  null,
+                                                         "kind":  "SGCluster",
+                                                         "match":  {
+
+                                                                   },
+                                                         "match_strategy_matrix":  null,
+                                                         "model":  {
+                                                                       "displayName":  "",
+                                                                       "id":  "00000000-0000-0000-0000-000000000000",
+                                                                       "model":  {
+                                                                                     "version":  ""
+                                                                                 },
+                                                                       "name":  "stackgres-operator",
+                                                                       "registrant":  {
+                                                                                          "kind":  "github"
+                                                                                      },
+                                                                       "version":  ""
+                                                                   },
+                                                         "patch":  {
+                                                                       "mutatedRef":  [
+                                                                                          [
+                                                                                              "configuration",
+                                                                                              "spec",
+                                                                                              "sgInstanceProfile"
+                                                                                          ]
+                                                                                      ],
+                                                                       "patchStrategy":  "replace"
+                                                                   }
+                                                     }
+                                                 ],
+                                        "to":  [
+                                                   {
+                                                       "id":  null,
+                                                       "kind":  "SGInstanceProfile",
+                                                       "match":  {
+
+                                                                 },
+                                                       "match_strategy_matrix":  null,
+                                                       "model":  {
+                                                                     "displayName":  "",
+                                                                     "id":  "00000000-0000-0000-0000-000000000000",
+                                                                     "model":  {
+                                                                                   "version":  ""
+                                                                               },
+                                                                     "name":  "stackgres-operator",
+                                                                     "registrant":  {
+                                                                                        "kind":  "github"
+                                                                                    },
+                                                                     "version":  ""
+                                                                 },
+                                                       "patch":  {
+                                                                     "mutatorRef":  [
+                                                                                        [
+                                                                                            "displayName"
+                                                                                        ]
+                                                                                    ],
+                                                                     "patchStrategy":  "replace"
+                                                                 }
+                                                   }
+                                               ]
+                                    },
+                          "deny":  {
+                                       "from":  [
+
+                                                ],
+                                       "to":  [
+
+                                              ]
+                                   }
+                      }
+                  ],
+    "subType":  "inventory",
+    "status":  "enabled",
+    "type":  "parent",
+    "version":  "v1.0.0"
 }

--- a/server/meshmodel/stackgres-operator/1.18.8/v1.0.0/relationships/hierarchical-parent-inventory-jk7l8.json
+++ b/server/meshmodel/stackgres-operator/1.18.8/v1.0.0/relationships/hierarchical-parent-inventory-jk7l8.json
@@ -1,0 +1,89 @@
+{
+  "id": "00000000-0000-0000-0000-000000000000",
+  "evaluationQuery": "",
+  "kind": "hierarchical",
+  "metadata": {
+    "description": "",
+    "isAnnotation": false,
+    "styles": {
+      "primaryColor": "",
+      "svgColor": "",
+      "svgWhite": ""
+    }
+  },
+  "model": {
+    "displayName": "",
+    "id": "00000000-0000-0000-0000-000000000000",
+    "model": {
+      "version": "1.18.8"
+    },
+    "name": "stackgres-operator",
+    "registrant": {
+      "kind": ""
+    },
+    "version": ""
+  },
+  "schemaVersion": "relationships.meshery.io/v1beta2",
+  "selectors": [
+    {
+      "allow": {
+        "from": [
+          {
+            "id": null,
+            "kind": "SGPostgresConfig",
+            "match": {},
+            "match_strategy_matrix": null,
+            "model": {
+              "displayName": "",
+              "id": "00000000-0000-0000-0000-000000000000",
+              "model": {
+                "version": ""
+              },
+              "name": "stackgres-operator",
+              "registrant": {
+                "kind": "github"
+              },
+              "version": ""
+            },
+            "patch": {
+              "mutatorRef": [["displayName"]],
+              "patchStrategy": "replace"
+            }
+          }
+        ],
+        "to": [
+          {
+            "id": null,
+            "kind": "SGCluster",
+            "match": {},
+            "match_strategy_matrix": null,
+            "model": {
+              "displayName": "",
+              "id": "00000000-0000-0000-0000-000000000000",
+              "model": {
+                "version": ""
+              },
+              "name": "stackgres-operator",
+              "registrant": {
+                "kind": "github"
+              },
+              "version": ""
+            },
+            "patch": {
+              "mutatedRef": [["configuration", "spec", "configurations", "sgPostgresConfig"]],
+              "patchStrategy": "replace"
+            }
+          }
+        ]
+      },
+      "deny": {
+        "from": [],
+        "to": []
+      }
+    }
+  ],
+  "subType": "inventory",
+  "status": "enabled",
+  "type": "parent",
+  "version": "v1.0.0"
+}

--- a/server/meshmodel/stackgres-operator/1.18.8/v1.0.0/relationships/hierarchical-parent-inventory-jk7l8.json
+++ b/server/meshmodel/stackgres-operator/1.18.8/v1.0.0/relationships/hierarchical-parent-inventory-jk7l8.json
@@ -1,89 +1,108 @@
 {
-  "id": "00000000-0000-0000-0000-000000000000",
-  "evaluationQuery": "",
-  "kind": "hierarchical",
-  "metadata": {
-    "description": "",
-    "isAnnotation": false,
-    "styles": {
-      "primaryColor": "",
-      "svgColor": "",
-      "svgWhite": ""
-    }
-  },
-  "model": {
-    "displayName": "",
-    "id": "00000000-0000-0000-0000-000000000000",
-    "model": {
-      "version": "1.18.8"
-    },
-    "name": "stackgres-operator",
-    "registrant": {
-      "kind": ""
-    },
-    "version": ""
-  },
-  "schemaVersion": "relationships.meshery.io/v1beta2",
-  "selectors": [
-    {
-      "allow": {
-        "from": [
-          {
-            "id": null,
-            "kind": "SGPostgresConfig",
-            "match": {},
-            "match_strategy_matrix": null,
-            "model": {
-              "displayName": "",
-              "id": "00000000-0000-0000-0000-000000000000",
-              "model": {
-                "version": ""
+    "id":  "00000000-0000-0000-0000-000000000000",
+    "evaluationQuery":  "",
+    "kind":  "hierarchical",
+    "metadata":  {
+                     "description":  "",
+                     "isAnnotation":  false,
+                     "styles":  {
+                                    "primaryColor":  "",
+                                    "svgColor":  "",
+                                    "svgWhite":  ""
+                                }
+                 },
+    "model":  {
+                  "displayName":  "",
+                  "id":  "00000000-0000-0000-0000-000000000000",
+                  "model":  {
+                                "version":  "1.18.8"
+                            },
+                  "name":  "stackgres-operator",
+                  "registrant":  {
+                                     "kind":  ""
+                                 },
+                  "version":  ""
               },
-              "name": "stackgres-operator",
-              "registrant": {
-                "kind": "github"
-              },
-              "version": ""
-            },
-            "patch": {
-              "mutatorRef": [["displayName"]],
-              "patchStrategy": "replace"
-            }
-          }
-        ],
-        "to": [
-          {
-            "id": null,
-            "kind": "SGCluster",
-            "match": {},
-            "match_strategy_matrix": null,
-            "model": {
-              "displayName": "",
-              "id": "00000000-0000-0000-0000-000000000000",
-              "model": {
-                "version": ""
-              },
-              "name": "stackgres-operator",
-              "registrant": {
-                "kind": "github"
-              },
-              "version": ""
-            },
-            "patch": {
-              "mutatedRef": [["configuration", "spec", "configurations", "sgPostgresConfig"]],
-              "patchStrategy": "replace"
-            }
-          }
-        ]
-      },
-      "deny": {
-        "from": [],
-        "to": []
-      }
-    }
-  ],
-  "subType": "inventory",
-  "status": "enabled",
-  "type": "parent",
-  "version": "v1.0.0"
+    "schemaVersion":  "relationships.meshery.io/v1beta2",
+    "selectors":  [
+                      {
+                          "allow":  {
+                                        "from":  [
+                                                     {
+                                                         "id":  null,
+                                                         "kind":  "SGCluster",
+                                                         "match":  {
+
+                                                                   },
+                                                         "match_strategy_matrix":  null,
+                                                         "model":  {
+                                                                       "displayName":  "",
+                                                                       "id":  "00000000-0000-0000-0000-000000000000",
+                                                                       "model":  {
+                                                                                     "version":  ""
+                                                                                 },
+                                                                       "name":  "stackgres-operator",
+                                                                       "registrant":  {
+                                                                                          "kind":  "github"
+                                                                                      },
+                                                                       "version":  ""
+                                                                   },
+                                                         "patch":  {
+                                                                       "mutatedRef":  [
+                                                                                          [
+                                                                                              "configuration",
+                                                                                              "spec",
+                                                                                              "configurations",
+                                                                                              "sgPostgresConfig"
+                                                                                          ]
+                                                                                      ],
+                                                                       "patchStrategy":  "replace"
+                                                                   }
+                                                     }
+                                                 ],
+                                        "to":  [
+                                                   {
+                                                       "id":  null,
+                                                       "kind":  "SGPostgresConfig",
+                                                       "match":  {
+
+                                                                 },
+                                                       "match_strategy_matrix":  null,
+                                                       "model":  {
+                                                                     "displayName":  "",
+                                                                     "id":  "00000000-0000-0000-0000-000000000000",
+                                                                     "model":  {
+                                                                                   "version":  ""
+                                                                               },
+                                                                     "name":  "stackgres-operator",
+                                                                     "registrant":  {
+                                                                                        "kind":  "github"
+                                                                                    },
+                                                                     "version":  ""
+                                                                 },
+                                                       "patch":  {
+                                                                     "mutatorRef":  [
+                                                                                        [
+                                                                                            "displayName"
+                                                                                        ]
+                                                                                    ],
+                                                                     "patchStrategy":  "replace"
+                                                                 }
+                                                   }
+                                               ]
+                                    },
+                          "deny":  {
+                                       "from":  [
+
+                                                ],
+                                       "to":  [
+
+                                              ]
+                                   }
+                      }
+                  ],
+    "subType":  "inventory",
+    "status":  "enabled",
+    "type":  "parent",
+    "version":  "v1.0.0"
 }

--- a/server/meshmodel/stackgres-operator/1.18.8/v1.0.0/relationships/hierarchical-parent-inventory-mn9o0.json
+++ b/server/meshmodel/stackgres-operator/1.18.8/v1.0.0/relationships/hierarchical-parent-inventory-mn9o0.json
@@ -1,89 +1,108 @@
 {
-  "id": "00000000-0000-0000-0000-000000000000",
-  "evaluationQuery": "",
-  "kind": "hierarchical",
-  "metadata": {
-    "description": "",
-    "isAnnotation": false,
-    "styles": {
-      "primaryColor": "",
-      "svgColor": "",
-      "svgWhite": ""
-    }
-  },
-  "model": {
-    "displayName": "",
-    "id": "00000000-0000-0000-0000-000000000000",
-    "model": {
-      "version": "1.18.8"
-    },
-    "name": "stackgres-operator",
-    "registrant": {
-      "kind": ""
-    },
-    "version": ""
-  },
-  "schemaVersion": "relationships.meshery.io/v1beta2",
-  "selectors": [
-    {
-      "allow": {
-        "from": [
-          {
-            "id": null,
-            "kind": "SGPoolingConfig",
-            "match": {},
-            "match_strategy_matrix": null,
-            "model": {
-              "displayName": "",
-              "id": "00000000-0000-0000-0000-000000000000",
-              "model": {
-                "version": ""
+    "id":  "00000000-0000-0000-0000-000000000000",
+    "evaluationQuery":  "",
+    "kind":  "hierarchical",
+    "metadata":  {
+                     "description":  "",
+                     "isAnnotation":  false,
+                     "styles":  {
+                                    "primaryColor":  "",
+                                    "svgColor":  "",
+                                    "svgWhite":  ""
+                                }
+                 },
+    "model":  {
+                  "displayName":  "",
+                  "id":  "00000000-0000-0000-0000-000000000000",
+                  "model":  {
+                                "version":  "1.18.8"
+                            },
+                  "name":  "stackgres-operator",
+                  "registrant":  {
+                                     "kind":  ""
+                                 },
+                  "version":  ""
               },
-              "name": "stackgres-operator",
-              "registrant": {
-                "kind": "github"
-              },
-              "version": ""
-            },
-            "patch": {
-              "mutatorRef": [["displayName"]],
-              "patchStrategy": "replace"
-            }
-          }
-        ],
-        "to": [
-          {
-            "id": null,
-            "kind": "SGCluster",
-            "match": {},
-            "match_strategy_matrix": null,
-            "model": {
-              "displayName": "",
-              "id": "00000000-0000-0000-0000-000000000000",
-              "model": {
-                "version": ""
-              },
-              "name": "stackgres-operator",
-              "registrant": {
-                "kind": "github"
-              },
-              "version": ""
-            },
-            "patch": {
-              "mutatedRef": [["configuration", "spec", "configurations", "sgPoolingConfig"]],
-              "patchStrategy": "replace"
-            }
-          }
-        ]
-      },
-      "deny": {
-        "from": [],
-        "to": []
-      }
-    }
-  ],
-  "subType": "inventory",
-  "status": "enabled",
-  "type": "parent",
-  "version": "v1.0.0"
+    "schemaVersion":  "relationships.meshery.io/v1beta2",
+    "selectors":  [
+                      {
+                          "allow":  {
+                                        "from":  [
+                                                     {
+                                                         "id":  null,
+                                                         "kind":  "SGCluster",
+                                                         "match":  {
+
+                                                                   },
+                                                         "match_strategy_matrix":  null,
+                                                         "model":  {
+                                                                       "displayName":  "",
+                                                                       "id":  "00000000-0000-0000-0000-000000000000",
+                                                                       "model":  {
+                                                                                     "version":  ""
+                                                                                 },
+                                                                       "name":  "stackgres-operator",
+                                                                       "registrant":  {
+                                                                                          "kind":  "github"
+                                                                                      },
+                                                                       "version":  ""
+                                                                   },
+                                                         "patch":  {
+                                                                       "mutatedRef":  [
+                                                                                          [
+                                                                                              "configuration",
+                                                                                              "spec",
+                                                                                              "configurations",
+                                                                                              "sgPoolingConfig"
+                                                                                          ]
+                                                                                      ],
+                                                                       "patchStrategy":  "replace"
+                                                                   }
+                                                     }
+                                                 ],
+                                        "to":  [
+                                                   {
+                                                       "id":  null,
+                                                       "kind":  "SGPoolingConfig",
+                                                       "match":  {
+
+                                                                 },
+                                                       "match_strategy_matrix":  null,
+                                                       "model":  {
+                                                                     "displayName":  "",
+                                                                     "id":  "00000000-0000-0000-0000-000000000000",
+                                                                     "model":  {
+                                                                                   "version":  ""
+                                                                               },
+                                                                     "name":  "stackgres-operator",
+                                                                     "registrant":  {
+                                                                                        "kind":  "github"
+                                                                                    },
+                                                                     "version":  ""
+                                                                 },
+                                                       "patch":  {
+                                                                     "mutatorRef":  [
+                                                                                        [
+                                                                                            "displayName"
+                                                                                        ]
+                                                                                    ],
+                                                                     "patchStrategy":  "replace"
+                                                                 }
+                                                   }
+                                               ]
+                                    },
+                          "deny":  {
+                                       "from":  [
+
+                                                ],
+                                       "to":  [
+
+                                              ]
+                                   }
+                      }
+                  ],
+    "subType":  "inventory",
+    "status":  "enabled",
+    "type":  "parent",
+    "version":  "v1.0.0"
 }

--- a/server/meshmodel/stackgres-operator/1.18.8/v1.0.0/relationships/hierarchical-parent-inventory-mn9o0.json
+++ b/server/meshmodel/stackgres-operator/1.18.8/v1.0.0/relationships/hierarchical-parent-inventory-mn9o0.json
@@ -1,0 +1,89 @@
+{
+  "id": "00000000-0000-0000-0000-000000000000",
+  "evaluationQuery": "",
+  "kind": "hierarchical",
+  "metadata": {
+    "description": "",
+    "isAnnotation": false,
+    "styles": {
+      "primaryColor": "",
+      "svgColor": "",
+      "svgWhite": ""
+    }
+  },
+  "model": {
+    "displayName": "",
+    "id": "00000000-0000-0000-0000-000000000000",
+    "model": {
+      "version": "1.18.8"
+    },
+    "name": "stackgres-operator",
+    "registrant": {
+      "kind": ""
+    },
+    "version": ""
+  },
+  "schemaVersion": "relationships.meshery.io/v1beta2",
+  "selectors": [
+    {
+      "allow": {
+        "from": [
+          {
+            "id": null,
+            "kind": "SGPoolingConfig",
+            "match": {},
+            "match_strategy_matrix": null,
+            "model": {
+              "displayName": "",
+              "id": "00000000-0000-0000-0000-000000000000",
+              "model": {
+                "version": ""
+              },
+              "name": "stackgres-operator",
+              "registrant": {
+                "kind": "github"
+              },
+              "version": ""
+            },
+            "patch": {
+              "mutatorRef": [["displayName"]],
+              "patchStrategy": "replace"
+            }
+          }
+        ],
+        "to": [
+          {
+            "id": null,
+            "kind": "SGCluster",
+            "match": {},
+            "match_strategy_matrix": null,
+            "model": {
+              "displayName": "",
+              "id": "00000000-0000-0000-0000-000000000000",
+              "model": {
+                "version": ""
+              },
+              "name": "stackgres-operator",
+              "registrant": {
+                "kind": "github"
+              },
+              "version": ""
+            },
+            "patch": {
+              "mutatedRef": [["configuration", "spec", "configurations", "sgPoolingConfig"]],
+              "patchStrategy": "replace"
+            }
+          }
+        ]
+      },
+      "deny": {
+        "from": [],
+        "to": []
+      }
+    }
+  ],
+  "subType": "inventory",
+  "status": "enabled",
+  "type": "parent",
+  "version": "v1.0.0"
+}

--- a/server/meshmodel/stackgres-operator/1.18.8/v1.0.0/relationships/hierarchical-parent-inventory-pq1r2.json
+++ b/server/meshmodel/stackgres-operator/1.18.8/v1.0.0/relationships/hierarchical-parent-inventory-pq1r2.json
@@ -1,89 +1,107 @@
 {
-  "id": "00000000-0000-0000-0000-000000000000",
-  "evaluationQuery": "",
-  "kind": "hierarchical",
-  "metadata": {
-    "description": "",
-    "isAnnotation": false,
-    "styles": {
-      "primaryColor": "",
-      "svgColor": "",
-      "svgWhite": ""
-    }
-  },
-  "model": {
-    "displayName": "",
-    "id": "00000000-0000-0000-0000-000000000000",
-    "model": {
-      "version": "1.18.8"
-    },
-    "name": "stackgres-operator",
-    "registrant": {
-      "kind": ""
-    },
-    "version": ""
-  },
-  "schemaVersion": "relationships.meshery.io/v1beta2",
-  "selectors": [
-    {
-      "allow": {
-        "from": [
-          {
-            "id": null,
-            "kind": "SGShardedCluster",
-            "match": {},
-            "match_strategy_matrix": null,
-            "model": {
-              "displayName": "",
-              "id": "00000000-0000-0000-0000-000000000000",
-              "model": {
-                "version": ""
+    "id":  "00000000-0000-0000-0000-000000000000",
+    "evaluationQuery":  "",
+    "kind":  "hierarchical",
+    "metadata":  {
+                     "description":  "",
+                     "isAnnotation":  false,
+                     "styles":  {
+                                    "primaryColor":  "",
+                                    "svgColor":  "",
+                                    "svgWhite":  ""
+                                }
+                 },
+    "model":  {
+                  "displayName":  "",
+                  "id":  "00000000-0000-0000-0000-000000000000",
+                  "model":  {
+                                "version":  "1.18.8"
+                            },
+                  "name":  "stackgres-operator",
+                  "registrant":  {
+                                     "kind":  ""
+                                 },
+                  "version":  ""
               },
-              "name": "stackgres-operator",
-              "registrant": {
-                "kind": "github"
-              },
-              "version": ""
-            },
-            "patch": {
-              "mutatorRef": [["displayName"]],
-              "patchStrategy": "replace"
-            }
-          }
-        ],
-        "to": [
-          {
-            "id": null,
-            "kind": "SGShardedBackup",
-            "match": {},
-            "match_strategy_matrix": null,
-            "model": {
-              "displayName": "",
-              "id": "00000000-0000-0000-0000-000000000000",
-              "model": {
-                "version": ""
-              },
-              "name": "stackgres-operator",
-              "registrant": {
-                "kind": "github"
-              },
-              "version": ""
-            },
-            "patch": {
-              "mutatedRef": [["configuration", "spec", "sgShardedCluster"]],
-              "patchStrategy": "replace"
-            }
-          }
-        ]
-      },
-      "deny": {
-        "from": [],
-        "to": []
-      }
-    }
-  ],
-  "subType": "inventory",
-  "status": "enabled",
-  "type": "parent",
-  "version": "v1.0.0"
+    "schemaVersion":  "relationships.meshery.io/v1beta2",
+    "selectors":  [
+                      {
+                          "allow":  {
+                                        "from":  [
+                                                     {
+                                                         "id":  null,
+                                                         "kind":  "SGShardedBackup",
+                                                         "match":  {
+
+                                                                   },
+                                                         "match_strategy_matrix":  null,
+                                                         "model":  {
+                                                                       "displayName":  "",
+                                                                       "id":  "00000000-0000-0000-0000-000000000000",
+                                                                       "model":  {
+                                                                                     "version":  ""
+                                                                                 },
+                                                                       "name":  "stackgres-operator",
+                                                                       "registrant":  {
+                                                                                          "kind":  "github"
+                                                                                      },
+                                                                       "version":  ""
+                                                                   },
+                                                         "patch":  {
+                                                                       "mutatedRef":  [
+                                                                                          [
+                                                                                              "configuration",
+                                                                                              "spec",
+                                                                                              "sgShardedCluster"
+                                                                                          ]
+                                                                                      ],
+                                                                       "patchStrategy":  "replace"
+                                                                   }
+                                                     }
+                                                 ],
+                                        "to":  [
+                                                   {
+                                                       "id":  null,
+                                                       "kind":  "SGShardedCluster",
+                                                       "match":  {
+
+                                                                 },
+                                                       "match_strategy_matrix":  null,
+                                                       "model":  {
+                                                                     "displayName":  "",
+                                                                     "id":  "00000000-0000-0000-0000-000000000000",
+                                                                     "model":  {
+                                                                                   "version":  ""
+                                                                               },
+                                                                     "name":  "stackgres-operator",
+                                                                     "registrant":  {
+                                                                                        "kind":  "github"
+                                                                                    },
+                                                                     "version":  ""
+                                                                 },
+                                                       "patch":  {
+                                                                     "mutatorRef":  [
+                                                                                        [
+                                                                                            "displayName"
+                                                                                        ]
+                                                                                    ],
+                                                                     "patchStrategy":  "replace"
+                                                                 }
+                                                   }
+                                               ]
+                                    },
+                          "deny":  {
+                                       "from":  [
+
+                                                ],
+                                       "to":  [
+
+                                              ]
+                                   }
+                      }
+                  ],
+    "subType":  "inventory",
+    "status":  "enabled",
+    "type":  "parent",
+    "version":  "v1.0.0"
 }

--- a/server/meshmodel/stackgres-operator/1.18.8/v1.0.0/relationships/hierarchical-parent-inventory-pq1r2.json
+++ b/server/meshmodel/stackgres-operator/1.18.8/v1.0.0/relationships/hierarchical-parent-inventory-pq1r2.json
@@ -1,0 +1,89 @@
+{
+  "id": "00000000-0000-0000-0000-000000000000",
+  "evaluationQuery": "",
+  "kind": "hierarchical",
+  "metadata": {
+    "description": "",
+    "isAnnotation": false,
+    "styles": {
+      "primaryColor": "",
+      "svgColor": "",
+      "svgWhite": ""
+    }
+  },
+  "model": {
+    "displayName": "",
+    "id": "00000000-0000-0000-0000-000000000000",
+    "model": {
+      "version": "1.18.8"
+    },
+    "name": "stackgres-operator",
+    "registrant": {
+      "kind": ""
+    },
+    "version": ""
+  },
+  "schemaVersion": "relationships.meshery.io/v1beta2",
+  "selectors": [
+    {
+      "allow": {
+        "from": [
+          {
+            "id": null,
+            "kind": "SGShardedCluster",
+            "match": {},
+            "match_strategy_matrix": null,
+            "model": {
+              "displayName": "",
+              "id": "00000000-0000-0000-0000-000000000000",
+              "model": {
+                "version": ""
+              },
+              "name": "stackgres-operator",
+              "registrant": {
+                "kind": "github"
+              },
+              "version": ""
+            },
+            "patch": {
+              "mutatorRef": [["displayName"]],
+              "patchStrategy": "replace"
+            }
+          }
+        ],
+        "to": [
+          {
+            "id": null,
+            "kind": "SGShardedBackup",
+            "match": {},
+            "match_strategy_matrix": null,
+            "model": {
+              "displayName": "",
+              "id": "00000000-0000-0000-0000-000000000000",
+              "model": {
+                "version": ""
+              },
+              "name": "stackgres-operator",
+              "registrant": {
+                "kind": "github"
+              },
+              "version": ""
+            },
+            "patch": {
+              "mutatedRef": [["configuration", "spec", "sgShardedCluster"]],
+              "patchStrategy": "replace"
+            }
+          }
+        ]
+      },
+      "deny": {
+        "from": [],
+        "to": []
+      }
+    }
+  ],
+  "subType": "inventory",
+  "status": "enabled",
+  "type": "parent",
+  "version": "v1.0.0"
+}

--- a/server/meshmodel/stackgres-operator/1.18.8/v1.0.0/relationships/hierarchical-parent-inventory-st3u4.json
+++ b/server/meshmodel/stackgres-operator/1.18.8/v1.0.0/relationships/hierarchical-parent-inventory-st3u4.json
@@ -1,89 +1,107 @@
 {
-  "id": "00000000-0000-0000-0000-000000000000",
-  "evaluationQuery": "",
-  "kind": "hierarchical",
-  "metadata": {
-    "description": "",
-    "isAnnotation": false,
-    "styles": {
-      "primaryColor": "",
-      "svgColor": "",
-      "svgWhite": ""
-    }
-  },
-  "model": {
-    "displayName": "",
-    "id": "00000000-0000-0000-0000-000000000000",
-    "model": {
-      "version": "1.18.8"
-    },
-    "name": "stackgres-operator",
-    "registrant": {
-      "kind": ""
-    },
-    "version": ""
-  },
-  "schemaVersion": "relationships.meshery.io/v1beta2",
-  "selectors": [
-    {
-      "allow": {
-        "from": [
-          {
-            "id": null,
-            "kind": "SGShardedCluster",
-            "match": {},
-            "match_strategy_matrix": null,
-            "model": {
-              "displayName": "",
-              "id": "00000000-0000-0000-0000-000000000000",
-              "model": {
-                "version": ""
+    "id":  "00000000-0000-0000-0000-000000000000",
+    "evaluationQuery":  "",
+    "kind":  "hierarchical",
+    "metadata":  {
+                     "description":  "",
+                     "isAnnotation":  false,
+                     "styles":  {
+                                    "primaryColor":  "",
+                                    "svgColor":  "",
+                                    "svgWhite":  ""
+                                }
+                 },
+    "model":  {
+                  "displayName":  "",
+                  "id":  "00000000-0000-0000-0000-000000000000",
+                  "model":  {
+                                "version":  "1.18.8"
+                            },
+                  "name":  "stackgres-operator",
+                  "registrant":  {
+                                     "kind":  ""
+                                 },
+                  "version":  ""
               },
-              "name": "stackgres-operator",
-              "registrant": {
-                "kind": "github"
-              },
-              "version": ""
-            },
-            "patch": {
-              "mutatorRef": [["displayName"]],
-              "patchStrategy": "replace"
-            }
-          }
-        ],
-        "to": [
-          {
-            "id": null,
-            "kind": "SGShardedDbOps",
-            "match": {},
-            "match_strategy_matrix": null,
-            "model": {
-              "displayName": "",
-              "id": "00000000-0000-0000-0000-000000000000",
-              "model": {
-                "version": ""
-              },
-              "name": "stackgres-operator",
-              "registrant": {
-                "kind": "github"
-              },
-              "version": ""
-            },
-            "patch": {
-              "mutatedRef": [["configuration", "spec", "sgShardedCluster"]],
-              "patchStrategy": "replace"
-            }
-          }
-        ]
-      },
-      "deny": {
-        "from": [],
-        "to": []
-      }
-    }
-  ],
-  "subType": "inventory",
-  "status": "enabled",
-  "type": "parent",
-  "version": "v1.0.0"
+    "schemaVersion":  "relationships.meshery.io/v1beta2",
+    "selectors":  [
+                      {
+                          "allow":  {
+                                        "from":  [
+                                                     {
+                                                         "id":  null,
+                                                         "kind":  "SGShardedDbOps",
+                                                         "match":  {
+
+                                                                   },
+                                                         "match_strategy_matrix":  null,
+                                                         "model":  {
+                                                                       "displayName":  "",
+                                                                       "id":  "00000000-0000-0000-0000-000000000000",
+                                                                       "model":  {
+                                                                                     "version":  ""
+                                                                                 },
+                                                                       "name":  "stackgres-operator",
+                                                                       "registrant":  {
+                                                                                          "kind":  "github"
+                                                                                      },
+                                                                       "version":  ""
+                                                                   },
+                                                         "patch":  {
+                                                                       "mutatedRef":  [
+                                                                                          [
+                                                                                              "configuration",
+                                                                                              "spec",
+                                                                                              "sgShardedCluster"
+                                                                                          ]
+                                                                                      ],
+                                                                       "patchStrategy":  "replace"
+                                                                   }
+                                                     }
+                                                 ],
+                                        "to":  [
+                                                   {
+                                                       "id":  null,
+                                                       "kind":  "SGShardedCluster",
+                                                       "match":  {
+
+                                                                 },
+                                                       "match_strategy_matrix":  null,
+                                                       "model":  {
+                                                                     "displayName":  "",
+                                                                     "id":  "00000000-0000-0000-0000-000000000000",
+                                                                     "model":  {
+                                                                                   "version":  ""
+                                                                               },
+                                                                     "name":  "stackgres-operator",
+                                                                     "registrant":  {
+                                                                                        "kind":  "github"
+                                                                                    },
+                                                                     "version":  ""
+                                                                 },
+                                                       "patch":  {
+                                                                     "mutatorRef":  [
+                                                                                        [
+                                                                                            "displayName"
+                                                                                        ]
+                                                                                    ],
+                                                                     "patchStrategy":  "replace"
+                                                                 }
+                                                   }
+                                               ]
+                                    },
+                          "deny":  {
+                                       "from":  [
+
+                                                ],
+                                       "to":  [
+
+                                              ]
+                                   }
+                      }
+                  ],
+    "subType":  "inventory",
+    "status":  "enabled",
+    "type":  "parent",
+    "version":  "v1.0.0"
 }

--- a/server/meshmodel/stackgres-operator/1.18.8/v1.0.0/relationships/hierarchical-parent-inventory-st3u4.json
+++ b/server/meshmodel/stackgres-operator/1.18.8/v1.0.0/relationships/hierarchical-parent-inventory-st3u4.json
@@ -1,0 +1,89 @@
+{
+  "id": "00000000-0000-0000-0000-000000000000",
+  "evaluationQuery": "",
+  "kind": "hierarchical",
+  "metadata": {
+    "description": "",
+    "isAnnotation": false,
+    "styles": {
+      "primaryColor": "",
+      "svgColor": "",
+      "svgWhite": ""
+    }
+  },
+  "model": {
+    "displayName": "",
+    "id": "00000000-0000-0000-0000-000000000000",
+    "model": {
+      "version": "1.18.8"
+    },
+    "name": "stackgres-operator",
+    "registrant": {
+      "kind": ""
+    },
+    "version": ""
+  },
+  "schemaVersion": "relationships.meshery.io/v1beta2",
+  "selectors": [
+    {
+      "allow": {
+        "from": [
+          {
+            "id": null,
+            "kind": "SGShardedCluster",
+            "match": {},
+            "match_strategy_matrix": null,
+            "model": {
+              "displayName": "",
+              "id": "00000000-0000-0000-0000-000000000000",
+              "model": {
+                "version": ""
+              },
+              "name": "stackgres-operator",
+              "registrant": {
+                "kind": "github"
+              },
+              "version": ""
+            },
+            "patch": {
+              "mutatorRef": [["displayName"]],
+              "patchStrategy": "replace"
+            }
+          }
+        ],
+        "to": [
+          {
+            "id": null,
+            "kind": "SGShardedDbOps",
+            "match": {},
+            "match_strategy_matrix": null,
+            "model": {
+              "displayName": "",
+              "id": "00000000-0000-0000-0000-000000000000",
+              "model": {
+                "version": ""
+              },
+              "name": "stackgres-operator",
+              "registrant": {
+                "kind": "github"
+              },
+              "version": ""
+            },
+            "patch": {
+              "mutatedRef": [["configuration", "spec", "sgShardedCluster"]],
+              "patchStrategy": "replace"
+            }
+          }
+        ]
+      },
+      "deny": {
+        "from": [],
+        "to": []
+      }
+    }
+  ],
+  "subType": "inventory",
+  "status": "enabled",
+  "type": "parent",
+  "version": "v1.0.0"
+}


### PR DESCRIPTION
Fixes #19796

## Description
Added hierarchical parent-inventory relationships for the StackGres operator model (v1.18.8):

- SGBackup → SGCluster: via `spec.sgCluster`
- SGDbOps → SGCluster: via `spec.sgCluster`
- SGCluster → SGInstanceProfile: via `spec.sgInstanceProfile`
- SGCluster → SGPostgresConfig: via `spec.configurations.sgPostgresConfig`
- SGCluster → SGPoolingConfig: via `spec.configurations.sgPoolingConfig`
- SGShardedBackup → SGShardedCluster: via `spec.sgShardedCluster`
- SGShardedDbOps → SGShardedCluster: via `spec.sgShardedCluster`

These relationships enable visual parent-child grouping in Kanvas.