### PR TITLE
Fix sort by count for database table in settings registry page

### DIFF
--- a/server/handlers/database_handlers.go
+++ b/server/handlers/database_handlers.go
@@ -33,9 +33,18 @@ func (h *Handler) GetSystemDatabase(w http.ResponseWriter, r *http.Request, _ *m
 
 	tableQueryBase.Count(&totalTables)
 
-	tableFinder := tableQueryBase.
-		Select("s.*, CAST(COALESCE(st.stat, '0') AS INTEGER) as count").
-		Joins("LEFT JOIN sqlite_stat1 st ON s.name = st.tbl")
+	// Check if stat table exists
+	hasStat := h.dbHandler.DB.Migrator().HasTable("sqlite_stat1")
+	tableFinder := tableQueryBase
+
+	if hasStat {
+		tableFinder = tableFinder.
+			Select("s.*, CAST(COALESCE(st.stat, '0') AS INTEGER) as count").
+			Joins("LEFT JOIN sqlite_stat1 st ON s.name = st.tbl")
+	} else {
+		tableFinder = tableFinder.
+			Select("s.*, 0 as count")
+	}
 
 	if limit != 0 {
 		tableFinder = tableFinder.Limit(limit)

--- a/server/handlers/database_handlers.go
+++ b/server/handlers/database_handlers.go
@@ -24,14 +24,18 @@ func (h *Handler) GetSystemDatabase(w http.ResponseWriter, r *http.Request, _ *m
 	var totalTables int64
 	page, offset, limit, search, order, sort, _ := getPaginationParams(r)
 
-	tableFinder := h.dbHandler.DB.Table("sqlite_schema").
+	tableQueryBase := h.dbHandler.DB.Table("sqlite_schema AS s").
 		Where("type = ?", "table")
 
 	if search != "" {
-		tableFinder = tableFinder.Where("name LIKE ?", "%"+search+"%")
+		tableQueryBase = tableQueryBase.Where("name LIKE ?", "%"+search+"%")
 	}
 
-	tableFinder.Count(&totalTables)
+	tableQueryBase.Count(&totalTables)
+
+	tableFinder := tableQueryBase.
+		Select("s.*, CAST(COALESCE(st.stat, '0') AS INTEGER) as count").
+		Joins("LEFT JOIN sqlite_stat1 st ON s.name = st.tbl")
 
 	if limit != 0 {
 		tableFinder = tableFinder.Limit(limit)
@@ -39,7 +43,7 @@ func (h *Handler) GetSystemDatabase(w http.ResponseWriter, r *http.Request, _ *m
 	if offset != 0 {
 		tableFinder = tableFinder.Offset(offset)
 	}
-	order = models.SanitizeOrderInput(order, []string{"created_at", "updated_at", "name"})
+	order = models.SanitizeOrderInput(order, []string{"created_at", "updated_at", "name", "count"})
 	if order != "" {
 		if sort == "desc" {
 			tableFinder = tableFinder.Order(clause.OrderByColumn{Column: clause.Column{Name: order}, Desc: true})
@@ -51,7 +55,6 @@ func (h *Handler) GetSystemDatabase(w http.ResponseWriter, r *http.Request, _ *m
 	tableFinder.Find(&tables)
 
 	for i := range tables {
-		h.dbHandler.DB.Table(tables[i].Name).Count(&tables[i].Count)
 		recordCount += int(tables[i].Count)
 	}
 

--- a/server/handlers/handler_instance.go
+++ b/server/handlers/handler_instance.go
@@ -94,6 +94,6 @@ func registerAnalysisCallBack(db *gorm.DB) {
 	}
 
 	db.Callback().Create().After("gorm:create").Register("analyze_create", runAnalysis)
-	db.Callback().Create().After("gorm:update").Register("analyze_create", runAnalysis)
-	db.Callback().Create().After("gorm:delete").Register("analyze_create", runAnalysis)
+	db.Callback().Update().After("gorm:update").Register("analyze_update", runAnalysis)
+	db.Callback().Delete().After("gorm:delete").Register("analyze_delete", runAnalysis)
 }

--- a/server/handlers/handler_instance.go
+++ b/server/handlers/handler_instance.go
@@ -2,6 +2,8 @@
 package handlers
 
 import (
+	"time"
+
 	"github.com/meshery/meshery/server/machines"
 	"github.com/meshery/meshery/server/models"
 	"github.com/meshery/meshery/server/models/connections"
@@ -15,7 +17,6 @@ import (
 	"github.com/meshery/schemas/models/core"
 	"github.com/spf13/viper"
 	"github.com/vmihailenco/taskq/v3"
-	"gorm.io/gorm"
 )
 
 // Handler type is the bucket for configs and http handlers
@@ -81,19 +82,15 @@ func NewHandlerInstance(
 		Handler: h.CollectStaticMetrics,
 	})
 
+	// Background routine to get tables stat
 	h.dbHandler.Exec("Analyze")
-	registerAnalysisCallBack(h.dbHandler.DB)
+	ticker := time.NewTicker(10 * time.Minute)
+	go func() {
+		for {
+			<-ticker.C
+			h.dbHandler.Exec("Analyze")
+		}
+	}()
 
 	return h
-}
-
-// add analyze callback every data mutations
-func registerAnalysisCallBack(db *gorm.DB) {
-	runAnalysis := func(db *gorm.DB) {
-		db.Exec("Analyze")
-	}
-
-	db.Callback().Create().After("gorm:create").Register("analyze_create", runAnalysis)
-	db.Callback().Update().After("gorm:update").Register("analyze_update", runAnalysis)
-	db.Callback().Delete().After("gorm:delete").Register("analyze_delete", runAnalysis)
 }

--- a/server/handlers/handler_instance.go
+++ b/server/handlers/handler_instance.go
@@ -15,6 +15,7 @@ import (
 	"github.com/meshery/schemas/models/core"
 	"github.com/spf13/viper"
 	"github.com/vmihailenco/taskq/v3"
+	"gorm.io/gorm"
 )
 
 // Handler type is the bucket for configs and http handlers
@@ -80,5 +81,19 @@ func NewHandlerInstance(
 		Handler: h.CollectStaticMetrics,
 	})
 
+	h.dbHandler.Exec("Analyze")
+	registerAnalysisCallBack(h.dbHandler.DB)
+
 	return h
+}
+
+// add analyze callback every data mutations
+func registerAnalysisCallBack(db *gorm.DB) {
+	runAnalysis := func(db *gorm.DB) {
+		db.Exec("Analyze")
+	}
+
+	db.Callback().Create().After("gorm:create").Register("analyze_create", runAnalysis)
+	db.Callback().Create().After("gorm:update").Register("analyze_create", runAnalysis)
+	db.Callback().Create().After("gorm:delete").Register("analyze_create", runAnalysis)
 }

--- a/ui/components/DatabaseSummary.tsx
+++ b/ui/components/DatabaseSummary.tsx
@@ -109,8 +109,18 @@ const DatabaseSummary: FC<DatabaseSummaryProps> = (props) => {
       if (searchText) setPage(0);
       setSearchText(searchText != null ? searchText : '');
     }),
-    onColumnSortChange: (_, direction) => {
-      setSortOrder(`name ${direction}`);
+    onColumnSortChange: (column, direction) => {
+      const allowedCollumns = ['name', 'count'];
+      const allowedDirection = ['asc', 'desc'];
+
+      if (
+        typeof column === 'string' &&
+        typeof direction === 'string' &&
+        allowedCollumns.includes(column) &&
+        allowedDirection.includes(direction)
+      ) {
+        setSortOrder(`${column} ${direction}`);
+      }
     },
   };
 


### PR DESCRIPTION
### Description

- This PR fixes #13958 and resumes the pending PR #17911 
- Offloads table sorting logic directly to the database using `sqlite_stat1`
- Implements global GORM lifecycle callbacks (hooks) for `Create`, `Update`, and `Delete` to keep sqlite stat table updated

### Verification
- The sorting table count runs as expected on local

### Notes for reviewers
- **GORM Hooks Overhead:** To ensure the table counts are always 100% accurate without N+1 queries, I added "Analyze" execution for every mutation request, but this feels a bit heavy/hacky
- I am very open to other suggestions. One approach I could think of is to add a background task that runs every few minutes/hours

**[Signed commits](https://github.com/meshery/meshery/blob/master/CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [x] Yes, I signed my commits.

<!--
Thank you for contributing to Meshery! 

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. Sign your commits.
4. Include before and after screenshots/terminal output.

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.
-->
