### PR TITLE
refactor(server): remove obsolete WASM filter startup seeding

### DIFF
--- a/server/models/default_local_provider.go
+++ b/server/models/default_local_provider.go
@@ -1,11 +1,7 @@
 package models
 
 import (
-	"sync"
-	"archive/tar"
 	"bytes"
-	"compress/gzip"
-	"encoding/base64"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -16,6 +12,7 @@ import (
 	"path/filepath"
 	"strconv"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/meshery/schemas/models/core"
@@ -40,52 +37,6 @@ import (
 	"github.com/spf13/viper"
 	"gopkg.in/yaml.v2"
 	"gorm.io/gorm"
-)
-
-// DefaultLocalProvider - represents a local provider
-type DefaultLocalProvider struct {
-	*MapPreferencePersister
-	*UserCapabilitiesPersister
-	*EventsPersister
-	ProviderProperties
-	ProviderBaseURL                 string
-	ResultPersister                 *MesheryResultsPersister
-	SmiResultPersister              *SMIResultsPersister
-	TestProfilesPersister           *TestProfilesPersister
-	PerformanceProfilesPersister    *PerformanceProfilePersister
-	MesheryPatternPersister         *MesheryPatternPersister
-	MesheryPatternResourcePersister *PatternResourcePersister
-	MesheryApplicationPersister     *MesheryApplicationPersister
-	MesheryFilterPersister          *MesheryFilterPersister
-	MesheryK8sContextPersister      *MesheryK8sContextPersister
-	OrganizationPersister           *OrganizationPersister
-	KeyPersister                    *KeyPersister
-	ConnectionPersister             *ConnectionPersister
-	EnvironmentPersister            *EnvironmentPersister
-	WorkspacePersister              *WorkspacePersister
-	GenericPersister                *database.Handler
-	KubeClient                      *mesherykube.Client
-	Log                             logger.Handler
-
-	MeshsyncDefaultDeploymentMode connections.MeshsyncDeploymentMode
-
-	// mu guards concurrent access to Extensions: InstallExtension and
-	// RemoveExtension take the write lock to mutate it, while readers such as
-	// GetProviderCapabilities/GetProviderProperties take the read lock.
-	mu sync.RWMutex
-	// downloadMu serializes provider package downloads so concurrent installs
-	// don't race on the shared on-disk package location.
-	downloadMu sync.Mutex
-}
-
-// LocalProviderName is the canonical name of the built-in local provider.
-// LocalProviderLegacyAlias is the prior name ("None"). It is still accepted on
-// inbound cookies/headers/env so existing sessions and ~/.meshery/config.yaml
-// entries continue to work after the rename. Normalization happens in
-// NormalizeProviderName (see models/providers.go).
-const (
-	LocalProviderName        = "Local"
-	LocalProviderLegacyAlias = "None"
 )
 
 func (l *DefaultLocalProvider) InstallExtension(extType string, packageUrl string, extensionMetadata map[string]interface{}) error {
@@ -336,83 +287,71 @@ func (l *DefaultLocalProvider) PackageLocation() string {
 	return filepath.Join(homedir.HomeDir(), ".meshery", "provider", l.ProviderName, l.PackageVersion)
 }
 
-func (l *DefaultLocalProvider) SetJWTCookie(_ http.ResponseWriter, _ string) {
-}
+func (l *DefaultLocalProvider) SeedContent(log logger.Handler) {
+	nilUserID := ""
 
-func (l *DefaultLocalProvider) UnSetJWTCookie(_ http.ResponseWriter) {
-}
-
-func (l *DefaultLocalProvider) GetProviderCapabilities(w http.ResponseWriter, _ *http.Request, _ string) {
-	var buf bytes.Buffer
-	// Read Extensions/ProviderProperties under the read lock so the encode does
-	// not race with concurrent InstallExtension/RemoveExtension mutations.
-	l.mu.RLock()
-	err := json.NewEncoder(&buf).Encode(l.ProviderProperties)
-	l.mu.RUnlock()
+	// Use the relative directory for patterns.
+	catalogDir := filepath.Join("..", "..", "docs", "data", "catalog")
+	files, err := walker.WalkLocalDirectory(catalogDir)
 	if err != nil {
-		errObj := ErrEncoding(err, "provider capabilities")
-		l.Log.Error(errObj)
-		httputil.WriteMeshkitError(w, errObj, http.StatusInternalServerError)
+		log.Error(err)
 		return
 	}
-	w.Header().Set("Content-Type", "application/json")
-	if _, err := buf.WriteTo(w); err != nil {
-		l.Log.Error(ErrEncoding(err, "provider capabilities"))
+
+	for _, file := range files {
+		if file.Name != "design.yml" && file.Name != "design.yaml" {
+			continue
+		}
+
+		id, err := uuid.NewV4()
+		if err != nil {
+			log.Error(err)
+			continue
+		}
+
+		patternName, err := GetPatternName(file.Content)
+		if err != nil {
+			log.Error(err)
+			continue
+		}
+
+		pattern := &MesheryPattern{
+			PatternFile: file.Content,
+			Name:        patternName,
+			ID:          &id,
+			UserID:      &nilUserID,
+			Visibility:  Published,
+			Location: map[string]interface{}{
+				"host":   "",
+				"path":   "",
+				"type":   "local",
+				"branch": "",
+			},
+		}
+
+		if _, err := l.MesheryPatternPersister.SaveMesheryPattern(pattern); err != nil {
+			log.Error(ErrGettingSeededComponents(err, "Patterns"))
+		}
+	}
+
+	// Seed default organization before the UI requests organizations.
+	id, _ := uuid.NewV4()
+	org := &organization.Organization{
+		ID:          id,
+		Name:        "My Org",
+		Country:     "",
+		Region:      "",
+		Description: "This is default organization",
+		Owner:       uuid.Nil,
+	}
+	count, _ := l.OrganizationPersister.GetOrganizationsCount()
+	if count == 0 {
+		_, err := l.OrganizationPersister.SaveOrganization(org)
+		if err != nil {
+			log.Error(ErrGettingSeededComponents(err, "organization"))
+		}
 	}
 }
-
-// InitiateLogin - initiates login flow and redirects to home for local provider.
-// When called from AuthMiddleware (fromMiddleWare=true), it's a no-op since the
-// local provider doesn't require authentication — the middleware will allow the
-// request to proceed. When called from the /user/login route (fromMiddleWare=false),
-// it redirects to / or to the deep-link target from the ref query param.
-func (l *DefaultLocalProvider) InitiateLogin(w http.ResponseWriter, r *http.Request, fromMiddleWare bool) {
-	if fromMiddleWare {
-		return
-	}
-	redirectURL := resolvePostLoginRedirect(r.URL.Query().Get("ref"), "/")
-	http.Redirect(w, r, redirectURL, http.StatusFound)
-}
-
-func (l *DefaultLocalProvider) fetchUserDetails() *User {
-	avatarUrl := ""
-	localEmail := types.Email("meshery@meshery.local")
-	return &User{
-		UserId:    "meshery",
-		FirstName: "Meshery",
-		LastName:  "Meshery",
-		Email:     localEmail,
-		AvatarUrl: &avatarUrl,
-	}
-}
-
-// GetUserDetails - returns the user details
-func (l *DefaultLocalProvider) GetUserDetails(_ *http.Request) (*User, error) {
-	return l.fetchUserDetails(), nil
-}
-
-func (l *DefaultLocalProvider) GetUserByID(_ *http.Request, _ string) ([]byte, error) {
-	return nil, nil
-}
-
-func (l *DefaultLocalProvider) GetUsers(_, _, _, _, _, _ string) ([]byte, error) {
-	return []byte(""), ErrLocalProviderSupport
-}
-
-func (l *DefaultLocalProvider) GetEnvironments(_, page, pageSize, search, order, filter string, orgID string) ([]byte, error) {
-	return l.EnvironmentPersister.GetEnvironments(orgID, search, order, page, pageSize, filter)
-}
-
-func (l *DefaultLocalProvider) GetEnvironmentByID(_ *http.Request, environmentID string, _ string) ([]byte, error) {
-	id := uuid.FromStringOrNil(environmentID)
-	return l.EnvironmentPersister.GetEnvironmentByID(id)
-}
-
-func (l *DefaultLocalProvider) DeleteEnvironment(_ *http.Request, environmentID string) ([]byte, error) {
-	id := uuid.FromStringOrNil(environmentID)
-	return l.EnvironmentPersister.DeleteEnvironmentByID(id)
-}
-
 func (l *DefaultLocalProvider) SaveEnvironment(_ *http.Request, environmentPayload *environment.EnvironmentPayload, _ string, _ bool) ([]byte, error) {
 	orgId := core.Uuid(environmentPayload.OrgId)
 	environment := &environment.Environment{
@@ -1438,108 +1377,6 @@ func (l *DefaultLocalProvider) GetKubeClient() *mesherykube.Client {
 	return l.KubeClient
 }
 
-func (l *DefaultLocalProvider) SeedContent(log logger.Handler) {
-	seedContents := []string{"Pattern", "Filter"}
-	nilUserID := ""
-
-	// Use the relative directory for patterns
-	catalogDir := filepath.Join("..", "..", "docs", "data", "catalog")
-
-	for _, seedContent := range seedContents {
-			switch seedContent {
-			case "Pattern":
-				files, err := walker.WalkLocalDirectory(catalogDir)
-				if err != nil {
-					log.Error(err)
-					return
-				}
-
-				for _, file := range files {
-    if file.Name != "design.yml" && file.Name != "design.yaml" {
-        continue
-    }
-
-    id, err := uuid.NewV4()
-    if err != nil {
-        log.Error(err)
-        continue
-    }
-
-    patternName, err := GetPatternName(file.Content)
-    if err != nil {
-        log.Error(err)
-        continue
-    }
-
-    pattern := &MesheryPattern{
-        PatternFile: file.Content,
-        Name:        patternName,
-        ID:          &id,
-        UserID:      &nilUserID,
-        Visibility:  Published,
-        Location: map[string]interface{}{
-            "host":   "",
-            "path":   "",
-            "type":   "local",
-            "branch": "",
-        },
-    }
-
-    if _, err := l.MesheryPatternPersister.SaveMesheryPattern(pattern); err != nil {
-        log.Error(ErrGettingSeededComponents(err, seedContent+"s"))
-    }
-
-}				
-
-			case "Filter":
-				// Keep the existing behavior for filters
-				names, content, err := getSeededComponents(seedContent, log)
-				if err != nil {
-					log.Error(ErrGettingSeededComponents(err, seedContent))
-				} else {
-					for i, name := range names {
-						id, _ := uuid.NewV4()
-						var filter = &MesheryFilter{
-							FilterFile: []byte(content[i]),
-							Name:       name,
-							ID:         &id,
-							UserID:     &nilUserID,
-							Visibility: Published,
-							Location: map[string]interface{}{
-								"host":   "",
-								"path":   "",
-								"type":   "local",
-								"branch": "",
-							},
-						}
-						_, err := l.MesheryFilterPersister.SaveMesheryFilter(filter)
-						if err != nil {
-							log.Error(ErrGettingSeededComponents(err, seedContent+"s"))
-						}
-					}
-				}
-			}
-	}
-
-	// Seed default organization before the UI requests organizations.
-	id, _ := uuid.NewV4()
-	org := &organization.Organization{
-		ID:          id,
-		Name:        "My Org",
-		Country:     "",
-		Region:      "",
-		Description: "This is default organization",
-		Owner:       uuid.Nil,
-	}
-	count, _ := l.OrganizationPersister.GetOrganizationsCount()
-	if count == 0 {
-		_, err := l.OrganizationPersister.SaveOrganization(org)
-		if err != nil {
-			log.Error(ErrGettingSeededComponents(err, "organization"))
-		}
-	}
-}
-
 func (l *DefaultLocalProvider) Cleanup() error {
 	if err := l.MesheryK8sContextPersister.DB.Migrator().DropTable(&K8sContext{}); err != nil {
 		return err
@@ -1992,150 +1829,6 @@ func genericHTTPFilterFile(fileURL string, log logger.Handler) ([]MesheryFilter,
 	}
 
 	return []MesheryFilter{ff}, nil
-}
-
-// getSeededComponents reads the directory recursively looking for seed content
-// Note- This function does not throw meshkit errors because the only method that calls it,"SeedContent" wraps the errors in meshkit errors.
-// If this function is reused somewhere else, make sure to wrap its errors in appropriate meshkit errors, otherwise it can cause can a panic.
-func getSeededComponents(comp string, log logger.Handler) ([]string, []string, error) {
-	wd := utils.GetHome()
-	switch comp {
-	case "Pattern":
-		wd = filepath.Join(wd, ".meshery", "content", "patterns")
-	case "Filter":
-		wd = filepath.Join(wd, ".meshery", "content", "filters", "binaries")
-
-	}
-	_, err := os.Stat(wd)
-	if err != nil && !os.IsNotExist(err) {
-		return nil, nil, err
-	} else if os.IsNotExist(err) {
-		log.Info("creating directories for seeding... ", wd)
-		er := os.MkdirAll(wd, 0777)
-		if er != nil {
-			return nil, nil, er
-		}
-	}
-	if !viper.GetBool("SKIP_DOWNLOAD_CONTENT") {
-		err = downloadContent(comp, wd)
-		if err != nil {
-			log.Error(ErrDownloadingSeededComponents(err, comp))
-		}
-	}
-	log.Info("extracting "+comp+"s from ", wd)
-	var names []string
-	var contents []string
-	err = filepath.WalkDir(wd,
-		func(path string, d os.DirEntry, err error) error {
-			if err != nil {
-				return err
-			}
-			if !d.IsDir() {
-				file, err := os.OpenFile(path, os.O_RDONLY, 0444)
-				if err != nil {
-					return err
-				}
-				content, err := io.ReadAll(file)
-				if err != nil {
-					return err
-				}
-				names = append(names, d.Name())
-				contents = append(contents, string(content))
-			}
-			return nil
-		})
-	if err != nil {
-		return nil, nil, err
-	}
-	return names, contents, nil
-}
-
-// Below helper functions are for downloading seed content and can be re used in future as the way of extracting them changes, like endpoint changes or so. That is why, they are encapsulated into general functions
-func downloadContent(comp string, downloadpath string) error {
-	switch comp {
-	case "Pattern":
-		walk := walker.NewGithub()
-		return walk.Owner("service-mesh-patterns").Repo("service-mesh-patterns").Root("samples/").Branch("master").RegisterFileInterceptor(func(gca walker.GithubContentAPI) error {
-			path := filepath.Join(downloadpath, gca.Name)
-			file, err := os.Create(path)
-			if err != nil {
-				return err
-			}
-			content, err := base64.StdEncoding.DecodeString(gca.Content)
-			if err != nil {
-				if closeErr := file.Close(); closeErr != nil {
-					return fmt.Errorf("%w (close error: %v)", err, closeErr)
-				}
-				return err
-			}
-			if _, err := fmt.Fprintf(file, "%s", content); err != nil {
-				if closeErr := file.Close(); closeErr != nil {
-					return fmt.Errorf("%w (close error: %v)", err, closeErr)
-				}
-				return err
-			}
-			if err := file.Close(); err != nil {
-				return err
-			}
-			return nil
-		}).Walk()
-	case "Filter":
-		return getFiltersFromWasmFiltersRepo(downloadpath)
-
-	}
-	return nil
-}
-
-func getFiltersFromWasmFiltersRepo(downloadPath string) error {
-	// releaseName, err := getLatestStableReleaseTag()
-	// if err != nil {
-	// 	return err
-	// }
-	//Temporary hardcoding until https://github.com/meshery-extensions/wasm-filters/issues/38 is resolved
-	downloadURL := "https://github.com/meshery-extensions/wasm-filters/releases/download/v0.1.0/wasm-filters-v0.1.0.tar.gz"
-	res, err := http.Get(downloadURL)
-	if err != nil {
-		return err
-	}
-	gzipStream := res.Body
-	return extractTarGz(gzipStream, downloadPath)
-}
-func extractTarGz(gzipStream io.Reader, downloadPath string) error {
-	uncompressedStream, err := gzip.NewReader(gzipStream)
-	if err != nil {
-		return err
-	}
-
-	tarReader := tar.NewReader(uncompressedStream)
-
-	for {
-		header, err := tarReader.Next()
-		if err == io.EOF {
-			break
-		}
-		if err != nil {
-			return err
-		}
-		switch header.Typeflag {
-		case tar.TypeReg:
-			if strings.HasSuffix(header.Name, ".wasm") {
-				outFile, err := os.Create(filepath.Join(downloadPath, header.Name))
-				if err != nil {
-					return err
-				}
-				if _, err := io.Copy(outFile, tarReader); err != nil {
-					if closeErr := outFile.Close(); closeErr != nil {
-						return fmt.Errorf("%w (close error: %v)", err, closeErr)
-					}
-					return err
-				}
-				if err := outFile.Close(); err != nil {
-					return err
-				}
-			}
-		}
-	}
-	return nil
 }
 
 // Events


### PR DESCRIPTION
**Notes for Reviewers**

- This PR fixes #19915
### Summary
Meshery no longer supports WASM Filters, so there is no need to seed filter content during Meshery Server startup.
This PR removes the obsolete filter seeding path from DefaultLocalProvider.SeedContent() and removes the associated helper functions that were only used for downloading and extracting seeded WASM filters.
This PR supersedes #19917, which was closed during conflict-resolution work

### Changes

- Removed `Filter` from startup seed content initialization.
- Removed obsolete WASM filter seeding logic from `SeedContent()`.
- Removed unused helper functions related to filter download and extraction.
- Removed now-unused imports associated with the deleted helper functions.

### Validation
#### Before
<img width="1602" height="767" alt="Screenshot 2026-06-06 092620" src="https://github.com/user-attachments/assets/91ee7595-045b-42dd-bce4-e253f58eabb0" />

Meshery Server attempted to seed filters during startup and emitted:
`Could not download seed content for Filter
`
#### After
<img width="1602" height="750" alt="Screenshot 2026-06-06 093758" src="https://github.com/user-attachments/assets/2238e580-3ae1-41c0-9ac5-bac1234e5090" />

Meshery Server no longer attempts filter seeding during startup.


**[Signed commits](https://github.com/meshery/meshery/blob/master/CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [x] Yes, I signed my commits.

<!--
Thank you for contributing to Meshery! 

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. Sign your commits.
4. Include before and after screenshots/terminal output.

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.
-->
