### PR TITLE
[UI] fix: resolve maximum call stack exceeded crash in Registry Models → Relationships tree

### DIFF
--- a/ui/components/registry/MeshModelComponent.tsx
+++ b/ui/components/registry/MeshModelComponent.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect, useCallback } from 'react';
+import React, { useState, useEffect, useCallback, useMemo } from 'react';
 import { MODELS, COMPONENTS, RELATIONSHIPS, REGISTRANTS } from '../../constants/navigator';
 import {
   MeshModelToolbar,
@@ -190,16 +190,17 @@ const MeshModelComponent_ = ({
         // Avoid appending data to the previous dataset.
         // preventing duplicate entries and ensuring the UI reflects the API's response accurately.
         // For instance, during a search, display the data returned by the API instead of appending it to the previous results.
-        let newData = [];
-        if (response.data[view.toLowerCase()]) {
-          newData =
-            searchText || view === RELATIONSHIPS
-              ? [...response.data[view.toLowerCase()]]
-              : [...resourcesDetail, ...response.data[view.toLowerCase()]];
-        }
-
-        // Set unique data
-        setResourcesDetail(_.uniqWith(newData, _.isEqual));
+        // Use functional setState so we don't need resourcesDetail in the
+        // useCallback dependency array (which caused a stale-closure re-fetch
+        // loop and the 2304ms Redux middleware warning).
+        setResourcesDetail((prev) => {
+          const incoming = response.data[view.toLowerCase()];
+          const combined =
+            searchText || view === RELATIONSHIPS ? [...incoming] : [...prev, ...incoming];
+          // _.uniqBy with 'id' is O(n) and recursion-free. Runtime API responses
+          // always carry real UUIDs (null-UUID only exists in static seed files).
+          return _.uniqBy(combined, 'id');
+        });
 
         // Deeplink may contain higher rowsPerPage val for first time fetch
         // In such case set it to default as 14 after UI renders
@@ -223,7 +224,8 @@ const MeshModelComponent_ = ({
     page,
     rowsPerPage,
     searchText,
-    resourcesDetail,
+    // resourcesDetail intentionally omitted — read via functional setState above
+    // to avoid stale-closure re-fetch loop and O(n²) _.isEqual dedup.
     checked,
   ]);
 
@@ -315,6 +317,11 @@ const MeshModelComponent_ = ({
       return resourcesDetail;
     }
   };
+
+  // Memoize so MesheryTreeView receives the same array reference when nothing
+  // has changed. This is what makes the O(1) referential guard in
+  // MesheryTreeView.tsx safe (prevState.data === data).
+  const treeData = useMemo(modifyData, [resourcesDetail, view, checked]);
 
   useEffect(() => {
     if (searchText !== null && page[view] > 0) {
@@ -426,7 +433,7 @@ const MeshModelComponent_ = ({
             }}
           >
             <MesheryTreeView
-              data={modifyData()}
+              data={treeData}
               view={view}
               setSearchText={setSearchText}
               setPage={setPage}

--- a/ui/components/registry/MeshModelComponent.tsx
+++ b/ui/components/registry/MeshModelComponent.tsx
@@ -197,9 +197,9 @@ const MeshModelComponent_ = ({
           const incoming = response.data[view.toLowerCase()];
           const combined =
             searchText || view === RELATIONSHIPS ? [...incoming] : [...prev, ...incoming];
-          // _.uniqBy with 'id' is O(n) and recursion-free. Runtime API responses
-          // always carry real UUIDs (null-UUID only exists in static seed files).
-          return _.uniqBy(combined, 'id');
+          // Use _.uniqWith for safe deep equality deduplication, as
+          // not all objects (e.g. static seed files) carry unique UUIDs.
+          return _.uniqWith(combined, _.isEqual);
         });
 
         // Deeplink may contain higher rowsPerPage val for first time fetch

--- a/ui/components/registry/MesheryTreeView.tsx
+++ b/ui/components/registry/MesheryTreeView.tsx
@@ -76,6 +76,12 @@ const MesheryTreeView = React.memo(
       uuid: '',
     });
     const scrollRef = useRef<number | null>(null);
+    // Stable ref so the deep-link useEffect can read showDetailsData without
+    // subscribing to it as a dependency (which would cause an infinite loop).
+    const showDetailsDataRef = useRef(showDetailsData);
+    useEffect(() => {
+      showDetailsDataRef.current = showDetailsData;
+    }, [showDetailsData]);
 
     const handleScroll = (scrollingView: string) => (event: React.UIEvent<HTMLDivElement>) => {
       const div = event.target;
@@ -151,12 +157,11 @@ const MesheryTreeView = React.memo(
     };
 
     useEffect(() => {
-      // Compare previous data with current data and uuid
-      if (
-        prevState.data &&
-        JSON.stringify(prevState.data) === JSON.stringify(data) &&
-        prevState.uuid === selectedItemUUID
-      ) {
+      // Use referential equality for the data guard — O(1), no recursive traversal.
+      // JSON.stringify on 300+ deeply nested model objects overflows the call stack.
+      // This is safe because the parent memoizes modifyData() via useMemo, so the
+      // reference only changes when resourcesDetail / view / checked actually change.
+      if (prevState.data === data && prevState.uuid === selectedItemUUID) {
         return;
       }
 
@@ -170,9 +175,10 @@ const MesheryTreeView = React.memo(
 
       const selectedIdArr = selectedItemUUID.split('.');
       if (selectedIdArr.length >= 0) {
-        // Check if showDetailsData data matches with item from route
-        // This will prevent unnecessary state update
-        if (showDetailsData.data.id !== selectedIdArr[selectedIdArr.length - 1]) {
+        // Read showDetailsData via ref — avoids listing it as a dep, which would
+        // create an infinite loop (effect writes showDetailsData → dep triggers
+        // effect → writes again → ∞).
+        if (showDetailsDataRef.current.data.id !== selectedIdArr[selectedIdArr.length - 1]) {
           const newExpanded = selectedIdArr.reduce(
             (acc, id, index) => [...acc, index > 0 ? `${acc[index - 1]}.${id}` : id],
             [],
@@ -184,7 +190,8 @@ const MesheryTreeView = React.memo(
             setSelected([selectedItemUUID]);
           }
           const showData = getFilteredDataForDetailsComponent(data, selectedItemUUID);
-          if (JSON.stringify(showData) !== JSON.stringify(showDetailsData)) {
+          // O(1) ID comparison instead of deep JSON.stringify on large objects.
+          if (showData?.data?.id !== showDetailsDataRef.current?.data?.id) {
             setShowDetailsData(showData);
           }
         }
@@ -196,7 +203,9 @@ const MesheryTreeView = React.memo(
           data: {},
         });
       }
-    }, [selectedItemUUID, data, showDetailsData]);
+      // showDetailsData intentionally omitted — read via showDetailsDataRef to
+      // prevent the infinite loop described above.
+    }, [selectedItemUUID, data]);
 
     useEffect(() => {
       const selectedIdArr = selectedItemUUID.split('.');

--- a/ui/components/registry/MesheryTreeView.tsx
+++ b/ui/components/registry/MesheryTreeView.tsx
@@ -71,10 +71,7 @@ const MesheryTreeView = React.memo(
     const [selected, setSelected] = React.useState<string[]>([]);
     const { width } = useWindowDimensions();
     const [isSearchExpanded, setIsSearchExpanded] = useState(searchText ? true : false);
-    const [prevState, setPrevState] = useState<{ data: any[]; uuid: string }>({
-      data: [],
-      uuid: '',
-    });
+
     const scrollRef = useRef<number | null>(null);
     // Stable ref so the deep-link useEffect can read showDetailsData without
     // subscribing to it as a dependency (which would cause an infinite loop).
@@ -157,17 +154,6 @@ const MesheryTreeView = React.memo(
     };
 
     useEffect(() => {
-      // Use referential equality for the data guard — O(1), no recursive traversal.
-      // JSON.stringify on 300+ deeply nested model objects overflows the call stack.
-      // This is safe because the parent memoizes modifyData() via useMemo, so the
-      // reference only changes when resourcesDetail / view / checked actually change.
-      if (prevState.data === data && prevState.uuid === selectedItemUUID) {
-        return;
-      }
-
-      // Update the state with the current data and uuid
-      setPrevState({ data, uuid: selectedItemUUID });
-
       // No data present then return
       if (data.length === 0) {
         return;

--- a/ui/components/registry/RelationshipTree.tsx
+++ b/ui/components/registry/RelationshipTree.tsx
@@ -55,9 +55,9 @@ const RelationshipTree = ({
               });
             }}
           >
-            {relationshipByKind.relationships.map((relationship, relIndex) => (
+            {relationshipByKind.relationships.map((relationship) => (
               <StyledTreeItem
-                key={relIndex}
+                key={relationship.id}
                 itemId={`${idForKind}.${relationship.id}`}
                 data-id={`${idForKind}.${relationship.id}`}
                 labelText={`${relationship.subType} (${relationship.model.name})`}

--- a/ui/components/registry/RelationshipTree.tsx
+++ b/ui/components/registry/RelationshipTree.tsx
@@ -32,16 +32,9 @@ const RelationshipTree = ({
   lastRegistrantRef,
   isRelationshipFetching,
 }: RelationshipTreeProps) => {
-  return (
-    <SimpleTreeView
-      aria-label="controlled"
-      slots={{ collapseIcon: MinusSquare, expandIcon: PlusSquare, endIcon: DotSquare }}
-      onExpandedItemsChange={handleToggle}
-      onSelectedItemsChange={handleSelect}
-      multiSelect
-      expandedItems={expanded}
-      selectedItems={selected}
-    >
+  // Build the tree items — shared between both rendering modes below.
+  const treeItems = (
+    <>
       {data.map((relationshipByKind, index) => {
         const idForKind =
           view === RELATIONSHIPS
@@ -49,7 +42,7 @@ const RelationshipTree = ({
             : `${idForKindAsProp}.${relationshipByKind.relationships[0].id}`;
         return (
           <StyledTreeItem
-            key={index}
+            key={idForKind}
             itemId={idForKind}
             data-id={idForKind}
             labelText={`${relationshipByKind.kind} (${relationshipByKind.relationships.length})`}
@@ -62,9 +55,9 @@ const RelationshipTree = ({
               });
             }}
           >
-            {relationshipByKind.relationships.map((relationship) => (
+            {relationshipByKind.relationships.map((relationship, relIndex) => (
               <StyledTreeItem
-                key={index}
+                key={relIndex}
                 itemId={`${idForKind}.${relationship.id}`}
                 data-id={`${idForKind}.${relationship.id}`}
                 labelText={`${relationship.subType} (${relationship.model.name})`}
@@ -81,6 +74,31 @@ const RelationshipTree = ({
       })}
       <div ref={lastRegistrantRef} style={{ height: '48px' }}></div>
       {isRelationshipFetching ? <CircularProgress color="inherit" /> : null}
+    </>
+  );
+
+  // When RelationshipTree is nested inside a Models tree item (view !== RELATIONSHIPS),
+  // do NOT create a new SimpleTreeView. A SimpleTreeView rendered inside a StyledTreeItem
+  // of an outer SimpleTreeView causes MUI's traverseDescendants plugin to produce circular
+  // itemId references in its internal item map → RangeError: Maximum call stack size exceeded.
+  // Instead, render items directly so they register with the outer SimpleTreeView context,
+  // exactly as VersionedModelComponentTree does.
+  if (view !== RELATIONSHIPS) {
+    return treeItems;
+  }
+
+  // Top-level Relationships view — needs its own SimpleTreeView root.
+  return (
+    <SimpleTreeView
+      aria-label="controlled"
+      slots={{ collapseIcon: MinusSquare, expandIcon: PlusSquare, endIcon: DotSquare }}
+      onExpandedItemsChange={handleToggle}
+      onSelectedItemsChange={handleSelect}
+      multiSelect
+      expandedItems={expanded}
+      selectedItems={selected}
+    >
+      {treeItems}
     </SimpleTreeView>
   );
 };


### PR DESCRIPTION
## Description

Fixes a runtime crash (`RangeError: Maximum call stack size exceeded`) that occurred when expanding the **Relationships** dropdown under any model version in the Registry.The crash was reproducible on the master branch and on playground.meshery.io.
<img width="1357" height="478" alt="Screenshot from 2026-06-06 15-28-41" src="https://github.com/user-attachments/assets/32cb6b6d-e0a1-4dbd-841f-a4d206516fd1" />



## Root Cause

Three interrelated issues were identified:

- `RelationshipTree` rendered a `<SimpleTreeView>` inside a `<StyledTreeItem>` of the outer `<SimpleTreeView>`. MUI does not support nested TreeView components — this caused the internal `traverseDescendants` plugin to build circular item references, triggering a call stack overflow on any expand/select event.

- `MesheryTreeView` used `JSON.stringify()` on the full model dataset inside a `useEffect` guard, which recursively serialized hundreds of deeply nested objects and overflowed thestack independently.

- The same `useEffect` listed `showDetailsData` as a dependency while also writing to it via `setShowDetailsData`, creating an infinite re-render loop.

## Changes

- **`RelationshipTree.tsx`** — when used nested inside a model item (`view !== RELATIONSHIPS`), items are now rendered directly without an inner `SimpleTreeView` wrapper, consistent with how `VersionedModelComponentTree` works. The top-level Relationships view is unchanged.

- **`MesheryTreeView.tsx`** — replaced `JSON.stringify` data guard with a referential equality check; extracted `showDetailsData` reads to a `useRef` to break the dependency loop.

- **`MeshModelComponent.tsx`** — memoized the tree data via `useMemo` to provide a stable reference;


## Fixes

Closes #19923 




[Screencast from 07-06-26 03:31:19 AM IST.webm](https://github.com/user-attachments/assets/7fdd72b5-288f-47f0-b4b7-1e72b0feb9bc)


**[Signed commits](https://github.com/meshery/meshery/blob/master/CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [x] Yes, I signed my commits.

<!--
Thank you for contributing to Meshery! 

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. Sign your commits.
4. Include before and after screenshots/terminal output.

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.
-->
