### PR TITLE
Remove inputs parameter from notify-providers workflow

### DIFF
--- a/.github/workflows/notify-providers.yaml
+++ b/.github/workflows/notify-providers.yaml
@@ -36,4 +36,3 @@ jobs:
         repo: meshery-extensions/meshery-extensions-packages
         token: ${{ secrets.GH_ACCESS_TOKEN }}
         ref: master
-        inputs: '{"version": "${{ steps.vars.outputs.tag }}"}'


### PR DESCRIPTION
Removed inputs parameter for workflow trigger.

**Notes for Reviewers**

- This PR removes the version as part of the input to the dispatched workflow given that this information is dynamically discerned.

**[Signed commits](https://github.com/meshery/meshery/blob/master/CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [x] Yes, I signed my commits.

<!--
Thank you for contributing to Meshery! 

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. Sign your commits.
4. Include before and after screenshots/terminal output.

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.
-->
