### PR TITLE
[CI] Recreate Discussion Forum data sync workflow

### DIFF
--- a/.github/workflows/discussions-data-files-update.yml
+++ b/.github/workflows/discussions-data-files-update.yml
@@ -1,0 +1,41 @@
+name: Discussion data files update
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: '0 0 * * *' #runs every day at midnight
+
+permissions:
+  contents: write
+jobs:
+  update:
+    runs-on: ubuntu-24.04
+    if: github.repository == 'meshery/meshery'
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+        with:
+          token: ${{ secrets.MESHERY_CI }}
+      - name: Fetch data for mesheryctl tag
+        run: |
+          mkdir -p docs/data/discuss
+          curl -L https://discuss.meshery.io/tag/mesheryctl.json -o docs/data/discuss/mesheryctl.json
+
+      - name: Fetch data for meshery tag
+        run: |
+          mkdir -p docs/data/discuss
+          curl -L https://discuss.meshery.io/tag/meshery.json -o docs/data/discuss/meshery.json
+
+      - name: Pull changes from remote
+        run: git pull origin master
+
+      - name: Commit changes
+        uses: stefanzweifel/git-auto-commit-action@v7
+        with:
+          file_pattern: docs/data/discuss/*.json
+          commit_user_name: Discussions bot
+          commit_user_email: discussions@meshery.io
+          commit_author: ${{ github.actor }} <${{ github.actor }}@users.noreply.github.com>
+          commit_options: "--signoff"
+          commit_message: "latest discussion data files added"
+          branch: master


### PR DESCRIPTION
**Notes for Reviewers**

Recreates the daily "Discussion data files update" workflow that was removed during incubation. This is the data-producing half for the `related-discussions` docs shortcode: it fetches Discourse topic data into `docs/data/discuss/*.json`, which the shortcode reads to render recent forum threads.

Details:

- Fetches from `https://discuss.meshery.io/tag/meshery.json` and `https://discuss.meshery.io/tag/mesheryctl.json`.
- Adds `mkdir -p docs/data/discuss` before the `curl -o`, since that directory is no longer present in the repo and the download would otherwise fail.
- Runs on a daily schedule and on manual dispatch, guarded to `meshery/meshery` only.

Pairs with #20100, which restores the shortcode that consumes this data.

Ref: https://github.com/layer5io/meshery-cloud/issues/5312

**Signed commits**
- [x] Yes, I signed my commits.
