### PR TITLE
[mesheryctl] fix: restore port-forward in e2e test setup for k8s

### DIFF
--- a/mesheryctl/tests/e2e/helpers/bats_libraries.bash
+++ b/mesheryctl/tests/e2e/helpers/bats_libraries.bash
@@ -3,6 +3,37 @@
 
 # Descirption: Centralization of helper functions for BATS Core and libraries
 
+_start_port_forward() {
+    if [[ "$MESHERY_PLATFORM" != "kubernetes" ]]; then
+        return
+    fi
+    echo "start: Port forwarding"
+    nohup kubectl -n meshery port-forward svc/meshery 9081:9081 > /dev/null 2>&1 &
+    export MESHERY_SERVER_PORT_FORWARD_PID="$!"
+    echo "done: Port forwarding"
+}
+
+_wait_for_meshery_server() {
+    local timeout_seconds=${1:-180}
+    local elapsed=0
+
+    echo "Waiting for Meshery server to be ready..."
+    until curl --silent --fail http://localhost:9081/api/system/version > /dev/null 2>&1; do
+        if (( elapsed >= timeout_seconds )); then
+            echo "Timed out waiting for Meshery server" >&2
+            return 1
+        fi
+        sleep 2
+        elapsed=$((elapsed + 2))
+    done
+    echo "Meshery server is ready"
+}
+
+_ensure_meshery_test_environment() {
+    _start_port_forward
+    _wait_for_meshery_server
+}
+
 _load_bats_libraries() {
     export BATS_LIB_PATH=${BATS_LIB_PATH:-"/usr/lib"}
     
@@ -20,4 +51,6 @@ _load_bats_libraries() {
         # for ci
         bats_load_library bats-detik/detik.bash
     fi
+
+    _ensure_meshery_test_environment
 }


### PR DESCRIPTION
## Root Cause

`port_forwarding()` was removed in c79fa05 assuming `mesheryctl system start` 
would handle it. But it doesn't - only `mesheryctl system dashboard` does.

So `localhost:9081` was never reachable during tests, causing all 
server-dependent tests to fail with:
`Unable to connect to Meshery server at http://localhost:9081`

- [x] Yes, I signed my commits.
