### PR TITLE
[mesheryctl] Fix design evaluate build and duplicate error codes

### DIFF
--- a/docs/data/errorref/mesheryctl_errors_export.json
+++ b/docs/data/errorref/mesheryctl_errors_export.json
@@ -2027,6 +2027,33 @@
         "short_description": "Server error while saving performance profile",
         "probable_cause": "Provider Database could be down or not reachable",
         "suggested_remediation": "Make sure provider is up and reachable"
+      },
+      "1246": {
+        "name": "ErrEmptyCSVDataCode",
+        "code": "1246",
+        "severity": "Alert",
+        "long_description": "",
+        "short_description": "Invalid or empty CSV file provided",
+        "probable_cause": "The CSV file must contain valid relationship entries with the required headers.",
+        "suggested_remediation": "Ensure the CSV file contains two header rows and at least one data row with a minimum of 15 columns. Refer to the Meshery relationship CSV template: \\\"https://github.com/meshery/meshery/blob/master/mesheryctl/templates/template-csvs/Relationships.csv\\"
+      },
+      "1247": {
+        "name": "ErrEvaluateDesignCode",
+        "code": "1247",
+        "severity": "Alert",
+        "long_description": "Exactly one of a design file path (-f) or a design ID must be provided, not both",
+        "short_description": "Design not specified for evaluation",
+        "probable_cause": "A design must be specified either by file path (-f) or by ID as an argument, but not both simultaneously",
+        "suggested_remediation": "Provide a design file using '-f' flag or pass a design ID as an argument (not both).\\n\\nUsage: mesheryctl design evaluate [ID] -o [output-file]\\n       mesheryctl design evaluate -f [file] -o [output-file]"
+      },
+      "1248": {
+        "name": "ErrEvaluateDesignResponseCode",
+        "code": "1248",
+        "severity": "Alert",
+        "long_description": "",
+        "short_description": "Failed to evaluate design",
+        "probable_cause": "The Meshery server returned an error while evaluating the design\nThe design file may be invalid or the server may be experiencing issues",
+        "suggested_remediation": "Ensure the design file is valid\nCheck that the Meshery server is running and accessible\nVerify that the server has the required policies loaded"
       }
     }
   }

--- a/mesheryctl/helpers/component_info.json
+++ b/mesheryctl/helpers/component_info.json
@@ -1,5 +1,5 @@
 {
   "name": "mesheryctl",
   "type": "client",
-  "next_error_code": 1247
+  "next_error_code": 1249
 }

--- a/mesheryctl/internal/cli/root/design/design.go
+++ b/mesheryctl/internal/cli/root/design/design.go
@@ -23,6 +23,7 @@ import (
 	"github.com/meshery/meshery/mesheryctl/pkg/utils"
 	"github.com/meshery/meshery/server/models"
 	"github.com/meshery/meshery/server/models/pattern/core"
+	patternutils "github.com/meshery/meshery/server/models/pattern/utils"
 	"github.com/meshery/schemas/models/v1beta1/pattern"
 	"github.com/spf13/cobra"
 )
@@ -112,5 +113,14 @@ func fetchDesignByID(baseUrl, designID string) (pattern.PatternFile, error) {
 	if err != nil {
 		return pattern.PatternFile{}, ErrParseDesignFile(err)
 	}
-	return pf, nil
+	// core.NewPatternFile returns a v1beta3/design.PatternFile; bridge it back
+	// to the v1beta1/pattern.PatternFile the evaluation request still consumes.
+	bridged, err := patternutils.PatternV1beta3ToV1beta1(&pf)
+	if err != nil {
+		return pattern.PatternFile{}, ErrParseDesignFile(err)
+	}
+	if bridged == nil {
+		return pattern.PatternFile{}, ErrParseDesignFile(fmt.Errorf("bridged design is nil"))
+	}
+	return *bridged, nil
 }

--- a/mesheryctl/internal/cli/root/design/error.go
+++ b/mesheryctl/internal/cli/root/design/error.go
@@ -38,8 +38,8 @@ const (
 	ErrInvalidCommandCode             = "mesheryctl-1191"
 	ErrDesignNameOrIDNotSpecifiedCode = "mesheryctl-1192"
 	ErrDesignInvalidApiResponseCode   = "mesheryctl-1199"
-	ErrEvaluateDesignCode             = "mesheryctl-1200"
-	ErrEvaluateDesignResponseCode     = "mesheryctl-1202"
+	ErrEvaluateDesignCode             = "mesheryctl-1247"
+	ErrEvaluateDesignResponseCode     = "mesheryctl-1248"
 )
 
 const (

--- a/mesheryctl/internal/cli/root/design/evaluate.go
+++ b/mesheryctl/internal/cli/root/design/evaluate.go
@@ -28,6 +28,7 @@ import (
 	"github.com/meshery/meshery/mesheryctl/internal/cli/root/config"
 	"github.com/meshery/meshery/mesheryctl/pkg/utils"
 	"github.com/meshery/meshery/server/models/pattern/core"
+	patternutils "github.com/meshery/meshery/server/models/pattern/utils"
 	encoding "github.com/meshery/meshkit/encoding"
 	meshkitutils "github.com/meshery/meshkit/utils"
 	"github.com/meshery/schemas/models/v1beta1/pattern"
@@ -124,7 +125,16 @@ func readDesignFromFile(filePath string) (pattern.PatternFile, error) {
 	if err != nil {
 		return pattern.PatternFile{}, ErrParseDesignFile(err)
 	}
-	return pf, nil
+	// core.NewPatternFile returns a v1beta3/design.PatternFile; bridge it back
+	// to the v1beta1/pattern.PatternFile the evaluation request still consumes.
+	bridged, err := patternutils.PatternV1beta3ToV1beta1(&pf)
+	if err != nil {
+		return pattern.PatternFile{}, ErrParseDesignFile(err)
+	}
+	if bridged == nil {
+		return pattern.PatternFile{}, ErrParseDesignFile(fmt.Errorf("bridged design is nil"))
+	}
+	return *bridged, nil
 }
 
 func sendEvaluationRequest(designPayload pattern.PatternFile) (*pattern.EvaluationResponse, error) {


### PR DESCRIPTION
**Notes for Reviewers**

Two checks are red on `master`; both trace back to the `design evaluate` subcommand and are fixed here.

- **`golangci-lint-cli` (typecheck).** `fetchDesignByID` / `readDesignFromFile` return `v1beta1/pattern.PatternFile`, but `core.NewPatternFile` now returns a `v1beta3/design.PatternFile` after the Phase 3 schemas migration (`f2064447`). The evaluation request/response types live only in `v1beta1/pattern`, so these files stay on v1beta1 and bridge the parsed design via `patternutils.PatternV1beta3ToV1beta1`, the same carve-out already used in `meshsync_handler.go`.
- **MeshKit Error Codes Utility (duplicate codes).** `ErrEvaluateDesignCode` / `ErrEvaluateDesignResponseCode` collided with the existing `ErrDeleteModelCode` (1200) and `ErrPromptCancelledCode` (1202). Reassigned them to the free 1247/1248, bumped `next_error_code`, and regenerated the reference export (which had drifted to 1245 while the utility was failing).

## Verification

- `go build ./...` and `go vet ./mesheryctl/internal/cli/root/design/...` clean
- `golangci-lint run --config=../.github/.golangci.yml` on `./mesheryctl` — 0 issues
- `errorutil analyze -i ./helpers` on `./mesheryctl` — empty output

**[Signed commits](https://github.com/meshery/meshery/blob/master/CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [x] Yes, I signed my commits.
