### PR TITLE
docs: add Organizations logical concept; expand provider extensibility

### DIFF
--- a/docs/content/en/concepts/logical/organizations/index.md
+++ b/docs/content/en/concepts/logical/organizations/index.md
@@ -86,5 +86,6 @@ How those choices combine — from a shared, hosted experience to a fully white-
 - Use separate Organizations to isolate tenants — distinct customers, partners, or business units — so their resources and access never overlap.
 - Keep ownership at the Organization level (rather than relying on individual users) so work persists as team membership changes.
 - When using a Remote Provider, assign access through teams and roles rather than per-user, and choose the [organization configuration](https://docs.layer5.io/cloud/guides/organizations/configuration-scenarios/) that matches your branding and identity needs.
+- When graduating from the Local provider to a Remote Provider, create an Organization first so resource ownership is established from the start.
 
 Organizations give Meshery a clear, isolated home for every team's work. Paired with a Remote Provider, they become the foundation for identity, access control, and a branded, multi-tenant experience.

--- a/docs/content/en/concepts/logical/organizations/index.md
+++ b/docs/content/en/concepts/logical/organizations/index.md
@@ -79,13 +79,13 @@ A Remote Provider can extend an Organization well beyond simple grouping. Using 
 - **Roles, teams, and fine-grained permissions** — extensible RBAC returned by the Remote Provider as part of the user's token.
 - **Controlled membership** — open self-service sign-up or invitation-only joining, optionally restricted to an email domain.
 
-How those choices combine — from a shared, hosted experience to a fully white-labeled deployment on the Organization's own domain — is described in the Remote Provider's documentation. For Meshery Cloud, see [Organization Configuration Scenarios](https://docs.layer5.io/cloud/guides/organizations/configuration-scenarios/) and the [Organizations concept](https://docs.layer5.io/cloud/concepts/identity-and-security/organizations/) in the Layer5 Cloud docs.
+How those choices combine differs based on your connected Remote Provider. Experiences vary from a shared, hosted experience to a fully white-labeled deployment on the Organization's own domain. See your respective Remote Provider's documentation.
 
 ## Best Practices
 
 - Use separate Organizations to isolate tenants — distinct customers, partners, or business units — so their resources and access never overlap.
 - Keep ownership at the Organization level (rather than relying on individual users) so work persists as team membership changes.
-- When using a Remote Provider, assign access through teams and roles rather than per-user, and choose the [organization configuration](https://docs.layer5.io/cloud/guides/organizations/configuration-scenarios/) that matches your branding and identity needs.
+- Depending upon your Remote Provider, you may assign access through teams and roles rather than per-user, and potentially customize your organization's branding and identity.
 - When graduating from the Local provider to a Remote Provider, create an Organization first so resource ownership is established from the start.
 
 Organizations give Meshery a clear, isolated home for every team's work. Paired with a Remote Provider, they become the foundation for identity, access control, and a branded, multi-tenant experience.

--- a/docs/content/en/concepts/logical/organizations/index.md
+++ b/docs/content/en/concepts/logical/organizations/index.md
@@ -18,7 +18,7 @@ Whether you have Organizations at all depends on which [Provider](/reference/ext
 - With the **Local** provider, Meshery runs in single-user mode. There is no authentication and no multi-tenancy, so Organizations, teams, and shared ownership do not come into play.
 - With a **Remote Provider** (such as [Meshery Cloud](https://cloud.meshery.io)), Meshery runs in multi-user mode. The Remote Provider supplies identity, and **Organizations become the structure through which users, ownership, and access control are managed.**
 
-In other words, Organizations are a capability that a Remote Provider extends Meshery with. Different Remote Providers can offer richer or simpler organization models — hierarchical organizations, teams as user groups, fine-grained roles — through Meshery's [extensible authorization](/reference/extensibility/providers) framework.
+In other words, Organizations are a capability that a Remote Provider extends Meshery with. Different Remote Providers can offer richer or simpler organization models — hierarchical organizations, teams as user groups, fine-grained roles — through Meshery's [provider extensibility](/reference/extensibility/providers) framework.
 
 ## Key Features
 
@@ -63,6 +63,12 @@ See "[Environments](/concepts/logical/environments)" for more information.
 - Designs — reusable, declarative characterizations of your infrastructure — are owned by an Organization and deployed within the context of a Workspace.
 
 See "[Designs](/concepts/logical/designs)" for more information.
+
+### Connections
+
+- Connections are the managed or discovered infrastructure resources (Kubernetes clusters, Prometheus instances, and so on) that Meshery works with. They are grouped by Environments and owned by an Organization.
+
+See "[Connections](/concepts/logical/connections)" for more information.
 
 ## Organizations with a Remote Provider
 

--- a/docs/content/en/concepts/logical/organizations/index.md
+++ b/docs/content/en/concepts/logical/organizations/index.md
@@ -1,0 +1,84 @@
+---
+title: Organizations
+description: Organizations are the unit of tenancy in Meshery — they group users together and own all of the resources those users create.
+aliases:
+- /concepts/organizations/
+---
+
+An **Organization** is the unit of tenancy in Meshery. Organizations group users together and **own all of the resources those users create** — Workspaces, Environments, Designs, Connections, and more. Where a [Workspace](/concepts/logical/workspaces) is your team's collaboration space, the Organization is the top-level container that everything else lives inside of, and the boundary that keeps one tenant's resources isolated from another's.
+
+{{% alert color="dark" title="The unit of tenancy" %}}
+Organizations are the outermost boundary of ownership and access in Meshery. Every Workspace, Environment, Design, and Connection belongs to exactly one Organization.
+{{% /alert %}}
+
+## Organizations and Providers
+
+Whether you have Organizations at all depends on which [Provider](/reference/extensibility/providers) Meshery is connected to:
+
+- With the **Local** provider, Meshery runs in single-user mode. There is no authentication and no multi-tenancy, so Organizations, teams, and shared ownership do not come into play.
+- With a **Remote Provider** (such as [Meshery Cloud](https://cloud.meshery.io)), Meshery runs in multi-user mode. The Remote Provider supplies identity, and **Organizations become the structure through which users, ownership, and access control are managed.**
+
+In other words, Organizations are a capability that a Remote Provider extends Meshery with. Different Remote Providers can offer richer or simpler organization models — hierarchical organizations, teams as user groups, fine-grained roles — through Meshery's [extensible authorization](/reference/extensibility/providers) framework.
+
+## Key Features
+
+- **Tenancy boundary** — an Organization isolates its resources from every other Organization. Members of one Organization cannot see or manage another's resources unless access is explicitly shared.
+- **Resource ownership** — Workspaces, Environments, Designs, and Connections are all owned by an Organization, not by an individual user, so work survives changes in team membership.
+- **Membership** — users belong to one or more Organizations. A user's permissions in one Organization are independent of their permissions in another.
+- **Access control** — with a Remote Provider, Organizations carry roles and permissions that govern what each member may do with the Organization's resources.
+- **Identity and branding** — a Remote Provider can extend an Organization with its own identity provider, custom domain, and branding (see [With a Remote Provider](#organizations-with-a-remote-provider) below).
+
+## Where Organizations fit
+
+Organizations sit at the top of Meshery's logical hierarchy:
+
+- An **Organization** groups **users** (and, with a Remote Provider, **teams** as user groups).
+- The Organization **owns** its **Workspaces**, **Environments**, **Designs**, and **Connections**.
+- **Teams** are granted access to **Workspaces**.
+- **Workspaces** bring together **Environments** (groupings of **Connections**) and the **Designs** deployed against them.
+
+So a typical path from the top down is: *Organization → Team → Workspace → Environment → Connection*, with Designs deployed into the infrastructure a Workspace can reach.
+
+## Key Relationships
+
+### Teams
+
+- Teams are groups of users **within** an Organization, used to grant access to Workspaces and their resources.
+- Teams are a Remote Provider extension; the depth of team and role support varies by provider.
+
+### Workspaces
+
+- Workspaces are owned by an Organization and serve as the collaboration point where teams do their work.
+
+See "[Workspaces](/concepts/logical/workspaces)" for more information.
+
+### Environments
+
+- Environments group Connections (Kubernetes clusters, Prometheus instances, and so on) and are owned by an Organization.
+
+See "[Environments](/concepts/logical/environments)" for more information.
+
+### Designs
+
+- Designs — reusable, declarative characterizations of your infrastructure — are owned by an Organization and deployed within the context of a Workspace.
+
+See "[Designs](/concepts/logical/designs)" for more information.
+
+## Organizations with a Remote Provider
+
+A Remote Provider can extend an Organization well beyond simple grouping. Using [Meshery Cloud](https://cloud.meshery.io) as the reference implementation, an Organization can be configured with:
+
+- **Its own identity provider** — email-and-password and social sign-in (Google, GitHub), or the Organization's own OAuth/OIDC single sign-on.
+- **A custom domain and branding** — its own URL, logo, colors, and login screen ("white-labeling").
+- **Roles, teams, and fine-grained permissions** — extensible RBAC returned by the Remote Provider as part of the user's token.
+- **Controlled membership** — open self-service sign-up or invitation-only joining, optionally restricted to an email domain.
+
+How those choices combine — from a shared, hosted experience to a fully white-labeled deployment on the Organization's own domain — is described in the Remote Provider's documentation. For Meshery Cloud, see [Organization Configuration Scenarios](https://docs.layer5.io/cloud/guides/organizations/configuration-scenarios/) and the [Organizations concept](https://docs.layer5.io/cloud/concepts/identity-and-security/organizations/) in the Layer5 Cloud docs.
+
+## Best Practices
+
+- Use separate Organizations to isolate tenants — distinct customers, partners, or business units — so their resources and access never overlap.
+- Keep ownership at the Organization level (rather than relying on individual users) so work persists as team membership changes.
+- When using a Remote Provider, assign access through teams and roles rather than per-user, and choose the [organization configuration](https://docs.layer5.io/cloud/guides/organizations/configuration-scenarios/) that matches your branding and identity needs.
+
+Organizations give Meshery a clear, isolated home for every team's work. Paired with a Remote Provider, they become the foundation for identity, access control, and a branded, multi-tenant experience.

--- a/docs/content/en/concepts/logical/organizations/index.md
+++ b/docs/content/en/concepts/logical/organizations/index.md
@@ -8,7 +8,7 @@ aliases:
 An **Organization** is the unit of tenancy in Meshery. Organizations group users together and **own all of the resources those users create** — Workspaces, Environments, Designs, Connections, and more. Where a [Workspace](/concepts/logical/workspaces) is your team's collaboration space, the Organization is the top-level container that everything else lives inside of, and the boundary that keeps one tenant's resources isolated from another's.
 
 {{% alert color="dark" title="The unit of tenancy" %}}
-Organizations are the outermost boundary of ownership and access in Meshery. Every Workspace, Environment, Design, and Connection belongs to exactly one Organization.
+Organizations are the outermost boundary of ownership and access in Meshery. When using a Remote Provider, every Workspace, Environment, Design, and Connection belongs to exactly one Organization.
 {{% /alert %}}
 
 ## Organizations and Providers
@@ -32,7 +32,7 @@ In other words, Organizations are a capability that a Remote Provider extends Me
 
 Organizations sit at the top of Meshery's logical hierarchy:
 
-- An **Organization** groups **users** (and, with a Remote Provider, **teams** as user groups).
+- An **Organization** groups **users** (and, with a Remote Provider, **teams**).
 - The Organization **owns** its **Workspaces**, **Environments**, **Designs**, and **Connections**.
 - **Teams** are granted access to **Workspaces**.
 - **Workspaces** bring together **Environments** (groupings of **Connections**) and the **Designs** deployed against them.

--- a/docs/content/en/reference/extensibility/providers/index.md
+++ b/docs/content/en/reference/extensibility/providers/index.md
@@ -55,7 +55,7 @@ There are two types of providers defined in Meshery, `local` and `remote`.
 The provider you choose determines whether Meshery is single-user or multi-tenant:
 
 - With the **Local** provider, Meshery is **single-user**: there is no authentication, no identity, and no multi-tenancy. There are no [Organizations](/concepts/logical/organizations), teams, or shared ownership — every resource belongs to the single local user.
-- With a **Remote Provider**, Meshery is **multi-user and multi-tenant**. The provider supplies identity, and [Organizations](/concepts/logical/organizations) become the unit of tenancy: they group users, own all of their Workspaces, Environments, Designs, and Connections, and carry the roles and permissions that govern access. A Remote Provider can extend an Organization further with its own identity provider, custom domain, and branding.
+- With a **Remote Provider**, Meshery is **multi-user and multi-tenant**. The provider supplies identity, and [Organizations](/concepts/logical/organizations) become the unit of tenancy: they group users, own all Workspaces, Environments, Designs, and Connections, and carry the roles and permissions that govern access. A Remote Provider can extend an Organization further with its own identity provider, custom domain, and branding.
 
 This is the central reason to use a Remote Provider for any shared, ongoing, or public-facing Meshery deployment — see [Recommended Production Deployment Settings](#recommended-production-deployment-settings) below. For the tenancy model itself, see [Organizations](/concepts/logical/organizations).
 

--- a/docs/content/en/reference/extensibility/providers/index.md
+++ b/docs/content/en/reference/extensibility/providers/index.md
@@ -23,6 +23,9 @@ Some examples include:
 
 - **Authentication and Authorization**
   - Examples: session management, two factor authentication, LDAP integration.
+- **Identity and Organization Management**
+  - Examples: multi-tenant [Organizations](/concepts/logical/organizations), teams as user groups, fine-grained roles and permissions.
+  - Examples: per-organization identity providers (OAuth/OIDC single sign-on), custom domains, and branding / white-labeling.
 - **Long-Term Persistence**
   - Examples: Storage and retrieval of performance test results.
   - Examples: Storage and retrieval of user preferences.
@@ -46,6 +49,15 @@ There are two types of providers defined in Meshery, `local` and `remote`.
 
 - The **Local** provider is built-into Meshery.
 - **Remote providers** can be implemented by anyone or an organization that wishes to integrate with Meshery. Any number of Remote providers may be available in your Meshery deployment.
+
+### Identity and Multi-Tenancy
+
+The provider you choose determines whether Meshery is single-user or multi-tenant:
+
+- With the **Local** provider, Meshery is **single-user**: there is no authentication, no identity, and no multi-tenancy. There are no [Organizations](/concepts/logical/organizations), teams, or shared ownership — every resource belongs to the single local user.
+- With a **Remote Provider**, Meshery is **multi-user and multi-tenant**. The provider supplies identity, and [Organizations](/concepts/logical/organizations) become the unit of tenancy: they group users, own all of their Workspaces, Environments, Designs, and Connections, and carry the roles and permissions that govern access. A Remote Provider can extend an Organization further with its own identity provider, custom domain, and branding.
+
+This is the central reason to use a Remote Provider for any shared, ongoing, or public-facing Meshery deployment — see [Recommended Production Deployment Settings](#recommended-production-deployment-settings) below. For the tenancy model itself, see [Organizations](/concepts/logical/organizations).
 
 ### Default Installation Configuration
 

--- a/docs/content/en/reference/extensibility/providers/index.md
+++ b/docs/content/en/reference/extensibility/providers/index.md
@@ -25,7 +25,7 @@ Some examples include:
   - Examples: session management, two factor authentication, LDAP integration.
 - **Identity and Organization Management**
   - Examples: multi-tenant [Organizations](/concepts/logical/organizations), teams as user groups, fine-grained roles and permissions.
-  - Examples: per-organization identity providers (OAuth/OIDC single sign-on), custom domains, and branding / white-labeling.
+  - Examples: per-organization identity providers (OAuth/OIDC single sign-on), custom domains, and branding/white-labeling.
 - **Long-Term Persistence**
   - Examples: Storage and retrieval of performance test results.
   - Examples: Storage and retrieval of user preferences.


### PR DESCRIPTION
## What & why

Organizations are referenced throughout Meshery's docs (workspaces, providers, CLI) but were never documented as a **logical concept** of their own — even though they are Meshery's unit of tenancy. This PR adds that page and deepens the local-vs-remote provider extensibility docs that explain where Organizations come from.

## New page — `concepts/logical/organizations`

A new logical-concept page that explains:
- **Organizations as the unit of tenancy** — they group users and own all of a tenant's Workspaces, Environments, Designs, and Connections, and form the isolation boundary between tenants.
- **Where they come from** — Organizations exist only under a **Remote Provider**; the **Local** provider is single-user with no tenancy. This is stated up front so the concept isn't confusing for local-only users.
- **How they fit the logical hierarchy** — *Organization → Team → Workspace → Environment → Connection*, with Designs deployed into a Workspace's reachable infrastructure. Cross-links to the existing workspaces / environments / designs / connections concept pages.
- **What a Remote Provider adds** — identity providers, custom domains, branding/white-labeling, roles/teams, and controlled membership — linking to the Layer5 Cloud docs (including the new Organization Configuration Scenarios guide) for the full catalog.

It follows the existing logical-concept page conventions (front matter, tone, `{{% alert %}}` shortcode, cross-references).

## Enhanced — provider extensibility reference

`reference/extensibility/providers/index.md`:
- Added **Identity and Organization Management** to the list of capabilities a Remote Provider can offer (multi-tenant organizations, teams, fine-grained roles, per-org identity providers, custom domains, white-labeling).
- Added an **Identity and Multi-Tenancy** subsection under "Types of providers" that contrasts the single-user Local provider (no organizations) with the multi-tenant Remote provider model (organizations as the unit of tenancy), cross-linking the new concept page and the production-deployment guidance.

## Test plan

- [x] New page placed at `concepts/logical/organizations/index.md`, matching the page-bundle convention of sibling concepts; it auto-lists in the Logical concepts sidebar.
- [x] Internal cross-links verified against existing pages (workspaces, environments, designs, connections, providers reference) and the `#recommended-production-deployment-settings` anchor.
- [x] `{{% alert %}}` shortcode form matches the surrounding docs.
- [ ] Visual check of the rendered page + sidebar in a Hugo/Netlify preview build.