### PR TITLE
Fix printf-style logging calls flagged by go vet

### DIFF
--- a/server/handlers/prometheus_handlers.go
+++ b/server/handlers/prometheus_handlers.go
@@ -226,7 +226,7 @@ func (h *Handler) PrometheusConfigHandler(w http.ResponseWriter, req *http.Reque
 		_ = provider.PersistEvent(*event, token)
 		go h.config.EventBroadcaster.Publish(userUUID, event)
 
-		h.log.Debug("Prometheus URL %s saved", promURL)
+		h.log.Debugf("Prometheus URL %s saved", promURL)
 	}
 
 	err := provider.RecordPreferences(req, user.UserId, prefObj)

--- a/server/machines/models.go
+++ b/server/machines/models.go
@@ -171,7 +171,7 @@ func (sm *StateMachine) SendEvent(ctx context.Context, eventType EventType, payl
 		if state.Action != nil {
 			// Execute entry actions for the state entered.
 			eventType, event, err = state.Action.ExecuteOnEntry(ctx, sm.Context, nil)
-			sm.Log.Debugf("%s: entry action executed, event emitted ", sm.Name, eventType)
+			sm.Log.Debugf("%s: entry action executed, event emitted %v", sm.Name, eventType)
 
 			if err != nil {
 				sm.Log.Error(err)
@@ -182,7 +182,7 @@ func (sm *StateMachine) SendEvent(ctx context.Context, eventType EventType, payl
 			} else {
 				eventType, event, err = state.Action.Execute(ctx, sm.Context, payload)
 
-				sm.Log.Debugf("%s: inside action executed, event emitted ", sm.Name, eventType)
+				sm.Log.Debugf("%s: inside action executed, event emitted %v", sm.Name, eventType)
 				if err != nil {
 					sm.Log.Error(err)
 					sm.Log.Debug(event)

--- a/server/models/remote_provider.go
+++ b/server/models/remote_provider.go
@@ -4627,7 +4627,11 @@ func (l *RemoteProvider) GetConnectionByID(token string, connectionID core.Uuid)
 		return &conn, resp.StatusCode, nil
 	}
 
-	l.Log.Errorf("unable to read response body for connection with id %s: %v, resp body: %s", connectionID, err, string(bdr))
+	if err != nil {
+		l.Log.Errorf("unable to read response body for connection with id %s: %v", connectionID, err)
+	} else {
+		l.Log.Errorf("failed to retrieve connection with id %s: unexpected status %d, resp body: %s", connectionID, resp.StatusCode, string(bdr))
+	}
 	return nil, resp.StatusCode, ErrFetch(fmt.Errorf("unable to retrieve connection with id %s", connectionID), "connection", resp.StatusCode)
 }
 

--- a/server/models/remote_provider.go
+++ b/server/models/remote_provider.go
@@ -4608,13 +4608,15 @@ func (l *RemoteProvider) GetConnectionByID(token string, connectionID core.Uuid)
 		statusCode := http.StatusInternalServerError
 		return nil, statusCode, ErrFetch(err, "connection", statusCode)
 	}
+	// Close the body on every path once DoRequest has handed us a response.
+	// This defer previously lived inside the 200 branch, leaking the
+	// connection whenever the provider returned a non-2xx status.
+	defer func() {
+		_ = resp.Body.Close()
+	}()
 
 	bdr, err := io.ReadAll(resp.Body)
 	if resp.StatusCode == http.StatusOK {
-		defer func() {
-			_ = resp.Body.Close()
-		}()
-
 		if err != nil {
 			l.Log.Errorf("unable to read response body for connection with id %s: %v, resp body: %s", connectionID, err, string(bdr))
 			return nil, resp.StatusCode, ErrFetch(fmt.Errorf("unable to retrieve connection with id %s, err body %s", connectionID, string(bdr)), "connection", resp.StatusCode)

--- a/server/models/remote_provider.go
+++ b/server/models/remote_provider.go
@@ -1707,7 +1707,7 @@ func (l *RemoteProvider) persistEventRemote(event events.Event, tokenString stri
 		return ErrMarshal(err, "meshery event")
 	}
 
-	l.Log.Info("attempting to publish event to remote provider, size: %d", len(data))
+	l.Log.Infof("attempting to publish event to remote provider, size: %d", len(data))
 	bf := bytes.NewBuffer(data)
 	remoteProviderURL, _ := url.Parse(l.RemoteProviderURL + ep)
 
@@ -2006,7 +2006,7 @@ func (l *RemoteProvider) PublishMetrics(tokenString string, result *MesheryResul
 		return ErrMarshal(err, "meshery metrics for shipping")
 	}
 
-	l.Log.Debug("Result: %s, size: %d", data, len(data))
+	l.Log.Debugf("Result: %s, size: %d", data, len(data))
 	l.Log.Info("attempting to publish metrics to remote provider")
 	bf := bytes.NewBuffer(data)
 
@@ -4616,7 +4616,7 @@ func (l *RemoteProvider) GetConnectionByID(token string, connectionID core.Uuid)
 		}()
 
 		if err != nil {
-			l.Log.Errorf("unable to read response body for connection with id %s: %v , resp body", connectionID, err, string(bdr))
+			l.Log.Errorf("unable to read response body for connection with id %s: %v, resp body: %s", connectionID, err, string(bdr))
 			return nil, resp.StatusCode, ErrFetch(fmt.Errorf("unable to retrieve connection with id %s, err body %s", connectionID, string(bdr)), "connection", resp.StatusCode)
 		}
 		var conn connections.Connection
@@ -4627,7 +4627,7 @@ func (l *RemoteProvider) GetConnectionByID(token string, connectionID core.Uuid)
 		return &conn, resp.StatusCode, nil
 	}
 
-	l.Log.Errorf("unable to read response body for connection with id %s: %v , resp body", connectionID, err, string(bdr))
+	l.Log.Errorf("unable to read response body for connection with id %s: %v, resp body: %s", connectionID, err, string(bdr))
 	return nil, resp.StatusCode, ErrFetch(fmt.Errorf("unable to retrieve connection with id %s", connectionID), "connection", resp.StatusCode)
 }
 


### PR DESCRIPTION
## Description

`go test` runs `go vet`, and several printf-style logging calls fail vet — which fails the build of the server `models`, `handlers`, and `machines` packages and breaks the **`server Unit tests`** job (`go test -json --short ./server/... -race`) on `master`. While fixing those, review surfaced a response-body leak and a misleading error log in the same `GetConnectionByID` path, both addressed here.

### Fixes
**`go vet` printf failures**
- `server/models/remote_provider.go`: `Info`/`Debug` called with format verbs (`%d`, `%s`) → `Infof`/`Debugf`, so the values are actually interpolated instead of dropped.
- `server/models/remote_provider.go`: two `Errorf` calls passed the response body as a third argument while the format string had only two verbs → added the missing `%s` so the body is logged.
- `server/handlers/prometheus_handlers.go`: `Debug("Prometheus URL %s saved", promURL)` → `Debugf`.
- `server/machines/models.go`: two `Debugf` calls had a single `%s` verb but two args → the emitted `eventType` was silently dropped; added the missing `%v`.

**`GetConnectionByID` correctness (from review)**
- Move `defer resp.Body.Close()` to immediately after the `DoRequest` error check so the body is closed on every path (it previously lived inside the `200` branch, leaking the connection on any non-2xx status).
- In the non-2xx branch, log a genuine read failure only when `err != nil`; otherwise report the unexpected status and response body, instead of always saying "unable to read response body".

### Verification
- `go vet ./...` across the whole server module is clean.
- `go test --short ./...` across the whole server module passes (every package `ok`).

Pre-existing on `master` and unrelated to feature work; split out so the `server Unit tests` job can go green again repo-wide.