### PR TITLE
fix: Reinstate install/deployment_yamls for mesheryctl system reset

### DIFF
--- a/install/deployment_yamls/istio.yaml
+++ b/install/deployment_yamls/istio.yaml
@@ -1,0 +1,37 @@
+# Sample VS and GW for deployment of Meshery on Istio
+apiVersion: networking.istio.io/v1alpha3
+kind: Gateway
+metadata:
+  name: meshery-gateway
+  namespace: meshery
+spec:
+  selector:
+    istio: ingressgateway # use istio default controller
+  servers:
+  - port:
+      number: 80
+      name: http
+      protocol: HTTP
+    hosts:
+    - "*"
+---
+apiVersion: networking.istio.io/v1alpha3
+kind: VirtualService
+metadata:
+  name: meshery
+  namespace: meshery
+spec:
+  hosts:
+  - "*"
+  gateways:
+  - meshery-gateway
+  http:
+  - match:
+    - uri:
+        prefix: /
+    route:
+    - destination:
+        host: meshery
+        port:
+          number: 9081
+---

--- a/install/deployment_yamls/k8s/meshery-app-mesh-deployment.yaml
+++ b/install/deployment_yamls/k8s/meshery-app-mesh-deployment.yaml
@@ -1,0 +1,32 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  annotations:
+    kompose.cmd: kompose convert -f ../docker-compose.yaml
+    kompose.version: 1.32.0 ()
+  creationTimestamp: null
+  labels:
+    io.kompose.service: meshery-app-mesh
+  name: meshery-app-mesh
+spec:
+  selector:
+    matchLabels:
+      io.kompose.service: meshery-app-mesh
+  replicas: 1
+  strategy: {}
+  template:
+    metadata:
+      creationTimestamp: null
+      labels:
+        io.kompose.service: meshery-app-mesh
+    spec:
+      serviceAccount: meshery-server
+      containers:
+      - image: meshery/meshery-app-mesh:stable-latest
+        imagePullPolicy: Always
+        name: meshery-app-mesh
+        ports:
+        - containerPort: 10005
+        resources: {}
+      restartPolicy: Always
+status: {}

--- a/install/deployment_yamls/k8s/meshery-app-mesh-deployment.yaml
+++ b/install/deployment_yamls/k8s/meshery-app-mesh-deployment.yaml
@@ -20,7 +20,7 @@ spec:
       labels:
         io.kompose.service: meshery-app-mesh
     spec:
-      serviceAccount: meshery-server
+      serviceAccountName: meshery-server
       containers:
       - image: meshery/meshery-app-mesh:stable-latest
         imagePullPolicy: Always

--- a/install/deployment_yamls/k8s/meshery-app-mesh-service.yaml
+++ b/install/deployment_yamls/k8s/meshery-app-mesh-service.yaml
@@ -1,0 +1,19 @@
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    kompose.cmd: kompose convert -f ../docker-compose.yaml
+    kompose.version: 1.32.0 ()
+  creationTimestamp: null
+  labels:
+    io.kompose.service: meshery-app-mesh
+  name: meshery-app-mesh
+spec:
+  ports:
+  - name: "10005"
+    port: 10005
+    targetPort: 10005
+  selector:
+    io.kompose.service: meshery-app-mesh
+status:
+  loadBalancer: {}

--- a/install/deployment_yamls/k8s/meshery-cilium-deployment.yaml
+++ b/install/deployment_yamls/k8s/meshery-cilium-deployment.yaml
@@ -1,0 +1,32 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  annotations:
+    kompose.cmd: kompose convert -f ../docker-compose.yaml
+    kompose.version: 1.32.0 ()
+  creationTimestamp: null
+  labels:
+    io.kompose.service: meshery-cilium
+  name: meshery-cilium
+spec:
+  selector:
+    matchLabels:
+      io.kompose.service: meshery-cilium
+  replicas: 1
+  strategy: {}
+  template:
+    metadata:
+      creationTimestamp: null
+      labels:
+        io.kompose.service: meshery-cilium
+    spec:
+      serviceAccount: meshery-server
+      containers:
+      - image: meshery/meshery-cilium:stable-latest
+        imagePullPolicy: Always
+        name: meshery-cilium
+        ports:
+        - containerPort: 10012
+        resources: {}
+      restartPolicy: Always
+status: {}

