### PR TITLE
[CI] Make docs preview pruning resilient to concurrent gh-pages pushes

### DIFF
--- a/.github/workflows/build-and-preview-docs.yml
+++ b/.github/workflows/build-and-preview-docs.yml
@@ -168,44 +168,88 @@ jobs:
       - name: Prune old PR previews
         id: prune-previews
         if: github.event_name == 'pull_request_target' && github.event.action != 'closed'
+        # Pruning is best-effort housekeeping on the shared gh-pages branch.
+        # Many docs preview runs write to gh-pages at once, so it must never be
+        # the reason a preview is reported as failed: the push is retried against
+        # the freshest state, and the step is continue-on-error as a backstop.
+        continue-on-error: true
         run: |
           cd gh-pages-maintenance
-          mkdir -p pr-preview
-          removed_prs=()
-
-          mapfile -t previews < <(
-            while IFS= read -r preview; do
-              timestamp="$(git log -1 --format=%ct -- "pr-preview/$preview" 2>/dev/null || echo 0)"
-              printf '%s %s\n' "$timestamp" "$preview"
-            done < <(find pr-preview -mindepth 1 -maxdepth 1 -type d -name 'pr-*' -printf '%f\n') \
-              | sort -nr \
-              | awk '{print $2}'
-          )
-
-          if (( ${#previews[@]} <= PREVIEW_RETENTION_LIMIT )); then
-            echo "removed_prs_json=[]" >> "$GITHUB_OUTPUT"
-            exit 0
-          fi
-
-          for preview in "${previews[@]:PREVIEW_RETENTION_LIMIT}"; do
-            rm -rf "pr-preview/$preview"
-            removed_prs+=("${preview#pr-}")
-          done
-
-          if git diff --quiet -- pr-preview; then
-            echo "removed_prs=" >> "$GITHUB_OUTPUT"
-            echo "removed_prs_json=[]" >> "$GITHUB_OUTPUT"
-            exit 0
-          fi
-
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
-          git add pr-preview
-          git commit -m "Prune old PR previews"
-          git push
 
-          echo "removed_prs=$(IFS=,; echo "${removed_prs[*]}")" >> "$GITHUB_OUTPUT"
-          echo "removed_prs_json=$(printf '%s\n' "${removed_prs[@]}" | jq -R . | jq -sc .)" >> "$GITHUB_OUTPUT"
+          # Write safe defaults first. $GITHUB_OUTPUT is last-write-wins, so even
+          # if this step is interrupted, the downstream "Comment on pruned
+          # previews" job sees a valid empty list rather than an empty string.
+          {
+            echo "removed_prs="
+            echo "removed_prs_json=[]"
+          } >> "$GITHUB_OUTPUT"
+
+          # A naive push to the shared gh-pages branch loses the race with other
+          # concurrent preview runs ("! [rejected] (fetch first)"). Re-derive the
+          # prune from the freshest remote state on every attempt and retry with
+          # backoff so a lost race self-heals instead of failing the workflow.
+          removed_prs=()
+          outcome=""
+          attempts=5
+
+          for attempt in $(seq 1 "$attempts"); do
+            git fetch --quiet origin gh-pages
+            git reset --quiet --hard FETCH_HEAD
+            mkdir -p pr-preview
+
+            mapfile -t previews < <(
+              while IFS= read -r preview; do
+                timestamp="$(git log -1 --format=%ct -- "pr-preview/$preview" 2>/dev/null || echo 0)"
+                printf '%s %s\n' "$timestamp" "$preview"
+              done < <(find pr-preview -mindepth 1 -maxdepth 1 -type d -name 'pr-*' -printf '%f\n') \
+                | sort -nr \
+                | awk '{print $2}'
+            )
+
+            removed_prs=()
+            if (( ${#previews[@]} > PREVIEW_RETENTION_LIMIT )); then
+              for preview in "${previews[@]:PREVIEW_RETENTION_LIMIT}"; do
+                rm -rf "pr-preview/$preview"
+                removed_prs+=("${preview#pr-}")
+              done
+            fi
+
+            # Within the retention limit, or another run already pruned: done.
+            if git diff --quiet -- pr-preview; then
+              outcome="noop"
+              break
+            fi
+
+            git add pr-preview
+            git commit --quiet -m "Prune old PR previews"
+
+            if git push origin HEAD:gh-pages; then
+              outcome="pushed"
+              break
+            fi
+
+            echo "Prune push lost the race (attempt ${attempt}/${attempts}); re-syncing gh-pages and retrying..."
+            sleep "$(( attempt * 5 + RANDOM % 5 ))"
+          done
+
+          if [ -z "$outcome" ]; then
+            echo "::warning::Could not prune old PR previews after ${attempts} attempts due to concurrent gh-pages updates; a later run will retry. Not failing the preview."
+            removed_prs=()
+          fi
+
+          if [ "${#removed_prs[@]}" -eq 0 ]; then
+            {
+              echo "removed_prs="
+              echo "removed_prs_json=[]"
+            } >> "$GITHUB_OUTPUT"
+          else
+            {
+              echo "removed_prs=$(IFS=,; echo "${removed_prs[*]}")"
+              echo "removed_prs_json=$(printf '%s\n' "${removed_prs[@]}" | jq -R . | jq -sc .)"
+            } >> "$GITHUB_OUTPUT"
+          fi
 
       - name: Comment PR with Preview URL
         if: github.event_name == 'pull_request_target' && github.event.action != 'closed'


### PR DESCRIPTION
**Notes for Reviewers**

Fixes #19978.

**Problem.** The `Build and Preview Docs` workflow's **"Prune old PR previews"** step pushed to the shared `gh-pages` branch with a naive `git push`. Because many docs preview runs write to `gh-pages` concurrently, that push routinely loses the race:

```
! [rejected]  gh-pages -> gh-pages (fetch first)
error: failed to push some refs to 'https://github.com/meshery/meshery'
```

The step failure marked the whole preview workflow as failed, so old `pr-preview/pr-<N>/` directories were never pruned, accumulated on `gh-pages`, and the **GitHub Pages build eventually errored** on the oversized branch — taking down PR preview serving.

**Fix (one step, `docs`-preview workflow).** Make pruning self-healing and non-fatal:

- **Retry against the freshest state.** On every attempt the step re-fetches `gh-pages`, `reset --hard FETCH_HEAD`, re-derives which previews to prune, commits, and pushes — retrying with backoff. A lost race re-syncs and succeeds instead of failing.
- **Safe default outputs.** It writes `removed_prs=` / `removed_prs_json=[]` up front (`$GITHUB_OUTPUT` is last-write-wins), so the downstream *Comment on pruned previews* job always parses valid JSON even if the step is interrupted.
- **`continue-on-error`.** Pruning is best-effort housekeeping that runs *after* the preview is already deployed; it must never be the reason a preview is reported as failed. If it still can't push after retries, it emits a warning and a later run prunes — the accumulated backlog self-heals on the next successful prune.

**Validation** (the step's script was extracted and exercised against a local bare repo standing in for `gh-pages`):

- ✅ **Happy path** — 10 previews, retention 6 → prunes the 4 oldest, pushes, outputs `["4","3","2","1"]`; remote left with exactly 6.
- ✅ **Noop** — 6 previews within retention → no commit/push, outputs `[]`.
- ✅ **Race-retry** — a fake `git` rejects the *first* push: the step makes 2 push attempts, logs one retry, re-syncs, and succeeds with the correct final state and outputs.
- ✅ `yaml.safe_load` parses the workflow; `bash -n` passes on the step script.

Note: `pull_request_target` runs the workflow from the **base** branch, so this PR's own preview run still uses the current (pre-fix) prune step; the hardening takes effect once merged to `master`.

**[Signed commits](https://github.com/meshery/meshery/blob/master/CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [x] Yes, I signed my commits.
