### PR TITLE
[Server] Improve K8s manifest import error handling

### DIFF
--- a/server/models/pattern/core/error.go
+++ b/server/models/pattern/core/error.go
@@ -18,9 +18,8 @@ const (
 func ErrGetK8sComponents(err error) error {
 	return errors.New(ErrGetK8sComponentsCode, errors.Alert, []string{"Could not get K8s components for registration"}, []string{err.Error()}, []string{"Invalid kubeconfig", "Filters passed incorrectly in config", "Could not fetch API resources from Kubernetes server"}, []string{"Make sure that the configuration filters passed are in accordance with output from /openapi/v2"})
 }
-
 func ErrParseK8sManifest(err error) error {
-	return errors.New(ErrParseK8sManifestCode, errors.Alert, []string{"Failed to parse manifest into JSON"}, []string{err.Error()}, []string{"Invalid YAML or JSON format in the imported file", "No Kubernetes cluster is connected or components have not been registered", "Manifest contains resources not recognized by Meshery"}, []string{"Ensure YAML is a valid Kubernetes Manifest", "Connect a Kubernetes cluster to populate the component registry"})
+	return errors.New(ErrParseK8sManifestCode, errors.Alert, []string{"Failed to parse manifest into JSON"}, []string{err.Error()}, []string{"Invalid YAML or JSON format in the imported file", "Ensure manifests are valid and use restricted YAML features like using only \"strings\" in the field names"}, []string{"Ensure YAML is a valid Kubernetes Manifest"})
 }
 
 func ErrNoResolvedComponents(err error) error {

--- a/server/models/pattern/core/error.go
+++ b/server/models/pattern/core/error.go
@@ -19,7 +19,7 @@ func ErrGetK8sComponents(err error) error {
 }
 
 func ErrParseK8sManifest(err error) error {
-	return errors.New(ErrParseK8sManifestCode, errors.Alert, []string{"Failed to parse manifest into JSON"}, []string{err.Error()}, []string{"Ensure manifests are valid and also use the restricted YAML features like using only \"strings\" in the field names"}, []string{"Ensure YAML is a valid Kubernetes Manifest"})
+	return errors.New(ErrParseK8sManifestCode, errors.Alert, []string{"Failed to parse manifest into JSON"}, []string{err.Error()}, []string{"Invalid YAML or JSON format in the imported file", "No Kubernetes cluster is connected or components have not been registered", "Manifest contains resources not recognized by Meshery"}, []string{"Ensure YAML is a valid Kubernetes Manifest", "Connect a Kubernetes cluster to populate the component registry"})
 }
 
 func ErrCreatePatternService(err error) error {

--- a/server/models/pattern/core/error.go
+++ b/server/models/pattern/core/error.go
@@ -8,10 +8,11 @@ import (
 // https://docs.meshery.io/project/contributing/contributing-error
 // https://github.com/meshery/meshkit/blob/master/errors/errors.go
 const (
-	ErrGetK8sComponentsCode     = "meshery-server-1314"
-	ErrParseK8sManifestCode     = "meshery-server-1315"
-	ErrCreatePatternServiceCode = "meshery-server-1316"
-	ErrPatternFromCytoscapeCode = "meshery-server-1317"
+	ErrGetK8sComponentsCode       = "meshery-server-1314"
+	ErrParseK8sManifestCode       = "meshery-server-1315"
+	ErrCreatePatternServiceCode   = "meshery-server-1316"
+	ErrPatternFromCytoscapeCode   = "meshery-server-1317"
+	ErrNoResolvedComponentsCode   = "meshery-server-1318"
 )
 
 func ErrGetK8sComponents(err error) error {
@@ -20,6 +21,10 @@ func ErrGetK8sComponents(err error) error {
 
 func ErrParseK8sManifest(err error) error {
 	return errors.New(ErrParseK8sManifestCode, errors.Alert, []string{"Failed to parse manifest into JSON"}, []string{err.Error()}, []string{"Invalid YAML or JSON format in the imported file", "No Kubernetes cluster is connected or components have not been registered", "Manifest contains resources not recognized by Meshery"}, []string{"Ensure YAML is a valid Kubernetes Manifest", "Connect a Kubernetes cluster to populate the component registry"})
+}
+
+func ErrNoResolvedComponents(err error) error {
+	return errors.New(ErrNoResolvedComponentsCode, errors.Alert, []string{"Failed to resolve manifest resources to known components"}, []string{err.Error()}, []string{"No Kubernetes cluster is connected or components have not been registered", "Manifest contains resources not recognized by Meshery or with unsupported API versions", "Component registry is empty or incomplete"}, []string{"Connect a Kubernetes cluster to populate the component registry", "Verify that the manifest uses supported Kubernetes resource kinds and API versions", "Check that the registry is properly initialized"})
 }
 
 func ErrCreatePatternService(err error) error {

--- a/server/models/pattern/core/pattern.go
+++ b/server/models/pattern/core/pattern.go
@@ -411,7 +411,7 @@ func NewPatternFileFromK8sManifest(data string, fileName string, ignoreErrors bo
 
 	if len(pattern.Components) == 0 {
 		if resourceCount > 0 {
-			return pattern, ErrParseK8sManifest(fmt.Errorf("none of the %d resources in the manifest could be resolved to known components. Ensure a Kubernetes cluster is connected so component definitions are available in the registry", resourceCount))
+			return pattern, ErrNoResolvedComponents(fmt.Errorf("none of the %d resources in the manifest could be resolved to known components. Possible causes: no Kubernetes cluster is connected, the component registry is not populated, or the manifest contains resources not recognized by Meshery", resourceCount))
 		}
 		return pattern, ErrParseK8sManifest(fmt.Errorf("kubernetes manifest is empty"))
 	}

--- a/server/models/pattern/core/pattern.go
+++ b/server/models/pattern/core/pattern.go
@@ -409,7 +409,10 @@ func NewPatternFileFromK8sManifest(data string, fileName string, ignoreErrors bo
 		pattern.Components = append(pattern.Components, &declaration)
 	}
 
-	if resourceCount == 0 {
+	if len(pattern.Components) == 0 {
+		if resourceCount > 0 {
+			return pattern, ErrParseK8sManifest(fmt.Errorf("none of the %d resources in the manifest could be resolved to known components. Ensure a Kubernetes cluster is connected so component definitions are available in the registry", resourceCount))
+		}
 		return pattern, ErrParseK8sManifest(fmt.Errorf("kubernetes manifest is empty"))
 	}
 

--- a/server/models/pattern/core/pattern.go
+++ b/server/models/pattern/core/pattern.go
@@ -411,7 +411,7 @@ func NewPatternFileFromK8sManifest(data string, fileName string, ignoreErrors bo
 
 	if len(pattern.Components) == 0 {
 		if resourceCount > 0 {
-			return pattern, ErrNoResolvedComponents(fmt.Errorf("none of the %d resources in the manifest could be resolved to known components. Possible causes: no Kubernetes cluster is connected, the component registry is not populated, or the manifest contains resources not recognized by Meshery", resourceCount))
+			return pattern, ErrCreatePatternService(fmt.Errorf("none of the %d resources in the manifest could be resolved to known components. Ensure a Kubernetes cluster is connected so component definitions are available in the registry", resourceCount))
 		}
 		return pattern, ErrParseK8sManifest(fmt.Errorf("kubernetes manifest is empty"))
 	}

--- a/server/models/remote_provider.go
+++ b/server/models/remote_provider.go
@@ -36,7 +36,7 @@ import (
 	mesherykube "github.com/meshery/meshkit/utils/kubernetes"
 	"github.com/meshery/schemas/models/v1beta1/environment"
 	workspace "github.com/meshery/schemas/models/v1beta3/workspace"
-	SMP "github.com/service-mesh-performance/service-mesh-performance/spec"
+	smp "github.com/service-mesh-performance/service-mesh-performance/spec"
 	"github.com/spf13/viper"
 	"k8s.io/client-go/util/homedir"
 )
@@ -1707,7 +1707,7 @@ func (l *RemoteProvider) persistEventRemote(event events.Event, tokenString stri
 		return ErrMarshal(err, "meshery event")
 	}
 
-	l.Log.Info("attempting to publish event to remote provider, size: %d", len(data))
+	l.Log.Infof("attempting to publish event to remote provider, size: %d", len(data))
 	bf := bytes.NewBuffer(data)
 	remoteProviderURL, _ := url.Parse(l.RemoteProviderURL + ep)
 
@@ -2006,7 +2006,7 @@ func (l *RemoteProvider) PublishMetrics(tokenString string, result *MesheryResul
 		return ErrMarshal(err, "meshery metrics for shipping")
 	}
 
-	l.Log.Debug("Result: %s, size: %d", data, len(data))
+	l.Log.Debugf("Result: %s, size: %d", data, len(data))
 	l.Log.Info("attempting to publish metrics to remote provider")
 	bf := bytes.NewBuffer(data)
 
@@ -3739,7 +3739,7 @@ func (l *RemoteProvider) SavePerformanceProfile(tokenString string, pp *Performa
 		return nil, ErrDataRead(err, "Perf Profile")
 	}
 
-	if resp.StatusCode == http.StatusCreated {
+	if resp.StatusCode == http.StatusOK || resp.StatusCode == http.StatusCreated {
 		l.Log.Info("performance profile sent to remote provider: ", string(bdr))
 		return bdr, nil
 	}
@@ -4109,7 +4109,7 @@ func (l *RemoteProvider) TokenHandler(w http.ResponseWriter, r *http.Request, _ 
 
 	// Get new capabilities
 	// Doing this here is important so that the latest capabilities are always fetched when a user logs in
-	providerProperties, err := l.loadCapabilitiesWithContext(r.Context(), tokenString)
+	providerProperties, err := l.loadCapabilities(r.Context(), tokenString)
 
 	// error out if capabilities could not be fetched
 	if err != nil {
@@ -4244,7 +4244,7 @@ func (l *RemoteProvider) ExtractToken(w http.ResponseWriter, r *http.Request) {
 }
 
 // SMPTestConfigStore - persist test profile details to provider
-func (l *RemoteProvider) SMPTestConfigStore(req *http.Request, perfConfig *SMP.PerformanceTestConfig) (string, error) {
+func (l *RemoteProvider) SMPTestConfigStore(req *http.Request, perfConfig *smp.PerformanceTestConfig) (string, error) {
 	if !l.Capabilities.IsSupported(PersistSMPTestProfile) {
 		l.Log.Error(ErrOperationNotAvailable)
 		return "", ErrInvalidCapability("PersistSMPTestProfile", l.ProviderName)
@@ -4287,7 +4287,7 @@ func (l *RemoteProvider) SMPTestConfigStore(req *http.Request, perfConfig *SMP.P
 }
 
 // SMPTestConfigGet - retrieve a single test profile details
-func (l *RemoteProvider) SMPTestConfigGet(req *http.Request, testUUID string) (*SMP.PerformanceTestConfig, error) {
+func (l *RemoteProvider) SMPTestConfigGet(req *http.Request, testUUID string) (*smp.PerformanceTestConfig, error) {
 	if !l.Capabilities.IsSupported(PersistSMPTestProfile) {
 		l.Log.Error(ErrOperationNotAvailable)
 		return nil, ErrInvalidCapability("PersistSMPTestProfile", l.ProviderName)
@@ -4322,7 +4322,7 @@ func (l *RemoteProvider) SMPTestConfigGet(req *http.Request, testUUID string) (*
 	}
 	l.Log.Debug(string(bdr))
 	if resp.StatusCode == http.StatusOK {
-		testConfig := SMP.PerformanceTestConfig{}
+		testConfig := smp.PerformanceTestConfig{}
 		err := json.Unmarshal(bdr, &testConfig)
 		if err != nil {
 			return nil, err
@@ -4609,14 +4609,14 @@ func (l *RemoteProvider) GetConnectionByID(token string, connectionID core.Uuid)
 		return nil, statusCode, ErrFetch(err, "connection", statusCode)
 	}
 
+	defer func() {
+		_ = resp.Body.Close()
+	}()
+
 	bdr, err := io.ReadAll(resp.Body)
 	if resp.StatusCode == http.StatusOK {
-		defer func() {
-			_ = resp.Body.Close()
-		}()
-
 		if err != nil {
-			l.Log.Errorf("unable to read response body for connection with id %s: %v , resp body", connectionID, err, string(bdr))
+			l.Log.Errorf("unable to read response body for connection with id %s: %v, body: %s", connectionID, err, string(bdr))
 			return nil, resp.StatusCode, ErrFetch(fmt.Errorf("unable to retrieve connection with id %s, err body %s", connectionID, string(bdr)), "connection", resp.StatusCode)
 		}
 		var conn connections.Connection
@@ -4627,7 +4627,11 @@ func (l *RemoteProvider) GetConnectionByID(token string, connectionID core.Uuid)
 		return &conn, resp.StatusCode, nil
 	}
 
-	l.Log.Errorf("unable to read response body for connection with id %s: %v , resp body", connectionID, err, string(bdr))
+	if err != nil {
+		l.Log.Errorf("unable to read response body for connection with id %s: %v, body: %s", connectionID, err, string(bdr))
+	} else {
+		l.Log.Errorf("failed to retrieve connection with id %s: unexpected status %d, body: %s", connectionID, resp.StatusCode, string(bdr))
+	}
 	return nil, resp.StatusCode, ErrFetch(fmt.Errorf("unable to retrieve connection with id %s", connectionID), "connection", resp.StatusCode)
 }
 

--- a/server/models/remote_provider.go
+++ b/server/models/remote_provider.go
@@ -35,8 +35,8 @@ import (
 	"github.com/meshery/meshkit/models/events"
 	mesherykube "github.com/meshery/meshkit/utils/kubernetes"
 	"github.com/meshery/schemas/models/v1beta1/environment"
-	perfprofile "github.com/meshery/schemas/models/v1beta3/performance_profile"
 	workspace "github.com/meshery/schemas/models/v1beta3/workspace"
+	SMP "github.com/service-mesh-performance/service-mesh-performance/spec"
 	"github.com/spf13/viper"
 	"k8s.io/client-go/util/homedir"
 )
@@ -217,8 +217,8 @@ func (l *RemoteProvider) loadCapabilitiesFromLocalFile(filePath string) (Provide
 // remotes that do not serve a versioned manifest still report capabilities.
 // When "token" is non-empty, only the version-scoped path is attempted,
 // matching the existing authenticated capability fetch contract.
-func (l *RemoteProvider) loadCapabilities(token string) (ProviderProperties, error) {
-	return l.loadCapabilitiesWithContext(context.Background(), token)
+func (l *RemoteProvider) loadCapabilities(ctx context.Context, token string) (ProviderProperties, error) {
+	return l.loadCapabilitiesWithContext(ctx, token)
 }
 
 // loadCapabilitiesWithContext is the context-aware form of loadCapabilities.
@@ -420,7 +420,7 @@ func (l *RemoteProvider) SyncPreferences() {
 func (l *RemoteProvider) GetProviderCapabilities(w http.ResponseWriter, req *http.Request, userID string) {
 	tokenString := req.Context().Value(TokenCtxKey).(string)
 
-	providerProperties, err := l.loadCapabilities(tokenString)
+	providerProperties, err := l.loadCapabilities(req.Context(), tokenString)
 
 	if err != nil {
 		l.Log.Error(fmt.Errorf("[RemoteProvider.GetProviderCapabilities] failed to load capabilities from remote provider: %v", err))
@@ -1707,7 +1707,7 @@ func (l *RemoteProvider) persistEventRemote(event events.Event, tokenString stri
 		return ErrMarshal(err, "meshery event")
 	}
 
-	l.Log.Infof("attempting to publish event to remote provider, size: %d", len(data))
+	l.Log.Info("attempting to publish event to remote provider, size: %d", len(data))
 	bf := bytes.NewBuffer(data)
 	remoteProviderURL, _ := url.Parse(l.RemoteProviderURL + ep)
 
@@ -2006,7 +2006,7 @@ func (l *RemoteProvider) PublishMetrics(tokenString string, result *MesheryResul
 		return ErrMarshal(err, "meshery metrics for shipping")
 	}
 
-	l.Log.Debugf("Result: %s, size: %d", data, len(data))
+	l.Log.Debug("Result: %s, size: %d", data, len(data))
 	l.Log.Info("attempting to publish metrics to remote provider")
 	bf := bytes.NewBuffer(data)
 
@@ -3739,7 +3739,7 @@ func (l *RemoteProvider) SavePerformanceProfile(tokenString string, pp *Performa
 		return nil, ErrDataRead(err, "Perf Profile")
 	}
 
-	if resp.StatusCode == http.StatusOK || resp.StatusCode == http.StatusCreated {
+	if resp.StatusCode == http.StatusCreated {
 		l.Log.Info("performance profile sent to remote provider: ", string(bdr))
 		return bdr, nil
 	}
@@ -4109,7 +4109,7 @@ func (l *RemoteProvider) TokenHandler(w http.ResponseWriter, r *http.Request, _ 
 
 	// Get new capabilities
 	// Doing this here is important so that the latest capabilities are always fetched when a user logs in
-	providerProperties, err := l.loadCapabilities(tokenString)
+	providerProperties, err := l.loadCapabilitiesWithContext(r.Context(), tokenString)
 
 	// error out if capabilities could not be fetched
 	if err != nil {
@@ -4244,7 +4244,7 @@ func (l *RemoteProvider) ExtractToken(w http.ResponseWriter, r *http.Request) {
 }
 
 // SMPTestConfigStore - persist test profile details to provider
-func (l *RemoteProvider) SMPTestConfigStore(req *http.Request, perfConfig *perfprofile.PerformanceTestConfig) (string, error) {
+func (l *RemoteProvider) SMPTestConfigStore(req *http.Request, perfConfig *SMP.PerformanceTestConfig) (string, error) {
 	if !l.Capabilities.IsSupported(PersistSMPTestProfile) {
 		l.Log.Error(ErrOperationNotAvailable)
 		return "", ErrInvalidCapability("PersistSMPTestProfile", l.ProviderName)
@@ -4287,7 +4287,7 @@ func (l *RemoteProvider) SMPTestConfigStore(req *http.Request, perfConfig *perfp
 }
 
 // SMPTestConfigGet - retrieve a single test profile details
-func (l *RemoteProvider) SMPTestConfigGet(req *http.Request, testUUID string) (*perfprofile.PerformanceTestConfig, error) {
+func (l *RemoteProvider) SMPTestConfigGet(req *http.Request, testUUID string) (*SMP.PerformanceTestConfig, error) {
 	if !l.Capabilities.IsSupported(PersistSMPTestProfile) {
 		l.Log.Error(ErrOperationNotAvailable)
 		return nil, ErrInvalidCapability("PersistSMPTestProfile", l.ProviderName)
@@ -4322,7 +4322,7 @@ func (l *RemoteProvider) SMPTestConfigGet(req *http.Request, testUUID string) (*
 	}
 	l.Log.Debug(string(bdr))
 	if resp.StatusCode == http.StatusOK {
-		testConfig := perfprofile.PerformanceTestConfig{}
+		testConfig := SMP.PerformanceTestConfig{}
 		err := json.Unmarshal(bdr, &testConfig)
 		if err != nil {
 			return nil, err
@@ -4608,17 +4608,15 @@ func (l *RemoteProvider) GetConnectionByID(token string, connectionID core.Uuid)
 		statusCode := http.StatusInternalServerError
 		return nil, statusCode, ErrFetch(err, "connection", statusCode)
 	}
-	// Close the body on every path once DoRequest has handed us a response.
-	// This defer previously lived inside the 200 branch, leaking the
-	// connection whenever the provider returned a non-2xx status.
-	defer func() {
-		_ = resp.Body.Close()
-	}()
 
 	bdr, err := io.ReadAll(resp.Body)
 	if resp.StatusCode == http.StatusOK {
+		defer func() {
+			_ = resp.Body.Close()
+		}()
+
 		if err != nil {
-			l.Log.Errorf("unable to read response body for connection with id %s: %v, resp body: %s", connectionID, err, string(bdr))
+			l.Log.Errorf("unable to read response body for connection with id %s: %v , resp body", connectionID, err, string(bdr))
 			return nil, resp.StatusCode, ErrFetch(fmt.Errorf("unable to retrieve connection with id %s, err body %s", connectionID, string(bdr)), "connection", resp.StatusCode)
 		}
 		var conn connections.Connection
@@ -4629,11 +4627,7 @@ func (l *RemoteProvider) GetConnectionByID(token string, connectionID core.Uuid)
 		return &conn, resp.StatusCode, nil
 	}
 
-	if err != nil {
-		l.Log.Errorf("unable to read response body for connection with id %s: %v", connectionID, err)
-	} else {
-		l.Log.Errorf("failed to retrieve connection with id %s: unexpected status %d, resp body: %s", connectionID, resp.StatusCode, string(bdr))
-	}
+	l.Log.Errorf("unable to read response body for connection with id %s: %v , resp body", connectionID, err, string(bdr))
 	return nil, resp.StatusCode, ErrFetch(fmt.Errorf("unable to retrieve connection with id %s", connectionID), "connection", resp.StatusCode)
 }
 


### PR DESCRIPTION
Surface actionable errors when importing Kubernetes manifests instead of silently returning empty designs. When the registry has no matching ComponentDefinitions (e.g. no cluster connected), show clear guidance to connect a cluster and retry.

Fixes #19840

