### PR TITLE
fix(kubernetes): show success/error notification after ping connectiv…

### DIFF
--- a/ui/utils/hooks/useKubernetesHook.tsx
+++ b/ui/utils/hooks/useKubernetesHook.tsx
@@ -1,5 +1,5 @@
 import { useNotification } from '../../utils/hooks/useNotification';
-import { errorHandlerGenerator, successHandlerGenerator } from '../../utils/helpers/common';
+import { formatApiError } from '../../utils/helpers/meshkitError';
 import { pingMesheryOperator } from '../../utils/helpers/mesheryOperator';
 import { useLazyPingKubernetesQuery } from '@/rtk-query/connection';
 import { EVENT_TYPES } from '../../lib/event-types';
@@ -23,12 +23,25 @@ export default function useKubernetesHook() {
     async (name, server, connectionID) => {
       dispatch(updateProgressAction({ showProgress: true }));
       try {
-        await triggerPing(connectionID).unwrap();
-        dispatch(updateProgressAction({ showProgress: false }));
-        successHandlerGenerator(notify, `Kubernetes context ${name} at ${server} pinged`)();
+        const result = await triggerPing(connectionID).unwrap();
+
+        const serverVersion = result?.server_version ?? result?.serverVersion ?? null;
+        const message = serverVersion
+          ? `Connected successfully - Kubernetes ${serverVersion}`
+          : 'Connected successfully - Kubernetes';
+
+        notify({
+          message,
+          event_type: EVENT_TYPES.SUCCESS,
+        });
       } catch (err) {
+        notify({
+          message: 'Connection failed - unable to reach cluster',
+          details: formatApiError(err).message,
+          event_type: EVENT_TYPES.ERROR,
+        });
+      } finally {
         dispatch(updateProgressAction({ showProgress: false }));
-        errorHandlerGenerator(notify, `Kubernetes context ${name} at ${server} not reachable`)(err);
       }
     },
     [dispatch, notify, triggerPing],

--- a/ui/utils/hooks/useKubernetesHook.tsx
+++ b/ui/utils/hooks/useKubernetesHook.tsx
@@ -1,5 +1,5 @@
 import { useNotification } from '../../utils/hooks/useNotification';
-import { formatApiError } from '../../utils/helpers/meshkitError';
+import { getErrorMessage } from '../../components/connections/ConnectionTable.constants';
 import { pingMesheryOperator } from '../../utils/helpers/mesheryOperator';
 import { useLazyPingKubernetesQuery } from '@/rtk-query/connection';
 import { EVENT_TYPES } from '../../lib/event-types';
@@ -27,8 +27,8 @@ export default function useKubernetesHook() {
 
         const serverVersion = result?.server_version ?? result?.serverVersion ?? null;
         const message = serverVersion
-          ? `Connected successfully - Kubernetes ${serverVersion}`
-          : 'Connected successfully - Kubernetes';
+          ? `Connected successfully to ${name} (${server}) - Kubernetes ${serverVersion}`
+          : `Connected successfully to ${name} (${server})`;
 
         notify({
           message,
@@ -36,8 +36,8 @@ export default function useKubernetesHook() {
         });
       } catch (err) {
         notify({
-          message: 'Connection failed - unable to reach cluster',
-          details: formatApiError(err).message,
+          message: `Connection failed for ${name} (${server}) - unable to reach cluster`,
+          details: getErrorMessage(err, 'Unable to reach cluster'),
           event_type: EVENT_TYPES.ERROR,
         });
       } finally {


### PR DESCRIPTION
## What does this PR do?

Fixes the missing toast notification after a Kubernetes connection chip ping in the Meshery UI.

Closes #19790

## Problem

When a user clicked a connection chip to ping a Kubernetes cluster, the loader appeared and dismissed but **no notification was shown**, leaving the user with zero feedback on whether the check passed or failed.

## Solution

Updated `useKubernetesHook` ping function to:
- Store the API response result
- Extract `server_version` from the response
- Show a **success toast** with server version on HTTP 200
- Show an **error toast** with details on failure
- Move loader dismiss to `finally` block to ensure it always runs

## Changes

**File:** `ui/utils/hooks/useKubernetesHook.tsx`
- Store result from `triggerPing().unwrap()`
- Extract `server_version` from response
- Call `notify()` with success message including server version
- Call `notify()` with error message in catch block
- Move `dispatch(updateProgressAction({ showProgress: false }))` to `finally` block

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## How to Test

1. Connect a Kubernetes cluster to Meshery (minikube works)
2. Go to **Connections** page
3. Click the Kubernetes connection chip
4. **Before fix:** No toast appears after loader dismisses
5. **After fix:** Green toast shows `Connected successfully - Kubernetes v1.x.x`
