### PR TITLE
server: return structured MeshKit errors for workspace input validation

### DIFF
--- a/server/handlers/workspace_handlers.go
+++ b/server/handlers/workspace_handlers.go
@@ -97,7 +97,7 @@ func (h *Handler) GetWorkspacesHandler(w http.ResponseWriter, req *http.Request,
 	if orgID == "" {
 		missingInput := models.ErrWorkspaceMissingInput()
 		h.log.Error(missingInput)
-		writeJSONError(w, missingInput.Error(), http.StatusBadRequest)
+		writeMeshkitError(w, missingInput, http.StatusBadRequest)
 		return
 	}
 	resp, err := provider.GetWorkspaces(token, q.Get("page"), q.Get("pagesize"), q.Get("search"), q.Get("order"), q.Get("filter"), orgID)
@@ -125,7 +125,7 @@ func (h *Handler) GetWorkspaceByIdHandler(w http.ResponseWriter, r *http.Request
 	if orgID == "" {
 		missingInput := models.ErrWorkspaceMissingInput()
 		h.log.Error(missingInput)
-		writeJSONError(w, missingInput.Error(), http.StatusBadRequest)
+		writeMeshkitError(w, missingInput, http.StatusBadRequest)
 		return
 	}
 	resp, err := provider.GetWorkspaceByID(r, workspaceID, orgID)


### PR DESCRIPTION
## Related Issue

Closes #19841

## Summary

This change updates workspace input validation error handling to use structured MeshKit error responses.

`GetWorkspacesHandler` and `GetWorkspaceByIdHandler` were creating and logging `models.ErrWorkspaceMissingInput()`, but returning the error through `writeJSONError()`, which discarded the structured MeshKit error metadata.

This PR replaces those responses with `writeMeshkitError()` so that clients receive the documented MeshKit error payload associated with `meshery-server-1375`.

## Changes

* Replaced `writeJSONError()` with `writeMeshkitError()` in:

  * `GetWorkspacesHandler`
  * `GetWorkspaceByIdHandler`

## Testing

Attempted to run:

`go test ./server/handlers/...`

Local execution encountered a CGO/SQLite environment issue unrelated to this change:

`Binary was compiled with 'CGO_ENABLED=0', go-sqlite3 requires cgo to work`
