### PR TITLE
[UI] Remove leftover console.log from CurrentSession

### DIFF
--- a/ui/components/general/error-404/CurrentSession.tsx
+++ b/ui/components/general/error-404/CurrentSession.tsx
@@ -34,8 +34,6 @@ const CurrentSessionInfo = () => {
     // error: providerRolesError,
   } = useGetUserProviderRolesQuery();
 
-  console.log('rolesRes', rolesRes, 'providerRolesRes', providerRolesRes);
-
   return (
     <ErrorSectionContent>
       <div>


### PR DESCRIPTION
**Notes for Reviewers**

* This PR fixes #17599

## Description

This PR removes a leftover debug `console.log` statement from `CurrentSession.tsx`.

The log printed `rolesRes` and `providerRolesRes` to the browser console whenever the permission-denied page was rendered. The statement was used for debugging purposes and does not affect application behavior.

## Changes

* Removed debug `console.log` from `CurrentSession.tsx`

## Notes

* No functional changes.
* No UI changes.
* Existing tests pass successfully.

**Signed commits**

* Yes, I signed my commits.