--- a/install/deployment_yamls/k8s/meshery-cilium-deployment.yaml
+++ b/install/deployment_yamls/k8s/meshery-cilium-deployment.yaml
@@ -20,7 +20,7 @@ spec:
       labels:
         io.kompose.service: meshery-cilium
     spec:
-      serviceAccount: meshery-server
+      serviceAccountName: meshery-server
       containers:
       - image: meshery/meshery-cilium:stable-latest
         imagePullPolicy: Always

--- a/install/deployment_yamls/k8s/meshery-cilium-service.yaml
+++ b/install/deployment_yamls/k8s/meshery-cilium-service.yaml
@@ -1,0 +1,19 @@
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    kompose.cmd: kompose convert -f ../docker-compose.yaml
+    kompose.version: 1.32.0 ()
+  creationTimestamp: null
+  labels:
+    io.kompose.service: meshery-cilium
+  name: meshery-cilium
+spec:
+  ports:
+  - name: "10012"
+    port: 10012
+    targetPort: 10012
+  selector:
+    io.kompose.service: meshery-cilium
+status:
+  loadBalancer: {}

--- a/install/deployment_yamls/k8s/meshery-consul-deployment.yaml
+++ b/install/deployment_yamls/k8s/meshery-consul-deployment.yaml
@@ -1,0 +1,32 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  annotations:
+    kompose.cmd: kompose convert -f ../docker-compose.yaml
+    kompose.version: 1.32.0 ()
+  creationTimestamp: null
+  labels:
+    io.kompose.service: meshery-consul
+  name: meshery-consul
+spec:
+  selector:
+    matchLabels:
+      io.kompose.service: meshery-consul
+  replicas: 1
+  strategy: {}
+  template:
+    metadata:
+      creationTimestamp: null
+      labels:
+        io.kompose.service: meshery-consul
+    spec:
+      serviceAccount: meshery-server
+      containers:
+      - image: meshery/meshery-consul:stable-latest
+        imagePullPolicy: Always
+        name: meshery-consul
+        ports:
+        - containerPort: 10002
+        resources: {}
+      restartPolicy: Always
+status: {}

--- a/install/deployment_yamls/k8s/meshery-consul-deployment.yaml
+++ b/install/deployment_yamls/k8s/meshery-consul-deployment.yaml
@@ -20,7 +20,7 @@ spec:
       labels:
         io.kompose.service: meshery-consul
     spec:
-      serviceAccount: meshery-server
+      serviceAccountName: meshery-server
       containers:
       - image: meshery/meshery-consul:stable-latest
         imagePullPolicy: Always

--- a/install/deployment_yamls/k8s/meshery-consul-service.yaml
+++ b/install/deployment_yamls/k8s/meshery-consul-service.yaml
@@ -1,0 +1,19 @@
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    kompose.cmd: kompose convert -f ../docker-compose.yaml
+    kompose.version: 1.32.0 ()
+  # creationTimestamp: null
+  labels:
+    io.kompose.service: meshery-consul
+  name: meshery-consul
+spec:
+  ports:
+  - name: "10002"
+    port: 10002
+    targetPort: 10002
+  selector:
+    io.kompose.service: meshery-consul
+status:
+  loadBalancer: {}

--- a/install/deployment_yamls/k8s/meshery-consul-service.yaml
+++ b/install/deployment_yamls/k8s/meshery-consul-service.yaml
@@ -4,7 +4,7 @@ metadata:
   annotations:
     kompose.cmd: kompose convert -f ../docker-compose.yaml
     kompose.version: 1.32.0 ()
