### PR TITLE
[Models] Add Prometheus and Grafana Connection and Credential Models

### DIFF
--- a/server/meshmodel/grafana/v1.0.0/v1.0.0/components/GrafanaConnection.json
+++ b/server/meshmodel/grafana/v1.0.0/v1.0.0/components/GrafanaConnection.json
@@ -1,19 +1,24 @@
 {
-  "id": "3b9d8c4a-6f2d-4b8a-9c1e-7f3a5b2c4d6e",
-  "schemaVersion": "components.meshery.io/v1beta1",
-  "version": "v1.0.0",
-  "displayName": "Grafana Connection",
-  "format": "JSON",
-  "model": {
-    "name": "grafana",
-    "version": "v1.0.0",
-    "displayName": "Grafana",
-    "category": {
-      "name": "Observability and Analysis"
-    }
-  },
-  "component": {
-    "kind": "GrafanaConnection",
-    "version": "core.meshery.io/v1alpha1"
-  }
+    "id":  "3b9d8c4a-6f2d-4b8a-9c1e-7f3a5b2c4d6e",
+    "schemaVersion":  "components.meshery.io/v1beta1",
+    "version":  "v1.0.0",
+    "displayName":  "Grafana Connection",
+    "format":  "JSON",
+    "model":  {
+                  "name":  "grafana",
+                  "version":  "v1.0.0",
+                  "displayName":  "Grafana",
+                  "category":  {
+                                   "name":  "Observability and Analysis"
+                               }
+              },
+    "component":  {
+                      "kind":  "GrafanaConnection",
+                      "version":  "core.meshery.io/v1alpha1",
+                      "schema":  ""
+                  },
+    "configuration":  null,
+    "metadata":  {
+                     "published":  false
+                 }
 }

