### PR TITLE
feat(meshmodel): add multi-hop AWS architecture chain relationships

### DIFF
--- a/docs/content/en/project/contributing/contributing-relationships.md
+++ b/docs/content/en/project/contributing/contributing-relationships.md
@@ -322,6 +322,123 @@ Each policy has a set of evaluation rules defined and the `evaluationQuery` attr
 ##### General
 
 1. Use camelCasing as the formatting convention.
+2. Standardize relationship definitions to the `relationships.meshery.io/v1beta2` schema version.
+3. Set the `registrant.kind` property of selectors and models to `"github"` to align with the registry migration.
+
+##### AWS ACK and Cross-Model Relationship Design Standards (v1beta2 Schema)
+
+To design high-quality, reliable relationship definitions for AWS ACK controllers and other cross-model integrations, authors must adhere to the following standards.
+
+###### 1. Core Data-Flow Terminology and Direction
+In a binding relationship definition, data configuration is matched and patched between two nodes: a **Giver (Source)** and a **Receiver (Destination)**. 
+* **Giver / Source (`mutatorRef`)**: This is the resource that inherently owns or generates the configuration property (e.g., an IAM Role generating its `arn`, a Subnet generating its `id`, or an SQS Queue providing its `name`). Its selector patch configuration **must** be marked as `mutatorRef`.
+* **Receiver / Destination (`mutatedRef`)**: This is the resource that consumes the configuration property (e.g., a Lambda Function setting its execution `role`, or an EKS Cluster specifying its VPC `subnetIDs`). Its selector patch configuration **must** be marked as `mutatedRef`.
+
+> [!WARNING]
+> Swapping `mutatorRef` and `mutatedRef` or using the same strategy key on both sides of a selector (e.g., both selectors using `mutatedRef`) is a schema violation and will break the policy evaluation engine.
+
+###### 2. Code Example: Binding Relationship Selector
+Here is a complete example of a valid `v1beta2` binding selector connecting an **SQS Queue (Giver/Source)** to a **Lambda EventSourceMapping (Receiver/Destination)**:
+
+```json
+{
+  "allow": {
+    "from": [
+      {
+        "id": null,
+        "kind": "Queue",
+        "match": {},
+        "match_strategy_matrix": null,
+        "model": {
+          "displayName": "",
+          "id": "00000000-0000-0000-0000-000000000000",
+          "model": {
+            "version": ""
+          },
+          "name": "aws-sqs-controller",
+          "registrant": {
+            "kind": "github"
+          },
+          "version": ""
+        },
+        "patch": {
+          "mutatorRef": [
+            [
+              "configuration",
+              "spec",
+              "name"
+            ]
+          ],
+          "patchStrategy": "replace"
+        }
+      }
+    ],
+    "to": [
+      {
+        "id": null,
+        "kind": "EventSourceMapping",
+        "match": {},
+        "match_strategy_matrix": null,
+        "model": {
+          "displayName": "",
+          "id": "00000000-0000-0000-0000-000000000000",
+          "model": {
+            "version": ""
+          },
+          "name": "aws-lambda-controller",
+          "registrant": {
+            "kind": "github"
+          },
+          "version": ""
+        },
+        "patch": {
+          "mutatedRef": [
+            [
+              "configuration",
+              "spec",
+              "queueRefs",
+              "0",
+              "from",
+              "name"
+            ]
+          ],
+          "patchStrategy": "replace"
+        }
+      }
+    ]
+  },
+  "deny": {
+    "from": [],
+    "to": []
+  }
+}
+```
+
+###### 3. Design-Time vs. Runtime Referencing
+* **Design-Time Reference Fields (Recommended)**: Prefer name-based Kubernetes references (e.g., targeting `spec.queueRefs.0.from.name` instead of `eventSourceARN`). Sourcing raw ARN or ID fields at design-time is fragile because these values are typically not known until the resources are created in the live cloud. Targeting ACK's reference wrapper fields allows users to connect resources on the design canvas using simple resource names, leaving ARN resolution to the ACK controller at runtime.
+* **Non-Binding Visual-Only Relationships**: If a relationship is purely visual/informational and represents a runtime dependency that does not require declarative configuration patching (e.g., a Lambda Function writing to a DynamoDB Table via custom application code), the patch selectors **must** be set to `null` to prevent the evaluation engine from attempting configuration mutations:
+  ```json
+  "patch": null
+  ```
+
+###### 4. Casing and Array Indexing Rules
+* **Strict OpenAPI Schema Matching**: The JSON paths specified in `mutatorRef` and `mutatedRef` must match the Go/Kubernetes OpenAPI property schemas of the controller components exactly. Watch out for case-sensitive fields (e.g., EKS uses `resourcesVPCConfig.subnetIDs` rather than `subnetIds`; RDS uses `vpcSecurityGroupIDs` rather than `vpcSecurityGroupIds`).
+* **Explicit Array Indexing**: When patching into an array/list field, you must specify the index explicitly (e.g., `["configuration", "spec", "vpcSecurityGroupIDs", "0"]`) rather than referencing the naked array field. Overwriting a naked array field with a string scalar value will corrupt the resulting resource specification.
+
+###### 5. Registrant Kind Migration
+Meshery is migrating from the legacy Artifact Hub registry to the GitHub registry format.
+* Ensure all relationship models and selector components specify `"registrant": {"kind": "github"}` instead of `"artifacthub"`.
+
+###### 6. Authoring Checklist for Contributors
+Before submitting a new relationship definition pull request, verify:
+* [ ] Is `schemaVersion` set to `"relationships.meshery.io/v1beta2"`?
+* [ ] Does the Giver/Source component define `mutatorRef`?
+* [ ] Does the Receiver/Destination component define `mutatedRef`?
+* [ ] Do all JSON paths match the exact casing in the component schemas?
+* [ ] Are array indices targeted explicitly (e.g., ending with `"0"`)?
+* [ ] Are visual-only/non-binding relationships configured with `"patch": null`?
+* [ ] Are all model registrant kinds set to `"github"`?
+* [ ] Have you validated the relationship files locally using `check_relationships.py`?
 
 ##### Scoping
 

