### PR TITLE
[UI] Use filter name in delete confirmation modal

### DIFF
--- a/ui/components/filters/Filters.fileActions.test.tsx
+++ b/ui/components/filters/Filters.fileActions.test.tsx
@@ -86,7 +86,7 @@ describe('createHandleSubmit', () => {
     await handleSubmit({ data: '', name: 'foo', id: 'i-1', type: 'DELETE' });
     await flush();
 
-    expect(showmodal).toHaveBeenCalledWith(1);
+    expect(showmodal).toHaveBeenCalledWith(1, 'foo');
     expect(deleteFilterFile).toHaveBeenCalledWith({ id: 'i-1' });
     expect(notify).toHaveBeenCalledWith({
       message: '"foo" filter deleted',

--- a/ui/components/filters/Filters.fileActions.ts
+++ b/ui/components/filters/Filters.fileActions.ts
@@ -25,7 +25,7 @@ type SubmitArgs = {
 type CreateSubmitHandlerArgs = {
   notify: Notify;
   handleError: ErrorHandler;
-  showmodal: (_count: number) => Promise<string | undefined>;
+  showmodal: (_count: number, _name?: string) => Promise<string | undefined>;
   resetSelectedRowData: () => () => void;
   deleteFilterFile: (_args: { id: string }) => { unwrap: () => Promise<any> };
   uploadFilterFile: (_args: { uploadBody: any }) => { unwrap: () => Promise<any> };
@@ -42,10 +42,9 @@ export function createHandleSubmit({
   updateFilterFile,
 }: CreateSubmitHandlerArgs) {
   return async function handleSubmit({ data, name, id, type, metadata, catalogData }: SubmitArgs) {
-    // TODO: use filter name
     updateProgress({ showProgress: true });
     if (type === FILE_OPS.DELETE) {
-      const response = await showmodal(1);
+      const response = await showmodal(1, name);
       if (response !== 'Delete') {
         updateProgress({ showProgress: false });
         return;

--- a/ui/components/filters/Filters.tsx
+++ b/ui/components/filters/Filters.tsx
@@ -216,7 +216,7 @@ function MesheryFilters() {
       subtitle:
         count > 1
           ? `Are you sure you want to delete these ${count} filters?`
-          : `Are you sure you want to delete "${name}"?`,
+          : `Are you sure you want to delete ${name ? `"${name}"` : 'this filter'}?`,
       primaryOption: 'Delete',
       variant: PROMPT_VARIANTS.DANGER,
     });

--- a/ui/components/filters/Filters.tsx
+++ b/ui/components/filters/Filters.tsx
@@ -210,16 +210,16 @@ function MesheryFilters() {
     };
   }
 
-  async function showmodal(count: number) {
-    let response = await modalRef.current?.show({
+  async function showmodal(count: number, name?: string) {
+    return await modalRef.current?.show({
       title: `Delete ${count ? count : ''} Filter${count > 1 ? 's' : ''}?`,
-      subtitle: `Are you sure you want to delete ${count > 1 ? 'these' : 'this'} ${
-        count ? count : ''
-      } filter${count > 1 ? 's' : ''}?`,
+      subtitle:
+        count > 1
+          ? `Are you sure you want to delete these ${count} filters?`
+          : `Are you sure you want to delete "${name}"?`,
       primaryOption: 'Delete',
       variant: PROMPT_VARIANTS.DANGER,
     });
-    return response;
   }
 
   const handleUnpublishModal = createHandleUnpublishModal({


### PR DESCRIPTION
**Notes for Reviewers**

* This PR fixes the TODO in `Filters.fileActions.ts` to include the filter name in the delete confirmation flow.
* Previously, the delete confirmation modal displayed a generic message when deleting a single filter.
* This change passes the filter name to the modal and displays it in the confirmation message, providing clearer context to users before deletion.
* Updated unit tests to verify that the filter name is passed to the modal.

**Testing**

```bash
npx vitest run components/filters/Filters.fileActions.test.tsx
```

Output:

```
✓ components/filters/Filters.fileActions.test.tsx (19 tests)
✓ 19 passed
```

**Before**

Delete confirmation for a single filter:

```
Are you sure you want to delete this 1 filter?
```

**After**

Delete confirmation for a single filter:

```
Are you sure you want to delete "foo"?
```

Bulk delete behavior remains unchanged.

**Signed commits**

* [x] Yes, I signed my commits.