--- a/server/meshmodel/grafana/v1.0.0/v1.0.0/components/GrafanaConnection.json
+++ b/server/meshmodel/grafana/v1.0.0/v1.0.0/components/GrafanaConnection.json
@@ -1,5 +1,5 @@
 {
-  "id": "00000000-0000-0000-0000-000000000000",
+  "id": "3b9d8c4a-6f2d-4b8a-9c1e-7f3a5b2c4d6e",
   "schemaVersion": "components.meshery.io/v1beta1",
   "version": "v1.0.0",
   "displayName": "Grafana Connection",

--- a/server/meshmodel/grafana/v1.0.0/v1.0.0/components/GrafanaConnection.json
+++ b/server/meshmodel/grafana/v1.0.0/v1.0.0/components/GrafanaConnection.json
@@ -1,0 +1,19 @@
+{
+  "id": "00000000-0000-0000-0000-000000000000",
+  "schemaVersion": "components.meshery.io/v1beta1",
+  "version": "v1.0.0",
+  "displayName": "Grafana Connection",
+  "format": "JSON",
+  "model": {
+    "name": "grafana",
+    "version": "v1.0.0",
+    "displayName": "Grafana",
+    "category": {
+      "name": "Observability and Analysis"
+    }
+  },
+  "component": {
+    "kind": "GrafanaConnection",
+    "version": "core.meshery.io/v1alpha1"
+  }
+}

--- a/server/meshmodel/grafana/v1.0.0/v1.0.0/components/GrafanaCredential.json
+++ b/server/meshmodel/grafana/v1.0.0/v1.0.0/components/GrafanaCredential.json
@@ -1,5 +1,5 @@
 {
-  "id": "00000000-0000-0000-0000-000000000000",
+  "id": "8f7e6d5c-4b3a-2a1b-0c9d-8e7f6a5b4c3d",
   "schemaVersion": "components.meshery.io/v1beta1",
   "version": "v1.0.0",
   "displayName": "Grafana Credential",

--- a/server/meshmodel/grafana/v1.0.0/v1.0.0/components/GrafanaCredential.json
+++ b/server/meshmodel/grafana/v1.0.0/v1.0.0/components/GrafanaCredential.json
@@ -1,0 +1,19 @@
+{
+  "id": "00000000-0000-0000-0000-000000000000",
+  "schemaVersion": "components.meshery.io/v1beta1",
+  "version": "v1.0.0",
+  "displayName": "Grafana Credential",
+  "format": "JSON",
+  "model": {
+    "name": "grafana",
+    "version": "v1.0.0",
+    "displayName": "Grafana",
+    "category": {
+      "name": "Observability and Analysis"
+    }
+  },
+  "component": {
+    "kind": "GrafanaCredential",
+    "version": "core.meshery.io/v1alpha1"
+  }
+}

--- a/server/meshmodel/grafana/v1.0.0/v1.0.0/components/GrafanaCredential.json
+++ b/server/meshmodel/grafana/v1.0.0/v1.0.0/components/GrafanaCredential.json
@@ -1,19 +1,24 @@
 {
-  "id": "8f7e6d5c-4b3a-2a1b-0c9d-8e7f6a5b4c3d",
-  "schemaVersion": "components.meshery.io/v1beta1",
-  "version": "v1.0.0",
-  "displayName": "Grafana Credential",
-  "format": "JSON",
-  "model": {
-    "name": "grafana",
-    "version": "v1.0.0",
-    "displayName": "Grafana",
-    "category": {
-      "name": "Observability and Analysis"
-    }
-  },
-  "component": {
-    "kind": "GrafanaCredential",
-    "version": "core.meshery.io/v1alpha1"
-  }
+    "id":  "8f7e6d5c-4b3a-2a1b-0c9d-8e7f6a5b4c3d",
+    "schemaVersion":  "components.meshery.io/v1beta1",
+    "version":  "v1.0.0",
+    "displayName":  "Grafana Credential",
+    "format":  "JSON",
+    "model":  {
+                  "name":  "grafana",
+                  "version":  "v1.0.0",
+                  "displayName":  "Grafana",
+                  "category":  {
+                                   "name":  "Observability and Analysis"
+                               }
+              },
+    "component":  {
+                      "kind":  "GrafanaCredential",
+                      "version":  "core.meshery.io/v1alpha1",
+                      "schema":  ""
+                  },
+    "configuration":  null,
+    "metadata":  {
+                     "published":  false
+                 }
 }

--- a/server/meshmodel/grafana/v1.0.0/v1.0.0/model.json
+++ b/server/meshmodel/grafana/v1.0.0/v1.0.0/model.json
@@ -1,5 +1,5 @@
 {
-  "id": "00000000-0000-0000-0000-000000000000",
+  "id": "1a2b3c4d-5e6f-7a8b-9c0d-1e2f3a4b5c6d",
   "schemaVersion": "models.meshery.io/v1beta1",
   "version": "v1.0.0",
   "name": "grafana",

--- a/server/meshmodel/grafana/v1.0.0/v1.0.0/model.json
+++ b/server/meshmodel/grafana/v1.0.0/v1.0.0/model.json
@@ -1,0 +1,14 @@
+{
+  "id": "00000000-0000-0000-0000-000000000000",
+  "schemaVersion": "models.meshery.io/v1beta1",
+  "version": "v1.0.0",
+  "name": "grafana",
+  "displayName": "Grafana",
+  "status": "enabled",
+  "category": {
+    "name": "Observability and Analysis"
+  },
+  "model": {
+    "version": "v1.0.0"
+  }
+}

--- a/server/meshmodel/prometheus/v1.0.0/v1.0.0/components/PrometheusConnection.json
+++ b/server/meshmodel/prometheus/v1.0.0/v1.0.0/components/PrometheusConnection.json
@@ -1,19 +1,24 @@
 {
-  "id": "9b8a7f6e-5d4c-3b2a-1b0c-9d8e7f6a5b4c",
-  "schemaVersion": "components.meshery.io/v1beta1",
-  "version": "v1.0.0",
-  "displayName": "Prometheus Connection",
-  "format": "JSON",
-  "model": {
-    "name": "prometheus",
-    "version": "v1.0.0",
-    "displayName": "Prometheus",
-    "category": {
-      "name": "Observability and Analysis"
-    }
-  },
-  "component": {
-    "kind": "PrometheusConnection",
-    "version": "core.meshery.io/v1alpha1"
-  }
+    "id":  "9b8a7f6e-5d4c-3b2a-1b0c-9d8e7f6a5b4c",
+    "schemaVersion":  "components.meshery.io/v1beta1",
+    "version":  "v1.0.0",
+    "displayName":  "Prometheus Connection",
+    "format":  "JSON",
+    "model":  {
+                  "name":  "prometheus",
+                  "version":  "v1.0.0",
+                  "displayName":  "Prometheus",
+                  "category":  {
+                                   "name":  "Observability and Analysis"
+                               }
+              },
+    "component":  {
+                      "kind":  "PrometheusConnection",
+                      "version":  "core.meshery.io/v1alpha1",
+                      "schema":  ""
+                  },
+    "configuration":  null,
+    "metadata":  {
+                     "published":  false
+                 }
 }

--- a/server/meshmodel/prometheus/v1.0.0/v1.0.0/components/PrometheusConnection.json
+++ b/server/meshmodel/prometheus/v1.0.0/v1.0.0/components/PrometheusConnection.json
@@ -1,0 +1,19 @@
+{
+  "id": "00000000-0000-0000-0000-000000000000",
+  "schemaVersion": "components.meshery.io/v1beta1",
+  "version": "v1.0.0",
+  "displayName": "Prometheus Connection",
+  "format": "JSON",
+  "model": {
+    "name": "prometheus",
+    "version": "v1.0.0",
+    "displayName": "Prometheus",
+    "category": {
+      "name": "Observability and Analysis"
+    }
+  },
+  "component": {
+    "kind": "PrometheusConnection",
+    "version": "core.meshery.io/v1alpha1"
+  }
+}

--- a/server/meshmodel/prometheus/v1.0.0/v1.0.0/components/PrometheusConnection.json
+++ b/server/meshmodel/prometheus/v1.0.0/v1.0.0/components/PrometheusConnection.json
@@ -1,5 +1,5 @@
 {
-  "id": "00000000-0000-0000-0000-000000000000",
+  "id": "9b8a7f6e-5d4c-3b2a-1b0c-9d8e7f6a5b4c",
   "schemaVersion": "components.meshery.io/v1beta1",
   "version": "v1.0.0",
   "displayName": "Prometheus Connection",

--- a/server/meshmodel/prometheus/v1.0.0/v1.0.0/components/PrometheusCredential.json
+++ b/server/meshmodel/prometheus/v1.0.0/v1.0.0/components/PrometheusCredential.json
@@ -1,0 +1,19 @@
+{
+  "id": "00000000-0000-0000-0000-000000000000",
+  "schemaVersion": "components.meshery.io/v1beta1",
+  "version": "v1.0.0",
+  "displayName": "Prometheus Credential",
+  "format": "JSON",
+  "model": {
+    "name": "prometheus",
+    "version": "v1.0.0",
+    "displayName": "Prometheus",
+    "category": {
+      "name": "Observability and Analysis"
+    }
+  },
+  "component": {
+    "kind": "PrometheusCredential",
+    "version": "core.meshery.io/v1alpha1"
+  }
+}

--- a/server/meshmodel/prometheus/v1.0.0/v1.0.0/components/PrometheusCredential.json
+++ b/server/meshmodel/prometheus/v1.0.0/v1.0.0/components/PrometheusCredential.json
@@ -1,19 +1,24 @@
 {
-  "id": "5c4b3a2d-1e0f-9a8b-7c6d-5e4f3a2b1c0d",
-  "schemaVersion": "components.meshery.io/v1beta1",
-  "version": "v1.0.0",
-  "displayName": "Prometheus Credential",
-  "format": "JSON",
-  "model": {
-    "name": "prometheus",
-    "version": "v1.0.0",
-    "displayName": "Prometheus",
-    "category": {
-      "name": "Observability and Analysis"
-    }
-  },
-  "component": {
-    "kind": "PrometheusCredential",
-    "version": "core.meshery.io/v1alpha1"
-  }
+    "id":  "5c4b3a2d-1e0f-9a8b-7c6d-5e4f3a2b1c0d",
+    "schemaVersion":  "components.meshery.io/v1beta1",
+    "version":  "v1.0.0",
+    "displayName":  "Prometheus Credential",
+    "format":  "JSON",
+    "model":  {
+                  "name":  "prometheus",
+                  "version":  "v1.0.0",
+                  "displayName":  "Prometheus",
+                  "category":  {
+                                   "name":  "Observability and Analysis"
+                               }
+              },
+    "component":  {
+                      "kind":  "PrometheusCredential",
+                      "version":  "core.meshery.io/v1alpha1",
+                      "schema":  ""
+                  },
+    "configuration":  null,
+    "metadata":  {
+                     "published":  false
+                 }
 }

--- a/server/meshmodel/prometheus/v1.0.0/v1.0.0/components/PrometheusCredential.json
+++ b/server/meshmodel/prometheus/v1.0.0/v1.0.0/components/PrometheusCredential.json
@@ -1,5 +1,5 @@
 {
-  "id": "00000000-0000-0000-0000-000000000000",
+  "id": "5c4b3a2d-1e0f-9a8b-7c6d-5e4f3a2b1c0d",
   "schemaVersion": "components.meshery.io/v1beta1",
   "version": "v1.0.0",
   "displayName": "Prometheus Credential",

--- a/server/meshmodel/prometheus/v1.0.0/v1.0.0/model.json
+++ b/server/meshmodel/prometheus/v1.0.0/v1.0.0/model.json
@@ -1,5 +1,5 @@
 {
-  "id": "00000000-0000-0000-0000-000000000000",
+  "id": "7d6c5b4a-3e2f-1a0b-9c8d-7e6f5a4b3c2d",
   "schemaVersion": "models.meshery.io/v1beta1",
   "version": "v1.0.0",
   "name": "prometheus",

--- a/server/meshmodel/prometheus/v1.0.0/v1.0.0/model.json
+++ b/server/meshmodel/prometheus/v1.0.0/v1.0.0/model.json
@@ -1,0 +1,14 @@
+{
+  "id": "00000000-0000-0000-0000-000000000000",
+  "schemaVersion": "models.meshery.io/v1beta1",
+  "version": "v1.0.0",
+  "name": "prometheus",
+  "displayName": "Prometheus",
+  "status": "enabled",
+  "category": {
+    "name": "Observability and Analysis"
+  },
+  "model": {
+    "version": "v1.0.0"
+  }
+}


### PR DESCRIPTION
**Notes for Reviewers**

- This PR fixes #20034

This PR seeds the `meshmodel` registry with the canonical component definitions for Prometheus and Grafana Connections and Credentials. By introducing these JSON schemas under `server/meshmodel/`, MeshSync dynamically discovered instances of Prometheus and Grafana will now properly map to a recognized `Connection` type in the UI.


Changes Made

1. `server/meshmodel/prometheus/v1.0.0/v1.0.0/...`
2. `server/meshmodel/grafana/v1.0.0/v1.0.0/...`

**[Signed commits](https://github.com/meshery/meshery/blob/master/CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [x] Yes, I signed my commits.

<!--
Thank you for contributing to Meshery! 

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. Sign your commits.
4. Include before and after screenshots/terminal output.

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.
-->