-  # creationTimestamp: null
+  creationTimestamp: null
   labels:
     io.kompose.service: meshery-consul
   name: meshery-consul

--- a/install/deployment_yamls/k8s/meshery-deployment.yaml
+++ b/install/deployment_yamls/k8s/meshery-deployment.yaml
@@ -1,0 +1,53 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  annotations:
+    kompose.cmd: kompose convert -f ../docker-compose.yaml
+    kompose.version: 1.32.0 ()
+  creationTimestamp: null
+  labels:
+    io.kompose.service: meshery
+  name: meshery
+spec:
+  selector:
+    matchLabels:
+      io.kompose.service: meshery
+  replicas: 1
+  strategy: {}
+  template:
+    metadata:
+      creationTimestamp: null
+      labels:
+        io.kompose.service: meshery
+    spec:
+      serviceAccountName: meshery-server
+      containers:
+      - env:
+        - name: EVENT
+          value: mesheryLocal
+        - name: PROVIDER_BASE_URLS
+          value: https://cloud.meshery.io,https://perf.smp-spec.io,https://cloud.layer5.io,https://platform.tata-consulting.co.uk,https://collab.eti.cisco.com,https://kickstart.metabit.com,https://provider.od10.in
+        - name: ADAPTER_URLS
+          value: meshery-istio:10000 meshery-linkerd:10001 meshery-consul:10002 meshery-nsm:10004 meshery-app-mesh:10005 meshery-kuma:10007 meshery-nginx-sm:10010
+        image: meshery/meshery:stable-latest
+        imagePullPolicy: Always
+        name: meshery
+        ports:
+        - containerPort: 8080
+        livenessProbe:
+          httpGet:
+            path: /healthz/live
+            port: 8080
+          initialDelaySeconds: 80
+          periodSeconds: 12
+          failureThreshold: 4
+        readinessProbe:
+          httpGet:
+            path: /healthz/ready
+            port: 8080
+          initialDelaySeconds: 10
+          periodSeconds: 4
+          failureThreshold: 4
+        resources: {}
+      restartPolicy: Always
+status: {}

--- a/install/deployment_yamls/k8s/meshery-istio-deployment.yaml
+++ b/install/deployment_yamls/k8s/meshery-istio-deployment.yaml
@@ -1,0 +1,32 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  annotations:
+    kompose.cmd: kompose convert -f ../docker-compose.yaml
+    kompose.version: 1.32.0 ()
+  creationTimestamp: null
+  labels:
+    io.kompose.service: meshery-istio
+  name: meshery-istio
+spec:
+  selector:
+    matchLabels:
+      io.kompose.service: meshery-istio
+  replicas: 1
+  strategy: {}
+  template:
+    metadata:
+      creationTimestamp: null
+      labels:
+        io.kompose.service: meshery-istio
+    spec:
+      serviceAccount: meshery-server
+      containers:
+      - image: meshery/meshery-istio:stable-latest
+        imagePullPolicy: Always
+        name: meshery-istio
+        ports:
+        - containerPort: 10000
+        resources: {}
+      restartPolicy: Always
+status: {}

--- a/install/deployment_yamls/k8s/meshery-istio-deployment.yaml
+++ b/install/deployment_yamls/k8s/meshery-istio-deployment.yaml
@@ -20,7 +20,7 @@ spec:
       labels:
         io.kompose.service: meshery-istio
     spec:
-      serviceAccount: meshery-server
+      serviceAccountName: meshery-server
       containers:
       - image: meshery/meshery-istio:stable-latest
         imagePullPolicy: Always

--- a/install/deployment_yamls/k8s/meshery-istio-service.yaml
+++ b/install/deployment_yamls/k8s/meshery-istio-service.yaml
@@ -1,0 +1,19 @@
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    kompose.cmd: kompose convert -f ../docker-compose.yaml
+    kompose.version: 1.32.0 ()
+  creationTimestamp: null
+  labels:
+    io.kompose.service: meshery-istio
+  name: meshery-istio
+spec:
+  ports:
+  - name: "10000"
+    port: 10000
+    targetPort: 10000
+  selector:
+    io.kompose.service: meshery-istio
+status:
+  loadBalancer: {}

