### PR TITLE
[Provider UI] Fix InfoOutlinedIcon import from Sistent

### DIFF
--- a/provider-ui/components/Provider.js
+++ b/provider-ui/components/Provider.js
@@ -27,12 +27,7 @@ import {
   CustomTooltip,
   IconButton,
   CircularProgress,
-  // Sistent re-exports the underlying InfoOutlinedIcon as InfoOutlined;
-  // the bundle does NOT export the original name, so importing it
-  // directly resolves to undefined and crashes at render with
-  // "Element type is invalid". Alias on import to keep the rest of the
-  // JSX untouched.
-  InfoOutlined as InfoOutlinedIcon,
+  InfoOutlinedIcon,
   Box,
   Chip,
   Link,


### PR DESCRIPTION
**Notes for Reviewers**

- This PR fixes a client-side crash (React error) on the provider chooser screen (/provider) by correcting a broken icon import from the @sistent/sistent package.

**[Signed commits](https://github.com/meshery/meshery/blob/master/CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [x] Yes, I signed my commits.

<!--
Thank you for contributing to Meshery! 

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. Sign your commits.
4. Include before and after screenshots/terminal output.

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.
-->