--- a/server/meshmodel/aws-ec2-controller/v1.13.1/v1.0.0/relationships/edge_binding_firewall_launchtemplate_sg.json
+++ b/server/meshmodel/aws-ec2-controller/v1.13.1/v1.0.0/relationships/edge_binding_firewall_launchtemplate_sg.json
@@ -1,29 +1,56 @@
 {
-  "schemaVersion": "relationships.meshery.io/v1alpha3",
-  "version": "v1.0.0",
-  "kind": "RelationshipDefinition",
+  "id": "00000000-0000-0000-0000-000000000000",
+  "evaluationQuery": "edge_binding_firewall_relationship",
+  "kind": "edge",
   "metadata": {
-    "description": "SecurityGroup to LaunchTemplate firewall binding. A LaunchTemplate references SecurityGroups via the securityGroupIDs field in its data block. This defines the network firewall rules that apply to every EC2 instance launched from the template, forming the blast radius boundary for EKS worker node access."
+    "description": "SecurityGroup to LaunchTemplate firewall binding. A LaunchTemplate references SecurityGroups via the securityGroupIDs field in its data block. This defines the network firewall rules that apply to every EC2 instance launched from the template, forming the blast radius boundary for EKS worker node access.",
+    "isAnnotation": false,
+    "styles": {
+      "primaryColor": "",
+      "svgColor": "",
+      "svgWhite": ""
+    }
   },
   "model": {
+    "displayName": "",
+    "id": "00000000-0000-0000-0000-000000000000",
+    "model": {
+      "version": "v1.13.1"
+    },
     "name": "aws-ec2-controller",
-    "version": "v1.13.1"
+    "registrant": {
+      "kind": "github"
+    },
+    "version": ""
   },
-  "type": "binding",
-  "subType": "firewall",
-  "evaluationQuery": "edge_binding_firewall_relationship",
+  "schemaVersion": "relationships.meshery.io/v1beta2",
   "selectors": [
     {
       "allow": {
         "from": [
           {
-            "model": "aws-ec2-controller",
+            "id": null,
             "kind": "SecurityGroup",
+            "match": {},
+            "match_strategy_matrix": null,
+            "model": {
+              "displayName": "",
+              "id": "00000000-0000-0000-0000-000000000000",
+              "model": {
+                "version": ""
+              },
+              "name": "aws-ec2-controller",
+              "registrant": {
+                "kind": "github"
+              },
+              "version": ""
+            },
             "patch": {
               "mutatorRef": [
                 [
                   "configuration",
-                  "name"
+                  "status",
+                  "id"
                 ]
               ],
               "patchStrategy": "replace"
@@ -32,8 +59,22 @@
         ],
         "to": [
           {
-            "model": "aws-ec2-controller",
+            "id": null,
             "kind": "LaunchTemplate",
+            "match": {},
+            "match_strategy_matrix": null,
+            "model": {
+              "displayName": "",
+              "id": "00000000-0000-0000-0000-000000000000",
+              "model": {
+                "version": ""
+              },
+              "name": "aws-ec2-controller",
+              "registrant": {
+                "kind": "github"
+              },
+              "version": ""
+            },
             "patch": {
               "mutatedRef": [
                 [
@@ -48,7 +89,15 @@
             }
           }
         ]
+      },
+      "deny": {
+        "from": [],
+        "to": []
       }
     }
-  ]
+  ],
+  "subType": "firewall",
+  "status": "enabled",
+  "type": "binding",
+  "version": "v1.0.0"
 }

--- a/server/meshmodel/aws-ec2-controller/v1.13.1/v1.0.0/relationships/edge_binding_firewall_launchtemplate_sg.json
+++ b/server/meshmodel/aws-ec2-controller/v1.13.1/v1.0.0/relationships/edge_binding_firewall_launchtemplate_sg.json
@@ -49,8 +49,8 @@
               "mutatorRef": [
                 [
                   "configuration",
-                  "status",
-                  "id"
+                  "spec",
+                  "name"
                 ]
               ],
               "patchStrategy": "replace"
@@ -81,7 +81,7 @@
                   "configuration",
                   "spec",
                   "data",
-                  "securityGroupIDs",
+                  "securityGroups",
                   "0"
                 ]
               ],

--- a/server/meshmodel/aws-ec2-controller/v1.13.1/v1.0.0/relationships/edge_binding_firewall_launchtemplate_sg.json
+++ b/server/meshmodel/aws-ec2-controller/v1.13.1/v1.0.0/relationships/edge_binding_firewall_launchtemplate_sg.json
@@ -1,0 +1,54 @@
+{
+  "schemaVersion": "relationships.meshery.io/v1alpha3",
+  "version": "v1.0.0",
+  "kind": "RelationshipDefinition",
+  "metadata": {
+    "description": "SecurityGroup to LaunchTemplate firewall binding. A LaunchTemplate references SecurityGroups via the securityGroupIDs field in its data block. This defines the network firewall rules that apply to every EC2 instance launched from the template, forming the blast radius boundary for EKS worker node access."
+  },
+  "model": {
+    "name": "aws-ec2-controller",
+    "version": "v1.13.1"
+  },
+  "type": "binding",
+  "subType": "firewall",
+  "evaluationQuery": "edge_binding_firewall_relationship",
+  "selectors": [
+    {
+      "allow": {
+        "from": [
+          {
+            "model": "aws-ec2-controller",
+            "kind": "SecurityGroup",
+            "patch": {
+              "mutatorRef": [
+                [
+                  "configuration",
+                  "name"
+                ]
+              ],
+              "patchStrategy": "replace"
+            }
+          }
+        ],
+        "to": [
+          {
+            "model": "aws-ec2-controller",
+            "kind": "LaunchTemplate",
+            "patch": {
+              "mutatedRef": [
+                [
+                  "configuration",
+                  "spec",
+                  "data",
+                  "securityGroupIDs",
+                  "0"
+                ]
+              ],
+              "patchStrategy": "replace"
+            }
+          }
+        ]
+      }
+    }
+  ]
+}

--- a/server/meshmodel/aws-ec2-controller/v1.13.1/v1.0.0/relationships/edge_binding_network_tgw_tgwattachment.json
+++ b/server/meshmodel/aws-ec2-controller/v1.13.1/v1.0.0/relationships/edge_binding_network_tgw_tgwattachment.json
@@ -1,0 +1,52 @@
+{
+  "schemaVersion": "relationships.meshery.io/v1alpha3",
+  "version": "v1.0.0",
+  "kind": "RelationshipDefinition",
+  "metadata": {
+    "description": "Transit Gateway to VPC Attachment network binding. In AWS hub-and-spoke topologies, a TransitGateway acts as the central routing hub. Each VPC connects to it via a TransitGatewayVPCAttachment, which references the transit gateway ID. This relationship enables Kanvas to visualize multi-account, multi-VPC routing architectures."
+  },
+  "model": {
+    "name": "aws-ec2-controller",
+    "version": "v1.13.1"
+  },
+  "type": "binding",
+  "subType": "network",
+  "evaluationQuery": "edge_binding_network_relationship",
+  "selectors": [
+    {
+      "allow": {
+        "from": [
+          {
+            "model": "aws-ec2-controller",
+            "kind": "TransitGateway",
+            "patch": {
+              "mutatorRef": [
+                [
+                  "configuration",
+                  "name"
+                ]
+              ],
+              "patchStrategy": "replace"
+            }
+          }
+        ],
+        "to": [
+          {
+            "model": "aws-ec2-controller",
+            "kind": "TransitGatewayVPCAttachment",
+            "patch": {
+              "mutatedRef": [
+                [
+                  "configuration",
+                  "spec",
+                  "transitGatewayID"
+                ]
+              ],
+              "patchStrategy": "replace"
+            }
+          }
+        ]
+      }
+    }
+  ]
+}

--- a/server/meshmodel/aws-ec2-controller/v1.13.1/v1.0.0/relationships/edge_binding_network_tgw_tgwattachment.json
+++ b/server/meshmodel/aws-ec2-controller/v1.13.1/v1.0.0/relationships/edge_binding_network_tgw_tgwattachment.json
@@ -1,29 +1,56 @@
 {
-  "schemaVersion": "relationships.meshery.io/v1alpha3",
-  "version": "v1.0.0",
-  "kind": "RelationshipDefinition",
+  "id": "00000000-0000-0000-0000-000000000000",
+  "evaluationQuery": "edge_binding_network_relationship",
+  "kind": "edge",
   "metadata": {
-    "description": "Transit Gateway to VPC Attachment network binding. In AWS hub-and-spoke topologies, a TransitGateway acts as the central routing hub. Each VPC connects to it via a TransitGatewayVPCAttachment, which references the transit gateway ID. This relationship enables Kanvas to visualize multi-account, multi-VPC routing architectures."
+    "description": "Transit Gateway to VPC Attachment network binding. In AWS hub-and-spoke topologies, a TransitGateway acts as the central routing hub. Each VPC connects to it via a TransitGatewayVPCAttachment, which references the transit gateway ID. This relationship enables Kanvas to visualize multi-account, multi-VPC routing architectures.",
+    "isAnnotation": false,
+    "styles": {
+      "primaryColor": "",
+      "svgColor": "",
+      "svgWhite": ""
+    }
   },
   "model": {
+    "displayName": "",
+    "id": "00000000-0000-0000-0000-000000000000",
+    "model": {
+      "version": "v1.13.1"
+    },
     "name": "aws-ec2-controller",
-    "version": "v1.13.1"
+    "registrant": {
+      "kind": "github"
+    },
+    "version": ""
   },
-  "type": "binding",
-  "subType": "network",
-  "evaluationQuery": "edge_binding_network_relationship",
+  "schemaVersion": "relationships.meshery.io/v1beta2",
   "selectors": [
     {
       "allow": {
         "from": [
           {
-            "model": "aws-ec2-controller",
+            "id": null,
             "kind": "TransitGateway",
+            "match": {},
+            "match_strategy_matrix": null,
+            "model": {
+              "displayName": "",
+              "id": "00000000-0000-0000-0000-000000000000",
+              "model": {
+                "version": ""
+              },
+              "name": "aws-ec2-controller",
+              "registrant": {
+                "kind": "github"
+              },
+              "version": ""
+            },
             "patch": {
               "mutatorRef": [
                 [
                   "configuration",
-                  "name"
+                  "status",
+                  "id"
                 ]
               ],
               "patchStrategy": "replace"
@@ -32,8 +59,22 @@
         ],
         "to": [
           {
-            "model": "aws-ec2-controller",
+            "id": null,
             "kind": "TransitGatewayVPCAttachment",
+            "match": {},
+            "match_strategy_matrix": null,
+            "model": {
+              "displayName": "",
+              "id": "00000000-0000-0000-0000-000000000000",
+              "model": {
+                "version": ""
+              },
+              "name": "aws-ec2-controller",
+              "registrant": {
+                "kind": "github"
+              },
+              "version": ""
+            },
             "patch": {
               "mutatedRef": [
                 [
@@ -46,7 +87,15 @@
             }
           }
         ]
+      },
+      "deny": {
+        "from": [],
+        "to": []
       }
     }
-  ]
+  ],
+  "subType": "network",
+  "status": "enabled",
+  "type": "binding",
+  "version": "v1.0.0"
 }

--- a/server/meshmodel/aws-ec2-controller/v1.13.1/v1.0.0/relationships/edge_binding_network_tgw_tgwattachment.json
+++ b/server/meshmodel/aws-ec2-controller/v1.13.1/v1.0.0/relationships/edge_binding_network_tgw_tgwattachment.json
@@ -49,8 +49,8 @@
               "mutatorRef": [
                 [
                   "configuration",
-                  "status",
-                  "id"
+                  "metadata",
+                  "name"
                 ]
               ],
               "patchStrategy": "replace"
@@ -80,7 +80,9 @@
                 [
                   "configuration",
                   "spec",
-                  "transitGatewayID"
+                  "transitGatewayRef",
+                  "from",
+                  "name"
                 ]
               ],
               "patchStrategy": "replace"

--- a/server/meshmodel/aws-ec2-controller/v1.13.1/v1.0.0/relationships/edge_binding_network_tgwattachment_vpc.json
+++ b/server/meshmodel/aws-ec2-controller/v1.13.1/v1.0.0/relationships/edge_binding_network_tgwattachment_vpc.json
@@ -1,29 +1,56 @@
 {
-  "schemaVersion": "relationships.meshery.io/v1alpha3",
-  "version": "v1.0.0",
-  "kind": "RelationshipDefinition",
+  "id": "00000000-0000-0000-0000-000000000000",
+  "evaluationQuery": "edge_binding_network_relationship",
+  "kind": "edge",
   "metadata": {
-    "description": "VPC to Transit Gateway VPC Attachment network binding. A TransitGatewayVPCAttachment references a specific VPC via its vpcID field, connecting that VPC to the transit gateway routing domain. This relationship completes the hub-and-spoke visualization in Kanvas."
+    "description": "VPC to Transit Gateway VPC Attachment network binding. A TransitGatewayVPCAttachment references a specific VPC via its vpcID field, connecting that VPC to the transit gateway routing domain. This relationship completes the hub-and-spoke visualization in Kanvas.",
+    "isAnnotation": false,
+    "styles": {
+      "primaryColor": "",
+      "svgColor": "",
+      "svgWhite": ""
+    }
   },
   "model": {
+    "displayName": "",
+    "id": "00000000-0000-0000-0000-000000000000",
+    "model": {
+      "version": "v1.13.1"
+    },
     "name": "aws-ec2-controller",
-    "version": "v1.13.1"
+    "registrant": {
+      "kind": "github"
+    },
+    "version": ""
   },
-  "type": "binding",
-  "subType": "network",
-  "evaluationQuery": "edge_binding_network_relationship",
+  "schemaVersion": "relationships.meshery.io/v1beta2",
   "selectors": [
     {
       "allow": {
         "from": [
           {
-            "model": "aws-ec2-controller",
+            "id": null,
             "kind": "VPC",
+            "match": {},
+            "match_strategy_matrix": null,
+            "model": {
+              "displayName": "",
+              "id": "00000000-0000-0000-0000-000000000000",
+              "model": {
+                "version": ""
+              },
+              "name": "aws-ec2-controller",
+              "registrant": {
+                "kind": "github"
+              },
+              "version": ""
+            },
             "patch": {
               "mutatorRef": [
                 [
                   "configuration",
-                  "name"
+                  "status",
+                  "id"
                 ]
               ],
               "patchStrategy": "replace"
@@ -32,8 +59,22 @@
         ],
         "to": [
           {
-            "model": "aws-ec2-controller",
+            "id": null,
             "kind": "TransitGatewayVPCAttachment",
+            "match": {},
+            "match_strategy_matrix": null,
+            "model": {
+              "displayName": "",
+              "id": "00000000-0000-0000-0000-000000000000",
+              "model": {
+                "version": ""
+              },
+              "name": "aws-ec2-controller",
+              "registrant": {
+                "kind": "github"
+              },
+              "version": ""
+            },
             "patch": {
               "mutatedRef": [
                 [
@@ -46,7 +87,15 @@
             }
           }
         ]
+      },
+      "deny": {
+        "from": [],
+        "to": []
       }
     }
-  ]
+  ],
+  "subType": "network",
+  "status": "enabled",
+  "type": "binding",
+  "version": "v1.0.0"
 }

--- a/server/meshmodel/aws-ec2-controller/v1.13.1/v1.0.0/relationships/edge_binding_network_tgwattachment_vpc.json
+++ b/server/meshmodel/aws-ec2-controller/v1.13.1/v1.0.0/relationships/edge_binding_network_tgwattachment_vpc.json
@@ -1,0 +1,52 @@
+{
+  "schemaVersion": "relationships.meshery.io/v1alpha3",
+  "version": "v1.0.0",
+  "kind": "RelationshipDefinition",
+  "metadata": {
+    "description": "VPC to Transit Gateway VPC Attachment network binding. A TransitGatewayVPCAttachment references a specific VPC via its vpcID field, connecting that VPC to the transit gateway routing domain. This relationship completes the hub-and-spoke visualization in Kanvas."
+  },
+  "model": {
+    "name": "aws-ec2-controller",
+    "version": "v1.13.1"
+  },
+  "type": "binding",
+  "subType": "network",
+  "evaluationQuery": "edge_binding_network_relationship",
+  "selectors": [
+    {
+      "allow": {
+        "from": [
+          {
+            "model": "aws-ec2-controller",
+            "kind": "VPC",
+            "patch": {
+              "mutatorRef": [
+                [
+                  "configuration",
+                  "name"
+                ]
+              ],
+              "patchStrategy": "replace"
+            }
+          }
+        ],
+        "to": [
+          {
+            "model": "aws-ec2-controller",
+            "kind": "TransitGatewayVPCAttachment",
+            "patch": {
+              "mutatedRef": [
+                [
+                  "configuration",
+                  "spec",
+                  "vpcID"
+                ]
+              ],
+              "patchStrategy": "replace"
+            }
+          }
+        ]
+      }
+    }
+  ]
+}

--- a/server/meshmodel/aws-ec2-controller/v1.13.1/v1.0.0/relationships/edge_binding_network_tgwattachment_vpc.json
+++ b/server/meshmodel/aws-ec2-controller/v1.13.1/v1.0.0/relationships/edge_binding_network_tgwattachment_vpc.json
@@ -49,8 +49,8 @@
               "mutatorRef": [
                 [
                   "configuration",
-                  "status",
-                  "id"
+                  "metadata",
+                  "name"
                 ]
               ],
               "patchStrategy": "replace"
@@ -80,7 +80,9 @@
                 [
                   "configuration",
                   "spec",
-                  "vpcID"
+                  "vpcRef",
+                  "from",
+                  "name"
                 ]
               ],
               "patchStrategy": "replace"

--- a/server/meshmodel/aws-eks-controller/v1.9.3/v1.0.0/relationships/edge_binding_network_cluster_nodegroup.json
+++ b/server/meshmodel/aws-eks-controller/v1.9.3/v1.0.0/relationships/edge_binding_network_cluster_nodegroup.json
@@ -49,7 +49,7 @@
               "mutatorRef": [
                 [
                   "configuration",
-                  "spec",
+                  "metadata",
                   "name"
                 ]
               ],
@@ -80,7 +80,9 @@
                 [
                   "configuration",
                   "spec",
-                  "clusterName"
+                  "clusterRef",
+                  "from",
+                  "name"
                 ]
               ],
               "patchStrategy": "replace"

--- a/server/meshmodel/aws-eks-controller/v1.9.3/v1.0.0/relationships/edge_binding_network_cluster_nodegroup.json
+++ b/server/meshmodel/aws-eks-controller/v1.9.3/v1.0.0/relationships/edge_binding_network_cluster_nodegroup.json
@@ -1,24 +1,50 @@
 {
-  "schemaVersion": "relationships.meshery.io/v1alpha3",
-  "version": "v1.0.0",
-  "kind": "RelationshipDefinition",
+  "id": "00000000-0000-0000-0000-000000000000",
+  "evaluationQuery": "edge_binding_network_relationship",
+  "kind": "edge",
   "metadata": {
-    "description": "EKS Cluster to Nodegroup network binding. A Nodegroup references its parent Cluster via the clusterName field. This relationship represents the first link in the EKS compute stack: the cluster defines the control plane, and nodegroups provision the worker nodes within it."
+    "description": "EKS Cluster to Nodegroup network binding. A Nodegroup references its parent Cluster via the clusterName field. This relationship represents the first link in the EKS compute stack: the cluster defines the control plane, and nodegroups provision the worker nodes within it.",
+    "isAnnotation": false,
+    "styles": {
+      "primaryColor": "",
+      "svgColor": "",
+      "svgWhite": ""
+    }
   },
   "model": {
+    "displayName": "",
+    "id": "00000000-0000-0000-0000-000000000000",
+    "model": {
+      "version": "v1.9.3"
+    },
     "name": "aws-eks-controller",
-    "version": "v1.9.3"
+    "registrant": {
+      "kind": "github"
+    },
+    "version": ""
   },
-  "type": "binding",
-  "subType": "network",
-  "evaluationQuery": "edge_binding_network_relationship",
+  "schemaVersion": "relationships.meshery.io/v1beta2",
   "selectors": [
     {
       "allow": {
         "from": [
           {
-            "model": "aws-eks-controller",
+            "id": null,
             "kind": "Cluster",
+            "match": {},
+            "match_strategy_matrix": null,
+            "model": {
+              "displayName": "",
+              "id": "00000000-0000-0000-0000-000000000000",
+              "model": {
+                "version": ""
+              },
+              "name": "aws-eks-controller",
+              "registrant": {
+                "kind": "github"
+              },
+              "version": ""
+            },
             "patch": {
               "mutatorRef": [
                 [
@@ -33,8 +59,22 @@
         ],
         "to": [
           {
-            "model": "aws-eks-controller",
+            "id": null,
             "kind": "Nodegroup",
+            "match": {},
+            "match_strategy_matrix": null,
+            "model": {
+              "displayName": "",
+              "id": "00000000-0000-0000-0000-000000000000",
+              "model": {
+                "version": ""
+              },
+              "name": "aws-eks-controller",
+              "registrant": {
+                "kind": "github"
+              },
+              "version": ""
+            },
             "patch": {
               "mutatedRef": [
                 [
@@ -47,7 +87,15 @@
             }
           }
         ]
+      },
+      "deny": {
+        "from": [],
+        "to": []
       }
     }
-  ]
+  ],
+  "subType": "network",
+  "status": "enabled",
+  "type": "binding",
+  "version": "v1.0.0"
 }

--- a/server/meshmodel/aws-eks-controller/v1.9.3/v1.0.0/relationships/edge_binding_network_cluster_nodegroup.json
+++ b/server/meshmodel/aws-eks-controller/v1.9.3/v1.0.0/relationships/edge_binding_network_cluster_nodegroup.json
@@ -1,0 +1,53 @@
+{
+  "schemaVersion": "relationships.meshery.io/v1alpha3",
+  "version": "v1.0.0",
+  "kind": "RelationshipDefinition",
+  "metadata": {
+    "description": "EKS Cluster to Nodegroup network binding. A Nodegroup references its parent Cluster via the clusterName field. This relationship represents the first link in the EKS compute stack: the cluster defines the control plane, and nodegroups provision the worker nodes within it."
+  },
+  "model": {
+    "name": "aws-eks-controller",
+    "version": "v1.9.3"
+  },
+  "type": "binding",
+  "subType": "network",
+  "evaluationQuery": "edge_binding_network_relationship",
+  "selectors": [
+    {
+      "allow": {
+        "from": [
+          {
+            "model": "aws-eks-controller",
+            "kind": "Cluster",
+            "patch": {
+              "mutatorRef": [
+                [
+                  "configuration",
+                  "spec",
+                  "name"
+                ]
+              ],
+              "patchStrategy": "replace"
+            }
+          }
+        ],
+        "to": [
+          {
+            "model": "aws-eks-controller",
+            "kind": "Nodegroup",
+            "patch": {
+              "mutatedRef": [
+                [
+                  "configuration",
+                  "spec",
+                  "clusterName"
+                ]
+              ],
+              "patchStrategy": "replace"
+            }
+          }
+        ]
+      }
+    }
+  ]
+}

--- a/server/meshmodel/aws-eks-controller/v1.9.3/v1.0.0/relationships/edge_binding_network_nodegroup_launchtemplate.json
+++ b/server/meshmodel/aws-eks-controller/v1.9.3/v1.0.0/relationships/edge_binding_network_nodegroup_launchtemplate.json
@@ -1,24 +1,50 @@
 {
-  "schemaVersion": "relationships.meshery.io/v1alpha3",
-  "version": "v1.0.0",
-  "kind": "RelationshipDefinition",
+  "id": "00000000-0000-0000-0000-000000000000",
+  "evaluationQuery": "edge_binding_network_relationship",
+  "kind": "edge",
   "metadata": {
-    "description": "LaunchTemplate to EKS Nodegroup network binding. A Nodegroup references a LaunchTemplate by name to define the EC2 instance configuration (AMI, instance type, user data) for its worker nodes. This relationship represents the second link in the EKS compute stack."
+    "description": "LaunchTemplate to EKS Nodegroup network binding. A Nodegroup references a LaunchTemplate by name to define the EC2 instance configuration (AMI, instance type, user data) for its worker nodes. This relationship represents the second link in the EKS compute stack.",
+    "isAnnotation": false,
+    "styles": {
+      "primaryColor": "",
+      "svgColor": "",
+      "svgWhite": ""
+    }
   },
   "model": {
+    "displayName": "",
+    "id": "00000000-0000-0000-0000-000000000000",
+    "model": {
+      "version": "v1.9.3"
+    },
     "name": "aws-eks-controller",
-    "version": "v1.9.3"
+    "registrant": {
+      "kind": "github"
+    },
+    "version": ""
   },
-  "type": "binding",
-  "subType": "network",
-  "evaluationQuery": "edge_binding_network_relationship",
+  "schemaVersion": "relationships.meshery.io/v1beta2",
   "selectors": [
     {
       "allow": {
         "from": [
           {
-            "model": "aws-ec2-controller",
+            "id": null,
             "kind": "LaunchTemplate",
+            "match": {},
+            "match_strategy_matrix": null,
+            "model": {
+              "displayName": "",
+              "id": "00000000-0000-0000-0000-000000000000",
+              "model": {
+                "version": ""
+              },
+              "name": "aws-ec2-controller",
+              "registrant": {
+                "kind": "github"
+              },
+              "version": ""
+            },
             "patch": {
               "mutatorRef": [
                 [
@@ -33,8 +59,22 @@
         ],
         "to": [
           {
-            "model": "aws-eks-controller",
+            "id": null,
             "kind": "Nodegroup",
+            "match": {},
+            "match_strategy_matrix": null,
+            "model": {
+              "displayName": "",
+              "id": "00000000-0000-0000-0000-000000000000",
+              "model": {
+                "version": ""
+              },
+              "name": "aws-eks-controller",
+              "registrant": {
+                "kind": "github"
+              },
+              "version": ""
+            },
             "patch": {
               "mutatedRef": [
                 [
@@ -48,7 +88,15 @@
             }
           }
         ]
+      },
+      "deny": {
+        "from": [],
+        "to": []
       }
     }
-  ]
+  ],
+  "subType": "network",
+  "status": "enabled",
+  "type": "binding",
+  "version": "v1.0.0"
 }

--- a/server/meshmodel/aws-eks-controller/v1.9.3/v1.0.0/relationships/edge_binding_network_nodegroup_launchtemplate.json
+++ b/server/meshmodel/aws-eks-controller/v1.9.3/v1.0.0/relationships/edge_binding_network_nodegroup_launchtemplate.json
@@ -1,0 +1,54 @@
+{
+  "schemaVersion": "relationships.meshery.io/v1alpha3",
+  "version": "v1.0.0",
+  "kind": "RelationshipDefinition",
+  "metadata": {
+    "description": "LaunchTemplate to EKS Nodegroup network binding. A Nodegroup references a LaunchTemplate by name to define the EC2 instance configuration (AMI, instance type, user data) for its worker nodes. This relationship represents the second link in the EKS compute stack."
+  },
+  "model": {
+    "name": "aws-eks-controller",
+    "version": "v1.9.3"
+  },
+  "type": "binding",
+  "subType": "network",
+  "evaluationQuery": "edge_binding_network_relationship",
+  "selectors": [
+    {
+      "allow": {
+        "from": [
+          {
+            "model": "aws-ec2-controller",
+            "kind": "LaunchTemplate",
+            "patch": {
+              "mutatorRef": [
+                [
+                  "configuration",
+                  "spec",
+                  "name"
+                ]
+              ],
+              "patchStrategy": "replace"
+            }
+          }
+        ],
+        "to": [
+          {
+            "model": "aws-eks-controller",
+            "kind": "Nodegroup",
+            "patch": {
+              "mutatedRef": [
+                [
+                  "configuration",
+                  "spec",
+                  "launchTemplate",
+                  "name"
+                ]
+              ],
+              "patchStrategy": "replace"
+            }
+          }
+        ]
+      }
+    }
+  ]
+}

--- a/server/meshmodel/aws-eks-controller/v1.9.3/v1.0.0/relationships/edge_binding_network_nodegroup_launchtemplate.json
+++ b/server/meshmodel/aws-eks-controller/v1.9.3/v1.0.0/relationships/edge_binding_network_nodegroup_launchtemplate.json
@@ -49,7 +49,7 @@
               "mutatorRef": [
                 [
                   "configuration",
-                  "spec",
+                  "metadata",
                   "name"
                 ]
               ],

--- a/server/meshmodel/aws-eventbridge-controller/v1.3.0/v1.0.0/relationships/edge_binding_network_rule_sqs.json
+++ b/server/meshmodel/aws-eventbridge-controller/v1.3.0/v1.0.0/relationships/edge_binding_network_rule_sqs.json
@@ -1,0 +1,55 @@
+{
+  "schemaVersion": "relationships.meshery.io/v1alpha3",
+  "version": "v1.0.0",
+  "kind": "RelationshipDefinition",
+  "metadata": {
+    "description": "SQS Queue to EventBridge Rule network binding. An EventBridge Rule targets an SQS Queue via the targets[].arn field. When the rule's event pattern matches, the matched event is delivered to the SQS queue. This relationship represents the first link in serverless event pipelines."
+  },
+  "model": {
+    "name": "aws-eventbridge-controller",
+    "version": "v1.3.0"
+  },
+  "type": "binding",
+  "subType": "network",
+  "evaluationQuery": "edge_binding_network_relationship",
+  "selectors": [
+    {
+      "allow": {
+        "from": [
+          {
+            "model": "aws-sqs-controller",
+            "kind": "Queue",
+            "patch": {
+              "mutatorRef": [
+                [
+                  "configuration",
+                  "spec",
+                  "queueName"
+                ]
+              ],
+              "patchStrategy": "replace"
+            }
+          }
+        ],
+        "to": [
+          {
+            "model": "aws-eventbridge-controller",
+            "kind": "Rule",
+            "patch": {
+              "mutatedRef": [
+                [
+                  "configuration",
+                  "spec",
+                  "targets",
+                  "0",
+                  "arn"
+                ]
+              ],
+              "patchStrategy": "replace"
+            }
+          }
+        ]
+      }
+    }
+  ]
+}

--- a/server/meshmodel/aws-eventbridge-controller/v1.3.0/v1.0.0/relationships/edge_binding_network_rule_sqs.json
+++ b/server/meshmodel/aws-eventbridge-controller/v1.3.0/v1.0.0/relationships/edge_binding_network_rule_sqs.json
@@ -1,26 +1,52 @@
 {
-  "schemaVersion": "relationships.meshery.io/v1alpha3",
-  "version": "v1.0.0",
-  "kind": "RelationshipDefinition",
+  "id": "00000000-0000-0000-0000-000000000000",
+  "evaluationQuery": "edge_binding_network_relationship",
+  "kind": "edge",
   "metadata": {
-    "description": "SQS Queue to EventBridge Rule network binding. An EventBridge Rule targets an SQS Queue via the targets[].arn field. When the rule's event pattern matches, the matched event is delivered to the SQS queue. This relationship represents the first link in serverless event pipelines."
+    "description": "SQS Queue to EventBridge Rule network binding. An EventBridge Rule targets an SQS Queue via the targets[].arn field. When the rule's event pattern matches, the matched event is delivered to the SQS queue. This relationship represents the first link in serverless event pipelines.",
+    "isAnnotation": false,
+    "styles": {
+      "primaryColor": "",
+      "svgColor": "",
+      "svgWhite": ""
+    }
   },
   "model": {
+    "displayName": "",
+    "id": "00000000-0000-0000-0000-000000000000",
+    "model": {
+      "version": "v1.3.0"
+    },
     "name": "aws-eventbridge-controller",
-    "version": "v1.3.0"
+    "registrant": {
+      "kind": "github"
+    },
+    "version": ""
   },
-  "type": "binding",
-  "subType": "network",
-  "evaluationQuery": "edge_binding_network_relationship",
+  "schemaVersion": "relationships.meshery.io/v1beta2",
   "selectors": [
     {
       "allow": {
         "from": [
           {
-            "model": "aws-sqs-controller",
+            "id": null,
             "kind": "Queue",
+            "match": {},
+            "match_strategy_matrix": null,
+            "model": {
+              "displayName": "",
+              "id": "00000000-0000-0000-0000-000000000000",
+              "model": {
+                "version": ""
+              },
+              "name": "aws-sqs-controller",
+              "registrant": {
+                "kind": "github"
+              },
+              "version": ""
+            },
             "patch": {
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "spec",
@@ -33,10 +59,24 @@
         ],
         "to": [
           {
-            "model": "aws-eventbridge-controller",
+            "id": null,
             "kind": "Rule",
+            "match": {},
+            "match_strategy_matrix": null,
+            "model": {
+              "displayName": "",
+              "id": "00000000-0000-0000-0000-000000000000",
+              "model": {
+                "version": ""
+              },
+              "name": "aws-eventbridge-controller",
+              "registrant": {
+                "kind": "github"
+              },
+              "version": ""
+            },
             "patch": {
-              "mutatedRef": [
+              "mutatorRef": [
                 [
                   "configuration",
                   "spec",
@@ -49,7 +89,15 @@
             }
           }
         ]
+      },
+      "deny": {
+        "from": [],
+        "to": []
       }
     }
-  ]
+  ],
+  "subType": "network",
+  "status": "enabled",
+  "type": "binding",
+  "version": "v1.0.0"
 }

--- a/server/meshmodel/aws-eventbridge-controller/v1.3.0/v1.0.0/relationships/edge_binding_network_rule_sqs.json
+++ b/server/meshmodel/aws-eventbridge-controller/v1.3.0/v1.0.0/relationships/edge_binding_network_rule_sqs.json
@@ -46,11 +46,11 @@
               "version": ""
             },
             "patch": {
-              "mutatedRef": [
+              "mutatorRef": [
                 [
                   "configuration",
-                  "spec",
-                  "queueName"
+                  "status",
+                  "arn"
                 ]
               ],
               "patchStrategy": "replace"
@@ -76,7 +76,7 @@
               "version": ""
             },
             "patch": {
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "spec",

--- a/server/meshmodel/aws-lambda-controller/v1.13.0/v1.0.0/relationships/edge_binding_network_kinesis_lambda.json
+++ b/server/meshmodel/aws-lambda-controller/v1.13.0/v1.0.0/relationships/edge_binding_network_kinesis_lambda.json
@@ -1,24 +1,50 @@
 {
-  "schemaVersion": "relationships.meshery.io/v1alpha3",
-  "version": "v1.0.0",
-  "kind": "RelationshipDefinition",
+  "id": "00000000-0000-0000-0000-000000000000",
+  "evaluationQuery": "edge_binding_network_relationship",
+  "kind": "edge",
   "metadata": {
-    "description": "Kinesis Stream to Lambda EventSourceMapping network binding. An EventSourceMapping polls a Kinesis data stream and invokes a Lambda function for each batch of records. The eventSourceARN field on the EventSourceMapping references the Kinesis stream. This relationship represents the ingestion layer of real-time data platform architectures."
+    "description": "Kinesis Stream to Lambda EventSourceMapping network binding. An EventSourceMapping polls a Kinesis data stream and invokes a Lambda function for each batch of records. The eventSourceARN field on the EventSourceMapping references the Kinesis stream. This relationship represents the ingestion layer of real-time data platform architectures.",
+    "isAnnotation": false,
+    "styles": {
+      "primaryColor": "",
+      "svgColor": "",
+      "svgWhite": ""
+    }
   },
   "model": {
+    "displayName": "",
+    "id": "00000000-0000-0000-0000-000000000000",
+    "model": {
+      "version": "v1.13.0"
+    },
     "name": "aws-lambda-controller",
-    "version": "v1.13.0"
+    "registrant": {
+      "kind": "github"
+    },
+    "version": ""
   },
-  "type": "binding",
-  "subType": "network",
-  "evaluationQuery": "edge_binding_network_relationship",
+  "schemaVersion": "relationships.meshery.io/v1beta2",
   "selectors": [
     {
       "allow": {
         "from": [
           {
-            "model": "aws-kinesis-controller",
+            "id": null,
             "kind": "Stream",
+            "match": {},
+            "match_strategy_matrix": null,
+            "model": {
+              "displayName": "",
+              "id": "00000000-0000-0000-0000-000000000000",
+              "model": {
+                "version": ""
+              },
+              "name": "aws-kinesis-controller",
+              "registrant": {
+                "kind": "github"
+              },
+              "version": ""
+            },
             "patch": {
               "mutatorRef": [
                 [
@@ -33,8 +59,22 @@
         ],
         "to": [
           {
-            "model": "aws-lambda-controller",
+            "id": null,
             "kind": "EventSourceMapping",
+            "match": {},
+            "match_strategy_matrix": null,
+            "model": {
+              "displayName": "",
+              "id": "00000000-0000-0000-0000-000000000000",
+              "model": {
+                "version": ""
+              },
+              "name": "aws-lambda-controller",
+              "registrant": {
+                "kind": "github"
+              },
+              "version": ""
+            },
             "patch": {
               "mutatedRef": [
                 [
@@ -47,7 +87,15 @@
             }
           }
         ]
+      },
+      "deny": {
+        "from": [],
+        "to": []
       }
     }
-  ]
+  ],
+  "subType": "network",
+  "status": "enabled",
+  "type": "binding",
+  "version": "v1.0.0"
 }

--- a/server/meshmodel/aws-lambda-controller/v1.13.0/v1.0.0/relationships/edge_binding_network_kinesis_lambda.json
+++ b/server/meshmodel/aws-lambda-controller/v1.13.0/v1.0.0/relationships/edge_binding_network_kinesis_lambda.json
@@ -1,0 +1,53 @@
+{
+  "schemaVersion": "relationships.meshery.io/v1alpha3",
+  "version": "v1.0.0",
+  "kind": "RelationshipDefinition",
+  "metadata": {
+    "description": "Kinesis Stream to Lambda EventSourceMapping network binding. An EventSourceMapping polls a Kinesis data stream and invokes a Lambda function for each batch of records. The eventSourceARN field on the EventSourceMapping references the Kinesis stream. This relationship represents the ingestion layer of real-time data platform architectures."
+  },
+  "model": {
+    "name": "aws-lambda-controller",
+    "version": "v1.13.0"
+  },
+  "type": "binding",
+  "subType": "network",
+  "evaluationQuery": "edge_binding_network_relationship",
+  "selectors": [
+    {
+      "allow": {
+        "from": [
+          {
+            "model": "aws-kinesis-controller",
+            "kind": "Stream",
+            "patch": {
+              "mutatorRef": [
+                [
+                  "configuration",
+                  "spec",
+                  "name"
+                ]
+              ],
+              "patchStrategy": "replace"
+            }
+          }
+        ],
+        "to": [
+          {
+            "model": "aws-lambda-controller",
+            "kind": "EventSourceMapping",
+            "patch": {
+              "mutatedRef": [
+                [
+                  "configuration",
+                  "spec",
+                  "eventSourceARN"
+                ]
+              ],
+              "patchStrategy": "replace"
+            }
+          }
+        ]
+      }
+    }
+  ]
+}

--- a/server/meshmodel/aws-lambda-controller/v1.13.0/v1.0.0/relationships/edge_binding_network_kinesis_lambda.json
+++ b/server/meshmodel/aws-lambda-controller/v1.13.0/v1.0.0/relationships/edge_binding_network_kinesis_lambda.json
@@ -49,7 +49,7 @@
               "mutatorRef": [
                 [
                   "configuration",
-                  "spec",
+                  "metadata",
                   "name"
                 ]
               ],
@@ -80,7 +80,9 @@
                 [
                   "configuration",
                   "spec",
-                  "eventSourceARN"
+                  "eventSourceRef",
+                  "from",
+                  "name"
                 ]
               ],
               "patchStrategy": "replace"

--- a/server/meshmodel/aws-lambda-controller/v1.13.0/v1.0.0/relationships/edge_binding_network_lambda_esm.json
+++ b/server/meshmodel/aws-lambda-controller/v1.13.0/v1.0.0/relationships/edge_binding_network_lambda_esm.json
@@ -49,7 +49,7 @@
               "mutatorRef": [
                 [
                   "configuration",
-                  "spec",
+                  "metadata",
                   "name"
                 ]
               ],
@@ -80,7 +80,9 @@
                 [
                   "configuration",
                   "spec",
-                  "functionName"
+                  "functionRef",
+                  "from",
+                  "name"
                 ]
               ],
               "patchStrategy": "replace"

--- a/server/meshmodel/aws-lambda-controller/v1.13.0/v1.0.0/relationships/edge_binding_network_lambda_esm.json
+++ b/server/meshmodel/aws-lambda-controller/v1.13.0/v1.0.0/relationships/edge_binding_network_lambda_esm.json
@@ -1,0 +1,53 @@
+{
+  "schemaVersion": "relationships.meshery.io/v1alpha3",
+  "version": "v1.0.0",
+  "kind": "RelationshipDefinition",
+  "metadata": {
+    "description": "Lambda Function to EventSourceMapping network binding. An EventSourceMapping references its target Lambda Function via the functionName field. This relationship connects the event source (SQS, Kinesis, DynamoDB Streams) to the function that processes the events."
+  },
+  "model": {
+    "name": "aws-lambda-controller",
+    "version": "v1.13.0"
+  },
+  "type": "binding",
+  "subType": "network",
+  "evaluationQuery": "edge_binding_network_relationship",
+  "selectors": [
+    {
+      "allow": {
+        "from": [
+          {
+            "model": "aws-lambda-controller",
+            "kind": "Function",
+            "patch": {
+              "mutatorRef": [
+                [
+                  "configuration",
+                  "spec",
+                  "name"
+                ]
+              ],
+              "patchStrategy": "replace"
+            }
+          }
+        ],
+        "to": [
+          {
+            "model": "aws-lambda-controller",
+            "kind": "EventSourceMapping",
+            "patch": {
+              "mutatedRef": [
+                [
+                  "configuration",
+                  "spec",
+                  "functionName"
+                ]
+              ],
+              "patchStrategy": "replace"
+            }
+          }
+        ]
+      }
+    }
+  ]
+}

--- a/server/meshmodel/aws-lambda-controller/v1.13.0/v1.0.0/relationships/edge_binding_network_lambda_esm.json
+++ b/server/meshmodel/aws-lambda-controller/v1.13.0/v1.0.0/relationships/edge_binding_network_lambda_esm.json
@@ -1,24 +1,50 @@
 {
-  "schemaVersion": "relationships.meshery.io/v1alpha3",
-  "version": "v1.0.0",
-  "kind": "RelationshipDefinition",
+  "id": "00000000-0000-0000-0000-000000000000",
+  "evaluationQuery": "edge_binding_network_relationship",
+  "kind": "edge",
   "metadata": {
-    "description": "Lambda Function to EventSourceMapping network binding. An EventSourceMapping references its target Lambda Function via the functionName field. This relationship connects the event source (SQS, Kinesis, DynamoDB Streams) to the function that processes the events."
+    "description": "Lambda Function to EventSourceMapping network binding. An EventSourceMapping references its target Lambda Function via the functionName field. This relationship connects the event source (SQS, Kinesis, DynamoDB Streams) to the function that processes the events.",
+    "isAnnotation": false,
+    "styles": {
+      "primaryColor": "",
+      "svgColor": "",
+      "svgWhite": ""
+    }
   },
   "model": {
+    "displayName": "",
+    "id": "00000000-0000-0000-0000-000000000000",
+    "model": {
+      "version": "v1.13.0"
+    },
     "name": "aws-lambda-controller",
-    "version": "v1.13.0"
+    "registrant": {
+      "kind": "github"
+    },
+    "version": ""
   },
-  "type": "binding",
-  "subType": "network",
-  "evaluationQuery": "edge_binding_network_relationship",
+  "schemaVersion": "relationships.meshery.io/v1beta2",
   "selectors": [
     {
       "allow": {
         "from": [
           {
-            "model": "aws-lambda-controller",
+            "id": null,
             "kind": "Function",
+            "match": {},
+            "match_strategy_matrix": null,
+            "model": {
+              "displayName": "",
+              "id": "00000000-0000-0000-0000-000000000000",
+              "model": {
+                "version": ""
+              },
+              "name": "aws-lambda-controller",
+              "registrant": {
+                "kind": "github"
+              },
+              "version": ""
+            },
             "patch": {
               "mutatorRef": [
                 [
@@ -33,8 +59,22 @@
         ],
         "to": [
           {
-            "model": "aws-lambda-controller",
+            "id": null,
             "kind": "EventSourceMapping",
+            "match": {},
+            "match_strategy_matrix": null,
+            "model": {
+              "displayName": "",
+              "id": "00000000-0000-0000-0000-000000000000",
+              "model": {
+                "version": ""
+              },
+              "name": "aws-lambda-controller",
+              "registrant": {
+                "kind": "github"
+              },
+              "version": ""
+            },
             "patch": {
               "mutatedRef": [
                 [
@@ -47,7 +87,15 @@
             }
           }
         ]
+      },
+      "deny": {
+        "from": [],
+        "to": []
       }
     }
-  ]
+  ],
+  "subType": "network",
+  "status": "enabled",
+  "type": "binding",
+  "version": "v1.0.0"
 }

--- a/server/meshmodel/aws-lambda-controller/v1.13.0/v1.0.0/relationships/edge_binding_network_sqs_lambda.json
+++ b/server/meshmodel/aws-lambda-controller/v1.13.0/v1.0.0/relationships/edge_binding_network_sqs_lambda.json
@@ -1,0 +1,53 @@
+{
+  "schemaVersion": "relationships.meshery.io/v1alpha3",
+  "version": "v1.0.0",
+  "kind": "RelationshipDefinition",
+  "metadata": {
+    "description": "SQS Queue to Lambda EventSourceMapping network binding. An EventSourceMapping polls an SQS queue and invokes a Lambda function for each batch of messages. The eventSourceARN field on the EventSourceMapping references the SQS queue. This relationship represents the SQS-to-Lambda leg of serverless event pipelines."
+  },
+  "model": {
+    "name": "aws-lambda-controller",
+    "version": "v1.13.0"
+  },
+  "type": "binding",
+  "subType": "network",
+  "evaluationQuery": "edge_binding_network_relationship",
+  "selectors": [
+    {
+      "allow": {
+        "from": [
+          {
+            "model": "aws-sqs-controller",
+            "kind": "Queue",
+            "patch": {
+              "mutatorRef": [
+                [
+                  "configuration",
+                  "spec",
+                  "queueName"
+                ]
+              ],
+              "patchStrategy": "replace"
+            }
+          }
+        ],
+        "to": [
+          {
+            "model": "aws-lambda-controller",
+            "kind": "EventSourceMapping",
+            "patch": {
+              "mutatedRef": [
+                [
+                  "configuration",
+                  "spec",
+                  "eventSourceARN"
+                ]
+              ],
+              "patchStrategy": "replace"
+            }
+          }
+        ]
+      }
+    }
+  ]
+}

--- a/server/meshmodel/aws-lambda-controller/v1.13.0/v1.0.0/relationships/edge_binding_network_sqs_lambda.json
+++ b/server/meshmodel/aws-lambda-controller/v1.13.0/v1.0.0/relationships/edge_binding_network_sqs_lambda.json
@@ -49,8 +49,8 @@
               "mutatorRef": [
                 [
                   "configuration",
-                  "spec",
-                  "queueName"
+                  "metadata",
+                  "name"
                 ]
               ],
               "patchStrategy": "replace"
@@ -80,7 +80,10 @@
                 [
                   "configuration",
                   "spec",
-                  "eventSourceARN"
+                  "queueRefs",
+                  "0",
+                  "from",
+                  "name"
                 ]
               ],
               "patchStrategy": "replace"

--- a/server/meshmodel/aws-lambda-controller/v1.13.0/v1.0.0/relationships/edge_binding_network_sqs_lambda.json
+++ b/server/meshmodel/aws-lambda-controller/v1.13.0/v1.0.0/relationships/edge_binding_network_sqs_lambda.json
@@ -1,24 +1,50 @@
 {
-  "schemaVersion": "relationships.meshery.io/v1alpha3",
-  "version": "v1.0.0",
-  "kind": "RelationshipDefinition",
+  "id": "00000000-0000-0000-0000-000000000000",
+  "evaluationQuery": "edge_binding_network_relationship",
+  "kind": "edge",
   "metadata": {
-    "description": "SQS Queue to Lambda EventSourceMapping network binding. An EventSourceMapping polls an SQS queue and invokes a Lambda function for each batch of messages. The eventSourceARN field on the EventSourceMapping references the SQS queue. This relationship represents the SQS-to-Lambda leg of serverless event pipelines."
+    "description": "SQS Queue to Lambda EventSourceMapping network binding. An EventSourceMapping polls an SQS queue and invokes a Lambda function for each batch of messages. The eventSourceARN field on the EventSourceMapping references the SQS queue. This relationship represents the SQS-to-Lambda leg of serverless event pipelines.",
+    "isAnnotation": false,
+    "styles": {
+      "primaryColor": "",
+      "svgColor": "",
+      "svgWhite": ""
+    }
   },
   "model": {
+    "displayName": "",
+    "id": "00000000-0000-0000-0000-000000000000",
+    "model": {
+      "version": "v1.13.0"
+    },
     "name": "aws-lambda-controller",
-    "version": "v1.13.0"
+    "registrant": {
+      "kind": "github"
+    },
+    "version": ""
   },
-  "type": "binding",
-  "subType": "network",
-  "evaluationQuery": "edge_binding_network_relationship",
+  "schemaVersion": "relationships.meshery.io/v1beta2",
   "selectors": [
     {
       "allow": {
         "from": [
           {
-            "model": "aws-sqs-controller",
+            "id": null,
             "kind": "Queue",
+            "match": {},
+            "match_strategy_matrix": null,
+            "model": {
+              "displayName": "",
+              "id": "00000000-0000-0000-0000-000000000000",
+              "model": {
+                "version": ""
+              },
+              "name": "aws-sqs-controller",
+              "registrant": {
+                "kind": "github"
+              },
+              "version": ""
+            },
             "patch": {
               "mutatorRef": [
                 [
@@ -33,8 +59,22 @@
         ],
         "to": [
           {
-            "model": "aws-lambda-controller",
+            "id": null,
             "kind": "EventSourceMapping",
+            "match": {},
+            "match_strategy_matrix": null,
+            "model": {
+              "displayName": "",
+              "id": "00000000-0000-0000-0000-000000000000",
+              "model": {
+                "version": ""
+              },
+              "name": "aws-lambda-controller",
+              "registrant": {
+                "kind": "github"
+              },
+              "version": ""
+            },
             "patch": {
               "mutatedRef": [
                 [
@@ -47,7 +87,15 @@
             }
           }
         ]
+      },
+      "deny": {
+        "from": [],
+        "to": []
       }
     }
-  ]
+  ],
+  "subType": "network",
+  "status": "enabled",
+  "type": "binding",
+  "version": "v1.0.0"
 }

--- a/server/meshmodel/aws-lambda-controller/v1.13.0/v1.0.0/relationships/edge_non_binding_network_lambda_dynamodb.json
+++ b/server/meshmodel/aws-lambda-controller/v1.13.0/v1.0.0/relationships/edge_non_binding_network_lambda_dynamodb.json
@@ -1,24 +1,50 @@
 {
-  "schemaVersion": "relationships.meshery.io/v1alpha3",
-  "version": "v1.0.0",
-  "kind": "RelationshipDefinition",
+  "id": "00000000-0000-0000-0000-000000000000",
+  "evaluationQuery": "edge_non_binding_network_relationship",
+  "kind": "edge",
   "metadata": {
-    "description": "Lambda Function to DynamoDB Table non-binding network relationship. A Lambda function writes to or reads from a DynamoDB table at runtime. Unlike binding relationships, this is a runtime data-flow dependency — the function's code references the table name but no Kubernetes spec field is mutated. This relationship enables Kanvas to visualize the end-to-end serverless event pipeline."
+    "description": "Lambda Function to DynamoDB Table non-binding network relationship. A Lambda function writes to or reads from a DynamoDB table at runtime. Unlike binding relationships, this is a runtime data-flow dependency \u2014 the function's code references the table name but no Kubernetes spec field is mutated. This relationship enables Kanvas to visualize the end-to-end serverless event pipeline.",
+    "isAnnotation": false,
+    "styles": {
+      "primaryColor": "",
+      "svgColor": "",
+      "svgWhite": ""
+    }
   },
   "model": {
+    "displayName": "",
+    "id": "00000000-0000-0000-0000-000000000000",
+    "model": {
+      "version": "v1.13.0"
+    },
     "name": "aws-lambda-controller",
-    "version": "v1.13.0"
+    "registrant": {
+      "kind": "github"
+    },
+    "version": ""
   },
-  "type": "non-binding",
-  "subType": "network",
-  "evaluationQuery": "edge_non_binding_network_relationship",
+  "schemaVersion": "relationships.meshery.io/v1beta2",
   "selectors": [
     {
       "allow": {
         "from": [
           {
-            "model": "aws-lambda-controller",
+            "id": null,
             "kind": "Function",
+            "match": {},
+            "match_strategy_matrix": null,
+            "model": {
+              "displayName": "",
+              "id": "00000000-0000-0000-0000-000000000000",
+              "model": {
+                "version": ""
+              },
+              "name": "aws-lambda-controller",
+              "registrant": {
+                "kind": "github"
+              },
+              "version": ""
+            },
             "patch": {
               "mutatorRef": [
                 [
@@ -33,8 +59,22 @@
         ],
         "to": [
           {
-            "model": "aws-dynamodb-controller",
+            "id": null,
             "kind": "Table",
+            "match": {},
+            "match_strategy_matrix": null,
+            "model": {
+              "displayName": "",
+              "id": "00000000-0000-0000-0000-000000000000",
+              "model": {
+                "version": ""
+              },
+              "name": "aws-dynamodb-controller",
+              "registrant": {
+                "kind": "github"
+              },
+              "version": ""
+            },
             "patch": {
               "mutatedRef": [
                 [
@@ -47,7 +87,15 @@
             }
           }
         ]
+      },
+      "deny": {
+        "from": [],
+        "to": []
       }
     }
-  ]
+  ],
+  "subType": "network",
+  "status": "enabled",
+  "type": "non-binding",
+  "version": "v1.0.0"
 }

--- a/server/meshmodel/aws-lambda-controller/v1.13.0/v1.0.0/relationships/edge_non_binding_network_lambda_dynamodb.json
+++ b/server/meshmodel/aws-lambda-controller/v1.13.0/v1.0.0/relationships/edge_non_binding_network_lambda_dynamodb.json
@@ -1,0 +1,53 @@
+{
+  "schemaVersion": "relationships.meshery.io/v1alpha3",
+  "version": "v1.0.0",
+  "kind": "RelationshipDefinition",
+  "metadata": {
+    "description": "Lambda Function to DynamoDB Table non-binding network relationship. A Lambda function writes to or reads from a DynamoDB table at runtime. Unlike binding relationships, this is a runtime data-flow dependency — the function's code references the table name but no Kubernetes spec field is mutated. This relationship enables Kanvas to visualize the end-to-end serverless event pipeline."
+  },
+  "model": {
+    "name": "aws-lambda-controller",
+    "version": "v1.13.0"
+  },
+  "type": "non-binding",
+  "subType": "network",
+  "evaluationQuery": "edge_non_binding_network_relationship",
+  "selectors": [
+    {
+      "allow": {
+        "from": [
+          {
+            "model": "aws-lambda-controller",
+            "kind": "Function",
+            "patch": {
+              "mutatorRef": [
+                [
+                  "configuration",
+                  "spec",
+                  "name"
+                ]
+              ],
+              "patchStrategy": "replace"
+            }
+          }
+        ],
+        "to": [
+          {
+            "model": "aws-dynamodb-controller",
+            "kind": "Table",
+            "patch": {
+              "mutatedRef": [
+                [
+                  "configuration",
+                  "spec",
+                  "tableName"
+                ]
+              ],
+              "patchStrategy": "replace"
+            }
+          }
+        ]
+      }
+    }
+  ]
+}

--- a/server/meshmodel/aws-lambda-controller/v1.13.0/v1.0.0/relationships/edge_non_binding_network_lambda_dynamodb.json
+++ b/server/meshmodel/aws-lambda-controller/v1.13.0/v1.0.0/relationships/edge_non_binding_network_lambda_dynamodb.json
@@ -45,16 +45,7 @@
               },
               "version": ""
             },
-            "patch": {
-              "mutatorRef": [
-                [
-                  "configuration",
-                  "spec",
-                  "name"
-                ]
-              ],
-              "patchStrategy": "replace"
-            }
+            "patch": null
           }
         ],
         "to": [
@@ -75,16 +66,7 @@
               },
               "version": ""
             },
-            "patch": {
-              "mutatedRef": [
-                [
-                  "configuration",
-                  "spec",
-                  "tableName"
-                ]
-              ],
-              "patchStrategy": "replace"
-            }
+            "patch": null
           }
         ]
       },

--- a/server/meshmodel/aws-lambda-controller/v1.13.0/v1.0.0/relationships/edge_non_binding_network_lambda_s3.json
+++ b/server/meshmodel/aws-lambda-controller/v1.13.0/v1.0.0/relationships/edge_non_binding_network_lambda_s3.json
@@ -1,24 +1,50 @@
 {
-  "schemaVersion": "relationships.meshery.io/v1alpha3",
-  "version": "v1.0.0",
-  "kind": "RelationshipDefinition",
+  "id": "00000000-0000-0000-0000-000000000000",
+  "evaluationQuery": "edge_non_binding_network_relationship",
+  "kind": "edge",
   "metadata": {
-    "description": "Lambda Function to S3 Bucket non-binding network relationship. A Lambda function writes processed data to an S3 bucket at runtime, forming the storage layer of data platform architectures (e.g., Kinesis → Lambda → S3 data lake). This is a runtime data-flow dependency rather than a spec-level binding."
+    "description": "Lambda Function to S3 Bucket non-binding network relationship. A Lambda function writes processed data to an S3 bucket at runtime, forming the storage layer of data platform architectures (e.g., Kinesis \u2192 Lambda \u2192 S3 data lake). This is a runtime data-flow dependency rather than a spec-level binding.",
+    "isAnnotation": false,
+    "styles": {
+      "primaryColor": "",
+      "svgColor": "",
+      "svgWhite": ""
+    }
   },
   "model": {
+    "displayName": "",
+    "id": "00000000-0000-0000-0000-000000000000",
+    "model": {
+      "version": "v1.13.0"
+    },
     "name": "aws-lambda-controller",
-    "version": "v1.13.0"
+    "registrant": {
+      "kind": "github"
+    },
+    "version": ""
   },
-  "type": "non-binding",
-  "subType": "network",
-  "evaluationQuery": "edge_non_binding_network_relationship",
+  "schemaVersion": "relationships.meshery.io/v1beta2",
   "selectors": [
     {
       "allow": {
         "from": [
           {
-            "model": "aws-lambda-controller",
+            "id": null,
             "kind": "Function",
+            "match": {},
+            "match_strategy_matrix": null,
+            "model": {
+              "displayName": "",
+              "id": "00000000-0000-0000-0000-000000000000",
+              "model": {
+                "version": ""
+              },
+              "name": "aws-lambda-controller",
+              "registrant": {
+                "kind": "github"
+              },
+              "version": ""
+            },
             "patch": {
               "mutatorRef": [
                 [
@@ -33,12 +59,27 @@
         ],
         "to": [
           {
-            "model": "aws-s3-controller",
+            "id": null,
             "kind": "Bucket",
+            "match": {},
+            "match_strategy_matrix": null,
+            "model": {
+              "displayName": "",
+              "id": "00000000-0000-0000-0000-000000000000",
+              "model": {
+                "version": ""
+              },
+              "name": "aws-s3-controller",
+              "registrant": {
+                "kind": "github"
+              },
+              "version": ""
+            },
             "patch": {
               "mutatedRef": [
                 [
                   "configuration",
+                  "spec",
                   "name"
                 ]
               ],
@@ -46,7 +87,15 @@
             }
           }
         ]
+      },
+      "deny": {
+        "from": [],
+        "to": []
       }
     }
-  ]
+  ],
+  "subType": "network",
+  "status": "enabled",
+  "type": "non-binding",
+  "version": "v1.0.0"
 }

--- a/server/meshmodel/aws-lambda-controller/v1.13.0/v1.0.0/relationships/edge_non_binding_network_lambda_s3.json
+++ b/server/meshmodel/aws-lambda-controller/v1.13.0/v1.0.0/relationships/edge_non_binding_network_lambda_s3.json
@@ -45,16 +45,7 @@
               },
               "version": ""
             },
-            "patch": {
-              "mutatorRef": [
-                [
-                  "configuration",
-                  "spec",
-                  "name"
-                ]
-              ],
-              "patchStrategy": "replace"
-            }
+            "patch": null
           }
         ],
         "to": [
@@ -75,16 +66,7 @@
               },
               "version": ""
             },
-            "patch": {
-              "mutatedRef": [
-                [
-                  "configuration",
-                  "spec",
-                  "name"
-                ]
-              ],
-              "patchStrategy": "replace"
-            }
+            "patch": null
           }
         ]
       },

--- a/server/meshmodel/aws-lambda-controller/v1.13.0/v1.0.0/relationships/edge_non_binding_network_lambda_s3.json
+++ b/server/meshmodel/aws-lambda-controller/v1.13.0/v1.0.0/relationships/edge_non_binding_network_lambda_s3.json
@@ -1,0 +1,52 @@
+{
+  "schemaVersion": "relationships.meshery.io/v1alpha3",
+  "version": "v1.0.0",
+  "kind": "RelationshipDefinition",
+  "metadata": {
+    "description": "Lambda Function to S3 Bucket non-binding network relationship. A Lambda function writes processed data to an S3 bucket at runtime, forming the storage layer of data platform architectures (e.g., Kinesis → Lambda → S3 data lake). This is a runtime data-flow dependency rather than a spec-level binding."
+  },
+  "model": {
+    "name": "aws-lambda-controller",
+    "version": "v1.13.0"
+  },
+  "type": "non-binding",
+  "subType": "network",
+  "evaluationQuery": "edge_non_binding_network_relationship",
+  "selectors": [
+    {
+      "allow": {
+        "from": [
+          {
+            "model": "aws-lambda-controller",
+            "kind": "Function",
+            "patch": {
+              "mutatorRef": [
+                [
+                  "configuration",
+                  "spec",
+                  "name"
+                ]
+              ],
+              "patchStrategy": "replace"
+            }
+          }
+        ],
+        "to": [
+          {
+            "model": "aws-s3-controller",
+            "kind": "Bucket",
+            "patch": {
+              "mutatedRef": [
+                [
+                  "configuration",
+                  "name"
+                ]
+              ],
+              "patchStrategy": "replace"
+            }
+          }
+        ]
+      }
+    }
+  ]
+}

--- a/server/meshmodel/meshery-core/0.7.2/v1.0.0/policies/evaluation.rego
+++ b/server/meshmodel/meshery-core/0.7.2/v1.0.0/policies/evaluation.rego
@@ -71,6 +71,7 @@ evaluate := eval_results if {
 		eval.alias_policy_identifier,
 		eval.edge_network_policy_identifier,
 		eval.hierarchical_parent_child_policy_identifier,
+		eval.multihop_policy_identifier,
 	]
 
 	# Iterate over relationships in the design file and resolve patches.

--- a/server/meshmodel/meshery-core/0.7.2/v1.0.0/policies/multihop_validation.rego
+++ b/server/meshmodel/meshery-core/0.7.2/v1.0.0/policies/multihop_validation.rego
@@ -1,0 +1,99 @@
+package eval
+
+import rego.v1
+
+import data.actions
+import data.eval_rules
+
+# Policy Identifier for Multi-hop Routing validation
+multihop_policy_identifier := "multihop-routing-validation"
+
+# Implicate relationships where the target is a TransitGatewayVPCAttachment.
+# This ensures we validate the multi-hop hub-and-spoke connection integrity.
+relationship_is_implicated_by_policy(relationship, policy_identifier) if {
+	policy_identifier == multihop_policy_identifier
+	lower(relationship.kind) == "edge"
+	lower(relationship.type) == "binding"
+	
+	some selector in relationship.selectors
+	some to_clause in selector.allow.to
+	to_clause.kind == "TransitGatewayVPCAttachment"
+}
+
+# A relationship is invalid if its referenced from or to components no longer exist in the design.
+relationship_is_invalid(relationship, design_file, policy_identifier) if {
+	policy_identifier == multihop_policy_identifier
+	eval_rules.from_or_to_components_dont_exist(relationship, design_file)
+}
+
+# A relationship targetting a TransitGatewayVPCAttachment is invalid if it forms an incomplete connection hop
+# (i.e. it lacks either the corresponding TransitGateway or VPC connection).
+relationship_is_invalid(relationship, design_file, policy_identifier) if {
+	policy_identifier == multihop_policy_identifier
+	
+	some selector in relationship.selectors
+	some to_clause in selector.allow.to
+	to_clause.kind == "TransitGatewayVPCAttachment"
+	attachment_id := to_clause.id
+	attachment_id != null
+	
+	is_incomplete_tgw_vpc_attachment(attachment_id, design_file)
+}
+
+# A TransitGatewayVPCAttachment connection is incomplete if it does not have BOTH a TransitGateway
+# and a VPC connected to it in the current design.
+is_incomplete_tgw_vpc_attachment(attachment_id, design_file) if {
+	not has_transit_gateway_connection(attachment_id, design_file)
+}
+
+is_incomplete_tgw_vpc_attachment(attachment_id, design_file) if {
+	not has_vpc_connection(attachment_id, design_file)
+}
+
+# Verify if there is an active relationship connecting a TransitGateway to the attachment ID.
+has_transit_gateway_connection(attachment_id, design_file) if {
+	some rel in design_file.relationships
+	rel.status != "deleted"
+	some selector in rel.selectors
+	some from_clause in selector.allow.from
+	from_clause.kind == "TransitGateway"
+	some to_clause in selector.allow.to
+	to_clause.id == attachment_id
+}
+
+# Verify if there is an active relationship connecting a VPC to the attachment ID.
+has_vpc_connection(attachment_id, design_file) if {
+	some rel in design_file.relationships
+	rel.status != "deleted"
+	some selector in rel.selectors
+	some from_clause in selector.allow.from
+	from_clause.kind == "VPC"
+	some to_clause in selector.allow.to
+	to_clause.id == attachment_id
+}
+
+# Cascading deletion: If a relationship is active/approved but is now dangling/incomplete,
+# trigger a side effect action to mark its status as "deleted".
+relationship_side_effects(relationship, design_file, policy_identifier) := side_effects if {
+	policy_identifier == multihop_policy_identifier
+	relationship.status == "approved"
+	
+	some selector in relationship.selectors
+	some to_clause in selector.allow.to
+	to_clause.kind == "TransitGatewayVPCAttachment"
+	attachment_id := to_clause.id
+	attachment_id != null
+	
+	is_incomplete_tgw_vpc_attachment(attachment_id, design_file)
+	
+	side_effects := {
+		{
+			"op": actions.update_relationship_op,
+			"value": {
+				"id": relationship.id,
+				"path": "/status",
+				"value": "deleted",
+			},
+		}
+	}
+} else := {}

--- a/server/meshmodel/meshery-core/0.7.2/v1.0.0/policies/tests/multihop_validation_test.rego
+++ b/server/meshmodel/meshery-core/0.7.2/v1.0.0/policies/tests/multihop_validation_test.rego
@@ -1,0 +1,160 @@
+package multihop_validation_test
+
+import rego.v1
+
+import data.eval
+
+# Test 1: Complete TGW VPC attachment hop (both TGW and VPC connections are present).
+# The relationship should be valid (relationship_is_invalid should be false).
+test_multihop_tgw_vpc_attachment_complete if {
+	design_file := {
+		"components": [
+			{
+				"id": "tgw-1",
+				"component": {"kind": "TransitGateway"},
+				"model": {"name": "aws-ec2-controller", "registrant": {"kind": "github"}},
+				"configuration": {"metadata": {"name": "my-tgw"}},
+			},
+			{
+				"id": "vpc-1",
+				"component": {"kind": "VPC"},
+				"model": {"name": "aws-ec2-controller", "registrant": {"kind": "github"}},
+				"configuration": {"metadata": {"name": "my-vpc"}},
+			},
+			{
+				"id": "tgw-attachment-1",
+				"component": {"kind": "TransitGatewayVPCAttachment"},
+				"model": {"name": "aws-ec2-controller", "registrant": {"kind": "github"}},
+				"configuration": {
+					"metadata": {"name": "my-attachment"},
+					"spec": {
+						"transitGatewayRef": {"from": {"name": "my-tgw"}},
+						"vpcRef": {"from": {"name": "my-vpc"}},
+					},
+				},
+			},
+		],
+		"relationships": [
+			{
+				"id": "rel-tgw-to-att",
+				"kind": "edge",
+				"type": "binding",
+				"subType": "network",
+				"status": "approved",
+				"selectors": [{
+					"allow": {
+						"from": [{"id": "tgw-1", "kind": "TransitGateway"}],
+						"to": [{"id": "tgw-attachment-1", "kind": "TransitGatewayVPCAttachment"}],
+					},
+				}],
+			},
+			{
+				"id": "rel-vpc-to-att",
+				"kind": "edge",
+				"type": "binding",
+				"subType": "network",
+				"status": "approved",
+				"selectors": [{
+					"allow": {
+						"from": [{"id": "vpc-1", "kind": "VPC"}],
+						"to": [{"id": "tgw-attachment-1", "kind": "TransitGatewayVPCAttachment"}],
+					},
+				}],
+			},
+		],
+	}
+
+	# Ensure it implicates the relationship
+	eval.relationship_is_implicated_by_policy(design_file.relationships[0], eval.multihop_policy_identifier)
+
+	# The relationship should NOT be marked invalid since both hops exist
+	not eval.relationship_is_invalid(design_file.relationships[0], design_file, eval.multihop_policy_identifier)
+}
+
+# Test 2: Incomplete TGW VPC attachment (missing the VPC connection).
+# The relationship should be invalid.
+test_multihop_tgw_vpc_attachment_missing_vpc if {
+	design_file := {
+		"components": [
+			{
+				"id": "tgw-1",
+				"component": {"kind": "TransitGateway"},
+				"model": {"name": "aws-ec2-controller", "registrant": {"kind": "github"}},
+				"configuration": {"metadata": {"name": "my-tgw"}},
+			},
+			{
+				"id": "tgw-attachment-1",
+				"component": {"kind": "TransitGatewayVPCAttachment"},
+				"model": {"name": "aws-ec2-controller", "registrant": {"kind": "github"}},
+				"configuration": {
+					"metadata": {"name": "my-attachment"},
+					"spec": {
+						"transitGatewayRef": {"from": {"name": "my-tgw"}},
+					},
+				},
+			},
+		],
+		"relationships": [
+			{
+				"id": "rel-tgw-to-att",
+				"kind": "edge",
+				"type": "binding",
+				"subType": "network",
+				"status": "approved",
+				"selectors": [{
+					"allow": {
+						"from": [{"id": "tgw-1", "kind": "TransitGateway"}],
+						"to": [{"id": "tgw-attachment-1", "kind": "TransitGatewayVPCAttachment"}],
+					},
+				}],
+			},
+		],
+	}
+
+	# The relationship should be invalid because VPC relationship is missing
+	eval.relationship_is_invalid(design_file.relationships[0], design_file, eval.multihop_policy_identifier)
+}
+
+# Test 3: Incomplete TGW VPC attachment (missing the TGW connection).
+# The relationship should be invalid.
+test_multihop_tgw_vpc_attachment_missing_tgw if {
+	design_file := {
+		"components": [
+			{
+				"id": "vpc-1",
+				"component": {"kind": "VPC"},
+				"model": {"name": "aws-ec2-controller", "registrant": {"kind": "github"}},
+				"configuration": {"metadata": {"name": "my-vpc"}},
+			},
+			{
+				"id": "tgw-attachment-1",
+				"component": {"kind": "TransitGatewayVPCAttachment"},
+				"model": {"name": "aws-ec2-controller", "registrant": {"kind": "github"}},
+				"configuration": {
+					"metadata": {"name": "my-attachment"},
+					"spec": {
+						"vpcRef": {"from": {"name": "my-vpc"}},
+					},
+				},
+			},
+		],
+		"relationships": [
+			{
+				"id": "rel-vpc-to-att",
+				"kind": "edge",
+				"type": "binding",
+				"subType": "network",
+				"status": "approved",
+				"selectors": [{
+					"allow": {
+						"from": [{"id": "vpc-1", "kind": "VPC"}],
+						"to": [{"id": "tgw-attachment-1", "kind": "TransitGatewayVPCAttachment"}],
+					},
+				}],
+			},
+		],
+	}
+
+	# The relationship should be invalid because TransitGateway relationship is missing
+	eval.relationship_is_invalid(design_file.relationships[0], design_file, eval.multihop_policy_identifier)
+}

--- a/server/policies/engine.go
+++ b/server/policies/engine.go
@@ -30,6 +30,7 @@ func NewGoEngine(log Logger) *GoEngine {
 			&EdgeBindingPolicy{},
 			&HierarchicalParentChildPolicy{},
 			&HierarchicalWalletPolicy{},
+			&MultihopValidationPolicy{},
 		},
 	}
 }

--- a/server/policies/policy_multihop.go
+++ b/server/policies/policy_multihop.go
@@ -1,0 +1,143 @@
+package policies
+
+import (
+	"strings"
+
+	"github.com/meshery/schemas/models/v1beta1/pattern"
+	"github.com/meshery/schemas/models/v1beta2/relationship"
+)
+
+// MultihopValidationPolicy handles validation of multi-hop network routing connections.
+type MultihopValidationPolicy struct{}
+
+// Identifier returns the unique identifier for this policy.
+func (p *MultihopValidationPolicy) Identifier() string {
+	return "multihop-routing-validation"
+}
+
+// IsImplicatedBy checks if the relationship is implicated by the multi-hop policy.
+func (p *MultihopValidationPolicy) IsImplicatedBy(rel *relationship.RelationshipDefinition) bool {
+	if !strings.EqualFold(string(rel.Kind), "edge") || !strings.EqualFold(rel.RelationshipType, "binding") {
+		return false
+	}
+	if rel.Selectors == nil {
+		return false
+	}
+	for _, ss := range *rel.Selectors {
+		for _, toSel := range ss.Allow.To {
+			if strings.EqualFold(toSel.Kind, "TransitGatewayVPCAttachment") {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+// IsInvalid checks if the relationship forms an invalid multi-hop routing chain.
+func (p *MultihopValidationPolicy) IsInvalid(rel *relationship.RelationshipDefinition, design *pattern.PatternFile) bool {
+	if rel.Selectors == nil {
+		return false
+	}
+	for _, ss := range *rel.Selectors {
+		for _, toSel := range ss.Allow.To {
+			if strings.EqualFold(toSel.Kind, "TransitGatewayVPCAttachment") {
+				if toSel.ID == nil {
+					continue
+				}
+				attachmentID := toSel.ID.String()
+				if p.isIncompleteTgwVpcAttachment(attachmentID, design) {
+					return true
+				}
+			}
+		}
+	}
+	return false
+}
+
+// AlreadyExists checks if the relationship already exists in the design.
+func (p *MultihopValidationPolicy) AlreadyExists(rel *relationship.RelationshipDefinition, design *pattern.PatternFile) bool {
+	return relationshipAlreadyExists(design, rel)
+}
+
+// IdentifyRelationship is handled by the general EdgeBindingPolicy.
+func (p *MultihopValidationPolicy) IdentifyRelationship(relDef *relationship.RelationshipDefinition, design *pattern.PatternFile) []*relationship.RelationshipDefinition {
+	return nil
+}
+
+// SideEffects returns update actions to mark incomplete/dangling attachments as deleted.
+func (p *MultihopValidationPolicy) SideEffects(rel *relationship.RelationshipDefinition, design *pattern.PatternFile) []PolicyAction {
+	if getRelStatus(rel) == StatusApproved {
+		if rel.Selectors == nil {
+			return nil
+		}
+		for _, ss := range *rel.Selectors {
+			for _, toSel := range ss.Allow.To {
+				if strings.EqualFold(toSel.Kind, "TransitGatewayVPCAttachment") {
+					if toSel.ID == nil {
+						continue
+					}
+					attachmentID := toSel.ID.String()
+					if p.isIncompleteTgwVpcAttachment(attachmentID, design) {
+						return []PolicyAction{
+							newUpdateRelationshipAction(rel.ID.String(), "/status", StatusDeleted),
+						}
+					}
+				}
+			}
+		}
+	}
+	return nil
+}
+
+// isIncompleteTgwVpcAttachment checks if the attachment is missing either TransitGateway or VPC connections.
+func (p *MultihopValidationPolicy) isIncompleteTgwVpcAttachment(attachmentID string, design *pattern.PatternFile) bool {
+	return !p.hasTransitGatewayConnection(attachmentID, design) || !p.hasVpcConnection(attachmentID, design)
+}
+
+// hasTransitGatewayConnection checks for an active TransitGateway connection to the attachment.
+func (p *MultihopValidationPolicy) hasTransitGatewayConnection(attachmentID string, design *pattern.PatternFile) bool {
+	for _, rel := range design.Relationships {
+		if getRelStatus(rel) == StatusDeleted {
+			continue
+		}
+		if rel.Selectors == nil {
+			continue
+		}
+		for _, ss := range *rel.Selectors {
+			for _, fromSel := range ss.Allow.From {
+				if strings.EqualFold(fromSel.Kind, "TransitGateway") {
+					for _, toSel := range ss.Allow.To {
+						if toSel.ID != nil && toSel.ID.String() == attachmentID {
+							return true
+						}
+					}
+				}
+			}
+		}
+	}
+	return false
+}
+
+// hasVpcConnection checks for an active VPC connection to the attachment.
+func (p *MultihopValidationPolicy) hasVpcConnection(attachmentID string, design *pattern.PatternFile) bool {
+	for _, rel := range design.Relationships {
+		if getRelStatus(rel) == StatusDeleted {
+			continue
+		}
+		if rel.Selectors == nil {
+			continue
+		}
+		for _, ss := range *rel.Selectors {
+			for _, fromSel := range ss.Allow.From {
+				if strings.EqualFold(fromSel.Kind, "VPC") {
+					for _, toSel := range ss.Allow.To {
+						if toSel.ID != nil && toSel.ID.String() == attachmentID {
+							return true
+						}
+					}
+				}
+			}
+		}
+	}
+	return false
+}

--- a/server/policies/policy_multihop_test.go
+++ b/server/policies/policy_multihop_test.go
@@ -1,0 +1,155 @@
+package policies
+
+import (
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/meshery/schemas/models/v1beta1/component"
+	"github.com/meshery/schemas/models/v1beta1/pattern"
+	"github.com/meshery/schemas/models/v1beta2/relationship"
+)
+
+func TestMultihopValidationPolicy_IsImplicatedBy(t *testing.T) {
+	policy := &MultihopValidationPolicy{}
+
+	tgwKind := "TransitGateway"
+	attachmentKind := "TransitGatewayVPCAttachment"
+
+	implicatedRel := &relationship.RelationshipDefinition{
+		Kind:             "edge",
+		RelationshipType: "binding",
+		Selectors: &relationship.SelectorSet{
+			{
+				Allow: relationship.Selector{
+					From: []relationship.SelectorItem{{Kind: &tgwKind}},
+					To:   []relationship.SelectorItem{{Kind: &attachmentKind}},
+				},
+			},
+		},
+	}
+
+	nonImplicatedRel := &relationship.RelationshipDefinition{
+		Kind:             "edge",
+		RelationshipType: "non-binding",
+		Selectors: &relationship.SelectorSet{
+			{
+				Allow: relationship.Selector{
+					From: []relationship.SelectorItem{{Kind: &tgwKind}},
+					To:   []relationship.SelectorItem{{Kind: &attachmentKind}},
+				},
+			},
+		},
+	}
+
+	if !policy.IsImplicatedBy(implicatedRel) {
+		t.Error("Expected relationship to be implicated by MultihopValidationPolicy")
+	}
+
+	if policy.IsImplicatedBy(nonImplicatedRel) {
+		t.Error("Expected relationship to not be implicated by MultihopValidationPolicy")
+	}
+}
+
+func TestMultihopValidationPolicy_IsInvalid(t *testing.T) {
+	policy := &MultihopValidationPolicy{}
+
+	tgwID := uuid.New()
+	vpcID := uuid.New()
+	attID := uuid.New()
+
+	tgwKind := "TransitGateway"
+	vpcKind := "VPC"
+	attKind := "TransitGatewayVPCAttachment"
+
+	designComplete := &pattern.PatternFile{
+		Components: []*component.ComponentDefinition{
+			{
+				ID: tgwID,
+				Component: component.Component{
+					Kind: "TransitGateway",
+				},
+			},
+			{
+				ID: vpcID,
+				Component: component.Component{
+					Kind: "VPC",
+				},
+			},
+			{
+				ID: attID,
+				Component: component.Component{
+					Kind: "TransitGatewayVPCAttachment",
+				},
+			},
+		},
+		Relationships: []*relationship.RelationshipDefinition{
+			{
+				Kind:             "edge",
+				RelationshipType: "binding",
+				Selectors: &relationship.SelectorSet{
+					{
+						Allow: relationship.Selector{
+							From: []relationship.SelectorItem{{Kind: &tgwKind, ID: &tgwID}},
+							To:   []relationship.SelectorItem{{Kind: &attKind, ID: &attID}},
+						},
+					},
+				},
+			},
+			{
+				Kind:             "edge",
+				RelationshipType: "binding",
+				Selectors: &relationship.SelectorSet{
+					{
+						Allow: relationship.Selector{
+							From: []relationship.SelectorItem{{Kind: &vpcKind, ID: &vpcID}},
+							To:   []relationship.SelectorItem{{Kind: &attKind, ID: &attID}},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	relToTest := designComplete.Relationships[0]
+
+	// Complete connections: should NOT be invalid
+	if policy.IsInvalid(relToTest, designComplete) {
+		t.Error("Expected relationship to be valid when both TGW and VPC connections exist")
+	}
+
+	// Missing VPC connection: should be invalid
+	designIncomplete := &pattern.PatternFile{
+		Components: []*component.ComponentDefinition{
+			{
+				ID: tgwID,
+				Component: component.Component{
+					Kind: "TransitGateway",
+				},
+			},
+			{
+				ID: attID,
+				Component: component.Component{
+					Kind: "TransitGatewayVPCAttachment",
+				},
+			},
+		},
+		Relationships: []*relationship.RelationshipDefinition{
+			{
+				Kind:             "edge",
+				RelationshipType: "binding",
+				Selectors: &relationship.SelectorSet{
+					{
+						Allow: relationship.Selector{
+							From: []relationship.SelectorItem{{Kind: &tgwKind, ID: &tgwID}},
+							To:   []relationship.SelectorItem{{Kind: &attKind, ID: &attID}},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	if !policy.IsInvalid(relToTest, designIncomplete) {
+		t.Error("Expected relationship to be invalid when VPC connection is missing")
+	}
+}


### PR DESCRIPTION
This pull request adds multi-hop AWS MeshModel relationship definitions including Transit Gateway configurations, NodeGroup launch templates, EventBridge rules, SQS-Lambda integrations, and Lambda-DynamoDB/S3 visual dependencies.

All definitions are standardized to the relationships.meshery.io/v1beta2 schema.

Related to #17096