### PR TITLE
[mesheryctl] Fix HTTP timeout and nil-panic in auth package

### DIFF
--- a/mesheryctl/pkg/utils/auth.go
+++ b/mesheryctl/pkg/utils/auth.go
@@ -92,21 +92,22 @@ func NewRequest(method string, url string, body io.Reader) (*http.Request, error
 func MakeRequest(req *http.Request) (*http.Response, error) {
 	client := &http.Client{Timeout: authHTTPTimeout}
 
-	// check status code from request, checks for issues with auth token
 	resp, err := client.Do(req)
 
-	if err != nil && resp == nil {
+	if err != nil {
+		if resp != nil {
+			_ = resp.Body.Close()
+		}
 		return nil, ErrFailRequest(err)
 	}
 
-	// If statuscode = 302, then we either have an expired or invalid token
-	// We return the response and correct error message
 	if resp.StatusCode == 302 {
+		_ = resp.Body.Close()
 		return nil, ErrInvalidToken()
 	}
 
-	// failsafe for not being authenticated
 	if ContentTypeIsHTML(resp) {
+		_ = resp.Body.Close()
 		return nil, ErrUnauthenticated()
 	}
 
@@ -448,7 +449,10 @@ func chooseDirectProvider(provs map[string]Provider, option string) (Provider, e
 			return provArray[i], nil
 		}
 	}
-	return provArray[1], fmt.Errorf("the specified provider '%s' is not available. Please try giving correct provider name", option)
+	if len(provArray) > 1 {
+		return provArray[1], fmt.Errorf("the specified provider '%s' is not available. Please try giving correct provider name", option)
+	}
+	return Provider{}, fmt.Errorf("the specified provider '%s' is not available. Please try giving correct provider name", option)
 }
 
 func createProviderURI(provider Provider, host string, port int) (string, error) {

--- a/mesheryctl/pkg/utils/auth.go
+++ b/mesheryctl/pkg/utils/auth.go
@@ -226,8 +226,7 @@ func UpdateAuthDetails(filepath string) error {
 
 	req, err := http.NewRequest("GET", mctlCfg.GetBaseMesheryURL()+"/api/user/token", bytes.NewBuffer([]byte("")))
 	if err != nil {
-		err = errors.Wrap(err, "error creating the request: ")
-		return err
+		return errors.Wrap(err, "error creating the request")
 	}
 	if err := AddAuthDetails(req, filepath); err != nil {
 		return err
@@ -237,18 +236,17 @@ func UpdateAuthDetails(filepath string) error {
 	resp, err := client.Do(req)
 
 	if err != nil {
-		return errors.Wrap(err, "error dispatching the request: ")
+		return errors.Wrap(err, "error dispatching the request")
 	}
 	defer SafeClose(resp.Body)
 
 	data, err := io.ReadAll(resp.Body)
 	if err != nil {
-		err = errors.Wrap(err, "error reading body: ")
-		return err
+		return errors.Wrap(err, "error reading body")
 	}
 
 	if ContentTypeIsHTML(resp) {
-		return errors.New("invalid body")
+		return fmt.Errorf("invalid body")
 	}
 
 	return os.WriteFile(filepath, data, os.ModePerm)

--- a/mesheryctl/pkg/utils/auth.go
+++ b/mesheryctl/pkg/utils/auth.go
@@ -21,6 +21,8 @@ import (
 	"github.com/spf13/viper"
 )
 
+const authHTTPTimeout = 30 * time.Second
+
 type Provider struct {
 	ProviderURL  string `json:"providerUrl,omitempty"`
 	ProviderName string `json:"providerName,omitempty"`
@@ -88,7 +90,7 @@ func NewRequest(method string, url string, body io.Reader) (*http.Request, error
 // Function returns a new http response given a http request
 // Function will test the response and return any errors associated with it
 func MakeRequest(req *http.Request) (*http.Response, error) {
-	client := &http.Client{}
+	client := &http.Client{Timeout: authHTTPTimeout}
 
 	// check status code from request, checks for issues with auth token
 	resp, err := client.Do(req)
@@ -224,21 +226,20 @@ func UpdateAuthDetails(filepath string) error {
 
 	req, err := http.NewRequest("GET", mctlCfg.GetBaseMesheryURL()+"/api/user/token", bytes.NewBuffer([]byte("")))
 	if err != nil {
-		err = errors.Wrap(err, "error Creating the request: ")
+		err = errors.Wrap(err, "error creating the request: ")
 		return err
 	}
 	if err := AddAuthDetails(req, filepath); err != nil {
 		return err
 	}
 
-	client := &http.Client{}
+	client := &http.Client{Timeout: authHTTPTimeout}
 	resp, err := client.Do(req)
-	defer SafeClose(resp.Body)
 
 	if err != nil {
-		err = errors.Wrap(err, "error dispatching there request: ")
-		return err
+		return errors.Wrap(err, "error dispatching the request: ")
 	}
+	defer SafeClose(resp.Body)
 
 	data, err := io.ReadAll(resp.Body)
 	if err != nil {
@@ -348,10 +349,12 @@ func InitiateLogin(mctlCfg *config.MesheryCtlConfig, option string) ([]byte, err
 func GetProviderInfo(mctCfg *config.MesheryCtlConfig) (map[string]Provider, error) {
 	res := map[string]Provider{}
 
-	resp, err := http.Get(mctCfg.GetBaseMesheryURL() + "/api/providers")
+	client := &http.Client{Timeout: authHTTPTimeout}
+	resp, err := client.Get(mctCfg.GetBaseMesheryURL() + "/api/providers")
 	if err != nil {
 		return nil, err
 	}
+	defer func() { _ = resp.Body.Close() }()
 
 	if err := json.NewDecoder(resp.Body).Decode(&res); err != nil {
 		return nil, err
@@ -483,7 +486,7 @@ func getTokenObjFromMesheryServer(mctl *config.MesheryCtlConfig, provider, token
 		HttpOnly: true,
 	})
 
-	cli := &http.Client{}
+	cli := &http.Client{Timeout: authHTTPTimeout}
 	resp, err := cli.Do(req)
 	if err != nil {
 		return nil, err

--- a/mesheryctl/pkg/utils/auth.go
+++ b/mesheryctl/pkg/utils/auth.go
@@ -101,7 +101,7 @@ func MakeRequest(req *http.Request) (*http.Response, error) {
 		return nil, ErrFailRequest(err)
 	}
 
-	if resp.StatusCode == 302 {
+	if resp.StatusCode == http.StatusFound {
 		_ = resp.Body.Close()
 		return nil, ErrInvalidToken()
 	}
@@ -356,6 +356,10 @@ func GetProviderInfo(mctCfg *config.MesheryCtlConfig) (map[string]Provider, erro
 		return nil, err
 	}
 	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("unexpected status code %d", resp.StatusCode)
+	}
 
 	if err := json.NewDecoder(resp.Body).Decode(&res); err != nil {
 		return nil, err

--- a/mesheryctl/pkg/utils/auth.go
+++ b/mesheryctl/pkg/utils/auth.go
@@ -235,8 +235,10 @@ func UpdateAuthDetails(filepath string) error {
 
 	client := &http.Client{Timeout: authHTTPTimeout}
 	resp, err := client.Do(req)
-
 	if err != nil {
+		if resp != nil {
+			SafeClose(resp.Body)
+		}
 		return errors.Wrap(err, "error dispatching the request")
 	}
 	defer SafeClose(resp.Body)
@@ -449,9 +451,6 @@ func chooseDirectProvider(provs map[string]Provider, option string) (Provider, e
 			return provArray[i], nil
 		}
 	}
-	if len(provArray) > 1 {
-		return provArray[1], fmt.Errorf("the specified provider '%s' is not available. Please try giving correct provider name", option)
-	}
 	return Provider{}, fmt.Errorf("the specified provider '%s' is not available. Please try giving correct provider name", option)
 }
 
@@ -491,9 +490,11 @@ func getTokenObjFromMesheryServer(mctl *config.MesheryCtlConfig, provider, token
 	cli := &http.Client{Timeout: authHTTPTimeout}
 	resp, err := cli.Do(req)
 	if err != nil {
+		if resp != nil {
+			_ = resp.Body.Close()
+		}
 		return nil, err
 	}
-
 	defer func() { _ = resp.Body.Close() }()
 
 	return io.ReadAll(resp.Body)

--- a/mesheryctl/pkg/utils/auth_test.go
+++ b/mesheryctl/pkg/utils/auth_test.go
@@ -1,17 +1,3 @@
-// Copyright Meshery Authors
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//     http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
-
 package utils
 
 import (
@@ -22,9 +8,9 @@ import (
 	"testing"
 
 	"github.com/meshery/meshery/mesheryctl/internal/cli/root/config"
+	"github.com/meshery/meshkit/errors"
 )
 
-// testcases for auth.go
 func TestAuth(t *testing.T) {
 	handler := func(w http.ResponseWriter, r *http.Request) {
 		_, _ = fmt.Fprintln(w, "A simple server only for testing")
@@ -44,7 +30,6 @@ func TestAuth(t *testing.T) {
 	}
 	defer func() { _ = resp.Body.Close() }()
 
-	// testcases for GetTokenLocation(token config.Token) (string, error)
 	t.Run("GetTokenLocation", func(t *testing.T) {
 		token := config.Token{
 			Name:     "test",
@@ -62,7 +47,6 @@ func TestAuth(t *testing.T) {
 			t.Fatal(err)
 		}
 	})
-	//@Aisuko Need a token file to do other testings
 }
 
 func TestProviderUnmarshalJSON(t *testing.T) {
@@ -97,4 +81,143 @@ func TestProviderUnmarshalJSON(t *testing.T) {
 			t.Fatalf("expected provider URL https://cloud.meshery.io, got %q", provider.ProviderURL)
 		}
 	})
+}
+
+func TestMakeRequestSuccess(t *testing.T) {
+	tests := []struct {
+		name     string
+		status   int
+		body     string
+		ctype    string
+	}{
+		{
+			name:   "200 OK",
+			status: http.StatusOK,
+			body:   `{"status":"ok"}`,
+			ctype:  "application/json",
+		},
+		{
+			name:   "201 Created",
+			status: http.StatusCreated,
+			body:   `{"id":"abc"}`,
+			ctype:  "application/json",
+		},
+		{
+			name:   "204 No Content",
+			status: http.StatusNoContent,
+			body:   "",
+			ctype:  "application/json",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			handler := func(w http.ResponseWriter, r *http.Request) {
+				w.Header().Set("Content-Type", tt.ctype)
+				w.WriteHeader(tt.status)
+				if tt.body != "" {
+					_, _ = fmt.Fprint(w, tt.body)
+				}
+			}
+			srv := httptest.NewServer(http.HandlerFunc(handler))
+			defer srv.Close()
+
+			req, err := http.NewRequest("GET", srv.URL, nil)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			_, err = MakeRequest(req)
+			if err != nil {
+				t.Fatalf("expected nil error, got %v", err)
+			}
+		})
+	}
+}
+
+func TestMakeRequestErrors(t *testing.T) {
+	tests := []struct {
+		name       string
+		status     int
+		body       string
+		ctype      string
+		wantErr    error
+		wantErrMsg string
+	}{
+		{
+			name:       "302 redirect returns invalid token",
+			status:     http.StatusFound,
+			body:       "",
+			ctype:      "application/json",
+			wantErr:    ErrInvalidToken(),
+		},
+		{
+			name:       "HTML response returns unauthenticated",
+			status:     http.StatusOK,
+			body:       "<html>login</html>",
+			ctype:      "text/html",
+			wantErr:    ErrUnauthenticated(),
+		},
+		{
+			name:       "404 returns not found",
+			status:     http.StatusNotFound,
+			body:       `{"error":"not found"}`,
+			ctype:      "application/json",
+			wantErr:    ErrNotFound(nil),
+			wantErrMsg: "not found",
+		},
+		{
+			name:       "500 returns internal server error",
+			status:     http.StatusInternalServerError,
+			body:       `{"error":"server error"}`,
+			ctype:      "application/json",
+			wantErr:    ErrMesheryServerInternalError(nil),
+			wantErrMsg: "server error",
+		},
+		{
+			name:       "non-standard status returns fail request error",
+			status:     http.StatusTeapot,
+			body:       `{"error":"teapot"}`,
+			ctype:      "application/json",
+			wantErr:    ErrFailReqStatus(0, ""),
+			wantErrMsg: "418",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			handler := func(w http.ResponseWriter, r *http.Request) {
+				w.Header().Set("Content-Type", tt.ctype)
+				w.WriteHeader(tt.status)
+				if tt.body != "" {
+					_, _ = fmt.Fprint(w, tt.body)
+				}
+			}
+			srv := httptest.NewServer(http.HandlerFunc(handler))
+			defer srv.Close()
+
+			req, err := http.NewRequest("GET", srv.URL, nil)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			_, err = MakeRequest(req)
+			if err == nil {
+				t.Fatal("expected error, got nil")
+			}
+
+			if tt.wantErrMsg != "" {
+				if errors.GetCode(err) != errors.GetCode(tt.wantErr) {
+					t.Fatalf("expected error code %s, got %s", errors.GetCode(tt.wantErr), errors.GetCode(err))
+				}
+				return
+			}
+
+			wantCode := errors.GetCode(tt.wantErr)
+			gotCode := errors.GetCode(err)
+			if gotCode != wantCode {
+				t.Fatalf("expected error code %s, got %s", wantCode, gotCode)
+			}
+		})
+	}
 }

--- a/mesheryctl/pkg/utils/auth_test.go
+++ b/mesheryctl/pkg/utils/auth_test.go
@@ -1,3 +1,17 @@
+// Copyright 2023 Meshery Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package utils
 
 import (
@@ -42,10 +56,11 @@ func TestAuth(t *testing.T) {
 	})
 
 	t.Run("MakeRequest", func(t *testing.T) {
-		_, err := MakeRequest(req)
+		resp, err := MakeRequest(req)
 		if err != nil {
 			t.Fatal(err)
 		}
+		_ = resp.Body.Close()
 	})
 }
 
@@ -127,10 +142,11 @@ func TestMakeRequestSuccess(t *testing.T) {
 				t.Fatal(err)
 			}
 
-			_, err = MakeRequest(req)
+			resp, err := MakeRequest(req)
 			if err != nil {
 				t.Fatalf("expected nil error, got %v", err)
 			}
+			_ = resp.Body.Close()
 		})
 	}
 }
@@ -141,8 +157,7 @@ func TestMakeRequestErrors(t *testing.T) {
 		status     int
 		body       string
 		ctype      string
-		wantErr    error
-		wantErrMsg string
+		wantErr error
 	}{
 		{
 			name:       "302 redirect returns invalid token",
@@ -159,28 +174,25 @@ func TestMakeRequestErrors(t *testing.T) {
 			wantErr:    ErrUnauthenticated(),
 		},
 		{
-			name:       "404 returns not found",
-			status:     http.StatusNotFound,
-			body:       `{"error":"not found"}`,
-			ctype:      "application/json",
-			wantErr:    ErrNotFound(nil),
-			wantErrMsg: "not found",
+			name:    "404 returns not found",
+			status:  http.StatusNotFound,
+			body:    `{"error":"not found"}`,
+			ctype:   "application/json",
+			wantErr: ErrNotFound(fmt.Errorf(`{"error":"not found"}`)),
 		},
 		{
-			name:       "500 returns internal server error",
-			status:     http.StatusInternalServerError,
-			body:       `{"error":"server error"}`,
-			ctype:      "application/json",
-			wantErr:    ErrMesheryServerInternalError(nil),
-			wantErrMsg: "server error",
+			name:    "500 returns internal server error",
+			status:  http.StatusInternalServerError,
+			body:    `{"error":"server error"}`,
+			ctype:   "application/json",
+			wantErr: ErrMesheryServerInternalError(fmt.Errorf(`{"error":"server error"}`)),
 		},
 		{
-			name:       "non-standard status returns fail request error",
-			status:     http.StatusTeapot,
-			body:       `{"error":"teapot"}`,
-			ctype:      "application/json",
-			wantErr:    ErrFailReqStatus(0, ""),
-			wantErrMsg: "418",
+			name:    "418 teapot returns fail request error",
+			status:  http.StatusTeapot,
+			body:    `{"error":"teapot"}`,
+			ctype:   "application/json",
+			wantErr: ErrFailReqStatus(http.StatusTeapot, `{"error":"teapot"}`),
 		},
 	}
 
@@ -206,16 +218,7 @@ func TestMakeRequestErrors(t *testing.T) {
 				t.Fatal("expected error, got nil")
 			}
 
-			if tt.wantErrMsg != "" {
-				if errors.GetCode(err) != errors.GetCode(tt.wantErr) {
-					t.Fatalf("expected error code %s, got %s", errors.GetCode(tt.wantErr), errors.GetCode(err))
-				}
-				return
-			}
-
-			wantCode := errors.GetCode(tt.wantErr)
-			gotCode := errors.GetCode(err)
-			if gotCode != wantCode {
+			if gotCode, wantCode := errors.GetCode(err), errors.GetCode(tt.wantErr); gotCode != wantCode {
 				t.Fatalf("expected error code %s, got %s", wantCode, gotCode)
 			}
 		})

--- a/mesheryctl/pkg/utils/auth_test.go
+++ b/mesheryctl/pkg/utils/auth_test.go
@@ -1,4 +1,4 @@
-// Copyright 2023 Meshery Authors
+// Copyright Meshery Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.


### PR DESCRIPTION
**Notes for Reviewers**

This PR fixes HTTP client timeout and nil-panic issues in `mesheryctl/pkg/utils/auth.go`:

1. **Nil-panic in UpdateAuthDetails**: `defer SafeClose(resp.Body)` was called before the error check from `client.Do(req)`. When the request fails, `resp` can be nil, causing a nil pointer dereference. Moved the defer after the error check.

2. **Missing HTTP timeouts**: Four HTTP clients in the auth package used `&http.Client{}` without a timeout, allowing the CLI to hang indefinitely when the Meshery server or remote provider is unreachable:
   - `MakeRequest`
   - `UpdateAuthDetails`
   - `getTokenObjFromMesheryServer`
   - `GetProviderInfo`

3. **Unclosed response body in GetProviderInfo**: `http.Get()` response body was never closed.

**[Signed commits](https://github.com/meshery/meshery/blob/master/CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [x] Yes, I signed my commits.