### PR TITLE
Fix/registry full screen bug

### DIFF
--- a/docs/content/en/extensions/academies/_index.md
+++ b/docs/content/en/extensions/academies/_index.md
@@ -31,4 +31,4 @@ This architecture supports multi-tenancy, white-labeling (for branded experience
 
 Meshery Academies exemplifies Meshery’s philosophy of extensibility—empowering the community to democratize cloud native knowledge through practical, visual, and interactive learning experiences. It serves as both an official learning hub for Meshery (with paths like “Mastering Meshery”) and a framework for anyone to create their own specialized academies.
 
-To find a complete list of academies available, explore the [meshery-extensions](https://github.com/meshery-extensions) repositories, like [meshery-academy](https://github.com/meshery-extensions/meshery-academy). Contributions and extensions are welcome in the Meshery Extensions organization.
+To find a complete list of academies available, explore the repositories over in the [meshery-academy-topic](https://github.com/topics/meshery-academy), like [meshery-academy](https://github.com/meshery-extensions/meshery-academy). Contributions and extensions are welcome in the Meshery Extensions organization.

--- a/docs/content/en/extensions/academies/_index.md
+++ b/docs/content/en/extensions/academies/_index.md
@@ -31,4 +31,4 @@ This architecture supports multi-tenancy, white-labeling (for branded experience
 
 Meshery Academies exemplifies Meshery’s philosophy of extensibility—empowering the community to democratize cloud native knowledge through practical, visual, and interactive learning experiences. It serves as both an official learning hub for Meshery (with paths like “Mastering Meshery”) and a framework for anyone to create their own specialized academies.
 
-To find a complete list of academies available, explore the repositories over in the [meshery-academy-topic](https://github.com/topics/meshery-academy), like [meshery-academy](https://github.com/meshery-extensions/meshery-academy). Contributions and extensions are welcome in the Meshery Extensions organization.
+To find a complete list of academies available, explore the repositories under the [meshery-academy topic](https://github.com/topics/meshery-academy), like [meshery-academy](https://github.com/meshery-extensions/meshery-academy). Contributions and extensions are welcome in the Meshery Extensions organization.

--- a/docs/meetings/2026/week-of-06-18-2026/index.md
+++ b/docs/meetings/2026/week-of-06-18-2026/index.md
@@ -1,0 +1,1 @@
+Mark your attendance by committing your markdown files with names.

--- a/ui/components/general/style.tsx
+++ b/ui/components/general/style.tsx
@@ -61,8 +61,8 @@ export const StyledListItem = styled(ListItem, {
   cursor: 'pointer',
   backgroundColor: charcoal[30],
   boxShadow: '0 -1px 0 #404854 inset',
-  paddingTop: '1.325rem',
-  paddingBottom: '1.325rem',
+  paddingTop: '1.625rem',
+  paddingBottom: '1.625rem',
   position: 'sticky',
   top: 0,
   zIndex: 5,
@@ -171,8 +171,8 @@ export const NavigatorListItem = styled(ListItemButton, {
       transition: 'opacity 200ms ease-in',
     },
   },
-  paddingTop: 4,
-  paddingBottom: 4,
+  paddingTop: 10,
+  paddingBottom: 10,
 }));
 
 export const NavigatorListItemII = styled(ListItemButton, {
@@ -196,8 +196,8 @@ export const NavigatorListItemII = styled(ListItemButton, {
       transition: 'opacity 200ms ease-in',
     },
   },
-  paddingTop: 4,
-  paddingBottom: 4,
+  paddingTop: 10,
+  paddingBottom: 10,
 }));
 
 export const NavigatorListItemIII = styled(ListItemButton, {
@@ -221,8 +221,8 @@ export const NavigatorListItemIII = styled(ListItemButton, {
       transition: 'opacity 200ms ease-in',
     },
   },
-  paddingTop: 4,
-  paddingBottom: 4,
+  paddingTop: 10,
+  paddingBottom: 10,
   pointerEvents: isShow ? 'none' : 'auto',
   opacity: isShow ? 0.5 : '',
 }));
@@ -248,8 +248,8 @@ export const SideBarListItem = styled(ListItemButton, {
       visibility: 'visible',
     },
   },
-  paddingTop: 4,
-  paddingBottom: 4,
+  paddingTop: 10,
+  paddingBottom: 10,
   pointerEvents: isShow ? 'none' : 'auto',
   opacity: isShow ? 0.5 : '',
   fontSize: '1rem',
@@ -414,8 +414,8 @@ export const NavigatorLink = styled('span')({
 
 export const HelpListItem = styled(ListItem)(({ theme }) => ({
   paddingLeft: 0,
-  paddingTop: 4,
-  paddingBottom: 4,
+  paddingTop: 10,
+  paddingBottom: 10,
   color: theme.palette.background.constant.disabled,
   fill: theme.palette.background.constant.white,
   '&:hover': {

--- a/ui/components/general/style.tsx
+++ b/ui/components/general/style.tsx
@@ -171,8 +171,8 @@ export const NavigatorListItem = styled(ListItemButton, {
       transition: 'opacity 200ms ease-in',
     },
   },
-  paddingTop: theme.spacing(1.25),
-  paddingBottom: theme.spacing(1.25),
+  paddingTop: 10,
+  paddingBottom: 10,
 }));
 
 export const NavigatorListItemII = styled(ListItemButton, {
@@ -196,8 +196,8 @@ export const NavigatorListItemII = styled(ListItemButton, {
       transition: 'opacity 200ms ease-in',
     },
   },
-  paddingTop: theme.spacing(1.25),
-  paddingBottom: theme.spacing(1.25),
+  paddingTop: 10,
+  paddingBottom: 10,
 }));
 
 export const NavigatorListItemIII = styled(ListItemButton, {
@@ -221,8 +221,8 @@ export const NavigatorListItemIII = styled(ListItemButton, {
       transition: 'opacity 200ms ease-in',
     },
   },
-  paddingTop: theme.spacing(1.25),
-  paddingBottom: theme.spacing(1.25),
+  paddingTop: 10,
+  paddingBottom: 10,
   pointerEvents: isShow ? 'none' : 'auto',
   opacity: isShow ? 0.5 : '',
 }));
@@ -248,8 +248,8 @@ export const SideBarListItem = styled(ListItemButton, {
       visibility: 'visible',
     },
   },
-  paddingTop: theme.spacing(1.25),
-  paddingBottom: theme.spacing(1.25),
+  paddingTop: 10,
+  paddingBottom: 10,
   pointerEvents: isShow ? 'none' : 'auto',
   opacity: isShow ? 0.5 : '',
   fontSize: '1rem',

--- a/ui/components/general/style.tsx
+++ b/ui/components/general/style.tsx
@@ -171,8 +171,8 @@ export const NavigatorListItem = styled(ListItemButton, {
       transition: 'opacity 200ms ease-in',
     },
   },
-  paddingTop: 10,
-  paddingBottom: 10,
+  paddingTop: theme.spacing(1.25),
+  paddingBottom: theme.spacing(1.25),
 }));
 
 export const NavigatorListItemII = styled(ListItemButton, {
@@ -196,8 +196,8 @@ export const NavigatorListItemII = styled(ListItemButton, {
       transition: 'opacity 200ms ease-in',
     },
   },
-  paddingTop: 10,
-  paddingBottom: 10,
+  paddingTop: theme.spacing(1.25),
+  paddingBottom: theme.spacing(1.25),
 }));
 
 export const NavigatorListItemIII = styled(ListItemButton, {
@@ -221,8 +221,8 @@ export const NavigatorListItemIII = styled(ListItemButton, {
       transition: 'opacity 200ms ease-in',
     },
   },
-  paddingTop: 10,
-  paddingBottom: 10,
+  paddingTop: theme.spacing(1.25),
+  paddingBottom: theme.spacing(1.25),
   pointerEvents: isShow ? 'none' : 'auto',
   opacity: isShow ? 0.5 : '',
 }));