--- a/install/deployment_yamls/k8s/meshery-kuma-deployment.yaml
+++ b/install/deployment_yamls/k8s/meshery-kuma-deployment.yaml
@@ -1,0 +1,32 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  annotations:
+    kompose.cmd: kompose convert -f ../docker-compose.yaml
+    kompose.version: 1.32.0 ()
+  creationTimestamp: null
+  labels:
+    io.kompose.service: meshery-kuma
+  name: meshery-kuma
+spec:
+  selector:
+    matchLabels:
+      io.kompose.service: meshery-kuma
+  replicas: 1
+  strategy: {}
+  template:
+    metadata:
+      creationTimestamp: null
+      labels:
+        io.kompose.service: meshery-kuma
+    spec:
+      serviceAccount: meshery-server
+      containers:
+      - image: meshery/meshery-kuma:stable-latest
+        imagePullPolicy: Always
+        name: meshery-kuma
+        ports:
+        - containerPort: 10007
+        resources: {}
+      restartPolicy: Always
+status: {}

--- a/install/deployment_yamls/k8s/meshery-kuma-deployment.yaml
+++ b/install/deployment_yamls/k8s/meshery-kuma-deployment.yaml
@@ -20,7 +20,7 @@ spec:
       labels:
         io.kompose.service: meshery-kuma
     spec:
-      serviceAccount: meshery-server
+      serviceAccountName: meshery-server
       containers:
       - image: meshery/meshery-kuma:stable-latest
         imagePullPolicy: Always

--- a/install/deployment_yamls/k8s/meshery-kuma-service.yaml
+++ b/install/deployment_yamls/k8s/meshery-kuma-service.yaml
@@ -1,0 +1,19 @@
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    kompose.cmd: kompose convert -f ../docker-compose.yaml
+    kompose.version: 1.32.0 ()
+  creationTimestamp: null
+  labels:
+    io.kompose.service: meshery-kuma
+  name: meshery-kuma
+spec:
+  ports:
+    - name: "10007"
+      port: 10007
+      targetPort: 10007
+  selector:
+    io.kompose.service: meshery-kuma
+status:
+  loadBalancer: {}

--- a/install/deployment_yamls/k8s/meshery-linkerd-deployment.yaml
+++ b/install/deployment_yamls/k8s/meshery-linkerd-deployment.yaml
@@ -1,0 +1,32 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  annotations:
+    kompose.cmd: kompose convert -f ../docker-compose.yaml
+    kompose.version: 1.32.0 ()
+  creationTimestamp: null
+  labels:
+    io.kompose.service: meshery-linkerd
+  name: meshery-linkerd
+spec:
+  selector:
+    matchLabels:
+      io.kompose.service: meshery-linkerd
+  replicas: 1
+  strategy: {}
+  template:
+    metadata:
+      creationTimestamp: null
+      labels:
+        io.kompose.service: meshery-linkerd
+    spec:
+      serviceAccount: meshery-server
+      containers:
+      - image: meshery/meshery-linkerd:stable-latest
+        imagePullPolicy: Always
+        name: meshery-linkerd
+        ports:
+        - containerPort: 10001
+        resources: {}
+      restartPolicy: Always
+status: {}

--- a/install/deployment_yamls/k8s/meshery-linkerd-deployment.yaml
+++ b/install/deployment_yamls/k8s/meshery-linkerd-deployment.yaml
@@ -20,7 +20,7 @@ spec:
       labels:
         io.kompose.service: meshery-linkerd
     spec:
-      serviceAccount: meshery-server
+      serviceAccountName: meshery-server
       containers:
       - image: meshery/meshery-linkerd:stable-latest
         imagePullPolicy: Always

