### PR TITLE
[Server] Verify connection kind before updating MeshSync deployment mode

### DIFF
--- a/server/handlers/connections_handlers.go
+++ b/server/handlers/connections_handlers.go
@@ -378,12 +378,11 @@ func (h *Handler) UpdateConnectionById(w http.ResponseWriter, req *http.Request,
 		return
 	}
 
-	// Check if meshsync deployment mode is specified in the payload metadata.
-	// Only handle mode changes if a mode is explicitly provided (not undefined).
-	// In fact this method is used (for now) only for perform meshsync deployment mode change.
-	// If mode change fails return error.
-	// TODO: also check that kind = "kubernetes" (when client starts to send full connection object)
-	if connections.MeshsyncDeploymentModeFromMetadata(connection.MetaData) != connections.MeshsyncDeploymentModeUndefined {
+	// MeshSync is a Kubernetes-only component. If the client sends Kind explicitly and it is
+	// not "kubernetes", skip this block. If Kind is omitted, handleMeshSyncDeploymentModeChange
+	// verifies the persisted connection kind internally.
+	if connections.MeshsyncDeploymentModeFromMetadata(connection.MetaData) != connections.MeshsyncDeploymentModeUndefined &&
+		(connection.Kind == "" || strings.EqualFold(connection.Kind, "kubernetes")) {
 		// Handle meshsync deployment mode changes before connection update
 		token, _ := req.Context().Value(models.TokenCtxKey).(string)
 		oldMode, newMode, modeChanged, err := h.handleMeshSyncDeploymentModeChange(


### PR DESCRIPTION
### Notes for Reviewers
This PR fixes [Server] Verify connection Kind is "kubernetes" before updating MeshSync deployment mode #20137

### Summary
MeshSync is a Kubernetes-only component, but the connection update handler (`UpdateConnectionById`) was processing MeshSync deployment mode changes for all connection kinds whenever deployment mode metadata was present in the payload.

### Changes
Added a Kind guard to the existing condition so MeshSync handling is skipped when the client explicitly sends a non-kubernetes Kind.

When `Kind` is omitted from the payload (which is the current UI behavior — RTK Query only sends `{ status, metadata }`), the condition allows entry and `handleMeshSyncDeploymentModeChange` verifies the persisted connection kind internally via its existing `GetConnectionByID` + `Kind != "kubernetes"` guard.

**Before:**
```go
// TODO: also check that kind = "kubernetes" (when client starts to send full connection object)
if connections.MeshsyncDeploymentModeFromMetadata(connection.MetaData) != connections.MeshsyncDeploymentModeUndefined {