@@ -248,8 +248,8 @@ export const SideBarListItem = styled(ListItemButton, {
       visibility: 'visible',
     },
   },
-  paddingTop: 10,
-  paddingBottom: 10,
+  paddingTop: theme.spacing(1.25),
+  paddingBottom: theme.spacing(1.25),
   pointerEvents: isShow ? 'none' : 'auto',
   opacity: isShow ? 0.5 : '',
   fontSize: '1rem',

--- a/ui/components/general/style.tsx
+++ b/ui/components/general/style.tsx
@@ -61,8 +61,8 @@ export const StyledListItem = styled(ListItem, {
   cursor: 'pointer',
   backgroundColor: charcoal[30],
   boxShadow: '0 -1px 0 #404854 inset',
-  paddingTop: '1.625rem',
-  paddingBottom: '1.625rem',
+  paddingTop: '1.325rem',
+  paddingBottom: '1.325rem',
   position: 'sticky',
   top: 0,
   zIndex: 5,
@@ -171,8 +171,8 @@ export const NavigatorListItem = styled(ListItemButton, {
       transition: 'opacity 200ms ease-in',
     },
   },
-  paddingTop: 10,
-  paddingBottom: 10,
+  paddingTop: 4,
+  paddingBottom: 4,
 }));
 
 export const NavigatorListItemII = styled(ListItemButton, {
@@ -196,8 +196,8 @@ export const NavigatorListItemII = styled(ListItemButton, {
       transition: 'opacity 200ms ease-in',
     },
   },
-  paddingTop: 10,
-  paddingBottom: 10,
+  paddingTop: 4,
+  paddingBottom: 4,
 }));
 
 export const NavigatorListItemIII = styled(ListItemButton, {
@@ -221,8 +221,8 @@ export const NavigatorListItemIII = styled(ListItemButton, {
       transition: 'opacity 200ms ease-in',
     },
   },
-  paddingTop: 10,
-  paddingBottom: 10,
+  paddingTop: 4,
+  paddingBottom: 4,
   pointerEvents: isShow ? 'none' : 'auto',
   opacity: isShow ? 0.5 : '',
 }));
