### PR TITLE
docs(sidebar): animated caret toggle and emphasize parent nav items

### DIFF
--- a/docs/assets/scss/_sidebar.scss
+++ b/docs/assets/scss/_sidebar.scss
@@ -325,11 +325,11 @@
   // navigation hierarchy reads clearly at a glance.
   & .td-sidebar-nav__section.with-child > a.td-sidebar-link,
   & .td-sidebar-nav__section.with-child > .sidebar-section-flex-wrapper > a.td-sidebar-link {
-    font-weight: 600;
+    font-weight: 800;
   }
 
   & .td-sidebar-nav__section.without-child > a.td-sidebar-link {
-    font-weight: 400;
+    font-weight: 600;
   }
 
   & .td-sidebar-link:hover,

--- a/docs/assets/scss/_sidebar.scss
+++ b/docs/assets/scss/_sidebar.scss
@@ -200,16 +200,31 @@
   }
 
   & .sidebar-section-toggle {
+    display: flex;
+    align-items: center;
+    justify-content: center;
     background: none;
     border: none;
     color: var(--color-secondary-medium);
     cursor: pointer;
     font-size: 1rem;
-    padding: 0 0.5rem 0 0;
+    padding: 0 0.4rem 0 0;
     line-height: 1;
     opacity: 0.7;
     flex-shrink: 0;
-    transition: opacity 0.2s, color 0.2s, transform 0.2s ease-in-out;
+    transition: opacity 0.2s, color 0.2s;
+
+    // Caret/chevron disclosure indicator. Points right when collapsed and
+    // rotates to point down when the section is expanded (see .active-path
+    // rule below) to convey expanded vs. collapsed state.
+    .caret-icon {
+      display: block;
+      width: 0.85em;
+      height: 0.85em;
+      transform: rotate(0deg);
+      transform-origin: center;
+      transition: transform 0.25s ease-in-out;
+    }
 
     &:hover {
       opacity: 1;
@@ -220,9 +235,17 @@
       font-size: 0.75rem;
       padding: 0;
       width: 1.5rem;
-      display: flex;
-      justify-content: center;
-      align-items: center;
+    }
+  }
+
+  // When a section is expanded, its <li> carries the `active-path` class.
+  // Rotate the caret 90deg (right -> down) and bring the toggle to full
+  // opacity so the expanded state reads clearly.
+  & li.active-path > .sidebar-section-flex-wrapper > .sidebar-section-toggle {
+    opacity: 1;
+
+    .caret-icon {
+      transform: rotate(90deg);
     }
   }
 
@@ -296,6 +319,17 @@
   & .td-sidebar-link.td-sidebar-link__page {
     font-weight: 400;
     font-size: 1rem;
+  }
+
+  // Sections that contain child pages are emphasised over leaf pages so the
+  // navigation hierarchy reads clearly at a glance.
+  & .td-sidebar-nav__section.with-child > a.td-sidebar-link,
+  & .td-sidebar-nav__section.with-child > .sidebar-section-flex-wrapper > a.td-sidebar-link {
+    font-weight: 600;
+  }
+
+  & .td-sidebar-nav__section.without-child > a.td-sidebar-link {
+    font-weight: 400;
   }
 
   & .td-sidebar-link:hover,

--- a/docs/layouts/partials/sidebar.html
+++ b/docs/layouts/partials/sidebar.html
@@ -80,14 +80,16 @@
       }
     }
 
+    var caretIcon = '<svg class="caret-icon" viewBox="0 0 16 16" width="1em" height="1em" aria-hidden="true" focusable="false"><path d="M6 4l4 4-4 4" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/></svg>';
+
     var rootLis = document.querySelectorAll(".td-sidebar-nav .ul-1 > li.with-child");
     rootLis.forEach(function(li) {
-      injectToggleButton(li, "⇅", "before", "");
+      injectToggleButton(li, caretIcon, "before", "");
     });
 
     var childLis = document.querySelectorAll(".td-sidebar-nav .ul-1 ul li.with-child");
     childLis.forEach(function(li) {
-      injectToggleButton(li, "⇅", "before", "child-toggle");
+      injectToggleButton(li, caretIcon, "before", "child-toggle");
     });
   })();
 </script>
@@ -145,9 +147,3 @@
     });
   });
 </script>
-
-<style>
-  .sidebar-section-toggle.is-expanded svg {
-    transform: rotate(90deg);
-  }
-</style>


### PR DESCRIPTION
## Description

Enhances the Meshery Docs sidebar navigation styling:

- **Caret toggle facet.** Replaces the double-arrow (`⇅`) section toggle with a caret/chevron icon. It points right when a section is collapsed and rotates to point down when expanded — the standard disclosure convention.
- **CSS-animated expand/collapse.** The caret rotates 90° via a CSS `transform` transition (`0.25s ease-in-out`) tied to the section's expanded state (`active-path`), so visitors get clear, smooth visual feedback for expanded vs. collapsed sections.
- **Hierarchy emphasis.** Menu items that have child pages (`.with-child`) are now rendered with a heavier font weight than leaf pages, making the navigation hierarchy easier to scan at a glance.

## Changes

- `docs/layouts/partials/sidebar.html` — inject an inline caret SVG (`.caret-icon`) for both root and child section toggles instead of the `⇅` glyph; removed the now-redundant inline `<style>` block (rotation is handled in SCSS).
- `docs/assets/scss/_sidebar.scss` — caret sizing and rotation transition, a rotate-on-expanded rule keyed off `active-path`, and `with-child` vs `without-child` font-weight emphasis.

## Notes

- No template/markup structure changes beyond the toggle icon; the existing toggle/slide behavior is preserved.
- Works in both light and dark mode (the caret uses `currentColor`).