### PR TITLE
feat(meshmodel): add AWS SNS to SQS relationship

### DIFF
--- a/server/meshmodel/aws-sns-controller/v1.3.2/v1.0.0/model.json
+++ b/server/meshmodel/aws-sns-controller/v1.3.2/v1.0.0/model.json
@@ -37,7 +37,7 @@
     "version": "v1.3.2"
   },
   "components_count": 0,
-  "relationships_count": 0,
+  "relationships_count": 1,
   "created_at": "0001-01-01T00:00:00Z",
   "updated_at": "0001-01-01T00:00:00Z",
   "components": null,

--- a/server/meshmodel/aws-sns-controller/v1.3.2/v1.0.0/model.json
+++ b/server/meshmodel/aws-sns-controller/v1.3.2/v1.0.0/model.json
@@ -37,7 +37,7 @@
     "version": "v1.3.2"
   },
   "components_count": 0,
-  "relationships_count": 1,
+  "relationships_count": 0,
   "created_at": "0001-01-01T00:00:00Z",
   "updated_at": "0001-01-01T00:00:00Z",
   "components": null,

--- a/server/meshmodel/aws-sns-controller/v1.3.2/v1.0.0/relationships/edge-non-binding-network-sns-sqs.json
+++ b/server/meshmodel/aws-sns-controller/v1.3.2/v1.0.0/relationships/edge-non-binding-network-sns-sqs.json
@@ -5,7 +5,7 @@
   "type": "Non-binding",
   "subType": "Network",
   "metadata": {
-    "description": "Visualizes the fan-out messaging flow where an SNS Topic publishes to an SQS Queue."
+    "description": "Visualizes the message flow from an SNS Topic to a subscribing SQS Queue."
   },
   "selectors": [
     {

--- a/server/meshmodel/aws-sns-controller/v1.3.2/v1.0.0/relationships/edge-non-binding-network-sns-sqs.json
+++ b/server/meshmodel/aws-sns-controller/v1.3.2/v1.0.0/relationships/edge-non-binding-network-sns-sqs.json
@@ -1,28 +1,103 @@
 {
-  "schemaVersion": "relationships.meshery.io/v1alpha3",
-  "version": "v1.0.0",
-  "kind": "Edge",
-  "type": "Non-binding",
-  "subType": "Network",
+  "id": "00000000-0000-0000-0000-000000000000",
+  "evaluationQuery": "edge_non_binding_network_relationship",
+  "kind": "edge",
   "metadata": {
-    "description": "Visualizes the message flow from an SNS Topic to a subscribing SQS Queue."
+    "description": "Visualizes the message flow from an SNS Topic to a subscribing SQS Queue.",
+    "isAnnotation": false,
+    "styles": {
+      "primaryColor": "",
+      "svgColor": "",
+      "svgWhite": ""
+    }
   },
+  "model": {
+    "displayName": "",
+    "id": "00000000-0000-0000-0000-000000000000",
+    "model": {
+      "version": "v1.3.2"
+    },
+    "name": "aws-sns-controller",
+    "registrant": {
+      "kind": ""
+    },
+    "version": ""
+  },
+  "schemaVersion": "relationships.meshery.io/v1alpha3",
   "selectors": [
     {
       "allow": {
         "from": [
           {
+            "id": null,
             "kind": "Topic",
-            "model": "aws-sns-controller"
+            "match": {},
+            "match_strategy_matrix": null,
+            "model": {
+              "displayName": "",
+              "id": "00000000-0000-0000-0000-000000000000",
+              "model": {
+                "version": ""
+              },
+              "name": "aws-sns-controller",
+              "registrant": {
+                "kind": "github"
+              },
+              "version": ""
+            },
+            "patch": {
+              "mutatedRef": [
+                [
+                  "configuration",
+                  "status",
+                  "ackResourceMetadata",
+                  "arn"
+                ]
+              ],
+              "patchStrategy": "replace"
+            }
           }
         ],
         "to": [
           {
+            "id": null,
             "kind": "Queue",
-            "model": "aws-sqs-controller"
+            "match": {},
+            "match_strategy_matrix": null,
+            "model": {
+              "displayName": "",
+              "id": "00000000-0000-0000-0000-000000000000",
+              "model": {
+                "version": ""
+              },
+              "name": "aws-sqs-controller",
+              "registrant": {
+                "kind": "github"
+              },
+              "version": ""
+            },
+            "patch": {
+              "mutatedRef": [
+                [
+                  "configuration",
+                  "status",
+                  "ackResourceMetadata",
+                  "arn"
+                ]
+              ],
+              "patchStrategy": "replace"
+            }
           }
         ]
+      },
+      "deny": {
+        "from": [],
+        "to": []
       }
     }
-  ]
+  ],
+  "subType": "network",
+  "status": "enabled",
+  "type": "non-binding",
+  "version": "v1.0.0"
 }

--- a/server/meshmodel/aws-sns-controller/v1.3.2/v1.0.0/relationships/edge-non-binding-network-sns-sqs.json
+++ b/server/meshmodel/aws-sns-controller/v1.3.2/v1.0.0/relationships/edge-non-binding-network-sns-sqs.json
@@ -1,0 +1,28 @@
+{
+  "schemaVersion": "relationships.meshery.io/v1alpha3",
+  "version": "v1.0.0",
+  "kind": "Edge",
+  "type": "Non-binding",
+  "subType": "Network",
+  "metadata": {
+    "description": "Visualizes the fan-out messaging flow where an SNS Topic publishes to an SQS Queue."
+  },
+  "selectors": [
+    {
+      "allow": {
+        "from": [
+          {
+            "kind": "Topic",
+            "model": "aws-sns-controller"
+          }
+        ],
+        "to": [
+          {
+            "kind": "Queue",
+            "model": "aws-sqs-controller"
+          }
+        ]
+      }
+    }
+  ]
+}

--- a/server/meshmodel/aws-sns-controller/v1.3.2/v1.0.0/relationships/edge-non-binding-network-sns-sqs.json
+++ b/server/meshmodel/aws-sns-controller/v1.3.2/v1.0.0/relationships/edge-non-binding-network-sns-sqs.json
@@ -19,11 +19,11 @@
     },
     "name": "aws-sns-controller",
     "registrant": {
-      "kind": ""
+      "kind": "github"
     },
     "version": ""
   },
-  "schemaVersion": "relationships.meshery.io/v1alpha3",
+  "schemaVersion": "relationships.meshery.io/v1beta2",
   "selectors": [
     {
       "allow": {
@@ -45,17 +45,7 @@
               },
               "version": ""
             },
-            "patch": {
-              "mutatedRef": [
-                [
-                  "configuration",
-                  "status",
-                  "ackResourceMetadata",
-                  "arn"
-                ]
-              ],
-              "patchStrategy": "replace"
-            }
+            "patch": null
           }
         ],
         "to": [
@@ -76,17 +66,7 @@
               },
               "version": ""
             },
-            "patch": {
-              "mutatedRef": [
-                [
-                  "configuration",
-                  "status",
-                  "ackResourceMetadata",
-                  "arn"
-                ]
-              ],
-              "patchStrategy": "replace"
-            }
+            "patch": null
           }
         ]
       },


### PR DESCRIPTION
This pull request adds the AWS SNS Topic to SQS Queue network relationship definition.

The definition is standardized to the relationships.meshery.io/v1beta2 schema as a non-binding network relationship.

Related to #17096