### PR TITLE
fix: improve primary alert color contrast for readability

### DIFF
--- a/docs/assets/scss/_alert.scss
+++ b/docs/assets/scss/_alert.scss
@@ -70,8 +70,8 @@
 }
 .alert-primary {
   border-style: solid;
-  border-color: var(--brand-color-primary, #1976d2);
-  background-color: #1976d222;
+  border-color: #0d5bbd;
+  background-color: #0d5bbd22;
   border-width: 0 0 0 4px;
   font-size: 1rem;
   & .alert-heading > *,

--- a/docs/assets/scss/_alert.scss
+++ b/docs/assets/scss/_alert.scss
@@ -76,7 +76,7 @@
   font-size: 1rem;
   & .alert-heading > *,
   & .alert-heading {
-    color: #0d5bbd;
+    color: #1976d2;
     margin: 0;
     margin-bottom: 1rem;
   }

--- a/docs/assets/scss/_alert.scss
+++ b/docs/assets/scss/_alert.scss
@@ -70,13 +70,13 @@
 }
 .alert-primary {
   border-style: solid;
-  border-color:  #1976d2;
-  background-color: #a3c8ed;
+  border-color: var(--brand-color-primary, #1976d2);
+  background-color: #1976d222;
   border-width: 0 0 0 4px;
   font-size: 1rem;
   & .alert-heading > *,
   & .alert-heading {
-    color:  #1976d2;
+    color: #0d5bbd;
     margin: 0;
     margin-bottom: 1rem;
   }


### PR DESCRIPTION
## Description
The primary alert had low contrast between the heading color (#1976d2) and background (#a3c8ed), making text hard to read in both light and dark modes.

## Changes
- Changed border-color to use CSS variable with fallback: 
- Changed background from opaque  to transparent  for better dark mode support
- Changed heading color from  to darker  for improved contrast

## Before/After
- **Before**: Light blue background (#a3c8ed) with blue text (#1976d2) — poor contrast
- **After**: Transparent blue background with dark blue text (#0d5bbd) — high contrast

## Fixes
Closes #19286

## Testing
1. Check any page using `{{% alert color="primary" %}}`
2. Verify text is readable in both light and dark modes
3. Compare with other alert types (info, warning, success) for consistency