### PR TITLE
fix(ui): correct useNotification hook call and move error notifications to useEffect in Header

### DIFF
--- a/ui/components/layout/Header/Header.tsx
+++ b/ui/components/layout/Header/Header.tsx
@@ -224,7 +224,11 @@ function K8sContextMenu({
             dispatch(updateK8SConfig({ k8sConfig: res.k8sConfig }));
           }
         } catch (e) {
-          console.error('An error occurred while loading k8sconfig', e);
+          notify({
+            message: 'An error occurred while loading k8sconfig',
+            event_type: EVENT_TYPES.ERROR,
+            details: e instanceof Error ? e.message : String(e),
+          });
         }
       };
       try {
@@ -428,7 +432,7 @@ const Header = ({
   setActiveContexts,
   searchContexts,
 }) => {
-  const { notify } = useNotification;
+  const { notify } = useNotification();
   const { openModal } = useContext(WorkspaceModalContext) || {};
   const theme = useTheme();
   const isSmallScreen = useMediaQuery(theme.breakpoints.up('md'));
@@ -439,13 +443,15 @@ const Header = ({
     error: providerCapabilitiesError,
   } = useGetProviderCapabilitiesQuery();
 
-  if (isProviderCapabilitiesError) {
-    notify({
-      message: 'Error fetching provider capabilities',
-      event_type: EVENT_TYPES.ERROR,
-      details: providerCapabilitiesError?.data,
-    });
-  }
+  React.useEffect(() => {
+    if (isProviderCapabilitiesError) {
+      notify({
+        message: 'Error fetching provider capabilities',
+        event_type: EVENT_TYPES.ERROR,
+        details: providerCapabilitiesError?.data,
+      });
+    }
+  }, [isProviderCapabilitiesError, providerCapabilitiesError, notify]);
 
   const remoteProviderUrl = providerCapabilities?.providerUrl;
   const collaboratorExtensionUri = providerCapabilities?.extensions?.collaborator?.[0]?.component;


### PR DESCRIPTION
## What this PR does / why we need it

This PR fixes three bugs in `ui/components/layout/Header/Header.tsx`:

1. **Missing `()` on `useNotification` hook call (line 431)**
   - `const { notify } = useNotification` was missing parentheses, making `notify` always `undefined`
   - Calling `notify()` when `isProviderCapabilitiesError` is true throws `TypeError: notify is not a function`
   - Fixed to: `const { notify } = useNotification()`

2. **`notify()` called directly in render body instead of inside `useEffect` (lines 442–448)**
   - Calling a state-updating function during render causes an infinite re-render loop
   - Moved into `React.useEffect` with proper dependencies
   - Same pattern already established in `HeaderMenu.tsx` via PR #19054

3. **`console.error` replaced with `notify()` in k8sConfig catch block (line 227)**
   - K8sConfig sync failures were only logged to the browser console — invisible to the user
   - Replaced with a proper `notify()` call using `EVENT_TYPES.ERROR`

## Screenshots / Terminal output

**Before:** Silent crash / infinite loop when provider capabilities or k8sConfig sync fails  
**After:** Error toast notification shown to the user

**Notes for Reviewers**

- This PR fixes #20078
- Follows the same fix pattern applied to `HeaderMenu.tsx` in PR #19054

**[Signed commits](https://github.com/meshery/meshery/blob/master/CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- - [x] Yes, I signed my commits.