### PR TITLE
[Docs] Restore "Exposing Meshery service(LoadBalancer)" section, fix dead GKE anchor

### DIFF
--- a/docs/content/en/installation/kubernetes/_index.md
+++ b/docs/content/en/installation/kubernetes/_index.md
@@ -28,7 +28,7 @@ Manage your Kubernetes clusters with Meshery. Deploy Meshery in Kubernetes [in-c
   - [Installation: Using `mesheryctl`](#installation-using-mesheryctl)
   - [Installation: Using Helm](#installation-using-helm)
   - [Post-Installation Steps](#post-installation-steps)
-  - [Exposing Meshery service(LoadBalancer)](#exposing-meshery-serviceloadbalancer)
+  - [Exposing Meshery Service (LoadBalancer)](#exposing-meshery-serviceloadbalancer)
 - [Out-of-cluster Installation](#out-of-cluster-installation)
   - [Set up Ingress on Minikube with the NGINX Ingress Controller](#set-up-ingress-on-minikube-with-the-nginx-ingress-controller)
   - [Installing cert-manager with kubectl](#installing-cert-manager-with-kubectl)
@@ -67,7 +67,7 @@ You're ready to use Meshery! Open your browser and navigate to the Meshery UI.
 
 {{< installation/accessing-meshery-ui >}}
 
-## Exposing Meshery service(LoadBalancer)
+## Exposing Meshery Service (LoadBalancer) {#exposing-meshery-serviceloadbalancer}
 
 When Meshery is installed in-cluster, Meshery UI is served by a Kubernetes `Service` named `meshery` in the `meshery` namespace. This `Service` is created as type `LoadBalancer` by default, forwarding port `9081` (Meshery UI) to the Meshery Server container on port `8080`.
 

--- a/docs/content/en/installation/kubernetes/_index.md
+++ b/docs/content/en/installation/kubernetes/_index.md
@@ -28,6 +28,7 @@ Manage your Kubernetes clusters with Meshery. Deploy Meshery in Kubernetes [in-c
   - [Installation: Using `mesheryctl`](#installation-using-mesheryctl)
   - [Installation: Using Helm](#installation-using-helm)
   - [Post-Installation Steps](#post-installation-steps)
+  - [Exposing Meshery service(LoadBalancer)](#exposing-meshery-serviceloadbalancer)
 - [Out-of-cluster Installation](#out-of-cluster-installation)
   - [Set up Ingress on Minikube with the NGINX Ingress Controller](#set-up-ingress-on-minikube-with-the-nginx-ingress-controller)
   - [Installing cert-manager with kubectl](#installing-cert-manager-with-kubectl)
@@ -65,6 +66,24 @@ Optionally, you can verify the health of your Meshery deployment using <a href='
 You're ready to use Meshery! Open your browser and navigate to the Meshery UI.
 
 {{< installation/accessing-meshery-ui >}}
+
+## Exposing Meshery service(LoadBalancer)
+
+When Meshery is installed in-cluster, Meshery UI is served by a Kubernetes `Service` named `meshery` in the `meshery` namespace. This `Service` is created as type `LoadBalancer` by default, forwarding port `9081` (Meshery UI) to the Meshery Server container on port `8080`.
+
+On a managed Kubernetes offering - such as GKE, EKS, AKS, or DigitalOcean Kubernetes - a `LoadBalancer` `Service` instructs the cloud provider to provision an external load balancer and assign it a routable `EXTERNAL-IP`. Retrieve the address with:
+
+{{< code code="kubectl get service meshery --namespace meshery" >}}
+
+Once the `EXTERNAL-IP` column shows an address instead of `<pending>`, open Meshery UI in your browser at `http://[EXTERNAL-IP]:9081`.
+
+If the `Service` was previously set to another type (for example, `ClusterIP`), switch it back to `LoadBalancer`:
+
+{{< code code=`kubectl patch service meshery --namespace meshery --type merge -p '{"spec":{"type":"LoadBalancer"}}'` >}}
+
+{{% alert title="EXTERNAL-IP not assigned?" color="warning" %}}
+A `LoadBalancer` `Service` is only assigned an external address when the cluster runs a load balancer controller. Managed clouds provide one out of the box; bare-metal and local clusters (for example, Minikube or kind) do not. On those clusters, install a load balancer implementation such as [MetalLB](https://metallb.universe.tf/), expose Meshery through a `NodePort` `Service` instead, or reach the UI with port-forwarding by following the [mesheryctl system dashboard](/reference/mesheryctl/system/dashboard) guide.
+{{% /alert %}}
 
 # Out-of-cluster Installation
 


### PR DESCRIPTION
**Notes for Reviewers**

The GKE installation guide ([`gke.md`](https://github.com/meshery/meshery/blob/master/docs/content/en/installation/kubernetes/gke.md) line 61) links to `/installation/kubernetes#exposing-meshery-serviceloadbalancer`, but that anchor had no target - the section was missing from the Kubernetes installation index. This was the only in-repo reference to the anchor (`grep -rn "exposing-meshery-service" docs/content/` returns just that one line), so the link was simply dead.

- **Symptom** - the "LoadBalancer" link in the GKE guide points to `#exposing-meshery-serviceloadbalancer`, which scrolls nowhere because no heading on `/installation/kubernetes` produces that id.
- **Root cause** - the "Exposing Meshery Service" content that once lived in the Kubernetes install page was lost; the anchor the GKE guide targets has no corresponding heading in `kubernetes/_index.md`.
- **Fix** - restore the section as `## Exposing Meshery service(LoadBalancer)` in `kubernetes/_index.md`. Hugo's default github-style anchorization turns that exact heading into `exposing-meshery-serviceloadbalancer`, so the existing GKE link resolves **with no change to `gke.md`**. The new section documents the real `meshery` Service (type `LoadBalancer` by default, port `9081` -> target `8080` per the bundled manifests and Helm `values.yaml`), how to read its `EXTERNAL-IP`, how to reset the Service type, and the `<pending>` bare-metal/local case (MetalLB / NodePort / port-forward). It also serves as a canonical reference the AKS, EKS, and DigitalOcean (DOKS) guides can point to. The TOC under "Available Deployment Methods" was updated to list it.
- **Watch for** - `aks.md` is the only cloud Kubernetes guide that does **not** render the standard `{{< installation/accessing-meshery-ui >}}` shortcode, so AKS users currently get no UI-access guidance after install. That is a separate gap, left out of this focused PR and tracked as a follow-up.

**Validation**

`cd docs && hugo -e dev -DFE` - the new content parses with no content/shortcode errors; the only failure is the local `sass`/SCSS asset-pipeline error in `head.html` (sandbox limitation, unrelated to content).

Anchor and shortcodes verified by rendering with the real Hugo binary + templates:

```
=== generated heading id ===
id="exposing-meshery-serviceloadbalancer"
MATCH: anchor == exposing-meshery-serviceloadbalancer (gke.md link will resolve)

=== code shortcodes rendered ===
<code class="clipboardjs">kubectl get service meshery --namespace meshery</code>
<code class="clipboardjs">kubectl patch service meshery --namespace meshery --type merge -p '{"spec":{"type":"LoadBalancer"}}'</code>
```

**[Signed commits](https://github.com/meshery/meshery/blob/master/CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [x] Yes, I signed my commits.
