### PR TITLE
fix: align active sidebar icon color with text color (#20065)

### DIFF
--- a/ui/components/layout/Navigator/Navigator.tsx
+++ b/ui/components/layout/Navigator/Navigator.tsx
@@ -619,7 +619,8 @@ const NavigatorContent = () => {
     const updatedIcon =
       React.isValidElement(iconc) && typeof iconc.type !== 'string'
         ? React.cloneElement(iconc, {
-            fill: currentPath === hrefc ? theme.palette.icon.brand : theme.palette.common.white,
+            fill:
+              currentPath === hrefc ? theme.palette.navigation.active : theme.palette.common.white,
           })
         : iconc;
     let linkContent = (


### PR DESCRIPTION
## Description
The active sidebar icon used `theme.palette.icon.brand` while the text used `theme.palette.navigation.active`, causing a visible color mismatch between icons and their labels.

## Changes
- Changed icon fill in `linkContent()` from `theme.palette.icon.brand` to `theme.palette.navigation.active` when the item is active
- This ensures the icon color always matches the text color in the sidebar navigation

## Fixes
Closes #20065

## Screenshots
Before: Icon and text have different colors when active
After: Icon and text share the same active color