### PR TITLE
[UI] Make permission error page responsive, remove logo, add role descriptions

### DIFF
--- a/ui/components/general/error-404/CurrentSession.tsx
+++ b/ui/components/general/error-404/CurrentSession.tsx
@@ -7,10 +7,17 @@ import {
   ErrorSectionContent,
   OrgNameDisabled,
   StyledTypographyDisabled,
+  HeaderContainer,
 } from './styles';
-import { NoSsr } from '@sistent/sistent';
+import {
+  NoSsr,
+  ErrorBoundary,
+  CustomTooltip,
+  InfoCircleIcon,
+  useTheme,
+  IconButton,
+} from '@sistent/sistent';
 import OrgIcon from 'assets/icons/OrgIcon';
-import { ErrorBoundary } from '@sistent/sistent';
 import CustomErrorFallback from '../../shared/ErrorBoundary/ErrorBoundary';
 import { useGetSelectedOrganization } from '@/rtk-query/user';
 
@@ -34,6 +41,8 @@ const CurrentSessionInfo = () => {
     // error: providerRolesError,
   } = useGetUserProviderRolesQuery();
 
+  const theme = useTheme();
+
   return (
     <ErrorSectionContent>
       <div>
@@ -46,9 +55,20 @@ const CurrentSessionInfo = () => {
         </StyledBox>
       </div>
       <div>
-        <StyledTypographyDisabled variant="h6" component="h6">
-          Organization Role(s)
-        </StyledTypographyDisabled>
+        <HeaderContainer>
+          <StyledTypographyDisabled variant="h6" component="h6">
+            Organization Role(s)
+          </StyledTypographyDisabled>
+          <CustomTooltip title="Organization Roles define your permissions within the selected organization (e.g., Organization Admin, Workspace Admin, Team Admin, User).">
+            <IconButton size="small" sx={{ padding: '4px' }} aria-label="Organization roles help">
+              <InfoCircleIcon
+                fill={theme.palette.icon?.secondary || theme.palette.text?.secondary}
+                width={16}
+                height={16}
+              />
+            </IconButton>
+          </CustomTooltip>
+        </HeaderContainer>
         <StyledBox>
           {rolesRes
             ? rolesRes?.roles?.map?.((role) => <StyledChip key={role.id} label={role.roleName} />)
@@ -56,9 +76,20 @@ const CurrentSessionInfo = () => {
         </StyledBox>
       </div>
       <div>
-        <StyledTypographyDisabled variant="h6" component="h6">
-          Provider Role(s)
-        </StyledTypographyDisabled>
+        <HeaderContainer>
+          <StyledTypographyDisabled variant="h6" component="h6">
+            Provider Role(s)
+          </StyledTypographyDisabled>
+          <CustomTooltip title="Provider Roles define your global roles and access rights across Meshery Cloud (e.g., Admin, MeshMap User, Curator).">
+            <IconButton size="small" sx={{ padding: '4px' }} aria-label="Provider roles help">
+              <InfoCircleIcon
+                fill={theme.palette.icon?.secondary || theme.palette.text?.secondary}
+                width={16}
+                height={16}
+              />
+            </IconButton>
+          </CustomTooltip>
+        </HeaderContainer>
         <StyledBox>
           {providerRolesRes
             ? providerRolesRes?.roleNames?.map?.((role, index) => (

--- a/ui/components/general/error-404/CurrentSession.tsx
+++ b/ui/components/general/error-404/CurrentSession.tsx
@@ -60,12 +60,15 @@ const CurrentSessionInfo = () => {
             Organization Role(s)
           </StyledTypographyDisabled>
           <CustomTooltip title="Organization Roles define your permissions within the selected organization (e.g., Organization Admin, Workspace Admin, Team Admin, User).">
-            <IconButton size="small" sx={{ padding: '4px' }} aria-label="Organization roles help">
-              <InfoCircleIcon
-                fill={theme.palette.icon?.secondary || theme.palette.text?.secondary}
-                width={16}
-                height={16}
-              />
+            <IconButton
+              size="small"
+              sx={{
+                padding: '4px',
+                color: theme.palette.icon?.secondary || theme.palette.text?.secondary,
+              }}
+              aria-label="Organization roles help"
+            >
+              <InfoCircleIcon width={16} height={16} />
             </IconButton>
           </CustomTooltip>
         </HeaderContainer>
@@ -81,12 +84,15 @@ const CurrentSessionInfo = () => {
             Provider Role(s)
           </StyledTypographyDisabled>
           <CustomTooltip title="Provider Roles define your global roles and access rights across Meshery Cloud (e.g., Admin, MeshMap User, Curator).">
-            <IconButton size="small" sx={{ padding: '4px' }} aria-label="Provider roles help">
-              <InfoCircleIcon
-                fill={theme.palette.icon?.secondary || theme.palette.text?.secondary}
-                width={16}
-                height={16}
-              />
+            <IconButton
+              size="small"
+              sx={{
+                padding: '4px',
+                color: theme.palette.icon?.secondary || theme.palette.text?.secondary,
+              }}
+              aria-label="Provider roles help"
+            >
+              <InfoCircleIcon width={16} height={16} />
             </IconButton>
           </CustomTooltip>
         </HeaderContainer>

--- a/ui/components/general/error-404/index.test.tsx
+++ b/ui/components/general/error-404/index.test.tsx
@@ -40,10 +40,7 @@ vi.mock('./styles', () => ({
     <div data-testid="content-container">{children}</div>
   ),
   StyledButton: ({ children, href }: any) => <a href={href}>{children}</a>,
-  ImageContainer: ({ children }: any) => <div>{children}</div>,
   IconWrapper: ({ children }: any) => <div>{children}</div>,
-  Logo: ({ src, alt }: any) => <img src={src} alt={alt} />,
-  LogoText: ({ src, alt }: any) => <img data-testid="logo-text" src={src} alt={alt} />,
   StyledDivider: () => <hr />,
   ErrorLink: ({ children, href }: any) => <a href={href}>{children}</a>,
 }));
@@ -53,7 +50,7 @@ import DefaultError from './index';
 describe('DefaultError', () => {
   it('renders the default permissions message when no errorTitle is provided', () => {
     render(<DefaultError />);
-    expect(screen.getByText(/you don't have the necessary permissions/i)).toBeInTheDocument();
+    expect(screen.getByText(/you don't have the required permissions/i)).toBeInTheDocument();
     expect(screen.getByTestId('org-switcher')).toBeInTheDocument();
     expect(screen.getByTestId('current-session')).toBeInTheDocument();
   });

--- a/ui/components/general/error-404/index.tsx
+++ b/ui/components/general/error-404/index.tsx
@@ -7,10 +7,7 @@ import {
   ErrorMain,
   ErrorSectionContent,
   StyledButton,
-  ImageContainer,
   IconWrapper,
-  Logo,
-  LogoText,
   StyledDivider,
   ErrorLink,
 } from './styles';
@@ -56,17 +53,6 @@ const DefaultError = (props) => {
           alignItems: 'center',
         }}
       >
-        <ImageContainer>
-          <Logo src="/static/img/meshery-logo/meshery-logo.svg" alt="Meshery logo" />
-          <LogoText
-            src={
-              theme.palette.mode === 'dark'
-                ? '/static/img/meshery-logo/meshery-white.svg'
-                : '/static/img/meshery-logo/meshery-black.svg'
-            }
-            alt="Meshery logo text"
-          />
-        </ImageContainer>
         <Typography
           variant="h4"
           component="h4"
@@ -76,7 +62,7 @@ const DefaultError = (props) => {
         >
           {errorTitle
             ? errorTitle
-            : "Oops! It seems like you don't have the necessary permissions to view this page."}
+            : "Oops! You don't have the required permissions to access this page."}
         </Typography>
         {errorType === ErrorTypes.UNKNOWN ? (
           <UnknownServerSideError errorContent={errorContent} />

--- a/ui/components/general/error-404/styles.tsx
+++ b/ui/components/general/error-404/styles.tsx
@@ -15,8 +15,14 @@ export const ErrorMain = styled('main')(({ theme }) => ({
   backgroundColor: theme.palette.background.default,
   padding: '4rem 8rem',
   minHeight: '100vh',
+  [theme.breakpoints.down('lg')]: {
+    padding: '4rem 4rem',
+  },
+  [theme.breakpoints.down('md')]: {
+    padding: '3rem 2rem',
+  },
   [theme.breakpoints.down('sm')]: {
-    padding: '4rem 0rem',
+    padding: '2rem 1rem',
   },
   display: 'flex',
   flexDirection: 'column',
@@ -35,22 +41,15 @@ export const ErrorContainer = styled('div')(({ theme }) => ({
   flexWrap: 'wrap',
 }));
 
-export const ImageContainer = styled('div')(({ theme }) => ({
+export const ErrorSectionContainer = styled('div')(({ theme }) => ({
   display: 'flex',
-  alignItems: 'center',
-  gap: '2rem',
-  marginBottom: '1rem',
-  [theme.breakpoints.down('sm')]: {
+  flexWrap: 'wrap',
+  [theme.breakpoints.down('md')]: {
     flexDirection: 'column',
   },
 }));
 
-export const ErrorSectionContainer = styled('div')(() => ({
-  display: 'flex',
-  flexWrap: 'wrap',
-}));
-
-export const ErrorSection = styled('div')(() => ({
+export const ErrorSection = styled('div')(({ theme }) => ({
   flex: '1',
   width: '100%',
   display: 'flex',
@@ -58,7 +57,12 @@ export const ErrorSection = styled('div')(() => ({
   paddingInline: '2rem',
   gap: '2rem',
   marginBlock: '2rem',
-  minWidth: 'max-content',
+  minWidth: '300px',
+  [theme.breakpoints.down('md')]: {
+    minWidth: 'auto',
+    marginBlock: '1rem',
+    paddingInline: '1rem',
+  },
 }));
 
 export const ErrorSectionContent = styled('div')(() => ({
@@ -123,6 +127,7 @@ export const StyledSelect = styled(Select)({
 
 export const StyledBox = styled(Box)(({ theme }) => ({
   display: 'flex',
+  flexWrap: 'wrap',
   gap: '10px',
   alignItems: 'center',
   borderRadius: '10px',
@@ -130,6 +135,12 @@ export const StyledBox = styled(Box)(({ theme }) => ({
   padding: '1.3rem',
   border: `1px solid ${theme.palette.background.brand.disabled}`,
   color: theme.palette.text.default,
+}));
+
+export const HeaderContainer = styled('div')(() => ({
+  display: 'flex',
+  alignItems: 'center',
+  gap: '0.25rem',
 }));
 
 export const FormField = styled('div')(() => ({
@@ -195,14 +206,6 @@ export const IconWrapper = styled('div')(({ theme }) => ({
   paddingTop: '1rem',
   alignSelf: 'flex-end',
   color: theme.palette.icon.secondary,
-}));
-
-export const Logo = styled('img')(() => ({
-  height: 'clamp(100px, 20vw, 150px)',
-}));
-
-export const LogoText = styled('img')(() => ({
-  height: 'clamp(30px, 5vw, 100px)',
 }));
 
 export const StyledDivider = styled(Divider)(({ theme }) => ({


### PR DESCRIPTION
## Summary

Cherry-picks #20099 with one fixup:

- **Responsive layout**: Progressive breakpoint padding (`lg` → `md` → `sm`) on `ErrorMain`; `ErrorSectionContainer` switches to column on `md`; `ErrorSection` replaces `minWidth: max-content` with `minWidth: 300px` (and clears it on `md`)
- **Logo removal**: Removes `ImageContainer`, `Logo`, `LogoText` styled components and their usage to focus the error page on recovery options
- **Clearer heading**: `"Oops! You don't have the required permissions to access this page."`
- **Role tooltips**: Adds `InfoCircleIcon` + `CustomTooltip` next to Organization Role(s) and Provider Role(s) headers in `CurrentSession.tsx`
- **Chip wrap**: Adds `flexWrap: wrap` to `StyledBox` so multiple role chips wrap gracefully

**Fixup applied on top of #20099:**
- Replaced `style={{ padding: 4 }}` with `sx={{ padding: '4px' }}` on `IconButton` (MUI convention)
- Changed `width="16"` / `height="16"` string props to numeric `width={16}` / `height={16}` on `InfoCircleIcon` (consistent with existing usage in `index.tsx`)

## Test plan
- [ ] Verify error/unauthorized page renders correctly at various viewport widths (mobile, tablet, desktop)
- [ ] Confirm role chips wrap without clipping when a user has multiple roles
- [ ] Hover over the info icons next to "Organization Role(s)" and "Provider Role(s)" to confirm tooltips appear with correct text
- [ ] Verify "Return to Dashboard" link and community links work
- [ ] Run unit tests: `ui/components/general/error-404/index.test.tsx`
