### PR TITLE
[mesheryctl] model: fix double-wrapped export flag validation error and add tests

### DIFF
--- a/mesheryctl/internal/cli/root/model/export.go
+++ b/mesheryctl/internal/cli/root/model/export.go
@@ -56,15 +56,7 @@ mesheryctl model export [model-name] --discard-components --discard-relationship
 mesheryctl model export [model-name] --version [version (ex: v0.7.3)]
 `,
 	PreRunE: func(cmd *cobra.Command, args []string) error {
-		flagValidator, ok := cmd.Context().Value(mesheryctlflags.FlagValidatorKey).(*mesheryctlflags.FlagValidator)
-		if !ok || flagValidator == nil {
-			return utils.ErrCommandContextMissing("flags-validator")
-		}
-		err := flagValidator.Validate(exportModelFlagsProvided)
-		if err != nil {
-			return utils.ErrFlagsInvalid(err)
-		}
-		return nil
+		return mesheryctlflags.ValidateCmdFlags(cmd, &exportModelFlagsProvided)
 	},
 	Args: func(_ *cobra.Command, args []string) error {
 		const errMsg = "Usage: mesheryctl model export [model-name]\nRun 'mesheryctl model export --help' to see detailed help message"

--- a/mesheryctl/internal/cli/root/model/export_test.go
+++ b/mesheryctl/internal/cli/root/model/export_test.go
@@ -60,6 +60,8 @@ func TestExportModelToFile(t *testing.T) {
 	defer utils.ResetCommandFlags(ModelCmd, t)
 	testContext := utils.InitTestEnvironment(t)
 	defer utils.StopMockery(t)
+	oldToken := utils.TokenFlag
+	defer func() { utils.TokenFlag = oldToken }()
 	utils.TokenFlag = utils.GetToken(t)
 	mesheryctlflags.InitValidators(ModelCmd)
 

--- a/mesheryctl/internal/cli/root/model/export_test.go
+++ b/mesheryctl/internal/cli/root/model/export_test.go
@@ -1,0 +1,94 @@
+package model
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"runtime"
+	"testing"
+
+	"github.com/jarcoal/httpmock"
+	mesheryctlflags "github.com/meshery/meshery/mesheryctl/internal/cli/pkg/flags"
+	"github.com/meshery/meshery/mesheryctl/pkg/utils"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestExportModel(t *testing.T) {
+	// get current directory
+	_, filename, _, ok := runtime.Caller(0)
+	if !ok {
+		t.Fatal("Not able to get current working directory")
+	}
+	currDir := filepath.Dir(filename)
+
+	const modelName = "model-test-0"
+	const exportUsage = "Usage: mesheryctl model export [model-name]\nRun 'mesheryctl model export --help' to see detailed help message"
+
+	tests := []utils.MesheryCommandTest{
+		{
+			Name:          "given no argument when model export then throw error",
+			Args:          []string{"export"},
+			ExpectError:   true,
+			ExpectedError: utils.ErrInvalidArgument(errors.New("Please provide a model name. " + exportUsage)),
+		},
+		{
+			Name:          "given an invalid output format when model export then throw error",
+			Args:          []string{"export", modelName, "--output-format", "invalid-format"},
+			ExpectError:   true,
+			ExpectedError: utils.ErrFlagsInvalid(errors.New("Invalid value for --output-format 'invalid-format': valid values are json yaml")),
+		},
+		{
+			Name:          "given an invalid output type when model export then throw error",
+			Args:          []string{"export", modelName, "--output-type", "invalid-type"},
+			ExpectError:   true,
+			ExpectedError: utils.ErrFlagsInvalid(errors.New("Invalid value for --output-type 'invalid-type': valid values are oci tar")),
+		},
+		{
+			Name:          "given an invalid version when model export then throw error",
+			Args:          []string{"export", modelName, "--version", "1.0.0"},
+			ExpectError:   true,
+			ExpectedError: utils.ErrFlagsInvalid(errors.New("Invalid value for --version '1.0.0': version must be in format vX.X.X")),
+		},
+	}
+
+	mesheryctlflags.InitValidators(ModelCmd)
+	utils.InvokeMesheryctlTestCommand(t, update, ModelCmd, tests, currDir, "model")
+}
+
+func TestExportModelToFile(t *testing.T) {
+	defer utils.ResetCommandFlags(ModelCmd, t)
+	testContext := utils.InitTestEnvironment(t)
+	defer utils.StopMockery(t)
+	utils.TokenFlag = utils.GetToken(t)
+	mesheryctlflags.InitValidators(ModelCmd)
+
+	const modelName = "test-model"
+	exportedContent := []byte("exported-model-archive-bytes")
+
+	// RunE builds the query string with url.Values.Encode(), which sorts the
+	// keys alphabetically. The defaults are: components/relationships enabled,
+	// file_type=oci, output_format=yaml, page=1.
+	exportURL := fmt.Sprintf("%s/api/meshmodels/export?components=true&file_type=oci&name=%s&output_format=yaml&page=1&relationships=true", testContext.BaseURL, modelName)
+	httpmock.RegisterResponder("GET", exportURL,
+		httpmock.NewBytesResponder(200, exportedContent))
+
+	outputDir := t.TempDir()
+	buf := utils.SetupMeshkitLoggerTesting(t, false)
+	ModelCmd.SetArgs([]string{"export", modelName, "--output-location", outputDir})
+	ModelCmd.SetOut(buf)
+
+	err := ModelCmd.Execute()
+	if err != nil {
+		t.Fatalf("expected export to succeed, got error: %v", err)
+	}
+
+	// The default output type "oci" produces a ".tar" file named after the model.
+	exportedPath := filepath.Join(outputDir, modelName+".tar")
+	got, readErr := os.ReadFile(exportedPath)
+	if readErr != nil {
+		t.Fatalf("expected exported file at %s: %v", exportedPath, readErr)
+	}
+	assert.Equal(t, exportedContent, got)
+	assert.Contains(t, buf.String(), "Exported model to")
+}

--- a/mesheryctl/internal/cli/root/model/export_test.go
+++ b/mesheryctl/internal/cli/root/model/export_test.go
@@ -1,18 +1,19 @@
 package model
 
 import (
+	"bytes"
 	"errors"
 	"fmt"
 	"net/url"
 	"os"
 	"path/filepath"
 	"runtime"
+	"strings"
 	"testing"
 
 	"github.com/jarcoal/httpmock"
 	mesheryctlflags "github.com/meshery/meshery/mesheryctl/internal/cli/pkg/flags"
 	"github.com/meshery/meshery/mesheryctl/pkg/utils"
-	"github.com/stretchr/testify/assert"
 )
 
 func TestExportModel(t *testing.T) {
@@ -100,6 +101,10 @@ func TestExportModelToFile(t *testing.T) {
 	if readErr != nil {
 		t.Fatalf("expected exported file at %s: %v", exportedPath, readErr)
 	}
-	assert.Equal(t, exportedContent, got)
-	assert.Contains(t, buf.String(), "Exported model to")
+	if !bytes.Equal(exportedContent, got) {
+		t.Errorf("exported content mismatch: got %q, want %q", got, exportedContent)
+	}
+	if !strings.Contains(buf.String(), "Exported model to") {
+		t.Errorf("expected completion log, got %q", buf.String())
+	}
 }

--- a/mesheryctl/internal/cli/root/model/export_test.go
+++ b/mesheryctl/internal/cli/root/model/export_test.go
@@ -3,6 +3,7 @@ package model
 import (
 	"errors"
 	"fmt"
+	"net/url"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -68,10 +69,18 @@ func TestExportModelToFile(t *testing.T) {
 	const modelName = "test-model"
 	exportedContent := []byte("exported-model-archive-bytes")
 
-	// RunE builds the query string with url.Values.Encode(), which sorts the
-	// keys alphabetically. The defaults are: components/relationships enabled,
-	// file_type=oci, output_format=yaml, page=1.
-	exportURL := fmt.Sprintf("%s/api/meshmodels/export?components=true&file_type=oci&name=%s&output_format=yaml&page=1&relationships=true", testContext.BaseURL, modelName)
+	// Mirror the query RunE builds, so the expectation tracks export.go rather
+	// than restating url.Values.Encode() ordering. Flag defaults: components and
+	// relationships enabled, file_type=oci, output_format=yaml, page=1.
+	queryParams := url.Values{}
+	queryParams.Set("name", modelName)
+	queryParams.Set("output_format", "yaml")
+	queryParams.Set("file_type", "oci")
+	queryParams.Set("components", "true")
+	queryParams.Set("relationships", "true")
+	queryParams.Set("page", "1")
+
+	exportURL := fmt.Sprintf("%s/api/meshmodels/export?%s", testContext.BaseURL, queryParams.Encode())
 	httpmock.RegisterResponder("GET", exportURL,
 		httpmock.NewBytesResponder(200, exportedContent))
 


### PR DESCRIPTION
**Notes for Reviewers**

`mesheryctl model export`'s `PreRunE` wrapped the result of `flagValidator.Validate()`
in `utils.ErrFlagsInvalid()` a second time. Because `Validate()` already returns an
`ErrFlagsInvalid` meshkit error, invalid flag input surfaced a *doubled* error message
(the `Short Description / Probable Cause / Suggested Remediation` block appeared twice).
Every sibling subcommand (`view`, `search`, `list`, `model`) uses the shared
`mesheryctlflags.ValidateCmdFlags(cmd, &flags)` helper, which wraps exactly once —
`export` was the only one doing manual context extraction + re-wrapping.

This PR switches `export`'s `PreRunE` to that same helper (dropping the redundant
boilerplate and the double-wrap) and adds the missing test coverage:

- `TestExportModel` — argument/flag validation error paths (no model name, invalid
  `--output-format`, invalid `--output-type`, invalid `--version`).
- `TestExportModelToFile` — happy path: mocks the export API and asserts the archive
  is written to disk with the expected contents.

`export` was the only `mesheryctl model` subcommand without a test file.

Validation:
- `cd mesheryctl && go test ./internal/cli/root/model/...` → ok (full package, no regressions)
- `golangci-lint run --config=.github/.golangci.yml ./internal/cli/root/model/...` → 0 issues
- `gofmt -s` / `go vet` → clean

**[Signed commits](https://github.com/meshery/meshery/blob/master/CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [x] Yes, I signed my commits.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Standardized validation handling for `mesheryctl model export`, including model name, output format, output type, and version options.
  * Preserved clear errors for invalid export options and missing model names.

* **Tests**
  * Added CLI coverage for invalid export options.
  * Verified successful file exports, including generated archive names, contents, default settings, and completion output.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->