### PR TITLE
fix: restore fullscreen toggle in Registry modal

### DIFF
--- a/ui/components/shared/Modal/Modal.tsx
+++ b/ui/components/shared/Modal/Modal.tsx
@@ -99,7 +99,7 @@ export const Modal: FC<ModalProps> = ({
       title={title}
       headerIcon={headerIcon}
       maxWidth={sizeToMaxWidth[size]}
-      fullScreen={size === 'fullscreen'}
+      {...(size === 'fullscreen' && { fullScreen: true })}
       fullWidth
       isFullScreenModeAllowed={isFullScreenModeAllowed}
       className={className}


### PR DESCRIPTION
## Summary

- Fixes the fullscreen toggle in the Registry modal (issue #19830) — and any other shared `Modal` consumer where `isFullScreenModeAllowed` is set
- Root cause: Meshery's `Modal.tsx` always passed `fullScreen={size === 'fullscreen'}` to the Sistent `Modal`, which evaluates to `fullScreen={false}` for the Registry modal (`size='md'`). Sistent's `Modal` manages its own fullscreen state internally via `useState(false)` but spreads external props onto `StyledDialog` **after** its own `fullScreen` state — so the externally-supplied `false` permanently overrode the toggle
- Fix: only pass `fullScreen={true}` when `size === 'fullscreen'` is explicitly requested; omit the prop otherwise, letting Sistent's internal toggle govern the state

## Test plan

- [ ] Open the Registry modal and click the fullscreen icon — modal should expand to full screen
- [ ] Click the exit-fullscreen icon — modal should return to its default size
- [ ] Verify the same toggle works in the Workspace modal (`WorkspaceFormModal`)
- [ ] Verify that modals using `size="fullscreen"` still open in fullscreen by default

Closes #19830

🤖 Generated with [Claude Code](https://claude.com/claude-code)