### PR TITLE
[GraphQL] Populate controlPlaneImageOrgs mapping in helpers

### DIFF
--- a/server/internal/graphql/model/helpers.go
+++ b/server/internal/graphql/model/helpers.go
@@ -45,9 +45,16 @@ var (
 	}
 )
 var (
-	//TODO: Add the image orgs of other control plane pods. This change is backwards compatible and wont break anything
 	controlPlaneImageOrgs = map[MeshType][]string{
-		MeshTypeCiliumServiceMesh: {"cilium"},
+		MeshTypeCiliumServiceMesh:  {"cilium"},
+		MeshTypeIstio:              {"istio"},
+		MeshTypeLinkerd:            {"linkerd"},
+		MeshTypeConsul:             {"hashicorp"},
+		MeshTypeKuma:               {"kumahq"},
+		MeshTypeTraefikMesh:        {"traefik"},
+		MeshTypeNetworkServiceMesh: {"networkservicemesh"},
+		MeshTypeNginxServiceMesh:   {"nginx"},
+		MeshTypeAppMesh:            {"amazon", "aws-appmesh"},
 	}
 )
 


### PR DESCRIPTION
**Notes for Reviewers**

- This PR fixes #20172

## Summary

Populate `controlPlaneImageOrgs` in `server/internal/graphql/model/helpers.go` with the official container image organizations for major supported self-hosted service meshes.

Previously, only `MeshTypeCiliumServiceMesh` had an image organization mapping. As a result, the image organization filter in `control_plane_helper.go` was skipped for other meshes, causing any pod running in a control plane namespace to be treated as a control plane member.

This change enables stricter and more accurate control plane pod identification by leveraging the existing image organization filtering logic.

Added mappings for:

- Istio → {"istio"}
- Linkerd → {"linkerd"}
- Consul → {"hashicorp"}
- Kuma → {"kumahq"}
- Traefik Mesh → {"traefik"}
- Network Service Mesh → {"networkservicemesh"}
- Nginx Service Mesh → {"nginx"}
- App Mesh → {"amazon", "aws-appmesh"}

Alignment with controlPlaneNamespace:

- `controlPlaneNamespace` was treated as the source of truth for meshes participating in control-plane detection.
- Added `MeshTypeAppMesh`, which participates in control-plane detection but previously lacked image organization filtering.
- Removed `MeshTypeOpenServiceMesh` from the proposed mappings because it is not present in `controlPlaneNamespace`, avoiding dead configuration and keeping the maps consistent.

## Verification

### Build

```bash
make build-server
```

Result: ✅ Successful

### GraphQL Model Package Tests

```bash
go test -v ./server/internal/graphql/model/...
```

Result: ✅ All tests passed

## Impact

- Improves control plane pod detection accuracy.
- Prevents false positives caused by unrelated pods residing in control plane namespaces.
- Reuses the existing filtering logic without introducing additional behavior.
- Backward compatible and low risk.

## Checklist

- [x] Signed commits
- [x] Build passes
- [x] GraphQL model package tests pass
- [x] Minimal, focused change