### PR TITLE
fix: persist dark/light theme preference across page refreshes

### DIFF
--- a/ui/components/user-preferences/index.tsx
+++ b/ui/components/user-preferences/index.tsx
@@ -57,9 +57,7 @@ import { SecondaryTab, SecondaryTabs } from '../dashboard/style';
 import { useDispatch, useSelector } from 'react-redux';
 import { toggleCatalogContent, updateProgress } from '@/store/slices/mesheryUi';
 
-interface ThemeTogglerProps {
-  handleUpdateUserPref: (_theme: string) => void;
-}
+interface ThemeTogglerProps {}
 
 interface ThemeComponentProps {
   mode: 'light' | 'dark';
@@ -104,7 +102,7 @@ interface _UserData {
   };
 }
 
-const ThemeToggler: React.FC<ThemeTogglerProps> = ({ handleUpdateUserPref }) => {
+const ThemeToggler: React.FC<ThemeTogglerProps> = () => {
   const Component: React.FC<ThemeComponentProps> = ({ mode, toggleTheme }) => {
     return (
       <div>
@@ -113,10 +111,9 @@ const ThemeToggler: React.FC<ThemeTogglerProps> = ({ handleUpdateUserPref }) => 
           checked={mode === 'dark'}
           onChange={() => {
             toggleTheme();
-            handleUpdateUserPref(mode === 'dark' ? 'light' : 'dark');
           }}
         />
-        Dark Mode
+        {mode === 'dark' ? 'Dark Mode' : 'Light Mode'}
       </div>
     );
   };
@@ -175,7 +172,11 @@ const UserPreference: React.FC<UserPreferenceProps> = (props) => {
         });
       })
       .catch(() => {
-        handleError('There was an error sending your preference');
+        updateProgress({ showProgress: false });
+        notify({
+          message: 'There was an error sending your preference',
+          event_type: EVENT_TYPES.ERROR,
+        });
       });
   };
 
@@ -187,11 +188,6 @@ const UserPreference: React.FC<UserPreferenceProps> = (props) => {
       setPerfResultStats(!perfResultStats);
       handleChange(name, !perfResultStats);
     }
-  };
-
-  const handleError = (name) => () => {
-    updateProgress({ showProgress: false });
-    notify({ message: name, event_type: EVENT_TYPES.ERROR });
   };
 
   const handleChange = (name, resultState) => {
@@ -207,10 +203,10 @@ const UserPreference: React.FC<UserPreferenceProps> = (props) => {
         : 'Sending anonymous performance results was disabled';
     }
 
-    const requestBody = JSON.stringify({
+    const requestBody = {
       anonymousUsageStats: name === 'anonymousUsageStats' ? val : anonymousStats,
       anonymousPerfResults: name === 'anonymousPerfResults' ? val : perfResultStats,
-    });
+    };
 
     updateProgress({ showProgress: true });
     updateUserPrefWithContext({ body: requestBody })
@@ -222,7 +218,11 @@ const UserPreference: React.FC<UserPreferenceProps> = (props) => {
         }
       })
       .catch(() => {
-        handleError('There was an error sending your preference');
+        updateProgress({ showProgress: false });
+        notify({
+          message: 'There was an error sending your preference',
+          event_type: EVENT_TYPES.ERROR,
+        });
       });
   };
 