--- a/install/deployment_yamls/k8s/meshery-linkerd-service.yaml
+++ b/install/deployment_yamls/k8s/meshery-linkerd-service.yaml
@@ -1,0 +1,19 @@
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    kompose.cmd: kompose convert -f ../docker-compose.yaml
+    kompose.version: 1.32.0 ()
+  creationTimestamp: null
+  labels:
+    io.kompose.service: meshery-linkerd
+  name: meshery-linkerd
+spec:
+  ports:
+  - name: "10001"
+    port: 10001
+    targetPort: 10001
+  selector:
+    io.kompose.service: meshery-linkerd
+status:
+  loadBalancer: {}

--- a/install/deployment_yamls/k8s/meshery-nginx-sm-deployment.yaml
+++ b/install/deployment_yamls/k8s/meshery-nginx-sm-deployment.yaml
@@ -1,0 +1,32 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  annotations:
+    kompose.cmd: kompose convert -f ../docker-compose.yaml
+    kompose.version: 1.32.0 ()
+  creationTimestamp: null
+  labels:
+    io.kompose.service: meshery-nginx-sm
+  name: meshery-nginx-sm
+spec:
+  selector:
+    matchLabels:
+      io.kompose.service: meshery-nginx-sm
+  replicas: 1
+  strategy: {}
+  template:
+    metadata:
+      creationTimestamp: null
+      labels:
+        io.kompose.service: meshery-nginx-sm
+    spec:
+      serviceAccount: meshery-server
+      containers:
+      - image: meshery/meshery-nginx-sm:stable-latest
+        imagePullPolicy: Always
+        name: meshery-nginx-sm
+        ports:
+        - containerPort: 10010
+        resources: {}
+      restartPolicy: Always
+status: {}

--- a/install/deployment_yamls/k8s/meshery-nginx-sm-deployment.yaml
+++ b/install/deployment_yamls/k8s/meshery-nginx-sm-deployment.yaml
@@ -20,7 +20,7 @@ spec:
       labels:
         io.kompose.service: meshery-nginx-sm
     spec:
-      serviceAccount: meshery-server
+      serviceAccountName: meshery-server
       containers:
       - image: meshery/meshery-nginx-sm:stable-latest
         imagePullPolicy: Always

--- a/install/deployment_yamls/k8s/meshery-nginx-sm-service.yaml
+++ b/install/deployment_yamls/k8s/meshery-nginx-sm-service.yaml
@@ -1,0 +1,19 @@
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    kompose.cmd: kompose convert -f ../docker-compose.yaml
+    kompose.version: 1.32.0 ()
+  creationTimestamp: null
+  labels:
+    io.kompose.service: meshery-nginx-sm
+  name: meshery-nginx-sm
+spec:
+  ports:
+  - name: "10010"
+    port: 10010
+    targetPort: 10010
+  selector:
+    io.kompose.service: meshery-nginx-sm
+status:
+  loadBalancer: {}

--- a/install/deployment_yamls/k8s/meshery-nsm-deployment.yaml
+++ b/install/deployment_yamls/k8s/meshery-nsm-deployment.yaml
@@ -1,0 +1,32 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  annotations:
+    kompose.cmd: kompose convert -f ../docker-compose.yaml
+    kompose.version: 1.32.0 ()
+  creationTimestamp: null
+  labels:
+    io.kompose.service: meshery-nsm
+  name: meshery-nsm
+spec:
+  selector:
+    matchLabels:
+      io.kompose.service: meshery-nsm
+  replicas: 1
+  strategy: {}
+  template:
+    metadata:
+      creationTimestamp: null
+      labels:
+        io.kompose.service: meshery-nsm
+    spec:
+      serviceAccount: meshery-server
+      containers:
+        - image: meshery/meshery-nsm:stable-latest
+          imagePullPolicy: Always
+          name: meshery-nsm
+          ports:
+            - containerPort: 10004
+          resources: {}
+      restartPolicy: Always
+status: {}

