### PR TITLE
[mesheryctl] Replace context.TODO() with cmd.Context()

### DIFF
--- a/mesheryctl/internal/cli/root/system/dashboard.go
+++ b/mesheryctl/internal/cli/root/system/dashboard.go
@@ -15,7 +15,6 @@
 package system
 
 import (
-	"context"
 	"fmt"
 	"net/http"
 	"net/url"
@@ -184,7 +183,7 @@ Note: Meshery's web-based user interface is embedded in Meshery Server and is av
 			}
 
 			var mesheryEndpoint string
-			endpoint, err := utils.GetMesheryEndpoint(context.TODO(), client)
+			endpoint, err := utils.GetMesheryEndpoint(cmd.Context(), client)
 			if err != nil {
 				utils.Log.Debugf("Error while GetMesheryEndpoint\n- Endpoint: %v\n- Error: %v", endpoint, err)
 				return err //the func return a meshkit error


### PR DESCRIPTION
**Notes for Reviewers**

- This PR fixes #
- ## Description

This PR replaces `context.TODO()` with `cmd.Context()` in:

`mesheryctl/internal/cli/root/system/dashboard.go`

Using `cmd.Context()` allows proper context propagation, cancellation, and timeout handling from the Cobra command execution chain, aligning with Go best practices.

**Notes for Reviewers**

- This PR fixes the usage of `context.TODO()` in `dashboard.go`.
- Replaced:
  ```go
  utils.GetMesheryEndpoint(context.TODO(), client)

**[Signed commits](https://github.com/meshery/meshery/blob/master/CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [ x] Yes, I signed my commits.

<!--
Thank you for contributing to Meshery! 

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. Sign your commits.
4. Include before and after screenshots/terminal output.

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.
-->