@@ -527,7 +527,7 @@ const UserPreference: React.FC<UserPreferenceProps> = (props) => {
 
   const handleUpdateUserPref = (key, value) => {
     const updates = _.set(_.cloneDeep(userData), key, value);
-    updateUserPrefWithContext(updates);
+    updateUserPrefWithContext({ body: updates });
   };
   return (
     <>
@@ -626,10 +626,7 @@ const UserPreference: React.FC<UserPreferenceProps> = (props) => {
                   <FormLegend component="legend">Theme</FormLegend>
 
                   <FormGroup>
-                    <ThemeToggler
-                      handleUpdateUserPref={handleUpdateUserPref}
-                      classes={props.classes}
-                    />
+                    <ThemeToggler />
                   </FormGroup>
                 </FormGroupWrapper>
               </FormContainerWrapper>

--- a/ui/rtk-query/user.ts
+++ b/ui/rtk-query/user.ts
@@ -76,7 +76,7 @@ export const userApi = api
           headers: {
             'Content-Type': 'application/json;charset=UTF-8',
           },
-          body: queryArg.body,
+          body: JSON.stringify(queryArg.body),
         }),
         invalidatesTags: [Tags.USER_PREF],
         // Perform optimistic update

--- a/ui/theme/hooks.tsx
+++ b/ui/theme/hooks.tsx
@@ -4,17 +4,64 @@ import _ from 'lodash/fp';
 import ProviderStoreWrapper from '@/store/ProviderStoreWrapper';
 import { useMediaQuery } from '@sistent/sistent';
 
-export const useThemePreference = () => {
-  const { data, ...res } = useGetUserPrefQuery();
-  // Default to dark on the server and first client render, matching the
-  // pre-hydration UI; resolves to the real system preference after mount.
+const THEME_STORAGE_KEY = 'meshery-theme';
+
+type ThemeMode = 'light' | 'dark';
+
+const isThemeMode = (value: string | null): value is ThemeMode =>
+  value === 'light' || value === 'dark';
+
+const getStoredTheme = (): ThemeMode | null => {
+  try {
+    const value = localStorage.getItem(THEME_STORAGE_KEY);
+    return isThemeMode(value) ? value : null;
+  } catch {
+    return null;
+  }
+};
+
+const setStoredTheme = (theme: ThemeMode): void => {
+  try {
+    localStorage.setItem(THEME_STORAGE_KEY, theme);
+  } catch {
+    // Ignore storage errors (e.g., storage disabled/unavailable).
+  }
+};
+
+// Default to dark on the server and first client render, matching the
+// pre-hydration UI; resolves to the real system preference after mount.
+export const useGetSystemTheme = (): ThemeMode => {
   const prefersDark = useMediaQuery('(prefers-color-scheme: dark)', { defaultMatches: true });
-  const mode = data?.remoteProviderPreferences?.theme || (prefersDark ? 'dark' : 'light');
+  return prefersDark ? 'dark' : 'light';
+};
+
+export const useThemePreference = () => {
+  const { data, isLoading, ...res } = useGetUserPrefQuery();
+  const systemPref = useGetSystemTheme();
+  const [storedMode, setStoredMode] = useState<ThemeMode | null>(getStoredTheme);
+
+  useEffect(() => {
+    const handler = () => setStoredMode(getStoredTheme());
+    window.addEventListener('theme-change', handler);
+    return () => window.removeEventListener('theme-change', handler);
+  }, []);
+
+  const remoteThemeValue = data?.remoteProviderPreferences?.theme ?? null;
+  const remoteMode = isThemeMode(remoteThemeValue) ? remoteThemeValue : null;
+  const mode = isLoading ? storedMode || systemPref : remoteMode || storedMode || systemPref;
+
+  useEffect(() => {
+    const remoteTheme = data?.remoteProviderPreferences?.theme;
+    if (!isLoading && isThemeMode(remoteTheme)) {
+      setStoredTheme(remoteTheme);
+      setStoredMode(remoteTheme);
+    }
+  }, [isLoading, data?.remoteProviderPreferences?.theme]);
 
   return {
-    data: {
-      mode,
-    },
+    data: { mode },
+    isLoading,
+    setStoredMode,
     ...res,
   };
 };
@@ -22,21 +69,23 @@ export const useThemePreference = () => {
 const ThemeTogglerCore_ = ({ Component }) => {
   const themePref = useThemePreference();
   const [handleUpdateUserPref] = useUpdateUserPrefWithContextMutation();
-  const { data: userPrefs } = useGetUserPrefQuery();
-  const [mode, setMode] = useState(themePref?.data?.mode);
+  const { data: userPrefs, isLoading } = useGetUserPrefQuery();
 
-  useEffect(() => {
-    setMode(themePref?.data?.mode);
-  }, [themePref?.data?.mode]);
+  const mode = themePref?.data?.mode;
+  const { setStoredMode } = themePref;
 
   const toggleTheme = () => {
+    if (isLoading) return;
     const newTheme = mode === 'light' ? 'dark' : 'light';
-    setMode(newTheme);
-    const updated = _.set('remoteProviderPreferences.theme', newTheme, userPrefs);
+    setStoredTheme(newTheme);
+    setStoredMode(newTheme);
+    window.dispatchEvent(new Event('theme-change'));
 
-    handleUpdateUserPref({
-      body: updated,
-    });
+    const isRemoteProvider = !!userPrefs?.remoteProviderPreferences;
+    if (isRemoteProvider) {
+      const updated = _.set('remoteProviderPreferences.theme', newTheme, userPrefs);
+      handleUpdateUserPref({ body: updated });
+    }
   };
 
   return <Component mode={mode} toggleTheme={toggleTheme} />;


### PR DESCRIPTION
**Notes for Reviewers**
The user's dark/light mode preference was being lost on page refresh. Theme state lived only in React component state, which resets on refresh, so toggling had no persistence.

- This PR fixes #8772 

**Changes made**
- Rewrote useThemePreference hook (themes/hooks.tsx) with the following behavior:
1. On app start / while RTK Query is loading (isLoading = true), reads localStorage directly as a placeholder to prevent theme flash
2. Once RTK Query resolves (isLoading = false), remote provider preference takes over as the source of truth
3. On toggle, writes to localStorage directly and dispatches a theme-change window event so all instances of useThemePreference (including the one in _app.tsx) stay in sync
4. For remote provider users, also calls handleUpdateUserPref to persist the preference server-side

- Added explicit JSON.stringify in rtk-query/user.ts for the POST body



https://github.com/user-attachments/assets/9fa08618-807b-43dd-acc0-38a889fbc40a





**[Signed commits](https://github.com/meshery/meshery/blob/master/CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [x] Yes, I signed my commits.

<!--
Thank you for contributing to Meshery! 

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. Sign your commits.
4. Include before and after screenshots/terminal output.

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Theme selection now persists across sessions and stays synchronized across open areas of the app.
  * When no saved preference exists, the app can follow the device’s light or dark mode.
  * Theme controls now clearly display “Dark Mode” or “Light Mode.”

* **Bug Fixes**
  * Improved reliability when saving theme and other user preferences.
  * Added consistent error notifications when preference updates fail.
  * Prevented theme changes while an update is still processing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->