### PR TITLE
feat(server): add provider-specific validation for model-provider connections

### DIFF
--- a/server/machines/helpers/helpers.go
+++ b/server/machines/helpers/helpers.go
@@ -7,6 +7,7 @@ import (
 	"github.com/meshery/meshery/server/machines"
 	"github.com/meshery/meshery/server/machines/grafana"
 	"github.com/meshery/meshery/server/machines/kubernetes"
+	model_provider "github.com/meshery/meshery/server/machines/model_provider"
 	"github.com/meshery/meshery/server/machines/prometheus"
 	"github.com/meshery/meshery/server/models"
 	"github.com/meshery/meshery/server/models/connections"
@@ -56,6 +57,18 @@ func getMachine(initialState machines.StateType, mtype, id string, userID core.U
 		}
 		register := mch.States[machines.REGISTERED]
 		mch.States[machines.REGISTERED] = *register.RegisterAction(&prometheus.RegisterAction{})
+
+		connect := mch.States[machines.CONNECTED]
+		mch.States[machines.CONNECTED] = *connect.RegisterAction(&machines.DefaultConnectAction{})
+
+		return mch, nil
+	case connections.KindOpenAI, connections.KindAnthropic, connections.KindAWSBedrock, connections.KindOllama:
+		mch, err := machines.New(initialState, id, userID, log, mtype)
+		if err != nil {
+			return mch, err
+		}
+		register := mch.States[machines.REGISTERED]
+		mch.States[machines.REGISTERED] = *register.RegisterAction(&model_provider.RegisterAction{})
 
 		connect := mch.States[machines.CONNECTED]
 		mch.States[machines.CONNECTED] = *connect.RegisterAction(&machines.DefaultConnectAction{})

--- a/server/machines/model_provider/error.go
+++ b/server/machines/model_provider/error.go
@@ -1,0 +1,46 @@
+package model_provider
+
+import (
+	"fmt"
+
+	"github.com/meshery/meshkit/errors"
+)
+
+const (
+	ErrInvalidModelProviderPayloadCode = "meshery-server-1432"
+	ErrMissingCredentialFieldCode      = "meshery-server-1433"
+	ErrUnsupportedProviderKindCode     = "meshery-server-1434"
+)
+
+func ErrInvalidModelProviderPayload(kind string, reason string) error {
+	return errors.New(
+		ErrInvalidModelProviderPayloadCode,
+		errors.Alert,
+		[]string{fmt.Sprintf("invalid payload for model-provider connection of kind %q: %s", kind, reason)},
+		[]string{},
+		[]string{"Ensure the connection metadata and credential secret match the required schema for the provider."},
+		[]string{"Provide all required fields for the chosen provider kind."},
+	)
+}
+
+func ErrMissingCredentialField(kind, field string) error {
+	return errors.New(
+		ErrMissingCredentialFieldCode,
+		errors.Alert,
+		[]string{fmt.Sprintf("missing required credential field %q for provider %q", field, kind)},
+		[]string{},
+		[]string{"The credential secret is missing a required field."},
+		[]string{fmt.Sprintf("Add the %q field to the credential secret for the %q provider.", field, kind)},
+	)
+}
+
+func ErrUnsupportedProviderKind(kind string) error {
+	return errors.New(
+		ErrUnsupportedProviderKindCode,
+		errors.Alert,
+		[]string{fmt.Sprintf("unsupported model-provider kind %q", kind)},
+		[]string{},
+		[]string{"The requested provider kind is not supported."},
+		[]string{"Use one of the supported provider kinds: openai, anthropic, aws-bedrock, ollama."},
+	)
+}

--- a/server/machines/model_provider/register.go
+++ b/server/machines/model_provider/register.go
@@ -1,0 +1,126 @@
+package model_provider
+
+import (
+	"context"
+	"strings"
+
+	"github.com/meshery/meshery/server/machines"
+	"github.com/meshery/meshery/server/models"
+	"github.com/meshery/meshery/server/models/connections"
+	"github.com/meshery/meshkit/models/events"
+	"github.com/meshery/meshkit/utils"
+	"github.com/meshery/schemas/models/core"
+)
+
+type RegisterAction struct{}
+
+func (ra *RegisterAction) ExecuteOnEntry(ctx context.Context, machineCtx interface{}, data interface{}) (machines.EventType, *events.Event, error) {
+	return machines.NoOp, nil, nil
+}
+
+func (ra *RegisterAction) Execute(ctx context.Context, machineCtx interface{}, data interface{}) (machines.EventType, *events.Event, error) {
+	user, _ := ctx.Value(models.UserCtxKey).(*models.User)
+	sysID, _ := ctx.Value(models.SystemIDKey).(*core.Uuid)
+	userUUID := user.ID
+
+	eventBuilder := events.NewEvent().
+		ActedUpon(userUUID).
+		WithCategory("connection").
+		WithAction("update").
+		FromSystem(*sysID).
+		FromUser(userUUID).
+		WithDescription("Failed to validate model-provider connection.").
+		WithSeverity(events.Error)
+
+	connPayload, err := utils.Cast[connections.ConnectionPayload](data)
+	if err != nil {
+		return machines.NoOp, eventBuilder.WithMetadata(map[string]interface{}{"error": err}).Build(), err
+	}
+
+	if connPayload.SkipCredentialVerification {
+		return machines.Exit, nil, nil
+	}
+
+	kind := strings.ToLower(connPayload.Kind)
+	if err := validateModelProviderPayload(kind, connPayload); err != nil {
+		return machines.NoOp, eventBuilder.WithMetadata(map[string]interface{}{"error": err}).Build(), err
+	}
+
+	return machines.Exit, nil, nil
+}
+
+func (ra *RegisterAction) ExecuteOnExit(ctx context.Context, machineCtx interface{}, data interface{}) (machines.EventType, *events.Event, error) {
+	return machines.NoOp, nil, nil
+}
+
+// validateModelProviderPayload dispatches provider-specific structural validation.
+func validateModelProviderPayload(kind string, payload connections.ConnectionPayload) error {
+	switch kind {
+	case connections.KindOpenAI:
+		return validateOpenAI(payload)
+	case connections.KindAnthropic:
+		return validateAnthropic(payload)
+	case connections.KindAWSBedrock:
+		return validateAWSBedrock(payload)
+	case connections.KindOllama:
+		return validateOllama(payload)
+	default:
+		return ErrUnsupportedProviderKind(kind)
+	}
+}
+
+func validateOpenAI(payload connections.ConnectionPayload) error {
+	cred, err := utils.MarshalAndUnmarshal[map[string]interface{}, connections.OpenAICred](payload.CredentialSecret)
+	if err != nil {
+		return ErrInvalidModelProviderPayload(connections.KindOpenAI, "credential secret could not be parsed")
+	}
+	if cred.APIKey == "" {
+		return ErrMissingCredentialField(connections.KindOpenAI, "apiKey")
+	}
+	if !strings.HasPrefix(cred.APIKey, "sk-") {
+		return ErrInvalidModelProviderPayload(connections.KindOpenAI, "apiKey must start with \"sk-\"")
+	}
+	return nil
+}
+
+func validateAnthropic(payload connections.ConnectionPayload) error {
+	cred, err := utils.MarshalAndUnmarshal[map[string]interface{}, connections.AnthropicCred](payload.CredentialSecret)
+	if err != nil {
+		return ErrInvalidModelProviderPayload(connections.KindAnthropic, "credential secret could not be parsed")
+	}
+	if cred.APIKey == "" {
+		return ErrMissingCredentialField(connections.KindAnthropic, "apiKey")
+	}
+	if !strings.HasPrefix(cred.APIKey, "sk-ant-") {
+		return ErrInvalidModelProviderPayload(connections.KindAnthropic, "apiKey must start with \"sk-ant-\"")
+	}
+	return nil
+}
+
+func validateAWSBedrock(payload connections.ConnectionPayload) error {
+	cred, err := utils.MarshalAndUnmarshal[map[string]interface{}, connections.AWSBedrockCred](payload.CredentialSecret)
+	if err != nil {
+		return ErrInvalidModelProviderPayload(connections.KindAWSBedrock, "credential secret could not be parsed")
+	}
+	if cred.AccessKeyID == "" {
+		return ErrMissingCredentialField(connections.KindAWSBedrock, "accessKeyId")
+	}
+	if cred.SecretAccessKey == "" {
+		return ErrMissingCredentialField(connections.KindAWSBedrock, "secretAccessKey")
+	}
+	if cred.Region == "" {
+		return ErrMissingCredentialField(connections.KindAWSBedrock, "region")
+	}
+	return nil
+}
+
+func validateOllama(payload connections.ConnectionPayload) error {
+	conn, err := utils.MarshalAndUnmarshal[map[string]interface{}, connections.ModelProviderConn](payload.MetaData)
+	if err != nil {
+		return ErrInvalidModelProviderPayload(connections.KindOllama, "connection metadata could not be parsed")
+	}
+	if conn.BaseURL == "" {
+		return ErrMissingCredentialField(connections.KindOllama, "baseURL")
+	}
+	return nil
+}

--- a/server/machines/model_provider/register_test.go
+++ b/server/machines/model_provider/register_test.go
@@ -1,0 +1,206 @@
+package model_provider
+
+import (
+	"testing"
+
+	"github.com/meshery/meshery/server/models/connections"
+)
+
+func TestValidateOpenAI(t *testing.T) {
+	tests := []struct {
+		name    string
+		payload connections.ConnectionPayload
+		wantErr bool
+	}{
+		{
+			name: "valid openai key",
+			payload: connections.ConnectionPayload{
+				Kind:             connections.KindOpenAI,
+				CredentialSecret: map[string]interface{}{"apiKey": "sk-abc123"},
+			},
+			wantErr: false,
+		},
+		{
+			name: "missing api key",
+			payload: connections.ConnectionPayload{
+				Kind:             connections.KindOpenAI,
+				CredentialSecret: map[string]interface{}{},
+			},
+			wantErr: true,
+		},
+		{
+			name: "wrong prefix",
+			payload: connections.ConnectionPayload{
+				Kind:             connections.KindOpenAI,
+				CredentialSecret: map[string]interface{}{"apiKey": "invalid-key"},
+			},
+			wantErr: true,
+		},
+		{
+			name: "skip credential verification",
+			payload: connections.ConnectionPayload{
+				Kind:                       connections.KindOpenAI,
+				CredentialSecret:           map[string]interface{}{},
+				SkipCredentialVerification: true,
+			},
+			wantErr: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if tt.payload.SkipCredentialVerification {
+				return
+			}
+			err := validateOpenAI(tt.payload)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("validateOpenAI() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}
+
+func TestValidateAnthropic(t *testing.T) {
+	tests := []struct {
+		name    string
+		payload connections.ConnectionPayload
+		wantErr bool
+	}{
+		{
+			name: "valid anthropic key",
+			payload: connections.ConnectionPayload{
+				Kind:             connections.KindAnthropic,
+				CredentialSecret: map[string]interface{}{"apiKey": "sk-ant-abc123"},
+			},
+			wantErr: false,
+		},
+		{
+			name: "missing api key",
+			payload: connections.ConnectionPayload{
+				Kind:             connections.KindAnthropic,
+				CredentialSecret: map[string]interface{}{},
+			},
+			wantErr: true,
+		},
+		{
+			name: "openai key used for anthropic",
+			payload: connections.ConnectionPayload{
+				Kind:             connections.KindAnthropic,
+				CredentialSecret: map[string]interface{}{"apiKey": "sk-abc123"},
+			},
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := validateAnthropic(tt.payload)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("validateAnthropic() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}
+
+func TestValidateAWSBedrock(t *testing.T) {
+	validCred := map[string]interface{}{
+		"accessKeyId":     "AKIAIOSFODNN7EXAMPLE",
+		"secretAccessKey": "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY",
+		"region":          "us-east-1",
+	}
+
+	tests := []struct {
+		name    string
+		payload connections.ConnectionPayload
+		wantErr bool
+	}{
+		{
+			name:    "valid aws bedrock creds",
+			payload: connections.ConnectionPayload{Kind: connections.KindAWSBedrock, CredentialSecret: validCred},
+			wantErr: false,
+		},
+		{
+			name: "missing access key id",
+			payload: connections.ConnectionPayload{
+				Kind: connections.KindAWSBedrock,
+				CredentialSecret: map[string]interface{}{
+					"secretAccessKey": "secret",
+					"region":          "us-east-1",
+				},
+			},
+			wantErr: true,
+		},
+		{
+			name: "missing secret access key",
+			payload: connections.ConnectionPayload{
+				Kind: connections.KindAWSBedrock,
+				CredentialSecret: map[string]interface{}{
+					"accessKeyId": "AKID",
+					"region":      "us-east-1",
+				},
+			},
+			wantErr: true,
+		},
+		{
+			name: "missing region",
+			payload: connections.ConnectionPayload{
+				Kind: connections.KindAWSBedrock,
+				CredentialSecret: map[string]interface{}{
+					"accessKeyId":     "AKID",
+					"secretAccessKey": "secret",
+				},
+			},
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := validateAWSBedrock(tt.payload)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("validateAWSBedrock() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}
+
+func TestValidateOllama(t *testing.T) {
+	tests := []struct {
+		name    string
+		payload connections.ConnectionPayload
+		wantErr bool
+	}{
+		{
+			name: "valid ollama with base url",
+			payload: connections.ConnectionPayload{
+				Kind:     connections.KindOllama,
+				MetaData: map[string]interface{}{"baseURL": "http://localhost:11434"},
+			},
+			wantErr: false,
+		},
+		{
+			name: "missing base url",
+			payload: connections.ConnectionPayload{
+				Kind:     connections.KindOllama,
+				MetaData: map[string]interface{}{},
+			},
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := validateOllama(tt.payload)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("validateOllama() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}
+
+func TestValidateModelProviderPayload_UnsupportedKind(t *testing.T) {
+	err := validateModelProviderPayload("unknown-provider", connections.ConnectionPayload{})
+	if err == nil {
+		t.Error("expected error for unsupported provider kind, got nil")
+	}
+}

--- a/server/models/connections/connections.go
+++ b/server/models/connections/connections.go
@@ -64,6 +64,44 @@ type GrafanaCred struct {
 	APIKeyOrBasicAuth string `json:"secret,omitempty"`
 }
 
+// ModelProviderConn holds non-secret configuration for a model-provider connection.
+// BaseURL is optional and used to override the default provider endpoint.
+type ModelProviderConn struct {
+	Name    string `json:"name,omitempty"`
+	BaseURL string `json:"baseURL,omitempty"`
+}
+
+// OpenAICred holds the secret credential for an OpenAI connection.
+type OpenAICred struct {
+	APIKey string `json:"apiKey,omitempty"`
+}
+
+// AnthropicCred holds the secret credential for an Anthropic connection.
+type AnthropicCred struct {
+	APIKey string `json:"apiKey,omitempty"`
+}
+
+// AWSBedrockCred holds the secret credential for an AWS Bedrock connection.
+type AWSBedrockCred struct {
+	AccessKeyID     string `json:"accessKeyId,omitempty"`
+	SecretAccessKey string `json:"secretAccessKey,omitempty"`
+	Region          string `json:"region,omitempty"`
+}
+
+// OllamaCred is intentionally empty — Ollama runs locally with no auth.
+type OllamaCred struct{}
+
+// Model-provider connection type and kind constants.
+const (
+	ModelProviderType    = "model-provider"
+	ModelProviderSubType = "inference"
+
+	KindOpenAI     = "openai"
+	KindAnthropic  = "anthropic"
+	KindAWSBedrock = "aws-bedrock"
+	KindOllama     = "ollama"
+)
+
 type Connection = schemasConnection.Connection
 
 var validConnectionStatusToManage = []ConnectionStatus{


### PR DESCRIPTION
## Summary

- Adds `ModelProviderConn`, `OpenAICred`, `AnthropicCred`, `AWSBedrockCred`, `OllamaCred` structs and kind constants (`openai`, `anthropic`, `aws-bedrock`, `ollama`) to the connections package.
- Introduces a new `server/machines/model_provider` package with a `RegisterAction` that validates connection payloads per provider kind before registration — enforcing key format (`sk-` for OpenAI, `sk-ant-` for Anthropic), required AWS Bedrock fields, and a `baseURL` for Ollama.
- Wires the four provider kinds into `getMachine()` in `server/machines/helpers/helpers.go` so the state machine router dispatches to the new machine.
- Adds 14 unit tests covering all provider validators and the unsupported-kind path.

Closes #19908

## Test plan

- [x] `go test ./server/machines/model_provider/...` — all 14 tests pass
- [x] `go test ./server/models/connections/...` — all existing tests pass
- [x] `go build ./server/machines/...` — compiles cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)