### PR TITLE
fix(docker): ship policy-engine wasm and wasm_exec.js in server image

### DIFF
--- a/install/docker/Dockerfile
+++ b/install/docker/Dockerfile
@@ -20,7 +20,7 @@ RUN go clean -modcache; cd server; cd cmd; GOPROXY=https://proxy.golang.org GOSU
 FROM golang:1.25.5 AS meshery-wasm
 WORKDIR /github.com/meshery/meshery
 ADD . .
-RUN cd server/policies/wasm && \
+RUN mkdir -p /wasm-dist && cd server/policies/wasm && \
     GOOS=js GOARCH=wasm GOPROXY=https://proxy.golang.org GOSUMDB=off \
         go build -trimpath -ldflags="-w -s" -o /wasm-dist/policy_engine.wasm . && \
     cp "$(go env GOROOT)/lib/wasm/wasm_exec.js" /wasm-dist/wasm_exec.js && \

--- a/install/docker/Dockerfile
+++ b/install/docker/Dockerfile
@@ -9,6 +9,25 @@ WORKDIR /github.com/meshery/meshery
 ADD . .
 RUN go clean -modcache; cd server; cd cmd; GOPROXY=https://proxy.golang.org GOSUMDB=off go build -ldflags="-w -s -X main.globalTokenForAnonymousResults=$TOKEN -X main.version=$GIT_VERSION -X main.commitsha=$GIT_COMMITSHA -X main.releasechannel=$RELEASE_CHANNEL" -tags draft -a -o /meshery .
 
+# Compile the Go relationship/policy engine to WebAssembly and stage Go's
+# wasm_exec.js runtime glue. ui/pages/_document.tsx loads
+# /static/wasm/wasm_exec.js on every page, and the engine fetches
+# /static/wasm/policy_engine.wasm at runtime. Both are .gitignore'd artifacts
+# emitted by the `wasm-engine` Makefile target, which this container build never
+# ran -- so the request fell through to the SPA HTML shell and the browser
+# refused to execute it (MIME 'text/plain'). Full source is copied because
+# server/policies/wasm/go.mod sets `replace github.com/meshery/meshery => ../../../`.
+FROM golang:1.25.5 AS meshery-wasm
+WORKDIR /github.com/meshery/meshery
+ADD . .
+RUN cd server/policies/wasm && \
+    GOOS=js GOARCH=wasm GOPROXY=https://proxy.golang.org GOSUMDB=off \
+        go build -trimpath -ldflags="-w -s" -o /wasm-dist/policy_engine.wasm . && \
+    cp "$(go env GOROOT)/lib/wasm/wasm_exec.js" /wasm-dist/wasm_exec.js && \
+    awk '{ print; if (index($0, "chdir() { throw enosys(); },") > 0) { print "\t\t\tenv: {},"; found=1 } } END { exit(found ? 0 : 1) }' \
+        /wasm-dist/wasm_exec.js > /wasm-dist/wasm_exec.js.tmp && \
+    mv /wasm-dist/wasm_exec.js.tmp /wasm-dist/wasm_exec.js
+
 FROM node:22-alpine AS base-node
 
 # Installing NodeJS Dependencies
@@ -30,6 +49,11 @@ FROM base-node AS meshery-ui-builder
 WORKDIR /app
 COPY --from=meshery-ui-deps /app/node_modules ./node_modules
 COPY ui .
+# Stage the relationship/policy engine wasm + Go wasm runtime glue into the UI's
+# public assets *before* the build so `next build` (output: 'export') emits them
+# to out/static/wasm -- the path Meshery serves the UI from
+# (server/router/server.go: ServeUI "../../ui/out/").
+COPY --from=meshery-wasm /wasm-dist/ ./public/static/wasm/
 # Disable NextJS Telemetry data collect
 ENV NEXT_TELEMETRY_DISABLED=1
 RUN npm run build


### PR DESCRIPTION
## Problem

On every Meshery UI page, `ui/pages/_document.tsx` injects:

```html
<script async src="/static/wasm/wasm_exec.js"></script>
```

This is Go's runtime glue for the client-side relationship/policy engine (`policy_engine.wasm`). In images built from `install/docker/Dockerfile` the file is missing, so the request falls through to the SPA HTML shell and the browser reports, on every page:

```
/static/wasm/wasm_exec.js   Failed to load resource: the server responded with a status of 404
Refused to execute script from '.../static/wasm/wasm_exec.js' because its MIME type
('text/plain') is not executable, and strict MIME type checking is enabled.
```

Reproducible today on `playground.meshery.io` (e.g. on `/extension/meshmap`): fetching `/static/wasm/wasm_exec.js` returns the `Provider | Meshery` HTML shell instead of JavaScript.

## Root cause

`/static/wasm/{wasm_exec.js,policy_engine.wasm}` are generated by the `wasm-engine` Makefile target and are `.gitignore`d (`ui/public/static/wasm/*`, `server/policies/wasm/*`). `wasm-engine` is a prerequisite of the local `ui-build` / `ui-meshery-build` flow, but the Docker build runs `npm run build` directly and never invokes it — so the artifacts are never produced and never reach the served UI assets.

The server serves the UI from `ui/out/` (`server/router/server.go` → `ServeUI(..., "../../ui/out/")`), and Next.js (`output: 'export'`) copies `public/*` → `out/*` at build time.

## Fix

- Add a `meshery-wasm` build stage that compiles `server/policies/wasm` to WebAssembly and stages Go's `wasm_exec.js`, applying the same `process.env` polyfill as `wasm-engine` (and failing the build if the patch anchor ever drifts).
- Copy the artifacts into the UI's `public/static/wasm/` **before** `next build`, so the static export carries them into `ui/out/static/wasm/`, which the server serves.

Full source is copied in the wasm stage because `server/policies/wasm/go.mod` uses `replace github.com/meshery/meshery => ../../../`.

## Testing

- `docker build -f install/docker/Dockerfile .` succeeds, and `/app/ui/out/static/wasm/wasm_exec.js` and `/app/ui/out/static/wasm/policy_engine.wasm` are present in the resulting image.
- Loading any UI page no longer logs the `wasm_exec.js` 404 / MIME console errors, and `window.Go` is defined.
