### PR TITLE
fix(extensions): symmetric local-provider install/remove + fix server unit test

### DIFF
--- a/server/models/default_local_provider.go
+++ b/server/models/default_local_provider.go
@@ -162,25 +162,33 @@ func (l *DefaultLocalProvider) InstallExtension(extType string, packageUrl strin
 // installs of the same extension are idempotent rather than accumulating
 // duplicate entries.
 func upsertNavigatorExtension(existing NavigatorExtensions, ext NavigatorExtension) NavigatorExtensions {
-	for i, e := range existing {
+	// Copy-on-write: build a new backing array instead of mutating in place, so a
+	// reader holding a previously returned slice header always observes an
+	// immutable snapshot even after the write lock is released.
+	newExts := make(NavigatorExtensions, len(existing), len(existing)+1)
+	copy(newExts, existing)
+	for i, e := range newExts {
 		if strings.EqualFold(strings.TrimSpace(e.Title), strings.TrimSpace(ext.Title)) {
-			existing[i] = ext
-			return existing
+			newExts[i] = ext
+			return newExts
 		}
 	}
-	return append(existing, ext)
+	return append(newExts, ext)
 }
 
 // upsertAccountExtension replaces the account extension that has a matching
 // (case-insensitive) title or appends it when none matches.
 func upsertAccountExtension(existing AccountExtensions, ext AccountExtension) AccountExtensions {
-	for i, e := range existing {
+	// Copy-on-write (see upsertNavigatorExtension).
+	newExts := make(AccountExtensions, len(existing), len(existing)+1)
+	copy(newExts, existing)
+	for i, e := range newExts {
 		if strings.EqualFold(strings.TrimSpace(e.Title), strings.TrimSpace(ext.Title)) {
-			existing[i] = ext
-			return existing
+			newExts[i] = ext
+			return newExts
 		}
 	}
-	return append(existing, ext)
+	return append(newExts, ext)
 }
 
 func (l *DefaultLocalProvider) RemoveExtension(extType, title string) error {

--- a/server/models/default_local_provider.go
+++ b/server/models/default_local_provider.go
@@ -69,6 +69,10 @@ type DefaultLocalProvider struct {
 	Log                             logger.Handler
 
 	MeshsyncDefaultDeploymentMode connections.MeshsyncDeploymentMode
+
+	// mu guards in-place mutations of Extensions performed by InstallExtension
+	// and RemoveExtension, which may be invoked concurrently from HTTP handlers.
+	mu sync.Mutex
 }
 
 // LocalProviderName is the canonical name of the built-in local provider.
@@ -94,6 +98,11 @@ func (l *DefaultLocalProvider) InstallExtension(extType string, packageUrl strin
 		return ErrMarshal(err, "extension metadata")
 	}
 
+	// Only the navigator and account extension points carry a Title, which is
+	// the identity used to upsert (on install) and locate (on remove) an
+	// extension. The other extension types have no stable identity here and
+	// therefore cannot be removed, so they are rejected to keep InstallExtension
+	// and RemoveExtension symmetric and to avoid accumulating duplicates.
 	switch extType {
 	case "navigator":
 		var parsed NavigatorExtension
@@ -115,51 +124,59 @@ func (l *DefaultLocalProvider) InstallExtension(extType string, packageUrl strin
 			return err
 		}
 
-		// replace existing extension with same title or append
-		replaced := false
-		for i, e := range l.Extensions.Navigator {
-			if strings.EqualFold(strings.TrimSpace(e.Title), strings.TrimSpace(parsed.Title)) && parsed.Title != "" {
-				l.Extensions.Navigator[i] = parsed
-				replaced = true
-				break
-			}
-		}
-		if !replaced {
-			l.Extensions.Navigator = append(l.Extensions.Navigator, parsed)
-		}
-
-	case "userprefs":
-		var parsed UserPrefsExtension
-		if err := json.Unmarshal(metaBytes, &parsed); err != nil {
-			return ErrUnmarshal(err, "userprefs extension metadata")
-		}
-		l.Extensions.UserPrefs = append(l.Extensions.UserPrefs, parsed)
-
-	case "graphql":
-		var parsed GraphQLExtension
-		if err := json.Unmarshal(metaBytes, &parsed); err != nil {
-			return ErrUnmarshal(err, "graphql extension metadata")
-		}
-		l.Extensions.GraphQL = append(l.Extensions.GraphQL, parsed)
+		l.mu.Lock()
+		l.Extensions.Navigator = upsertNavigatorExtension(l.Extensions.Navigator, parsed)
+		l.mu.Unlock()
 
 	case "account":
 		var parsed AccountExtension
 		if err := json.Unmarshal(metaBytes, &parsed); err != nil {
 			return ErrUnmarshal(err, "account extension metadata")
 		}
-		l.Extensions.Acccount = append(l.Extensions.Acccount, parsed)
 
-	case "collaborator":
-		var parsed CollaboratorExtension
-		if err := json.Unmarshal(metaBytes, &parsed); err != nil {
-			return ErrUnmarshal(err, "collaborator extension metadata")
+		if parsed.Title == "" {
+			if t, ok := extensionMetadata["title"].(string); ok {
+				parsed.Title = t
+			}
 		}
-		l.Extensions.Collaborator = append(l.Extensions.Collaborator, parsed)
+		if strings.TrimSpace(parsed.Title) == "" {
+			return fmt.Errorf("InstallExtension: account extension title is required")
+		}
+
+		l.mu.Lock()
+		l.Extensions.Acccount = upsertAccountExtension(l.Extensions.Acccount, parsed)
+		l.mu.Unlock()
 
 	default:
-		return fmt.Errorf("InstallExtension: unsupported extension type '%s'", extType)
+		return fmt.Errorf("InstallExtension: unsupported extension type %q (supported types: navigator, account)", extType)
 	}
 	return nil
+}
+
+// upsertNavigatorExtension replaces the navigator extension that has a matching
+// (case-insensitive) title or appends it when none matches, so repeated
+// installs of the same extension are idempotent rather than accumulating
+// duplicate entries.
+func upsertNavigatorExtension(existing NavigatorExtensions, ext NavigatorExtension) NavigatorExtensions {
+	for i, e := range existing {
+		if strings.EqualFold(strings.TrimSpace(e.Title), strings.TrimSpace(ext.Title)) {
+			existing[i] = ext
+			return existing
+		}
+	}
+	return append(existing, ext)
+}
+
+// upsertAccountExtension replaces the account extension that has a matching
+// (case-insensitive) title or appends it when none matches.
+func upsertAccountExtension(existing AccountExtensions, ext AccountExtension) AccountExtensions {
+	for i, e := range existing {
+		if strings.EqualFold(strings.TrimSpace(e.Title), strings.TrimSpace(ext.Title)) {
+			existing[i] = ext
+			return existing
+		}
+	}
+	return append(existing, ext)
 }
 
 func (l *DefaultLocalProvider) RemoveExtension(extType, title string) error {
@@ -168,6 +185,9 @@ func (l *DefaultLocalProvider) RemoveExtension(extType, title string) error {
 	if title == "" {
 		return fmt.Errorf("RemoveExtension called with empty title")
 	}
+
+	l.mu.Lock()
+	defer l.mu.Unlock()
 
 	switch extType {
 	case "navigator":
@@ -199,7 +219,7 @@ func (l *DefaultLocalProvider) RemoveExtension(extType, title string) error {
 		}
 		l.Extensions.Acccount = filtered
 	default:
-		return fmt.Errorf("RemoveExtension: unsupported extension type '%s'", extType)
+		return fmt.Errorf("RemoveExtension: unsupported extension type %q (supported types: navigator, account)", extType)
 	}
 
 	return nil
@@ -217,8 +237,6 @@ func (l *DefaultLocalProvider) Initialize() {
 	l.ProviderType = LocalProviderType
 	l.PackageVersion = viper.GetString("BUILD")
 	l.PackageURL = ""
-	// t := true
-	// f := false
 	l.Extensions = Extensions{Navigator: NavigatorExtensions{}}
 	l.Capabilities = Capabilities{
 		{Feature: PersistMesheryPatterns},
@@ -278,7 +296,6 @@ func (l *DefaultLocalProvider) DownloadProviderExtensionPackageFromURL(packageUr
 	}
 
 	log.Info(fmt.Sprintf("[Initialize]: Package not found at %s proceeding to download", loc))
-	// logrus the provider package
 	if err := TarXZF(packageUrl, loc, log); err != nil {
 		return ErrDownloadPackage(err, "provider package")
 	}

--- a/server/models/default_local_provider.go
+++ b/server/models/default_local_provider.go
@@ -70,9 +70,13 @@ type DefaultLocalProvider struct {
 
 	MeshsyncDefaultDeploymentMode connections.MeshsyncDeploymentMode
 
-	// mu guards in-place mutations of Extensions performed by InstallExtension
-	// and RemoveExtension, which may be invoked concurrently from HTTP handlers.
-	mu sync.Mutex
+	// mu guards concurrent access to Extensions: InstallExtension and
+	// RemoveExtension take the write lock to mutate it, while readers such as
+	// GetProviderCapabilities/GetProviderProperties take the read lock.
+	mu sync.RWMutex
+	// downloadMu serializes provider package downloads so concurrent installs
+	// don't race on the shared on-disk package location.
+	downloadMu sync.Mutex
 }
 
 // LocalProviderName is the canonical name of the built-in local provider.
@@ -277,6 +281,11 @@ func (l *DefaultLocalProvider) DownloadProviderExtensionPackageFromURL(packageUr
 		return nil
 	}
 
+	// Serialize the check-then-download so concurrent installs don't extract to
+	// the same shared location simultaneously and corrupt the package.
+	l.downloadMu.Lock()
+	defer l.downloadMu.Unlock()
+
 	// Location for the package to be stored
 	loc := l.PackageLocation()
 
@@ -309,6 +318,8 @@ func (l *DefaultLocalProvider) SetProviderProperties(providerProperties Provider
 
 // GetProviderProperties - Returns all the provider properties required
 func (l *DefaultLocalProvider) GetProviderProperties() ProviderProperties {
+	l.mu.RLock()
+	defer l.mu.RUnlock()
 	return l.ProviderProperties
 }
 
@@ -326,7 +337,12 @@ func (l *DefaultLocalProvider) UnSetJWTCookie(_ http.ResponseWriter) {
 
 func (l *DefaultLocalProvider) GetProviderCapabilities(w http.ResponseWriter, _ *http.Request, _ string) {
 	var buf bytes.Buffer
-	if err := json.NewEncoder(&buf).Encode(l.ProviderProperties); err != nil {
+	// Read Extensions/ProviderProperties under the read lock so the encode does
+	// not race with concurrent InstallExtension/RemoveExtension mutations.
+	l.mu.RLock()
+	err := json.NewEncoder(&buf).Encode(l.ProviderProperties)
+	l.mu.RUnlock()
+	if err != nil {
 		errObj := ErrEncoding(err, "provider capabilities")
 		l.Log.Error(errObj)
 		httputil.WriteMeshkitError(w, errObj, http.StatusInternalServerError)

--- a/server/models/default_local_provider_test.go
+++ b/server/models/default_local_provider_test.go
@@ -249,7 +249,10 @@ func TestDefaultLocalProviderRemoveExtension_ReturnsErrorForMissingExtension(t *
 func TestDefaultLocalProviderInstallExtension_RequiresPackageWhenAssetsMissing(t *testing.T) {
 	t.Setenv("HOME", t.TempDir())
 	// Exercise the real download path (not skipped) so the missing package URL
-	// is surfaced as an error. viper is the source of truth for this flag.
+	// is surfaced as an error. viper is the source of truth for this flag;
+	// capture and restore its original value to avoid leaking state to other tests.
+	origSkip := viper.Get(SKIP_DOWNLOAD_EXTENSIONS_ENV)
+	defer viper.Set(SKIP_DOWNLOAD_EXTENSIONS_ENV, origSkip)
 	viper.Set(SKIP_DOWNLOAD_EXTENSIONS_ENV, false)
 
 	provider := &DefaultLocalProvider{}
@@ -282,8 +285,10 @@ func TestDefaultLocalProviderInstallExtension_ReplacesMatchingNavigatorExtension
 	// viper, not the OS environment, is the source of truth for this flag, and
 	// the test binary never calls viper.AutomaticEnv(); set it via viper so the
 	// package download is deterministically skipped without network access.
+	// Capture and restore the original value to avoid leaking state to other tests.
+	origSkip := viper.Get(SKIP_DOWNLOAD_EXTENSIONS_ENV)
+	defer viper.Set(SKIP_DOWNLOAD_EXTENSIONS_ENV, origSkip)
 	viper.Set(SKIP_DOWNLOAD_EXTENSIONS_ENV, true)
-	defer viper.Set(SKIP_DOWNLOAD_EXTENSIONS_ENV, false)
 
 	provider := &DefaultLocalProvider{}
 	provider.Initialize()

--- a/server/models/default_local_provider_test.go
+++ b/server/models/default_local_provider_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/meshery/meshkit/database"
 	"github.com/meshery/meshkit/logger"
 	"github.com/meshery/meshkit/models/events"
+	"github.com/spf13/viper"
 	"gorm.io/driver/sqlite"
 	"gorm.io/gorm"
 )
@@ -247,7 +248,9 @@ func TestDefaultLocalProviderRemoveExtension_ReturnsErrorForMissingExtension(t *
 
 func TestDefaultLocalProviderInstallExtension_RequiresPackageWhenAssetsMissing(t *testing.T) {
 	t.Setenv("HOME", t.TempDir())
-	t.Setenv(SKIP_DOWNLOAD_EXTENSIONS_ENV, "false")
+	// Exercise the real download path (not skipped) so the missing package URL
+	// is surfaced as an error. viper is the source of truth for this flag.
+	viper.Set(SKIP_DOWNLOAD_EXTENSIONS_ENV, false)
 
 	provider := &DefaultLocalProvider{}
 	provider.Initialize()
@@ -276,7 +279,11 @@ func TestDefaultLocalProviderInstallExtension_RequiresPackageWhenAssetsMissing(t
 }
 
 func TestDefaultLocalProviderInstallExtension_ReplacesMatchingNavigatorExtension(t *testing.T) {
-	t.Setenv(SKIP_DOWNLOAD_EXTENSIONS_ENV, "true")
+	// viper, not the OS environment, is the source of truth for this flag, and
+	// the test binary never calls viper.AutomaticEnv(); set it via viper so the
+	// package download is deterministically skipped without network access.
+	viper.Set(SKIP_DOWNLOAD_EXTENSIONS_ENV, true)
+	defer viper.Set(SKIP_DOWNLOAD_EXTENSIONS_ENV, false)
 
 	provider := &DefaultLocalProvider{}
 	provider.Initialize()

--- a/ui/components/extensions/installableExtensions.tsx
+++ b/ui/components/extensions/installableExtensions.tsx
@@ -108,6 +108,10 @@ const resolveExtensionHref = (href?: ExtensionMetadata['href']) => {
     return '';
   }
 
+  // Guarantee exactly one separating slash so a relative href such as 'meshmap'
+  // resolves to '/extension/meshmap' rather than the malformed '/extensionmeshmap'.
+  const ensureLeadingSlash = (path: string) => (path.startsWith('/') ? path : '/' + path);
+
   if (typeof href === 'string') {
     if (
       href.startsWith('http://') ||
@@ -117,7 +121,7 @@ const resolveExtensionHref = (href?: ExtensionMetadata['href']) => {
       return href;
     }
 
-    return '/extension' + href;
+    return '/extension' + ensureLeadingSlash(href);
   }
 
   if (!href.uri) {
@@ -132,7 +136,7 @@ const resolveExtensionHref = (href?: ExtensionMetadata['href']) => {
     return href.uri;
   }
 
-  return '/extension' + href.uri;
+  return '/extension' + ensureLeadingSlash(href.uri);
 };
 
 const InstallableExtension: React.FC<InstallableExtensionProps> = ({ extension }) => {

--- a/ui/next-env.d.ts
+++ b/ui/next-env.d.ts
@@ -1,6 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
-import "./.next/dev/types/routes.d.ts";
+import "./.next/types/routes.d.ts";
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/pages/api-reference/config/typescript for more information.


### PR DESCRIPTION
Targets the `local-extension` branch to fold these fixes into #19956 (installing extensions in the local provider). Merging this updates that PR.

### Fixes the failing `server Unit tests` check
`TestDefaultLocalProviderInstallExtension_ReplacesMatchingNavigatorExtension` set the skip-download flag with `t.Setenv`, but `viper.GetBool` only reads the OS environment after `viper.AutomaticEnv()` — which runs in `main.go`, **not** in the test binary. The download therefore ran, the empty package URL errored, and the test failed. The tests now set the flag via `viper.Set`, so the download is deterministically skipped without depending on env binding or network access.

### Review feedback addressed
- **Install/remove symmetry + duplicate installs:** only `navigator` and `account` extensions carry a `Title` (the identity `RemoveExtension` uses to locate an entry). `InstallExtension` now supports exactly that titled set, upserting by title so repeated installs are idempotent, and rejects the title-less types (`userprefs`, `graphql`, `collaborator`) — keeping install and remove symmetric instead of silently accumulating duplicates.
- **Concurrency:** `Extensions` mutations in both methods are now guarded by a `sync.Mutex` (the local provider is a shared singleton reached by concurrent HTTP handlers).
- **Malformed URL:** `resolveExtensionHref` now ensures a single leading slash, so a relative href like `meshmap` resolves to `/extension/meshmap` instead of `/extensionmeshmap`.
- **Cleanup:** removed the dead `// t := true` / `// f := false` lines in `Initialize()` and the stray `// logrus the provider package` comment.
- **Unintended change:** reverted `ui/next-env.d.ts` back to `.next/types/routes.d.ts`.

All commits are signed off (DCO). `server/handlers` and `server/models` tests pass locally; `gofmt` and `go vet` are clean.

> The "typed MeshKit errors" suggestion (handlers using `fmt.Errorf`) was intentionally left out — the reviewer flagged it as "minor for now" and it's a broader refactor better handled separately.