### PR TITLE
fix(extensions): use filepath.Join for local provider package location

### DIFF
--- a/server/models/default_local_provider.go
+++ b/server/models/default_local_provider.go
@@ -12,7 +12,6 @@ import (
 	"net/http"
 	"net/url"
 	"os"
-	"path"
 	"path/filepath"
 	"strconv"
 	"strings"
@@ -334,7 +333,7 @@ func (l *DefaultLocalProvider) GetProviderProperties() ProviderProperties {
 // PackageLocation returns the location of where the package for the current
 // provider is located
 func (l *DefaultLocalProvider) PackageLocation() string {
-	return path.Join(homedir.HomeDir(), ".meshery", "provider", l.ProviderName, l.PackageVersion)
+	return filepath.Join(homedir.HomeDir(), ".meshery", "provider", l.ProviderName, l.PackageVersion)
 }
 
 func (l *DefaultLocalProvider) SetJWTCookie(_ http.ResponseWriter, _ string) {


### PR DESCRIPTION
Follow-up to #19971, targeting `local-extension` to fold one more fix into #19956.

A second Gemini review on #19956 flagged that `DefaultLocalProvider.PackageLocation()` builds filesystem paths with `path.Join`, which always uses forward slashes and produces malformed paths on Windows. This switches it to `filepath.Join` (and drops the now-unused `path` import) for cross-platform correctness.

`server/models` tests and gofmt pass.