### PR TITLE
[UI] Clean up RTK Query and console warnings

### DIFF
--- a/ui/components/User.test.tsx
+++ b/ui/components/User.test.tsx
@@ -51,12 +51,12 @@ vi.mock('next/link', () => ({
 }));
 
 vi.mock('@sistent/sistent', () => ({
-  Avatar: ({ src, sx, imgProps }: any) => (
+  Avatar: ({ src, sx, slotProps }: any) => (
     <img
       data-testid="avatar"
       src={src || ''}
       data-size={JSON.stringify(sx || {})}
-      data-referrer={imgProps?.referrerPolicy}
+      data-referrer={slotProps?.img?.referrerPolicy}
     />
   ),
   Button: ({ children, variant, color, ...props }: any) => (

--- a/ui/components/User.tsx
+++ b/ui/components/User.tsx
@@ -88,7 +88,7 @@ const User = (props) => {
             <Avatar
               sx={{ height: 36, width: 36 }}
               src={isGetUserSuccess ? userData?.avatarUrl : null}
-              imgProps={{ referrerPolicy: 'no-referrer' }}
+              slotProps={{ img: { referrerPolicy: 'no-referrer' } }}
             />
           </IconButtonAvatar>
         </div>

--- a/ui/components/dashboard/components.tsx
+++ b/ui/components/dashboard/components.tsx
@@ -26,7 +26,6 @@ type Widget = {
 
 const layoutIconProps = (theme: Theme) => ({
   fill: theme.palette.background.neutral.default,
-  primaryFill: theme.palette.background.neutral.default,
   width: '30',
   height: '30',
 });
@@ -154,7 +153,6 @@ export const StyledCard = ({ title, icon, children, sx = {}, button }: StyledCar
 type LayoutActionButtonProps = {
   Icon: React.ComponentType<{
     fill?: string;
-    primaryFill?: string;
     width?: string;
     height?: string;
   }>;

--- a/ui/components/dashboard/index.tsx
+++ b/ui/components/dashboard/index.tsx
@@ -131,11 +131,9 @@ const Dashboard = () => {
   const iconsProps = useMemo(
     () => ({
       fill: theme.palette.icon.default,
-      primaryFill: theme.palette.icon.default,
-      secondaryFill: theme.palette.icon.secondary,
       width: '40',
     }),
-    [theme.palette.icon.default, theme.palette.icon.secondary],
+    [theme.palette.icon.default],
   );
 
   const widgets = useMemo(() => getWidgets({ iconsProps, isEditMode }), [iconsProps, isEditMode]);
@@ -393,8 +391,7 @@ const Dashboard = () => {
                 direction="row"
                 useFlexGap
                 gap="0rem 2rem"
-                justifyContent="end"
-                flexWrap={'wrap-reverse'}
+                sx={{ justifyContent: 'end', flexWrap: 'wrap-reverse' }}
               >
                 {topBarActions.map(({ key, ...layoutAction }) => (
                   <LayoutActionButton {...layoutAction} key={key} />

--- a/ui/components/dashboard/widgets/HelpCenterWidget.tsx
+++ b/ui/components/dashboard/widgets/HelpCenterWidget.tsx
@@ -52,7 +52,14 @@ const HelpCenterWidget = ({ iconsProps }: HelpCenterWidgetProps) => {
     () =>
       HELP_CENTER_RESOURCES.map((resource) => ({
         ...resource,
-        icon: <DesignIcon width="15px" height="15px" fill="currentColor" />,
+        icon: (
+          <DesignIcon
+            width="15px"
+            height="15px"
+            primaryFill="currentColor"
+            secondaryFill="currentColor"
+          />
+        ),
       })),
     [],
   );
@@ -60,7 +67,14 @@ const HelpCenterWidget = ({ iconsProps }: HelpCenterWidgetProps) => {
   return (
     <PlainCard
       resources={resources}
-      icon={<DocumentIcon {...iconsProps} fill={theme.palette.icon.default} {...iconMedium} />}
+      icon={
+        <DocumentIcon
+          {...iconsProps}
+          primaryFill={theme.palette.icon.default}
+          secondaryFill={theme.palette.icon.default}
+          {...iconMedium}
+        />
+      }
       title="HELP CENTER"
     />
   );

--- a/ui/components/dashboard/widgets/HelpCenterWidget.tsx
+++ b/ui/components/dashboard/widgets/HelpCenterWidget.tsx
@@ -52,14 +52,7 @@ const HelpCenterWidget = ({ iconsProps }: HelpCenterWidgetProps) => {
     () =>
       HELP_CENTER_RESOURCES.map((resource) => ({
         ...resource,
-        icon: (
-          <DesignIcon
-            width="15px"
-            height="15px"
-            primaryFill="currentColor"
-            secondaryFill="currentColor"
-          />
-        ),
+        icon: <DesignIcon width="15px" height="15px" fill="currentColor" />,
       })),
     [],
   );
@@ -67,14 +60,7 @@ const HelpCenterWidget = ({ iconsProps }: HelpCenterWidgetProps) => {
   return (
     <PlainCard
       resources={resources}
-      icon={
-        <DocumentIcon
-          {...iconsProps}
-          fill={theme.palette.icon.default}
-          secondaryFill={theme.palette.icon.disabled}
-          {...iconMedium}
-        />
-      }
+      icon={<DocumentIcon {...iconsProps} fill={theme.palette.icon.default} {...iconMedium} />}
       title="HELP CENTER"
     />
   );

--- a/ui/components/dashboard/widgets/MyDesignsWidget.tsx
+++ b/ui/components/dashboard/widgets/MyDesignsWidget.tsx
@@ -74,7 +74,14 @@ const MyDesignsWidget = ({ iconsProps }: MyDesignsWidgetProps) => {
         name: pattern.name,
         timestamp: pattern.updatedAt,
         link: `/extension/meshmap?mode=design&design=${pattern.id}`,
-        icon: <DesignIcon width="15px" height="15px" fill="currentColor" />,
+        icon: (
+          <DesignIcon
+            width="15px"
+            height="15px"
+            primaryFill="currentColor"
+            secondaryFill="currentColor"
+          />
+        ),
       })) ?? [],
     [patternsData?.patterns],
   );
@@ -104,7 +111,6 @@ const MyDesignsWidget = ({ iconsProps }: MyDesignsWidgetProps) => {
         icon={
           <DesignIcon
             {...iconsProps}
-            fill={theme.palette.icon.default}
             primaryFill={theme.palette.icon.default}
             secondaryFill={theme.palette.icon.default}
           />

--- a/ui/components/dashboard/widgets/MyDesignsWidget.tsx
+++ b/ui/components/dashboard/widgets/MyDesignsWidget.tsx
@@ -74,14 +74,7 @@ const MyDesignsWidget = ({ iconsProps }: MyDesignsWidgetProps) => {
         name: pattern.name,
         timestamp: pattern.updatedAt,
         link: `/extension/meshmap?mode=design&design=${pattern.id}`,
-        icon: (
-          <DesignIcon
-            width="15px"
-            height="15px"
-            primaryFill="currentColor"
-            secondaryFill="currentColor"
-          />
-        ),
+        icon: <DesignIcon width="15px" height="15px" fill="currentColor" />,
       })) ?? [],
     [patternsData?.patterns],
   );

--- a/ui/components/general/error-404/socials/index.tsx
+++ b/ui/components/general/error-404/socials/index.tsx
@@ -11,12 +11,15 @@ import {
 } from './styles';
 
 export default function Socials() {
+  const tooltipSlots = { transition: Fade };
+  const tooltipSlotProps = { transition: { timeout: 600 } };
+
   return (
     <SocialMain>
       <SocialContainer>
         <Tooltip
-          TransitionComponent={Fade}
-          TransitionProps={{ timeout: 600 }}
+          slots={tooltipSlots}
+          slotProps={tooltipSlotProps}
           title="Get connected with the Meshery community"
         >
           <a href="mailto:maintainers@meshery.io">
@@ -24,29 +27,21 @@ export default function Socials() {
           </a>
         </Tooltip>
 
-        <Tooltip
-          TransitionComponent={Fade}
-          TransitionProps={{ timeout: 600 }}
-          title="Join the community Slack"
-        >
+        <Tooltip slots={tooltipSlots} slotProps={tooltipSlotProps} title="Join the community Slack">
           <a href="https://slack.meshery.io">
             <SlackIcon height={45} width={45} />
           </a>
         </Tooltip>
 
-        <Tooltip
-          TransitionComponent={Fade}
-          TransitionProps={{ timeout: 600 }}
-          title="Follow Meshery on X"
-        >
+        <Tooltip slots={tooltipSlots} slotProps={tooltipSlotProps} title="Follow Meshery on X">
           <a href="https://x.com/mesheryio">
             <TwitterIcon height={40} width={40} />
           </a>
         </Tooltip>
 
         <Tooltip
-          TransitionComponent={Fade}
-          TransitionProps={{ timeout: 600 }}
+          slots={tooltipSlots}
+          slotProps={tooltipSlotProps}
           title="Contribute to Meshery projects"
         >
           <a href="https://github.com/meshery">
@@ -55,8 +50,8 @@ export default function Socials() {
         </Tooltip>
 
         <Tooltip
-          TransitionComponent={Fade}
-          TransitionProps={{ timeout: 600 }}
+          slots={tooltipSlots}
+          slotProps={tooltipSlotProps}
           title="Watch community meeting recordings"
         >
           <a href="https://www.youtube.com/playlist?list=PL3A-A6hPO2IMPPqVjuzgqNU5xwnFFn3n0">
@@ -64,11 +59,7 @@ export default function Socials() {
           </a>
         </Tooltip>
 
-        <Tooltip
-          TransitionComponent={Fade}
-          TransitionProps={{ timeout: 600 }}
-          title="Access Docker images"
-        >
+        <Tooltip slots={tooltipSlots} slotProps={tooltipSlotProps} title="Access Docker images">
           <a href="https://hub.docker.com/u/meshery/">
             <DockerIcon height={45} width={45} />
           </a>

--- a/ui/components/general/style.tsx
+++ b/ui/components/general/style.tsx
@@ -277,7 +277,9 @@ export const SideBarListItem = styled(ListItemButton, {
   fontSize: '1rem',
 }));
 
-export const SideBarText = styled(ListItemText)(({ drawerCollapsed }) => ({
+export const SideBarText = styled(ListItemText, {
+  shouldForwardProp: (prop) => prop !== 'drawerCollapsed',
+})(({ drawerCollapsed }) => ({
   opacity: drawerCollapsed ? 0 : 1,
   transition: 'opacity 200ms ease-in-out, visibility 200ms ease-in-out',
   fontSize: '1rem',
@@ -351,7 +353,9 @@ export const ListIconSide = styled(ListItemIcon)(({ theme }) => ({
   },
 }));
 
-export const HiddenText = styled(ListItemText)(({ drawerCollapsed, theme }) => ({
+export const HiddenText = styled(ListItemText, {
+  shouldForwardProp: (prop) => prop !== 'drawerCollapsed',
+})(({ drawerCollapsed, theme }) => ({
   opacity: drawerCollapsed ? 0 : 1,
   color: theme.palette.background.constant.white,
   fontSize: '14px',

--- a/ui/components/general/style.tsx
+++ b/ui/components/general/style.tsx
@@ -359,7 +359,7 @@ export const HiddenText = styled(ListItemText, {
   opacity: drawerCollapsed ? 0 : 1,
   color: theme.palette.background.constant.white,
   fontSize: '14px',
-  transition: drawerCollapsed ? 'opacity 200ms ease-in-out' : 'opacity 200ms ease-in-out',
+  transition: 'opacity 200ms ease-in-out',
 }));
 
 export const LinkContainer = styled('div')(() => ({

--- a/ui/components/layout/Navigator/Navigator.tsx
+++ b/ui/components/layout/Navigator/Navigator.tsx
@@ -483,7 +483,6 @@ const NavigatorContent = () => {
         return (
           <RootDiv key={id} data-testid={depth === 1 ? 'extension-nav-root-item' : undefined}>
             <NavigatorListItem
-              button
               depth={depth}
               isDrawerCollapsed={isDrawerCollapsed}
               isActive={isActive}
@@ -505,7 +504,11 @@ const NavigatorContent = () => {
     }
 
     return (
-      <NavigatorList disablePadding data-testid="extension-nav-submenu">
+      <NavigatorList
+        key={`extension-nav-submenu-${depth}`}
+        disablePadding
+        data-testid="extension-nav-submenu"
+      >
         {extensionItems}
       </NavigatorList>
     );
@@ -561,7 +564,7 @@ const NavigatorContent = () => {
     const ListItemComponent = isLifecycleGroup ? NavigatorListItemIII : NavigatorListItemII;
 
     return (
-      <List disablePadding>
+      <List disablePadding key={`${idname}-${depth}`}>
         {children.map(
           ({
             id: idc,
@@ -588,7 +591,6 @@ const NavigatorContent = () => {
                         isShow: !showc,
                       }
                     : {})}
-                  button
                   data-testid={idc}
                   depth={depth}
                   isDrawerCollapsed={isDrawerCollapsed}
@@ -706,7 +708,6 @@ const NavigatorContent = () => {
               <RootDiv key={childId}>
                 <SideBarListItem
                   dense
-                  key={childId}
                   link={!!link}
                   isActive={currentPath === href}
                   isShow={!show}
@@ -733,12 +734,16 @@ const NavigatorContent = () => {
                       disableFocusListener={!isDrawerCollapsed}
                       disableHoverListener={true}
                       disableTouchListener={!isDrawerCollapsed}
-                      TransitionComponent={Zoom}
+                      slots={{ transition: Zoom }}
                     >
                       {isDrawerCollapsed &&
                       (hoveredId === childId || (openItems.includes(childId) && submenu)) ? (
                         <div>
-                          <CustomTooltip title={title} placement="right" TransitionComponent={Zoom}>
+                          <CustomTooltip
+                            title={title}
+                            placement="right"
+                            slots={{ transition: Zoom }}
+                          >
                             <ListItemIcon style={{ marginLeft: '20%', marginBottom: '0.4rem' }}>
                               {hovericon}
                             </ListItemIcon>

--- a/ui/components/layout/Navigator/navigatorComponents.tsx
+++ b/ui/components/layout/Navigator/navigatorComponents.tsx
@@ -142,7 +142,12 @@ export const getNavigatorComponents = (
         id: CATALOG,
         icon: (
           <CatalogIcon
-            fill={
+            primaryFill={
+              window.location.pathname === '/configuration/catalog'
+                ? theme.palette.background.constant.white
+                : theme.palette.icon.default
+            }
+            secondaryFill={
               window.location.pathname === '/configuration/catalog'
                 ? theme.palette.background.constant.white
                 : theme.palette.icon.default

--- a/ui/components/layout/Navigator/navigatorComponents.tsx
+++ b/ui/components/layout/Navigator/navigatorComponents.tsx
@@ -142,17 +142,11 @@ export const getNavigatorComponents = (
         id: CATALOG,
         icon: (
           <CatalogIcon
-            primaryFill={
+            fill={
               window.location.pathname === '/configuration/catalog'
                 ? theme.palette.background.constant.white
-                : ''
+                : theme.palette.icon.default
             }
-            secondaryFill={
-              window.location.pathname === '/configuration/catalog'
-                ? theme.palette.background.constant.white
-                : ''
-            }
-            tertiaryFill="transparent"
             style={{ ...drawerIconsStyle }}
           />
         ),

--- a/ui/components/workspaces/MesheryWorkspaceCard.tsx
+++ b/ui/components/workspaces/MesheryWorkspaceCard.tsx
@@ -220,18 +220,14 @@ const MesheryWorkspaceCard = ({
         onClose={teamAssignment.handleAssignModalClose}
         title={`Assign Teams to ${workspaceDetails.name}`}
         headerIcon={
-          <TeamsIcon height="40" width="40" primaryFill={theme.palette.background.constant.white} />
+          <TeamsIcon height="40" width="40" fill={theme.palette.background.constant.white} />
         }
         name="Teams"
         assignableData={teamAssignment.data}
         handleAssignedData={teamAssignment.handleAssignData}
         originalAssignedData={teamAssignment.workspaceData}
         emptyStateIcon={
-          <TeamsIcon
-            height="5rem"
-            width="5rem"
-            primaryFill={theme.palette.background.supplementary}
-          />
+          <TeamsIcon height="5rem" width="5rem" fill={theme.palette.background.supplementary} />
         }
         handleAssignablePage={teamAssignment.handleAssignablePage}
         handleAssignedPage={teamAssignment.handleAssignedPage}

--- a/ui/components/workspaces/MesheryWorkspaceCard.tsx
+++ b/ui/components/workspaces/MesheryWorkspaceCard.tsx
@@ -220,14 +220,24 @@ const MesheryWorkspaceCard = ({
         onClose={teamAssignment.handleAssignModalClose}
         title={`Assign Teams to ${workspaceDetails.name}`}
         headerIcon={
-          <TeamsIcon height="40" width="40" fill={theme.palette.background.constant.white} />
+          <TeamsIcon
+            height="40"
+            width="40"
+            primaryFill={theme.palette.background.constant.white}
+            secondaryFill={theme.palette.background.constant.white}
+          />
         }
         name="Teams"
         assignableData={teamAssignment.data}
         handleAssignedData={teamAssignment.handleAssignData}
         originalAssignedData={teamAssignment.workspaceData}
         emptyStateIcon={
-          <TeamsIcon height="5rem" width="5rem" fill={theme.palette.background.supplementary} />
+          <TeamsIcon
+            height="5rem"
+            width="5rem"
+            primaryFill={theme.palette.background.supplementary}
+            secondaryFill={theme.palette.background.supplementary}
+          />
         }
         handleAssignablePage={teamAssignment.handleAssignablePage}
         handleAssignedPage={teamAssignment.handleAssignedPage}

--- a/ui/components/workspaces/SpacesSwitcher/DesignViewListItem.tsx
+++ b/ui/components/workspaces/SpacesSwitcher/DesignViewListItem.tsx
@@ -216,7 +216,7 @@ const DesignViewListItem = ({
                       key={user.client_id}
                       alt={user.name}
                       src={user.avatar_url}
-                      imgProps={{ referrerPolicy: 'no-referrer' }}
+                      slotProps={{ img: { referrerPolicy: 'no-referrer' } }}
                     />
                   </CustomTooltip>
                 ))}

--- a/ui/components/workspaces/WorkspaceFormModalNav.tsx
+++ b/ui/components/workspaces/WorkspaceFormModalNav.tsx
@@ -58,7 +58,13 @@ const getNavItem = (theme: Theme): NavConfigItem[] => {
     {
       id: 'My-Designs',
       label: 'My Designs',
-      icon: <DesignIcon fill={theme.palette.icon.default} {...iconSmall} />,
+      icon: (
+        <DesignIcon
+          primaryFill={theme.palette.icon.default}
+          secondaryFill={theme.palette.icon.default}
+          {...iconSmall}
+        />
+      ),
       content: <MyDesignsContent />,
     },
     {

--- a/ui/components/workspaces/WorkspaceFormModalNav.tsx
+++ b/ui/components/workspaces/WorkspaceFormModalNav.tsx
@@ -58,14 +58,7 @@ const getNavItem = (theme: Theme): NavConfigItem[] => {
     {
       id: 'My-Designs',
       label: 'My Designs',
-      icon: (
-        <DesignIcon
-          fill={theme.palette.icon.default}
-          secondaryFill={theme.palette.icon.default}
-          {...iconSmall}
-          primaryFill={theme.palette.icon.default}
-        />
-      ),
+      icon: <DesignIcon fill={theme.palette.icon.default} {...iconSmall} />,
       content: <MyDesignsContent />,
     },
     {

--- a/ui/components/workspaces/index.tsx
+++ b/ui/components/workspaces/index.tsx
@@ -538,7 +538,7 @@ const Workspaces = ({ onSelectWorkspace }) => {
           open={teamsModal.open}
           closeModal={handleTeamsModalClose}
           title={`Manage "${teamsModal.workspaceName}" Teams`}
-          headerIcon={<TeamsIcon {...iconMedium} primaryFill={theme.palette.common.white} />}
+          headerIcon={<TeamsIcon {...iconMedium} fill={theme.palette.common.white} />}
         >
           <WorkspaceTeamsTable
             workspaceId={teamsModal.workspaceId}

--- a/ui/components/workspaces/index.tsx
+++ b/ui/components/workspaces/index.tsx
@@ -538,7 +538,13 @@ const Workspaces = ({ onSelectWorkspace }) => {
           open={teamsModal.open}
           closeModal={handleTeamsModalClose}
           title={`Manage "${teamsModal.workspaceName}" Teams`}
-          headerIcon={<TeamsIcon {...iconMedium} fill={theme.palette.common.white} />}
+          headerIcon={
+            <TeamsIcon
+              {...iconMedium}
+              primaryFill={theme.palette.common.white}
+              secondaryFill={theme.palette.common.white}
+            />
+          }
         >
           <WorkspaceTeamsTable
             workspaceId={teamsModal.workspaceId}

--- a/ui/rtk-query/__tests__/workspace.test.ts
+++ b/ui/rtk-query/__tests__/workspace.test.ts
@@ -22,14 +22,13 @@ beforeAll(() => {
 
 // ---------------------------------------------------------------------------
 // workspace.ts re-`injectEndpoints` into the shared `api` defined by
-// @meshery/schemas. Because the file does NOT pass `overrideExisting: true`,
-// any endpoint with a name already defined in the schemas package is ignored
-// (with a console warning). The endpoint definitions in workspace.ts that
-// share names with the schemas — e.g. getWorkspaces, getDesignsOfWorkspace —
-// never take effect at runtime; the schemas' simpler `query` definitions
-// run instead. The tests below assert the URLs/methods that REALLY run.
-// `getEventsOfWorkspace` is unique to workspace.ts, so its definition does
-// take effect — that one is asserted in full.
+// @meshery/schemas. Because this file now passes `overrideExisting: true`,
+// the local endpoint implementations in ui/rtk-query/workspace.ts are the
+// effective runtime definitions for overlapping workspace endpoints.
+//
+// The tests below assert the custom behavior that now runs, including
+// getWorkspaces, expandInfo enrichment, and infinite-scroll
+// serializeQueryArgs / merge behavior.
 // ---------------------------------------------------------------------------
 
 const okResponse = (body: unknown = {}) => ({
@@ -91,7 +90,7 @@ describe('workspace endpoints', () => {
     expect(mod.useDeleteWorkspaceMutation).toBeTypeOf('function');
   });
 
-  it('getWorkspaces (effective definition wins) GETs /api/workspaces with params', async () => {
+  it('getWorkspaces GETs /api/workspaces with params through the active workspace.ts implementation', async () => {
     fetchMock.mockResolvedValue(okResponse({ workspaces: [], total_count: 0 }));
     const { api, store } = await setupStore();
     await store.dispatch(
@@ -105,6 +104,102 @@ describe('workspace endpoints', () => {
     expect(req.method).toBe('GET');
     expect(req.url).toContain('/api/workspaces');
     expect(req.url).toContain('orgId=org-1');
+    expect(req.url).not.toContain('expandInfo');
+  });
+
+  it('getWorkspaces with expandInfo enriches workspaces with related resource counts', async () => {
+    fetchMock.mockImplementation((input) => {
+      const url = (input as Request).url || String(input);
+
+      if (url.includes('/api/workspaces?')) {
+        return Promise.resolve(
+          okResponse({
+            workspaces: [
+              { id: 'ws-1', name: 'Workspace 1' },
+              { id: 'ws-2', name: 'Workspace 2' },
+            ],
+            total_count: 2,
+          }),
+        );
+      }
+
+      if (url.includes('/api/workspaces/ws-1/designs')) {
+        return Promise.resolve(okResponse({ designs: [], total_count: 11 }));
+      }
+
+      if (url.includes('/api/workspaces/ws-1/environments')) {
+        return Promise.resolve(okResponse({ environments: [], total_count: 12 }));
+      }
+
+      if (url.includes('/api/extensions/api/workspaces/ws-1/views')) {
+        return Promise.resolve(okResponse({ views: [], total_count: 13 }));
+      }
+
+      if (url.includes('/api/extensions/api/workspaces/ws-1/teams')) {
+        return Promise.resolve(okResponse({ teams: [], total_count: 14 }));
+      }
+
+      if (url.includes('/api/workspaces/ws-2/designs')) {
+        return Promise.resolve(okResponse({ designs: [], total_count: 21 }));
+      }
+
+      if (url.includes('/api/workspaces/ws-2/environments')) {
+        return Promise.resolve(okResponse({ environments: [], total_count: 22 }));
+      }
+
+      if (url.includes('/api/extensions/api/workspaces/ws-2/views')) {
+        return Promise.resolve(okResponse({ views: [], total_count: 23 }));
+      }
+
+      if (url.includes('/api/extensions/api/workspaces/ws-2/teams')) {
+        return Promise.resolve(okResponse({ teams: [], total_count: 24 }));
+      }
+
+      return Promise.resolve(okResponse({}));
+    });
+
+    const { api, store } = await setupStore();
+
+    const result = await store.dispatch(
+      api.endpoints.getWorkspaces.initiate({
+        page: 0,
+        pagesize: 10,
+        orgId: 'org-1',
+        expandInfo: true,
+      }),
+    );
+
+    expect(fetchMock).toHaveBeenCalledTimes(9);
+    expect(result.data.workspaces).toEqual([
+      {
+        id: 'ws-1',
+        name: 'Workspace 1',
+        designCount: 11,
+        environmentCount: 12,
+        viewCount: 13,
+        teamCount: 14,
+      },
+      {
+        id: 'ws-2',
+        name: 'Workspace 2',
+        designCount: 21,
+        environmentCount: 22,
+        viewCount: 23,
+        teamCount: 24,
+      },
+    ]);
+
+    const requestedUrls = fetchMock.mock.calls.map((call) => (call[0] as Request).url);
+    expect(requestedUrls.some((url) => url.includes('/api/workspaces/ws-1/designs'))).toBe(true);
+    expect(requestedUrls.some((url) => url.includes('/api/workspaces/ws-1/environments'))).toBe(
+      true,
+    );
+    expect(
+      requestedUrls.some((url) => url.includes('/api/extensions/api/workspaces/ws-1/views')),
+    ).toBe(true);
+    expect(
+      requestedUrls.some((url) => url.includes('/api/extensions/api/workspaces/ws-1/teams')),
+    ).toBe(true);
   });
 
   it('getEnvironmentsOfWorkspace GETs on /api/workspaces/:id/environments', async () => {
@@ -155,18 +250,52 @@ describe('workspace endpoints', () => {
     expect(req.url).toContain('/api/workspaces/ws-1/environments/env-1');
   });
 
-  it('getDesignsOfWorkspace GETs on /api/workspaces/:id/designs', async () => {
+  it('getDesignsOfWorkspace GETs on /api/workspaces/:id/designs and normalizes the response', async () => {
     fetchMock.mockResolvedValue(okResponse({ designs: [], total_count: 0 }));
     const { api, store } = await setupStore();
-    await store.dispatch(
+
+    const result = await store.dispatch(
       api.endpoints.getDesignsOfWorkspace.initiate({
         workspaceId: 'ws-7',
         page: 0,
         pagesize: 10,
       }),
     );
+
     const req = fetchMock.mock.calls[0][0] as Request;
+    expect(req.method).toBe('GET');
     expect(req.url).toContain('/api/workspaces/ws-7/designs');
+    expect(result.data.designs).toEqual([]);
+  });
+
+  it('getDesignsOfWorkspace merges pages when infiniteScroll is enabled', async () => {
+    fetchMock
+      .mockResolvedValueOnce(okResponse({ designs: [{ id: 'design-1' }], total_count: 2 }))
+      .mockResolvedValueOnce(okResponse({ designs: [{ id: 'design-2' }], total_count: 2 }));
+
+    const { api, store } = await setupStore();
+
+    const firstPage = await store.dispatch(
+      api.endpoints.getDesignsOfWorkspace.initiate({
+        workspaceId: 'ws-1',
+        infiniteScroll: true,
+        page: 0,
+        pagesize: 1,
+      }),
+    );
+
+    const secondPage = await store.dispatch(
+      api.endpoints.getDesignsOfWorkspace.initiate({
+        workspaceId: 'ws-1',
+        infiniteScroll: true,
+        page: 1,
+        pagesize: 1,
+      }),
+    );
+
+    expect(firstPage.data.designs).toEqual([{ id: 'design-1' }]);
+    expect(secondPage.data.designs).toEqual([{ id: 'design-1' }, { id: 'design-2' }]);
+    expect(fetchMock).toHaveBeenCalledTimes(2);
   });
 
   it('assignDesignToWorkspace POSTs and unassignDesignFromWorkspace DELETEs', async () => {
@@ -193,7 +322,7 @@ describe('workspace endpoints', () => {
     expect(req.url).toContain('/api/workspaces/ws-1/designs/d-1');
   });
 
-  it('getViewsOfWorkspace GETs on the workspace views URL', async () => {
+  it('getViewsOfWorkspace GETs on the extensions workspace views URL', async () => {
     fetchMock.mockResolvedValue(okResponse({ views: [], total_count: 0 }));
     const { api, store } = await setupStore();
     await store.dispatch(
@@ -204,7 +333,38 @@ describe('workspace endpoints', () => {
       }),
     );
     const req = fetchMock.mock.calls[0][0] as Request;
-    expect(req.url).toContain('/api/workspaces/ws-9/views');
+    expect(req.method).toBe('GET');
+    expect(req.url).toContain('/api/extensions/api/workspaces/ws-9/views');
+  });
+
+  it('getViewsOfWorkspace merges pages when infiniteScroll is enabled', async () => {
+    fetchMock
+      .mockResolvedValueOnce(okResponse({ views: [{ id: 'view-1' }], total_count: 2 }))
+      .mockResolvedValueOnce(okResponse({ views: [{ id: 'view-2' }], total_count: 2 }));
+
+    const { api, store } = await setupStore();
+
+    const firstPage = await store.dispatch(
+      api.endpoints.getViewsOfWorkspace.initiate({
+        workspaceId: 'ws-1',
+        infiniteScroll: true,
+        page: 0,
+        pagesize: 1,
+      }),
+    );
+
+    const secondPage = await store.dispatch(
+      api.endpoints.getViewsOfWorkspace.initiate({
+        workspaceId: 'ws-1',
+        infiniteScroll: true,
+        page: 1,
+        pagesize: 1,
+      }),
+    );
+
+    expect(firstPage.data.views).toEqual([{ id: 'view-1' }]);
+    expect(secondPage.data.views).toEqual([{ id: 'view-1' }, { id: 'view-2' }]);
+    expect(fetchMock).toHaveBeenCalledTimes(2);
   });
 
   it('assignViewToWorkspace POSTs and unassignViewFromWorkspace DELETEs', async () => {
@@ -215,17 +375,17 @@ describe('workspace endpoints', () => {
     );
     let req = fetchMock.mock.calls[0][0] as Request;
     expect(req.method).toBe('POST');
-    expect(req.url).toContain('/api/workspaces/w/views/v');
+    expect(req.url).toContain('/api/extensions/api/workspaces/w/views/v');
 
     await store.dispatch(
       api.endpoints.unassignViewFromWorkspace.initiate({ workspaceId: 'w', viewId: 'v' }),
     );
     req = fetchMock.mock.calls[1][0] as Request;
     expect(req.method).toBe('DELETE');
-    expect(req.url).toContain('/api/workspaces/w/views/v');
+    expect(req.url).toContain('/api/extensions/api/workspaces/w/views/v');
   });
 
-  it('getTeamsOfWorkspace GETs the workspace teams URL with params', async () => {
+  it('getTeamsOfWorkspace GETs the extensions workspace teams URL with params', async () => {
     fetchMock.mockResolvedValue(okResponse({ teams: [], total_count: 0 }));
     const { api, store } = await setupStore();
     await store.dispatch(
@@ -238,7 +398,7 @@ describe('workspace endpoints', () => {
     );
     const req = fetchMock.mock.calls[0][0] as Request;
     expect(req.method).toBe('GET');
-    expect(req.url).toContain('/api/workspaces/ws/teams');
+    expect(req.url).toContain('/api/extensions/api/workspaces/ws/teams');
     expect(req.url).toContain('search=s');
   });
 
@@ -250,17 +410,17 @@ describe('workspace endpoints', () => {
     );
     let req = fetchMock.mock.calls[0][0] as Request;
     expect(req.method).toBe('POST');
-    expect(req.url).toContain('/api/workspaces/w/teams/t');
+    expect(req.url).toContain('/api/extensions/api/workspaces/w/teams/t');
 
     await store.dispatch(
       api.endpoints.unassignTeamFromWorkspace.initiate({ workspaceId: 'w', teamId: 't' }),
     );
     req = fetchMock.mock.calls[1][0] as Request;
     expect(req.method).toBe('DELETE');
-    expect(req.url).toContain('/api/workspaces/w/teams/t');
+    expect(req.url).toContain('/api/extensions/api/workspaces/w/teams/t');
   });
 
-  it('getEventsOfWorkspace (unique to workspace.ts) hits the extensions events URL', async () => {
+  it('getEventsOfWorkspace hits the extensions events URL', async () => {
     fetchMock.mockResolvedValue(okResponse({ events: [] }));
     const { api, store } = await setupStore();
     await store.dispatch(
@@ -283,7 +443,9 @@ describe('workspace endpoints', () => {
     const { api, store } = await setupStore();
     await store.dispatch(
       api.endpoints.createWorkspace.initiate({
-        body: { name: 'w-name', description: 'desc', organizationId: 'org-1' },
+        name: 'w-name',
+        description: 'desc',
+        organizationId: 'org-1',
       }),
     );
     const req = fetchMock.mock.calls[0][0] as Request;
@@ -314,10 +476,7 @@ describe('workspace endpoints', () => {
     expect(req.url).toContain('/api/workspaces/w-2');
   });
 
-  it('normalizePaginatedCollectionResponse used by getDesignsOfWorkspace is reachable', async () => {
-    // workspace.ts imports normalizePaginatedCollectionResponse from ./transforms.
-    // We can't easily verify it runs during dispatch (since the schema's
-    // basic query wins), but importing the module should at minimum not throw.
+  it('imports the active workspace module successfully', async () => {
     const { workspaceMod } = await setupStore();
     expect(workspaceMod).toBeDefined();
   });

--- a/ui/rtk-query/notificationCenter.ts
+++ b/ui/rtk-query/notificationCenter.ts
@@ -83,6 +83,7 @@ export const notificationCenterApi = api
     addTagTypes: Object.values(PROVIDER_TAGS),
   })
   .injectEndpoints({
+    overrideExisting: true,
     endpoints: (builder) => ({
       getEvents: builder.query({
         query: ({ page = 0, filters = {} }) => {
@@ -229,7 +230,6 @@ export const notificationCenterApi = api
         invalidatesTags: [PROVIDER_TAGS.EVENT],
       }),
     }),
-    overrideExisting: false,
   });
 
 export const {

--- a/ui/rtk-query/system.ts
+++ b/ui/rtk-query/system.ts
@@ -7,116 +7,121 @@ const TAGS = {
   SYNC: 'sync',
 };
 
-const systemApi = api.injectEndpoints({
-  endpoints: (builder) => ({
-    getDatabaseSummary: builder.query({
-      query: (queryArg) => ({
-        url: mesheryApiPath(`system/database`),
-        params: {
-          page: queryArg.page,
-          pagesize: queryArg.pagesize,
-          search: queryArg.search,
-          order: queryArg.order,
-        },
-        method: 'GET',
+const systemApi = api
+  .enhanceEndpoints({
+    addTagTypes: [TAGS.SYSTEM, TAGS.ADAPTERS, TAGS.SYNC],
+  })
+  .injectEndpoints({
+    overrideExisting: true,
+    endpoints: (builder) => ({
+      getDatabaseSummary: builder.query({
+        query: (queryArg) => ({
+          url: mesheryApiPath(`system/database`),
+          params: {
+            page: queryArg.page,
+            pagesize: queryArg.pagesize,
+            search: queryArg.search,
+            order: queryArg.order,
+          },
+          method: 'GET',
+        }),
+        providesTags: () => [{ type: TAGS.SYSTEM }],
       }),
-      providesTags: () => [{ type: TAGS.SYSTEM }],
-    }),
-    getAdapters: builder.query({
-      query: () => ({
-        url: mesheryApiPath('system/adapters'),
-        method: 'GET',
-        credentials: 'include',
+      getAdapters: builder.query({
+        query: () => ({
+          url: mesheryApiPath('system/adapters'),
+          method: 'GET',
+          credentials: 'include',
+        }),
+        providesTags: [TAGS.ADAPTERS],
       }),
-      providesTags: [TAGS.ADAPTERS],
-    }),
 
-    getAvailableAdapters: builder.query({
-      query: () => ({
-        url: mesheryApiPath('system/availableAdapters'),
-        method: 'GET',
-        credentials: 'include',
+      getAvailableAdapters: builder.query({
+        query: () => ({
+          url: mesheryApiPath('system/availableAdapters'),
+          method: 'GET',
+          credentials: 'include',
+        }),
+        providesTags: [TAGS.ADAPTERS],
       }),
-      providesTags: [TAGS.ADAPTERS],
-    }),
 
-    pingAdapter: builder.query({
-      query: (adapterLoc) => ({
-        url: mesheryApiPath(`system/adapters`),
-        params: { adapter: adapterLoc },
-        credentials: 'include',
+      pingAdapter: builder.query({
+        query: (adapterLoc) => ({
+          url: mesheryApiPath(`system/adapters`),
+          params: { adapter: adapterLoc },
+          credentials: 'include',
+        }),
+        providesTags: (result, error, adapterLoc) => [{ type: TAGS.ADAPTERS, id: adapterLoc }],
       }),
-      providesTags: (result, error, adapterLoc) => [{ type: TAGS.ADAPTERS, id: adapterLoc }],
-    }),
-    getSystemSync: builder.query({
-      query: () => ({
-        url: mesheryApiPath('system/sync'),
-        method: 'GET',
-        credentials: 'include',
+      getSystemSync: builder.query({
+        query: () => ({
+          url: mesheryApiPath('system/sync'),
+          method: 'GET',
+          credentials: 'include',
+        }),
+        providesTags: [TAGS.SYNC],
       }),
-      providesTags: [TAGS.SYNC],
-    }),
 
-    getKubernetesContexts: builder.query({
-      query: (queryArg) => ({
-        url: mesheryApiPath('system/kubernetes/contexts'),
-        params: {
-          pagesize: queryArg?.pagesize || 10,
-          search: queryArg?.search || '',
-        },
-        method: 'GET',
+      getKubernetesContexts: builder.query({
+        query: (queryArg) => ({
+          url: mesheryApiPath('system/kubernetes/contexts'),
+          params: {
+            pagesize: queryArg?.pagesize || 10,
+            search: queryArg?.search || '',
+          },
+          method: 'GET',
+        }),
+        transformResponse: normalizeKubernetesContextsResponse,
+        providesTags: [TAGS.SYSTEM],
       }),
-      transformResponse: normalizeKubernetesContextsResponse,
-      providesTags: [TAGS.SYSTEM],
-    }),
 
-    adapterOperation: builder.mutation({
-      query: (queryArg) => ({
-        url: mesheryApiPath(queryArg.url || 'system/adapter/operation'),
-        method: 'POST',
-        credentials: 'include',
-        headers: { 'Content-Type': 'application/x-www-form-urlencoded;charset=UTF-8' },
-        body: queryArg.body,
-      }),
-    }),
-
-    getSmiResults: builder.query({
-      query: (queryArg) => ({
-        url: mesheryApiPath('smi/results'),
-        params: {
-          page: queryArg?.page,
-          pagesize: queryArg?.pagesize,
-          search: queryArg?.search,
-          order: queryArg?.order,
-        },
-        method: 'GET',
-        credentials: 'include',
-      }),
-    }),
-
-    manageAdapter: builder.mutation({
-      query: (queryArg) => {
-        if (queryArg.method === 'DELETE') {
-          return {
-            url: mesheryApiPath(`system/adapter/manage`),
-            method: 'DELETE',
-            credentials: 'include',
-            params: { adapter: queryArg.adapter },
-          };
-        }
-
-        return {
-          url: mesheryApiPath('system/adapter/manage'),
+      adapterOperation: builder.mutation({
+        query: (queryArg) => ({
+          url: mesheryApiPath(queryArg.url || 'system/adapter/operation'),
           method: 'POST',
           credentials: 'include',
           headers: { 'Content-Type': 'application/x-www-form-urlencoded;charset=UTF-8' },
-          body: `meshLocationURL=${encodeURIComponent(queryArg.meshLocationURL)}`,
-        };
-      },
-      invalidatesTags: [TAGS.ADAPTERS],
+          body: queryArg.body,
+        }),
+      }),
+
+      getSmiResults: builder.query({
+        query: (queryArg) => ({
+          url: mesheryApiPath('smi/results'),
+          params: {
+            page: queryArg?.page,
+            pagesize: queryArg?.pagesize,
+            search: queryArg?.search,
+            order: queryArg?.order,
+          },
+          method: 'GET',
+          credentials: 'include',
+        }),
+      }),
+
+      manageAdapter: builder.mutation({
+        query: (queryArg) => {
+          if (queryArg.method === 'DELETE') {
+            return {
+              url: mesheryApiPath(`system/adapter/manage`),
+              method: 'DELETE',
+              credentials: 'include',
+              params: { adapter: queryArg.adapter },
+            };
+          }
+
+          return {
+            url: mesheryApiPath('system/adapter/manage'),
+            method: 'POST',
+            credentials: 'include',
+            headers: { 'Content-Type': 'application/x-www-form-urlencoded;charset=UTF-8' },
+            body: `meshLocationURL=${encodeURIComponent(queryArg.meshLocationURL)}`,
+          };
+        },
+        invalidatesTags: [TAGS.ADAPTERS],
+      }),
     }),
-  }),
-});
+  });
 
 export const {
   useGetDatabaseSummaryQuery,

--- a/ui/rtk-query/workspace.ts
+++ b/ui/rtk-query/workspace.ts
@@ -17,6 +17,7 @@ const workspacesApi = api
     addTagTypes: [TAGS.WORKSPACES, TAGS.DESIGNS, TAGS.ENVIRONMENTS, TAGS.VIEWS, TAGS.TEAMS],
   })
   .injectEndpoints({
+    overrideExisting: true,
     endpoints: (builder) => ({
       getWorkspaces: builder.query({
         keepUnusedDataFor: 0,
@@ -345,23 +346,31 @@ const workspacesApi = api
       }),
 
       updateWorkspace: builder.mutation({
-        query: (queryArg) => ({
-          url: mesheryApiPath(`workspaces/${queryArg.id}`),
-          method: 'PUT',
-          body: {
-            name: queryArg.name,
-            description: queryArg.description,
-            organizationId: queryArg.organizationId || queryArg.organization_id,
-          },
-        }),
+        query: (queryArg) => {
+          const workspaceId = queryArg.workspaceId || queryArg.id;
+
+          return {
+            url: mesheryApiPath(`workspaces/${workspaceId}`),
+            method: 'PUT',
+            body: queryArg.body || {
+              name: queryArg.name,
+              description: queryArg.description,
+              organizationId: queryArg.organizationId || queryArg.organization_id,
+            },
+          };
+        },
         invalidatesTags: () => [{ type: TAGS.WORKSPACES }],
       }),
 
       deleteWorkspace: builder.mutation({
-        query: (queryArg) => ({
-          url: mesheryApiPath(`workspaces/${queryArg.id}`),
-          method: 'DELETE',
-        }),
+        query: (queryArg) => {
+          const workspaceId = queryArg.workspaceId || queryArg.id;
+
+          return {
+            url: mesheryApiPath(`workspaces/${workspaceId}`),
+            method: 'DELETE',
+          };
+        },
         invalidatesTags: () => [{ type: TAGS.WORKSPACES }],
       }),
     }),

--- a/ui/rtk-query/workspace.ts
+++ b/ui/rtk-query/workspace.ts
@@ -12,6 +12,28 @@ const TAGS = {
   VIEWS: 'workspaces_views',
   TEAMS: 'workspaces_teams',
 };
+
+const EXPAND_INFO_CONCURRENCY_LIMIT = 3;
+
+const mapWithConcurrency = async <T, R>(
+  items: T[],
+  limit: number,
+  mapper: (item: T, index: number) => Promise<R>,
+): Promise<R[]> => {
+  const results: R[] = [];
+  let nextIndex = 0;
+
+  const workers = Array.from({ length: Math.min(limit, items.length) }, async () => {
+    while (nextIndex < items.length) {
+      const currentIndex = nextIndex++;
+      results[currentIndex] = await mapper(items[currentIndex], currentIndex);
+    }
+  });
+
+  await Promise.all(workers);
+  return results;
+};
+
 const workspacesApi = api
   .enhanceEndpoints({
     addTagTypes: [TAGS.WORKSPACES, TAGS.DESIGNS, TAGS.ENVIRONMENTS, TAGS.VIEWS, TAGS.TEAMS],
@@ -21,7 +43,7 @@ const workspacesApi = api
     endpoints: (builder) => ({
       getWorkspaces: builder.query({
         keepUnusedDataFor: 0,
-        queryFn: async (queryArgs, { dispatch }, _extraOptions, baseQuery) => {
+        queryFn: async (queryArgs = {}, { dispatch }, _extraOptions, baseQuery) => {
           const { expandInfo, ...otherArgs } = queryArgs;
           const params = urlEncodeParams(otherArgs);
           const workspaces = await baseQuery({
@@ -30,8 +52,12 @@ const workspacesApi = api
           });
 
           if (expandInfo && workspaces.data && !workspaces.error) {
-            const modifiedWorkspaces = await Promise.all(
-              workspaces.data.workspaces.map(async (workspace) => {
+            const workspaceList = workspaces.data.workspaces || [];
+
+            const modifiedWorkspaces = await mapWithConcurrency(
+              workspaceList,
+              EXPAND_INFO_CONCURRENCY_LIMIT,
+              async (workspace) => {
                 const [designs, environments, views, teams] = await Promise.all([
                   dispatch(
                     workspacesApi.endpoints.getDesignsOfWorkspace.initiate({
@@ -73,7 +99,7 @@ const workspacesApi = api
                   viewCount: views.data?.totalCount ?? views.data?.total_count ?? 0,
                   teamCount: teams.data?.totalCount ?? teams.data?.total_count ?? 0,
                 };
-              }),
+              },
             );
 
             return _.merge({}, workspaces, { data: { workspaces: modifiedWorkspaces } });

--- a/ui/themes/App.styles.tsx
+++ b/ui/themes/App.styles.tsx
@@ -83,7 +83,7 @@ export const StyledDrawer = styled('nav', {
       ? theme.transitions.duration.leavingScreen
       : theme.transitions.duration.enteringScreen,
   }),
-  '& > div:first-child': {
+  '& > div:first-of-type': {
     height: 'inherit',
     width: 'inherit',
   },


### PR DESCRIPTION
**Notes for Reviewers**

* This PR fixes #20122 
* Cleans up RTK Query endpoint override warnings by adding `overrideExisting: true` where endpoints are intentionally overridden.
* Registers the missing `sync` tag type.
* Fixes styled/Sistent prop leakage warnings by preventing unsupported props from reaching DOM elements.
* Replaces deprecated/unsupported MUI props such as `imgProps` and `TransitionComponent` with `slotProps` / `slots`.
* Replaces unsupported icon color props with supported `fill` usage where applicable.
* Moves layout props like `justifyContent` and `flexWrap` into `sx`.
* Replaces unsafe `:first-child` usage with `:first-of-type`.

**Testing**

* Ran `make ui`
* Ran relevant UI tests

**Note**

* Local Node deprecation warnings from the dev server/dependency chain remain outside the scope of this PR.

**[[Signed commits](https://github.com/meshery/meshery/blob/master/CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)](https://github.com/meshery/meshery/blob/master/CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**

* [x] Yes, I signed my commits.