### PR TITLE
ci(docs): sparse, blobless checkout for Hugo Pages deploy

### DIFF
--- a/.github/workflows/hugo.yml
+++ b/.github/workflows/hugo.yml
@@ -26,29 +26,60 @@ jobs:
     env:
       HUGO_VERSION: 0.157.0
     steps:
+      - name: Checkout docs source
+        uses: actions/checkout@v6
+        with:
+          persist-credentials: false
+          fetch-depth: 1
+          # Only the Hugo site input is needed to build docs.meshery.io.
+          # A blobless, cone-mode sparse checkout pulls the docs/ tree (plus
+          # the root files the Makefile target needs) instead of cloning the
+          # entire repository, which materially cuts checkout IO. There are no
+          # submodules, so submodule fetching is intentionally omitted.
+          filter: blob:none
+          sparse-checkout: docs
+          sparse-checkout-cone-mode: true
+      - name: Checkout gh-pages for preview retention
+        if: github.event.action != 'closed'
+        uses: actions/checkout@v6
+        with:
+          ref: gh-pages
+          persist-credentials: false
+          fetch-depth: 1
+          # Blobless sparse checkout: we only read the existing pr-preview/
+          # umbrella so the full-site deploy below can carry it forward and
+          # avoid clobbering live PR previews. No history or other blobs needed.
+          filter: blob:none
+          sparse-checkout: |
+            pr-preview
+          path: gh-pages-maintenance
       - name: Install Hugo CLI
         run: |
           wget -O ${{ runner.temp }}/hugo.deb https://github.com/gohugoio/hugo/releases/download/v${HUGO_VERSION}/hugo_extended_${HUGO_VERSION}_linux-amd64.deb \
           && sudo dpkg -i ${{ runner.temp }}/hugo.deb
       - name: Install Dart Sass
-        run: sudo snap install dart-sass
-      - name: Checkout
-        uses: actions/checkout@v6
-        with:
-          submodules: recursive
-          fetch-depth: 1
-      - name: Checkout existing GitHub Pages content
-        uses: actions/checkout@v6
-        with:
-          ref: gh-pages
-          path: gh-pages-existing
-          fetch-depth: 1
-          sparse-checkout: pr-preview
-          sparse-checkout-cone-mode: false
+        # Direct download from the dart-sass GitHub release rather than
+        # `sudo snap install dart-sass` (snap.io's storeserver was flaky on
+        # GitHub-hosted runners and broke docs builds on unrelated PRs, see
+        # #19574). Hugo Extended ships embedded Dart Sass as of v0.114+ but
+        # keeping the standalone binary on PATH is the most reliable path
+        # through `resources.toCSS` with transpiler "dartsass".
+        env:
+          DART_SASS_VERSION: 1.79.5
+        run: |
+          set -eu
+          cd "${RUNNER_TEMP}"
+          curl -fsSL -o dart-sass.tar.gz "https://github.com/sass/dart-sass/releases/download/${DART_SASS_VERSION}/dart-sass-${DART_SASS_VERSION}-linux-x64.tar.gz"
+          sudo tar -xzf dart-sass.tar.gz -C /usr/local/lib
+          sudo ln -sf /usr/local/lib/dart-sass/sass /usr/local/bin/sass
+          sudo ln -sf /usr/local/lib/dart-sass/sass /usr/local/bin/dart-sass
+          dart-sass --version
       - name: Setup Node
         uses: actions/setup-node@v6
         with:
           node-version: 22
+          cache: npm
+          cache-dependency-path: docs/package-lock.json
       - name: Install Node.js dependencies
         run: |
           cd docs
@@ -62,8 +93,8 @@ jobs:
           make docs-build-production BASE_URL="/"
           cp docs/CNAME docs/public/CNAME
           touch docs/public/.nojekyll
-          if [ -d gh-pages-existing/pr-preview ]; then
-            cp -a gh-pages-existing/pr-preview docs/public/pr-preview
+          if [ -d gh-pages-maintenance/pr-preview ]; then
+            cp -a gh-pages-maintenance/pr-preview docs/public/pr-preview
           fi
       - name: Deploy to GitHub Pages
         uses: peaceiris/actions-gh-pages@v4


### PR DESCRIPTION
## Description

Makes `.github/workflows/hugo.yml` (the production GitHub Pages deploy for docs.meshery.io) substantially more efficient and brings it in line with the patterns already used in `build-and-preview-docs.yml`.

### Changes

- **Sparse, blobless source checkout.** Only the `docs/` Hugo site (plus the root files the `make docs-build-production` target needs) is required to build the site. The source checkout now uses cone-mode `sparse-checkout: docs` with `filter: blob:none` instead of cloning the full repository.
- **Dropped `submodules: recursive`.** The repository has no submodules (`.gitmodules` is absent), so submodule fetching was pure overhead.
- **Blobless gh-pages preview-retention checkout.** The step that carries the existing `pr-preview/` umbrella forward (so a full-site deploy doesn't clobber live PR previews) now uses `filter: blob:none` and only sparse-checks-out `pr-preview`. Renamed its path to `gh-pages-maintenance` and guarded with `if: github.event.action != 'closed'`.
- **Reliable Dart Sass install.** Replaced the flaky `sudo snap install dart-sass` (snap storeserver outages broke unrelated builds, see #19574) with a direct download from the dart-sass GitHub release.
- **npm caching.** Enabled `cache: npm` on `setup-node` keyed on `docs/package-lock.json` to speed up `npm ci`.
- **`persist-credentials: false`** on both checkouts since neither needs to push via the checkout credentials.

### Why

These changes cut checkout IO (no full clone, no blobs, no submodules), remove a known flaky dependency, and speed up dependency installation — without changing what gets deployed.