--- a/install/deployment_yamls/k8s/meshery-nsm-deployment.yaml
+++ b/install/deployment_yamls/k8s/meshery-nsm-deployment.yaml
@@ -20,7 +20,7 @@ spec:
       labels:
         io.kompose.service: meshery-nsm
     spec:
-      serviceAccount: meshery-server
+      serviceAccountName: meshery-server
       containers:
         - image: meshery/meshery-nsm:stable-latest
           imagePullPolicy: Always

--- a/install/deployment_yamls/k8s/meshery-nsm-service.yaml
+++ b/install/deployment_yamls/k8s/meshery-nsm-service.yaml
@@ -1,0 +1,19 @@
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    kompose.cmd: kompose convert -f ../docker-compose.yaml
+    kompose.version: 1.32.0 ()
+  creationTimestamp: null
+  labels:
+    io.kompose.service: meshery-nsm
+  name: meshery-nsm
+spec:
+  ports:
+  - name: "10004"
+    port: 10004
+    targetPort: 10004
+  selector:
+    io.kompose.service: meshery-nsm
+status:
+  loadBalancer: {}

--- a/install/deployment_yamls/k8s/meshery-service.yaml
+++ b/install/deployment_yamls/k8s/meshery-service.yaml
@@ -1,0 +1,20 @@
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    kompose.cmd: kompose convert -f ../docker-compose.yaml
+    kompose.version: 1.32.0 ()
+  creationTimestamp: null
+  labels:
+    io.kompose.service: meshery
+  name: meshery
+spec:
+  ports:
+  - name: "http"
+    port: 9081
+    targetPort: 8080
+  selector:
+    io.kompose.service: meshery
+  type: LoadBalancer
+
+

--- a/install/deployment_yamls/k8s/meshery-traefik-mesh-deployment.yaml
+++ b/install/deployment_yamls/k8s/meshery-traefik-mesh-deployment.yaml
@@ -1,0 +1,32 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  annotations:
+    kompose.cmd: kompose convert -f ../docker-compose.yaml
+    kompose.version: 1.32.0 ()
+  creationTimestamp: null
+  labels:
+    io.kompose.service: meshery-traefik-mesh
+  name: meshery-traefik-mesh
+spec:
+  selector:
+    matchLabels:
+      io.kompose.service: meshery-traefik-mesh
+  replicas: 1
+  strategy: {}
+  template:
+    metadata:
+      creationTimestamp: null
+      labels:
+        io.kompose.service: meshery-traefik-mesh
+    spec:
+      serviceAccount: meshery-server
+      containers:
+      - image: meshery/meshery-traefik-mesh:stable-latest
+        imagePullPolicy: Always
+        name: meshery-traefik-mesh
+        ports:
+        - containerPort: 10006
+        resources: {}
+      restartPolicy: Always
+status: {}

--- a/install/deployment_yamls/k8s/meshery-traefik-mesh-deployment.yaml
+++ b/install/deployment_yamls/k8s/meshery-traefik-mesh-deployment.yaml
@@ -20,7 +20,7 @@ spec:
       labels:
         io.kompose.service: meshery-traefik-mesh
     spec:
-      serviceAccount: meshery-server
+      serviceAccountName: meshery-server
       containers:
       - image: meshery/meshery-traefik-mesh:stable-latest
         imagePullPolicy: Always

--- a/install/deployment_yamls/k8s/meshery-traefik-mesh-service.yaml
+++ b/install/deployment_yamls/k8s/meshery-traefik-mesh-service.yaml
@@ -1,0 +1,19 @@
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    kompose.cmd: kompose convert -f ../docker-compose.yaml
+    kompose.version: 1.32.0 ()
+  creationTimestamp: null
+  labels:
+    io.kompose.service: meshery-traefik-mesh
+  name: meshery-traefik-mesh
+spec:
+  ports:
+  - name: "10000"
+    port: 10006
+    targetPort: 10006
+  selector:
+    io.kompose.service: meshery-traefik-mesh
+status:
+  loadBalancer: {}

