### PR TITLE
fix(ui): repair DeleteForever icon re-export crashing Connections page

### DIFF
--- a/ui/assets/icons/index.test.ts
+++ b/ui/assets/icons/index.test.ts
@@ -21,7 +21,14 @@ import * as iconBarrel from './index';
  */
 describe('icon barrel integrity', () => {
   it('exposes no undefined value exports (every re-export resolves)', () => {
-    const undefinedExports = Object.entries(iconBarrel)
+    const entries = Object.entries(iconBarrel);
+
+    // Guard against a vacuous pass: if the barrel ever fails to load or
+    // resolves to an empty namespace, the undefined-filter below would be
+    // trivially satisfied and hide a real breakage.
+    expect(entries.length).toBeGreaterThan(0);
+
+    const undefinedExports = entries
       .filter(([, value]) => value === undefined)
       .map(([name]) => name);
 

--- a/ui/assets/icons/index.test.ts
+++ b/ui/assets/icons/index.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from 'vitest';
+
+import * as iconBarrel from './index';
+
+/**
+ * Integrity guard for the canonical icon barrel.
+ *
+ * The barrel re-exports design-system glyphs from `@sistent/sistent` under
+ * legacy names (e.g. `DeleteForeverIcon as DeleteForever`). When a re-export
+ * names a member that the installed Sistent build does not actually export,
+ * the alias silently resolves to `undefined` at runtime. Rendering such an
+ * alias throws React error #130 ("Element type is invalid ... got: undefined")
+ * and takes down the whole page — this is exactly what happened to the
+ * Connections page, where `DeleteForever` had been pointed at a non-existent
+ * `@sistent/sistent` export instead of `DeleteForeverIcon`.
+ *
+ * Neither `tsc` (Sistent's types and runtime diverge for this case) nor the
+ * mocked component unit tests can catch the mismatch, so this test imports the
+ * REAL barrel (no `vi.mock`) and asserts that every value export resolves to a
+ * defined value.
+ */
+describe('icon barrel integrity', () => {
+  it('exposes no undefined value exports (every re-export resolves)', () => {
+    const undefinedExports = Object.entries(iconBarrel)
+      .filter(([, value]) => value === undefined)
+      .map(([name]) => name);
+
+    expect(undefinedExports).toEqual([]);
+  });
+
+  it('re-exports DeleteForever from the real Sistent glyph', () => {
+    // Direct regression assertion for the Connections-page crash.
+    expect(iconBarrel.DeleteForever).toBeDefined();
+  });
+});

--- a/ui/assets/icons/index.ts
+++ b/ui/assets/icons/index.ts
@@ -58,7 +58,7 @@ export {
   CodeIcon as Code,
   DeleteIcon,
   DeleteIcon as Delete,
-  DeleteForever,
+  DeleteForeverIcon as DeleteForever,
   DirectionsCarIcon as DirectionsCar,
   DoneAllIcon as DoneAll,
   EditIcon as Edit,

--- a/ui/components/connections/ConnectionChip.test.tsx
+++ b/ui/components/connections/ConnectionChip.test.tsx
@@ -33,6 +33,7 @@ vi.mock('@sistent/sistent', () => {
         {children}
       </div>
     ),
+    DeleteForeverIcon: () => <svg data-testid="delete-forever-icon" />,
     ExploreIcon: () => <svg data-testid="explore-icon" />,
     HandymanIcon: () => <svg data-testid="handyman-icon" />,
     RemoveIcon: () => <svg data-testid="remove-icon" />,
@@ -196,5 +197,17 @@ describe('ConnectionStateChip', () => {
 
     rerender(<ConnectionStateChip status="mystery-state" />);
     expect(screen.getByTestId('discovered-state-chip')).toHaveTextContent('mystery-state');
+  });
+
+  it('renders the deleted-state chip with its DeleteForever avatar icon', () => {
+    // Regression guard: the icon barrel re-exported a non-existent
+    // `DeleteForever` from Sistent (which only exports `DeleteForeverIcon`),
+    // so the avatar resolved to `undefined` and crashed the Connections page
+    // with "Element type is invalid" (React error #130) whenever a DELETED
+    // connection was listed.
+    render(<ConnectionStateChip status="deleted" />);
+
+    expect(screen.getByTestId('deleted-state-chip')).toHaveTextContent('deleted');
+    expect(screen.getByTestId('delete-forever-icon')).toBeInTheDocument();
   });
 });


### PR DESCRIPTION
## Problem

The Connections page (`/management/connections`) crashes with **React error #130** — _"Element type is invalid: expected a string ... but got: undefined"_ — rendering the global "Uh-oh! Please pardon the mesh." error boundary instead of the table.

### Root cause

The canonical icon barrel (`ui/assets/icons/index.ts`) re-exported `DeleteForever` directly from `@sistent/sistent`:

```ts
export { /* ... */ DeleteForever, /* ... */ } from '@sistent/sistent';
```

but Sistent only exports `DeleteForeverIcon` (the `*Icon`-suffixed name) — there is no bare `DeleteForever`, so the alias resolved to `undefined`. `ConnectionChip` consumes it through the barrel (`DeleteForever as DeleteForeverIcon`) and renders it as the avatar for `DELETED`-state connections in `STATE_CHIP_CONFIG`. As soon as a deleted connection is listed, React tries to render an element whose type is `undefined` and throws #130, which the page-level `ErrorBoundary` catches.

This regressed in the "Rename DeleteIcon to DeleteForever" change, which switched the re-export source from the valid `DeleteIcon` to the non-existent `DeleteForever`.

## Fix

Point the re-export at the real glyph while keeping the legacy export name stable for all consumers:

```diff
-  DeleteForever,
+  DeleteForeverIcon as DeleteForever,
```

This matches every other line in the same block (`SistentName as LegacyName`) and honours the original rename's intent (the _DeleteForever_ glyph, not the generic _Delete_ glyph).

## Why it slipped through

- **tsc**: Sistent's published types and its runtime exports diverge for this glyph, so `next build`'s typecheck did not flag the bad re-export (verified locally — `tsc --noEmit` is clean on both the broken and fixed code).
- **Unit tests**: `ConnectionChip.test.tsx` mocks `@sistent/sistent` and never rendered the `DELETED` state, so the undefined avatar was never exercised.

## Tests added

- **`ui/assets/icons/index.test.ts`** — a runtime icon-barrel integrity test that imports the _real_ barrel (no mock) and asserts no value export resolves to `undefined`, plus a non-empty-namespace guard so it can't pass vacuously. This is the guard that actually catches this class of bug, since neither tsc nor the mocked component tests can.
- **`ui/components/connections/ConnectionChip.test.tsx`** — a `DELETED`-state render test covering the avatar path the crash came from.

Both new tests fail on the pre-fix code (the ConnectionChip test reproduces the exact `Element type is invalid ... got: undefined` error) and pass after the fix.

## Test plan

- [x] `npx vitest run assets/icons/index.test.ts components/connections/` → **53 passed**
- [x] Reverted the fix and confirmed all new assertions fail, reproducing React #130, then restored
- [x] `npx tsc --noEmit` → clean
- [x] `npx eslint` + `npx prettier --check` on changed files → clean

## Related findings (out of scope — flagged for a follow-up)

While tracing this I found the same undefined-import pattern in files **not** on the Connections path, which will crash their own pages the same way when the relevant component renders:

- `components/CustomToolbarSelect.tsx` — imports `CompareArrows`, `GetApp`, `IndeterminateCheckBox` from `@sistent/sistent` (only the `*Icon` variants exist)
- `components/designs/lifecycle/DeployConfirmationModal.tsx` — imports `Search` (only `SearchIcon` exists)
- `components/telemetry/grafana/GrafanaCharts.tsx` — imports `ExpansionPanelDetails` (not an MUI v5+ export at all)

These are separate, page-specific fixes and are intentionally left out of this focused change.