### PR TITLE
[refactor] Standardize Method Not Allowed error in ServerEventConfigu…

### DIFF
--- a/server/handlers/server_events_configuration_handler.go
+++ b/server/handlers/server_events_configuration_handler.go
@@ -74,8 +74,7 @@ func (h *Handler) ServerEventConfigurationHandler(w http.ResponseWriter, req *ht
 	case http.MethodGet:
 		h.ServerEventConfigurationGet(w, req, prefObj, user, provider)
 	default:
-		// TODO(error-code): promote to MeshKit code
-		writeJSONError(w, "Method not allowed", http.StatusMethodNotAllowed)
+		writeMeshkitError(w, ErrMethodNotAllowed(req.Method), http.StatusMethodNotAllowed)
 	}
 }
 


### PR DESCRIPTION
## Description

This PR standardizes the response for unsupported HTTP methods in `ServerEventConfigurationHandler` by replacing the ad-hoc JSON error helper with Meshery's structured MeshKit error framework.

### Changes

Replaced:

```go
writeJSONError(w, "Method not allowed", http.StatusMethodNotAllowed)
```

with:

```go
writeMeshkitError(w, ErrMethodNotAllowed(req.Method), http.StatusMethodNotAllowed)
```

### Why

Previously, the handler returned a minimal response:

```json
{
  "error": "Method not allowed"
}
```

This bypassed Meshery's standardized error framework and omitted metadata such as:

- Error code
- Severity
- Probable cause
- Suggested remediation
- Long description

Using the existing `ErrMethodNotAllowed(req.Method)` helper aligns this endpoint with the rest of the codebase and reuses the already registered error code `meshery-server-1408`.

### Impact Analysis

- No change in HTTP status code (`405 Method Not Allowed` remains unchanged).
- No frontend changes required.
- No OpenAPI changes required.
- No new error codes introduced.
- No additional imports required.
- No backend or frontend tests depend on the previous response body.
- Request handling behavior remains unchanged.

### Notes for Reviewers

- Reuses the existing `ErrMethodNotAllowed(req.Method)` helper.
- Follows the same pattern already used elsewhere in the handlers package.
- This change only standardizes the error response structure and does not alter endpoint behavior.

Fixes #20162

## [Signed commits](https://github.com/meshery/meshery/blob/master/CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)

- [x] Yes, I signed my commits.