### PR TITLE
fix(designs): render imported designs misclassified as legacy v1alpha2

### DIFF
--- a/server/models/pattern/utils/utils.go
+++ b/server/models/pattern/utils/utils.go
@@ -8,7 +8,6 @@ import (
 	"strings"
 
 	"github.com/meshery/meshkit/encoding"
-	"github.com/meshery/schemas/models/v1beta1"
 )
 
 // RecursiveCastMapStringInterfaceToMapStringInterface will convert a
@@ -112,15 +111,30 @@ func GetRandomAlphabetsOfDigit(length int) (s string) {
 	return
 }
 
+// IsDesignInAlpha2Format reports whether a stored design predates the versioned
+// design schema and therefore must be migrated by convertV1alpha2ToV1beta3.
+//
+// Every design schema from v1beta1 onward stamps a versioned
+// "designs.meshery.io/<version>" schemaVersion (v1beta1, v1beta3, ...); the
+// legacy v1alpha2 format carries none (it is identified instead by a top-level
+// `services` map). Detection therefore keys off the canonical schemaVersion
+// prefix rather than whitelisting a single "current" version.
+//
+// Whitelisting one version is what regressed imported-design rendering: the
+// import pipeline (NewPatternFileFromK8sManifest) stamps v1beta3, but this
+// guard only recognized v1beta1, so every freshly imported design failed the
+// check, was misclassified as alpha2, and convertV1alpha2ToV1beta3 reparsed it
+// as a v1alpha2.PatternFile (which has `services`, not `components`) -
+// producing a design with zero components that rendered as an empty canvas.
+// Matching the prefix keeps current and future design schema versions out of
+// the lossy migration path.
 func IsDesignInAlpha2Format(patternFile string) (bool, error) {
 	design := map[string]interface{}{}
-	err := encoding.Unmarshal([]byte(patternFile), &design)
-	if err != nil {
+	if err := encoding.Unmarshal([]byte(patternFile), &design); err != nil {
 		return true, err
 	}
 
-	val, ok := design["schemaVersion"]
-	if ok && val == v1beta1.DesignSchemaVersion {
+	if sv, ok := design["schemaVersion"].(string); ok && strings.HasPrefix(sv, "designs.meshery.io/") {
 		return false, nil
 	}
 	return true, nil

--- a/server/models/pattern/utils/utils_test.go
+++ b/server/models/pattern/utils/utils_test.go
@@ -1,0 +1,56 @@
+package utils
+
+import "testing"
+
+// TestIsDesignInAlpha2Format guards the design-import rendering regression:
+// freshly imported designs (Kubernetes manifests, Helm charts, Compose files)
+// are produced by NewPatternFileFromK8sManifest in v1beta3 form. They must be
+// recognized as a current design schema - NOT misclassified as legacy
+// v1alpha2 - otherwise convertV1alpha2ToV1beta3 reparses them as a
+// v1alpha2.PatternFile (which has `services`, not `components`) and strips
+// every component, leaving an empty canvas in Kanvas.
+func TestIsDesignInAlpha2Format(t *testing.T) {
+	tests := []struct {
+		name        string
+		patternFile string
+		wantAlpha2  bool
+	}{
+		{
+			// The regression: import stamps v1beta3; this must be current.
+			name:        "v1beta3 imported design is current (not alpha2)",
+			patternFile: `{"schemaVersion":"designs.meshery.io/v1beta3","name":"nginx","components":[{"component":{"kind":"Deployment"},"model":{"name":"kubernetes"}}]}`,
+			wantAlpha2:  false,
+		},
+		{
+			name:        "v1beta1 design is current (not alpha2)",
+			patternFile: `{"schemaVersion":"designs.meshery.io/v1beta1","name":"legacy-beta1","components":[]}`,
+			wantAlpha2:  false,
+		},
+		{
+			// Future-proofing: a new design schema version must not regress
+			// the way v1beta3 did when only v1beta1 was whitelisted.
+			name:        "future designs.meshery.io version is current (not alpha2)",
+			patternFile: `{"schemaVersion":"designs.meshery.io/v1beta4","name":"future","components":[]}`,
+			wantAlpha2:  false,
+		},
+		{
+			// Genuine legacy format: carries `services`, no versioned
+			// schemaVersion. This is the only case that should migrate.
+			name:        "v1alpha2 design (services, no schemaVersion) is alpha2",
+			patternFile: `{"name":"old","services":{"svc":{"type":"Deployment"}}}`,
+			wantAlpha2:  true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := IsDesignInAlpha2Format(tt.patternFile)
+			if err != nil {
+				t.Fatalf("IsDesignInAlpha2Format() unexpected error: %v", err)
+			}
+			if got != tt.wantAlpha2 {
+				t.Errorf("IsDesignInAlpha2Format() = %v, want %v", got, tt.wantAlpha2)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Symptom

Designs imported from a Kubernetes manifest, Helm chart, or Docker Compose file - whether dropped on the Kanvas canvas or brought in through the Import Design modal - stopped rendering. They open to an empty canvas.

`GET /api/pattern/{id}` returns `"components": null` for a freshly imported design, so Kanvas has nothing to render.

## Root cause

`NewPatternFileFromK8sManifest` produces designs in **v1beta3** form (`designs.meshery.io/v1beta3`). On read, `GetMesheryPatternHandler` gates the legacy v1alpha2 -> v1beta3 migration on `IsDesignInAlpha2Format`, which recognized only **v1beta1** as a current schema:

```go
val, ok := design["schemaVersion"]
if ok && val == v1beta1.DesignSchemaVersion { // only v1beta1
    return false, nil
}
return true, nil // v1beta3 falls through here -> treated as "alpha2"
```

So every v1beta3 design was misclassified as alpha2 and run through `convertV1alpha2ToV1beta3`, which reparses it as a `v1alpha2.PatternFile`. That type carries `services`, not `components`, so the conversion produced a design with **zero components**. One call site additionally re-persisted the emptied design, corrupting it in storage.

The regression was introduced when the import pipeline advanced to v1beta3 while this read-path guard's whitelist stayed at v1beta1.

## Fix

Detect alpha2 by the **absence** of a canonical `designs.meshery.io/*` schemaVersion - legacy v1alpha2 carries a top-level `services` map and no versioned schemaVersion - instead of whitelisting a single "current" version. This keeps current and future design schema versions (v1beta1, v1beta3, ...) out of the lossy migration path and prevents the same regression at the next schema bump.

The change is in the shared `IsDesignInAlpha2Format`, so it covers all three call sites that gate on it (one GET handler and two POST handlers), including the one that re-persisted the gutted design.

## Reproduction (before this PR)

1. Import an nginx Deployment manifest via the Import Design modal (or drop it on the canvas).
2. `POST /api/pattern/import` returns the converted design with its components.
3. `GET /api/pattern/{id}` returns `"components": null`.
4. Kanvas renders an empty canvas.

Confirmed identically on both the local provider and the Layer5 remote provider.

## Recovery

Designs already corrupted in storage are recoverable: the original uploaded source is retained in the record's `SourceContent` and can be re-converted.

## Test plan

- [x] `go test ./server/models/pattern/utils/` - new `TestIsDesignInAlpha2Format` covers v1beta3 (the regression), v1beta1, a future `designs.meshery.io/*` version (all classified current), and genuine v1alpha2 (classified legacy). Existing package tests still pass.
- [x] `go vet` and `go build` of `server/models/pattern/utils` and `server/handlers` - clean (removed the now-unused `v1beta1` import).
