### PR TITLE
[UI] fix: prevent parent nav item from showing active when child is active

### DIFF
--- a/ui/components/layout/Navigator/Navigator.tsx
+++ b/ui/components/layout/Navigator/Navigator.tsx
@@ -376,6 +376,14 @@ const NavigatorContent = () => {
     );
   };
 
+  const hasActiveChild = (children): boolean => {
+    if (!children?.length) return false;
+    return children.some(
+      ({ href: childHref, children: grandchildren }) =>
+        currentPath === childHref || hasActiveChild(grandchildren),
+    );
+  };
+
   const getMesheryVersionText = () => {
     const { build, outdated, release_channel } = versionDetail;
 
@@ -701,6 +709,15 @@ const NavigatorContent = () => {
             submenu,
             permission,
           }) => {
+            const isItemActive = currentPath === href && !hasActiveChild(children);
+            const iconFill = isItemActive ? theme.palette.icon.brand : theme.palette.common.white;
+            const iconWithFill =
+              React.isValidElement(icon) && typeof icon.type !== 'string'
+                ? React.cloneElement(icon as React.ReactElement<{ fill?: string }>, {
+                    fill: iconFill,
+                  })
+                : icon;
+
             return (
               <RootDiv key={childId}>
                 <SideBarListItem
@@ -708,7 +725,7 @@ const NavigatorContent = () => {
                   dense
                   key={childId}
                   link={!!link}
-                  isActive={currentPath === href}
+                  isActive={isItemActive}
                   isShow={!show}
                   onClick={() => toggleItemCollapse(childId)}
                   onMouseOver={() => (isDrawerCollapsed ? setHoveredId(childId) : null)}
@@ -744,7 +761,7 @@ const NavigatorContent = () => {
                             </CustomTooltip>
                           </div>
                         ) : (
-                          <MainListIcon>{icon}</MainListIcon>
+                          <MainListIcon>{iconWithFill}</MainListIcon>
                         )}
                       </CustomTooltip>
                       <SideBarText drawerCollapsed={isDrawerCollapsed}>{title}</SideBarText>

--- a/ui/components/layout/Navigator/Navigator.tsx
+++ b/ui/components/layout/Navigator/Navigator.tsx
@@ -376,7 +376,7 @@ const NavigatorContent = () => {
     );
   };
 
-  const hasActiveChild = (children): boolean => {
+  const hasActiveChild = (children: any[] | undefined): boolean => {
     if (!children?.length) return false;
     return children.some(
       ({ href: childHref, children: grandchildren }) =>


### PR DESCRIPTION
**Notes for Reviewers**

- This PR fixes #19964

**[Signed commits](https://github.com/meshery/meshery/blob/master/CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [x] Yes, I signed my commits.


Screenshot before fixing the issue:
<img width="280" height="481" alt="before" src="https://github.com/user-attachments/assets/c5785b9f-cc06-469e-ade2-606f411aaeb2" />

Screenshot after
<img width="287" height="491" alt="after" src="https://github.com/user-attachments/assets/3a413d20-e65f-43da-a481-647b6bec6299" />


Changes made into ui/components/layout/Navigator/Navigator.tsx

Added a hasActiveChild helper to check if any child route is currently active. A nav item is now only marked as active when it matches the current path and has no active children, preventing parent items like Lifecycle from staying highlighted when a child (e.g. Connections) is selected.
