### PR TITLE
fix(designs): render imported designs misclassified as legacy v1alpha2

### DIFF
--- a/server/handlers/meshery_pattern_handler.go
+++ b/server/handlers/meshery_pattern_handler.go
@@ -891,7 +891,7 @@ func (h *Handler) DownloadMesheryPatternHandler(
 		return
 	}
 
-	// v1beta1
+	// Detect and migrate legacy v1alpha2 designs to the current schema.
 	isOldFormat, err := patternutils.IsDesignInAlpha2Format(pattern.PatternFile)
 	if err != nil {
 		err = ErrPatternFile(err)

--- a/server/models/pattern/utils/utils.go
+++ b/server/models/pattern/utils/utils.go
@@ -8,7 +8,6 @@ import (
 	"strings"
 
 	"github.com/meshery/meshkit/encoding"
-	"github.com/meshery/schemas/models/v1beta1"
 )
 
 // RecursiveCastMapStringInterfaceToMapStringInterface will convert a
@@ -112,15 +111,30 @@ func GetRandomAlphabetsOfDigit(length int) (s string) {
 	return
 }
 
+// IsDesignInAlpha2Format reports whether a stored design predates the versioned
+// design schema and therefore must be migrated by convertV1alpha2ToV1beta3.
+//
+// Every design schema from v1beta1 onward stamps a versioned
+// "designs.meshery.io/<version>" schemaVersion (v1beta1, v1beta3, ...); the
+// legacy v1alpha2 format carries none (it is identified instead by a top-level
+// `services` map). Detection therefore keys off the canonical schemaVersion
+// prefix rather than whitelisting a single "current" version.
+//
+// Whitelisting one version is what regressed imported-design rendering: the
+// import pipeline (NewPatternFileFromK8sManifest) stamps v1beta3, but this
+// guard only recognized v1beta1, so every freshly imported design failed the
+// check, was misclassified as alpha2, and convertV1alpha2ToV1beta3 reparsed it
+// as a v1alpha2.PatternFile (which has `services`, not `components`) -
+// producing a design with zero components that rendered as an empty canvas.
+// Matching the prefix keeps current and future design schema versions out of
+// the lossy migration path.
 func IsDesignInAlpha2Format(patternFile string) (bool, error) {
 	design := map[string]interface{}{}
-	err := encoding.Unmarshal([]byte(patternFile), &design)
-	if err != nil {
+	if err := encoding.Unmarshal([]byte(patternFile), &design); err != nil {
 		return true, err
 	}
 
-	val, ok := design["schemaVersion"]
-	if ok && val == v1beta1.DesignSchemaVersion {
+	if sv, ok := design["schemaVersion"].(string); ok && strings.HasPrefix(sv, "designs.meshery.io/") {
 		return false, nil
 	}
 	return true, nil

--- a/server/models/pattern/utils/utils.go
+++ b/server/models/pattern/utils/utils.go
@@ -129,12 +129,20 @@ func GetRandomAlphabetsOfDigit(length int) (s string) {
 // Matching the prefix keeps current and future design schema versions out of
 // the lossy migration path.
 func IsDesignInAlpha2Format(patternFile string) (bool, error) {
-	design := map[string]interface{}{}
+	// Decode only schemaVersion into a targeted struct instead of the whole
+	// file into a map[string]interface{}, which would allocate the entire
+	// nested design tree just to read one field. Both the json and yaml tags
+	// are required: encoding.Unmarshal tries encoding/json first and falls back
+	// to gopkg.in/yaml.v3, so a json-only tag would miss the camelCase
+	// schemaVersion key in a YAML-encoded pattern file and misclassify it.
+	var design struct {
+		SchemaVersion string `json:"schemaVersion" yaml:"schemaVersion"`
+	}
 	if err := encoding.Unmarshal([]byte(patternFile), &design); err != nil {
 		return true, err
 	}
 
-	if sv, ok := design["schemaVersion"].(string); ok && strings.HasPrefix(sv, "designs.meshery.io/") {
+	if strings.HasPrefix(design.SchemaVersion, "designs.meshery.io/") {
 		return false, nil
 	}
 	return true, nil

--- a/server/models/pattern/utils/utils_test.go
+++ b/server/models/pattern/utils/utils_test.go
@@ -34,6 +34,15 @@ func TestIsDesignInAlpha2Format(t *testing.T) {
 			wantAlpha2:  false,
 		},
 		{
+			// YAML-encoded pattern file: guards the json+yaml tag pair on the
+			// decode struct. With a json-only tag the yaml.v3 fallback in
+			// encoding.Unmarshal would miss the camelCase key and misclassify
+			// this current design as alpha2.
+			name:        "v1beta3 design encoded as YAML is current (not alpha2)",
+			patternFile: "schemaVersion: designs.meshery.io/v1beta3\nname: yaml-nginx\ncomponents: []\n",
+			wantAlpha2:  false,
+		},
+		{
 			// Genuine legacy format: carries `services`, no versioned
 			// schemaVersion. This is the only case that should migrate.
 			name:        "v1alpha2 design (services, no schemaVersion) is alpha2",

--- a/server/models/pattern/utils/utils_test.go
+++ b/server/models/pattern/utils/utils_test.go
@@ -1,0 +1,56 @@
+package utils
+
+import "testing"
+
+// TestIsDesignInAlpha2Format guards the design-import rendering regression:
+// freshly imported designs (Kubernetes manifests, Helm charts, Compose files)
+// are produced by NewPatternFileFromK8sManifest in v1beta3 form. They must be
+// recognized as a current design schema - NOT misclassified as legacy
+// v1alpha2 - otherwise convertV1alpha2ToV1beta3 reparses them as a
+// v1alpha2.PatternFile (which has `services`, not `components`) and strips
+// every component, leaving an empty canvas in Kanvas.
+func TestIsDesignInAlpha2Format(t *testing.T) {
+	tests := []struct {
+		name        string
+		patternFile string
+		wantAlpha2  bool
+	}{
+		{
+			// The regression: import stamps v1beta3; this must be current.
+			name:        "v1beta3 imported design is current (not alpha2)",
+			patternFile: `{"schemaVersion":"designs.meshery.io/v1beta3","name":"nginx","components":[{"component":{"kind":"Deployment"},"model":{"name":"kubernetes"}}]}`,
+			wantAlpha2:  false,
+		},
+		{
+			name:        "v1beta1 design is current (not alpha2)",
+			patternFile: `{"schemaVersion":"designs.meshery.io/v1beta1","name":"legacy-beta1","components":[]}`,
+			wantAlpha2:  false,
+		},
+		{
+			// Future-proofing: a new design schema version must not regress
+			// the way v1beta3 did when only v1beta1 was whitelisted.
+			name:        "future designs.meshery.io version is current (not alpha2)",
+			patternFile: `{"schemaVersion":"designs.meshery.io/v1beta4","name":"future","components":[]}`,
+			wantAlpha2:  false,
+		},
+		{
+			// Genuine legacy format: carries `services`, no versioned
+			// schemaVersion. This is the only case that should migrate.
+			name:        "v1alpha2 design (services, no schemaVersion) is alpha2",
+			patternFile: `{"name":"old","services":{"svc":{"type":"Deployment"}}}`,
+			wantAlpha2:  true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := IsDesignInAlpha2Format(tt.patternFile)
+			if err != nil {
+				t.Fatalf("IsDesignInAlpha2Format() unexpected error: %v", err)
+			}
+			if got != tt.wantAlpha2 {
+				t.Errorf("IsDesignInAlpha2Format() = %v, want %v", got, tt.wantAlpha2)
+			}
+		})
+	}
+}

--- a/server/models/pattern/utils/utils_test.go
+++ b/server/models/pattern/utils/utils_test.go
@@ -49,6 +49,18 @@ func TestIsDesignInAlpha2Format(t *testing.T) {
 			patternFile: `{"name":"old","services":{"svc":{"type":"Deployment"}}}`,
 			wantAlpha2:  true,
 		},
+		{
+			// Defensive edge cases: a missing or empty schemaVersion has no
+			// canonical prefix, so it is classified legacy (migrate).
+			name:        "missing schemaVersion key is alpha2",
+			patternFile: `{"name":"no-version","components":[]}`,
+			wantAlpha2:  true,
+		},
+		{
+			name:        "empty schemaVersion is alpha2",
+			patternFile: `{"schemaVersion":"","name":"empty-ver"}`,
+			wantAlpha2:  true,
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
Imported designs (Kubernetes manifests, Helm charts, Compose files) are produced by NewPatternFileFromK8sManifest in v1beta3 form. GetMesheryPatternHandler gated the legacy v1alpha2->v1beta3 migration on IsDesignInAlpha2Format, which recognized only v1beta1 as a current schema. Every freshly imported v1beta3 design therefore failed the check, was treated as alpha2, and convertV1alpha2ToV1beta3 reparsed it as a v1alpha2.PatternFile (which carries 'services', not 'components') - yielding a design with zero components that rendered as an empty canvas in Kanvas. The POST get-handler path additionally re-persisted the emptied design, corrupting it in storage.

Detect alpha2 by the absence of a canonical 'designs.meshery.io/*' schemaVersion (legacy alpha2 carries a top-level 'services' map and no versioned schemaVersion) instead of whitelisting a single current version, so current and future design schema versions are never routed through the lossy migration. Add a regression test covering v1beta3/v1beta1/future-version (current) and v1alpha2 (legacy).

Signed-off-by: Lee Calcote <lee.calcote@layer5.io>
