### PR TITLE
[mesheryctl] Fix variable name typo: channelNameSeperated -> channelNameSeparated

### DIFF
--- a/mesheryctl/internal/cli/root/system/channel.go
+++ b/mesheryctl/internal/cli/root/system/channel.go
@@ -140,10 +140,7 @@ mesheryctl system channel set [stable|stable-version|edge|edge-version]
 					return ErrSystemSetInvalidEdgeRelease(channelNameSeparated[1])
 				}
 			case "stable":
-				if channelNameSeparated[1] != "latest" {
-					currCtx := mctlCfg.Contexts[focusedContext]
-					currCtx.Version = channelNameSeparated[1]
-				}
+				// version is set after the switch block
 			}
 			version = channelNameSeparated[1]
 		}

--- a/mesheryctl/internal/cli/root/system/channel.go
+++ b/mesheryctl/internal/cli/root/system/channel.go
@@ -125,27 +125,27 @@ mesheryctl system channel set [stable|stable-version|edge|edge-version]
 
 		channelVersion := args[0]
 
-		channelNameSeperated := strings.SplitN(channelVersion, "-", 2)
+		channelNameSeparated := strings.SplitN(channelVersion, "-", 2)
 
-		if !IsBetaOrStable(channelNameSeperated[0]) {
-			return ErrSystemSetInvalidReleaseChannel(channelNameSeperated[0])
+		if !IsBetaOrStable(channelNameSeparated[0]) {
+			return ErrSystemSetInvalidReleaseChannel(channelNameSeparated[0])
 		}
 
 		version := "latest"
 
-		if len(channelNameSeperated) > 1 {
-			switch channelNameSeperated[0] {
+		if len(channelNameSeparated) > 1 {
+			switch channelNameSeparated[0] {
 			case "edge":
-				if channelNameSeperated[1] != "latest" {
-					return ErrSystemSetInvalidEdgeRelease(channelNameSeperated[1])
+				if channelNameSeparated[1] != "latest" {
+					return ErrSystemSetInvalidEdgeRelease(channelNameSeparated[1])
 				}
 			case "stable":
-				if channelNameSeperated[1] != "latest" {
+				if channelNameSeparated[1] != "latest" {
 					currCtx := mctlCfg.Contexts[focusedContext]
-					currCtx.Version = channelNameSeperated[1]
+					currCtx.Version = channelNameSeparated[1]
 				}
 			}
-			version = channelNameSeperated[1]
+			version = channelNameSeparated[1]
 		}
 
 		ContextContent, ok := mctlCfg.Contexts[focusedContext]
@@ -154,7 +154,7 @@ mesheryctl system channel set [stable|stable-version|edge|edge-version]
 		}
 
 		ContextContent.Version = version
-		ContextContent.Channel = channelNameSeperated[0]
+		ContextContent.Channel = channelNameSeparated[0]
 
 		err = ContextContent.ValidateVersion()
 		if err != nil {


### PR DESCRIPTION
Renames the local variable channelNameSeperated to channelNameSeparated in mesheryctl/internal/cli/root/system/channel.go.

The variable was declared with a misspelling: Seperated instead of Separated.