### PR TITLE
feat(meshmodel): add core AWS relationships

### DIFF
--- a/server/meshmodel/aws-eks-controller/v1.14.1/v1.0.0/relationships/edge_binding_network_cluster_subnet.json
+++ b/server/meshmodel/aws-eks-controller/v1.14.1/v1.0.0/relationships/edge_binding_network_cluster_subnet.json
@@ -1,26 +1,58 @@
 {
-  "kind": "edge",
-  "type": "binding",
-  "subType": "network",
+  "id": "00000000-0000-0000-0000-000000000000",
   "evaluationQuery": "edge_binding_network_relationship",
-  "model": {
-    "name": "aws-eks-controller",
-    "version": "v1.14.1"
+  "kind": "edge",
+  "metadata": {
+    "description": "",
+    "isAnnotation": false,
+    "styles": {
+      "primaryColor": "",
+      "svgColor": "",
+      "svgWhite": ""
+    }
   },
+  "model": {
+    "displayName": "",
+    "id": "00000000-0000-0000-0000-000000000000",
+    "model": {
+      "version": "v1.14.1"
+    },
+    "name": "aws-eks-controller",
+    "registrant": {
+      "kind": "github"
+    },
+    "version": ""
+  },
+  "schemaVersion": "relationships.meshery.io/v1beta2",
   "selectors": [
     {
       "allow": {
         "from": [
           {
-            "model": "aws-eks-controller",
+            "id": null,
             "kind": "Cluster",
+            "match": {},
+            "match_strategy_matrix": null,
+            "model": {
+              "displayName": "",
+              "id": "00000000-0000-0000-0000-000000000000",
+              "model": {
+                "version": ""
+              },
+              "name": "aws-eks-controller",
+              "registrant": {
+                "kind": "github"
+              },
+              "version": ""
+            },
             "patch": {
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "spec",
-                  "vpcConfig",
-                  "subnetIds"
+                  "resourcesVPCConfig",
+                  "subnetIDs",
+                  "0"
                 ]
               ],
               "patchStrategy": "replace"
@@ -29,12 +61,27 @@
         ],
         "to": [
           {
-            "model": "aws-ec2-controller",
+            "id": null,
             "kind": "Subnet",
+            "match": {},
+            "match_strategy_matrix": null,
+            "model": {
+              "displayName": "",
+              "id": "00000000-0000-0000-0000-000000000000",
+              "model": {
+                "version": ""
+              },
+              "name": "aws-ec2-controller",
+              "registrant": {
+                "kind": "github"
+              },
+              "version": ""
+            },
             "patch": {
-              "mutatedRef": [
+              "mutatorRef": [
                 [
                   "configuration",
+                  "status",
                   "id"
                 ]
               ],
@@ -42,7 +89,15 @@
             }
           }
         ]
+      },
+      "deny": {
+        "from": [],
+        "to": []
       }
     }
-  ]
+  ],
+  "subType": "network",
+  "status": "enabled",
+  "type": "binding",
+  "version": "v1.0.0"
 }

--- a/server/meshmodel/aws-eks-controller/v1.14.1/v1.0.0/relationships/edge_binding_network_cluster_subnet.json
+++ b/server/meshmodel/aws-eks-controller/v1.14.1/v1.0.0/relationships/edge_binding_network_cluster_subnet.json
@@ -1,0 +1,48 @@
+{
+  "kind": "edge",
+  "type": "binding",
+  "subType": "network",
+  "evaluationQuery": "edge_binding_network_relationship",
+  "model": {
+    "name": "aws-eks-controller",
+    "version": "v1.14.1"
+  },
+  "selectors": [
+    {
+      "allow": {
+        "from": [
+          {
+            "model": "aws-eks-controller",
+            "kind": "Cluster",
+            "patch": {
+              "mutatorRef": [
+                [
+                  "configuration",
+                  "spec",
+                  "vpcConfig",
+                  "subnetIds"
+                ]
+              ],
+              "patchStrategy": "replace"
+            }
+          }
+        ],
+        "to": [
+          {
+            "model": "aws-ec2-controller",
+            "kind": "Subnet",
+            "patch": {
+              "mutatedRef": [
+                [
+                  "configuration",
+                  "id"
+                ]
+              ],
+              "patchStrategy": "replace"
+            }
+          }
+        ]
+      }
+    }
+  ]
+}

--- a/server/meshmodel/aws-eks-controller/v1.14.1/v1.0.0/relationships/edge_binding_permission_eks_sa_iam_role.json
+++ b/server/meshmodel/aws-eks-controller/v1.14.1/v1.0.0/relationships/edge_binding_permission_eks_sa_iam_role.json
@@ -1,0 +1,48 @@
+{
+  "kind": "edge",
+  "type": "binding",
+  "subType": "permission",
+  "evaluationQuery": "edge_binding_permission_relationship",
+  "model": {
+    "name": "aws-eks-controller",
+    "version": "v1.14.1"
+  },
+  "selectors": [
+    {
+      "allow": {
+        "from": [
+          {
+            "model": "aws-eks-controller",
+            "kind": "ServiceAccount",
+            "patch": {
+              "mutatorRef": [
+                [
+                  "configuration",
+                  "metadata",
+                  "annotations",
+                  "eks.amazonaws.com/role-arn"
+                ]
+              ],
+              "patchStrategy": "replace"
+            }
+          }
+        ],
+        "to": [
+          {
+            "model": "aws-iam-controller",
+            "kind": "Role",
+            "patch": {
+              "mutatedRef": [
+                [
+                  "configuration",
+                  "arn"
+                ]
+              ],
+              "patchStrategy": "replace"
+            }
+          }
+        ]
+      }
+    }
+  ]
+}

--- a/server/meshmodel/aws-eks-controller/v1.14.1/v1.0.0/relationships/edge_binding_permission_eks_sa_iam_role.json
+++ b/server/meshmodel/aws-eks-controller/v1.14.1/v1.0.0/relationships/edge_binding_permission_eks_sa_iam_role.json
@@ -1,21 +1,52 @@
 {
-  "kind": "edge",
-  "type": "binding",
-  "subType": "permission",
+  "id": "00000000-0000-0000-0000-000000000000",
   "evaluationQuery": "edge_binding_permission_relationship",
-  "model": {
-    "name": "aws-eks-controller",
-    "version": "v1.14.1"
+  "kind": "edge",
+  "metadata": {
+    "description": "",
+    "isAnnotation": false,
+    "styles": {
+      "primaryColor": "",
+      "svgColor": "",
+      "svgWhite": ""
+    }
   },
+  "model": {
+    "displayName": "",
+    "id": "00000000-0000-0000-0000-000000000000",
+    "model": {
+      "version": "v1.14.1"
+    },
+    "name": "aws-eks-controller",
+    "registrant": {
+      "kind": "github"
+    },
+    "version": ""
+  },
+  "schemaVersion": "relationships.meshery.io/v1beta2",
   "selectors": [
     {
       "allow": {
         "from": [
           {
-            "model": "aws-eks-controller",
+            "id": null,
             "kind": "ServiceAccount",
+            "match": {},
+            "match_strategy_matrix": null,
+            "model": {
+              "displayName": "",
+              "id": "00000000-0000-0000-0000-000000000000",
+              "model": {
+                "version": ""
+              },
+              "name": "kubernetes",
+              "registrant": {
+                "kind": "github"
+              },
+              "version": ""
+            },
             "patch": {
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "metadata",
@@ -29,12 +60,28 @@
         ],
         "to": [
           {
-            "model": "aws-iam-controller",
+            "id": null,
             "kind": "Role",
+            "match": {},
+            "match_strategy_matrix": null,
+            "model": {
+              "displayName": "",
+              "id": "00000000-0000-0000-0000-000000000000",
+              "model": {
+                "version": ""
+              },
+              "name": "aws-iam-controller",
+              "registrant": {
+                "kind": "github"
+              },
+              "version": ""
+            },
             "patch": {
-              "mutatedRef": [
+              "mutatorRef": [
                 [
                   "configuration",
+                  "status",
+                  "ackResourceMetadata",
                   "arn"
                 ]
               ],
@@ -42,7 +89,15 @@
             }
           }
         ]
+      },
+      "deny": {
+        "from": [],
+        "to": []
       }
     }
-  ]
+  ],
+  "subType": "permission",
+  "status": "enabled",
+  "type": "binding",
+  "version": "v1.0.0"
 }

--- a/server/meshmodel/aws-lambda-controller/v1.13.0/v1.0.0/relationships/edge_binding_permission_lambda_iam_role.json
+++ b/server/meshmodel/aws-lambda-controller/v1.13.0/v1.0.0/relationships/edge_binding_permission_lambda_iam_role.json
@@ -1,0 +1,47 @@
+{
+  "kind": "edge",
+  "type": "binding",
+  "subType": "permission",
+  "evaluationQuery": "edge_binding_permission_relationship",
+  "model": {
+    "name": "aws-lambda-controller",
+    "version": "v1.13.0"
+  },
+  "selectors": [
+    {
+      "allow": {
+        "from": [
+          {
+            "model": "aws-lambda-controller",
+            "kind": "Function",
+            "patch": {
+              "mutatorRef": [
+                [
+                  "configuration",
+                  "spec",
+                  "role"
+                ]
+              ],
+              "patchStrategy": "replace"
+            }
+          }
+        ],
+        "to": [
+          {
+            "model": "aws-iam-controller",
+            "kind": "Role",
+            "patch": {
+              "mutatedRef": [
+                [
+                  "configuration",
+                  "arn"
+                ]
+              ],
+              "patchStrategy": "replace"
+            }
+          }
+        ]
+      }
+    }
+  ]
+}

--- a/server/meshmodel/aws-lambda-controller/v1.13.0/v1.0.0/relationships/edge_binding_permission_lambda_iam_role.json
+++ b/server/meshmodel/aws-lambda-controller/v1.13.0/v1.0.0/relationships/edge_binding_permission_lambda_iam_role.json
@@ -1,21 +1,52 @@
 {
-  "kind": "edge",
-  "type": "binding",
-  "subType": "permission",
+  "id": "00000000-0000-0000-0000-000000000000",
   "evaluationQuery": "edge_binding_permission_relationship",
-  "model": {
-    "name": "aws-lambda-controller",
-    "version": "v1.13.0"
+  "kind": "edge",
+  "metadata": {
+    "description": "",
+    "isAnnotation": false,
+    "styles": {
+      "primaryColor": "",
+      "svgColor": "",
+      "svgWhite": ""
+    }
   },
+  "model": {
+    "displayName": "",
+    "id": "00000000-0000-0000-0000-000000000000",
+    "model": {
+      "version": "v1.13.0"
+    },
+    "name": "aws-lambda-controller",
+    "registrant": {
+      "kind": "github"
+    },
+    "version": ""
+  },
+  "schemaVersion": "relationships.meshery.io/v1beta2",
   "selectors": [
     {
       "allow": {
         "from": [
           {
-            "model": "aws-lambda-controller",
+            "id": null,
             "kind": "Function",
+            "match": {},
+            "match_strategy_matrix": null,
+            "model": {
+              "displayName": "",
+              "id": "00000000-0000-0000-0000-000000000000",
+              "model": {
+                "version": ""
+              },
+              "name": "aws-lambda-controller",
+              "registrant": {
+                "kind": "github"
+              },
+              "version": ""
+            },
             "patch": {
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "spec",
@@ -28,12 +59,28 @@
         ],
         "to": [
           {
-            "model": "aws-iam-controller",
+            "id": null,
             "kind": "Role",
+            "match": {},
+            "match_strategy_matrix": null,
+            "model": {
+              "displayName": "",
+              "id": "00000000-0000-0000-0000-000000000000",
+              "model": {
+                "version": ""
+              },
+              "name": "aws-iam-controller",
+              "registrant": {
+                "kind": "github"
+              },
+              "version": ""
+            },
             "patch": {
-              "mutatedRef": [
+              "mutatorRef": [
                 [
                   "configuration",
+                  "status",
+                  "ackResourceMetadata",
                   "arn"
                 ]
               ],
@@ -41,7 +88,15 @@
             }
           }
         ]
+      },
+      "deny": {
+        "from": [],
+        "to": []
       }
     }
-  ]
+  ],
+  "subType": "permission",
+  "status": "enabled",
+  "type": "binding",
+  "version": "v1.0.0"
 }

--- a/server/meshmodel/aws-rds-controller/v1.9.1/v1.0.0/relationships/edge_binding_firewall_rds_ec2_sg.json
+++ b/server/meshmodel/aws-rds-controller/v1.9.1/v1.0.0/relationships/edge_binding_firewall_rds_ec2_sg.json
@@ -1,25 +1,57 @@
 {
-  "kind": "edge",
-  "type": "binding",
-  "subType": "firewall",
+  "id": "00000000-0000-0000-0000-000000000000",
   "evaluationQuery": "edge_binding_firewall_relationship",
-  "model": {
-    "name": "aws-rds-controller",
-    "version": "v1.9.1"
+  "kind": "edge",
+  "metadata": {
+    "description": "",
+    "isAnnotation": false,
+    "styles": {
+      "primaryColor": "",
+      "svgColor": "",
+      "svgWhite": ""
+    }
   },
+  "model": {
+    "displayName": "",
+    "id": "00000000-0000-0000-0000-000000000000",
+    "model": {
+      "version": "v1.9.1"
+    },
+    "name": "aws-rds-controller",
+    "registrant": {
+      "kind": "github"
+    },
+    "version": ""
+  },
+  "schemaVersion": "relationships.meshery.io/v1beta2",
   "selectors": [
     {
       "allow": {
         "from": [
           {
-            "model": "aws-rds-controller",
+            "id": null,
             "kind": "DBInstance",
+            "match": {},
+            "match_strategy_matrix": null,
+            "model": {
+              "displayName": "",
+              "id": "00000000-0000-0000-0000-000000000000",
+              "model": {
+                "version": ""
+              },
+              "name": "aws-rds-controller",
+              "registrant": {
+                "kind": "github"
+              },
+              "version": ""
+            },
             "patch": {
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "spec",
-                  "vpcSecurityGroupIds"
+                  "vpcSecurityGroupIDs",
+                  "0"
                 ]
               ],
               "patchStrategy": "replace"
@@ -28,12 +60,27 @@
         ],
         "to": [
           {
-            "model": "aws-ec2-controller",
+            "id": null,
             "kind": "SecurityGroup",
+            "match": {},
+            "match_strategy_matrix": null,
+            "model": {
+              "displayName": "",
+              "id": "00000000-0000-0000-0000-000000000000",
+              "model": {
+                "version": ""
+              },
+              "name": "aws-ec2-controller",
+              "registrant": {
+                "kind": "github"
+              },
+              "version": ""
+            },
             "patch": {
-              "mutatedRef": [
+              "mutatorRef": [
                 [
                   "configuration",
+                  "status",
                   "id"
                 ]
               ],
@@ -41,7 +88,15 @@
             }
           }
         ]
+      },
+      "deny": {
+        "from": [],
+        "to": []
       }
     }
-  ]
+  ],
+  "subType": "firewall",
+  "status": "enabled",
+  "type": "binding",
+  "version": "v1.0.0"
 }

--- a/server/meshmodel/aws-rds-controller/v1.9.1/v1.0.0/relationships/edge_binding_firewall_rds_ec2_sg.json
+++ b/server/meshmodel/aws-rds-controller/v1.9.1/v1.0.0/relationships/edge_binding_firewall_rds_ec2_sg.json
@@ -1,0 +1,47 @@
+{
+  "kind": "edge",
+  "type": "binding",
+  "subType": "firewall",
+  "evaluationQuery": "edge_binding_firewall_relationship",
+  "model": {
+    "name": "aws-rds-controller",
+    "version": "v1.9.1"
+  },
+  "selectors": [
+    {
+      "allow": {
+        "from": [
+          {
+            "model": "aws-rds-controller",
+            "kind": "DBInstance",
+            "patch": {
+              "mutatorRef": [
+                [
+                  "configuration",
+                  "spec",
+                  "vpcSecurityGroupIds"
+                ]
+              ],
+              "patchStrategy": "replace"
+            }
+          }
+        ],
+        "to": [
+          {
+            "model": "aws-ec2-controller",
+            "kind": "SecurityGroup",
+            "patch": {
+              "mutatedRef": [
+                [
+                  "configuration",
+                  "id"
+                ]
+              ],
+              "patchStrategy": "replace"
+            }
+          }
+        ]
+      }
+    }
+  ]
+}


### PR DESCRIPTION
This pull request adds core AWS MeshModel relationship definitions for EKS cluster subnets, EKS ServiceAccount-Role binding, Lambda execution role binding, and RDS Security Group firewall configuration.

All definitions are standardized to the relationships.meshery.io/v1beta2 schema.

Related to #17096