### PR TITLE
[Server] Fix swagger annotation typo

### DIFF
--- a/server/handlers/doc.go
+++ b/server/handlers/doc.go
@@ -222,7 +222,7 @@ type listProvidersRespWrapper struct {
 }
 
 // Returns provider capabilities
-// swaggere:response providerPropertiesRespWrapper
+// swagger:response providerPropertiesRespWrapper
 type providerPropertiesRespWrapper struct {
 	// in: body
 	Body models.ProviderProperties


### PR DESCRIPTION
Corrects a typo in a swagger annotation in server/handlers/doc.go.

swaggere -> swagger

The annotation was previously unrecognized by swagger tooling due to the misspelling. Fixing it allows the providerPropertiesRespWrapper response to be properly documented.