### PR TITLE
docs: fix broken Codespaces documentation links

### DIFF
--- a/docs/content/en/installation/advanced/codespaces/index.md
+++ b/docs/content/en/installation/advanced/codespaces/index.md
@@ -3,7 +3,6 @@ title: Codespaces
 categories: [kubernetes]
 aliases:
 - /installation/platforms/codespaces
-- /installation/codespaces
 # display_title: false
 image: ./images/codespaces.png
 description: Build and contribute to Meshery using GitHub Codespaces

--- a/docs/content/en/installation/advanced/codespaces/index.md
+++ b/docs/content/en/installation/advanced/codespaces/index.md
@@ -3,6 +3,7 @@ title: Codespaces
 categories: [kubernetes]
 aliases:
 - /installation/platforms/codespaces
+- /installation/codespaces
 # display_title: false
 image: ./images/codespaces.png
 description: Build and contribute to Meshery using GitHub Codespaces


### PR DESCRIPTION
## Notes for Reviewers

* Fixes #20006

### Root Cause

The GitHub Codespaces guide exists at `/installation/advanced/codespaces`, but requests to `/installation/codespaces` were not covered by a Hugo alias. Internal documentation also referenced the legacy path, resulting in 404 errors.

### Changes

* Updated references in the compatibility matrix to use the canonical path `/installation/advanced/codespaces`.

### Signed Commits

* [x] Yes, I signed my commits.
