### PR TITLE
[UI] Clear stale permission keys and workspace on organization switch

### DIFF
--- a/ui/components/general/error-404/OrgSwitcher.tsx
+++ b/ui/components/general/error-404/OrgSwitcher.tsx
@@ -64,6 +64,10 @@ const OrgSwitcher = () => {
     try {
       await updateSelectedOrg(id).unwrap();
       dispatchSetOrganization({ organization: selected });
+      if (typeof window !== 'undefined' && window.sessionStorage) {
+        sessionStorage.removeItem('keys');
+        sessionStorage.removeItem('currentWorkspace');
+      }
       window.location.reload();
     } catch (err) {
       notify({

--- a/ui/components/workspaces/SpacesSwitcher/SpaceSwitcher.tsx
+++ b/ui/components/workspaces/SpacesSwitcher/SpaceSwitcher.tsx
@@ -171,8 +171,14 @@ export function OrgMenu(props) {
 
   const handleOrgSelect = async (e) => {
     const id = e.target.value;
+    const selected = uniqueOrgs.find((org) => org.id === id);
     try {
       await updateSelectedOrg(id).unwrap();
+      if (selected && typeof window !== 'undefined' && window.sessionStorage) {
+        sessionStorage.setItem('currentOrg', JSON.stringify(selected));
+        sessionStorage.removeItem('keys');
+        sessionStorage.removeItem('currentWorkspace');
+      }
       window.location.reload();
     } catch (err) {
       notify({


### PR DESCRIPTION
### Description

This PR fixes an issue where permission data and workspace information from a previously selected organization could persist after switching organizations.

When switching organizations, the application stored `keys` and `currentWorkspace` in `sessionStorage`. After a page reload, the app could reuse this stale data instead of fetching the permissions and workspace context for the newly selected organization. In some cases, users would continue operating with capabilities from the previous organization until the cache was refreshed.

Additionally, the workspace switcher was not updating `currentOrg` in `sessionStorage`, which could cause the application to reload into the wrong organization context.

### Changes

* Clear `keys` and `currentWorkspace` from `sessionStorage` when switching organizations through `OrgSwitcher`.
* Update `SpaceSwitcher` to persist the selected organization as `currentOrg` before reloading.
* Clear stale permission and workspace data before reload so the application starts with a clean state.
* Ensure the application fetches fresh permissions and initializes the correct workspace context after an organization change.

### Verification

* Verified that all existing tests pass.
* Manually tested organization switching through both the organization switcher and workspace switcher.
* Confirmed that `sessionStorage` is updated correctly.
* Confirmed that stale permissions are removed and fresh capabilities are fetched after reload.


https://github.com/user-attachments/assets/fc8ac5fe-2b3b-43e3-8c17-45fce2b13d2f





**[Signed commits](https://github.com/meshery/meshery/blob/master/CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [x] Yes, I signed my commits.

<!--
Thank you for contributing to Meshery! 

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. Sign your commits.
4. Include before and after screenshots/terminal output.

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.
-->
