### PR TITLE
feat(aws): add cross-model permission and network relationships

### DIFF
--- a/server/meshmodel/aws-apigatewayv2-controller/v1.3.0/v1.0.0/relationships/edge_binding_permission_apigw_lambda.json
+++ b/server/meshmodel/aws-apigatewayv2-controller/v1.3.0/v1.0.0/relationships/edge_binding_permission_apigw_lambda.json
@@ -1,25 +1,29 @@
 {
-  "kind": "edge",
-  "type": "binding",
-  "subType": "permission",
-  "evaluationQuery": "edge_binding_permission_relationship",
+  "schemaVersion": "relationships.meshery.io/v1alpha3",
+  "version": "v1.0.0",
+  "kind": "RelationshipDefinition",
+  "metadata": {
+    "description": "API Gateway to Lambda Permission Binding"
+  },
   "model": {
     "name": "aws-apigatewayv2-controller",
     "version": "v1.3.0"
   },
+  "type": "binding",
+  "subType": "permission",
+  "evaluationQuery": "edge_binding_permission_relationship",
   "selectors": [
     {
       "allow": {
         "from": [
           {
-            "model": "aws-apigatewayv2-controller",
-            "kind": "Integration",
+            "model": "aws-lambda-controller",
+            "kind": "Function",
             "patch": {
               "mutatorRef": [
                 [
                   "configuration",
-                  "spec",
-                  "integrationUri"
+                  "arn"
                 ]
               ],
               "patchStrategy": "replace"
@@ -28,13 +32,14 @@
         ],
         "to": [
           {
-            "model": "aws-lambda-controller",
-            "kind": "Function",
+            "model": "aws-apigatewayv2-controller",
+            "kind": "Integration",
             "patch": {
               "mutatedRef": [
                 [
                   "configuration",
-                  "arn"
+                  "spec",
+                  "integrationUri"
                 ]
               ],
               "patchStrategy": "replace"

--- a/server/meshmodel/aws-apigatewayv2-controller/v1.3.0/v1.0.0/relationships/edge_binding_permission_apigw_lambda.json
+++ b/server/meshmodel/aws-apigatewayv2-controller/v1.3.0/v1.0.0/relationships/edge_binding_permission_apigw_lambda.json
@@ -50,7 +50,7 @@
                 [
                   "configuration",
                   "spec",
-                  "integrationUri"
+                  "integrationURI"
                 ]
               ],
               "patchStrategy": "replace"

--- a/server/meshmodel/aws-apigatewayv2-controller/v1.3.0/v1.0.0/relationships/edge_binding_permission_apigw_lambda.json
+++ b/server/meshmodel/aws-apigatewayv2-controller/v1.3.0/v1.0.0/relationships/edge_binding_permission_apigw_lambda.json
@@ -3,7 +3,7 @@
   "version": "v1.0.0",
   "kind": "RelationshipDefinition",
   "metadata": {
-    "description": "API Gateway to Lambda Permission Binding"
+    "description": "Lambda to API Gateway Permission Binding"
   },
   "model": {
     "name": "aws-apigatewayv2-controller",

--- a/server/meshmodel/aws-apigatewayv2-controller/v1.3.0/v1.0.0/relationships/edge_binding_permission_apigw_lambda.json
+++ b/server/meshmodel/aws-apigatewayv2-controller/v1.3.0/v1.0.0/relationships/edge_binding_permission_apigw_lambda.json
@@ -1,39 +1,50 @@
 {
-  "schemaVersion": "relationships.meshery.io/v1alpha3",
-  "version": "v1.0.0",
-  "kind": "RelationshipDefinition",
+  "id": "00000000-0000-0000-0000-000000000000",
+  "evaluationQuery": "edge_binding_permission_relationship",
+  "kind": "edge",
   "metadata": {
-    "description": "Lambda to API Gateway Permission Binding"
+    "description": "Lambda to API Gateway Permission Binding",
+    "isAnnotation": false,
+    "styles": {
+      "primaryColor": "",
+      "svgColor": "",
+      "svgWhite": ""
+    }
   },
   "model": {
+    "displayName": "",
+    "id": "00000000-0000-0000-0000-000000000000",
+    "model": {
+      "version": "v1.3.0"
+    },
     "name": "aws-apigatewayv2-controller",
-    "version": "v1.3.0"
+    "registrant": {
+      "kind": "github"
+    },
+    "version": ""
   },
-  "type": "binding",
-  "subType": "permission",
-  "evaluationQuery": "edge_binding_permission_relationship",
+  "schemaVersion": "relationships.meshery.io/v1beta2",
   "selectors": [
     {
       "allow": {
         "from": [
           {
-            "model": "aws-lambda-controller",
-            "kind": "Function",
-            "patch": {
-              "mutatorRef": [
-                [
-                  "configuration",
-                  "arn"
-                ]
-              ],
-              "patchStrategy": "replace"
-            }
-          }
-        ],
-        "to": [
-          {
-            "model": "aws-apigatewayv2-controller",
+            "id": null,
             "kind": "Integration",
+            "match": {},
+            "match_strategy_matrix": null,
+            "model": {
+              "displayName": "",
+              "id": "00000000-0000-0000-0000-000000000000",
+              "model": {
+                "version": ""
+              },
+              "name": "aws-apigatewayv2-controller",
+              "registrant": {
+                "kind": "github"
+              },
+              "version": ""
+            },
             "patch": {
               "mutatedRef": [
                 [
@@ -45,8 +56,47 @@
               "patchStrategy": "replace"
             }
           }
+        ],
+        "to": [
+          {
+            "id": null,
+            "kind": "Function",
+            "match": {},
+            "match_strategy_matrix": null,
+            "model": {
+              "displayName": "",
+              "id": "00000000-0000-0000-0000-000000000000",
+              "model": {
+                "version": ""
+              },
+              "name": "aws-lambda-controller",
+              "registrant": {
+                "kind": "github"
+              },
+              "version": ""
+            },
+            "patch": {
+              "mutatorRef": [
+                [
+                  "configuration",
+                  "status",
+                  "ackResourceMetadata",
+                  "arn"
+                ]
+              ],
+              "patchStrategy": "replace"
+            }
+          }
         ]
+      },
+      "deny": {
+        "from": [],
+        "to": []
       }
     }
-  ]
+  ],
+  "subType": "permission",
+  "status": "enabled",
+  "type": "binding",
+  "version": "v1.0.0"
 }

--- a/server/meshmodel/aws-apigatewayv2-controller/v1.3.0/v1.0.0/relationships/edge_binding_permission_apigw_lambda.json
+++ b/server/meshmodel/aws-apigatewayv2-controller/v1.3.0/v1.0.0/relationships/edge_binding_permission_apigw_lambda.json
@@ -1,0 +1,47 @@
+{
+  "kind": "edge",
+  "type": "binding",
+  "subType": "permission",
+  "evaluationQuery": "edge_binding_permission_relationship",
+  "model": {
+    "name": "aws-apigatewayv2-controller",
+    "version": "v1.3.0"
+  },
+  "selectors": [
+    {
+      "allow": {
+        "from": [
+          {
+            "model": "aws-apigatewayv2-controller",
+            "kind": "Integration",
+            "patch": {
+              "mutatorRef": [
+                [
+                  "configuration",
+                  "spec",
+                  "integrationUri"
+                ]
+              ],
+              "patchStrategy": "replace"
+            }
+          }
+        ],
+        "to": [
+          {
+            "model": "aws-lambda-controller",
+            "kind": "Function",
+            "patch": {
+              "mutatedRef": [
+                [
+                  "configuration",
+                  "arn"
+                ]
+              ],
+              "patchStrategy": "replace"
+            }
+          }
+        ]
+      }
+    }
+  ]
+}

--- a/server/meshmodel/aws-cloudfront-controller/v1.5.0/v1.0.0/relationships/edge_binding_permission_cloudfront_s3.json
+++ b/server/meshmodel/aws-cloudfront-controller/v1.5.0/v1.0.0/relationships/edge_binding_permission_cloudfront_s3.json
@@ -1,39 +1,50 @@
 {
-  "schemaVersion": "relationships.meshery.io/v1alpha3",
-  "version": "v1.0.0",
-  "kind": "RelationshipDefinition",
+  "id": "00000000-0000-0000-0000-000000000000",
+  "evaluationQuery": "edge_binding_permission_relationship",
+  "kind": "edge",
   "metadata": {
-    "description": "S3 to CloudFront Permission Binding"
+    "description": "CloudFront to S3 Permission Binding",
+    "isAnnotation": false,
+    "styles": {
+      "primaryColor": "",
+      "svgColor": "",
+      "svgWhite": ""
+    }
   },
   "model": {
+    "displayName": "",
+    "id": "00000000-0000-0000-0000-000000000000",
+    "model": {
+      "version": "v1.5.0"
+    },
     "name": "aws-cloudfront-controller",
-    "version": "v1.5.0"
+    "registrant": {
+      "kind": "github"
+    },
+    "version": ""
   },
-  "type": "binding",
-  "subType": "permission",
-  "evaluationQuery": "edge_binding_permission_relationship",
+  "schemaVersion": "relationships.meshery.io/v1beta2",
   "selectors": [
     {
       "allow": {
         "from": [
           {
-            "model": "aws-s3-controller",
-            "kind": "Bucket",
-            "patch": {
-              "mutatorRef": [
-                [
-                  "configuration",
-                  "name"
-                ]
-              ],
-              "patchStrategy": "replace"
-            }
-          }
-        ],
-        "to": [
-          {
-            "model": "aws-cloudfront-controller",
+            "id": null,
             "kind": "Distribution",
+            "match": {},
+            "match_strategy_matrix": null,
+            "model": {
+              "displayName": "",
+              "id": "00000000-0000-0000-0000-000000000000",
+              "model": {
+                "version": ""
+              },
+              "name": "aws-cloudfront-controller",
+              "registrant": {
+                "kind": "github"
+              },
+              "version": ""
+            },
             "patch": {
               "mutatedRef": [
                 [
@@ -49,8 +60,46 @@
               "patchStrategy": "replace"
             }
           }
+        ],
+        "to": [
+          {
+            "id": null,
+            "kind": "Bucket",
+            "match": {},
+            "match_strategy_matrix": null,
+            "model": {
+              "displayName": "",
+              "id": "00000000-0000-0000-0000-000000000000",
+              "model": {
+                "version": ""
+              },
+              "name": "aws-s3-controller",
+              "registrant": {
+                "kind": "github"
+              },
+              "version": ""
+            },
+            "patch": {
+              "mutatorRef": [
+                [
+                  "configuration",
+                  "spec",
+                  "name"
+                ]
+              ],
+              "patchStrategy": "replace"
+            }
+          }
         ]
+      },
+      "deny": {
+        "from": [],
+        "to": []
       }
     }
-  ]
+  ],
+  "subType": "permission",
+  "status": "enabled",
+  "type": "binding",
+  "version": "v1.0.0"
 }

--- a/server/meshmodel/aws-cloudfront-controller/v1.5.0/v1.0.0/relationships/edge_binding_permission_cloudfront_s3.json
+++ b/server/meshmodel/aws-cloudfront-controller/v1.5.0/v1.0.0/relationships/edge_binding_permission_cloudfront_s3.json
@@ -1,0 +1,50 @@
+{
+  "kind": "edge",
+  "type": "binding",
+  "subType": "permission",
+  "evaluationQuery": "edge_binding_permission_relationship",
+  "model": {
+    "name": "aws-cloudfront-controller",
+    "version": "v1.5.0"
+  },
+  "selectors": [
+    {
+      "allow": {
+        "from": [
+          {
+            "model": "aws-cloudfront-controller",
+            "kind": "Distribution",
+            "patch": {
+              "mutatorRef": [
+                [
+                  "configuration",
+                  "spec",
+                  "distributionConfig",
+                  "origins",
+                  "items",
+                  "domainName"
+                ]
+              ],
+              "patchStrategy": "replace"
+            }
+          }
+        ],
+        "to": [
+          {
+            "model": "aws-s3-controller",
+            "kind": "Bucket",
+            "patch": {
+              "mutatedRef": [
+                [
+                  "configuration",
+                  "name"
+                ]
+              ],
+              "patchStrategy": "replace"
+            }
+          }
+        ]
+      }
+    }
+  ]
+}

--- a/server/meshmodel/aws-cloudfront-controller/v1.5.0/v1.0.0/relationships/edge_binding_permission_cloudfront_s3.json
+++ b/server/meshmodel/aws-cloudfront-controller/v1.5.0/v1.0.0/relationships/edge_binding_permission_cloudfront_s3.json
@@ -1,28 +1,29 @@
 {
-  "kind": "edge",
-  "type": "binding",
-  "subType": "permission",
-  "evaluationQuery": "edge_binding_permission_relationship",
+  "schemaVersion": "relationships.meshery.io/v1alpha3",
+  "version": "v1.0.0",
+  "kind": "RelationshipDefinition",
+  "metadata": {
+    "description": "CloudFront to S3 Permission Binding"
+  },
   "model": {
     "name": "aws-cloudfront-controller",
     "version": "v1.5.0"
   },
+  "type": "binding",
+  "subType": "permission",
+  "evaluationQuery": "edge_binding_permission_relationship",
   "selectors": [
     {
       "allow": {
         "from": [
           {
-            "model": "aws-cloudfront-controller",
-            "kind": "Distribution",
+            "model": "aws-s3-controller",
+            "kind": "Bucket",
             "patch": {
               "mutatorRef": [
                 [
                   "configuration",
-                  "spec",
-                  "distributionConfig",
-                  "origins",
-                  "items",
-                  "domainName"
+                  "name"
                 ]
               ],
               "patchStrategy": "replace"
@@ -31,13 +32,17 @@
         ],
         "to": [
           {
-            "model": "aws-s3-controller",
-            "kind": "Bucket",
+            "model": "aws-cloudfront-controller",
+            "kind": "Distribution",
             "patch": {
               "mutatedRef": [
                 [
                   "configuration",
-                  "name"
+                  "spec",
+                  "distributionConfig",
+                  "origins",
+                  "items",
+                  "domainName"
                 ]
               ],
               "patchStrategy": "replace"

--- a/server/meshmodel/aws-cloudfront-controller/v1.5.0/v1.0.0/relationships/edge_binding_permission_cloudfront_s3.json
+++ b/server/meshmodel/aws-cloudfront-controller/v1.5.0/v1.0.0/relationships/edge_binding_permission_cloudfront_s3.json
@@ -3,7 +3,7 @@
   "version": "v1.0.0",
   "kind": "RelationshipDefinition",
   "metadata": {
-    "description": "CloudFront to S3 Permission Binding"
+    "description": "S3 to CloudFront Permission Binding"
   },
   "model": {
     "name": "aws-cloudfront-controller",

--- a/server/meshmodel/aws-cloudfront-controller/v1.5.0/v1.0.0/relationships/edge_binding_permission_cloudfront_s3.json
+++ b/server/meshmodel/aws-cloudfront-controller/v1.5.0/v1.0.0/relationships/edge_binding_permission_cloudfront_s3.json
@@ -42,6 +42,7 @@
                   "distributionConfig",
                   "origins",
                   "items",
+                  "0",
                   "domainName"
                 ]
               ],

--- a/server/meshmodel/aws-elasticache-controller/v1.4.0/v1.0.0/relationships/edge_binding_firewall_elasticache_ec2_sg.json
+++ b/server/meshmodel/aws-elasticache-controller/v1.4.0/v1.0.0/relationships/edge_binding_firewall_elasticache_ec2_sg.json
@@ -1,0 +1,47 @@
+{
+  "kind": "edge",
+  "type": "binding",
+  "subType": "network",
+  "evaluationQuery": "edge_binding_network_relationship",
+  "model": {
+    "name": "aws-elasticache-controller",
+    "version": "v1.4.0"
+  },
+  "selectors": [
+    {
+      "allow": {
+        "from": [
+          {
+            "model": "aws-elasticache-controller",
+            "kind": "ReplicationGroup",
+            "patch": {
+              "mutatorRef": [
+                [
+                  "configuration",
+                  "spec",
+                  "securityGroupIds"
+                ]
+              ],
+              "patchStrategy": "replace"
+            }
+          }
+        ],
+        "to": [
+          {
+            "model": "aws-ec2-controller",
+            "kind": "SecurityGroup",
+            "patch": {
+              "mutatedRef": [
+                [
+                  "configuration",
+                  "id"
+                ]
+              ],
+              "patchStrategy": "replace"
+            }
+          }
+        ]
+      }
+    }
+  ]
+}

--- a/server/meshmodel/aws-elasticache-controller/v1.4.0/v1.0.0/relationships/edge_binding_firewall_elasticache_ec2_sg.json
+++ b/server/meshmodel/aws-elasticache-controller/v1.4.0/v1.0.0/relationships/edge_binding_firewall_elasticache_ec2_sg.json
@@ -1,25 +1,29 @@
 {
-  "kind": "edge",
-  "type": "binding",
-  "subType": "network",
-  "evaluationQuery": "edge_binding_network_relationship",
+  "schemaVersion": "relationships.meshery.io/v1alpha3",
+  "version": "v1.0.0",
+  "kind": "RelationshipDefinition",
+  "metadata": {
+    "description": "ElastiCache to EC2 Security Group Firewall Binding"
+  },
   "model": {
     "name": "aws-elasticache-controller",
     "version": "v1.4.0"
   },
+  "type": "binding",
+  "subType": "firewall",
+  "evaluationQuery": "edge_binding_firewall_relationship",
   "selectors": [
     {
       "allow": {
         "from": [
           {
-            "model": "aws-elasticache-controller",
-            "kind": "ReplicationGroup",
+            "model": "aws-ec2-controller",
+            "kind": "SecurityGroup",
             "patch": {
               "mutatorRef": [
                 [
                   "configuration",
-                  "spec",
-                  "securityGroupIds"
+                  "id"
                 ]
               ],
               "patchStrategy": "replace"
@@ -28,13 +32,14 @@
         ],
         "to": [
           {
-            "model": "aws-ec2-controller",
-            "kind": "SecurityGroup",
+            "model": "aws-elasticache-controller",
+            "kind": "ReplicationGroup",
             "patch": {
               "mutatedRef": [
                 [
                   "configuration",
-                  "id"
+                  "spec",
+                  "securityGroupIds"
                 ]
               ],
               "patchStrategy": "replace"

--- a/server/meshmodel/aws-elasticache-controller/v1.4.0/v1.0.0/relationships/edge_binding_firewall_elasticache_ec2_sg.json
+++ b/server/meshmodel/aws-elasticache-controller/v1.4.0/v1.0.0/relationships/edge_binding_firewall_elasticache_ec2_sg.json
@@ -1,39 +1,50 @@
 {
-  "schemaVersion": "relationships.meshery.io/v1alpha3",
-  "version": "v1.0.0",
-  "kind": "RelationshipDefinition",
+  "id": "00000000-0000-0000-0000-000000000000",
+  "evaluationQuery": "edge_binding_firewall_relationship",
+  "kind": "edge",
   "metadata": {
-    "description": "ElastiCache to EC2 Security Group Firewall Binding"
+    "description": "ElastiCache to EC2 Security Group Firewall Binding",
+    "isAnnotation": false,
+    "styles": {
+      "primaryColor": "",
+      "svgColor": "",
+      "svgWhite": ""
+    }
   },
   "model": {
+    "displayName": "",
+    "id": "00000000-0000-0000-0000-000000000000",
+    "model": {
+      "version": "v1.4.0"
+    },
     "name": "aws-elasticache-controller",
-    "version": "v1.4.0"
+    "registrant": {
+      "kind": "github"
+    },
+    "version": ""
   },
-  "type": "binding",
-  "subType": "firewall",
-  "evaluationQuery": "edge_binding_firewall_relationship",
+  "schemaVersion": "relationships.meshery.io/v1beta2",
   "selectors": [
     {
       "allow": {
         "from": [
           {
-            "model": "aws-ec2-controller",
-            "kind": "SecurityGroup",
-            "patch": {
-              "mutatorRef": [
-                [
-                  "configuration",
-                  "id"
-                ]
-              ],
-              "patchStrategy": "replace"
-            }
-          }
-        ],
-        "to": [
-          {
-            "model": "aws-elasticache-controller",
+            "id": null,
             "kind": "ReplicationGroup",
+            "match": {},
+            "match_strategy_matrix": null,
+            "model": {
+              "displayName": "",
+              "id": "00000000-0000-0000-0000-000000000000",
+              "model": {
+                "version": ""
+              },
+              "name": "aws-elasticache-controller",
+              "registrant": {
+                "kind": "github"
+              },
+              "version": ""
+            },
             "patch": {
               "mutatedRef": [
                 [
@@ -46,8 +57,46 @@
               "patchStrategy": "replace"
             }
           }
+        ],
+        "to": [
+          {
+            "id": null,
+            "kind": "SecurityGroup",
+            "match": {},
+            "match_strategy_matrix": null,
+            "model": {
+              "displayName": "",
+              "id": "00000000-0000-0000-0000-000000000000",
+              "model": {
+                "version": ""
+              },
+              "name": "aws-ec2-controller",
+              "registrant": {
+                "kind": "github"
+              },
+              "version": ""
+            },
+            "patch": {
+              "mutatorRef": [
+                [
+                  "configuration",
+                  "status",
+                  "id"
+                ]
+              ],
+              "patchStrategy": "replace"
+            }
+          }
         ]
+      },
+      "deny": {
+        "from": [],
+        "to": []
       }
     }
-  ]
+  ],
+  "subType": "firewall",
+  "status": "enabled",
+  "type": "binding",
+  "version": "v1.0.0"
 }

--- a/server/meshmodel/aws-elasticache-controller/v1.4.0/v1.0.0/relationships/edge_binding_firewall_elasticache_ec2_sg.json
+++ b/server/meshmodel/aws-elasticache-controller/v1.4.0/v1.0.0/relationships/edge_binding_firewall_elasticache_ec2_sg.json
@@ -50,7 +50,7 @@
                 [
                   "configuration",
                   "spec",
-                  "securityGroupIds",
+                  "securityGroupIDs",
                   "0"
                 ]
               ],

--- a/server/meshmodel/aws-elasticache-controller/v1.4.0/v1.0.0/relationships/edge_binding_firewall_elasticache_ec2_sg.json
+++ b/server/meshmodel/aws-elasticache-controller/v1.4.0/v1.0.0/relationships/edge_binding_firewall_elasticache_ec2_sg.json
@@ -39,7 +39,8 @@
                 [
                   "configuration",
                   "spec",
-                  "securityGroupIds"
+                  "securityGroupIds",
+                  "0"
                 ]
               ],
               "patchStrategy": "replace"

--- a/server/meshmodel/aws-s3-controller/v1.6.0/v1.0.0/relationships/edge_binding_permission_s3_iam.json
+++ b/server/meshmodel/aws-s3-controller/v1.6.0/v1.0.0/relationships/edge_binding_permission_s3_iam.json
@@ -1,0 +1,47 @@
+{
+  "kind": "edge",
+  "type": "binding",
+  "subType": "permission",
+  "evaluationQuery": "edge_binding_permission_relationship",
+  "model": {
+    "name": "aws-s3-controller",
+    "version": "v1.6.0"
+  },
+  "selectors": [
+    {
+      "allow": {
+        "from": [
+          {
+            "model": "aws-s3-controller",
+            "kind": "Bucket",
+            "patch": {
+              "mutatorRef": [
+                [
+                  "configuration",
+                  "spec",
+                  "policy"
+                ]
+              ],
+              "patchStrategy": "replace"
+            }
+          }
+        ],
+        "to": [
+          {
+            "model": "aws-iam-controller",
+            "kind": "Role",
+            "patch": {
+              "mutatedRef": [
+                [
+                  "configuration",
+                  "arn"
+                ]
+              ],
+              "patchStrategy": "replace"
+            }
+          }
+        ]
+      }
+    }
+  ]
+}

--- a/server/meshmodel/aws-s3-controller/v1.6.0/v1.0.0/relationships/edge_binding_permission_s3_iam.json
+++ b/server/meshmodel/aws-s3-controller/v1.6.0/v1.0.0/relationships/edge_binding_permission_s3_iam.json
@@ -3,7 +3,7 @@
   "version": "v1.0.0",
   "kind": "RelationshipDefinition",
   "metadata": {
-    "description": "S3 to IAM Role Permission Binding"
+    "description": "IAM Role to S3 Permission Binding"
   },
   "model": {
     "name": "aws-s3-controller",

--- a/server/meshmodel/aws-s3-controller/v1.6.0/v1.0.0/relationships/edge_binding_permission_s3_iam.json
+++ b/server/meshmodel/aws-s3-controller/v1.6.0/v1.0.0/relationships/edge_binding_permission_s3_iam.json
@@ -50,11 +50,7 @@
                 [
                   "configuration",
                   "spec",
-                  "policy",
-                  "Statement",
-                  "0",
-                  "Principal",
-                  "AWS"
+                  "policy"
                 ]
               ],
               "patchStrategy": "replace"

--- a/server/meshmodel/aws-s3-controller/v1.6.0/v1.0.0/relationships/edge_binding_permission_s3_iam.json
+++ b/server/meshmodel/aws-s3-controller/v1.6.0/v1.0.0/relationships/edge_binding_permission_s3_iam.json
@@ -1,25 +1,29 @@
 {
-  "kind": "edge",
-  "type": "binding",
-  "subType": "permission",
-  "evaluationQuery": "edge_binding_permission_relationship",
+  "schemaVersion": "relationships.meshery.io/v1alpha3",
+  "version": "v1.0.0",
+  "kind": "RelationshipDefinition",
+  "metadata": {
+    "description": "S3 to IAM Role Permission Binding"
+  },
   "model": {
     "name": "aws-s3-controller",
     "version": "v1.6.0"
   },
+  "type": "binding",
+  "subType": "permission",
+  "evaluationQuery": "edge_binding_permission_relationship",
   "selectors": [
     {
       "allow": {
         "from": [
           {
-            "model": "aws-s3-controller",
-            "kind": "Bucket",
+            "model": "aws-iam-controller",
+            "kind": "Role",
             "patch": {
               "mutatorRef": [
                 [
                   "configuration",
-                  "spec",
-                  "policy"
+                  "arn"
                 ]
               ],
               "patchStrategy": "replace"
@@ -28,13 +32,18 @@
         ],
         "to": [
           {
-            "model": "aws-iam-controller",
-            "kind": "Role",
+            "model": "aws-s3-controller",
+            "kind": "Bucket",
             "patch": {
               "mutatedRef": [
                 [
                   "configuration",
-                  "arn"
+                  "spec",
+                  "policy",
+                  "Statement",
+                  "0",
+                  "Principal",
+                  "AWS"
                 ]
               ],
               "patchStrategy": "replace"

--- a/server/meshmodel/aws-s3-controller/v1.6.0/v1.0.0/relationships/edge_binding_permission_s3_iam.json
+++ b/server/meshmodel/aws-s3-controller/v1.6.0/v1.0.0/relationships/edge_binding_permission_s3_iam.json
@@ -1,39 +1,50 @@
 {
-  "schemaVersion": "relationships.meshery.io/v1alpha3",
-  "version": "v1.0.0",
-  "kind": "RelationshipDefinition",
+  "id": "00000000-0000-0000-0000-000000000000",
+  "evaluationQuery": "edge_binding_permission_relationship",
+  "kind": "edge",
   "metadata": {
-    "description": "IAM Role to S3 Permission Binding"
+    "description": "IAM Role to S3 Permission Binding",
+    "isAnnotation": false,
+    "styles": {
+      "primaryColor": "",
+      "svgColor": "",
+      "svgWhite": ""
+    }
   },
   "model": {
+    "displayName": "",
+    "id": "00000000-0000-0000-0000-000000000000",
+    "model": {
+      "version": "v1.6.0"
+    },
     "name": "aws-s3-controller",
-    "version": "v1.6.0"
+    "registrant": {
+      "kind": "github"
+    },
+    "version": ""
   },
-  "type": "binding",
-  "subType": "permission",
-  "evaluationQuery": "edge_binding_permission_relationship",
+  "schemaVersion": "relationships.meshery.io/v1beta2",
   "selectors": [
     {
       "allow": {
         "from": [
           {
-            "model": "aws-iam-controller",
-            "kind": "Role",
-            "patch": {
-              "mutatorRef": [
-                [
-                  "configuration",
-                  "arn"
-                ]
-              ],
-              "patchStrategy": "replace"
-            }
-          }
-        ],
-        "to": [
-          {
-            "model": "aws-s3-controller",
+            "id": null,
             "kind": "Bucket",
+            "match": {},
+            "match_strategy_matrix": null,
+            "model": {
+              "displayName": "",
+              "id": "00000000-0000-0000-0000-000000000000",
+              "model": {
+                "version": ""
+              },
+              "name": "aws-s3-controller",
+              "registrant": {
+                "kind": "github"
+              },
+              "version": ""
+            },
             "patch": {
               "mutatedRef": [
                 [
@@ -49,8 +60,47 @@
               "patchStrategy": "replace"
             }
           }
+        ],
+        "to": [
+          {
+            "id": null,
+            "kind": "Role",
+            "match": {},
+            "match_strategy_matrix": null,
+            "model": {
+              "displayName": "",
+              "id": "00000000-0000-0000-0000-000000000000",
+              "model": {
+                "version": ""
+              },
+              "name": "aws-iam-controller",
+              "registrant": {
+                "kind": "github"
+              },
+              "version": ""
+            },
+            "patch": {
+              "mutatorRef": [
+                [
+                  "configuration",
+                  "status",
+                  "ackResourceMetadata",
+                  "arn"
+                ]
+              ],
+              "patchStrategy": "replace"
+            }
+          }
         ]
+      },
+      "deny": {
+        "from": [],
+        "to": []
       }
     }
-  ]
+  ],
+  "subType": "permission",
+  "status": "enabled",
+  "type": "binding",
+  "version": "v1.0.0"
 }


### PR DESCRIPTION
# Pull Request Description

### Overview
This PR implements cross-model relationship definitions for AWS components, enabling Kanvas to act as a true single pane of glass by connecting resources that span across isolated AWS controllers (e.g., bridging `aws-ec2-controller` and `aws-rds-controller`).

### Key Fixes
Based on recent review feedback, the following core structural logic has been corrected across the binding relationships:

1. **Schema Envelopes:** All JSON relationship files now include the required `schemaVersion: relationships.meshery.io/v1alpha3` and `metadata` wrappers to ensure the Meshery evaluation engine parses them as valid rulebooks.
2. **Data-Flow Logic:** Fixed the inverted binding logic so data properly flows from the **Foundational Resource** (`mutatorRef`) to the **Dependent Resource** (`mutatedRef`).
3. **Safe Patch Strategies:** Refined the `mutatedRef` patch strategies (e.g., targeting `Statement.0.Principal.AWS` for S3 policies) to prevent destructive overwrites of complex configuration objects.

Related to [issue #17096](https://github.com/meshery/meshery/issues/17096)
