### PR TITLE
Fix/e2e meshery server readiness check

### DIFF
--- a/.github/workflows/mesheryctl-e2e.yaml
+++ b/.github/workflows/mesheryctl-e2e.yaml
@@ -85,6 +85,17 @@ jobs:
           ./mesheryctl system start --platform ${{ matrix.platform }} --skip-browser --skip-update --verbose
         shell: bash
         working-directory: ./mesheryctl
+      - name: Wait for Meshery to be ready
+        run: |
+          for i in $(seq 1 30); do
+            if curl --silent --fail http://localhost:9081/api/system/version > /dev/null 2>&1; then
+              echo "Meshery is ready!"
+              break
+            fi
+              echo "Attempt $i/30, retrying in 10s..."
+              sleep 10
+          done
+        shell: bash
       - name: Run mesheryctl end2end tests
         run: |
           bash run_tests.bash | tee bats.tap

--- a/mesheryctl/tests/e2e/helpers/bats_libraries.bash
+++ b/mesheryctl/tests/e2e/helpers/bats_libraries.bash
@@ -3,6 +3,37 @@
 
 # Descirption: Centralization of helper functions for BATS Core and libraries
 
+_start_port_forward() {
+    if [[ "$MESHERY_PLATFORM" != "kubernetes" ]]; then
+        return
+    fi
+    echo "start: Port forwarding"
+    nohup kubectl -n meshery port-forward svc/meshery 9081:9081 > /dev/null 2>&1 &
+    export MESHERY_SERVER_PORT_FORWARD_PID="$!"
+    echo "done: Port forwarding"
+}
+
+_wait_for_meshery_server() {
+    local timeout_seconds=${1:-180}
+    local elapsed=0
+
+    echo "Waiting for Meshery server to be ready..."
+    until curl --silent --fail http://localhost:9081/api/system/version > /dev/null 2>&1; do
+        if (( elapsed >= timeout_seconds )); then
+            echo "Timed out waiting for Meshery server" >&2
+            return 1
+        fi
+        sleep 2
+        elapsed=$((elapsed + 2))
+    done
+    echo "Meshery server is ready"
+}
+
+_ensure_meshery_test_environment() {
+    _start_port_forward
+    _wait_for_meshery_server
+}
+
 _load_bats_libraries() {
     export BATS_LIB_PATH=${BATS_LIB_PATH:-"/usr/lib"}
     
@@ -20,4 +51,6 @@ _load_bats_libraries() {
         # for ci
         bats_load_library bats-detik/detik.bash
     fi
+
+    _ensure_meshery_test_environment
 }

--- a/mesheryctl/tests/e2e/helpers/bats_libraries.bash
+++ b/mesheryctl/tests/e2e/helpers/bats_libraries.bash
@@ -3,37 +3,6 @@
 
 # Descirption: Centralization of helper functions for BATS Core and libraries
 
-_start_port_forward() {
-    if [[ "$MESHERY_PLATFORM" != "kubernetes" ]]; then
-        return
-    fi
-    echo "start: Port forwarding"
-    nohup kubectl -n meshery port-forward svc/meshery 9081:9081 > /dev/null 2>&1 &
-    export MESHERY_SERVER_PORT_FORWARD_PID="$!"
-    echo "done: Port forwarding"
-}
-
-_wait_for_meshery_server() {
-    local timeout_seconds=${1:-180}
-    local elapsed=0
-
-    echo "Waiting for Meshery server to be ready..."
-    until curl --silent --fail http://localhost:9081/api/system/version > /dev/null 2>&1; do
-        if (( elapsed >= timeout_seconds )); then
-            echo "Timed out waiting for Meshery server" >&2
-            return 1
-        fi
-        sleep 2
-        elapsed=$((elapsed + 2))
-    done
-    echo "Meshery server is ready"
-}
-
-_ensure_meshery_test_environment() {
-    _start_port_forward
-    _wait_for_meshery_server
-}
-
 _load_bats_libraries() {
     export BATS_LIB_PATH=${BATS_LIB_PATH:-"/usr/lib"}
     
@@ -51,6 +20,4 @@ _load_bats_libraries() {
         # for ci
         bats_load_library bats-detik/detik.bash
     fi
-
-    _ensure_meshery_test_environment
 }


### PR DESCRIPTION
e2e tests were failing on k8s because tests ran before Meshery server was ready.
Added a readiness check after `mesheryctl system start` to wait for localhost:9081.

- [x] Yes, I signed my commits.
