### PR TITLE
fix(ui): resolve undefined @sistent/sistent imports that crash on render

### DIFF
--- a/ui/__tests__/architecture/sistent-imports-resolve.test.ts
+++ b/ui/__tests__/architecture/sistent-imports-resolve.test.ts
@@ -1,0 +1,124 @@
+import { describe, expect, it } from 'vitest';
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import * as Sistent from '@sistent/sistent';
+
+/**
+ * Architecture guard: every value imported by name from `@sistent/sistent`
+ * must exist as a real runtime export of the installed package.
+ *
+ * This catches a recurring, whole-page-killing bug class:
+ *
+ *   import { DeleteForever } from '@sistent/sistent';   // ❌ runtime undefined
+ *
+ * Sistent ships the `*Icon`-suffixed names (`DeleteForeverIcon`, `SearchIcon`,
+ * `CompareArrowsIcon`, `GetAppIcon`, `IndeterminateCheckBoxIcon`, …) and the
+ * MUI-v5 `Accordion*` family rather than the v4 `ExpansionPanel*` names. An
+ * import that names something the package does not export resolves to
+ * `undefined` at runtime; rendering it throws React error #130 ("Element type
+ * is invalid … got: undefined") and the page-level ErrorBoundary swallows the
+ * whole view.
+ *
+ * Neither `tsc` (Sistent's published types and runtime can diverge for a given
+ * glyph) nor the component unit tests (which `vi.mock('@sistent/sistent')` and
+ * therefore supply whatever name the test asks for) catch this. So this test
+ * imports the REAL package and validates every named *value* import in the
+ * source tree against `Object.keys(Sistent)`.
+ *
+ * Type-only imports are skipped: `import type { X }` and inline `import
+ * { type X }` are erased under `verbatimModuleSyntax` and never reach the
+ * runtime namespace, so they cannot cause this failure.
+ */
+
+const RUNTIME_EXPORTS = new Set(Object.keys(Sistent));
+
+// Type-only Sistent exports imported somewhere WITHOUT the `type` keyword.
+// Prefer to keep this empty: the correct fix for a new entry is a `type`
+// import at the call site (required by `verbatimModuleSyntax` anyway), not an
+// allowlist addition. Only add a name here if it is genuinely type-only and a
+// `type` import is somehow not viable.
+const ALLOWED_TYPE_ONLY: ReadonlySet<string> = new Set<string>();
+
+const UI_ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../..');
+
+const PRUNE_DIRS = new Set([
+  'node_modules',
+  '.next',
+  'out',
+  'coverage',
+  '.git',
+  'public',
+  'docs',
+  'tests', // playwright e2e
+  'cypress',
+]);
+
+const SOURCE_EXT = new Set(['.ts', '.tsx', '.js', '.jsx', '.mjs', '.cjs']);
+
+function collectSourceFiles(dir: string, acc: string[]): string[] {
+  let entries: fs.Dirent[];
+  try {
+    entries = fs.readdirSync(dir, { withFileTypes: true });
+  } catch {
+    return acc;
+  }
+  for (const entry of entries) {
+    const full = path.join(dir, entry.name);
+    if (entry.isDirectory()) {
+      if (!PRUNE_DIRS.has(entry.name)) collectSourceFiles(full, acc);
+    } else if (entry.isFile()) {
+      if (/\.(test|spec|stories)\.[cm]?[tj]sx?$/.test(entry.name)) continue;
+      if (SOURCE_EXT.has(path.extname(entry.name))) acc.push(full);
+    }
+  }
+  return acc;
+}
+
+// Matches `import [type] [Default,] { ...names... } from '@sistent/sistent'`.
+// `[^}]*` spans newlines, so multi-line import blocks are covered.
+const IMPORT_RE =
+  /import\s+(type\s+)?(?:[A-Za-z_$][\w$]*\s*,\s*)?\{([^}]*)\}\s*from\s*['"]@sistent\/sistent['"]/g;
+
+function unresolvedValueImports(source: string): string[] {
+  const bad: string[] = [];
+  for (const match of source.matchAll(IMPORT_RE)) {
+    if (match[1]) continue; // whole statement is `import type { ... }`
+    for (const rawSpecifier of match[2].split(',')) {
+      const specifier = rawSpecifier.trim();
+      if (!specifier || specifier.startsWith('//')) continue;
+      if (specifier.startsWith('type ')) continue; // inline type-only specifier
+      const sourceName = specifier.split(/\s+as\s+/)[0].trim();
+      if (!/^[A-Za-z_$][\w$]*$/.test(sourceName)) continue;
+      if (RUNTIME_EXPORTS.has(sourceName)) continue;
+      if (ALLOWED_TYPE_ONLY.has(sourceName)) continue;
+      bad.push(sourceName);
+    }
+  }
+  return bad;
+}
+
+describe('@sistent/sistent named imports resolve at runtime', () => {
+  it('reads a non-empty set of real runtime exports (guards a vacuous pass)', () => {
+    expect(RUNTIME_EXPORTS.size).toBeGreaterThan(0);
+  });
+
+  it('imports no value that is missing from the installed package', () => {
+    const files = collectSourceFiles(UI_ROOT, []);
+    expect(files.length).toBeGreaterThan(0);
+
+    const violations: string[] = [];
+    for (const file of files) {
+      for (const name of unresolvedValueImports(fs.readFileSync(file, 'utf8'))) {
+        violations.push(`${name}  <-  ${path.relative(UI_ROOT, file)}`);
+      }
+    }
+
+    // A non-empty list means a component imports a name that does not exist in
+    // the installed @sistent/sistent — it will be `undefined` at runtime and
+    // crash the page when rendered. Use the `*Icon` name (or the MUI-v5
+    // Accordion* name), or a `type` import if the symbol is type-only.
+    expect(violations).toEqual([]);
+  });
+});

--- a/ui/__tests__/architecture/sistent-imports-resolve.test.ts
+++ b/ui/__tests__/architecture/sistent-imports-resolve.test.ts
@@ -85,10 +85,13 @@ function unresolvedValueImports(source: string): string[] {
   const bad: string[] = [];
   for (const match of source.matchAll(IMPORT_RE)) {
     if (match[1]) continue; // whole statement is `import type { ... }`
-    for (const rawSpecifier of match[2].split(',')) {
+    // Strip block and line comments first, otherwise a specifier sitting after
+    // an inline comment (`Foo, // note`) would be skipped and never validated.
+    const cleanBlock = match[2].replace(/\/\*[\s\S]*?\*\/|\/\/.*/g, '');
+    for (const rawSpecifier of cleanBlock.split(',')) {
       const specifier = rawSpecifier.trim();
-      if (!specifier || specifier.startsWith('//')) continue;
-      if (specifier.startsWith('type ')) continue; // inline type-only specifier
+      if (!specifier) continue;
+      if (/^type\s+/.test(specifier)) continue; // inline type-only specifier
       const sourceName = specifier.split(/\s+as\s+/)[0].trim();
       if (!/^[A-Za-z_$][\w$]*$/.test(sourceName)) continue;
       if (RUNTIME_EXPORTS.has(sourceName)) continue;

--- a/ui/__tests__/architecture/sistent-imports-resolve.test.ts
+++ b/ui/__tests__/architecture/sistent-imports-resolve.test.ts
@@ -82,13 +82,19 @@ const IMPORT_RE =
   /import\s+(type\s+)?(?:[A-Za-z_$][\w$]*\s*,\s*)?\{([^}]*)\}\s*from\s*['"]@sistent\/sistent['"]/g;
 
 function unresolvedValueImports(source: string): string[] {
+  // Strip block and line comments from the whole file before matching, so a
+  // commented-out import cannot raise a false positive and a specifier after
+  // an inline comment is still validated. String literals are preserved so a
+  // `//` inside a URL (e.g. 'https://…') is never mistaken for a comment.
+  const cleanSource = source.replace(
+    /("([^"\\]|\\.)*"|'([^'\\]|\\.)*'|`([^`\\]|\\.)*`)|\/\*[\s\S]*?\*\/|\/\/.*/g,
+    (full, stringLiteral) => (stringLiteral ? stringLiteral : ''),
+  );
+
   const bad: string[] = [];
-  for (const match of source.matchAll(IMPORT_RE)) {
+  for (const match of cleanSource.matchAll(IMPORT_RE)) {
     if (match[1]) continue; // whole statement is `import type { ... }`
-    // Strip block and line comments first, otherwise a specifier sitting after
-    // an inline comment (`Foo, // note`) would be skipped and never validated.
-    const cleanBlock = match[2].replace(/\/\*[\s\S]*?\*\/|\/\/.*/g, '');
-    for (const rawSpecifier of cleanBlock.split(',')) {
+    for (const rawSpecifier of match[2].split(',')) {
       const specifier = rawSpecifier.trim();
       if (!specifier) continue;
       if (/^type\s+/.test(specifier)) continue; // inline type-only specifier

--- a/ui/components/CustomToolbarSelect.test.tsx
+++ b/ui/components/CustomToolbarSelect.test.tsx
@@ -17,9 +17,9 @@ vi.mock('@/store/slices/prefTest', () => ({
 }));
 
 vi.mock('@sistent/sistent', () => ({
-  IndeterminateCheckBox: () => <span data-testid="indeterminate-checkbox" />,
-  CompareArrows: () => <span data-testid="compare-arrows" />,
-  GetApp: () => <span data-testid="get-app" />,
+  IndeterminateCheckBoxIcon: () => <span data-testid="indeterminate-checkbox" />,
+  CompareArrowsIcon: () => <span data-testid="compare-arrows" />,
+  GetAppIcon: () => <span data-testid="get-app" />,
   IconButton: ({ children, onClick, href, download, 'aria-label': ariaLabel }: any) => (
     <a
       data-testid={ariaLabel ? `icon-button-${ariaLabel}` : 'icon-button'}

--- a/ui/components/CustomToolbarSelect.tsx
+++ b/ui/components/CustomToolbarSelect.tsx
@@ -1,8 +1,8 @@
 import React, { useState } from 'react';
 import {
-  IndeterminateCheckBox,
-  CompareArrows,
-  GetApp,
+  IndeterminateCheckBoxIcon as IndeterminateCheckBox,
+  CompareArrowsIcon as CompareArrows,
+  GetAppIcon as GetApp,
   IconButton,
   Tooltip,
   styled,

--- a/ui/components/dashboard/components.tsx
+++ b/ui/components/dashboard/components.tsx
@@ -12,7 +12,7 @@ import {
   Button,
   DeleteIcon,
   DragIcon,
-  Theme,
+  type Theme,
 } from '@sistent/sistent';
 
 import { iconMedium } from 'css/icons.styles';

--- a/ui/components/dashboard/overview.tsx
+++ b/ui/components/dashboard/overview.tsx
@@ -5,7 +5,7 @@ import { useGetMeshSyncResourceKindsQuery } from '@/rtk-query/meshsync';
 import { getK8sClusterIdsFromCtxId } from '@/utils/multi-ctx';
 import ConnectCluster from './charts/ConnectCluster';
 import { ErrorContainer, HoneycombRoot } from './style';
-import { ErrorIcon, Typography, useTheme, Theme } from '@sistent/sistent';
+import { ErrorIcon, Typography, useTheme, type Theme } from '@sistent/sistent';
 import { useSelector } from 'react-redux';
 
 const ErrorDisplay = ({ theme }: { theme: Theme }) => (

--- a/ui/components/designs/lifecycle/DeployConfirmationModal.tsx
+++ b/ui/components/designs/lifecycle/DeployConfirmationModal.tsx
@@ -22,7 +22,7 @@ import {
   DoneAllIcon,
   DoneIcon,
   RemoveDoneIcon,
-  Search,
+  SearchIcon as Search,
   Tab,
   Tabs,
   TextField,

--- a/ui/components/shared/LoadingState/Animations/AnimatedMeshPattern.tsx
+++ b/ui/components/shared/LoadingState/Animations/AnimatedMeshPattern.tsx
@@ -1,4 +1,4 @@
-import { useTheme, Theme } from '@sistent/sistent';
+import { useTheme, type Theme } from '@sistent/sistent';
 import React, { useState, useEffect } from 'react';
 
 function getClassName(className: string, isActive: boolean): string {

--- a/ui/components/telemetry/grafana/GrafanaCharts.tsx
+++ b/ui/components/telemetry/grafana/GrafanaCharts.tsx
@@ -1,7 +1,8 @@
 import React, { Suspense, lazy, useState } from 'react';
 import PropTypes from 'prop-types';
-import { ExpandMoreIcon, NoSsr } from '@sistent/sistent';
 import {
+  ExpandMoreIcon,
+  NoSsr,
   Grid2,
   Accordion,
   AccordionSummary,

--- a/ui/components/telemetry/grafana/GrafanaCharts.tsx
+++ b/ui/components/telemetry/grafana/GrafanaCharts.tsx
@@ -1,9 +1,15 @@
 import React, { Suspense, lazy, useState } from 'react';
 import PropTypes from 'prop-types';
 import { ExpandMoreIcon, NoSsr } from '@sistent/sistent';
-import { Grid2, ExpansionPanelDetails, Typography, styled } from '@sistent/sistent';
+import {
+  Grid2,
+  Accordion,
+  AccordionSummary,
+  AccordionDetails,
+  Typography,
+  styled,
+} from '@sistent/sistent';
 import GrafanaDateRangePicker from './GrafanaDateRangePicker';
-import { ExpansionPanel, ExpansionPanelSummary } from '../../ExpansionPanels';
 
 const Wrapper = styled('div')({
   width: '100%',
@@ -81,8 +87,8 @@ const GrafanaCharts = ({ grafanaURL, boardPanelConfigs }) => {
           />
         </DateRangePickerContainer>
         {boardPanelConfigs.map((config, ind) => (
-          <ExpansionPanel key={ind} square defaultExpanded={false}>
-            <ExpansionPanelSummary expandIcon={<ExpandMoreIcon />}>
+          <Accordion key={ind} square defaultExpanded={false}>
+            <AccordionSummary expandIcon={<ExpandMoreIcon />}>
               <Column>
                 <StyledHeading variant="subtitle1" gutterBottom>
                   {config.board.title}
@@ -95,8 +101,8 @@ const GrafanaCharts = ({ grafanaURL, boardPanelConfigs }) => {
                     : ''}
                 </SecondaryHeading>
               </Column>
-            </ExpansionPanelSummary>
-            <ExpansionPanelDetails>
+            </AccordionSummary>
+            <AccordionDetails>
               <Grid2 container spacing={5} size="grow">
                 {config.panels.map((panel, ind) => (
                   <IframeGridItem key={ind} size={{ xs: 12, sm: 6, md: 4 }}>
@@ -112,8 +118,8 @@ const GrafanaCharts = ({ grafanaURL, boardPanelConfigs }) => {
                   </IframeGridItem>
                 ))}
               </Grid2>
-            </ExpansionPanelDetails>
-          </ExpansionPanel>
+            </AccordionDetails>
+          </Accordion>
         ))}
       </Wrapper>
     </NoSsr>


### PR DESCRIPTION
## Summary

Follow-up to #19957. While fixing the Connections-page crash there, I found the same undefined-import pattern in other components. Each imports a name the installed `@sistent/sistent` does **not** export, so it resolves to `undefined` and throws **React error #130** (_"Element type is invalid … got: undefined"_) when the component renders — taking down that view via the page-level ErrorBoundary.

## Fixes

| File | Bad import(s) | Fix | Where it crashed |
|---|---|---|---|
| `components/CustomToolbarSelect.tsx` | `CompareArrows`, `GetApp`, `IndeterminateCheckBox` | `*Icon` aliases | Performance + Designs tables, on row selection |
| `components/designs/lifecycle/DeployConfirmationModal.tsx` | `Search` | `SearchIcon as Search` | Deploy / undeploy / validate dialog |
| `components/telemetry/grafana/GrafanaCharts.tsx` | `ExpansionPanelDetails` + `ExpansionPanel`/`ExpansionPanelSummary` (from `../../ExpansionPanels`, **a module that doesn't exist in the repo**) | migrate to Sistent's MUI-v5 `Accordion`/`AccordionSummary`/`AccordionDetails`; drop the dead import | telemetry/Grafana view |

Sistent ships the `*Icon`-suffixed glyph names and the `Accordion*` family, not the bare/v4 names. The icon fixes alias on import so render sites stay unchanged.

Also: three `Theme` value-imports → `type Theme`. Under this repo's `verbatimModuleSyntax: true`, a type imported without `type` is emitted as a runtime import of a type-only export (undefined at runtime) — the benign tail of the same class, and it lets the new guard stay allowlist-free.

## New regression guard

`ui/__tests__/architecture/sistent-imports-resolve.test.ts` imports the **real** `@sistent/sistent` and asserts every named **value** import across the source tree resolves against `Object.keys()` (type-only imports skipped). This is the generalized form of the icon-barrel guard from #19957 — it catches this entire bug class, which **neither `tsc`** (Sistent's published types and runtime can diverge) **nor the mocked component tests** (the mock supplies whatever the test asks for) can. Proven to fail on a reintroduced bad import and pass after the fixes.

## Note on GrafanaCharts

`GrafanaCharts` is currently unreferenced (its only test is `describe.skip`), so it isn't in the build graph today — that's why its missing-module import hadn't reddened CI. Fixed in place (rather than deleted) so it's correct and renderable if it's wired back up.

## Test plan

- [x] `npx vitest run` (full suite) → **380 files / 2556 tests passed, 31 skipped, 0 failed** (incl. the new guard)
- [x] Reverted one fix and confirmed the architecture guard fails with the exact offender, then restored
- [x] `npx tsc --noEmit` → clean
- [x] `npx eslint` + `npx prettier --check` on all changed files → clean
- [x] Updated the `CustomToolbarSelect` test mock to the new icon names