### PR TITLE
[mesheryctl] (fix) corrected mesheryctl design undeploy output when used without args

### DIFF
--- a/mesheryctl/internal/cli/root/design/undeploy.go
+++ b/mesheryctl/internal/cli/root/design/undeploy.go
@@ -42,13 +42,19 @@ mesheryctl design undeploy -f [filepath]
 	`,
 
 	Args: func(cmd *cobra.Command, args []string) error {
-		if cmd.Flags().Changed("file") && file == "" {
-			errMsg := `Usage: mesheryctl design undeploy -f [filepath]`
-			return ErrUndeployDesign(fmt.Errorf("%s", errMsg))
-		}
-		return nil
-	},
+    if len(args) == 0 && file == "" {
+        return ErrUndeployDesign(
+            fmt.Errorf("provide either a design ID or -f [filepath]"),
+        )
+    }
 
+    if cmd.Flags().Changed("file") && file == "" {
+        errMsg := `Usage: mesheryctl design undeploy -f [filepath]`
+        return ErrUndeployDesign(fmt.Errorf("%s", errMsg))
+    }
+
+    return nil
+},
 	RunE: func(cmd *cobra.Command, args []string) error {
 		var req *http.Request
 		var err error

--- a/mesheryctl/internal/cli/root/design/undeploy_test.go
+++ b/mesheryctl/internal/cli/root/design/undeploy_test.go
@@ -53,6 +53,17 @@ func TestUndeployCmd(t *testing.T) {
 			ExpectedError:    utils.ErrFileRead(fmt.Errorf("open %s: no such file or directory", invalidFilePath)),
 		},
 		{
+			Name:             "given no args when design undeploy then usage error is returned",
+			Args:             []string{"undeploy"},
+			ExpectedResponse: "",
+			URLs:             []utils.MockURL{},
+			ExpectError:      true,
+			IsOutputGolden:   false,
+			ExpectedError: ErrUndeployDesign(
+				fmt.Errorf("provide either a design ID or -f [filepath]"),
+			),
+		},
+		{
 			Name:             "given nonexistent design provided when design undeploy then error is thrown",
 			Args:             []string{"undeploy", "-f", filepath.Join(fixturesDir, "sampleDesign.golden")},
 			ExpectedResponse: "",


### PR DESCRIPTION
**Notes for Reviewers**

- This PR fixes #19893 
Running `mesheryctl design undeploy` with neither a design ID nor -f causes the command to fall through to `os.ReadFile("")` and return:  `open : no such file or directory`

Fix
Added argument validation to ensure either a design ID or -f [filepath] is provided before execution proceeds.

Tests
Added a test covering the no-input case.

### Before: 
<img width="938" height="120" alt="Screenshot 2026-06-04 095936" src="https://github.com/user-attachments/assets/cb51053c-3cde-4dc3-aeff-4c3d1764aec4" />

### After:
<img width="987" height="223" alt="Screenshot 2026-06-05 163103" src="https://github.com/user-attachments/assets/44c4ef35-396e-4f0d-a1fe-d4d9b5256d82" />


**[Signed commits](https://github.com/meshery/meshery/blob/master/CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [x] Yes, I signed my commits.

<!--
Thank you for contributing to Meshery! 

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. Sign your commits.
4. Include before and after screenshots/terminal output.

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.
-->
