### PR TITLE
[server][mesheryctl] Migrate to v1beta2/model and v1beta3/connection at wire boundary

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -12,7 +12,7 @@ replace github.com/compose-spec/compose-go/v2 => github.com/compose-spec/compose
 
 // replace github.com/meshery/schemas => ../schemas
 
-// replace github.com/meshery/meshkit => ../meshkit
+replace github.com/meshery/meshkit => ../meshkit
 
 // replace github.com/meshery/meshsync v0.8.26 => ../meshsync
 

--- a/go.mod
+++ b/go.mod
@@ -12,7 +12,7 @@ replace github.com/compose-spec/compose-go/v2 => github.com/compose-spec/compose
 
 // replace github.com/meshery/schemas => ../schemas
 
-replace github.com/meshery/meshkit => ../meshkit
+// replace github.com/meshery/meshkit => ../meshkit
 
 // replace github.com/meshery/meshsync v0.8.26 => ../meshsync
 

--- a/mesheryctl/internal/cli/root/model/common.go
+++ b/mesheryctl/internal/cli/root/model/common.go
@@ -7,7 +7,7 @@ import (
 	"github.com/meshery/meshery/mesheryctl/pkg/utils"
 	"github.com/meshery/meshery/server/models"
 	meshkiterrors "github.com/meshery/meshkit/errors"
-	"github.com/meshery/schemas/models/v1beta1/model"
+	"github.com/meshery/schemas/models/v1beta2/model"
 )
 
 var modelsApiPath = "api/meshmodels/models"

--- a/mesheryctl/internal/cli/root/model/view.go
+++ b/mesheryctl/internal/cli/root/model/view.go
@@ -10,7 +10,7 @@ import (
 	"github.com/meshery/meshery/mesheryctl/internal/cli/pkg/display"
 	mesheryctlflags "github.com/meshery/meshery/mesheryctl/internal/cli/pkg/flags"
 	"github.com/meshery/meshery/mesheryctl/pkg/utils"
-	"github.com/meshery/schemas/models/v1beta1/model"
+	"github.com/meshery/schemas/models/v1beta2/model"
 	"github.com/spf13/cobra"
 )
 

