### PR TITLE
refactor: migrate UUID library from gofrs/uuid to google/uuid

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -45,7 +45,7 @@ require (
 	github.com/jinzhu/copier v0.4.0
 	github.com/manifoldco/promptui v0.9.0
 	github.com/meshery/meshery-operator v0.8.11
-	github.com/meshery/meshkit v1.0.14
+	github.com/meshery/meshkit v1.0.15
 	github.com/meshery/meshsync v1.0.0
 	github.com/meshery/schemas v1.3.12
 	github.com/nsf/termbox-go v1.1.1

--- a/go.mod
+++ b/go.mod
@@ -45,9 +45,9 @@ require (
 	github.com/jinzhu/copier v0.4.0
 	github.com/manifoldco/promptui v0.9.0
 	github.com/meshery/meshery-operator v0.8.11
-	github.com/meshery/meshkit v1.0.13
+	github.com/meshery/meshkit v1.0.14
 	github.com/meshery/meshsync v1.0.0
-	github.com/meshery/schemas v1.3.10
+	github.com/meshery/schemas v1.3.12
 	github.com/nsf/termbox-go v1.1.1
 	github.com/oapi-codegen/runtime v1.4.1
 	github.com/olekukonko/tablewriter v1.1.4

--- a/go.mod
+++ b/go.mod
@@ -34,7 +34,6 @@ require (
 	github.com/ghodss/yaml v1.0.0
 	github.com/go-openapi/strfmt v0.25.0
 	github.com/go-playground/validator/v10 v10.30.1
-	github.com/gofrs/uuid v4.4.0+incompatible
 	github.com/golang-jwt/jwt/v5 v5.3.0
 	github.com/google/go-cmp v0.7.0
 	github.com/google/uuid v1.6.0
@@ -230,6 +229,7 @@ require (
 	github.com/gocarina/gocsv v0.0.0-20240520201108-78e41c74b4b1 // indirect
 	github.com/goccy/go-json v0.10.5 // indirect
 	github.com/gofrs/flock v0.13.0 // indirect
+	github.com/gofrs/uuid v4.4.0+incompatible // indirect
 	github.com/gogo/protobuf v1.3.2 // indirect
 	github.com/golang/groupcache v0.0.0-20241129210726-2c02b8208cf8 // indirect
 	github.com/golang/protobuf v1.5.4 // indirect

--- a/go.sum
+++ b/go.sum
@@ -698,12 +698,8 @@ github.com/maxatome/go-testdeep v1.14.0 h1:rRlLv1+kI8eOI3OaBXZwb3O7xY3exRzdW5QyX
 github.com/maxatome/go-testdeep v1.14.0/go.mod h1:lPZc/HAcJMP92l7yI6TRz1aZN5URwUBUAfUNvrclaNM=
 github.com/meshery/meshery-operator v0.8.11 h1:eDo2Sw0jjVrXsvvhF8LenADM58pK+7Z68ROPVIejTPc=
 github.com/meshery/meshery-operator v0.8.11/go.mod h1:hQEtFKKa5Fr/Mskk6bV5ip3bQ0+3F0u1voYS3XisBp4=
-github.com/meshery/meshkit v1.0.13 h1:jAbg2w36MxnHhPMfizS+z0JUWP+7Jh0xdqmuupVQjnk=
-github.com/meshery/meshkit v1.0.13/go.mod h1:gw8kLughiSJE2XNq0QefYTW+CzxJDEBd6hwLiUOczIk=
-github.com/meshery/meshkit v1.0.14-0.20260621024538-0bdfb5363c35 h1:sfsUVySOmRGlz9SSd39yIRhAbLpgFTEaGQWapGyiR6A=
-github.com/meshery/meshkit v1.0.14-0.20260621024538-0bdfb5363c35/go.mod h1:V1/PNdlN3QiOVRooP/7TpEPcyQY2MCyJ3EMMeWlJyDY=
-github.com/meshery/meshkit v1.0.14 h1:nDGTvJppGGMjHTEXuAVxmlduxHHM3K3CZZs8p90g3sg=
-github.com/meshery/meshkit v1.0.14/go.mod h1:V1/PNdlN3QiOVRooP/7TpEPcyQY2MCyJ3EMMeWlJyDY=
+github.com/meshery/meshkit v1.0.15 h1:sLHMseryAdW+z+PJNl+whoqw+FUdCW62zpiiwwPD9GQ=
+github.com/meshery/meshkit v1.0.15/go.mod h1:V1/PNdlN3QiOVRooP/7TpEPcyQY2MCyJ3EMMeWlJyDY=
 github.com/meshery/meshsync v1.0.0 h1:BIHEVG4BDjqOnSd3vBt9B4IfWJNTfMRAgdwLroBcCfY=
 github.com/meshery/meshsync v1.0.0/go.mod h1:mFsPXkZRiCSuk5DhxBTrkWdlo6peItRBUoIEEQCovIg=
 github.com/meshery/schemas v1.3.12 h1:KBP7rN8KnL29yeCfiK8Y1LVfDnzxjgvoUao5bHS8yFM=

--- a/go.sum
+++ b/go.sum
@@ -700,10 +700,14 @@ github.com/meshery/meshery-operator v0.8.11 h1:eDo2Sw0jjVrXsvvhF8LenADM58pK+7Z68
 github.com/meshery/meshery-operator v0.8.11/go.mod h1:hQEtFKKa5Fr/Mskk6bV5ip3bQ0+3F0u1voYS3XisBp4=
 github.com/meshery/meshkit v1.0.13 h1:jAbg2w36MxnHhPMfizS+z0JUWP+7Jh0xdqmuupVQjnk=
 github.com/meshery/meshkit v1.0.13/go.mod h1:gw8kLughiSJE2XNq0QefYTW+CzxJDEBd6hwLiUOczIk=
+github.com/meshery/meshkit v1.0.14-0.20260621024538-0bdfb5363c35 h1:sfsUVySOmRGlz9SSd39yIRhAbLpgFTEaGQWapGyiR6A=
+github.com/meshery/meshkit v1.0.14-0.20260621024538-0bdfb5363c35/go.mod h1:V1/PNdlN3QiOVRooP/7TpEPcyQY2MCyJ3EMMeWlJyDY=
+github.com/meshery/meshkit v1.0.14 h1:nDGTvJppGGMjHTEXuAVxmlduxHHM3K3CZZs8p90g3sg=
+github.com/meshery/meshkit v1.0.14/go.mod h1:V1/PNdlN3QiOVRooP/7TpEPcyQY2MCyJ3EMMeWlJyDY=
 github.com/meshery/meshsync v1.0.0 h1:BIHEVG4BDjqOnSd3vBt9B4IfWJNTfMRAgdwLroBcCfY=
 github.com/meshery/meshsync v1.0.0/go.mod h1:mFsPXkZRiCSuk5DhxBTrkWdlo6peItRBUoIEEQCovIg=
-github.com/meshery/schemas v1.3.10 h1:54MdwAisIccO61hdlNfzV3BC+K+qf6ozR9veElnjexg=
-github.com/meshery/schemas v1.3.10/go.mod h1:Ms8bfwux/bAiogaSJirBaLwkvPxOsCT4KCH76SlhU0E=
+github.com/meshery/schemas v1.3.12 h1:KBP7rN8KnL29yeCfiK8Y1LVfDnzxjgvoUao5bHS8yFM=
+github.com/meshery/schemas v1.3.12/go.mod h1:Ms8bfwux/bAiogaSJirBaLwkvPxOsCT4KCH76SlhU0E=
 github.com/miekg/dns v1.1.57 h1:Jzi7ApEIzwEPLHWRcafCN9LZSBbqQpxjt/wpgvg7wcM=
 github.com/miekg/dns v1.1.57/go.mod h1:uqRjCRUuEAA6qsOiJvDd+CFo/vW+y5WR6SNmHE55hZk=
 github.com/miekg/pkcs11 v1.0.2/go.mod h1:XsNlhZGX73bx86s2hdc/FuaLm2CPZJemRLMA+WTFxgs=

--- a/mesheryctl/internal/cli/root/connections/view.go
+++ b/mesheryctl/internal/cli/root/connections/view.go
@@ -21,7 +21,7 @@ import (
 	"path/filepath"
 	"strings"
 
-	"github.com/gofrs/uuid"
+	"github.com/google/uuid"
 	"github.com/meshery/meshery/mesheryctl/internal/cli/pkg/api"
 	"github.com/meshery/meshery/mesheryctl/internal/cli/pkg/display"
 	"github.com/meshery/meshery/mesheryctl/pkg/utils"
@@ -150,7 +150,7 @@ func selectConnectionPrompt(connectionsList []*connection.Connection) (*connecti
 }
 
 func isArgumentUUID(arg string) bool {
-	_, err := uuid.FromString(arg)
+	_, err := uuid.Parse(arg)
 	return err == nil
 }
 

--- a/mesheryctl/internal/cli/root/environments/create.go
+++ b/mesheryctl/internal/cli/root/environments/create.go
@@ -18,7 +18,7 @@ import (
 	"bytes"
 	"encoding/json"
 
-	googleUUID "github.com/google/uuid"
+	"github.com/google/uuid"
 	"github.com/meshery/meshery/mesheryctl/internal/cli/pkg/api"
 	mesheryctlflags "github.com/meshery/meshery/mesheryctl/internal/cli/pkg/flags"
 	"github.com/meshery/meshery/mesheryctl/pkg/utils"
@@ -47,7 +47,7 @@ mesheryctl environment create --orgId [orgId] --name [name] --description [descr
 		return mesheryctlflags.ValidateCmdFlags(cmd, &createEnvironmentFlags)
 	},
 	RunE: func(cmd *cobra.Command, args []string) error {
-		organizationID, err := googleUUID.Parse(createEnvironmentFlags.OrganizationID)
+		organizationID, err := uuid.Parse(createEnvironmentFlags.OrganizationID)
 		if err != nil {
 			return err
 		}

--- a/mesheryctl/internal/cli/root/perf/result.go
+++ b/mesheryctl/internal/cli/root/perf/result.go
@@ -21,7 +21,7 @@ import (
 	"strings"
 	"time"
 
-	"github.com/gofrs/uuid"
+	"github.com/google/uuid"
 
 	"github.com/meshery/meshery/mesheryctl/internal/cli/pkg/display"
 	"github.com/meshery/meshery/mesheryctl/internal/cli/root/config"

--- a/mesheryctl/internal/cli/root/perf/result_test.go
+++ b/mesheryctl/internal/cli/root/perf/result_test.go
@@ -7,7 +7,7 @@ import (
 	"runtime"
 	"testing"
 
-	"github.com/gofrs/uuid"
+	"github.com/google/uuid"
 	"github.com/meshery/meshery/mesheryctl/internal/cli/pkg/display"
 	"github.com/meshery/meshery/mesheryctl/pkg/utils"
 	core "github.com/meshery/schemas/models/core"

--- a/mesheryctl/internal/cli/root/workspaces/create.go
+++ b/mesheryctl/internal/cli/root/workspaces/create.go
@@ -19,7 +19,7 @@ import (
 	"encoding/json"
 	"fmt"
 
-	googleUUID "github.com/google/uuid"
+	"github.com/google/uuid"
 	"github.com/meshery/meshery/mesheryctl/internal/cli/pkg/api"
 	mesheryctlflags "github.com/meshery/meshery/mesheryctl/internal/cli/pkg/flags"
 	"github.com/meshery/meshery/mesheryctl/pkg/utils"
@@ -50,7 +50,7 @@ mesheryctl workspace create --orgId [orgId] --name [name] --description [descrip
 		return mesheryctlflags.ValidateCmdFlags(cmd, &workspaceCreateFlags)
 	},
 	RunE: func(cmd *cobra.Command, args []string) error {
-		organizationID, err := googleUUID.Parse(workspaceCreateFlags.OrganizationID)
+		organizationID, err := uuid.Parse(workspaceCreateFlags.OrganizationID)
 		if err != nil {
 			return err
 		}

--- a/server/cmd/main.go
+++ b/server/cmd/main.go
@@ -17,7 +17,7 @@ import (
 
 	"github.com/fsnotify/fsnotify"
 
-	"github.com/gofrs/uuid"
+	"github.com/google/uuid"
 	"github.com/meshery/meshery/mesheryctl/pkg/constants"
 	"github.com/meshery/meshery/server/handlers"
 	"github.com/meshery/meshery/server/helpers"
@@ -101,11 +101,7 @@ func main() {
 		log.SetLevel(logrus.Level(viper.GetInt("LOG_LEVEL")))
 	})
 
-	instanceID, err := uuid.NewV4()
-	if err != nil {
-		log.Error(ErrCreatingUUIDInstance(err))
-		os.Exit(1)
-	}
+	instanceID := uuid.New()
 
 	// operatingSystem, err := exec.Command("uname", "-s").Output()
 	// if err != nil {
@@ -218,7 +214,7 @@ func main() {
 	queryTracker := helpers.NewUUIDQueryTracker()
 
 	// Uncomment line below to generate a new UUID and force the user to login every time Meshery is started.
-	// fileSessionStore := sessions.NewFilesystemStore("", []byte(uuid.NewV4().Bytes()))
+	// fileSessionStore := sessions.NewFilesystemStore("", []byte(uuid.New().Bytes()))
 	// fileSessionStore := sessions.NewFilesystemStore("", []byte("Meshery"))
 	// fileSessionStore.MaxLength(0)
 

--- a/server/handlers/component_handler.go
+++ b/server/handlers/component_handler.go
@@ -13,7 +13,7 @@ import (
 	"strings"
 	"sync"
 
-	"github.com/gofrs/uuid"
+	"github.com/google/uuid"
 	"github.com/gorilla/mux"
 
 	"github.com/meshery/meshery/server/helpers"
@@ -1504,7 +1504,7 @@ func RegisterEntity(content []byte, entityType entity.EntityType, h *Handler) er
 
 func (h *Handler) DeleteModel(rw http.ResponseWriter, r *http.Request, _ *models.Preference, _ *models.User, provider models.Provider) {
 	modelID := mux.Vars(r)["id"]
-	modelUUID, err := uuid.FromString(modelID)
+	modelUUID, err := uuid.Parse(modelID)
 	if err != nil {
 		h.log.Error(ErrInvalidUUID(err))
 		writeMeshkitError(rw, ErrInvalidUUID(err), http.StatusBadRequest)

--- a/server/handlers/connection_definition_handler.go
+++ b/server/handlers/connection_definition_handler.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"net/http"
 
-	"github.com/gofrs/uuid"
+	"github.com/google/uuid"
 	"github.com/gorilla/mux"
 	"gorm.io/gorm"
 	"gorm.io/gorm/clause"
@@ -90,7 +90,7 @@ func (h *Handler) GetConnectionDefinitions(rw http.ResponseWriter, r *http.Reque
 func (h *Handler) GetConnectionDefinitionByID(rw http.ResponseWriter, r *http.Request) {
 	rw.Header().Add("Content-Type", "application/json")
 	connectionDefinitionID := mux.Vars(r)["connectionDefinitionId"]
-	if _, err := uuid.FromString(connectionDefinitionID); err != nil {
+	if _, err := uuid.Parse(connectionDefinitionID); err != nil {
 		h.log.Error(ErrInvalidUUID(err))
 		writeMeshkitError(rw, ErrInvalidUUID(err), http.StatusBadRequest)
 		return
@@ -164,7 +164,7 @@ func (h *Handler) RegisterConnectionDefinition(rw http.ResponseWriter, r *http.R
 func (h *Handler) UpdateConnectionDefinition(rw http.ResponseWriter, r *http.Request, _ *models.Preference, _ *models.User, _ models.Provider) {
 	obj := "connection definition"
 	connectionDefinitionID := mux.Vars(r)["connectionDefinitionId"]
-	id, err := uuid.FromString(connectionDefinitionID)
+	id, err := uuid.Parse(connectionDefinitionID)
 	if err != nil {
 		h.log.Error(ErrInvalidUUID(err))
 		writeMeshkitError(rw, ErrInvalidUUID(err), http.StatusBadRequest)
@@ -203,7 +203,7 @@ func (h *Handler) UpdateConnectionDefinition(rw http.ResponseWriter, r *http.Req
 //	204:
 func (h *Handler) DeleteConnectionDefinition(rw http.ResponseWriter, r *http.Request, _ *models.Preference, _ *models.User, _ models.Provider) {
 	connectionDefinitionID := mux.Vars(r)["connectionDefinitionId"]
-	id, err := uuid.FromString(connectionDefinitionID)
+	id, err := uuid.Parse(connectionDefinitionID)
 	if err != nil {
 		h.log.Error(ErrInvalidUUID(err))
 		writeMeshkitError(rw, ErrInvalidUUID(err), http.StatusBadRequest)

--- a/server/handlers/connections_handlers.go
+++ b/server/handlers/connections_handlers.go
@@ -11,7 +11,7 @@ import (
 
 	"github.com/meshery/schemas/models/core"
 
-	"github.com/gofrs/uuid"
+	"github.com/google/uuid"
 	"github.com/gorilla/mux"
 	"github.com/meshery/meshery/server/machines"
 	"github.com/meshery/meshery/server/machines/helpers"
@@ -104,7 +104,7 @@ func (h *Handler) handleProcessTermination(w http.ResponseWriter, req *http.Requ
 
 	id, ok := body["id"]
 	if ok {
-		smInstancetracker.Remove(uuid.FromStringOrNil(id))
+		smInstancetracker.Remove(parseUUIDOrNil(id))
 	}
 }
 
@@ -131,7 +131,7 @@ func (h *Handler) handleRegistrationInitEvent(w http.ResponseWriter, req *http.R
 	}
 	// id act as a connection registration process tracker.
 	// The clients should always include this "id" in the subsequent API calls until the process is completed or terminated.
-	id, _ := uuid.NewV4()
+	id := uuid.New()
 	schema["id"] = id
 
 	err := json.NewEncoder(w).Encode(&schema)
@@ -331,7 +331,7 @@ func (h *Handler) GetConnectionsByKind(w http.ResponseWriter, req *http.Request,
 }
 
 func (h *Handler) GetConnectionByID(w http.ResponseWriter, req *http.Request, _ *models.Preference, user *models.User, provider models.Provider) {
-	connectionID := uuid.FromStringOrNil(mux.Vars(req)["connectionId"])
+	connectionID := parseUUIDOrNil(mux.Vars(req)["connectionId"])
 	if connectionID == uuid.Nil {
 		invalidIDErr := ErrInvalidUUID(fmt.Errorf("invalid connection ID"))
 		h.log.Error(invalidIDErr)
@@ -357,7 +357,7 @@ func (h *Handler) GetConnectionByID(w http.ResponseWriter, req *http.Request, _ 
 }
 
 func (h *Handler) UpdateConnectionById(w http.ResponseWriter, req *http.Request, _ *models.Preference, user *models.User, provider models.Provider) {
-	connectionID := uuid.FromStringOrNil(mux.Vars(req)["connectionId"])
+	connectionID := parseUUIDOrNil(mux.Vars(req)["connectionId"])
 	userID := user.ID
 
 	bd, err := io.ReadAll(req.Body)
@@ -545,7 +545,7 @@ func (h *Handler) NotifySmOfConnectionStatusChange(ctx context.Context, userID c
 }
 
 func (h *Handler) DeleteConnection(w http.ResponseWriter, req *http.Request, _ *models.Preference, user *models.User, provider models.Provider) {
-	connectionID := uuid.FromStringOrNil(mux.Vars(req)["connectionId"])
+	connectionID := parseUUIDOrNil(mux.Vars(req)["connectionId"])
 	userID := user.ID
 	token, err := provider.GetProviderToken(req)
 	if err != nil {

--- a/server/handlers/contexts_handler.go
+++ b/server/handlers/contexts_handler.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"net/http"
 
-	"github.com/google/uuid"
 	"github.com/gorilla/mux"
 	"github.com/meshery/meshery/server/machines"
 	mhelpers "github.com/meshery/meshery/server/machines/helpers"

--- a/server/handlers/contexts_handler.go
+++ b/server/handlers/contexts_handler.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"net/http"
 
-	"github.com/gofrs/uuid"
+	"github.com/google/uuid"
 	"github.com/gorilla/mux"
 	"github.com/meshery/meshery/server/machines"
 	mhelpers "github.com/meshery/meshery/server/machines/helpers"
@@ -71,7 +71,7 @@ func (h *Handler) DeleteContext(w http.ResponseWriter, req *http.Request, _ *mod
 	userID := user.ID
 	contextID := mux.Vars(req)["id"]
 
-	eventBuilder := events.NewEvent().ActedUpon(uuid.FromStringOrNil(contextID)).FromOwner(userID).FromSystem(*h.SystemID).WithCategory("connection").WithAction("delete")
+	eventBuilder := events.NewEvent().ActedUpon(parseUUIDOrNil(contextID)).FromOwner(userID).FromSystem(*h.SystemID).WithCategory("connection").WithAction("delete")
 
 	token, ok := req.Context().Value(models.TokenCtxKey).(string)
 	if !ok {
@@ -102,7 +102,7 @@ func (h *Handler) DeleteContext(w http.ResponseWriter, req *http.Request, _ *mod
 		RegistryManager:    h.registryManager,
 	}
 
-	connectionUUID := uuid.FromStringOrNil(contextID)
+	connectionUUID := parseUUIDOrNil(contextID)
 
 	inst, err := mhelpers.InitializeMachineWithContext(
 		machineCtx,

--- a/server/handlers/credentials_handlers.go
+++ b/server/handlers/credentials_handlers.go
@@ -7,7 +7,6 @@ import (
 	"net/http"
 	"strconv"
 
-	"github.com/google/uuid"
 	"github.com/gorilla/mux"
 	"github.com/meshery/meshery/server/models"
 )

--- a/server/handlers/credentials_handlers.go
+++ b/server/handlers/credentials_handlers.go
@@ -7,7 +7,7 @@ import (
 	"net/http"
 	"strconv"
 
-	"github.com/gofrs/uuid"
+	"github.com/google/uuid"
 	"github.com/gorilla/mux"
 	"github.com/meshery/meshery/server/models"
 )
@@ -50,7 +50,7 @@ func (h *Handler) SaveUserCredential(w http.ResponseWriter, req *http.Request, _
 }
 
 func (h *Handler) GetUserCredentialByID(w http.ResponseWriter, req *http.Request, _ *models.Preference, user *models.User, provider models.Provider) {
-	credentialID := uuid.FromStringOrNil(mux.Vars(req)["credentialID"])
+	credentialID := parseUUIDOrNil(mux.Vars(req)["credentialID"])
 	token, _ := req.Context().Value(models.TokenCtxKey).(string)
 	credential, statusCode, err := provider.GetCredentialByID(token, credentialID)
 	if err != nil {
@@ -142,7 +142,7 @@ func (h *Handler) UpdateUserCredential(w http.ResponseWriter, req *http.Request,
 func (h *Handler) DeleteUserCredential(w http.ResponseWriter, req *http.Request, _ *models.Preference, _ *models.User, provider models.Provider) {
 	q := req.URL.Query()
 
-	credentialID := uuid.FromStringOrNil(q.Get("credential_id"))
+	credentialID := parseUUIDOrNil(q.Get("credential_id"))
 	_, err := provider.DeleteUserCredential(req, credentialID)
 	if err != nil {
 		h.log.Error(ErrDeleteUserCredential(err))

--- a/server/handlers/credentials_handlers_test.go
+++ b/server/handlers/credentials_handlers_test.go
@@ -9,7 +9,7 @@ import (
 	"sync/atomic"
 	"testing"
 
-	"github.com/gofrs/uuid"
+	"github.com/google/uuid"
 	"github.com/meshery/meshery/server/models"
 )
 
@@ -47,8 +47,8 @@ func (m *credentialSpyProvider) UpdateUserCredential(_ *http.Request, c *models.
 // to the authenticated user's ID after unmarshal precisely so this
 // overwrite attempt fails safely.
 func TestSaveUserCredential_ClientSuppliedUserIdCannotOverride(t *testing.T) {
-	authUser := &models.User{ID: uuid.Must(uuid.FromString("11111111-1111-1111-1111-111111111111"))}
-	attacker := uuid.Must(uuid.FromString("22222222-2222-2222-2222-222222222222"))
+	authUser := &models.User{ID: uuid.MustParse("11111111-1111-1111-1111-111111111111")}
+	attacker := uuid.MustParse("22222222-2222-2222-2222-222222222222")
 	body := fmt.Sprintf(`{"userId":%q,"name":"poisoned","type":"token","secret":{"k":"v"}}`, attacker)
 
 	h := newTestHandler(t, map[string]models.Provider{}, "")
@@ -80,8 +80,8 @@ func TestSaveUserCredential_ClientSuppliedUserIdCannotOverride(t *testing.T) {
 // update onto another user's credential by supplying a foreign
 // `userId` in the body.
 func TestUpdateUserCredential_ClientSuppliedUserIdCannotOverride(t *testing.T) {
-	authUser := &models.User{ID: uuid.Must(uuid.FromString("33333333-3333-3333-3333-333333333333"))}
-	attacker := uuid.Must(uuid.FromString("44444444-4444-4444-4444-444444444444"))
+	authUser := &models.User{ID: uuid.MustParse("33333333-3333-3333-3333-333333333333")}
+	attacker := uuid.MustParse("44444444-4444-4444-4444-444444444444")
 	body := fmt.Sprintf(`{"userId":%q,"id":"abcdefab-abcd-abcd-abcd-abcdefabcdef","name":"renamed","type":"token","secret":{}}`, attacker)
 
 	h := newTestHandler(t, map[string]models.Provider{}, "")

--- a/server/handlers/design_engine_handler.go
+++ b/server/handlers/design_engine_handler.go
@@ -12,7 +12,7 @@ import (
 
 	"github.com/meshery/schemas/models/core"
 
-	"github.com/gofrs/uuid"
+	"github.com/google/uuid"
 	"github.com/meshery/meshery/server/meshes"
 	"github.com/meshery/meshery/server/models"
 	patterncore "github.com/meshery/meshery/server/models/pattern/core"

--- a/server/handlers/events_streamer.go
+++ b/server/handlers/events_streamer.go
@@ -10,7 +10,7 @@ import (
 	"sync"
 	"time"
 
-	"github.com/gofrs/uuid"
+	"github.com/google/uuid"
 	"github.com/gorilla/mux"
 	"github.com/meshery/meshery/server/meshes"
 	"github.com/meshery/meshery/server/models"
@@ -133,7 +133,7 @@ func (h *Handler) GetEventTypes(w http.ResponseWriter, req *http.Request, prefOb
 }
 
 func (h *Handler) UpdateEventStatus(w http.ResponseWriter, req *http.Request, prefObj *models.Preference, user *models.User, provider models.Provider) {
-	eventID := uuid.FromStringOrNil(mux.Vars(req)["id"])
+	eventID := parseUUIDOrNil(mux.Vars(req)["id"])
 	token, _ := req.Context().Value(models.TokenCtxKey).(string)
 
 	defer func() {
@@ -218,7 +218,7 @@ func (h *Handler) BulkDeleteEvent(w http.ResponseWriter, req *http.Request, pref
 }
 
 func (h *Handler) DeleteEvent(w http.ResponseWriter, req *http.Request, prefObj *models.Preference, user *models.User, provider models.Provider) {
-	eventID := uuid.FromStringOrNil(mux.Vars(req)["id"])
+	eventID := parseUUIDOrNil(mux.Vars(req)["id"])
 	token, _ := req.Context().Value(models.TokenCtxKey).(string)
 	err := provider.DeleteEvent(token, eventID)
 
@@ -467,7 +467,7 @@ func listenForCoreEvents(ctx context.Context, eb *_events.EventStreamer, resp ch
 func listenForAdapterEvents(ctx context.Context, mClient *meshes.MeshClient, respChan chan []byte, log logger.Handler, p models.Provider, ec *models.Broadcast, systemID core.Uuid, userID string) {
 	log.Debug("Received a stream client...")
 	token, _ := ctx.Value(models.TokenCtxKey).(string)
-	userUUID := uuid.FromStringOrNil(userID)
+	userUUID := parseUUIDOrNil(userID)
 	streamClient, err := mClient.MClient.StreamEvents(ctx, &meshes.EventsRequest{})
 	if err != nil {
 		log.Error(ErrStreamEvents(err))
@@ -490,7 +490,7 @@ func listenForAdapterEvents(ctx context.Context, mClient *meshes.MeshClient, res
 		// log.Debugf("received an event: %+#v", event)
 		log.Debug("Received an event.")
 		eventType := event.EventType.String()
-		eventBuilder := events.NewEvent().FromSystem(uuid.FromStringOrNil(event.Component)).
+		eventBuilder := events.NewEvent().FromSystem(parseUUIDOrNil(event.Component)).
 			WithSeverity(events.Informational).WithDescription(event.Summary).WithCategory(event.ComponentName).WithAction("deploy").FromOwner(userUUID)
 		if strings.Contains(event.Summary, "removed") {
 			eventBuilder.WithAction("undeploy")

--- a/server/handlers/events_streamer.go
+++ b/server/handlers/events_streamer.go
@@ -557,7 +557,7 @@ func (h *Handler) ClientEventHandler(w http.ResponseWriter, req *http.Request, p
 		return
 	}
 
-	if evt.ActedUpon.IsNil() || evt.Action == "" || evt.Category == "" || evt.Severity == "" {
+	if evt.ActedUpon == uuid.Nil || evt.Action == "" || evt.Category == "" || evt.Severity == "" {
 		h.log.Error(models.ErrInvalidEventData())
 		writeMeshkitError(w, models.ErrInvalidEventData(), http.StatusBadRequest)
 		return

--- a/server/handlers/extension_install_test.go
+++ b/server/handlers/extension_install_test.go
@@ -6,7 +6,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/gofrs/uuid"
+	"github.com/google/uuid"
 	"github.com/meshery/meshery/server/models"
 )
 
@@ -19,10 +19,7 @@ func TestInstallExtensionHandler_RemoteProviderReturnsNotImplemented(t *testing.
 	h := newTestHandler(t, map[string]models.Provider{}, "")
 	req := httptest.NewRequest(http.MethodPost, "/api/provider/extension/install", strings.NewReader(`{"extType":"navigator"}`))
 	rec := httptest.NewRecorder()
-	userID, err := uuid.NewV4()
-	if err != nil {
-		t.Fatalf("failed to generate user id: %v", err)
-	}
+	userID := uuid.New()
 
 	h.InstallExtensionHandler(rec, req, nil, &models.User{ID: userID}, remote)
 

--- a/server/handlers/fetch_results_handler.go
+++ b/server/handlers/fetch_results_handler.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"net/http"
 
-	"github.com/gofrs/uuid"
+	"github.com/google/uuid"
 	"github.com/gorilla/mux"
 	"github.com/meshery/meshery/server/models"
 	"gopkg.in/yaml.v2"
@@ -73,7 +73,7 @@ func (h *Handler) GetResultHandler(w http.ResponseWriter, req *http.Request, _ *
 		writeMeshkitError(w, ErrMissingResultID(), http.StatusBadRequest)
 		return
 	}
-	key := uuid.FromStringOrNil(id)
+	key := parseUUIDOrNil(id)
 	if key == uuid.Nil {
 		h.log.Error(ErrQueryGet("key"))
 		writeMeshkitError(w, ErrInvalidUUID(fmt.Errorf("invalid result id: %q", id)), http.StatusBadRequest)
@@ -138,7 +138,7 @@ func (h *Handler) FetchSingleSmiResultHandler(w http.ResponseWriter, req *http.R
 	}
 	q := req.Form
 	id := mux.Vars(req)["id"]
-	key := uuid.FromStringOrNil(id)
+	key := parseUUIDOrNil(id)
 	if key == uuid.Nil {
 		h.log.Error(ErrQueryGet("key"))
 		writeMeshkitError(w, ErrInvalidUUID(fmt.Errorf("invalid result id: %q", id)), http.StatusBadRequest)

--- a/server/handlers/grafana_handlers.go
+++ b/server/handlers/grafana_handlers.go
@@ -10,7 +10,6 @@ import (
 	"net/url"
 	"strings"
 
-	"github.com/google/uuid"
 	"github.com/gorilla/mux"
 	"github.com/meshery/meshery/server/helpers/utils"
 	"github.com/meshery/meshery/server/models"

--- a/server/handlers/grafana_handlers.go
+++ b/server/handlers/grafana_handlers.go
@@ -10,7 +10,7 @@ import (
 	"net/url"
 	"strings"
 
-	"github.com/gofrs/uuid"
+	"github.com/google/uuid"
 	"github.com/gorilla/mux"
 	"github.com/meshery/meshery/server/helpers/utils"
 	"github.com/meshery/meshery/server/models"
@@ -116,7 +116,7 @@ func (h *Handler) GrafanaConfigHandler(w http.ResponseWriter, req *http.Request,
 // GrafanaPingHandler - used to initiate a Grafana ping
 func (h *Handler) GrafanaPingHandler(w http.ResponseWriter, req *http.Request, prefObj *models.Preference, _ *models.User, p models.Provider) {
 	token, _ := req.Context().Value(models.TokenCtxKey).(string)
-	connectionID := uuid.FromStringOrNil(mux.Vars(req)["connectionID"])
+	connectionID := parseUUIDOrNil(mux.Vars(req)["connectionID"])
 
 	connection, statusCode, err := p.GetConnectionByID(token, connectionID)
 	if err != nil {
@@ -151,7 +151,7 @@ func (h *Handler) GrafanaBoardsHandler(w http.ResponseWriter, req *http.Request,
 		return
 	}
 	token, _ := req.Context().Value(models.TokenCtxKey).(string)
-	connectionID := uuid.FromStringOrNil(mux.Vars(req)["connectionID"])
+	connectionID := parseUUIDOrNil(mux.Vars(req)["connectionID"])
 	connection, statusCode, err := p.GetConnectionByID(token, connectionID)
 	h.log.Debug("connection id : ", connectionID)
 	if err != nil {
@@ -199,7 +199,7 @@ func (h *Handler) GrafanaQueryHandler(w http.ResponseWriter, req *http.Request, 
 
 	reqQuery := req.URL.Query()
 	token, _ := req.Context().Value(models.TokenCtxKey).(string)
-	connectionID := uuid.FromStringOrNil(mux.Vars(req)["connectionID"])
+	connectionID := parseUUIDOrNil(mux.Vars(req)["connectionID"])
 	connection, statusCode, err := p.GetConnectionByID(token, connectionID)
 	if err != nil {
 		writeMeshkitError(w, err, statusCode)
@@ -240,7 +240,7 @@ func (h *Handler) GrafanaQueryRangeHandler(w http.ResponseWriter, req *http.Requ
 	reqQuery := req.URL.Query()
 
 	token, _ := req.Context().Value(models.TokenCtxKey).(string)
-	connectionID := uuid.FromStringOrNil(mux.Vars(req)["connectionID"])
+	connectionID := parseUUIDOrNil(mux.Vars(req)["connectionID"])
 	connection, statusCode, err := provider.GetConnectionByID(token, connectionID)
 	if err != nil {
 		writeMeshkitError(w, err, statusCode)
@@ -302,7 +302,7 @@ func (h *Handler) SaveSelectedGrafanaBoardsHandler(w http.ResponseWriter, req *h
 	}
 
 	token, _ := req.Context().Value(models.TokenCtxKey).(string)
-	connectionID := uuid.FromStringOrNil(mux.Vars(req)["connectionID"])
+	connectionID := parseUUIDOrNil(mux.Vars(req)["connectionID"])
 	connection, statusCode, err := p.GetConnectionByID(token, connectionID)
 	if err != nil {
 		writeMeshkitError(w, err, statusCode)

--- a/server/handlers/k8sconfig_handler.go
+++ b/server/handlers/k8sconfig_handler.go
@@ -393,7 +393,7 @@ func (h *Handler) K8sRegistrationHandler(w http.ResponseWriter, req *http.Reques
 
 func (h *Handler) DiscoverK8SContextFromKubeConfig(userID string, token string, prov models.Provider) ([]*models.K8sContext, error) {
 	var contexts []*models.K8sContext
-	// userUUID := uuid.FromStringOrNil(userID)
+	// userUUID := parseUUIDOrNil(userID)
 
 	// Get meshery instance ID
 	mid, ok := viper.Get("INSTANCE_ID").(*core.Uuid)

--- a/server/handlers/load_test_handler.go
+++ b/server/handlers/load_test_handler.go
@@ -17,7 +17,7 @@ import (
 
 	"fortio.org/fortio/periodic"
 	yaml "github.com/ghodss/yaml"
-	"github.com/gofrs/uuid"
+	"github.com/google/uuid"
 	"github.com/gorilla/mux"
 	"github.com/meshery/meshery/server/helpers"
 	"github.com/meshery/meshery/server/helpers/utils"
@@ -583,9 +583,9 @@ func (h *Handler) persistPerformanceTestResult(ctx context.Context, req *http.Re
 		})
 	}
 
-	key := uuid.FromStringOrNil(resultID)
+	key := parseUUIDOrNil(resultID)
 	if key == uuid.Nil {
-		key, _ = uuid.NewV4()
+		key = uuid.New()
 	}
 	result.ID = key
 	respChan <- &models.LoadTestResponse{
@@ -632,7 +632,7 @@ func (h *Handler) CollectStaticMetrics(config *models.SubmitMetricsConfig) error
 	}
 	// TODO: we are NOT persisting the Node metrics for now
 
-	resultUUID, err := uuid.FromString(config.ResultID)
+	resultUUID, err := uuid.Parse(config.ResultID)
 	if err != nil {
 		h.log.Error(ErrParseBool(err, "result uuid"))
 		return err

--- a/server/handlers/mesh_ops_handlers.go
+++ b/server/handlers/mesh_ops_handlers.go
@@ -8,7 +8,7 @@ import (
 	"net/http"
 	"strings"
 
-	"github.com/gofrs/uuid"
+	"github.com/google/uuid"
 	"github.com/meshery/meshery/server/meshes"
 	"github.com/meshery/meshery/server/models"
 	"github.com/spf13/viper"
@@ -329,13 +329,8 @@ func (h *Handler) MeshOpsHandler(w http.ResponseWriter, req *http.Request, prefO
 	defer func() {
 		_ = mClient.Close()
 	}()
-	operationID, err := uuid.NewV4()
+	operationID := uuid.New()
 
-	if err != nil {
-		h.log.Error(ErrGenerateUUID(err))
-		writeMeshkitError(w, ErrGenerateUUID(err), http.StatusInternalServerError)
-		return
-	}
 	_, err = mClient.MClient.ApplyOperation(req.Context(), &meshes.ApplyRuleRequest{
 		OperationId: operationID.String(),
 		OpName:      opName,

--- a/server/handlers/meshery_filter_handler.go
+++ b/server/handlers/meshery_filter_handler.go
@@ -8,8 +8,7 @@ import (
 	"net/http"
 	"strings"
 
-	"github.com/gofrs/uuid"
-	guid "github.com/google/uuid"
+	"github.com/google/uuid"
 	"github.com/gorilla/mux"
 	"github.com/meshery/meshery/server/meshes"
 	"github.com/meshery/meshery/server/models"
@@ -96,7 +95,7 @@ func (h *Handler) handleFilterPOST(
 	res := meshes.EventsResponse{
 		Component:     "core",
 		ComponentName: "Filters",
-		OperationId:   guid.NewString(),
+		OperationId:   uuid.NewString(),
 		EventType:     meshes.EventType_INFO,
 	}
 	var parsedBody *models.MesheryFilterRequestBody
@@ -573,7 +572,7 @@ func (h *Handler) generateFilterComponent(config string) (string, error) {
 		filterEntity := res[0]
 		filterCompDef, ok := filterEntity.(*component.ComponentDefinition)
 		if ok {
-			filterID, _ := uuid.NewV4()
+			filterID := uuid.New()
 			filterSvc := component.ComponentDefinition{
 				ID:          filterID,
 				DisplayName: strings.ToLower(filterCompDef.Component.Kind) + utils.GetRandomAlphabetsOfDigit(5),

--- a/server/handlers/meshery_pattern_handler.go
+++ b/server/handlers/meshery_pattern_handler.go
@@ -14,8 +14,7 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/gofrs/uuid"
-	guid "github.com/google/uuid"
+	"github.com/google/uuid"
 	"github.com/gorilla/mux"
 	helpers "github.com/meshery/meshery/server/helpers/utils"
 	"github.com/meshery/meshery/server/meshes"
@@ -757,7 +756,7 @@ func (h *Handler) DeleteMesheryPatternHandler(
 ) {
 	patternID := mux.Vars(r)["id"]
 	userID := user.ID
-	eventBuilder := events.NewEvent().FromOwner(userID).FromSystem(*h.SystemID).WithCategory("pattern").WithAction("delete").ActedUpon(uuid.FromStringOrNil(patternID))
+	eventBuilder := events.NewEvent().FromOwner(userID).FromSystem(*h.SystemID).WithCategory("pattern").WithAction("delete").ActedUpon(parseUUIDOrNil(patternID))
 
 	token, err := provider.GetProviderToken(r)
 	if err != nil {
@@ -1251,7 +1250,7 @@ func (h *Handler) CloneMesheryPatternHandler(
 	provider models.Provider,
 ) {
 	patternID := mux.Vars(r)["id"]
-	patternUUID := uuid.FromStringOrNil(patternID)
+	patternUUID := parseUUIDOrNil(patternID)
 
 	userID := user.ID
 	eventBuilder := events.NewEvent().FromOwner(userID).FromSystem(*h.SystemID).WithCategory("pattern").WithAction("clone").ActedUpon(patternUUID).WithSeverity(events.Informational)
@@ -1566,7 +1565,7 @@ func (h *Handler) GetMesheryPatternHandler(
 	provider models.Provider,
 ) {
 	patternID := mux.Vars(r)["id"]
-	patternUUID := uuid.FromStringOrNil(patternID)
+	patternUUID := parseUUIDOrNil(patternID)
 	userID := user.ID
 	eventBuilder := events.NewEvent().FromOwner(userID).FromSystem(*h.SystemID).WithCategory("pattern").WithAction("view").ActedUpon(patternUUID)
 
@@ -1772,7 +1771,7 @@ func (h *Handler) handlePatternUpdate(
 	res := meshes.EventsResponse{
 		Component:     "core",
 		ComponentName: "Design",
-		OperationId:   guid.NewString(),
+		OperationId:   uuid.NewString(),
 		EventType:     meshes.EventType_INFO,
 	}
 

--- a/server/handlers/meshery_pattern_handler_test.go
+++ b/server/handlers/meshery_pattern_handler_test.go
@@ -4,7 +4,7 @@ import (
 	"encoding/json"
 	"testing"
 
-	"github.com/gofrs/uuid"
+	"github.com/google/uuid"
 	"github.com/meshery/meshery/server/models"
 	"github.com/meshery/meshkit/errors"
 	component "github.com/meshery/schemas/models/v1beta2/component"
@@ -608,7 +608,7 @@ func TestErrEncodePattern_PreservesMeshKitCode(t *testing.T) {
 // regression and ensures the legacy spelling cannot be re-introduced
 // silently.
 func TestBuildDesignSavedEventMetadata_UsesCanonicalCamelCaseKeys(t *testing.T) {
-	id := uuid.Must(uuid.NewV4())
+	id := uuid.New()
 	df := design.PatternFile{
 		ID:            id,
 		Name:          "test-design",

--- a/server/handlers/meshsync_handler.go
+++ b/server/handlers/meshsync_handler.go
@@ -8,7 +8,6 @@ import (
 
 	"github.com/meshery/schemas/models/core"
 
-	"github.com/google/uuid"
 	"github.com/gorilla/mux"
 	"github.com/meshery/meshery/server/models"
 	patternutils "github.com/meshery/meshery/server/models/pattern/utils"

--- a/server/handlers/meshsync_handler.go
+++ b/server/handlers/meshsync_handler.go
@@ -8,7 +8,7 @@ import (
 
 	"github.com/meshery/schemas/models/core"
 
-	"github.com/gofrs/uuid"
+	"github.com/google/uuid"
 	"github.com/gorilla/mux"
 	"github.com/meshery/meshery/server/models"
 	patternutils "github.com/meshery/meshery/server/models/pattern/utils"
@@ -75,7 +75,7 @@ func KubernetesResourceToComponentDef(resource model.KubernetesResource, stripSc
 		return nil, fmt.Errorf("failed to map component metadata: %w", err)
 	}
 
-	componentDef.ID = uuid.FromStringOrNil(resource.KubernetesResourceMeta.UID)
+	componentDef.ID = parseUUIDOrNil(resource.KubernetesResourceMeta.UID)
 	componentDef.DisplayName = resource.KubernetesResourceMeta.Name
 
 	var spec interface{}

--- a/server/handlers/middlewares.go
+++ b/server/handlers/middlewares.go
@@ -10,7 +10,6 @@ import (
 	"strings"
 	"sync"
 
-	"github.com/google/uuid"
 	"github.com/meshery/meshery/server/machines"
 	mhelpers "github.com/meshery/meshery/server/machines/helpers"
 	"github.com/meshery/meshery/server/machines/kubernetes"

--- a/server/handlers/middlewares.go
+++ b/server/handlers/middlewares.go
@@ -10,7 +10,7 @@ import (
 	"strings"
 	"sync"
 
-	"github.com/gofrs/uuid"
+	"github.com/google/uuid"
 	"github.com/meshery/meshery/server/machines"
 	mhelpers "github.com/meshery/meshery/server/machines/helpers"
 	"github.com/meshery/meshery/server/machines/kubernetes"
@@ -336,7 +336,7 @@ func KubernetesMiddleware(ctx context.Context, h *Handler, provider models.Provi
 			EventBroadcaster:   h.config.EventBroadcaster,
 			RegistryManager:    h.registryManager,
 		}
-		connectionUUID := uuid.FromStringOrNil(k8sContext.ConnectionID)
+		connectionUUID := parseUUIDOrNil(k8sContext.ConnectionID)
 
 		inst, err := mhelpers.InitializeMachineWithContext(
 			machineCtx,
@@ -395,7 +395,7 @@ func K8sFSMMiddleware(ctx context.Context, h *Handler, provider models.Provider,
 			EventBroadcaster:   h.config.EventBroadcaster,
 			RegistryManager:    h.registryManager,
 		}
-		connectionUUID := uuid.FromStringOrNil(k8sContext.ConnectionID)
+		connectionUUID := parseUUIDOrNil(k8sContext.ConnectionID)
 
 		inst, err := mhelpers.InitializeMachineWithContext(
 			machineCtx,

--- a/server/handlers/pattern_handler_test.go
+++ b/server/handlers/pattern_handler_test.go
@@ -6,7 +6,7 @@ package handlers
 // 	"path"
 // 	"testing"
 
-// 	"github.com/gofrs/uuid"
+// 	"github.com/google/uuid"
 // 	"github.com/meshery/meshery/server/models"
 // 	"github.com/meshery/meshkit/logger"
 // 	meshmodel "github.com/meshery/meshkit/models/meshmodel/registry"

--- a/server/handlers/performance_profiles_handler.go
+++ b/server/handlers/performance_profiles_handler.go
@@ -7,7 +7,7 @@ import (
 	"io"
 	"net/http"
 
-	"github.com/gofrs/uuid"
+	"github.com/google/uuid"
 	"github.com/gorilla/mux"
 	"github.com/meshery/meshery/server/models"
 )

--- a/server/handlers/policy_relationship_handler_test.go
+++ b/server/handlers/policy_relationship_handler_test.go
@@ -6,7 +6,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/gofrs/uuid"
+	"github.com/google/uuid"
 	"github.com/meshery/meshkit/database"
 	"github.com/meshery/meshkit/models/meshmodel/registry"
 	"github.com/meshery/schemas/models/core"
@@ -262,8 +262,7 @@ func TestProcessEvaluationResponse_NilPointerGuard(t *testing.T) {
 		t.Parallel()
 		rm, _ := newTestRegistryManager(t)
 		seedTestComponent(t, rm)
-		id, err := uuid.NewV4()
-		require.NoError(t, err)
+		id := uuid.New()
 		position := &struct {
 			X float64 `json:"x" yaml:"x"`
 			Y float64 `json:"y" yaml:"y"`
@@ -459,10 +458,8 @@ func TestProcessEvaluationResponse_PreservesUserCustomizationsOnExistingComponen
 	seedTestComponent(t, rm)        // Job, registry BackgroundColor "#123456"
 	seedNamespaceComponent(t, rm)   // Namespace, registry BackgroundColor "#326CE5"
 
-	existingPodID, err := uuid.NewV4()
-	require.NoError(t, err)
-	addedNamespaceID, err := uuid.NewV4()
-	require.NoError(t, err)
+	existingPodID := uuid.New()
+	addedNamespaceID := uuid.New()
 
 	// User customization on the existing component: red background. The
 	// registry's default for "Job" is "#123456"; if hydration accidentally
@@ -540,10 +537,8 @@ func TestProcessEvaluationResponse_HydratesMultipleAddedComponents(t *testing.T)
 	seedTestComponent(t, rm)       // Job → BackgroundColor "#123456"
 	seedNamespaceComponent(t, rm)  // Namespace → BackgroundColor "#326CE5"
 
-	jobID, err := uuid.NewV4()
-	require.NoError(t, err)
-	nsID, err := uuid.NewV4()
-	require.NoError(t, err)
+	jobID := uuid.New()
+	nsID := uuid.New()
 
 	bareJob := &component.ComponentDefinition{
 		ID:             jobID,
@@ -589,9 +584,9 @@ func TestProcessEvaluationResponse_HydratesMultipleAddedComponents(t *testing.T)
 }
 
 func TestParseRelationshipToAlias(t *testing.T) {
-	fromID := uuid.Must(uuid.NewV4())
-	toID := uuid.Must(uuid.NewV4())
-	relID := uuid.Must(uuid.NewV4())
+	fromID := uuid.New()
+	toID := uuid.New()
+	relID := uuid.New()
 
 	tests := []struct {
 		name   string

--- a/server/handlers/prometheus_handlers.go
+++ b/server/handlers/prometheus_handlers.go
@@ -11,7 +11,6 @@ import (
 	"strings"
 	"sync"
 
-	"github.com/google/uuid"
 	"github.com/gorilla/mux"
 	"github.com/meshery/meshery/server/helpers/utils"
 	"github.com/meshery/meshery/server/models"

--- a/server/handlers/prometheus_handlers.go
+++ b/server/handlers/prometheus_handlers.go
@@ -11,7 +11,7 @@ import (
 	"strings"
 	"sync"
 
-	"github.com/gofrs/uuid"
+	"github.com/google/uuid"
 	"github.com/gorilla/mux"
 	"github.com/meshery/meshery/server/helpers/utils"
 	"github.com/meshery/meshery/server/models"
@@ -242,7 +242,7 @@ func (h *Handler) PrometheusConfigHandler(w http.ResponseWriter, req *http.Reque
 // PrometheusPingHandler - fetches server version to simulate ping
 func (h *Handler) PrometheusPingHandler(w http.ResponseWriter, req *http.Request, prefObj *models.Preference, _ *models.User, p models.Provider) {
 	token, _ := req.Context().Value(models.TokenCtxKey).(string)
-	connectionID := uuid.FromStringOrNil(mux.Vars(req)["connectionID"])
+	connectionID := parseUUIDOrNil(mux.Vars(req)["connectionID"])
 
 	connection, statusCode, err := p.GetConnectionByID(token, connectionID)
 	if err != nil {
@@ -301,7 +301,7 @@ func (h *Handler) GrafanaBoardImportForPrometheusHandler(w http.ResponseWriter, 
 // PrometheusQueryHandler handles prometheus queries
 func (h *Handler) PrometheusQueryHandler(w http.ResponseWriter, req *http.Request, prefObj *models.Preference, _ *models.User, p models.Provider) {
 	token, _ := req.Context().Value(models.TokenCtxKey).(string)
-	connectionID := uuid.FromStringOrNil(mux.Vars(req)["connectionID"])
+	connectionID := parseUUIDOrNil(mux.Vars(req)["connectionID"])
 
 	connection, statusCode, err := p.GetConnectionByID(token, connectionID)
 	if err != nil {
@@ -333,7 +333,7 @@ func (h *Handler) PrometheusQueryHandler(w http.ResponseWriter, req *http.Reques
 // PrometheusQueryRangeHandler handles prometheus range queries
 func (h *Handler) PrometheusQueryRangeHandler(w http.ResponseWriter, req *http.Request, prefObj *models.Preference, user *models.User, provider models.Provider) {
 	token, _ := req.Context().Value(models.TokenCtxKey).(string)
-	connectionID := uuid.FromStringOrNil(mux.Vars(req)["connectionID"])
+	connectionID := parseUUIDOrNil(mux.Vars(req)["connectionID"])
 
 	connection, statusCode, err := provider.GetConnectionByID(token, connectionID)
 	if err != nil {
@@ -369,7 +369,7 @@ func (h *Handler) PrometheusQueryRangeHandler(w http.ResponseWriter, req *http.R
 // PrometheusStaticBoardHandler returns the static board
 func (h *Handler) PrometheusStaticBoardHandler(w http.ResponseWriter, req *http.Request, prefObj *models.Preference, _ *models.User, provider models.Provider) {
 	token, _ := req.Context().Value(models.TokenCtxKey).(string)
-	connectionID := uuid.FromStringOrNil(mux.Vars(req)["connectionID"])
+	connectionID := parseUUIDOrNil(mux.Vars(req)["connectionID"])
 
 	connection, statusCode, err := provider.GetConnectionByID(token, connectionID)
 	if err != nil {
@@ -446,7 +446,7 @@ func (h *Handler) SaveSelectedPrometheusBoardsHandler(w http.ResponseWriter, req
 	}
 
 	token, _ := req.Context().Value(models.TokenCtxKey).(string)
-	connectionID := uuid.FromStringOrNil(mux.Vars(req)["connectionID"])
+	connectionID := parseUUIDOrNil(mux.Vars(req)["connectionID"])
 	connection, statusCode, err := provider.GetConnectionByID(token, connectionID)
 	if err != nil {
 		writeMeshkitError(w, err, statusCode)

--- a/server/handlers/user_handler.go
+++ b/server/handlers/user_handler.go
@@ -8,7 +8,7 @@ import (
 
 	"encoding/json"
 
-	"github.com/gofrs/uuid"
+	"github.com/google/uuid"
 	"github.com/gorilla/mux"
 	pkgerrors "github.com/pkg/errors"
 
@@ -28,7 +28,7 @@ func (h *Handler) UserHandler(w http.ResponseWriter, _ *http.Request, _ *models.
 
 func (h *Handler) GetUserByIDHandler(w http.ResponseWriter, r *http.Request, _ *models.Preference, _ *models.User, provider models.Provider) {
 	userID := mux.Vars(r)["id"]
-	_, err := uuid.FromString(userID)
+	_, err := uuid.Parse(userID)
 	if err != nil {
 		writeMeshkitError(w, ErrInvalidUUID(err), http.StatusBadRequest)
 		return

--- a/server/handlers/uuid_helpers.go
+++ b/server/handlers/uuid_helpers.go
@@ -1,0 +1,13 @@
+package handlers
+
+import "github.com/google/uuid"
+
+// parseUUIDOrNil parses s as a UUID and returns uuid.Nil if parsing fails.
+// This is a compatibility shim replacing gofrs/uuid's FromStringOrNil.
+func parseUUIDOrNil(s string) uuid.UUID {
+	id, err := uuid.Parse(s)
+	if err != nil {
+		return uuid.Nil
+	}
+	return id
+}

--- a/server/helpers/common_registry_logs.go
+++ b/server/helpers/common_registry_logs.go
@@ -8,7 +8,6 @@ import (
 
 	"github.com/meshery/schemas/models/core"
 
-	"github.com/google/uuid"
 	"github.com/meshery/meshery/server/models"
 	mutils "github.com/meshery/meshkit/utils"
 	"github.com/meshery/schemas/models/v1alpha3/relationship"

--- a/server/helpers/common_registry_logs.go
+++ b/server/helpers/common_registry_logs.go
@@ -8,7 +8,7 @@ import (
 
 	"github.com/meshery/schemas/models/core"
 
-	gofrs "github.com/gofrs/uuid"
+	"github.com/google/uuid"
 	"github.com/meshery/meshery/server/models"
 	mutils "github.com/meshery/meshkit/utils"
 	"github.com/meshery/schemas/models/v1alpha3/relationship"
@@ -192,7 +192,7 @@ func FailedEventCompute(hostname string, mesheryInstanceID core.Uuid, provider *
 		})
 		_ = (*provider).PersistSystemEvent(*errorEvent)
 		if userID != "" {
-			userUUID := gofrs.FromStringOrNil(userID)
+			userUUID := parseUUIDOrNil(userID)
 			ec.Publish(userUUID, errorEvent)
 
 		}

--- a/server/helpers/uuid_helpers.go
+++ b/server/helpers/uuid_helpers.go
@@ -1,0 +1,13 @@
+package helpers
+
+import "github.com/google/uuid"
+
+// parseUUIDOrNil parses s as a UUID and returns uuid.Nil if parsing fails.
+// This is a compatibility shim replacing gofrs/uuid's FromStringOrNil.
+func parseUUIDOrNil(s string) uuid.UUID {
+	id, err := uuid.Parse(s)
+	if err != nil {
+		return uuid.Nil
+	}
+	return id
+}

--- a/server/internal/graphql/resolver/meshsync.go
+++ b/server/internal/graphql/resolver/meshsync.go
@@ -8,7 +8,7 @@ import (
 	"os"
 	"path"
 
-	"github.com/gofrs/uuid"
+	"github.com/google/uuid"
 	"github.com/meshery/meshery/server/handlers"
 	"github.com/meshery/meshery/server/internal/graphql/model"
 	mhelpers "github.com/meshery/meshery/server/machines/helpers"
@@ -239,7 +239,7 @@ func (r *Resolver) resyncCluster(ctx context.Context, provider models.Provider, 
 		}
 		connectionID := k8sCtx.ConnectionID
 
-		machine, ok := instanceTracker.Get(uuid.FromStringOrNil(connectionID))
+		machine, ok := instanceTracker.Get(parseUUIDOrNil(connectionID))
 		if !ok || machine == nil {
 			return "", ErrResyncCluster(
 				fmt.Errorf(

--- a/server/internal/graphql/resolver/meshsync.go
+++ b/server/internal/graphql/resolver/meshsync.go
@@ -8,7 +8,6 @@ import (
 	"os"
 	"path"
 
-	"github.com/google/uuid"
 	"github.com/meshery/meshery/server/handlers"
 	"github.com/meshery/meshery/server/internal/graphql/model"
 	mhelpers "github.com/meshery/meshery/server/machines/helpers"

--- a/server/internal/graphql/resolver/operator.go
+++ b/server/internal/graphql/resolver/operator.go
@@ -3,7 +3,7 @@ package resolver
 import (
 	"context"
 
-	"github.com/gofrs/uuid"
+	"github.com/google/uuid"
 	"github.com/meshery/meshery/server/handlers"
 	"github.com/meshery/meshery/server/internal/graphql/model"
 	"github.com/meshery/meshery/server/machines/kubernetes"
@@ -180,7 +180,7 @@ func (r *Resolver) getOperatorStatus(ctx context.Context, _ models.Provider, con
 		return unknowStatus, nil
 	}
 
-	inst, ok := handler.ConnectionToStateMachineInstanceTracker.Get(uuid.FromStringOrNil(connectionID))
+	inst, ok := handler.ConnectionToStateMachineInstanceTracker.Get(parseUUIDOrNil(connectionID))
 	// If machine instance is not present or points to nil, return unknown status
 	if !ok || inst == nil {
 		return unknowStatus, nil
@@ -216,7 +216,7 @@ func (r *Resolver) getMeshsyncStatus(ctx context.Context, provider models.Provid
 		return unknowStatus, nil
 	}
 
-	inst, ok := handler.ConnectionToStateMachineInstanceTracker.Get(uuid.FromStringOrNil(connectionID))
+	inst, ok := handler.ConnectionToStateMachineInstanceTracker.Get(parseUUIDOrNil(connectionID))
 	// If machine instance is not present or points to nil, return unknown status
 	if !ok || inst == nil {
 		return unknowStatus, nil
@@ -250,7 +250,7 @@ func (r *Resolver) getNatsStatus(ctx context.Context, provider models.Provider, 
 		return unknowStatus, nil
 	}
 
-	connectionUUID := uuid.FromStringOrNil(connectionID)
+	connectionUUID := parseUUIDOrNil(connectionID)
 	if connectionUUID == uuid.Nil {
 		return unknowStatus, nil
 	}

--- a/server/internal/graphql/resolver/performance.go
+++ b/server/internal/graphql/resolver/performance.go
@@ -5,7 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 
-	"github.com/gofrs/uuid"
+	"github.com/google/uuid"
 	"github.com/meshery/meshery/server/handlers"
 	"github.com/meshery/meshery/server/internal/graphql/model"
 	"github.com/meshery/meshery/server/models"
@@ -16,7 +16,7 @@ func (r *Resolver) getPerfResult(ctx context.Context, provider models.Provider, 
 		return nil, handlers.ErrQueryGet("*id")
 	}
 
-	resultID, err := uuid.FromString(id)
+	resultID, err := uuid.Parse(id)
 
 	if err != nil {
 		r.Log.Error(err)

--- a/server/internal/graphql/resolver/schema.resolvers.go
+++ b/server/internal/graphql/resolver/schema.resolvers.go
@@ -10,7 +10,6 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/google/uuid"
 	"github.com/meshery/meshery/server/handlers"
 	"github.com/meshery/meshery/server/internal/graphql/generated"
 	"github.com/meshery/meshery/server/internal/graphql/model"

--- a/server/internal/graphql/resolver/schema.resolvers.go
+++ b/server/internal/graphql/resolver/schema.resolvers.go
@@ -10,7 +10,7 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/gofrs/uuid"
+	"github.com/google/uuid"
 	"github.com/meshery/meshery/server/handlers"
 	"github.com/meshery/meshery/server/internal/graphql/generated"
 	"github.com/meshery/meshery/server/internal/graphql/model"
@@ -178,7 +178,7 @@ func (r *subscriptionResolver) SubscribeMesheryControllersStatus(ctx context.Con
 	// initialize the map
 
 	for _, connectionID := range connectionIDs {
-		inst, ok := handler.ConnectionToStateMachineInstanceTracker.Get(uuid.FromStringOrNil(connectionID))
+		inst, ok := handler.ConnectionToStateMachineInstanceTracker.Get(parseUUIDOrNil(connectionID))
 		if ok && inst != nil {
 			machinectx, err := utils.Cast[*kubernetes.MachineCtx](inst.Context)
 			if err != nil {
@@ -236,7 +236,7 @@ func (r *subscriptionResolver) SubscribeMesheryControllersStatus(ctx context.Con
 			}
 
 			for _, connectionID := range connectionIDs {
-				inst, ok := handler.ConnectionToStateMachineInstanceTracker.Get(uuid.FromStringOrNil(connectionID))
+				inst, ok := handler.ConnectionToStateMachineInstanceTracker.Get(parseUUIDOrNil(connectionID))
 				if !ok || inst == nil {
 					continue
 				}

--- a/server/internal/graphql/resolver/uuid_helpers.go
+++ b/server/internal/graphql/resolver/uuid_helpers.go
@@ -1,0 +1,13 @@
+package resolver
+
+import "github.com/google/uuid"
+
+// parseUUIDOrNil parses s as a UUID and returns uuid.Nil if parsing fails.
+// This is a compatibility shim replacing gofrs/uuid's FromStringOrNil.
+func parseUUIDOrNil(s string) uuid.UUID {
+	id, err := uuid.Parse(s)
+	if err != nil {
+		return uuid.Nil
+	}
+	return id
+}

--- a/server/machines/actions.go
+++ b/server/machines/actions.go
@@ -6,7 +6,7 @@ import (
 
 	"github.com/meshery/schemas/models/core"
 
-	"github.com/gofrs/uuid"
+	"github.com/google/uuid"
 	"github.com/meshery/meshery/server/models"
 	"github.com/meshery/meshery/server/models/connections"
 	"github.com/meshery/meshkit/models/events"
@@ -78,7 +78,7 @@ func (da *DefaultConnectAction) Execute(ctx context.Context, machineCtx interfac
 				WithSeverity(events.Error).
 				WithMetadata(map[string]interface{}{"error": parseErr}).Build(), _err
 		}
-		parsed, parseErr := uuid.FromString(idStr)
+		parsed, parseErr := uuid.Parse(idStr)
 		if parseErr != nil {
 			_err := models.ErrPersistCredential(parseErr)
 			return NoOp, eventBuilder.

--- a/server/machines/default_machine.go
+++ b/server/machines/default_machine.go
@@ -1,7 +1,7 @@
 package machines
 
 import (
-	"github.com/gofrs/uuid"
+	"github.com/google/uuid"
 	"github.com/meshery/meshkit/logger"
 	"github.com/meshery/schemas/models/core"
 )
@@ -44,7 +44,7 @@ func Initial() State {
 }
 
 func New(initialState StateType, ID string, userID core.Uuid, log logger.Handler, mtype string) (*StateMachine, error) {
-	connectionID, err := uuid.FromString(ID)
+	connectionID, err := uuid.Parse(ID)
 	if err != nil {
 		return nil, ErrInititalizeK8sMachine(err)
 	}

--- a/server/machines/helpers/auto_register.go
+++ b/server/machines/helpers/auto_register.go
@@ -10,7 +10,7 @@ import (
 
 	"github.com/meshery/schemas/models/core"
 
-	"github.com/gofrs/uuid"
+	"github.com/google/uuid"
 	helpers "github.com/meshery/meshery/server/helpers/utils"
 	"github.com/meshery/meshery/server/machines"
 	"github.com/meshery/meshery/server/models"
@@ -189,5 +189,5 @@ func getTypeOfConnection(obj *meshsyncmodel.KubernetesResource) string {
 func generateUUID(data map[string]interface{}) (core.Uuid, error) {
 	marshalledData, _ := utils.Marshal(data)
 	hash := md5.Sum([]byte(marshalledData))
-	return uuid.FromString(hex.EncodeToString(hash[:]))
+	return uuid.Parse(hex.EncodeToString(hash[:]))
 }

--- a/server/machines/kubernetes/connect.go
+++ b/server/machines/kubernetes/connect.go
@@ -6,7 +6,7 @@ import (
 
 	"github.com/meshery/schemas/models/core"
 
-	"github.com/gofrs/uuid"
+	"github.com/google/uuid"
 	"github.com/meshery/meshery/server/machines"
 	"github.com/meshery/meshery/server/models"
 	"github.com/meshery/meshery/server/models/connections"
@@ -42,7 +42,7 @@ func (ca *ConnectAction) Execute(ctx context.Context, machineCtx interface{}, da
 		return machines.NoOp, eventBuilder.Build(), errToken
 
 	}
-	connectionID := uuid.FromStringOrNil(machinectx.K8sContext.ConnectionID)
+	connectionID := parseUUIDOrNil(machinectx.K8sContext.ConnectionID)
 	if connectionID == uuid.Nil {
 		errConnection := ErrConnectAction(fmt.Errorf("k8sCtx.ConnectionID is empty or invalid"))
 		eventBuilder.WithMetadata(map[string]interface{}{"error": errConnection})

--- a/server/machines/kubernetes/helpers.go
+++ b/server/machines/kubernetes/helpers.go
@@ -6,7 +6,6 @@ import (
 
 	"github.com/meshery/schemas/models/core"
 
-	"github.com/google/uuid"
 	"github.com/meshery/meshery/server/helpers"
 	"github.com/meshery/meshery/server/helpers/utils"
 	"github.com/meshery/meshery/server/machines"

--- a/server/machines/kubernetes/helpers.go
+++ b/server/machines/kubernetes/helpers.go
@@ -6,7 +6,7 @@ import (
 
 	"github.com/meshery/schemas/models/core"
 
-	"github.com/gofrs/uuid"
+	"github.com/google/uuid"
 	"github.com/meshery/meshery/server/helpers"
 	"github.com/meshery/meshery/server/helpers/utils"
 	"github.com/meshery/meshery/server/machines"
@@ -35,7 +35,7 @@ func getAdapterTracker() *helpers.AdaptersTracker {
 }
 
 func GenerateClientSetAction(k8sContext *models.K8sContext, eventBuilder *events.EventBuilder, log logger.Handler) (*kubernetes.Client, error) {
-	eventBuilder.ActedUpon(uuid.FromStringOrNil(k8sContext.ConnectionID))
+	eventBuilder.ActedUpon(parseUUIDOrNil(k8sContext.ConnectionID))
 
 	eventMetadata := map[string]interface{}{}
 
@@ -67,7 +67,7 @@ func AssignClientSetToContext(machinectx *MachineCtx, eventBuilder *events.Event
 	}
 
 	k8sContext := machinectx.K8sContext
-	eventBuilder.ActedUpon(uuid.FromStringOrNil(k8sContext.ConnectionID))
+	eventBuilder.ActedUpon(parseUUIDOrNil(k8sContext.ConnectionID))
 
 	handler, err := GenerateClientSetAction(&k8sContext, eventBuilder, machinectx.log)
 	if err != nil {

--- a/server/machines/kubernetes/machine.go
+++ b/server/machines/kubernetes/machine.go
@@ -5,7 +5,7 @@ import (
 
 	"github.com/meshery/schemas/models/core"
 
-	"github.com/gofrs/uuid"
+	"github.com/google/uuid"
 	"github.com/meshery/meshery/server/machines"
 	"github.com/meshery/meshery/server/models"
 	"github.com/meshery/meshkit/logger"
@@ -121,7 +121,7 @@ const (
 )
 
 func New(ID string, userID core.Uuid, log logger.Handler) (*machines.StateMachine, error) {
-	connectionID, err := uuid.FromString(ID)
+	connectionID, err := uuid.Parse(ID)
 	log.Info("initialising K8s machine for connetion Id", connectionID)
 	if err != nil {
 		return nil, machines.ErrInititalizeK8sMachine(err)

--- a/server/machines/kubernetes/machine_test.go
+++ b/server/machines/kubernetes/machine_test.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"testing"
 
-	"github.com/gofrs/uuid"
+	"github.com/google/uuid"
 	"github.com/meshery/meshery/server/models"
 	"github.com/meshery/meshkit/logger"
 	"github.com/meshery/schemas/models/core"
@@ -39,13 +39,10 @@ func TestAssignInitialCtx_AttachesLoggerBeforeClientSetAssignment(t *testing.T) 
 	// Fail fast on UUID generation so the event builder always sees a valid
 	// user ID and the test setup is deterministic; silently leaving user.ID
 	// unset would change the code path we're exercising.
-	userID, err := uuid.NewV4()
-	if err != nil {
-		t.Fatalf("failed to generate user UUID: %v", err)
-	}
+	userID := uuid.New()
 	user := &models.User{ID: core.Uuid(userID)}
 
-	sysID := core.Uuid(uuid.FromStringOrNil("00000000-0000-0000-0000-000000000000"))
+	sysID := core.Uuid(parseUUIDOrNil("00000000-0000-0000-0000-000000000000"))
 
 	ctx := context.Background()
 	ctx = context.WithValue(ctx, models.UserCtxKey, user)
@@ -64,7 +61,7 @@ func TestAssignInitialCtx_AttachesLoggerBeforeClientSetAssignment(t *testing.T) 
 			// previously panicking log.Warn path runs.
 			Name:         "unreachable-test-context",
 			Server:       "https://127.0.0.1:1", // RFC-reserved, refused instantly
-			ConnectionID: uuid.Must(uuid.NewV4()).String(),
+			ConnectionID: uuid.New().String(),
 		},
 		// clientset left nil to force AssignClientSetToContext to attempt
 		// GenerateClientSetAction (the panicking path).

--- a/server/machines/kubernetes/register.go
+++ b/server/machines/kubernetes/register.go
@@ -6,7 +6,7 @@ import (
 
 	"github.com/meshery/schemas/models/core"
 
-	"github.com/gofrs/uuid"
+	"github.com/google/uuid"
 	"github.com/meshery/meshery/server/machines"
 	"github.com/meshery/meshery/server/models"
 	meshmodelcore "github.com/meshery/meshery/server/models/meshmodel/core"

--- a/server/machines/kubernetes/uuid_helpers.go
+++ b/server/machines/kubernetes/uuid_helpers.go
@@ -1,0 +1,13 @@
+package kubernetes
+
+import "github.com/google/uuid"
+
+// parseUUIDOrNil parses s as a UUID and returns uuid.Nil if parsing fails.
+// This is a compatibility shim replacing gofrs/uuid's FromStringOrNil.
+func parseUUIDOrNil(s string) uuid.UUID {
+	id, err := uuid.Parse(s)
+	if err != nil {
+		return uuid.Nil
+	}
+	return id
+}

--- a/server/models/connection_persister.go
+++ b/server/models/connection_persister.go
@@ -6,7 +6,7 @@ import (
 
 	"github.com/meshery/schemas/models/core"
 
-	"github.com/gofrs/uuid"
+	"github.com/google/uuid"
 	"github.com/meshery/meshery/server/helpers/utils"
 	"github.com/meshery/meshery/server/models/connections"
 	"github.com/meshery/meshery/server/models/environments"
@@ -149,10 +149,7 @@ func (cp *ConnectionPersister) getConnectionsStatusSummary() (*map[schemasConnec
 
 func (cp *ConnectionPersister) SaveConnection(connection *connections.Connection) (*connections.Connection, error) {
 	if connection.ID == uuid.Nil {
-		id, err := uuid.NewV4()
-		if err != nil {
-			return nil, ErrGenerateUUID(err)
-		}
+		id := uuid.New()
 		connection.ID = id
 	}
 

--- a/server/models/default_local_provider.go
+++ b/server/models/default_local_provider.go
@@ -18,7 +18,7 @@ import (
 	"github.com/meshery/schemas/models/core"
 	"k8s.io/client-go/util/homedir"
 
-	"github.com/gofrs/uuid"
+	"github.com/google/uuid"
 	"github.com/meshery/meshery/server/models/connections"
 	"github.com/meshery/meshery/server/models/httputil"
 	"github.com/meshery/meshkit/database"
@@ -401,12 +401,12 @@ func (l *DefaultLocalProvider) GetEnvironments(_, page, pageSize, search, order,
 }
 
 func (l *DefaultLocalProvider) GetEnvironmentByID(_ *http.Request, environmentID string, _ string) ([]byte, error) {
-	id := uuid.FromStringOrNil(environmentID)
+	id := parseUUIDOrNil(environmentID)
 	return l.EnvironmentPersister.GetEnvironmentByID(id)
 }
 
 func (l *DefaultLocalProvider) DeleteEnvironment(_ *http.Request, environmentID string) ([]byte, error) {
-	id := uuid.FromStringOrNil(environmentID)
+	id := parseUUIDOrNil(environmentID)
 	return l.EnvironmentPersister.DeleteEnvironmentByID(id)
 }
 
@@ -424,7 +424,7 @@ func (l *DefaultLocalProvider) SaveEnvironment(_ *http.Request, environmentPaylo
 }
 
 func (l *DefaultLocalProvider) UpdateEnvironment(_ *http.Request, environmentPayload *environment.EnvironmentPayload, environmentID string) (*environment.Environment, error) {
-	id, _ := uuid.FromString(environmentID)
+	id, _ := uuid.Parse(environmentID)
 	orgId := core.Uuid(environmentPayload.OrgId)
 	environment := &environment.Environment{
 		ID:             id,
@@ -439,19 +439,19 @@ func (l *DefaultLocalProvider) UpdateEnvironment(_ *http.Request, environmentPay
 }
 
 func (l *DefaultLocalProvider) AddConnectionToEnvironment(_ *http.Request, environmentID string, connectionID string) ([]byte, error) {
-	envId, _ := uuid.FromString(environmentID)
-	conId, _ := uuid.FromString(connectionID)
+	envId, _ := uuid.Parse(environmentID)
+	conId, _ := uuid.Parse(connectionID)
 	return l.EnvironmentPersister.AddConnectionToEnvironment(envId, conId)
 }
 
 func (l *DefaultLocalProvider) RemoveConnectionFromEnvironment(_ *http.Request, environmentID string, connectionID string) ([]byte, error) {
-	envId, _ := uuid.FromString(environmentID)
-	conId, _ := uuid.FromString(connectionID)
+	envId, _ := uuid.Parse(environmentID)
+	conId, _ := uuid.Parse(connectionID)
 	return l.EnvironmentPersister.DeleteConnectionFromEnvironment(envId, conId)
 }
 
 func (l *DefaultLocalProvider) GetConnectionsOfEnvironment(_ *http.Request, environmentID, page, pageSize, search, order, filter string) ([]byte, error) {
-	envId, _ := uuid.FromString(environmentID)
+	envId, _ := uuid.Parse(environmentID)
 	return l.EnvironmentPersister.GetEnvironmentConnections(envId, search, order, page, pageSize, filter)
 }
 
@@ -482,7 +482,7 @@ func (l *DefaultLocalProvider) SaveK8sContext(_ string, k8sContext K8sContext, a
 	var connID core.Uuid
 	id, err := K8sContextGenerateID(k8sContext)
 	if err == nil {
-		connID, _ = uuid.FromString(id)
+		connID, _ = uuid.Parse(id)
 	}
 
 	_metadata := map[string]string{
@@ -648,7 +648,7 @@ func (l *DefaultLocalProvider) FetchAllResults(_, page, pageSize, _, _, _, _ str
 
 // GetResult - fetches result from provider backend for the given result id
 func (l *DefaultLocalProvider) GetResult(_ string, resultID core.Uuid) (*MesheryResult, error) {
-	// key := uuid.FromStringOrNil(resultID)
+	// key := parseUUIDOrNil(resultID)
 	if resultID == uuid.Nil {
 		return nil, ErrResultID
 	}
@@ -657,7 +657,7 @@ func (l *DefaultLocalProvider) GetResult(_ string, resultID core.Uuid) (*Meshery
 
 // PublishResults - publishes results to the provider backend synchronously
 func (l *DefaultLocalProvider) PublishResults(req *http.Request, result *MesheryResult, profileID string) (string, error) {
-	profileUUID, err := uuid.FromString(profileID)
+	profileUUID, err := uuid.Parse(profileID)
 	if err != nil {
 		return "", ErrPerfID(err)
 	}
@@ -676,10 +676,10 @@ func (l *DefaultLocalProvider) PublishResults(req *http.Request, result *Meshery
 	l.Log.Debug(fmt.Sprintf("Result: %s, size: %d", data, len(data)))
 	resultID, _ := l.shipResults(req, data)
 
-	key := uuid.FromStringOrNil(resultID)
+	key := parseUUIDOrNil(resultID)
 	l.Log.Debug(fmt.Sprintf("key: %s, is nil: %t", key.String(), (key == uuid.Nil)))
 	if key == uuid.Nil {
-		key, _ = uuid.NewV4()
+		key = uuid.New()
 		result.ID = key
 		data, err = json.Marshal(result)
 		if err != nil {
@@ -713,7 +713,7 @@ func (l *DefaultLocalProvider) FetchSmiResult(_ *http.Request, _, _, _, _ string
 
 // PublishSmiResults - publishes results to the provider backend synchronously
 func (l *DefaultLocalProvider) PublishSmiResults(result *SmiResult) (string, error) {
-	key, _ := uuid.NewV4()
+	key := uuid.New()
 	result.ID = key
 	data, err := json.Marshal(result)
 	if err != nil {
@@ -843,10 +843,7 @@ func (l *DefaultLocalProvider) ExtractToken(w http.ResponseWriter, _ *http.Reque
 
 // SMPTestConfigStore Stores the given PerformanceTestConfig into local datastore
 func (l *DefaultLocalProvider) SMPTestConfigStore(_ *http.Request, perfConfig *perfprofile.PerformanceTestConfig) (string, error) {
-	uid, err := uuid.NewV4()
-	if err != nil {
-		return "", ErrGenerateUUID(err)
-	}
+	uid := uuid.New()
 	perfConfig.ID = uid.String()
 	data, err := json.Marshal(perfConfig)
 	if err != nil {
@@ -857,7 +854,7 @@ func (l *DefaultLocalProvider) SMPTestConfigStore(_ *http.Request, perfConfig *p
 
 // SMPTestConfigGet gets the given PerformanceTestConfig from the local datastore
 func (l *DefaultLocalProvider) SMPTestConfigGet(_ *http.Request, testUUID string) (*perfprofile.PerformanceTestConfig, error) {
-	uid, err := uuid.FromString(testUUID)
+	uid, err := uuid.Parse(testUUID)
 	if err != nil {
 		return nil, ErrGenerateUUID(err)
 	}
@@ -879,7 +876,7 @@ func (l *DefaultLocalProvider) SMPTestConfigFetch(_ *http.Request, page, pageSiz
 
 // SMPTestConfigDelete deletes the given PerformanceTestConfig from the local datastore
 func (l *DefaultLocalProvider) SMPTestConfigDelete(_ *http.Request, testUUID string) error {
-	uid, err := uuid.FromString(testUUID)
+	uid, err := uuid.Parse(testUUID)
 	if err != nil {
 		return ErrGenerateUUID(err)
 	}
@@ -896,7 +893,7 @@ func (l *DefaultLocalProvider) SaveMesheryPatternResource(_ string, resource *Pa
 }
 
 func (l *DefaultLocalProvider) GetMesheryPatternResource(_, resourceID string) (*PatternResource, error) {
-	id := uuid.FromStringOrNil(resourceID)
+	id := parseUUIDOrNil(resourceID)
 	return l.MesheryPatternResourcePersister.GetPatternResource(id)
 }
 
@@ -934,7 +931,7 @@ func (l *DefaultLocalProvider) GetMesheryPatternResources(
 }
 
 func (l *DefaultLocalProvider) DeleteMesheryPatternResource(_, resourceID string) error {
-	id := uuid.FromStringOrNil(resourceID)
+	id := parseUUIDOrNil(resourceID)
 	return l.MesheryPatternResourcePersister.DeletePatternResource(id)
 }
 
@@ -981,13 +978,13 @@ func (l *DefaultLocalProvider) UnPublishCatalogPattern(_ *http.Request, _ *Meshe
 
 // GetMesheryPattern gets pattern for the given patternID
 func (l *DefaultLocalProvider) GetMesheryPattern(_ *http.Request, patternID, _ string) ([]byte, error) {
-	id := uuid.FromStringOrNil(patternID)
+	id := parseUUIDOrNil(patternID)
 	return l.MesheryPatternPersister.GetMesheryPattern(id)
 }
 
 // DeleteMesheryPattern deletes a meshery pattern with the given id
 func (l *DefaultLocalProvider) DeleteMesheryPattern(_ *http.Request, patternID string) ([]byte, error) {
-	id := uuid.FromStringOrNil(patternID)
+	id := parseUUIDOrNil(patternID)
 	return l.MesheryPatternPersister.DeleteMesheryPattern(id)
 }
 
@@ -1003,7 +1000,7 @@ func (l *DefaultLocalProvider) CloneMesheryPattern(_ *http.Request, patternID st
 
 // GetDesignSourceContent returns design source-content from provider
 func (l *DefaultLocalProvider) GetDesignSourceContent(_, designID string) ([]byte, error) {
-	id := uuid.FromStringOrNil(designID)
+	id := parseUUIDOrNil(designID)
 	return l.MesheryPatternPersister.GetMesheryPatternSource(id)
 }
 
@@ -1103,19 +1100,19 @@ func (l *DefaultLocalProvider) UnPublishCatalogFilter(_ *http.Request, _ *Mesher
 
 // GetMesheryFilterFile gets filter for the given filterID without the metadata
 func (l *DefaultLocalProvider) GetMesheryFilterFile(_ *http.Request, filterID string) ([]byte, error) {
-	id := uuid.FromStringOrNil(filterID)
+	id := parseUUIDOrNil(filterID)
 	return l.MesheryFilterPersister.GetMesheryFilterFile(id)
 }
 
 // GetMesheryFilter gets filter for the given filterID
 func (l *DefaultLocalProvider) GetMesheryFilter(_ *http.Request, filterID string) ([]byte, error) {
-	id := uuid.FromStringOrNil(filterID)
+	id := parseUUIDOrNil(filterID)
 	return l.MesheryFilterPersister.GetMesheryFilter(id)
 }
 
 // DeleteMesheryFilter deletes a meshery filter with the given id
 func (l *DefaultLocalProvider) DeleteMesheryFilter(_ *http.Request, filterID string) ([]byte, error) {
-	id := uuid.FromStringOrNil(filterID)
+	id := parseUUIDOrNil(filterID)
 	return l.MesheryFilterPersister.DeleteMesheryFilter(id)
 }
 
@@ -1177,7 +1174,7 @@ func (l *DefaultLocalProvider) RemoteFilterFile(_ *http.Request, resourceURL, pa
 
 // GetApplicationSourceContent returns application source-content from provider
 func (l *DefaultLocalProvider) GetApplicationSourceContent(_ *http.Request, applicationID string) ([]byte, error) {
-	id := uuid.FromStringOrNil(applicationID)
+	id := parseUUIDOrNil(applicationID)
 	return l.MesheryApplicationPersister.GetMesheryApplicationSource(id)
 }
 
@@ -1205,13 +1202,13 @@ func (l *DefaultLocalProvider) GetMesheryApplications(_, page, pageSize, search,
 
 // GetMesheryApplication gets application for the given applicationID
 func (l *DefaultLocalProvider) GetMesheryApplication(_ *http.Request, applicationID string) ([]byte, error) {
-	id := uuid.FromStringOrNil(applicationID)
+	id := parseUUIDOrNil(applicationID)
 	return l.MesheryApplicationPersister.GetMesheryApplication(id)
 }
 
 // DeleteMesheryApplication deletes a meshery application with the given id
 func (l *DefaultLocalProvider) DeleteMesheryApplication(_ *http.Request, applicationID string) ([]byte, error) {
-	id := uuid.FromStringOrNil(applicationID)
+	id := parseUUIDOrNil(applicationID)
 	return l.MesheryApplicationPersister.DeleteMesheryApplication(id)
 }
 
@@ -1230,10 +1227,7 @@ func (l *DefaultLocalProvider) SavePerformanceProfile(_ string, performanceProfi
 	}
 
 	if performanceProfile.ID == (core.Uuid{}) {
-		uid, err := uuid.NewV4()
-		if err != nil {
-			return nil, ErrGenerateUUID(err)
-		}
+		uid := uuid.New()
 		performanceProfile.ID = uid
 	}
 
@@ -1273,7 +1267,7 @@ func (l *DefaultLocalProvider) GetPerformanceProfiles(_, page, pageSize, _, _ st
 
 // GetPerformanceProfile gets performance profile for the given performance profileID
 func (l *DefaultLocalProvider) GetPerformanceProfile(_ *http.Request, performanceProfileID string) ([]byte, error) {
-	uid, err := uuid.FromString(performanceProfileID)
+	uid, err := uuid.Parse(performanceProfileID)
 	if err != nil {
 		return nil, ErrPerfID(err)
 	}
@@ -1293,7 +1287,7 @@ func (l *DefaultLocalProvider) GetPerformanceProfile(_ *http.Request, performanc
 
 // DeletePerformanceProfile deletes a meshery performance profile with the given id
 func (l *DefaultLocalProvider) DeletePerformanceProfile(_ *http.Request, performanceProfileID string) ([]byte, error) {
-	uid, err := uuid.FromString(performanceProfileID)
+	uid, err := uuid.Parse(performanceProfileID)
 	if err != nil {
 		return nil, ErrPerfID(err)
 	}
@@ -1409,7 +1403,7 @@ func (l *DefaultLocalProvider) DeleteConnection(_ *http.Request, connectionID co
 }
 
 func (l *DefaultLocalProvider) DeleteMesheryConnection() error {
-	mesheryConnectionID := uuid.FromStringOrNil(viper.GetString("INSTANCE_ID"))
+	mesheryConnectionID := parseUUIDOrNil(viper.GetString("INSTANCE_ID"))
 	_, err := l.DeleteConnection(nil, mesheryConnectionID)
 	return err
 }
@@ -1456,11 +1450,7 @@ func (l *DefaultLocalProvider) SeedContent(log logger.Handler) {
 					continue
 				}
 
-				id, err := uuid.NewV4()
-				if err != nil {
-					log.Error(err)
-					continue
-				}
+				id := uuid.New()
 
 				patternName, err := GetPatternName(file.Content)
 				if err != nil {
@@ -1489,7 +1479,7 @@ func (l *DefaultLocalProvider) SeedContent(log logger.Handler) {
 		}
 	}
 	// Seed default organization before the UI requests organizations.
-	id, _ := uuid.NewV4()
+	id := uuid.New()
 	org := &organization.Organization{
 		ID:          id,
 		Name:        "My Org",
@@ -1636,7 +1626,7 @@ func (l *DefaultLocalProvider) GetUsersKeys(_, _, _, search, order, updatedAfter
 
 // GetKey returns the key for the given keyID
 func (l *DefaultLocalProvider) GetUsersKey(_ *http.Request, keyID string) ([]byte, error) {
-	id := uuid.FromStringOrNil(keyID)
+	id := parseUUIDOrNil(keyID)
 	return l.KeyPersister.GetUsersKey(id)
 }
 
@@ -1650,12 +1640,12 @@ func (l *DefaultLocalProvider) GetWorkspaces(_, page, pageSize, search, order, f
 }
 
 func (l *DefaultLocalProvider) GetWorkspaceByID(_ *http.Request, workspaceID string, _ string) ([]byte, error) {
-	id := uuid.FromStringOrNil(workspaceID)
+	id := parseUUIDOrNil(workspaceID)
 	return l.WorkspacePersister.GetWorkspaceByID(id)
 }
 
 func (l *DefaultLocalProvider) DeleteWorkspace(_ *http.Request, workspaceID string) ([]byte, error) {
-	id := uuid.FromStringOrNil(workspaceID)
+	id := parseUUIDOrNil(workspaceID)
 	return l.WorkspacePersister.DeleteWorkspaceByID(id)
 }
 
@@ -1672,7 +1662,7 @@ func (l *DefaultLocalProvider) SaveWorkspace(_ *http.Request, workspacePayload *
 }
 
 func (l *DefaultLocalProvider) UpdateWorkspace(_ *http.Request, workspacePayload *workspace.WorkspaceUpdatePayload, workspaceID string) (*workspace.Workspace, error) {
-	id, err := uuid.FromString(workspaceID)
+	id, err := uuid.Parse(workspaceID)
 	if err != nil {
 		return nil, err
 	}
@@ -1680,39 +1670,39 @@ func (l *DefaultLocalProvider) UpdateWorkspace(_ *http.Request, workspacePayload
 }
 
 func (l *DefaultLocalProvider) AddEnvironmentToWorkspace(_ *http.Request, workspaceID string, environmentID string) ([]byte, error) {
-	workspaceId, _ := uuid.FromString(workspaceID)
-	envId, _ := uuid.FromString(environmentID)
+	workspaceId, _ := uuid.Parse(workspaceID)
+	envId, _ := uuid.Parse(environmentID)
 	return l.WorkspacePersister.AddEnvironmentToWorkspace(workspaceId, envId)
 }
 
 func (l *DefaultLocalProvider) RemoveEnvironmentFromWorkspace(_ *http.Request, workspaceID string, environmentID string) ([]byte, error) {
-	workspaceId, _ := uuid.FromString(workspaceID)
-	envId, _ := uuid.FromString(environmentID)
+	workspaceId, _ := uuid.Parse(workspaceID)
+	envId, _ := uuid.Parse(environmentID)
 	return l.WorkspacePersister.DeleteEnvironmentFromWorkspace(workspaceId, envId)
 }
 
 func (l *DefaultLocalProvider) GetEnvironmentsOfWorkspace(_ *http.Request, workspaceID, page, pageSize, search, order, filter string) ([]byte, error) {
-	workspaceId, _ := uuid.FromString(workspaceID)
+	workspaceId, _ := uuid.Parse(workspaceID)
 	return l.WorkspacePersister.GetWorkspaceEnvironments(workspaceId, search, order, page, pageSize, filter)
 }
 
 func (l *DefaultLocalProvider) AddDesignToWorkspace(_ *http.Request, workspaceID string, designID string) ([]byte, error) {
-	workspaceId, _ := uuid.FromString(workspaceID)
-	designId, _ := uuid.FromString(designID)
+	workspaceId, _ := uuid.Parse(workspaceID)
+	designId, _ := uuid.Parse(designID)
 	return l.WorkspacePersister.AddDesignToWorkspace(workspaceId, designId)
 }
 
 func (l *DefaultLocalProvider) GetDesignsOfWorkspace(_ *http.Request, workspaceID, page, pageSize, search, order, filter string, visibility []string) ([]byte, error) {
-	workspaceId, _ := uuid.FromString(workspaceID)
+	workspaceId, _ := uuid.Parse(workspaceID)
 	return l.WorkspacePersister.GetWorkspaceDesigns(workspaceId, search, order, page, pageSize, filter, visibility)
 }
 
 func (l *DefaultLocalProvider) RemoveDesignFromWorkspace(_ *http.Request, workspaceID string, designID string) ([]byte, error) {
-	wsID, err := uuid.FromString(workspaceID)
+	wsID, err := uuid.Parse(workspaceID)
 	if err != nil {
 		return nil, err
 	}
-	dID, err := uuid.FromString(designID)
+	dID, err := uuid.Parse(designID)
 	if err != nil {
 		return nil, err
 	}
@@ -1720,7 +1710,7 @@ func (l *DefaultLocalProvider) RemoveDesignFromWorkspace(_ *http.Request, worksp
 }
 
 func (l *DefaultLocalProvider) GetViewsOfWorkspace(_ *http.Request, workspaceID, page, pageSize, search, order, filter string) ([]byte, error) {
-	wsID, err := uuid.FromString(workspaceID)
+	wsID, err := uuid.Parse(workspaceID)
 	if err != nil {
 		return nil, err
 	}
@@ -1728,11 +1718,11 @@ func (l *DefaultLocalProvider) GetViewsOfWorkspace(_ *http.Request, workspaceID,
 }
 
 func (l *DefaultLocalProvider) AddViewToWorkspace(_ *http.Request, workspaceID string, viewID string) ([]byte, error) {
-	wsID, err := uuid.FromString(workspaceID)
+	wsID, err := uuid.Parse(workspaceID)
 	if err != nil {
 		return nil, err
 	}
-	vID, err := uuid.FromString(viewID)
+	vID, err := uuid.Parse(viewID)
 	if err != nil {
 		return nil, err
 	}
@@ -1740,11 +1730,11 @@ func (l *DefaultLocalProvider) AddViewToWorkspace(_ *http.Request, workspaceID s
 }
 
 func (l *DefaultLocalProvider) RemoveViewFromWorkspace(_ *http.Request, workspaceID string, viewID string) ([]byte, error) {
-	wsID, err := uuid.FromString(workspaceID)
+	wsID, err := uuid.Parse(workspaceID)
 	if err != nil {
 		return nil, err
 	}
-	vID, err := uuid.FromString(viewID)
+	vID, err := uuid.Parse(viewID)
 	if err != nil {
 		return nil, err
 	}
@@ -1752,7 +1742,7 @@ func (l *DefaultLocalProvider) RemoveViewFromWorkspace(_ *http.Request, workspac
 }
 
 func (l *DefaultLocalProvider) GetTeamsOfWorkspace(_ *http.Request, workspaceID, page, pageSize, search, order, filter string) ([]byte, error) {
-	wsID, err := uuid.FromString(workspaceID)
+	wsID, err := uuid.Parse(workspaceID)
 	if err != nil {
 		return nil, err
 	}
@@ -1760,11 +1750,11 @@ func (l *DefaultLocalProvider) GetTeamsOfWorkspace(_ *http.Request, workspaceID,
 }
 
 func (l *DefaultLocalProvider) AddTeamToWorkspace(_ *http.Request, workspaceID string, teamID string) ([]byte, error) {
-	wsID, err := uuid.FromString(workspaceID)
+	wsID, err := uuid.Parse(workspaceID)
 	if err != nil {
 		return nil, err
 	}
-	tID, err := uuid.FromString(teamID)
+	tID, err := uuid.Parse(teamID)
 	if err != nil {
 		return nil, err
 	}
@@ -1772,11 +1762,11 @@ func (l *DefaultLocalProvider) AddTeamToWorkspace(_ *http.Request, workspaceID s
 }
 
 func (l *DefaultLocalProvider) RemoveTeamFromWorkspace(_ *http.Request, workspaceID string, teamID string) ([]byte, error) {
-	wsID, err := uuid.FromString(workspaceID)
+	wsID, err := uuid.Parse(workspaceID)
 	if err != nil {
 		return nil, err
 	}
-	tID, err := uuid.FromString(teamID)
+	tID, err := uuid.Parse(teamID)
 	if err != nil {
 		return nil, err
 	}
@@ -1785,7 +1775,7 @@ func (l *DefaultLocalProvider) RemoveTeamFromWorkspace(_ *http.Request, workspac
 
 // GetOrganization returns the organization for the given organizationID
 func (l *DefaultLocalProvider) GetOrganization(_ *http.Request, organizationId string) ([]byte, error) {
-	id := uuid.FromStringOrNil(organizationId)
+	id := parseUUIDOrNil(organizationId)
 	return l.OrganizationPersister.GetOrganzation(id)
 }
 

--- a/server/models/default_local_provider_test.go
+++ b/server/models/default_local_provider_test.go
@@ -4,7 +4,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/gofrs/uuid"
+	"github.com/google/uuid"
 	"github.com/meshery/meshkit/database"
 	"github.com/meshery/meshkit/logger"
 	"github.com/meshery/meshkit/models/events"
@@ -72,14 +72,8 @@ func TestEventsPersisterPersistEventAcceptsStructValue(t *testing.T) {
 
 	persister := &EventsPersister{DB: &database.Handler{DB: db}}
 
-	eventID, err := uuid.NewV4()
-	if err != nil {
-		t.Fatalf("failed to generate event id: %v", err)
-	}
-	systemID, err := uuid.NewV4()
-	if err != nil {
-		t.Fatalf("failed to generate system id: %v", err)
-	}
+	eventID := uuid.New()
+	systemID := uuid.New()
 
 	built := events.NewEvent().
 		FromSystem(systemID).
@@ -118,14 +112,8 @@ func TestEventsPersisterPersistSystemEventAcceptsStructValue(t *testing.T) {
 
 	persister := &EventsPersister{DB: &database.Handler{DB: db}}
 
-	systemID, err := uuid.NewV4()
-	if err != nil {
-		t.Fatalf("failed to generate system id: %v", err)
-	}
-	eventID, err := uuid.NewV4()
-	if err != nil {
-		t.Fatalf("failed to generate event id: %v", err)
-	}
+	systemID := uuid.New()
+	eventID := uuid.New()
 
 	built := events.NewEvent().
 		FromSystem(systemID).

--- a/server/models/environment_persister.go
+++ b/server/models/environment_persister.go
@@ -8,7 +8,7 @@ import (
 
 	"github.com/meshery/schemas/models/core"
 
-	"github.com/gofrs/uuid"
+	"github.com/google/uuid"
 	"github.com/meshery/meshery/server/helpers/utils"
 	"github.com/meshery/meshery/server/models/connections"
 	"github.com/meshery/meshkit/database"
@@ -106,10 +106,7 @@ func (ep *EnvironmentPersister) GetEnvironments(orgID, search, order, page, page
 
 func (ep *EnvironmentPersister) SaveEnvironment(environment *environment.Environment) ([]byte, error) {
 	if environment.ID == uuid.Nil {
-		id, err := uuid.NewV4()
-		if err != nil {
-			return nil, ErrGenerateUUID(err)
-		}
+		id := uuid.New()
 		environment.ID = id
 	}
 
@@ -216,10 +213,7 @@ func (ep *EnvironmentPersister) AddConnectionToEnvironment(environmentID, connec
 		UpdatedAt:     time.Now(),
 	}
 
-	id, err := uuid.NewV4()
-	if err != nil {
-		return nil, ErrGenerateUUID(err)
-	}
+	id := uuid.New()
 	envConMapping.ID = id
 
 	// Add connection to environment

--- a/server/models/events_persister.go
+++ b/server/models/events_persister.go
@@ -1,7 +1,6 @@
 package models
 
 import (
-	"github.com/gofrs/uuid"
 	"github.com/meshery/meshkit/database"
 	"github.com/meshery/meshkit/models/events"
 	"github.com/meshery/schemas/models/core"
@@ -33,7 +32,7 @@ func (e *EventsPersister) getCountBySeverity(userID core.Uuid, eventStatus event
 	}
 	// Get the system ID from the config for the current instance. This is used to filter events that are not associated with the user but are associated with the system
 	systemID := viper.GetString("INSTANCE_ID")
-	sysID := uuid.FromStringOrNil(systemID)
+	sysID := parseUUIDOrNil(systemID)
 
 	eventsBySeverity := []*CountBySeverityLevel{}
 	err := e.DB.Model(&events.Event{}).

--- a/server/models/k8s_components_registration.go
+++ b/server/models/k8s_components_registration.go
@@ -11,7 +11,7 @@ import (
 
 	"github.com/meshery/schemas/models/core"
 
-	"github.com/gofrs/uuid"
+	"github.com/google/uuid"
 	"github.com/meshery/schemas/models/v1beta1/capability"
 	"github.com/meshery/schemas/models/v1beta3/component"
 
@@ -94,11 +94,11 @@ func (cg *ComponentsRegistrationHelper) RegisterComponents(ctxs []*K8sContext, r
 		return
 	}
 
-	userUUID, _ := uuid.FromString(userID)
+	userUUID, _ := uuid.Parse(userID)
 
 	for _, ctx := range ctxs {
 		ctxID := ctx.ID
-		connectionID, _ := uuid.FromString(ctx.ConnectionID)
+		connectionID, _ := uuid.Parse(ctx.ConnectionID)
 		ctxName := ctx.Name
 
 		cg.mx.Lock()

--- a/server/models/k8s_context.go
+++ b/server/models/k8s_context.go
@@ -14,7 +14,7 @@ import (
 
 	"github.com/meshery/schemas/models/core"
 
-	"github.com/gofrs/uuid"
+	"github.com/google/uuid"
 	"github.com/meshery/meshery/server/helpers/utils"
 	"github.com/meshery/meshery/server/internal/sql"
 	"github.com/meshery/meshery/server/models/connections"
@@ -175,7 +175,7 @@ func NewK8sContextWithServerID(
 		return nil, err
 	}
 	uid := ksns.GetUID()
-	ksUUID := uuid.FromStringOrNil(string(uid))
+	ksUUID := parseUUIDOrNil(string(uid))
 
 	ctx.KubernetesServerID = &ksUUID
 
@@ -203,7 +203,7 @@ func K8sContextsFromKubeconfigWithOptions(provider Provider, userID string, _ *B
 		return kcs
 	}
 
-	userUUID := uuid.FromStringOrNil(userID)
+	userUUID := parseUUIDOrNil(userID)
 
 	kcfg := InternalKubeConfig{}
 	if err := yaml.Unmarshal(kubeconfig, &kcfg); err != nil {
@@ -213,7 +213,7 @@ func K8sContextsFromKubeconfigWithOptions(provider Provider, userID string, _ *B
 	for name := range parsed.Contexts {
 		metadata := map[string]interface{}{}
 		kc, _ := kcfg.K8sContext(name, instanceID, log)
-		eventBuilder := events.NewEvent().ActedUpon(uuid.FromStringOrNil(kc.ConnectionID)).WithCategory("connection").WithAction("register").FromSystem(*instanceID).FromOwner(userUUID)
+		eventBuilder := events.NewEvent().ActedUpon(parseUUIDOrNil(kc.ConnectionID)).WithCategory("connection").WithAction("register").FromSystem(*instanceID).FromOwner(userUUID)
 
 		metadata["context"] = RedactCredentialsForContext(&kc)
 
@@ -487,7 +487,7 @@ func (kc *K8sContext) AssignServerID(handler *kubernetes.Client) error {
 		return ErrUnreachableKubeAPI(err, kc.Server)
 	}
 	uid := ksns.GetUID()
-	ksUUID := uuid.FromStringOrNil(string(uid))
+	ksUUID := parseUUIDOrNil(string(uid))
 
 	kc.KubernetesServerID = &ksUUID
 
@@ -497,8 +497,8 @@ func (kc *K8sContext) AssignServerID(handler *kubernetes.Client) error {
 // FlushMeshSyncData will flush the meshsync data for the passed kubernetes contextID
 func FlushMeshSyncData(ctx context.Context, k8sContext K8sContext, provider Provider, eventsChan *Broadcast, userID string, mesheryInstanceID *core.Uuid, log logger.Handler) {
 	ctxID := k8sContext.ID
-	ctxUUID, _ := uuid.FromString(ctxID)
-	userUUID, _ := uuid.FromString(userID)
+	ctxUUID, _ := uuid.Parse(ctxID)
+	userUUID, _ := uuid.Parse(userID)
 	// Gets all the available kubernetes contexts
 
 	ctxName := k8sContext.Name

--- a/server/models/k8s_context_test.go
+++ b/server/models/k8s_context_test.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"testing"
 
-	"github.com/gofrs/uuid"
+	"github.com/google/uuid"
 )
 
 // TestFlushMeshSyncDataNilKubernetesServerIDNoPanic verifies that FlushMeshSyncData
@@ -31,10 +31,7 @@ func TestFlushMeshSyncDataNilKubernetesServerIDNoPanic(t *testing.T) {
 // correctly skips nil entries while still counting non-nil ones, and that no panic
 // occurs when both nil and populated KubernetesServerID values are present.
 func TestFlushMeshSyncDataMixedNilAndPopulatedServerIDs(t *testing.T) {
-	serverID, err := uuid.NewV4()
-	if err != nil {
-		t.Fatalf("failed to generate UUID: %v", err)
-	}
+	serverID := uuid.New()
 
 	k8sctxs := []*K8sContext{
 		{ID: "ctx-1", Name: "cluster-a", KubernetesServerID: nil},

--- a/server/models/meshery_application_persister.go
+++ b/server/models/meshery_application_persister.go
@@ -6,7 +6,7 @@ import (
 
 	"github.com/meshery/schemas/models/core"
 
-	"github.com/gofrs/uuid"
+	"github.com/google/uuid"
 	"github.com/meshery/meshkit/database"
 )
 
@@ -69,10 +69,7 @@ func (maap *MesheryApplicationPersister) SaveMesheryApplications(applications []
 	finalApplications := []MesheryApplication{}
 	for _, application := range applications {
 		if application.ID == nil {
-			id, err := uuid.NewV4()
-			if err != nil {
-				return nil, ErrGenerateUUID(err)
-			}
+			id := uuid.New()
 
 			application.ID = &id
 		}

--- a/server/models/meshery_controllers.go
+++ b/server/models/meshery_controllers.go
@@ -11,7 +11,7 @@ import (
 
 	"maps"
 
-	"github.com/gofrs/uuid"
+	"github.com/google/uuid"
 	"github.com/meshery/meshkit/broker"
 	channelBroker "github.com/meshery/meshkit/broker/channel"
 	"github.com/meshery/meshkit/broker/nats"
@@ -168,7 +168,7 @@ func (mch *MesheryControllersHelper) AddMeshsynDataHandlers(ctx context.Context,
 			return mch
 		}
 		token, _ := ctx.Value(TokenCtxKey).(string)
-		msDataHandler := NewMeshsyncDataHandler(brokerHandler, *mch.dbHandler, mch.log, provider, userID, uuid.FromStringOrNil(k8scontext.ConnectionID), mesheryInstanceID, token, stopFunc)
+		msDataHandler := NewMeshsyncDataHandler(brokerHandler, *mch.dbHandler, mch.log, provider, userID, parseUUIDOrNil(k8scontext.ConnectionID), mesheryInstanceID, token, stopFunc)
 		err := msDataHandler.Run()
 		if err != nil {
 			mch.log.Warn(err)
@@ -687,7 +687,7 @@ func controllerEventActedUpon(userID core.Uuid, metadata map[string]any) core.Uu
 	if metadata != nil {
 		switch connectionID := metadata["connectionID"].(type) {
 		case string:
-			if parsedID := uuid.FromStringOrNil(connectionID); parsedID != uuid.Nil {
+			if parsedID := parseUUIDOrNil(connectionID); parsedID != uuid.Nil {
 				return parsedID
 			}
 		case core.Uuid:

--- a/server/models/meshery_controllers_test.go
+++ b/server/models/meshery_controllers_test.go
@@ -3,14 +3,14 @@ package models
 import (
 	"testing"
 
-	"github.com/gofrs/uuid"
+	"github.com/google/uuid"
 	"github.com/meshery/meshkit/logger"
 	"github.com/meshery/meshkit/models/controllers"
 )
 
 func TestControllerEventActedUponPrefersConnectionID(t *testing.T) {
-	userID := uuid.Must(uuid.NewV4())
-	connectionID := uuid.Must(uuid.NewV4())
+	userID := uuid.New()
+	connectionID := uuid.New()
 
 	actedUpon := controllerEventActedUpon(userID, map[string]any{
 		"connectionID": connectionID.String(),
@@ -22,7 +22,7 @@ func TestControllerEventActedUponPrefersConnectionID(t *testing.T) {
 }
 
 func TestControllerEventActedUponFallsBackToUserID(t *testing.T) {
-	userID := uuid.Must(uuid.NewV4())
+	userID := uuid.New()
 
 	actedUpon := controllerEventActedUpon(userID, map[string]any{
 		"connectionID": "not-a-uuid",
@@ -44,8 +44,8 @@ func TestControllerEventActedUponReturnsNilWithoutValidIDs(t *testing.T) {
 }
 
 func TestShouldPersistControllerEvent(t *testing.T) {
-	userID := uuid.Must(uuid.NewV4())
-	resourceID := uuid.Must(uuid.NewV4())
+	userID := uuid.New()
+	resourceID := uuid.New()
 
 	if !shouldPersistControllerEvent(userID, resourceID) {
 		t.Fatal("expected controller event to be persisted when user and resource IDs are valid")

--- a/server/models/meshery_filter_persister.go
+++ b/server/models/meshery_filter_persister.go
@@ -8,7 +8,7 @@ import (
 
 	"github.com/meshery/schemas/models/core"
 
-	"github.com/gofrs/uuid"
+	"github.com/google/uuid"
 	"github.com/meshery/meshkit/database"
 )
 
@@ -132,16 +132,13 @@ func (mfp *MesheryFilterPersister) GetMesheryCatalogFilters(page, pageSize, sear
 // CloneMesheryFilter clones meshery filter to private
 func (mfp *MesheryFilterPersister) CloneMesheryFilter(filterID string, cloneFilterRequest *MesheryCloneFilterRequestBody) ([]byte, error) {
 	var mesheryFilter MesheryFilter
-	filterUUID, _ := uuid.FromString(filterID)
+	filterUUID, _ := uuid.Parse(filterID)
 	err := mfp.DB.First(&mesheryFilter, filterUUID).Error
 	if err != nil || *mesheryFilter.ID == uuid.Nil {
 		return nil, fmt.Errorf("unable to get filter: %w", err)
 	}
 
-	id, err := uuid.NewV4()
-	if err != nil {
-		return nil, err
-	}
+	id := uuid.New()
 
 	mesheryFilter.Visibility = Private
 	mesheryFilter.ID = &id
@@ -163,10 +160,7 @@ func (mfp *MesheryFilterPersister) SaveMesheryFilter(filter *MesheryFilter) ([]b
 		filter.Visibility = Private
 	}
 	if filter.ID == nil {
-		id, err := uuid.NewV4()
-		if err != nil {
-			return nil, ErrGenerateUUID(err)
-		}
+		id := uuid.New()
 
 		filter.ID = &id
 	}
@@ -184,10 +178,7 @@ func (mfp *MesheryFilterPersister) SaveMesheryFilters(filters []MesheryFilter) (
 		}
 		filter.Owner = &nilOwner
 		if filter.ID == nil {
-			id, err := uuid.NewV4()
-			if err != nil {
-				return nil, ErrGenerateUUID(err)
-			}
+			id := uuid.New()
 
 			filter.ID = &id
 		}

--- a/server/models/meshery_pattern_persister.go
+++ b/server/models/meshery_pattern_persister.go
@@ -8,7 +8,7 @@ import (
 
 	"github.com/meshery/schemas/models/core"
 
-	"github.com/gofrs/uuid"
+	"github.com/google/uuid"
 	"gopkg.in/yaml.v2"
 
 	"github.com/meshery/meshkit/database"
@@ -135,16 +135,13 @@ func (mpp *MesheryPatternPersister) GetMesheryCatalogPatterns(page, pageSize, se
 // CloneMesheryPattern clones meshery pattern to private
 func (mpp *MesheryPatternPersister) CloneMesheryPattern(patternID string, clonePatternRequest *MesheryClonePatternRequestBody) ([]byte, error) {
 	var mesheryPattern MesheryPattern
-	patternUUID, _ := uuid.FromString(patternID)
+	patternUUID, _ := uuid.Parse(patternID)
 	err := mpp.DB.First(&mesheryPattern, patternUUID).Error
 	if err != nil || *mesheryPattern.ID == uuid.Nil {
 		return nil, fmt.Errorf("unable to get design: %w", err)
 	}
 
-	id, err := uuid.NewV4()
-	if err != nil {
-		return nil, err
-	}
+	id := uuid.New()
 
 	mesheryPattern.Visibility = Private
 	mesheryPattern.ID = &id
@@ -165,7 +162,7 @@ func (mpp *MesheryPatternPersister) DeleteMesheryPattern(id core.Uuid) ([]byte, 
 func (mpp *MesheryPatternPersister) DeleteMesheryPatterns(patterns MesheryPatternDeleteRequestBody) ([]byte, error) {
 	var deletedMaptterns []MesheryPattern
 	for _, pObj := range patterns.Patterns {
-		id := uuid.FromStringOrNil(pObj.ID)
+		id := parseUUIDOrNil(pObj.ID)
 		pattern := MesheryPattern{ID: &id}
 		mpp.DB.Delete(&pattern)
 		deletedMaptterns = append(deletedMaptterns, pattern)
@@ -184,10 +181,7 @@ func (mpp *MesheryPatternPersister) SaveMesheryPattern(pattern *MesheryPattern) 
 		pattern.Visibility = Private
 	}
 	if pattern.ID == nil {
-		id, err := uuid.NewV4()
-		if err != nil {
-			return nil, ErrGenerateUUID(err)
-		}
+		id := uuid.New()
 
 		patterns.AssignVersion(pf)
 
@@ -224,10 +218,7 @@ func (mpp *MesheryPatternPersister) SaveMesheryPatterns(mesheryPatterns []Mesher
 		}
 		pattern.Owner = &nilOwner
 		if pattern.ID == nil {
-			id, err := uuid.NewV4()
-			if err != nil {
-				return nil, ErrGenerateUUID(err)
-			}
+			id := uuid.New()
 			patterns.AssignVersion(pf)
 			pattern.ID = &id
 		} else {

--- a/server/models/meshmodel/core/register.go
+++ b/server/models/meshmodel/core/register.go
@@ -12,7 +12,6 @@ import (
 	"cuelang.org/go/cue"
 	"cuelang.org/go/cue/cuecontext"
 	cueJson "cuelang.org/go/encoding/json"
-	"github.com/google/uuid"
 	"github.com/meshery/meshery/server/helpers"
 
 	"github.com/meshery/meshery/server/models"

--- a/server/models/meshmodel/core/register.go
+++ b/server/models/meshmodel/core/register.go
@@ -12,7 +12,7 @@ import (
 	"cuelang.org/go/cue"
 	"cuelang.org/go/cue/cuecontext"
 	cueJson "cuelang.org/go/encoding/json"
-	"github.com/gofrs/uuid"
+	"github.com/google/uuid"
 	"github.com/meshery/meshery/server/helpers"
 
 	"github.com/meshery/meshery/server/models"
@@ -52,8 +52,8 @@ type names struct {
 }
 
 func RegisterK8sMeshModelComponents(provider *models.Provider, _ context.Context, config []byte, ctxID string, connectionID string, userID string, mesheryInstanceID core.Uuid, reg *registry.RegistryManager, ec *models.Broadcast, log logger.Handler, ctxName string) (err error) {
-	connectionUUID := uuid.FromStringOrNil(connectionID)
-	userUUID := uuid.FromStringOrNil(userID)
+	connectionUUID := parseUUIDOrNil(connectionID)
+	userUUID := parseUUIDOrNil(userID)
 
 	man, err := GetK8sMeshModelComponents(config)
 	eventMetadata := make(map[string]interface{}, 0)

--- a/server/models/meshmodel/core/uuid_helpers.go
+++ b/server/models/meshmodel/core/uuid_helpers.go
@@ -1,0 +1,13 @@
+package core
+
+import "github.com/google/uuid"
+
+// parseUUIDOrNil parses s as a UUID and returns uuid.Nil if parsing fails.
+// This is a compatibility shim replacing gofrs/uuid's FromStringOrNil.
+func parseUUIDOrNil(s string) uuid.UUID {
+	id, err := uuid.Parse(s)
+	if err != nil {
+		return uuid.Nil
+	}
+	return id
+}

--- a/server/models/meshsync_events_test.go
+++ b/server/models/meshsync_events_test.go
@@ -6,7 +6,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/gofrs/uuid"
+	"github.com/google/uuid"
 	meshkitBroker "github.com/meshery/meshkit/broker"
 	"github.com/meshery/meshkit/database"
 	meshkitErrors "github.com/meshery/meshkit/errors"
@@ -220,8 +220,8 @@ func TestGetComponentMetadataReturnsAssociatedModelName(t *testing.T) {
 		t.Fatalf("Failed to migrate schema: %v", err)
 	}
 
-	modelID := uuid.FromStringOrNil("11111111-1111-1111-1111-111111111111")
-	componentID := uuid.FromStringOrNil("22222222-2222-2222-2222-222222222222")
+	modelID := parseUUIDOrNil("11111111-1111-1111-1111-111111111111")
+	componentID := parseUUIDOrNil("22222222-2222-2222-2222-222222222222")
 
 	modelDef := modelv1beta1.ModelDefinition{
 		ID:   modelID,

--- a/server/models/organization_persistor.go
+++ b/server/models/organization_persistor.go
@@ -6,7 +6,7 @@ import (
 
 	"github.com/meshery/schemas/models/core"
 
-	"github.com/gofrs/uuid"
+	"github.com/google/uuid"
 	"github.com/meshery/meshkit/database"
 	"github.com/meshery/schemas/models/v1beta2/organization"
 )
@@ -51,10 +51,7 @@ func (op *OrganizationPersister) GetOrganizations(search, order string, page, pa
 
 func (op *OrganizationPersister) SaveOrganization(org *organization.Organization) ([]byte, error) {
 	if org.ID == uuid.Nil {
-		id, err := uuid.NewV4()
-		if err != nil {
-			return nil, ErrGenerateUUID(err)
-		}
+		id := uuid.New()
 
 		org.ID = id
 	}

--- a/server/models/pattern/core/pattern.go
+++ b/server/models/pattern/core/pattern.go
@@ -8,7 +8,7 @@ import (
 	"path/filepath"
 	"strings"
 
-	"github.com/gofrs/uuid"
+	"github.com/google/uuid"
 	"github.com/meshery/meshery/server/models/pattern/utils"
 	"github.com/meshery/meshkit/encoding"
 	"github.com/meshery/meshkit/logger"
@@ -219,7 +219,7 @@ func NewPatternFileFromCytoscapeJSJSON(name string, byt []byte) (pattern.Pattern
 		name = "MesheryGeneratedPattern"
 	}
 
-	id, _ := uuid.NewV4()
+	id := uuid.New()
 	// Convert cytoscape struct to patternfile
 	pf := pattern.PatternFile{
 		ID:         id,
@@ -467,7 +467,7 @@ func createPatternDeclarationFromK8s(manifest map[string]interface{}, regManager
 	}
 
 	rest = Format.Prettify(rest, false)
-	uuidV4, _ := uuid.NewV4()
+	uuidV4 := uuid.New()
 	defaultCapabilities := []capability.Capability{} // only assign empty capabilities for component declarations
 	status := (*component.ComponentDefinitionStatus)(nil)
 	if comp.Status != nil {

--- a/server/models/pattern/utils/patternfile_version_bridge_test.go
+++ b/server/models/pattern/utils/patternfile_version_bridge_test.go
@@ -14,7 +14,7 @@ import (
 	relationshipv1beta2 "github.com/meshery/schemas/models/v1beta2/relationship"
 	designv1beta3 "github.com/meshery/schemas/models/v1beta3/design"
 
-	"github.com/gofrs/uuid"
+	"github.com/google/uuid"
 )
 
 func TestPatternV1beta1ToV1beta3_PreservesAliasedFields(t *testing.T) {
@@ -218,9 +218,9 @@ func newPatternV1beta1Fixture() *patternv1beta1.PatternFile {
 
 func mustUUID(t *testing.T, raw string) uuid.UUID {
 	t.Helper()
-	id, err := uuid.FromString(raw)
+	id, err := uuid.Parse(raw)
 	if err != nil {
-		t.Fatalf("uuid.FromString(%q): %v", raw, err)
+		t.Fatalf("uuid.Parse(%q): %v", raw, err)
 	}
 	return id
 }

--- a/server/models/pattern_resource_persister.go
+++ b/server/models/pattern_resource_persister.go
@@ -3,7 +3,7 @@ package models
 import (
 	"strings"
 
-	"github.com/gofrs/uuid"
+	"github.com/google/uuid"
 	"github.com/meshery/meshkit/database"
 	"github.com/meshery/schemas/models/core"
 )
@@ -21,10 +21,7 @@ type PatternResourcePage struct {
 
 func (prp *PatternResourcePersister) SavePatternResource(pr *PatternResource) (*PatternResource, error) {
 	if pr.ID == nil {
-		id, err := uuid.NewV4()
-		if err != nil {
-			return nil, ErrGenerateUUID(err)
-		}
+		id := uuid.New()
 
 		pr.ID = &id
 	}

--- a/server/models/remote_provider.go
+++ b/server/models/remote_provider.go
@@ -25,7 +25,7 @@ import (
 
 	"github.com/meshery/schemas/models/core"
 
-	"github.com/gofrs/uuid"
+	"github.com/google/uuid"
 	servercore "github.com/meshery/meshery/server/core"
 	"github.com/meshery/meshery/server/models/connections"
 	"github.com/meshery/meshery/server/models/httputil"
@@ -1041,7 +1041,7 @@ func (l *RemoteProvider) HandleUnAuthenticated(w http.ResponseWriter, req *http.
 
 func (l *RemoteProvider) SaveK8sContext(token string, k8sContext K8sContext, additionalMetadata map[string]any) (connections.Connection, error) {
 	if k8sContext.ConnectionID != "" {
-		connectionID := uuid.FromStringOrNil(k8sContext.ConnectionID)
+		connectionID := parseUUIDOrNil(k8sContext.ConnectionID)
 		if connectionID != uuid.Nil {
 			conn, status, _ := l.GetConnectionByID(token, connectionID)
 			if status >= http.StatusOK && status < http.StatusMultipleChoices && conn != nil && conn.Kind == "kubernetes" {
@@ -1265,7 +1265,7 @@ func (l *RemoteProvider) GetK8sContext(token, connectionID string) (K8sContext, 
 		return K8sContext{}, ErrInvalidCapability("PersistConnection", l.ProviderName)
 	}
 
-	connID := uuid.FromStringOrNil(connectionID)
+	connID := parseUUIDOrNil(connectionID)
 	if connID == uuid.Nil {
 		return K8sContext{}, fmt.Errorf("invalid connection id: %s", connectionID)
 	}

--- a/server/models/remote_provider_patterns_test.go
+++ b/server/models/remote_provider_patterns_test.go
@@ -8,7 +8,7 @@ import (
 	"sync/atomic"
 	"testing"
 
-	"github.com/gofrs/uuid"
+	"github.com/google/uuid"
 )
 
 // TestSaveMesheryPattern_SendsPatternDataWrapperKey verifies that
@@ -51,10 +51,7 @@ func TestSaveMesheryPattern_SendsPatternDataWrapperKey(t *testing.T) {
 	provider := newTestRemoteProvider(t, server.URL)
 	provider.Capabilities = Capabilities{{Feature: PersistMesheryPatterns, Endpoint: "/patterns"}}
 
-	id, err := uuid.NewV4()
-	if err != nil {
-		t.Fatalf("failed to generate pattern id: %v", err)
-	}
+	id := uuid.New()
 	pattern := &MesheryPattern{
 		ID:          &id,
 		Name:        "Untitled Design",

--- a/server/models/seed_models_logs.go
+++ b/server/models/seed_models_logs.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"strings"
 
-	gofrs "github.com/gofrs/uuid"
 	"github.com/meshery/meshkit/logger"
 	"github.com/meshery/meshkit/models/events"
 	"github.com/meshery/meshkit/models/meshmodel/core/v1beta1"
@@ -116,7 +115,7 @@ func FailedEventCompute(hostname string, mesheryInstanceID core.Uuid, provider *
 		})
 		_ = (*provider).PersistSystemEvent(*errorEvent)
 		if userID != "" {
-			userUUID := gofrs.FromStringOrNil(userID)
+			userUUID := parseUUIDOrNil(userID)
 			ec.Publish(userUUID, errorEvent)
 
 		}
@@ -167,7 +166,7 @@ func RegistryLog(log logger.Handler, handlerConfig *HandlerConfig, regManager *m
 
 	systemID := viper.GetString("INSTANCE_ID")
 
-	sysID := gofrs.FromStringOrNil(systemID)
+	sysID := parseUUIDOrNil(systemID)
 	hosts, _, err := regManager.GetRegistrants(&v1beta1.HostFilter{})
 	if err != nil {
 		log.Error(err)

--- a/server/models/uuid_helpers.go
+++ b/server/models/uuid_helpers.go
@@ -1,0 +1,13 @@
+package models
+
+import "github.com/google/uuid"
+
+// parseUUIDOrNil parses s as a UUID and returns uuid.Nil if parsing fails.
+// This is a compatibility shim replacing gofrs/uuid's FromStringOrNil.
+func parseUUIDOrNil(s string) uuid.UUID {
+	id, err := uuid.Parse(s)
+	if err != nil {
+		return uuid.Nil
+	}
+	return id
+}

--- a/server/models/workspace_persister.go
+++ b/server/models/workspace_persister.go
@@ -9,7 +9,7 @@ import (
 
 	"github.com/meshery/schemas/models/core"
 
-	"github.com/gofrs/uuid"
+	"github.com/google/uuid"
 	"github.com/meshery/meshery/server/helpers/utils"
 	"github.com/meshery/meshkit/database"
 	"github.com/meshery/schemas/models/v1beta1/environment"
@@ -138,10 +138,7 @@ func (wp *WorkspacePersister) GetWorkspaces(orgID, search, order, page, pageSize
 
 func (wp *WorkspacePersister) SaveWorkspace(workspace *workspace.Workspace) ([]byte, error) {
 	if workspace.ID == uuid.Nil {
-		id, err := uuid.NewV4()
-		if err != nil {
-			return nil, ErrGenerateUUID(err)
-		}
+		id := uuid.New()
 		workspace.ID = id
 	}
 
@@ -257,10 +254,7 @@ func (wp *WorkspacePersister) AddEnvironmentToWorkspace(workspaceID, environment
 		UpdatedAt:     time.Now(),
 	}
 
-	id, err := uuid.NewV4()
-	if err != nil {
-		return nil, ErrGenerateUUID(err)
-	}
+	id := uuid.New()
 	wsEnvMapping.ID = id
 
 	// Add environment to workspace
@@ -410,10 +404,7 @@ func (wp *WorkspacePersister) AddDesignToWorkspace(workspaceID, designID core.Uu
 		UpdatedAt:   time.Now(),
 	}
 
-	id, err := uuid.NewV4()
-	if err != nil {
-		return nil, ErrGenerateUUID(err)
-	}
+	id := uuid.New()
 	wsDesignMapping.ID = id
 
 	// Add design to workspace
@@ -563,10 +554,7 @@ func (wp *WorkspacePersister) AddViewToWorkspace(workspaceID, viewID core.Uuid) 
 		UpdatedAt:   time.Now(),
 	}
 
-	id, err := uuid.NewV4()
-	if err != nil {
-		return nil, ErrGenerateUUID(err)
-	}
+	id := uuid.New()
 	wsViewMapping.ID = id
 
 	if err := wp.DB.Create(wsViewMapping).Error; err != nil {
@@ -691,10 +679,7 @@ func (wp *WorkspacePersister) AddTeamToWorkspace(workspaceID, teamID core.Uuid) 
 		UpdatedAt:   time.Now(),
 	}
 
-	id, err := uuid.NewV4()
-	if err != nil {
-		return nil, ErrGenerateUUID(err)
-	}
+	id := uuid.New()
 	wsTeamMapping.ID = id
 
 	if err := wp.DB.Create(wsTeamMapping).Error; err != nil {

--- a/server/models/workspace_persister_test.go
+++ b/server/models/workspace_persister_test.go
@@ -4,7 +4,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/gofrs/uuid"
+	"github.com/google/uuid"
 	"github.com/meshery/meshkit/database"
 	"github.com/meshery/schemas/models/core"
 	workspace "github.com/meshery/schemas/models/v1beta3/workspace"
@@ -29,15 +29,9 @@ func TestSchemasWorkspaceAutoMigrateAndPersistMetadata(t *testing.T) {
 		t.Fatalf("failed to auto-migrate schemas workspace: %v", err)
 	}
 
-	workspaceID, err := uuid.NewV4()
-	if err != nil {
-		t.Fatalf("failed to generate workspace id: %v", err)
-	}
+	workspaceID := uuid.New()
 
-	organizationID, err := uuid.NewV4()
-	if err != nil {
-		t.Fatalf("failed to generate organization id: %v", err)
-	}
+	organizationID := uuid.New()
 
 	now := time.Now().UTC().Round(time.Second)
 	ws := workspace.Workspace{
@@ -74,15 +68,9 @@ func TestWorkspacePersisterUpdateWorkspace_PreservesOrganizationIDWhenOmitted(t 
 		t.Fatalf("failed to auto-migrate schemas workspace: %v", err)
 	}
 
-	workspaceID, err := uuid.NewV4()
-	if err != nil {
-		t.Fatalf("failed to generate workspace id: %v", err)
-	}
+	workspaceID := uuid.New()
 
-	organizationID, err := uuid.NewV4()
-	if err != nil {
-		t.Fatalf("failed to generate organization id: %v", err)
-	}
+	organizationID := uuid.New()
 
 	now := time.Now().UTC().Round(time.Second)
 	ws := workspace.Workspace{

--- a/server/policies/engine_test.go
+++ b/server/policies/engine_test.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/gofrs/uuid"
+	"github.com/google/uuid"
 	"github.com/meshery/meshkit/logger"
 	relationshipv1alpha3 "github.com/meshery/schemas/models/v1alpha3/relationship"
 	"github.com/meshery/schemas/models/v1beta1/component"
@@ -201,10 +201,10 @@ func TestPolicyImplication(t *testing.T) {
 
 func TestFromAndToComponentsExist(t *testing.T) {
 	compA := &component.ComponentDefinition{}
-	compA.ID, _ = uuid.FromString("00000000-0000-0000-0000-000000000001")
+	compA.ID, _ = uuid.Parse("00000000-0000-0000-0000-000000000001")
 
 	compB := &component.ComponentDefinition{}
-	compB.ID, _ = uuid.FromString("00000000-0000-0000-0000-000000000002")
+	compB.ID, _ = uuid.Parse("00000000-0000-0000-0000-000000000002")
 
 	design := makePatternFile([]*component.ComponentDefinition{compA, compB}, nil)
 
@@ -222,7 +222,7 @@ func TestFromAndToComponentsExist(t *testing.T) {
 		t.Error("Expected both components to exist")
 	}
 
-	missingID, _ := uuid.FromString("00000000-0000-0000-0000-000000000099")
+	missingID, _ := uuid.Parse("00000000-0000-0000-0000-000000000099")
 	selectorSetMissing := relationship.SelectorSet{
 		relationship.SelectorSetItem{
 			Allow: relationship.Selector{
@@ -309,10 +309,10 @@ func TestConvertRelationships(t *testing.T) {
 
 func TestValidateRelationshipsInDesign(t *testing.T) {
 	compA := &component.ComponentDefinition{}
-	compA.ID, _ = uuid.FromString("00000000-0000-0000-0000-0000000000aa")
+	compA.ID, _ = uuid.Parse("00000000-0000-0000-0000-0000000000aa")
 
 	compDeleted := &component.ComponentDefinition{}
-	compDeleted.ID, _ = uuid.FromString("00000000-0000-0000-0000-00000000dead")
+	compDeleted.ID, _ = uuid.Parse("00000000-0000-0000-0000-00000000dead")
 
 	relStatus := relationship.RelationshipDefinitionStatus("approved")
 	selectorSet := relationship.SelectorSet{
@@ -329,7 +329,7 @@ func TestValidateRelationshipsInDesign(t *testing.T) {
 		Status:           &relStatus,
 		Selectors:        &selectorSet,
 	}
-	rel.ID, _ = uuid.FromString("00000000-0000-0000-0000-000000000001")
+	rel.ID, _ = uuid.Parse("00000000-0000-0000-0000-000000000001")
 
 	design := makePatternFile([]*component.ComponentDefinition{compA}, []*relationship.RelationshipDefinition{rel})
 
@@ -368,8 +368,8 @@ func TestEdgeBindingPolicyImplication(t *testing.T) {
 }
 
 func TestIsValidBinding(t *testing.T) {
-	roleID, _ := uuid.FromString("00000000-0000-0000-0000-000000000001")
-	rbID, _ := uuid.FromString("00000000-0000-0000-0000-000000000002")
+	roleID, _ := uuid.Parse("00000000-0000-0000-0000-000000000001")
+	rbID, _ := uuid.Parse("00000000-0000-0000-0000-000000000002")
 
 	role := &component.ComponentDefinition{
 		Component:     component.Component{Kind: "Role"},
@@ -403,7 +403,7 @@ func TestIsValidBinding(t *testing.T) {
 		t.Error("Expected valid binding")
 	}
 
-	badRbID, _ := uuid.FromString("00000000-0000-0000-0000-000000000003")
+	badRbID, _ := uuid.Parse("00000000-0000-0000-0000-000000000003")
 	badBinding := &component.ComponentDefinition{
 		Component:     component.Component{Kind: "RoleBinding"},
 		Configuration: map[string]interface{}{"roleRef": map[string]interface{}{"name": "other-role"}},
@@ -419,8 +419,8 @@ func TestIsValidBinding(t *testing.T) {
 func TestHierarchicalIdentifyRelationship(t *testing.T) {
 	p := &HierarchicalParentChildPolicy{}
 
-	nsID, _ := uuid.FromString("00000000-0000-0000-0000-000000000001")
-	deployID, _ := uuid.FromString("00000000-0000-0000-0000-000000000002")
+	nsID, _ := uuid.Parse("00000000-0000-0000-0000-000000000001")
+	deployID, _ := uuid.Parse("00000000-0000-0000-0000-000000000002")
 
 	ns := &component.ComponentDefinition{
 		Component:      component.Component{Kind: "Namespace"},
@@ -474,7 +474,7 @@ func TestHierarchicalIdentifyRelationship(t *testing.T) {
 		Model:            modelv1beta1.ModelReference{Name: "kubernetes"},
 		Selectors:        &selectorSet,
 	}
-	relDef.ID, _ = uuid.FromString("00000000-0000-0000-0000-000000000010")
+	relDef.ID, _ = uuid.Parse("00000000-0000-0000-0000-000000000010")
 
 	identified := p.IdentifyRelationship(relDef, design)
 	if len(identified) != 1 {
@@ -488,8 +488,8 @@ func TestHierarchicalIdentifyRelationship(t *testing.T) {
 func TestHierarchicalSideEffects(t *testing.T) {
 	p := &HierarchicalParentChildPolicy{}
 
-	nsID, _ := uuid.FromString("00000000-0000-0000-0000-000000000001")
-	deployID, _ := uuid.FromString("00000000-0000-0000-0000-000000000002")
+	nsID, _ := uuid.Parse("00000000-0000-0000-0000-000000000001")
+	deployID, _ := uuid.Parse("00000000-0000-0000-0000-000000000002")
 
 	ns := &component.ComponentDefinition{
 		Component:     component.Component{Kind: "Namespace"},
@@ -537,7 +537,7 @@ func TestHierarchicalSideEffects(t *testing.T) {
 		Status:           &relStatus,
 		Selectors:        &selectorSet,
 	}
-	rel.ID, _ = uuid.FromString("00000000-0000-0000-0000-000000000001")
+	rel.ID, _ = uuid.Parse("00000000-0000-0000-0000-000000000001")
 
 	actions := p.SideEffects(rel, design)
 	if len(actions) == 0 {
@@ -562,8 +562,8 @@ func TestGoEngineCreation(t *testing.T) {
 func TestAliasIsInvalidStatusMatrix(t *testing.T) {
 	p := &AliasPolicy{}
 
-	fromID, _ := uuid.FromString("00000000-0000-0000-0000-000000000001")
-	toID, _ := uuid.FromString("00000000-0000-0000-0000-000000000002")
+	fromID, _ := uuid.Parse("00000000-0000-0000-0000-000000000001")
+	toID, _ := uuid.Parse("00000000-0000-0000-0000-000000000002")
 
 	fromComp := &component.ComponentDefinition{
 		Component: component.Component{Kind: "Container"},
@@ -648,7 +648,7 @@ func TestMatchLabelsPolicyIdentificationIsDeterministic(t *testing.T) {
 				},
 			},
 		}
-		c.ID, _ = uuid.FromString("00000000-0000-0000-0000-" + idHex)
+		c.ID, _ = uuid.Parse("00000000-0000-0000-0000-" + idHex)
 		return c
 	}
 	podA, podB, podC := pod("00000000aaa1"), pod("00000000bbb2"), pod("00000000ccc3")

--- a/server/policies/eval_rules.go
+++ b/server/policies/eval_rules.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/gofrs/uuid"
+	"github.com/google/uuid"
 	"github.com/meshery/schemas/models/v1beta2/relationship"
 	"github.com/meshery/schemas/models/v1beta1/component"
 	"github.com/meshery/schemas/models/v1beta1/pattern"
@@ -377,11 +377,11 @@ func buildIdentifiedRelationship(
 	relDef *relationship.RelationshipDefinition,
 ) *relationship.RelationshipDefinition {
 	newFromSel := fromSel
-	fromUUID, _ := uuid.FromString(compFromID)
+	fromUUID, _ := uuid.Parse(compFromID)
 	newFromSel.ID = &fromUUID
 
 	newToSel := toSel
-	toUUID, _ := uuid.FromString(compToID)
+	toUUID, _ := uuid.Parse(compToID)
 	newToSel.ID = &toUUID
 
 	selectorSet := relationship.SelectorSetItem{

--- a/server/policies/patching_test.go
+++ b/server/policies/patching_test.go
@@ -3,7 +3,7 @@ package policies
 import (
 	"testing"
 
-	"github.com/gofrs/uuid"
+	"github.com/google/uuid"
 	"github.com/meshery/meshkit/logger"
 	"github.com/meshery/schemas/models/v1beta2/relationship"
 	"github.com/meshery/schemas/models/v1beta1/component"
@@ -17,8 +17,8 @@ import (
 func TestWalletPatching(t *testing.T) {
 	p := &HierarchicalWalletPolicy{}
 
-	deployID, _ := uuid.FromString("00000000-0000-0000-0000-000000000001")
-	podTplID, _ := uuid.FromString("00000000-0000-0000-0000-000000000002")
+	deployID, _ := uuid.Parse("00000000-0000-0000-0000-000000000001")
+	podTplID, _ := uuid.Parse("00000000-0000-0000-0000-000000000002")
 
 	deploy := &component.ComponentDefinition{
 		Component:      component.Component{Kind: "Deployment"},
@@ -90,7 +90,7 @@ func TestWalletPatching(t *testing.T) {
 		Model:            modelv1beta1.ModelReference{Name: "kubernetes"},
 		Selectors:        &selectorSet,
 	}
-	rel.ID, _ = uuid.FromString("00000000-0000-0000-0000-000000000010")
+	rel.ID, _ = uuid.Parse("00000000-0000-0000-0000-000000000010")
 
 	actions := p.SideEffects(rel, design)
 	if len(actions) == 0 {
@@ -118,8 +118,8 @@ func TestWalletPatching(t *testing.T) {
 
 // TestWalletPatchingFullPipeline tests wallet patching through the full evaluation pipeline.
 func TestWalletPatchingFullPipeline(t *testing.T) {
-	deployID, _ := uuid.FromString("00000000-0000-0000-0000-000000000001")
-	podTplID, _ := uuid.FromString("00000000-0000-0000-0000-000000000002")
+	deployID, _ := uuid.Parse("00000000-0000-0000-0000-000000000001")
+	podTplID, _ := uuid.Parse("00000000-0000-0000-0000-000000000002")
 
 	deploy := &component.ComponentDefinition{
 		Component:      component.Component{Kind: "Deployment"},
@@ -151,7 +151,7 @@ func TestWalletPatchingFullPipeline(t *testing.T) {
 	mutatorRef := relationship.MutatorRef{[]string{"configuration", "spec", "template", "spec", "serviceAccountName"}}
 	mutatedRef := relationship.MutatedRef{[]string{"configuration", "spec", "serviceAccountName"}}
 	relStatus := relationship.RelationshipDefinitionStatus("approved")
-	relID, _ := uuid.FromString("00000000-0000-0000-0000-000000000010")
+	relID, _ := uuid.Parse("00000000-0000-0000-0000-000000000010")
 	selectorSet := relationship.SelectorSet{
 		relationship.SelectorSetItem{
 			Allow: relationship.Selector{
@@ -222,9 +222,9 @@ func TestWalletPatchingFullPipeline(t *testing.T) {
 func TestBindingPatching(t *testing.T) {
 	p := &EdgeBindingPolicy{}
 
-	roleID, _ := uuid.FromString("00000000-0000-0000-0000-000000000001")
-	saID, _ := uuid.FromString("00000000-0000-0000-0000-000000000002")
-	rbID, _ := uuid.FromString("00000000-0000-0000-0000-000000000003")
+	roleID, _ := uuid.Parse("00000000-0000-0000-0000-000000000001")
+	saID, _ := uuid.Parse("00000000-0000-0000-0000-000000000002")
+	rbID, _ := uuid.Parse("00000000-0000-0000-0000-000000000003")
 
 	role := &component.ComponentDefinition{
 		Component:      component.Component{Kind: "ClusterRole"},
@@ -325,7 +325,7 @@ func TestBindingPatching(t *testing.T) {
 		Model:            modelv1beta1.ModelReference{Name: "kubernetes"},
 		Selectors:        &selectorSet,
 	}
-	rel.ID, _ = uuid.FromString("00000000-0000-0000-0000-000000000020")
+	rel.ID, _ = uuid.Parse("00000000-0000-0000-0000-000000000020")
 
 	actions := p.SideEffects(rel, design)
 
@@ -359,8 +359,8 @@ func TestBindingPatching(t *testing.T) {
 func TestAliasSideEffects(t *testing.T) {
 	p := &AliasPolicy{}
 
-	deployID, _ := uuid.FromString("00000000-0000-0000-0000-000000000001")
-	aliasID, _ := uuid.FromString("00000000-0000-0000-0000-000000000099")
+	deployID, _ := uuid.Parse("00000000-0000-0000-0000-000000000001")
+	aliasID, _ := uuid.Parse("00000000-0000-0000-0000-000000000099")
 
 	deploy := &component.ComponentDefinition{
 		Component:      component.Component{Kind: "Deployment"},
@@ -420,7 +420,7 @@ func TestAliasSideEffects(t *testing.T) {
 		Model:            modelv1beta1.ModelReference{Name: "meshery-core"},
 		Selectors:        &selectorSet,
 	}
-	rel.ID, _ = uuid.FromString("00000000-0000-0000-0000-000000000030")
+	rel.ID, _ = uuid.Parse("00000000-0000-0000-0000-000000000030")
 
 	actions := p.SideEffects(rel, design)
 	if len(actions) == 0 {
@@ -445,9 +445,9 @@ func TestAliasSideEffects(t *testing.T) {
 func TestBindingIdentification(t *testing.T) {
 	p := &EdgeBindingPolicy{}
 
-	roleID, _ := uuid.FromString("00000000-0000-0000-0000-000000000001")
-	rbID, _ := uuid.FromString("00000000-0000-0000-0000-000000000002")
-	saID, _ := uuid.FromString("00000000-0000-0000-0000-000000000003")
+	roleID, _ := uuid.Parse("00000000-0000-0000-0000-000000000001")
+	rbID, _ := uuid.Parse("00000000-0000-0000-0000-000000000002")
+	saID, _ := uuid.Parse("00000000-0000-0000-0000-000000000003")
 
 	role := &component.ComponentDefinition{
 		Component:      component.Component{Kind: "Role"},
@@ -533,7 +533,7 @@ func TestBindingIdentification(t *testing.T) {
 		Model:            modelv1beta1.ModelReference{Name: "kubernetes"},
 		Selectors:        &selectorSet,
 	}
-	relDef.ID, _ = uuid.FromString("00000000-0000-0000-0000-000000000050")
+	relDef.ID, _ = uuid.Parse("00000000-0000-0000-0000-000000000050")
 
 	// Debug: check isValidBinding manually.
 	fromSel := selectorSet[0].Allow.From[0]
@@ -563,9 +563,9 @@ func TestBindingIdentification(t *testing.T) {
 func TestBindingIdentificationEmptyValues(t *testing.T) {
 	p := &EdgeBindingPolicy{}
 
-	roleID, _ := uuid.FromString("00000000-0000-0000-0000-000000000001")
-	rbID, _ := uuid.FromString("00000000-0000-0000-0000-000000000002")
-	saID, _ := uuid.FromString("00000000-0000-0000-0000-000000000003")
+	roleID, _ := uuid.Parse("00000000-0000-0000-0000-000000000001")
+	rbID, _ := uuid.Parse("00000000-0000-0000-0000-000000000002")
+	saID, _ := uuid.Parse("00000000-0000-0000-0000-000000000003")
 
 	role := &component.ComponentDefinition{
 		Component:      component.Component{Kind: "Role"},
@@ -627,7 +627,7 @@ func TestBindingIdentificationEmptyValues(t *testing.T) {
 		Kind: relationship.Edge, RelationshipType: "binding", SubType: "permission",
 		Model: modelv1beta1.ModelReference{Name: "kubernetes"}, Selectors: &selectorSet,
 	}
-	relDef.ID, _ = uuid.FromString("00000000-0000-0000-0000-000000000060")
+	relDef.ID, _ = uuid.Parse("00000000-0000-0000-0000-000000000060")
 
 	identified := p.IdentifyRelationship(relDef, design)
 	if len(identified) == 0 {
@@ -638,9 +638,9 @@ func TestBindingIdentificationEmptyValues(t *testing.T) {
 // TestBindingIdentificationFullPipeline tests binding identification through the full engine,
 // simulating the e2e flow where relationships are stripped and re-evaluated.
 func TestBindingIdentificationFullPipeline(t *testing.T) {
-	roleID, _ := uuid.FromString("00000000-0000-0000-0000-000000000001")
-	rbID, _ := uuid.FromString("00000000-0000-0000-0000-000000000002")
-	saID, _ := uuid.FromString("00000000-0000-0000-0000-000000000003")
+	roleID, _ := uuid.Parse("00000000-0000-0000-0000-000000000001")
+	rbID, _ := uuid.Parse("00000000-0000-0000-0000-000000000002")
+	saID, _ := uuid.Parse("00000000-0000-0000-0000-000000000003")
 
 	role := &component.ComponentDefinition{
 		Component:      component.Component{Kind: "Role"},
@@ -703,7 +703,7 @@ func TestBindingIdentificationFullPipeline(t *testing.T) {
 		Kind: relationship.Edge, RelationshipType: "binding", SubType: "permission",
 		Model: modelv1beta1.ModelReference{Name: "kubernetes"}, Selectors: &selectorSet,
 	}
-	relDef.ID, _ = uuid.FromString("00000000-0000-0000-0000-000000000070")
+	relDef.ID, _ = uuid.Parse("00000000-0000-0000-0000-000000000070")
 
 	log, _ := logger.New("test", logger.Options{Format: logger.SyslogLogFormat})
 	engine := NewGoEngine(log)
@@ -731,9 +731,9 @@ func TestBindingIdentificationFullPipeline(t *testing.T) {
 func TestInventoryNamespaceIdentification(t *testing.T) {
 	p := &HierarchicalParentChildPolicy{}
 
-	nsID, _ := uuid.FromString("00000000-0000-0000-0000-000000000001")
-	deployID, _ := uuid.FromString("00000000-0000-0000-0000-000000000002")
-	svcID, _ := uuid.FromString("00000000-0000-0000-0000-000000000003")
+	nsID, _ := uuid.Parse("00000000-0000-0000-0000-000000000001")
+	deployID, _ := uuid.Parse("00000000-0000-0000-0000-000000000002")
+	svcID, _ := uuid.Parse("00000000-0000-0000-0000-000000000003")
 
 	ns := &component.ComponentDefinition{
 		Component:      component.Component{Kind: "Namespace"},
@@ -802,7 +802,7 @@ func TestInventoryNamespaceIdentification(t *testing.T) {
 		Kind: relationship.Hierarchical, RelationshipType: "parent", SubType: "inventory",
 		Model: modelv1beta1.ModelReference{Name: "kubernetes"}, Selectors: &selectorSet,
 	}
-	relDef.ID, _ = uuid.FromString("00000000-0000-0000-0000-000000000080")
+	relDef.ID, _ = uuid.Parse("00000000-0000-0000-0000-000000000080")
 
 	identified := p.IdentifyRelationship(relDef, design)
 	t.Logf("Identified: %d relationships", len(identified))
@@ -823,8 +823,8 @@ func TestInventoryNamespaceIdentification(t *testing.T) {
 // The relationship is pre-existing (approved) in the design, and the mutator value
 // differs from the mutated value, so patching should update it.
 func TestInventoryPatchingFullPipeline(t *testing.T) {
-	nsID, _ := uuid.FromString("00000000-0000-0000-0000-000000000001")
-	deployID, _ := uuid.FromString("00000000-0000-0000-0000-000000000002")
+	nsID, _ := uuid.Parse("00000000-0000-0000-0000-000000000001")
+	deployID, _ := uuid.Parse("00000000-0000-0000-0000-000000000002")
 
 	ns := &component.ComponentDefinition{
 		Component:      component.Component{Kind: "Namespace"},
@@ -877,7 +877,7 @@ func TestInventoryPatchingFullPipeline(t *testing.T) {
 		Model:            modelv1beta1.ModelReference{Name: "kubernetes"},
 		Selectors:        &selectorSet,
 	}
-	existingRel.ID, _ = uuid.FromString("00000000-0000-0000-0000-000000000040")
+	existingRel.ID, _ = uuid.Parse("00000000-0000-0000-0000-000000000040")
 
 	design := makePatternFile(
 		[]*component.ComponentDefinition{ns, deploy},
@@ -910,8 +910,8 @@ func TestInventoryPatchingFullPipeline(t *testing.T) {
 func TestWalletPatchingCleanupOnDelete(t *testing.T) {
 	p := &HierarchicalWalletPolicy{}
 
-	deployID, _ := uuid.FromString("00000000-0000-0000-0000-000000000001")
-	podTplID, _ := uuid.FromString("00000000-0000-0000-0000-000000000002")
+	deployID, _ := uuid.Parse("00000000-0000-0000-0000-000000000001")
+	podTplID, _ := uuid.Parse("00000000-0000-0000-0000-000000000002")
 
 	// Both components already hold the mutator value (simulating a prior patch
 	// that has been applied and persisted).
@@ -979,7 +979,7 @@ func TestWalletPatchingCleanupOnDelete(t *testing.T) {
 		Model:            modelv1beta1.ModelReference{Name: "kubernetes"},
 		Selectors:        &selectorSet,
 	}
-	rel.ID, _ = uuid.FromString("00000000-0000-0000-0000-000000000010")
+	rel.ID, _ = uuid.Parse("00000000-0000-0000-0000-000000000010")
 
 	actions := p.SideEffects(rel, design)
 	if len(actions) == 0 {
@@ -1003,8 +1003,8 @@ func TestWalletPatchingCleanupOnDelete(t *testing.T) {
 func TestWalletPatchingCleanupUsesSchemaDefault(t *testing.T) {
 	p := &HierarchicalWalletPolicy{}
 
-	deployID, _ := uuid.FromString("00000000-0000-0000-0000-000000000001")
-	podTplID, _ := uuid.FromString("00000000-0000-0000-0000-000000000002")
+	deployID, _ := uuid.Parse("00000000-0000-0000-0000-000000000001")
+	podTplID, _ := uuid.Parse("00000000-0000-0000-0000-000000000002")
 
 	deploy := &component.ComponentDefinition{
 		Component:      component.Component{Kind: "Deployment"},
@@ -1081,7 +1081,7 @@ func TestWalletPatchingCleanupUsesSchemaDefault(t *testing.T) {
 		Model:            modelv1beta1.ModelReference{Name: "kubernetes"},
 		Selectors:        &selectorSet,
 	}
-	rel.ID, _ = uuid.FromString("00000000-0000-0000-0000-000000000010")
+	rel.ID, _ = uuid.Parse("00000000-0000-0000-0000-000000000010")
 
 	actions := p.SideEffects(rel, design)
 	found := false
@@ -1098,8 +1098,8 @@ func TestWalletPatchingCleanupUsesSchemaDefault(t *testing.T) {
 // TestWalletCleanupOnDeleteFullPipeline verifies that a deleted wallet relationship
 // restores the mutated field through the full evaluation pipeline.
 func TestWalletCleanupOnDeleteFullPipeline(t *testing.T) {
-	deployID, _ := uuid.FromString("00000000-0000-0000-0000-000000000001")
-	podTplID, _ := uuid.FromString("00000000-0000-0000-0000-000000000002")
+	deployID, _ := uuid.Parse("00000000-0000-0000-0000-000000000001")
+	podTplID, _ := uuid.Parse("00000000-0000-0000-0000-000000000002")
 
 	deploy := &component.ComponentDefinition{
 		Component:      component.Component{Kind: "Deployment"},
@@ -1132,7 +1132,7 @@ func TestWalletCleanupOnDeleteFullPipeline(t *testing.T) {
 	mutatorRef := relationship.MutatorRef{[]string{"configuration", "spec", "template", "spec", "serviceAccountName"}}
 	mutatedRef := relationship.MutatedRef{[]string{"configuration", "spec", "serviceAccountName"}}
 	relStatus := relationship.RelationshipDefinitionStatus("deleted")
-	relID, _ := uuid.FromString("00000000-0000-0000-0000-000000000010")
+	relID, _ := uuid.Parse("00000000-0000-0000-0000-000000000010")
 	selectorSet := relationship.SelectorSet{
 		relationship.SelectorSetItem{
 			Allow: relationship.Selector{
@@ -1201,8 +1201,8 @@ func TestWalletCleanupOnDeleteFullPipeline(t *testing.T) {
 func TestWalletPatchingSkipsWhenValueDiverged(t *testing.T) {
 	p := &HierarchicalWalletPolicy{}
 
-	deployID, _ := uuid.FromString("00000000-0000-0000-0000-000000000001")
-	podTplID, _ := uuid.FromString("00000000-0000-0000-0000-000000000002")
+	deployID, _ := uuid.Parse("00000000-0000-0000-0000-000000000001")
+	podTplID, _ := uuid.Parse("00000000-0000-0000-0000-000000000002")
 
 	deploy := &component.ComponentDefinition{
 		Component:      component.Component{Kind: "Deployment"},
@@ -1269,7 +1269,7 @@ func TestWalletPatchingSkipsWhenValueDiverged(t *testing.T) {
 		Model:            modelv1beta1.ModelReference{Name: "kubernetes"},
 		Selectors:        &selectorSet,
 	}
-	rel.ID, _ = uuid.FromString("00000000-0000-0000-0000-000000000010")
+	rel.ID, _ = uuid.Parse("00000000-0000-0000-0000-000000000010")
 
 	actions := p.SideEffects(rel, design)
 	if len(actions) != 0 {
@@ -1283,8 +1283,8 @@ func TestWalletPatchingSkipsWhenValueDiverged(t *testing.T) {
 func TestInventoryPatchingCleanupOnDelete(t *testing.T) {
 	p := &HierarchicalParentChildPolicy{}
 
-	nsID, _ := uuid.FromString("00000000-0000-0000-0000-000000000001")
-	deployID, _ := uuid.FromString("00000000-0000-0000-0000-000000000002")
+	nsID, _ := uuid.Parse("00000000-0000-0000-0000-000000000001")
+	deployID, _ := uuid.Parse("00000000-0000-0000-0000-000000000002")
 
 	ns := &component.ComponentDefinition{
 		Component:      component.Component{Kind: "Namespace"},
@@ -1340,7 +1340,7 @@ func TestInventoryPatchingCleanupOnDelete(t *testing.T) {
 		Model:            modelv1beta1.ModelReference{Name: "kubernetes"},
 		Selectors:        &selectorSet,
 	}
-	rel.ID, _ = uuid.FromString("00000000-0000-0000-0000-000000000010")
+	rel.ID, _ = uuid.Parse("00000000-0000-0000-0000-000000000010")
 
 	actions := p.SideEffects(rel, design)
 	found := false
@@ -1359,8 +1359,8 @@ func TestInventoryPatchingCleanupOnDelete(t *testing.T) {
 func TestEdgeNetworkPatchingCleanupOnDelete(t *testing.T) {
 	p := &EdgeNonBindingPolicy{}
 
-	svcID, _ := uuid.FromString("00000000-0000-0000-0000-000000000001")
-	podID, _ := uuid.FromString("00000000-0000-0000-0000-000000000002")
+	svcID, _ := uuid.Parse("00000000-0000-0000-0000-000000000001")
+	podID, _ := uuid.Parse("00000000-0000-0000-0000-000000000002")
 
 	svc := &component.ComponentDefinition{
 		Component:      component.Component{Kind: "Service"},
@@ -1423,7 +1423,7 @@ func TestEdgeNetworkPatchingCleanupOnDelete(t *testing.T) {
 		Model:            modelv1beta1.ModelReference{Name: "kubernetes"},
 		Selectors:        &selectorSet,
 	}
-	rel.ID, _ = uuid.FromString("00000000-0000-0000-0000-000000000010")
+	rel.ID, _ = uuid.Parse("00000000-0000-0000-0000-000000000010")
 
 	actions := p.SideEffects(rel, design)
 	found := false
@@ -1443,9 +1443,9 @@ func TestEdgeNetworkPatchingCleanupOnDelete(t *testing.T) {
 func TestBindingPatchingCleanupOnDelete(t *testing.T) {
 	p := &EdgeBindingPolicy{}
 
-	roleID, _ := uuid.FromString("00000000-0000-0000-0000-000000000001")
-	saID, _ := uuid.FromString("00000000-0000-0000-0000-000000000002")
-	rbID, _ := uuid.FromString("00000000-0000-0000-0000-000000000003")
+	roleID, _ := uuid.Parse("00000000-0000-0000-0000-000000000001")
+	saID, _ := uuid.Parse("00000000-0000-0000-0000-000000000002")
+	rbID, _ := uuid.Parse("00000000-0000-0000-0000-000000000003")
 
 	role := &component.ComponentDefinition{
 		Component:      component.Component{Kind: "ClusterRole"},
@@ -1537,7 +1537,7 @@ func TestBindingPatchingCleanupOnDelete(t *testing.T) {
 		Model:            modelv1beta1.ModelReference{Name: "kubernetes"},
 		Selectors:        &selectorSet,
 	}
-	rel.ID, _ = uuid.FromString("00000000-0000-0000-0000-000000000020")
+	rel.ID, _ = uuid.Parse("00000000-0000-0000-0000-000000000020")
 
 	actions := p.SideEffects(rel, design)
 	found := false
@@ -1562,9 +1562,9 @@ func TestBindingPatchingCleanupOnDelete(t *testing.T) {
 // (see PR #18885 review). The test pins current behavior so a future fix is
 // visible as a diff.
 func TestCleanupConcurrentRelationshipsSameField(t *testing.T) {
-	deployAID, _ := uuid.FromString("00000000-0000-0000-0000-000000000001")
-	deployBID, _ := uuid.FromString("00000000-0000-0000-0000-000000000002")
-	podTplID, _ := uuid.FromString("00000000-0000-0000-0000-000000000003")
+	deployAID, _ := uuid.Parse("00000000-0000-0000-0000-000000000001")
+	deployBID, _ := uuid.Parse("00000000-0000-0000-0000-000000000002")
+	podTplID, _ := uuid.Parse("00000000-0000-0000-0000-000000000003")
 
 	// Two Deployments both hold the same serviceAccountName; PodTemplate
 	// already holds that value (simulating prior patches from both rels).
@@ -1640,7 +1640,7 @@ func TestCleanupConcurrentRelationshipsSameField(t *testing.T) {
 			Model:            modelv1beta1.ModelReference{Name: "kubernetes"},
 			Selectors:        &selectorSet,
 		}
-		rel.ID, _ = uuid.FromString(relID)
+		rel.ID, _ = uuid.Parse(relID)
 		return rel
 	}
 

--- a/server/policies/policy_binding.go
+++ b/server/policies/policy_binding.go
@@ -4,7 +4,7 @@ import (
 	"sort"
 	"strings"
 
-	"github.com/gofrs/uuid"
+	"github.com/google/uuid"
 	"github.com/meshery/schemas/models/v1beta2/relationship"
 	"github.com/meshery/schemas/models/v1beta1/component"
 	"github.com/meshery/schemas/models/v1beta1/pattern"

--- a/server/policies/policy_inventory.go
+++ b/server/policies/policy_inventory.go
@@ -4,7 +4,7 @@ import (
 	"encoding/json"
 	"strings"
 
-	"github.com/gofrs/uuid"
+	"github.com/google/uuid"
 	"github.com/meshery/schemas/models/v1beta1/component"
 	modelv1beta1 "github.com/meshery/schemas/models/v1beta1/model"
 	"github.com/meshery/schemas/models/v1beta1/pattern"
@@ -242,10 +242,7 @@ func buildInventoryParentCandidate(
 	if kind == "" {
 		return nil
 	}
-	id, err := uuid.NewV4()
-	if err != nil {
-		return nil
-	}
+	id := uuid.New()
 
 	candidate := &component.ComponentDefinition{
 		ID:        id,

--- a/server/policies/policy_inventory_test.go
+++ b/server/policies/policy_inventory_test.go
@@ -7,7 +7,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/gofrs/uuid"
+	"github.com/google/uuid"
 	"github.com/meshery/schemas/models/v1beta1/component"
 	modelv1beta1 "github.com/meshery/schemas/models/v1beta1/model"
 	"github.com/meshery/schemas/models/v1beta1/pattern"
@@ -99,8 +99,7 @@ func crossModelInventoryRelationship() *relationship.RelationshipDefinition {
 // referencing a Namespace that does not yet exist.
 func makePodWithNamespace(t *testing.T, ns string) (*pattern.PatternFile, *component.ComponentDefinition) {
 	t.Helper()
-	id, err := uuid.NewV4()
-	require.NoError(t, err)
+	id := uuid.New()
 	pod := &component.ComponentDefinition{
 		ID:        id,
 		Component: component.Component{Kind: "Pod", Version: "v1"},
@@ -148,8 +147,7 @@ func TestIdentifyInventoryAdditions_PodImpliesNamespace(t *testing.T) {
 func TestIdentifyInventoryAdditions_SkipsWhenParentAlreadyPresent(t *testing.T) {
 	t.Parallel()
 	design, pod := makePodWithNamespace(t, "default")
-	nsID, err := uuid.NewV4()
-	require.NoError(t, err)
+	nsID := uuid.New()
 	ns := &component.ComponentDefinition{
 		ID:             nsID,
 		Component:      component.Component{Kind: "Namespace", Version: "v1"},
@@ -172,8 +170,7 @@ func TestIdentifyInventoryAdditions_SkipsWhenParentAlreadyPresent(t *testing.T) 
 // test pins the correct contract.
 func TestIdentifyInventoryAdditions_PreservesToSideModelForCrossModelRelationships(t *testing.T) {
 	t.Parallel()
-	id, err := uuid.NewV4()
-	require.NoError(t, err)
+	id := uuid.New()
 	sub := &component.ComponentDefinition{
 		ID:        id,
 		Component: component.Component{Kind: "EventSubscription", Version: "v1"},

--- a/server/policies/policy_matchlabels.go
+++ b/server/policies/policy_matchlabels.go
@@ -4,7 +4,7 @@ import (
 	"sort"
 	"strings"
 
-	"github.com/gofrs/uuid"
+	"github.com/google/uuid"
 	"github.com/meshery/schemas/models/v1beta2/relationship"
 	"github.com/meshery/schemas/models/v1beta1/component"
 	"github.com/meshery/schemas/models/v1beta1/pattern"

--- a/server/policies/utils.go
+++ b/server/policies/utils.go
@@ -9,7 +9,7 @@ import (
 	"strings"
 	"time"
 
-	"github.com/gofrs/uuid"
+	"github.com/google/uuid"
 	"github.com/meshery/schemas/models/v1beta1/pattern"
 	"github.com/meshery/schemas/models/v1beta2/relationship"
 )
@@ -170,7 +170,7 @@ func deepEqual(a, b interface{}) bool {
 
 // uuidFromString parses a UUID from a string, returning zero UUID on error.
 func uuidFromString(s string) (uuid.UUID, error) {
-	return uuid.FromString(s)
+	return uuid.Parse(s)
 }
 
 // deepCopyDesign creates a deep copy of a PatternFile via JSON round-trip.

--- a/server/policies/utils.go
+++ b/server/policies/utils.go
@@ -93,12 +93,12 @@ func canonicalSeed(seed interface{}) string {
 func newUUID(seed interface{}) uuid.UUID {
 	now := fmt.Sprintf("%d", time.Now().UnixNano())
 	data := canonicalSeed(seed) + now
-	return uuid.NewV5(uuid.NamespaceDNS, data)
+	return uuid.NewSHA1(uuid.NameSpaceDNS, []byte(data))
 }
 
 // staticUUID generates a deterministic UUID from a seed (no time component).
 func staticUUID(seed interface{}) uuid.UUID {
-	return uuid.NewV5(uuid.NamespaceDNS, canonicalSeed(seed))
+	return uuid.NewSHA1(uuid.NameSpaceDNS, []byte(canonicalSeed(seed)))
 }
 
 // matchName checks if a component name matches a selector pattern.

--- a/server/policies/wasm/go.mod
+++ b/server/policies/wasm/go.mod
@@ -13,7 +13,7 @@ replace github.com/meshery/meshery => ../../../
 
 require (
 	github.com/meshery/meshery v0.0.0-00010101000000-000000000000
-	github.com/meshery/schemas v1.3.10
+	github.com/meshery/schemas v1.3.12
 )
 
 require (
@@ -187,7 +187,7 @@ require (
 	github.com/mattn/go-shellwords v1.0.12 // indirect
 	github.com/mattn/go-sqlite3 v1.14.32 // indirect
 	github.com/meshery/meshery-operator v0.8.11 // indirect
-	github.com/meshery/meshkit v1.0.13 // indirect
+	github.com/meshery/meshkit v1.0.14 // indirect
 	github.com/meshery/meshsync v1.0.0 // indirect
 	github.com/mitchellh/copystructure v1.2.0 // indirect
 	github.com/mitchellh/go-homedir v1.1.0 // indirect

--- a/server/policies/wasm/go.mod
+++ b/server/policies/wasm/go.mod
@@ -187,7 +187,7 @@ require (
 	github.com/mattn/go-shellwords v1.0.12 // indirect
 	github.com/mattn/go-sqlite3 v1.14.32 // indirect
 	github.com/meshery/meshery-operator v0.8.11 // indirect
-	github.com/meshery/meshkit v1.0.14 // indirect
+	github.com/meshery/meshkit v1.0.15 // indirect
 	github.com/meshery/meshsync v1.0.0 // indirect
 	github.com/mitchellh/copystructure v1.2.0 // indirect
 	github.com/mitchellh/go-homedir v1.1.0 // indirect

--- a/server/policies/wasm/go.sum
+++ b/server/policies/wasm/go.sum
@@ -536,8 +536,8 @@ github.com/mattn/go-sqlite3 v1.14.32 h1:JD12Ag3oLy1zQA+BNn74xRgaBbdhbNIDYvQUEuuE
 github.com/mattn/go-sqlite3 v1.14.32/go.mod h1:Uh1q+B4BYcTPb+yiD3kU8Ct7aC0hY9fxUwlHK0RXw+Y=
 github.com/meshery/meshery-operator v0.8.11 h1:eDo2Sw0jjVrXsvvhF8LenADM58pK+7Z68ROPVIejTPc=
 github.com/meshery/meshery-operator v0.8.11/go.mod h1:hQEtFKKa5Fr/Mskk6bV5ip3bQ0+3F0u1voYS3XisBp4=
-github.com/meshery/meshkit v1.0.14 h1:nDGTvJppGGMjHTEXuAVxmlduxHHM3K3CZZs8p90g3sg=
-github.com/meshery/meshkit v1.0.14/go.mod h1:V1/PNdlN3QiOVRooP/7TpEPcyQY2MCyJ3EMMeWlJyDY=
+github.com/meshery/meshkit v1.0.15 h1:sLHMseryAdW+z+PJNl+whoqw+FUdCW62zpiiwwPD9GQ=
+github.com/meshery/meshkit v1.0.15/go.mod h1:V1/PNdlN3QiOVRooP/7TpEPcyQY2MCyJ3EMMeWlJyDY=
 github.com/meshery/meshsync v1.0.0 h1:BIHEVG4BDjqOnSd3vBt9B4IfWJNTfMRAgdwLroBcCfY=
 github.com/meshery/meshsync v1.0.0/go.mod h1:mFsPXkZRiCSuk5DhxBTrkWdlo6peItRBUoIEEQCovIg=
 github.com/meshery/schemas v1.3.12 h1:KBP7rN8KnL29yeCfiK8Y1LVfDnzxjgvoUao5bHS8yFM=

--- a/server/policies/wasm/go.sum
+++ b/server/policies/wasm/go.sum
@@ -536,12 +536,12 @@ github.com/mattn/go-sqlite3 v1.14.32 h1:JD12Ag3oLy1zQA+BNn74xRgaBbdhbNIDYvQUEuuE
 github.com/mattn/go-sqlite3 v1.14.32/go.mod h1:Uh1q+B4BYcTPb+yiD3kU8Ct7aC0hY9fxUwlHK0RXw+Y=
 github.com/meshery/meshery-operator v0.8.11 h1:eDo2Sw0jjVrXsvvhF8LenADM58pK+7Z68ROPVIejTPc=
 github.com/meshery/meshery-operator v0.8.11/go.mod h1:hQEtFKKa5Fr/Mskk6bV5ip3bQ0+3F0u1voYS3XisBp4=
-github.com/meshery/meshkit v1.0.13 h1:jAbg2w36MxnHhPMfizS+z0JUWP+7Jh0xdqmuupVQjnk=
-github.com/meshery/meshkit v1.0.13/go.mod h1:gw8kLughiSJE2XNq0QefYTW+CzxJDEBd6hwLiUOczIk=
+github.com/meshery/meshkit v1.0.14 h1:nDGTvJppGGMjHTEXuAVxmlduxHHM3K3CZZs8p90g3sg=
+github.com/meshery/meshkit v1.0.14/go.mod h1:V1/PNdlN3QiOVRooP/7TpEPcyQY2MCyJ3EMMeWlJyDY=
 github.com/meshery/meshsync v1.0.0 h1:BIHEVG4BDjqOnSd3vBt9B4IfWJNTfMRAgdwLroBcCfY=
 github.com/meshery/meshsync v1.0.0/go.mod h1:mFsPXkZRiCSuk5DhxBTrkWdlo6peItRBUoIEEQCovIg=
-github.com/meshery/schemas v1.3.10 h1:54MdwAisIccO61hdlNfzV3BC+K+qf6ozR9veElnjexg=
-github.com/meshery/schemas v1.3.10/go.mod h1:Ms8bfwux/bAiogaSJirBaLwkvPxOsCT4KCH76SlhU0E=
+github.com/meshery/schemas v1.3.12 h1:KBP7rN8KnL29yeCfiK8Y1LVfDnzxjgvoUao5bHS8yFM=
+github.com/meshery/schemas v1.3.12/go.mod h1:Ms8bfwux/bAiogaSJirBaLwkvPxOsCT4KCH76SlhU0E=
 github.com/miekg/dns v1.1.57 h1:Jzi7ApEIzwEPLHWRcafCN9LZSBbqQpxjt/wpgvg7wcM=
 github.com/miekg/dns v1.1.57/go.mod h1:uqRjCRUuEAA6qsOiJvDd+CFo/vW+y5WR6SNmHE55hZk=
 github.com/miekg/pkcs11 v1.1.1 h1:Ugu9pdy6vAYku5DEpVWVFPYnzV+bxB+iRdbuFSu7TvU=

--- a/server/policies/wasm_diff_test.go
+++ b/server/policies/wasm_diff_test.go
@@ -9,7 +9,7 @@ import (
 	"sync"
 	"testing"
 
-	"github.com/gofrs/uuid"
+	"github.com/google/uuid"
 	"github.com/meshery/meshkit/logger"
 	"github.com/meshery/schemas/models/v1beta1/component"
 	"github.com/meshery/schemas/models/v1beta1/pattern"
@@ -182,9 +182,9 @@ func TestWasmEngineMatchesNative(t *testing.T) {
 	}
 
 	compA := &component.ComponentDefinition{}
-	compA.ID, _ = uuid.FromString("00000000-0000-0000-0000-0000000000aa")
+	compA.ID, _ = uuid.Parse("00000000-0000-0000-0000-0000000000aa")
 	compMissing := &component.ComponentDefinition{}
-	compMissing.ID, _ = uuid.FromString("00000000-0000-0000-0000-00000000dead")
+	compMissing.ID, _ = uuid.Parse("00000000-0000-0000-0000-00000000dead")
 
 	relStatus := relationship.RelationshipDefinitionStatus("approved")
 	rel := &relationship.RelationshipDefinition{
@@ -200,7 +200,7 @@ func TestWasmEngineMatchesNative(t *testing.T) {
 			},
 		},
 	}
-	rel.ID, _ = uuid.FromString("00000000-0000-0000-0000-000000000001")
+	rel.ID, _ = uuid.Parse("00000000-0000-0000-0000-000000000001")
 
 	design := *makePatternFile([]*component.ComponentDefinition{compA}, []*relationship.RelationshipDefinition{rel})
 	rels := []*relationship.RelationshipDefinition{rel}


### PR DESCRIPTION
## Summary

Migrates UUID generation and parsing from `github.com/gofrs/uuid` to `github.com/google/uuid` across all hand-written Go files.

### Changes

- Replaces all `gofrs/uuid` imports with `google/uuid` in non-generated Go files
- Updates `uuid.NewV4()` → `uuid.New()` (google/uuid has no error return; orphaned `if err != nil` blocks cleaned up)
- Updates `uuid.FromString()` → `uuid.Parse()` (same signature)
- Updates `uuid.FromStringOrNil()` to `parseUUIDOrNil()` helper in each affected package
- Updates `uuid.Must(uuid.FromString())` → `uuid.MustParse()`
- Removes the `guid`/`googleUUID` import aliases in handler files that previously imported both libraries simultaneously
- Adds `parseUUIDOrNil` helper function in each affected package (`handlers`, `helpers`, `models`, `machines/kubernetes`, `models/meshmodel/core`, `internal/graphql/resolver`) as a clean replacement for gofrs's `FromStringOrNil` semantics

### Motivation

This is a prerequisite for bumping the `meshery/schemas` dependency to the version that ships `google/uuid` types (meshery/schemas#727). Once that dep bump lands, the `core.Uuid` type will resolve against `google/uuid.UUID` directly, eliminating the current dual-import workaround.

### Notes

- Generated files (with `// Code generated` header) are NOT modified
- `go build ./...` shows type-mismatch errors involving `core.Uuid` from `meshery/schemas` — these are expected and will be resolved by a follow-up schemas dep bump PR
- `gofrs/uuid` remains as an indirect dependency (required transitively by the current `meshery/schemas` version which still uses gofrs)

Closes #20165