### PR TITLE
Fix provider dropdown crash from invalid InfoOutlined import

### DIFF
--- a/provider-ui/components/Provider.js
+++ b/provider-ui/components/Provider.js
@@ -27,12 +27,11 @@ import {
   CustomTooltip,
   IconButton,
   CircularProgress,
-  // Sistent re-exports the underlying InfoOutlinedIcon as InfoOutlined;
-  // the bundle does NOT export the original name, so importing it
-  // directly resolves to undefined and crashes at render with
-  // "Element type is invalid". Alias on import to keep the rest of the
-  // JSX untouched.
-  InfoOutlined as InfoOutlinedIcon,
+  // Sistent exports this icon as InfoOutlinedIcon. There is no
+  // `InfoOutlined` export, so importing that name bound to undefined and
+  // crashed the provider dropdown at render with "Element type is
+  // invalid" once a row tried to render the icon.
+  InfoOutlinedIcon,
   Box,
   Chip,
   Link,


### PR DESCRIPTION
## Description

Fixes a crash in the provider selection UI (`/provider`): clicking the **Select Provider** dropdown blanked/crashed the page.

### Symptom
Clicking the provider selection dropdown crashed the UI.

### Root cause
`provider-ui/components/Provider.js` imported the info icon as:

```js
InfoOutlined as InfoOutlinedIcon,
```

from `@sistent/sistent`. Sistent exports the icon as **`InfoOutlinedIcon`** - there is **no `InfoOutlined` export**. The aliased binding resolved to `undefined`.

The dropdown *button* rendered fine because it does not use the icon. But opening the popover renders one `<InfoOutlinedIcon />` per provider row, so React threw:

```
Element type is invalid: expected a string (for built-in components) or a
class/function (for composite components) but got: undefined.
```

which unmounted the whole tree. The pre-existing code comment claimed the opposite of the real export surface (it asserted `InfoOutlined` was the valid re-export and `InfoOutlinedIcon` was not).

### Fix
Import the name Sistent actually exports (`InfoOutlinedIcon`, no alias) and correct the misleading comment. The JSX usage was already `<InfoOutlinedIcon />`, so no other change was needed.

### Watch for
This class of bug - a named import resolving to `undefined` - passes the Next.js build and only fails at render. I grepped `provider-ui` and `ui` for other stray `InfoOutlined` (non-`Icon`) usages and found only comments, no other bad imports.

## Notes for Reviewers
Verified against the installed `@sistent/sistent@0.21.19`: its type defs and compiled bundle reference only `InfoOutlinedIcon`, never `InfoOutlined`.

## Signed commits
- [x] Yes, I signed my commits.
