### PR TITLE
fix(make): run go mod tidy before wasm-engine build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -493,8 +493,9 @@ policy-test:
 
 ## Build the Go relationship engine as a wasm binary for browser/extension use
 .PHONY: wasm-engine
-wasm-engine:
+wasm-engine: dep-check-go
 	@echo "Building Go relationship engine wasm..."
+	@cd server/policies/wasm && go clean && go mod tidy
 	@cd server/policies/wasm && \
 		GOOS=js GOARCH=wasm go build -trimpath -ldflags="-s -w" -o policy_engine.wasm .
 	@cp -f "$$(go env GOROOT)/lib/wasm/wasm_exec.js" server/policies/wasm/wasm_exec.js

--- a/Makefile
+++ b/Makefile
@@ -495,8 +495,8 @@ policy-test:
 .PHONY: wasm-engine
 wasm-engine: dep-check-go
 	@echo "Building Go relationship engine wasm..."
-	@cd server/policies/wasm && go clean && go mod tidy
 	@cd server/policies/wasm && \
+		go mod tidy && \
 		GOOS=js GOARCH=wasm go build -trimpath -ldflags="-s -w" -o policy_engine.wasm .
 	@cp -f "$$(go env GOROOT)/lib/wasm/wasm_exec.js" server/policies/wasm/wasm_exec.js
 	@echo "Patching wasm_exec.js to add process.env polyfill..."


### PR DESCRIPTION
Fixes #19813

## Summary

`make wasm-engine` (and targets that depend on it, such as `ui-build` and `ui-meshery-build`) could fail with:

```text
go: updates to go.mod needed; to update it:
	go mod tidy
make: *** [wasm-engine] Error 1
```

This change aligns `wasm-engine` with other server Go build targets:

- Adds `dep-check-go` as a prerequisite
- Runs `go clean && go mod tidy` in `server/policies/wasm` before the WASM build

## Test plan

- [x] `make wasm-engine` completes successfully
- [x] `make ui-meshery-build` completes successfully (or `make ui-build` if you run the full UI build)

## Notes for Reviewers

- This PR fixes #19813 by ensuring the wasm policy engine module is tidied before `GOOS=js GOARCH=wasm go build`.
- Only `Makefile` is changed; no `go.mod` / `go.sum` updates in-repo (tidy runs at build time, as discussed in the issue).

**[Signed commits](https://github.com/meshery/meshery/blob/master/CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [x] Yes, I signed my commits.


<!--
Thank you for contributing to Meshery! 

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. Sign your commits.
4. Include before and after screenshots/terminal output.

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.
-->