--- a/install/deployment_yamls/k8s/meshery-traefik-mesh-service.yaml
+++ b/install/deployment_yamls/k8s/meshery-traefik-mesh-service.yaml
@@ -10,7 +10,7 @@ metadata:
   name: meshery-traefik-mesh
 spec:
   ports:
-  - name: "10000"
+  - name: "10006"
     port: 10006
     targetPort: 10006
   selector:

--- a/install/deployment_yamls/k8s/service-account.yaml
+++ b/install/deployment_yamls/k8s/service-account.yaml
@@ -1,0 +1,37 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: meshery-server
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: meshery-server
+  labels:
+    app: meshery
+rules:
+- apiGroups:
+  - '*'
+  resources:
+  - '*'
+  verbs:
+  - '*'
+- nonResourceURLs: ["/metrics", "/health", "/ping"]
+  verbs:
+  - get
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: meshery-server
+  labels:
+    app: meshery
+roleRef:
+  kind: ClusterRole
+  name: meshery-server
+  apiGroup: rbac.authorization.k8s.io
+subjects:
+- kind: ServiceAccount
+  name: meshery-server
+  namespace: meshery
+---

--- a/install/docker-extension/ui/src/components/utils/constants.js
+++ b/install/docker-extension/ui/src/components/utils/constants.js
@@ -28,8 +28,16 @@ export const REMOTE_PROVIDERS = [
         url: "https://cloud.layer5.io",
     },
     {
-        name: "TCS Labs",
-        url: "https://meshery.tcs-labs.in",
+        name: "TATA Labs",
+        url: "https://platform.tata-consulting.co.uk",
+    },
+    {
+        name: "Cisco ET&I",
+        url: "https://collab.eti.cisco.com",
+    },
+    {
+        name: "Metabit Trading",
+        url: "https://kickstart.metabit.com",
     },
     {
         name: "OD10 Ventures",

--- a/install/docker/docker-compose.yaml
+++ b/install/docker/docker-compose.yaml
@@ -4,7 +4,7 @@ services:
     labels:
       - "com.centurylinklabs.watchtower.enable=true"
     environment:
-      - "PROVIDER_BASE_URLS=https://cloud.meshery.io,https://perf.smp-spec.io,https://cloud.layer5.io,https://meshery.tcs-labs.in,https://provider.od10.in"
+      - "PROVIDER_BASE_URLS=https://cloud.meshery.io,https://perf.smp-spec.io,https://cloud.layer5.io,https://platform.tata-consulting.co.uk,https://collab.eti.cisco.com,https://kickstart.metabit.com,https://provider.od10.in"
       # - "ADAPTER_URLS=meshery-istio:10000 meshery-linkerd:10001 meshery-consul:10002 meshery-nsm:10004 meshery-app-mesh:10005 meshery-kuma:10007 meshery-traefik-mesh:10006 meshery-nginx-sm:10010 meshery-cilium:10012"
       - "EVENT=mesheryLocal"
       - "KUBECONFIG_FOLDER=/home/appuser/.kube"

--- a/install/kubernetes/helm/meshery/values.yaml
+++ b/install/kubernetes/helm/meshery/values.yaml
@@ -13,7 +13,7 @@ image:
 
 env:
   EVENT: mesheryLocal
-  PROVIDER_BASE_URLS: "https://cloud.meshery.io,https://perf.smp-spec.io,https://cloud.layer5.io,https://meshery.tcs-labs.in,https://provider.od10.in"
+  PROVIDER_BASE_URLS: "https://cloud.meshery.io,https://perf.smp-spec.io,https://cloud.layer5.io,https://platform.tata-consulting.co.uk,https://collab.eti.cisco.com,https://kickstart.metabit.com,https://provider.od10.in"
   ADAPTER_URLS: meshery-istio:10000 meshery-linkerd:10001 meshery-consul:10002 meshery-kuma:10007 meshery-nginx-sm:10010 meshery-nsm:10004 meshery-app-mesh:10005 meshery-traefik-mesh:10006 meshery-cilium:10012
   PROVIDER: ""
   KEYS_PATH: "../../server/permissions/keys.csv"

--- a/install/mesheryapp.dockerapp/docker-compose.yml
+++ b/install/mesheryapp.dockerapp/docker-compose.yml
@@ -4,7 +4,7 @@ services:
     labels:
       - ${labels.watchtower}
     environment:
-      - "PROVIDER_BASE_URLS=https://cloud.meshery.io,https://perf.smp-spec.io,https://cloud.layer5.io,https://meshery.tcs-labs.in,https://provider.od10.in"
+      - "PROVIDER_BASE_URLS=https://cloud.meshery.io,https://perf.smp-spec.io,https://cloud.layer5.io,https://platform.tata-consulting.co.uk,https://collab.eti.cisco.com,https://kickstart.metabit.com,https://provider.od10.in"
       - "ADAPTER_URLS=meshery-istio:10000 meshery-linkerd:10001 meshery-consul:10002 meshery-nsm:10004"
       - "EVENT=mesheryLocal"
     ports:

--- a/mesheryctl/pkg/utils/providers_gen.go
+++ b/mesheryctl/pkg/utils/providers_gen.go
@@ -5,4 +5,4 @@ package utils
 // DefaultProviderBaseURLs is the canonical comma-joined list of Meshery's active
 // remote providers, compiled into mesheryctl as the fallback used when the install
 // docker-compose file cannot be downloaded.
-const DefaultProviderBaseURLs = "https://cloud.meshery.io,https://perf.smp-spec.io,https://cloud.layer5.io,https://meshery.tcs-labs.in,https://provider.od10.in"
+const DefaultProviderBaseURLs = "https://cloud.meshery.io,https://perf.smp-spec.io,https://cloud.layer5.io,https://platform.tata-consulting.co.uk,https://collab.eti.cisco.com,https://kickstart.metabit.com,https://provider.od10.in"

--- a/server/models/default_remote_providers.go
+++ b/server/models/default_remote_providers.go
@@ -5,7 +5,7 @@ package models
 // DefaultRemoteProviderURLs is the comma-joined list of active default remote
 // provider URLs. The server seeds it via SetDefault("PROVIDER_BASE_URLS", ...) so
 // operators who do not set the env var still register the canonical providers.
-const DefaultRemoteProviderURLs = "https://cloud.meshery.io,https://perf.smp-spec.io,https://cloud.layer5.io,https://meshery.tcs-labs.in,https://provider.od10.in"
+const DefaultRemoteProviderURLs = "https://cloud.meshery.io,https://perf.smp-spec.io,https://cloud.layer5.io,https://platform.tata-consulting.co.uk,https://collab.eti.cisco.com,https://kickstart.metabit.com,https://provider.od10.in"
 
 // PrimaryProviderURL is the single canonical provider host used by single-URL
 // consumers (the built-in local provider's capability paths, SaaS deep links,


### PR DESCRIPTION

### Description

This PR reinstates the `install/deployment_yamls` directory that was previously removed in `970902f19dec`. 

Currently, running `mesheryctl system reset` throws an `Error walking through manifests` because `mesheryctl` (specifically within `platform.go`) relies on the GitHub API to fetch these static manifests from the `install/deployment_yamls/k8s` directory. Restoring these files allows the CLI to successfully pull the manifests and complete the reset process.

**Notes for Reviewers**
- This PR fixes #19862
- If the long-term goal is to deprecate these static YAMLs in favor of Helm charts, we may want to follow this up by updating `mesheryctl/pkg/utils/platform.go` to pull from Helm, or set up a GitHub Action to auto-generate these YAMLs from the charts to prevent configuration drift.

**[Signed commits](https://github.com/meshery/meshery/blob/master/CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [x] Yes, I signed my commits.

