### PR TITLE
[UI] Fix Registry action dialogs opening behind modal

### DIFF
--- a/ui/components/registry/CreateModelModal.tsx
+++ b/ui/components/registry/CreateModelModal.tsx
@@ -30,6 +30,7 @@ const CreateModelModal: FC<CreateModelModalProps> = ({
       title="Create Model"
       size="sm"
       disableBodyWrap
+      sx={{ zIndex: (theme) => theme.zIndex.modal + 10 }}
     >
       <UrlStepper handleClose={handleClose} />
     </Modal>

--- a/ui/components/registry/CreateRelationshipModal.tsx
+++ b/ui/components/registry/CreateRelationshipModal.tsx
@@ -31,6 +31,7 @@ const CreateRelationshipModal: FC<CreateRelationshipModalProps> = ({
       title="Create Relationship"
       size="md"
       disableBodyWrap
+      sx={{ zIndex: (theme) => theme.zIndex.modal + 10 }}
     >
       <RelationshipFormStepper handleClose={handleClose} />
     </Modal>

--- a/ui/components/registry/ImportModelModal.tsx
+++ b/ui/components/registry/ImportModelModal.tsx
@@ -321,6 +321,7 @@ const ImportModelModal = memo<ImportModelModalProps>(
             onSubmit={handleImportModelSubmit}
             submitText="Next"
             helpText={helpText}
+            sx={{ zIndex: (theme) => theme.zIndex.modal + 10 }}
           />
         ) : (
           <Modal
@@ -330,6 +331,7 @@ const ImportModelModal = memo<ImportModelModalProps>(
             size="sm"
             helpText="Click Finish to complete the model import process. The imported model will be available in your Model Registry."
             actions={<ModalButtonPrimary onClick={handleClose}>Finish</ModalButtonPrimary>}
+            sx={{ zIndex: (theme) => theme.zIndex.modal + 10 }}
           >
             <FinishDeploymentStep deploymentType="register" />
           </Modal>
@@ -341,6 +343,7 @@ const ImportModelModal = memo<ImportModelModalProps>(
           title="Import CSV"
           size="sm"
           disableBodyWrap
+          sx={{ zIndex: (theme) => theme.zIndex.modal + 10 }}
         >
           <CsvStepper handleClose={handleClose} />
         </Modal>

--- a/ui/components/shared/Modal/FormModal.tsx
+++ b/ui/components/shared/Modal/FormModal.tsx
@@ -63,6 +63,7 @@ interface FormModalBaseProps {
   isSubmitDisabled?: boolean;
   /** Size token; defaults to `md`. */
   size?: ModalSize;
+  sx?: import('react').ComponentProps<typeof Modal>['sx'];
 }
 
 export interface RjsfFormModalProps<TFormData = unknown> extends FormModalBaseProps {
@@ -106,6 +107,7 @@ export const FormModal = <TFormData,>(props: FormModalProps<TFormData>) => {
     cancelText = 'Cancel',
     isSubmitDisabled = false,
     size = 'md',
+    sx,
   } = props;
 
   const rjsfRef = useRef<RjsfFormRef['current']>(null);
@@ -150,6 +152,7 @@ export const FormModal = <TFormData,>(props: FormModalProps<TFormData>) => {
       headerIcon={headerIcon}
       helpText={helpText}
       size={size}
+      sx={sx}
       actions={
         <>
           <ModalButtonSecondary onClick={onClose}>{cancelText}</ModalButtonSecondary>

--- a/ui/components/shared/Modal/Modal.tsx
+++ b/ui/components/shared/Modal/Modal.tsx
@@ -67,6 +67,7 @@ export interface ModalProps {
   /** Forwarded to the underlying Dialog root for cypress/test selectors. */
   'aria-labelledby'?: string;
   'aria-describedby'?: string;
+  sx?: import('react').ComponentProps<typeof SistentModal>['sx'];
 }
 
 const sizeToMaxWidth = {
@@ -90,6 +91,7 @@ export const Modal: FC<ModalProps> = ({
   isFullScreenModeAllowed,
   disableBodyWrap = false,
   className,
+  sx,
   ...ariaProps
 }) => {
   return (
@@ -103,6 +105,7 @@ export const Modal: FC<ModalProps> = ({
       fullWidth
       isFullScreenModeAllowed={isFullScreenModeAllowed}
       className={className}
+      sx={sx}
       {...ariaProps}
     >
       {disableBodyWrap ? children : <SistentModalBody>{children}</SistentModalBody>}


### PR DESCRIPTION
**Notes for Reviewers**

- This PR fixes #19831

**[Signed commits](https://github.com/meshery/meshery/blob/master/CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [x] Yes, I signed my commits.

### Description
**Issue Addressed:** Action dialogs triggered from within the Registry modal (Create Model, Import Model, Create Relationship) were rendering behind the parent Registry modal, making them unclickable.

**Summary of Changes:**
Updated the stacking context of the child modals. Initially attempted to use standard inline `sx` z-index properties, but am now targeting the root modal container (`& .MuiDialog-root`) to ensure it escapes the parent's stacking context using the theme's dynamic `zIndex` properties. 

**Impact:**
The Create Model, Import Model, and Create Relationship dialogs now correctly render in the foreground above the parent Registry modal without hardcoding arbitrary high z-index values that might interfere with tooltips or snackbars.