@@ -248,8 +248,8 @@ export const SideBarListItem = styled(ListItemButton, {
       visibility: 'visible',
     },
   },
-  paddingTop: 10,
-  paddingBottom: 10,
+  paddingTop: 4,
+  paddingBottom: 4,
   pointerEvents: isShow ? 'none' : 'auto',
   opacity: isShow ? 0.5 : '',
   fontSize: '1rem',
@@ -414,8 +414,8 @@ export const NavigatorLink = styled('span')({
 
 export const HelpListItem = styled(ListItem)(({ theme }) => ({
   paddingLeft: 0,
-  paddingTop: 10,
-  paddingBottom: 10,
+  paddingTop: 4,
+  paddingBottom: 4,
   color: theme.palette.background.constant.disabled,
   fill: theme.palette.background.constant.white,
   '&:hover': {

--- a/ui/components/registry/RegistryModal.test.tsx
+++ b/ui/components/registry/RegistryModal.test.tsx
@@ -50,6 +50,8 @@ vi.mock('@sistent/sistent', () => ({
     React.createElement('svg', { 'data-component': 'chevron-left-icon', ...props }),
   ChevronRightIcon: (props) =>
     React.createElement('svg', { 'data-component': 'chevron-right-icon', ...props }),
+  LeftArrowIcon: (props) =>
+    React.createElement('svg', { 'data-component': 'left-arrow-icon', ...props }),
   FileIcon: () => <svg data-testid="file-icon" />,
   InfoIcon: () => <svg data-testid="info-icon" />,
   DatabaseIcon: () => <svg data-testid="database-icon" />,
@@ -150,6 +152,19 @@ vi.mock('@/rtk-query/meshModel', () => ({
 
 vi.mock('./helper', () => ({
   removeDuplicateVersions: (m: any[]) => m,
+}));
+
+vi.mock('../general/style', () => ({
+  ChevronButtonWrapper: ({ children, onClick, isCollapsed }: any) => (
+    <button
+      type="button"
+      onClick={onClick}
+      data-collapsed={String(!!isCollapsed)}
+      data-testid="sidebar-collapse-toggle"
+    >
+      {children}
+    </button>
+  ),
 }));
 
 import RegistryModal, { Navigation } from './RegistryModal';

--- a/ui/components/registry/RegistryModal.tsx
+++ b/ui/components/registry/RegistryModal.tsx
@@ -135,11 +135,7 @@ const StyledRegistryModal = styled(Modal)(({ theme }) => ({
     height: '80%',
   },
   '& .MuiDialog-paperFullScreen': {
-    margin: '0 !important',
-    width: '100% !important',
-    height: '100% !important',
-    maxWidth: '100% !important',
-    maxHeight: '100% !important',
+    margin: 0,
   },
   '& .MuiDialog-paper': {
     maxWidth: '100%',

--- a/ui/components/registry/RegistryModal.tsx
+++ b/ui/components/registry/RegistryModal.tsx
@@ -130,12 +130,16 @@ const StyledMainContent = styled(Box)(() => ({
 // screens. Mirrors the legacy `StyledModal` behaviour.
 const StyledRegistryModal = styled(Modal)(({ theme }) => ({
   zIndex: 1500,
-  '& .MuiDialog-paperFullScreen': {
-    margin: 0,
-  },
-  '& .MuiDialog-paperFullWidth': {
+  '& .MuiDialog-paperFullWidth:not(.MuiDialog-paperFullScreen)': {
     width: '90%',
     height: '80%',
+  },
+  '& .MuiDialog-paperFullScreen': {
+    margin: '0 !important',
+    width: '100% !important',
+    height: '100% !important',
+    maxWidth: '100% !important',
+    maxHeight: '100% !important',
   },
   '& .MuiDialog-paper': {
     maxWidth: '100%',

--- a/ui/components/registry/RegistryModal.tsx
+++ b/ui/components/registry/RegistryModal.tsx
@@ -328,17 +328,22 @@ export const Navigation: FC<NavigationProps> = ({ setHeaderInfo }) => {
       <ChevronButtonWrapper
         isCollapsed={!open}
         onClick={handleDrawerToggle}
-        style={{
+        sx={{
           position: 'absolute',
           bottom: '12%',
-          left: open ? `${DRAWER_WIDTH}px` : `calc(${theme.spacing(8)} + 1px - 1.2rem)`,
+          left: open
+            ? `${DRAWER_WIDTH}px`
+            : {
+                xs: `calc(${theme.spacing(7)} + 1px - 1.2rem)`,
+                sm: `calc(${theme.spacing(8)} + 1px - 1.2rem)`,
+              },
           right: 'auto',
           top: 'auto',
           zIndex: 1400,
         }}
       >
         <LeftArrowIcon
-          alt="Sidebar collapse toggle"
+          aria-label="Sidebar collapse toggle"
           style={{
             cursor: 'pointer',
             verticalAlign: 'middle',

--- a/ui/components/registry/RegistryModal.tsx
+++ b/ui/components/registry/RegistryModal.tsx
@@ -14,9 +14,7 @@ import { useContext, useState, useEffect, ReactNode, FC } from 'react';
 import {
   ModalBody,
   List,
-  ChevronLeftIcon,
-  ChevronRightIcon,
-  IconButton,
+  LeftArrowIcon,
   ListItem,
   ListItemButton,
   ListItemIcon,
@@ -31,6 +29,7 @@ import {
 } from '@sistent/sistent';
 import { styled, useTheme } from '@/theme';
 import { Modal } from '@/components/shared/Modal';
+import { ChevronButtonWrapper } from '../general/style';
 import ConnectionIcon from '@/assets/icons/Connection';
 import ComponentIcon from '@/assets/icons/Component';
 import MeshModelComponent from './MeshModelComponent';
@@ -46,17 +45,6 @@ import {
 import { removeDuplicateVersions } from './helper';
 
 const DRAWER_WIDTH = 250;
-
-const DrawerHeader = styled('div', {
-  shouldForwardProp: (prop) => prop !== 'open',
-})<{ open?: boolean }>(({ theme, open }) => ({
-  display: 'flex',
-  alignItems: 'flex-end',
-  justifyContent: open ? 'flex-end' : 'center',
-  marginBottom: '1rem',
-  height: '100%',
-  ...theme.mixins.toolbar,
-}));
 
 const StyledDrawer = styled(Drawer, { shouldForwardProp: (prop) => prop !== 'open' })<{
   open?: boolean;
@@ -329,11 +317,6 @@ export const Navigation: FC<NavigationProps> = ({ setHeaderInfo }) => {
             />
           ))}
         </List>
-        <DrawerHeader open={open}>
-          <IconButton onClick={handleDrawerToggle}>
-            {open ? <ChevronLeftIcon /> : <ChevronRightIcon />}
-          </IconButton>
-        </DrawerHeader>
       </StyledDrawer>
       <StyledMainContent>
         <RegistryContentWrapper
@@ -342,6 +325,30 @@ export const Navigation: FC<NavigationProps> = ({ setHeaderInfo }) => {
           selectedItemUUID={selectedItemUUID}
         />
       </StyledMainContent>
+      <ChevronButtonWrapper
+        isCollapsed={!open}
+        onClick={handleDrawerToggle}
+        style={{
+          position: 'absolute',
+          bottom: '12%',
+          left: open ? `${DRAWER_WIDTH}px` : `calc(${theme.spacing(8)} + 1px - 1.2rem)`,
+          right: 'auto',
+          top: 'auto',
+          zIndex: 1400,
+        }}
+      >
+        <LeftArrowIcon
+          alt="Sidebar collapse toggle"
+          style={{
+            cursor: 'pointer',
+            verticalAlign: 'middle',
+          }}
+          fill={theme.palette.icon.default}
+          stroke={theme.palette.icon.default}
+          width="1.2rem"
+          height="2.8rem"
+        />
+      </ChevronButtonWrapper>
     </Box>
   );
 };

--- a/ui/components/shared/Modal/Modal.tsx
+++ b/ui/components/shared/Modal/Modal.tsx
@@ -102,6 +102,7 @@ export const Modal: FC<ModalProps> = ({
       headerIcon={headerIcon}
       maxWidth={sizeToMaxWidth[size]}
       {...(size === 'fullscreen' ? { fullScreen: true } : {})}
+      fullWidth
       isFullScreenModeAllowed={isFullScreenModeAllowed}
       className={className}
       sx={sx}

--- a/ui/components/shared/Modal/Modal.tsx
+++ b/ui/components/shared/Modal/Modal.tsx
@@ -101,8 +101,7 @@ export const Modal: FC<ModalProps> = ({
       title={title}
       headerIcon={headerIcon}
       maxWidth={sizeToMaxWidth[size]}
-      fullScreen={size === 'fullscreen'}
-      fullWidth
+      {...(size === 'fullscreen' ? { fullScreen: true } : {})}
       isFullScreenModeAllowed={isFullScreenModeAllowed}
       className={className}
       sx={sx}


### PR DESCRIPTION
**Notes for Reviewers**

- This PR updates the shared `Modal` wrapper to stop overriding the internal fullscreen behavior of `SistentModal`.
- Previously, the wrapper always supplied fullscreen-related props, which prevented `SistentModal` from managing its own fullscreen state. As a result, clicking **Enter Fullscreen** updated the modal's internal state but did not expand the modal because the wrapper immediately forced it back to its default size.
This PR fixes #20130

**[Signed commits](https://github.com/meshery/meshery/blob/master/CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [ ] Yes, I signed my commits.

<!--
Thank you for contributing to Meshery! 

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. Sign your commits.
4. Include before and after screenshots/terminal output.

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.
-->
