### PR TITLE
Fix link to meshery-academy in documentation

### DIFF
--- a/docs/content/en/extensions/academies/_index.md
+++ b/docs/content/en/extensions/academies/_index.md
@@ -31,4 +31,4 @@ This architecture supports multi-tenancy, white-labeling (for branded experience
 
 Meshery Academies exemplifies Meshery’s philosophy of extensibility—empowering the community to democratize cloud native knowledge through practical, visual, and interactive learning experiences. It serves as both an official learning hub for Meshery (with paths like “Mastering Meshery”) and a framework for anyone to create their own specialized academies.
 
-To find a complete list of academies available, exploore https://meshery-extensions/ repositories, like the [https://meshery-extensions/meshery-academy](https://meshery-extensions/meshery-academy). Contributions and extensions are welcome in the Meshery Extensions organization.
+To find a complete list of academies available, exploore https://meshery-extensions/ repositories, like the [https://github.com/meshery-extensions/meshery-academy](https://github.com/meshery-extensions/meshery-academy). Contributions and extensions are welcome in the Meshery Extensions organization.

--- a/docs/content/en/extensions/academies/_index.md
+++ b/docs/content/en/extensions/academies/_index.md
@@ -31,4 +31,4 @@ This architecture supports multi-tenancy, white-labeling (for branded experience
 
 Meshery Academies exemplifies Meshery’s philosophy of extensibility—empowering the community to democratize cloud native knowledge through practical, visual, and interactive learning experiences. It serves as both an official learning hub for Meshery (with paths like “Mastering Meshery”) and a framework for anyone to create their own specialized academies.
 
-To find a complete list of academies available, exploore https://meshery-extensions/ repositories, like the [https://github.com/meshery-extensions/meshery-academy](https://github.com/meshery-extensions/meshery-academy). Contributions and extensions are welcome in the Meshery Extensions organization.
+To find a complete list of academies available, explore the [meshery-extensions](https://github.com/meshery-extensions) repositories, like [meshery-academy](https://github.com/meshery-extensions/meshery-academy). Contributions and extensions are welcome in the Meshery Extensions organization.


### PR DESCRIPTION
Correct the link to the meshery-academy repository.

**Notes for Reviewers**

- This PR fixes #

**[Signed commits](https://github.com/meshery/meshery/blob/master/CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [x] Yes, I signed my commits.

<!--
Thank you for contributing to Meshery! 

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. Sign your commits.
4. Include before and after screenshots/terminal output.

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.
-->