--- a/mesheryctl/internal/cli/root/registry/publish.go
+++ b/mesheryctl/internal/cli/root/registry/publish.go
@@ -19,7 +19,7 @@ import (
 	"path/filepath"
 	"strings"
 
-	"github.com/meshery/schemas/models/v1beta1/model"
+	"github.com/meshery/schemas/models/v1beta2/model"
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 

--- a/server/handlers/component_handler.go
+++ b/server/handlers/component_handler.go
@@ -34,7 +34,8 @@ import (
 	schemav1beta1 "github.com/meshery/schemas/models/v1beta1"
 	"github.com/meshery/schemas/models/v1beta3/component"
 	"github.com/meshery/schemas/models/v1beta1/connection"
-	_model "github.com/meshery/schemas/models/v1beta1/model"
+	_model "github.com/meshery/schemas/models/v1beta2/model"
+	modelv1beta1 "github.com/meshery/schemas/models/v1beta1/model"
 
 	"github.com/meshery/meshkit/models/meshmodel/entity"
 	"github.com/meshery/meshkit/models/meshmodel/registry"
@@ -1397,7 +1398,15 @@ func (h *Handler) ExportModel(rw http.ResponseWriter, r *http.Request) {
 
 	}
 	for _, rel := range relationships {
-		rel.Model = model.ToReference()
+		v2ref := model.ToReference()
+		rel.Model = modelv1beta1.ModelReference{
+			DisplayName: v2ref.DisplayName,
+			ID:          v2ref.ID,
+			Model:       modelv1beta1.Model{Version: v2ref.Model.Version},
+			Name:        v2ref.Name,
+			Registrant:  modelv1beta1.RegistrantReference{Kind: v2ref.Registrant.Kind},
+			Version:     v2ref.Version,
+		}
 		err := rel.WriteRelationshipDefinition(relationshipsDir, outputFormat)
 		if err != nil {
 			h.log.Error(err)

--- a/server/handlers/meshery_filter_handler.go
+++ b/server/handlers/meshery_filter_handler.go
@@ -18,7 +18,7 @@ import (
 	regv1beta1 "github.com/meshery/meshkit/models/meshmodel/registry/v1beta1"
 	"github.com/meshery/schemas/models/v1beta1"
 	"github.com/meshery/schemas/models/v1beta3/component"
-	"github.com/meshery/schemas/models/v1beta1/model"
+	"github.com/meshery/schemas/models/v1beta2/model"
 )
 
 func (h *Handler) GetMesheryFilterFileHandler(

--- a/server/handlers/meshery_pattern_handler.go
+++ b/server/handlers/meshery_pattern_handler.go
@@ -39,7 +39,7 @@ import (
 	regv1beta1 "github.com/meshery/meshkit/models/meshmodel/registry/v1beta1"
 	"github.com/meshery/schemas/models/core"
 	"github.com/meshery/schemas/models/v1alpha2"
-	"github.com/meshery/schemas/models/v1beta1/connection"
+	"github.com/meshery/schemas/models/v1beta3/connection"
 	"github.com/meshery/schemas/models/v1beta2/component"
 	design "github.com/meshery/schemas/models/v1beta3/design"
 	"gopkg.in/yaml.v3"

--- a/server/handlers/policy_relationship_handler.go
+++ b/server/handlers/policy_relationship_handler.go
@@ -649,8 +649,8 @@ func registryComponentDefinitionToV1beta1(entity interface{}) (*component.Compon
 		DisplayName:    src.DisplayName,
 		Description:    src.Description,
 		Format:         component.ComponentDefinitionFormat(src.Format),
-		Model:          src.Model,
-		ModelReference: src.ModelReference,
+		Model:          utils.ModelDefV1beta2ToV1beta1(src.Model),
+		ModelReference: utils.ModelRefV1beta2ToV1beta1(src.ModelReference),
 		Styles:         src.Styles,
 		Capabilities:   src.Capabilities,
 		Metadata: component.ComponentDefinition_Metadata{

--- a/server/models/meshery_meshmodels_api_response.go
+++ b/server/models/meshery_meshmodels_api_response.go
@@ -5,7 +5,7 @@ import (
 
 	models "github.com/meshery/meshkit/models/meshmodel/core/v1beta1"
 	"github.com/meshery/meshkit/models/meshmodel/entity"
-	"github.com/meshery/schemas/models/v1beta1/model"
+	"github.com/meshery/schemas/models/v1beta2/model"
 	"github.com/meshery/schemas/models/v1beta3/component"
 )
 

--- a/server/models/meshmodel/core/register.go
+++ b/server/models/meshmodel/core/register.go
@@ -26,7 +26,7 @@ import (
 	mesheryutils "github.com/meshery/meshery/server/helpers/utils"
 	"github.com/meshery/schemas/models/v1beta1/category"
 	"github.com/meshery/schemas/models/v1beta1/connection"
-	"github.com/meshery/schemas/models/v1beta1/model"
+	"github.com/meshery/schemas/models/v1beta2/model"
 	"github.com/meshery/schemas/models/v1beta3/component"
 
 	"github.com/meshery/schemas/models/v1beta3"

--- a/server/models/meshsync_events.go
+++ b/server/models/meshsync_events.go
@@ -11,7 +11,7 @@ import (
 	"github.com/meshery/meshkit/logger"
 	"github.com/meshery/meshkit/utils"
 	"github.com/meshery/schemas/models/core"
-	modelv1beta1 "github.com/meshery/schemas/models/v1beta1/model"
+	modelv1beta2 "github.com/meshery/schemas/models/v1beta2/model"
 
 	meshsyncmodel "github.com/meshery/meshsync/pkg/model"
 	"github.com/meshery/schemas/models/v1beta3/component"
@@ -349,13 +349,13 @@ func (mh *MeshsyncDataHandler) getComponentMetadata(apiVersion string, kind stri
 	}
 
 	if componentDef.ModelID != nil {
-		modelDef := modelv1beta1.ModelDefinition{}
-		result = mh.dbHandler.Session(&gorm.Session{NewDB: true}).Model(&modelv1beta1.ModelDefinition{}).
+		modelDef := modelv1beta2.ModelDefinition{}
+		result = mh.dbHandler.Session(&gorm.Session{NewDB: true}).Model(&modelv1beta2.ModelDefinition{}).
 			Where("id = ?", componentDef.ModelID).
 			First(&modelDef)
 		if result.Error == nil {
 			componentDef.Model = &modelDef
-		} else if result.Error != gorm.ErrRecordNotFound && !isMissingTableError(result.Error, modelv1beta1.ModelDefinition{}.TableName()) {
+		} else if result.Error != gorm.ErrRecordNotFound && !isMissingTableError(result.Error, modelv1beta2.ModelDefinition{}.TableName()) {
 			mh.log.Error(ErrDBRead(result.Error))
 		}
 	}

--- a/server/models/pattern/utils/component_version_bridge.go
+++ b/server/models/pattern/utils/component_version_bridge.go
@@ -24,10 +24,12 @@ package utils
 
 import (
 	componentv1beta1 "github.com/meshery/schemas/models/v1beta1/component"
+	connectionv1beta1 "github.com/meshery/schemas/models/v1beta1/connection"
 	modelv1beta1 "github.com/meshery/schemas/models/v1beta1/model"
 	componentv1beta2 "github.com/meshery/schemas/models/v1beta2/component"
 	modelv1beta2 "github.com/meshery/schemas/models/v1beta2/model"
 	componentv1beta3 "github.com/meshery/schemas/models/v1beta3/component"
+	connectionv1beta3 "github.com/meshery/schemas/models/v1beta3/connection"
 )
 
 // ComponentV1beta1ToV1beta2 returns a v1beta2/component.ComponentDefinition
@@ -272,7 +274,14 @@ func ModelDefV1beta1ToV1beta2(src *modelv1beta1.ModelDefinition) *modelv1beta2.M
 		Description:        src.Description,
 		Status:             modelv1beta2.ModelDefinitionStatus(src.Status),
 		CategoryId:         src.CategoryId,
-		Registrant:         src.Registrant,
+		Registrant: connectionv1beta3.Connection{
+			ID:      src.Registrant.ID,
+			Name:    src.Registrant.Name,
+			Kind:    src.Registrant.Kind,
+			Type:    src.Registrant.Type,
+			SubType: src.Registrant.SubType,
+			Status:  connectionv1beta3.ConnectionStatus(src.Registrant.Status),
+		},
 		RegistrantId:       src.RegistrantId,
 		Category:           src.Category,
 		SubCategory:        src.SubCategory,
@@ -313,7 +322,14 @@ func ModelDefV1beta2ToV1beta1(src *modelv1beta2.ModelDefinition) *modelv1beta1.M
 		Description:        src.Description,
 		Status:             modelv1beta1.ModelDefinitionStatus(src.Status),
 		CategoryId:         src.CategoryId,
-		Registrant:         src.Registrant,
+		Registrant: connectionv1beta1.Connection{
+			ID:      src.Registrant.ID,
+			Name:    src.Registrant.Name,
+			Kind:    src.Registrant.Kind,
+			Type:    src.Registrant.Type,
+			SubType: src.Registrant.SubType,
+			Status:  connectionv1beta1.ConnectionStatus(src.Registrant.Status),
+		},
 		RegistrantId:       src.RegistrantId,
 		Category:           src.Category,
 		SubCategory:        src.SubCategory,

--- a/server/models/pattern/utils/component_version_bridge.go
+++ b/server/models/pattern/utils/component_version_bridge.go
@@ -14,17 +14,19 @@
 //
 // The two struct types are nominally distinct in Go, so a pattern
 // iteration (v1beta2) that wants to call a meshkit helper (v1beta3) must
-// convert. The shared inner types (*v1beta1/model.ModelDefinition,
+// convert. The shared inner types (*v1beta2/model.ModelDefinition,
 // *core.ComponentStyles, capabilities slice, configuration map, Metadata
-// AdditionalProperties map) are pointer-identical across both
-// representations, so the conversion is a shallow field copy rather than
-// a deep clone. Mutations through the aliased pointer targets on the
-// returned value therefore remain visible on the source.
+// AdditionalProperties map) are pointer-identical across v1beta2 and
+// v1beta3. The v1beta1↔v1beta2 boundary requires field-copy conversion
+// because v1beta1 components still carry *v1beta1/model.ModelDefinition
+// while v1beta2 components now carry *v1beta2/model.ModelDefinition.
 package utils
 
 import (
 	componentv1beta1 "github.com/meshery/schemas/models/v1beta1/component"
+	modelv1beta1 "github.com/meshery/schemas/models/v1beta1/model"
 	componentv1beta2 "github.com/meshery/schemas/models/v1beta2/component"
+	modelv1beta2 "github.com/meshery/schemas/models/v1beta2/model"
 	componentv1beta3 "github.com/meshery/schemas/models/v1beta3/component"
 )
 
@@ -45,8 +47,8 @@ func ComponentV1beta1ToV1beta2(src *componentv1beta1.ComponentDefinition) *compo
 		DisplayName:    src.DisplayName,
 		Description:    src.Description,
 		Format:         componentv1beta2.ComponentDefinitionFormat(src.Format),
-		Model:          src.Model,
-		ModelReference: src.ModelReference,
+		Model:          ModelDefV1beta1ToV1beta2(src.Model),
+		ModelReference: ModelRefV1beta1ToV1beta2(src.ModelReference),
 		Styles:         src.Styles,
 		Capabilities:   src.Capabilities,
 		Metadata: componentv1beta2.ComponentDefinition_Metadata{
@@ -90,8 +92,8 @@ func ComponentV1beta2ToV1beta1(src *componentv1beta2.ComponentDefinition) *compo
 		DisplayName:    src.DisplayName,
 		Description:    src.Description,
 		Format:         componentv1beta1.ComponentDefinitionFormat(src.Format),
-		Model:          src.Model,
-		ModelReference: src.ModelReference,
+		Model:          ModelDefV1beta2ToV1beta1(src.Model),
+		ModelReference: ModelRefV1beta2ToV1beta1(src.ModelReference),
 		Styles:         src.Styles,
 		Capabilities:   src.Capabilities,
 		Metadata: componentv1beta1.ComponentDefinition_Metadata{
@@ -241,4 +243,124 @@ func ApplyV1beta3MetadataChanges(
 	// out of sync between the registry-hydrated v1beta3 and the pattern-
 	// level v1beta2 components.
 	dst.Metadata = componentv1beta2.ComponentDefinition_Metadata(src.Metadata)
+}
+
+// --------------------------------------------------------------------------
+// Private model-version conversion helpers
+// --------------------------------------------------------------------------
+//
+// v1beta1 and v1beta2 ModelDefinition / ModelReference carry identical fields
+// (same names, same field types for all but Status and the nested Model/
+// Registrant sub-structs, which are simple string/semver wrappers).
+// Registrant, Category, and SubCategory are the SAME imported types in both
+// versions, so they can be copied directly.
+
+// ModelDefV1beta1ToV1beta2 converts a *v1beta1.ModelDefinition to *v1beta2.ModelDefinition.
+// Registrant, Category, and SubCategory are the SAME imported types in both
+// versions, so they are copied directly. Exported for use by handlers that
+// bridge the v1beta1↔v1beta2 component boundary.
+func ModelDefV1beta1ToV1beta2(src *modelv1beta1.ModelDefinition) *modelv1beta2.ModelDefinition {
+	if src == nil {
+		return nil
+	}
+	dst := &modelv1beta2.ModelDefinition{
+		ID:                 src.ID,
+		SchemaVersion:      src.SchemaVersion,
+		Version:            src.Version,
+		Name:               src.Name,
+		DisplayName:        src.DisplayName,
+		Description:        src.Description,
+		Status:             modelv1beta2.ModelDefinitionStatus(src.Status),
+		CategoryId:         src.CategoryId,
+		Registrant:         src.Registrant,
+		RegistrantId:       src.RegistrantId,
+		Category:           src.Category,
+		SubCategory:        src.SubCategory,
+		Model:              modelv1beta2.Model{Version: src.Model.Version},
+		ComponentsCount:    src.ComponentsCount,
+		RelationshipsCount: src.RelationshipsCount,
+		CreatedAt:          src.CreatedAt,
+		UpdatedAt:          src.UpdatedAt,
+	}
+	if src.Metadata != nil {
+		dst.Metadata = &modelv1beta2.ModelDefinition_Metadata{
+			Capabilities:         src.Metadata.Capabilities,
+			IsAnnotation:         src.Metadata.IsAnnotation,
+			PrimaryColor:         src.Metadata.PrimaryColor,
+			SecondaryColor:       src.Metadata.SecondaryColor,
+			SvgWhite:             src.Metadata.SvgWhite,
+			SvgColor:             src.Metadata.SvgColor,
+			SvgComplete:          src.Metadata.SvgComplete,
+			Shape:                src.Metadata.Shape,
+			AdditionalProperties: src.Metadata.AdditionalProperties,
+		}
+	}
+	return dst
+}
+
+// ModelDefV1beta2ToV1beta1 is the inverse of ModelDefV1beta1ToV1beta2.
+// Exported for use by handlers that bridge the v1beta2↔v1beta1 component boundary.
+func ModelDefV1beta2ToV1beta1(src *modelv1beta2.ModelDefinition) *modelv1beta1.ModelDefinition {
+	if src == nil {
+		return nil
+	}
+	dst := &modelv1beta1.ModelDefinition{
+		ID:                 src.ID,
+		SchemaVersion:      src.SchemaVersion,
+		Version:            src.Version,
+		Name:               src.Name,
+		DisplayName:        src.DisplayName,
+		Description:        src.Description,
+		Status:             modelv1beta1.ModelDefinitionStatus(src.Status),
+		CategoryId:         src.CategoryId,
+		Registrant:         src.Registrant,
+		RegistrantId:       src.RegistrantId,
+		Category:           src.Category,
+		SubCategory:        src.SubCategory,
+		Model:              modelv1beta1.Model{Version: src.Model.Version},
+		ComponentsCount:    src.ComponentsCount,
+		RelationshipsCount: src.RelationshipsCount,
+		CreatedAt:          src.CreatedAt,
+		UpdatedAt:          src.UpdatedAt,
+	}
+	if src.Metadata != nil {
+		dst.Metadata = &modelv1beta1.ModelDefinition_Metadata{
+			Capabilities:         src.Metadata.Capabilities,
+			IsAnnotation:         src.Metadata.IsAnnotation,
+			PrimaryColor:         src.Metadata.PrimaryColor,
+			SecondaryColor:       src.Metadata.SecondaryColor,
+			SvgWhite:             src.Metadata.SvgWhite,
+			SvgColor:             src.Metadata.SvgColor,
+			SvgComplete:          src.Metadata.SvgComplete,
+			Shape:                src.Metadata.Shape,
+			AdditionalProperties: src.Metadata.AdditionalProperties,
+		}
+	}
+	return dst
+}
+
+// ModelRefV1beta1ToV1beta2 converts a v1beta1.ModelReference to v1beta2.ModelReference.
+// Exported for use by handlers that bridge the v1beta1↔v1beta2 boundary.
+func ModelRefV1beta1ToV1beta2(src modelv1beta1.ModelReference) modelv1beta2.ModelReference {
+	return modelv1beta2.ModelReference{
+		DisplayName: src.DisplayName,
+		ID:          src.ID,
+		Model:       modelv1beta2.Model{Version: src.Model.Version},
+		Name:        src.Name,
+		Registrant:  modelv1beta2.RegistrantReference{Kind: src.Registrant.Kind},
+		Version:     src.Version,
+	}
+}
+
+// ModelRefV1beta2ToV1beta1 is the inverse of ModelRefV1beta1ToV1beta2.
+// Exported for use by handlers that bridge the v1beta2↔v1beta1 boundary.
+func ModelRefV1beta2ToV1beta1(src modelv1beta2.ModelReference) modelv1beta1.ModelReference {
+	return modelv1beta1.ModelReference{
+		DisplayName: src.DisplayName,
+		ID:          src.ID,
+		Model:       modelv1beta1.Model{Version: src.Model.Version},
+		Name:        src.Name,
+		Registrant:  modelv1beta1.RegistrantReference{Kind: src.Registrant.Kind},
+		Version:     src.Version,
+	}
 }


### PR DESCRIPTION
## Description

Companion PR to:
- [meshery/schemas](https://github.com/meshery/schemas/pull/914)  — migrates `ModelDefinition.Registrant` to `v1beta3/connection` and `ComponentDefinition.Model` to `v1beta2/model`
- [meshery/meshkit](https://github.com/meshery/meshkit/pull/1018) — introduces `connV3ToV1` bridge and read-path fix for the new connection boundary

This PR resolves the ripple effects of those upstream schema changes in the Meshery server and CLI.

**Changes:**
- `server/handlers/component_handler.go`, `meshery_filter_handler.go`, `meshery_pattern_handler.go` — updated model/connection imports to v1beta2/v1beta3
- `server/models/meshery_meshmodels_api_response.go`, `meshsync_events.go`, `meshmodel/core/register.go` — import updates only; no DB schema changes (identical `db:` tags)
- `server/models/pattern/utils/component_version_bridge.go` — added bidirectional v1beta1↔v1beta2 bridge helpers for `ComponentDefinition`, `ModelDefinition`, and `ModelReference` including Registrant field-copy across the connection version boundary
- `server/handlers/policy_relationship_handler.go` — uses new bridge helpers at the internal v1beta1 evaluation boundary
- `mesheryctl/internal/cli/root/model/common.go`, `model/view.go`, `registry/publish.go` — updated to v1beta2 model types to match server API response

**No database migrations required** — `db:` column tags are identical across v1beta1 and v1beta3 connection types.

## Related Issue
Closes #20087 

> [!NOTE]
> **CI failures are expected and intentional.**
> This PR is part of a 3-PR chain and depends on upstream changes that are not yet published.
> The `golangci-lint` jobs fail because `go.mod` currently references published versions of
> `meshery/schemas` and `meshery/meshkit` that do not yet include the type changes this PR
> consumes. CI will go green after the following merge sequence is completed:
>
> 1. Merge **meshery/schemas#`<SCHEMAS_PR_NUMBER>`** → publish new version tag
> 2. Merge **meshery/meshkit#`<MESHKIT_PR_NUMBER>`** → publish new version tag
> 3. Update `go.mod` in this PR with the new published version tags → run `go mod tidy` → CI passes
>
> **Do not merge this PR until steps 1 and 2 are complete.**




**[Signed commits](https://github.com/meshery/meshery/blob/master/CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [x] Yes, I signed my commits.

<!--
Thank you for contributing to Meshery! 

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. Sign your commits.
4. Include before and after screenshots/terminal output.

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.
-->
