### PR TITLE
feat: add hardened runner step to GitHub workflows for enhanced security

### DIFF
--- a/.github/workflows/build-and-preview-docs.yml
+++ b/.github/workflows/build-and-preview-docs.yml
@@ -32,6 +32,11 @@ jobs:
       PREVIEW_RETENTION_LIMIT: 6
 
     steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4
+        with:
+          egress-policy: audit
+          
       - name: Checkout PR code
         if: github.event.action != 'closed'
         uses: actions/checkout@v6

--- a/.github/workflows/build-meshery-image.yml
+++ b/.github/workflows/build-meshery-image.yml
@@ -15,6 +15,12 @@ jobs:
     outputs:
       artifact-name: ${{ steps.set-name.outputs.name }}
     steps:
+
+      - name: Harden Runner
+        uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4
+        with:
+          egress-policy: audit
+
       - name: Check out code
         uses: actions/checkout@v6
       

--- a/.github/workflows/test-e2e.yml
+++ b/.github/workflows/test-e2e.yml
@@ -38,6 +38,11 @@ jobs:
       playwright-report-artifact: playwright-report
     
     steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4
+        with:
+          egress-policy: audit
+          
       - name: Check out code
         uses: actions/checkout@v6
         


### PR DESCRIPTION
This PR adds a [security harden action](https://github.com/step-security/harden-runner) to a few of our workflows. This will allow our workflows to monitor outbound network traffic, source code integrity, and other functions - https://docs.stepsecurity.io/github-actions/harden-runner. 

This PR sets the action to audit only. After some analysis of the workflow summariese we can build further rules around it and switch action to block. 

I think we could benefit from visibility into the data across some of workflows to continue to iterate towards better security practices.