### PR TITLE
[mesheryctl] model: fix typos, misspelled function names, and corrupted license header

### DIFF
--- a/mesheryctl/internal/cli/root/model/import.go
+++ b/mesheryctl/internal/cli/root/model/import.go
@@ -205,13 +205,13 @@ func registerModel(data []byte, componentData []byte, relationshipData []byte, f
 
 func displayEntities(response *models.RegistryAPIResponse) {
 	displaySummary(response)
-	ok := displayEmtpyModel(response)
+	ok := displayEmptyModel(response)
 	if !ok {
 		return
 	}
-	displayEntitisIfModel(response)
+	displayEntitiesIfModel(response)
 }
-func displayEmtpyModel(response *models.RegistryAPIResponse) bool {
+func displayEmptyModel(response *models.RegistryAPIResponse) bool {
 	if len(response.ModelName) != 0 && response.EntityCount.CompCount == 0 && response.EntityCount.RelCount == 0 {
 		if response.EntityCount.TotalErrCount == 0 {
 			return false
@@ -220,13 +220,13 @@ func displayEmtpyModel(response *models.RegistryAPIResponse) bool {
 	return true
 }
 
-// TO check the case if we were never able to read the file at first palce
+// TO check the case if we were never able to read the file at first place
 func hasExtension(name string) bool {
 	extension := filepath.Ext(name)
 	return extension != ""
 }
 
-func displayEntitisIfModel(response *models.RegistryAPIResponse) {
+func displayEntitiesIfModel(response *models.RegistryAPIResponse) {
 	var modelsWithoutExtension []string
 	var modelsWithExtension []string
 

--- a/mesheryctl/internal/cli/root/model/init.go
+++ b/mesheryctl/internal/cli/root/model/init.go
@@ -161,7 +161,7 @@ mesheryctl model init [model-name] --output-format [json|yaml|csv] (default is j
 		if err != nil {
 			utils.Log.Info("Failure, cleaning up...")
 			if !isModelFolderAlreadyExists {
-				// if model folder didn'tv exist before -> delete it
+				// if model folder didn't exist before -> delete it
 				utils.Log.Infof("Removing %s", modelFolder)
 				_ = os.RemoveAll(modelFolder)
 			} else {

--- a/mesheryctl/internal/cli/root/model/list.go
+++ b/mesheryctl/internal/cli/root/model/list.go
@@ -19,7 +19,7 @@ var modelListFlags cmdModelListFlags
 var listModelCmd = &cobra.Command{
 	Use:   "list",
 	Short: "List registered models",
-	Long: `List all registered models by pagingation (10 models per page)
+	Long: `List all registered models by pagination (10 models per page)
 Find more information at: https://docs.meshery.io/reference/mesheryctl/model/list`,
 	Example: `
 // List of models

--- a/mesheryctl/internal/cli/root/model/model.go
+++ b/mesheryctl/internal/cli/root/model/model.go
@@ -6,7 +6,7 @@
 //
 //     http://www.apache.org/licenses/LICENSE-2.0
 //
-// Unless required by a, filepath.Dir(${1:}modelDefPathpplicable law or agreed to in writing, software
+// Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
@@ -42,7 +42,7 @@ var (
 // ModelCmd represents the mesheryctl model command
 var ModelCmd = &cobra.Command{
 	Use:   "model",
-	Short: "Manage models in the registery",
+	Short: "Manage models in the registry",
 	Long: `Export, generate, import, list, search and view model(s) and detailed informations
 Find more information at: https://docs.meshery.io/reference/mesheryctl/model`,
 	Example: `

--- a/mesheryctl/internal/cli/root/model/view.go
+++ b/mesheryctl/internal/cli/root/model/view.go
@@ -30,7 +30,7 @@ Find more information at: https://docs.meshery.io/reference/mesheryctl/model/vie
 // View a specific model from current provider by using [model-name] or [model-id] in default format yaml
 mesheryctl model view [model-name]
 
-// View a specific model in specifed format
+// View a specific model in specified format
 mesheryctl model view [model-name] --output-format [json|yaml]
 
 // View a specific model in specified format and save it as a file


### PR DESCRIPTION
**Notes for Reviewers**

Resolves the typos, misspelled internal function names, and corrupted Apache 2.0 license header across the `mesheryctl model` subcommands, exactly as itemized in #19135. No behavior change — string, identifier, and comment fixes only.

Changes:
- `model.go` — restore corrupted Apache 2.0 license header (line 9); fix `registery` → `registry` in command short help
- `list.go` — fix `pagingation` → `pagination` in long help
- `view.go` — fix `specifed` → `specified` in example comment
- `import.go` — rename internal funcs `displayEmtpyModel` → `displayEmptyModel` and `displayEntitisIfModel` → `displayEntitiesIfModel`; fix `palce` → `place` comment
- `init.go` — fix `didn'tv` → `didn't` comment

The renamed functions are unexported and referenced only within the `model` package, so this is not a public API change.

Validation (scoped to the touched package):
- `go build ./mesheryctl/internal/cli/root/model/` — passes
- `go vet ./mesheryctl/internal/cli/root/model/` — passes
- `go test --short ./mesheryctl/internal/cli/root/model/` — ok
- `golangci-lint run --config=.github/.golangci.yml ./mesheryctl/internal/cli/root/model/...` — 0 issues
- `gofmt -l` — clean

- This PR fixes #19135

**[Signed commits](https://github.com/meshery/meshery/blob/master/CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [x] Yes, I signed my commits.