### PR TITLE
[UI] Fix Registry action dialogs opening behind modal

### DIFF
--- a/ui/components/RelationshipBuilder/CreateRelationshipModal.tsx
+++ b/ui/components/RelationshipBuilder/CreateRelationshipModal.tsx
@@ -10,7 +10,7 @@ const CreateRelationshipModal = ({ isRelationshipModalOpen, setIsRelationshipMod
       closeModal={() => setIsRelationshipModalOpen(false)}
       title="Create Relationship"
       style={{
-        zIndex: 1500,
+        zIndex: 1600,
       }}
       disableBackdropClick={false}
       disableEscapeKeyDown={false}

--- a/ui/components/RelationshipBuilder/CreateRelationshipModal.tsx
+++ b/ui/components/RelationshipBuilder/CreateRelationshipModal.tsx
@@ -1,8 +1,9 @@
 import React from 'react';
-import { Modal } from '@sistent/sistent';
+import { Modal, useTheme } from '@sistent/sistent';
 import RelationshipFormStepper from './RelationshipFormStepper';
 
 const CreateRelationshipModal = ({ isRelationshipModalOpen, setIsRelationshipModalOpen }) => {
+  const theme = useTheme();
   return (
     <Modal
       maxWidth="md"
@@ -10,7 +11,7 @@ const CreateRelationshipModal = ({ isRelationshipModalOpen, setIsRelationshipMod
       closeModal={() => setIsRelationshipModalOpen(false)}
       title="Create Relationship"
       style={{
-        zIndex: 1600,
+        zIndex: theme.zIndex.modal + 100,
       }}
       disableBackdropClick={false}
       disableEscapeKeyDown={false}

--- a/ui/components/Settings/Registry/CreateModelModal.tsx
+++ b/ui/components/Settings/Registry/CreateModelModal.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Modal } from '@sistent/sistent';
+import { Modal, useTheme } from '@sistent/sistent';
 import UrlStepper from './Stepper/UrlStepper';
 
 type CreateModelModalProps = {
@@ -8,6 +8,7 @@ type CreateModelModalProps = {
 };
 
 const CreateModelModal = ({ isCreateModalOpen, setIsCreateModalOpen }: CreateModelModalProps) => {
+  const theme = useTheme();
   return (
     <Modal
       maxWidth="sm"
@@ -15,7 +16,7 @@ const CreateModelModal = ({ isCreateModalOpen, setIsCreateModalOpen }: CreateMod
       closeModal={() => setIsCreateModalOpen(false)}
       title="Create Model"
       style={{
-        zIndex: 1600,
+        zIndex: theme.zIndex.modal + 100,
       }}
     >
       <UrlStepper handleClose={() => setIsCreateModalOpen(false)} />

--- a/ui/components/Settings/Registry/CreateModelModal.tsx
+++ b/ui/components/Settings/Registry/CreateModelModal.tsx
@@ -15,7 +15,7 @@ const CreateModelModal = ({ isCreateModalOpen, setIsCreateModalOpen }: CreateMod
       closeModal={() => setIsCreateModalOpen(false)}
       title="Create Model"
       style={{
-        zIndex: 1500,
+        zIndex: 1600,
       }}
     >
       <UrlStepper handleClose={() => setIsCreateModalOpen(false)} />

--- a/ui/components/Settings/Registry/ImportModelModal.tsx
+++ b/ui/components/Settings/Registry/ImportModelModal.tsx
@@ -227,7 +227,7 @@ const ImportModelModal = React.memo(
           maxWidth="sm"
           title="Import Model"
           style={{
-            zIndex: 1500,
+            zIndex: 1600,
           }}
         >
           {activeStep === 0 ? (
@@ -264,7 +264,7 @@ const ImportModelModal = React.memo(
           maxWidth="sm"
           title="Import CSV"
           style={{
-            zIndex: 1500,
+            zIndex: 1600,
           }}
         >
           <CsvStepper handleClose={handleClose} />

--- a/ui/components/Settings/Registry/ImportModelModal.tsx
+++ b/ui/components/Settings/Registry/ImportModelModal.tsx
@@ -99,6 +99,7 @@ type ImportModelModalProps = {
 
 const ImportModelModal = React.memo(
   ({ isImportModalOpen, setIsImportModalOpen }: ImportModelModalProps) => {
+    const theme = useTheme();
     const [importModalDescription, setImportModalDescription] = useState('');
     const [isCsvModalOpen, setIsCsvModalOpen] = useState(false);
     const [importModelReq] = useImportMeshModelMutation();
@@ -227,7 +228,7 @@ const ImportModelModal = React.memo(
           maxWidth="sm"
           title="Import Model"
           style={{
-            zIndex: 1600,
+            zIndex: theme.zIndex.modal + 100,
           }}
         >
           {activeStep === 0 ? (
@@ -264,7 +265,7 @@ const ImportModelModal = React.memo(
           maxWidth="sm"
           title="Import CSV"
           style={{
-            zIndex: 1600,
+            zIndex: theme.zIndex.modal + 100,
           }}
         >
           <CsvStepper handleClose={handleClose} />


### PR DESCRIPTION
**Notes for Reviewers**

* This PR fixes #19831

**Signed commits**

* [x] Yes, I signed my commits.

### Description

This PR fixes an issue where action dialogs within the Registry modal were rendered behind the parent modal, making them inaccessible to users.

The issue was caused by the dialogs using a lower `z-index` than the Registry modal. To ensure they are displayed correctly in the foreground, the `z-index` value has been updated from `1500` to `1600` in the following components:

* `CreateModelModal.tsx`
* `ImportModelModal.tsx` (Import Model and CSV Import dialogs)
* `CreateRelationshipModal.tsx`

With this change, all Registry action dialogs now appear above the parent modal and remain fully interactive.

### Screenshots
<img width="641" height="400" alt="3" src="https://github.com/user-attachments/assets/b18b9c9b-d90c-4fc1-8e6b-b32dd00751a1" />
<img width="708" height="419" alt="2" src="https://github.com/user-attachments/assets/b2ab1430-ecd0-4077-9375-ccc26223c2f9" />
<img width="611" height="397" alt="1" src="https://github.com/user-attachments/assets/f3e8bc0c-1748-46f7-86fe-f58ed21e8454" />

