### PR TITLE
[Chore] Bump @meshery/schemas to 1.3.13 in UI packages (ui, provider-ui, docker-extension)

### DIFF
--- a/install/docker-extension/ui/package-lock.json
+++ b/install/docker-extension/ui/package-lock.json
@@ -14,7 +14,7 @@
         "@fortawesome/fontawesome-svg-core": "^7.1.0",
         "@fortawesome/free-solid-svg-icons": "^7.1.0",
         "@fortawesome/react-fontawesome": "^3.2.0",
-        "@meshery/schemas": "^1.3.7",
+        "@meshery/schemas": "^1.3.13",
         "@mui/icons-material": "^7.3.7",
         "@mui/material": "^7.3.7",
         "@mui/styled-engine-sc": "^7.3.7",
@@ -3938,9 +3938,9 @@
       "license": "MIT"
     },
     "node_modules/@meshery/schemas": {
-      "version": "1.3.7",
-      "resolved": "https://registry.npmjs.org/@meshery/schemas/-/schemas-1.3.7.tgz",
-      "integrity": "sha512-eaEwLN2krtclsCD0f3g5JhABdxBD/CsBKfiUqUN4HmKuyFeNJNK4y8kLTLzgk9G8OVC+ZS0w2nnhKNU2KCE06A==",
+      "version": "1.3.13",
+      "resolved": "https://registry.npmjs.org/@meshery/schemas/-/schemas-1.3.13.tgz",
+      "integrity": "sha512-VZw8yrKiBrxvJxFysOMQuuPJkDwGZ2DuW7ifPGJ6OxfBygAGIYuN4kofmPTglcW/WPhEYn656HM7/zahSmlcRg==",
       "license": "ISC",
       "peerDependencies": {
         "@reduxjs/toolkit": "^2.8.1",
@@ -4461,44 +4461,6 @@
       "integrity": "sha512-Pc/AFTdwZwEKJxFJvlxrSmGe/di+aAOBn60sremrpLo6VI/6cmiUYNNwlI5KNYttg7uypzA3ILPMPgxB2GYZEg==",
       "license": "MIT"
     },
-    "node_modules/@reduxjs/toolkit": {
-      "version": "2.12.0",
-      "resolved": "https://registry.npmjs.org/@reduxjs/toolkit/-/toolkit-2.12.0.tgz",
-      "integrity": "sha512-KiT+RzZbp6mQET+Mg+h2c97+9j1sNflUxQkIHI7Yuzf6Peu+OYpmkn6nbHWmLLWj+1ZODUJFwGZ7gx3L9R9EOw==",
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "@standard-schema/spec": "^1.0.0",
-        "@standard-schema/utils": "^0.3.0",
-        "immer": "^11.0.0",
-        "redux": "^5.0.1",
-        "redux-thunk": "^3.1.0",
-        "reselect": "^5.1.0"
-      },
-      "peerDependencies": {
-        "react": "^16.9.0 || ^17.0.0 || ^18 || ^19",
-        "react-redux": "^7.2.1 || ^8.1.3 || ^9.0.0"
-      },
-      "peerDependenciesMeta": {
-        "react": {
-          "optional": true
-        },
-        "react-redux": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@reduxjs/toolkit/node_modules/immer": {
-      "version": "11.1.8",
-      "resolved": "https://registry.npmjs.org/immer/-/immer-11.1.8.tgz",
-      "integrity": "sha512-/tbkHMW7y10Lx6i1crLjD4/OhNkRG+Fo7byZHtah0547nIeXYcpIXaUh0IAQY6gO5459qpGGYapcEOHtFXkIuA==",
-      "license": "MIT",
-      "peer": true,
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/immer"
-      }
-    },
     "node_modules/@rollup/plugin-babel": {
       "version": "5.3.1",
       "resolved": "https://registry.npmjs.org/@rollup/plugin-babel/-/plugin-babel-5.3.1.tgz",
@@ -4861,20 +4823,6 @@
         }
       }
     },
-    "node_modules/@standard-schema/spec": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
-      "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
-      "license": "MIT",
-      "peer": true
-    },
-    "node_modules/@standard-schema/utils": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/@standard-schema/utils/-/utils-0.3.0.tgz",
-      "integrity": "sha512-e7Mew686owMaPJVNNLs55PUvgz371nKgwsc4vxE49zsODpJEnxgxRo2y/OKrqueavXgZNMDVj3DdHFlaSAeU8g==",
-      "license": "MIT",
-      "peer": true
-    },
     "node_modules/@surma/rollup-plugin-off-main-thread": {
       "version": "2.2.3",
       "resolved": "https://registry.npmjs.org/@surma/rollup-plugin-off-main-thread/-/rollup-plugin-off-main-thread-2.2.3.tgz",
@@ -5108,43 +5056,6 @@
         "url": "https://github.com/sponsors/gregberge"
       }
     },
-    "node_modules/@testing-library/dom": {
-      "version": "10.4.1",
-      "resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-10.4.1.tgz",
-      "integrity": "sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==",
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "@babel/code-frame": "^7.10.4",
-        "@babel/runtime": "^7.12.5",
-        "@types/aria-query": "^5.0.1",
-        "aria-query": "5.3.0",
-        "dom-accessibility-api": "^0.5.9",
-        "lz-string": "^1.5.0",
-        "picocolors": "1.1.1",
-        "pretty-format": "^27.0.2"
-      },
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@testing-library/dom/node_modules/aria-query": {
-      "version": "5.3.0",
-      "resolved": "https://registry.npmjs.org/aria-query/-/aria-query-5.3.0.tgz",
-      "integrity": "sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A==",
-      "license": "Apache-2.0",
-      "peer": true,
-      "dependencies": {
-        "dequal": "^2.0.3"
-      }
-    },
-    "node_modules/@testing-library/dom/node_modules/dom-accessibility-api": {
-      "version": "0.5.16",
-      "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz",
-      "integrity": "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==",
-      "license": "MIT",
-      "peer": true
-    },
     "node_modules/@testing-library/jest-dom": {
       "version": "6.9.1",
       "resolved": "https://registry.npmjs.org/@testing-library/jest-dom/-/jest-dom-6.9.1.tgz",
@@ -5221,13 +5132,6 @@
       "engines": {
         "node": ">=10.13.0"
       }
-    },
-    "node_modules/@types/aria-query": {
-      "version": "5.0.4",
-      "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.4.tgz",
-      "integrity": "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==",
-      "license": "MIT",
-      "peer": true
     },
     "node_modules/@types/babel__core": {
       "version": "7.20.5",
@@ -5825,13 +5729,6 @@
       "resolved": "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-2.0.7.tgz",
       "integrity": "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==",
       "license": "MIT"
-    },
-    "node_modules/@types/use-sync-external-store": {
-      "version": "0.0.6",
-      "resolved": "https://registry.npmjs.org/@types/use-sync-external-store/-/use-sync-external-store-0.0.6.tgz",
-      "integrity": "sha512-zFDAD+tlpf2r4asuHEj0XH6pY6i0g5NeAHPn+15wk3BV6JA69eERFXC1gyGThDkVa1zCyKr5jox1+2LbV/AMLg==",
-      "license": "MIT",
-      "peer": true
     },
     "node_modules/@types/ws": {
       "version": "8.18.1",
@@ -9003,16 +8900,6 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
-      }
-    },
-    "node_modules/dequal": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz",
-      "integrity": "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==",
-      "license": "MIT",
-      "peer": true,
-      "engines": {
-        "node": ">=6"
       }
     },
     "node_modules/destroy": {
@@ -15541,16 +15428,6 @@
         "yallist": "^3.0.2"
       }
     },
-    "node_modules/lz-string": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/lz-string/-/lz-string-1.5.0.tgz",
-      "integrity": "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==",
-      "license": "MIT",
-      "peer": true,
-      "bin": {
-        "lz-string": "bin/bin.js"
-      }
-    },
     "node_modules/magic-string": {
       "version": "0.25.9",
       "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.25.9.tgz",
@@ -18443,30 +18320,6 @@
       "integrity": "sha512-fBASbA6LnOU9dOU2eW7aQ8xmYBSXUIWr+UmF9b1efZBazGNO+rcXT/icdKnYm2pTwcRylVUYwW7H1PHfLekVzA==",
       "license": "MIT"
     },
-    "node_modules/react-redux": {
-      "version": "9.3.0",
-      "resolved": "https://registry.npmjs.org/react-redux/-/react-redux-9.3.0.tgz",
-      "integrity": "sha512-KQopgqFo/p/fgmAs5qz6p5RWaNAzq40WAu7fJIXnQpYxFPbJYtsJPWvGeF2rOBaY/kEuV77AVsX8TsQzKm+A/g==",
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "@types/use-sync-external-store": "^0.0.6",
-        "use-sync-external-store": "^1.4.0"
-      },
-      "peerDependencies": {
-        "@types/react": "^18.2.25 || ^19",
-        "react": "^18.0 || ^19",
-        "redux": "^5.0.0"
-      },
-      "peerDependenciesMeta": {
-        "@types/react": {
-          "optional": true
-        },
-        "redux": {
-          "optional": true
-        }
-      }
-    },
     "node_modules/react-refresh": {
       "version": "0.11.0",
       "resolved": "https://registry.npmjs.org/react-refresh/-/react-refresh-0.11.0.tgz",
@@ -18759,23 +18612,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/redux": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/redux/-/redux-5.0.1.tgz",
-      "integrity": "sha512-M9/ELqF6fy8FwmkpnF0S3YKOqMyoWJ4+CS5Efg2ct3oY9daQvd/Pc71FpGZsVsbl3Cpb+IIcjBDUnnyBdQbq4w==",
-      "license": "MIT",
-      "peer": true
-    },
-    "node_modules/redux-thunk": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/redux-thunk/-/redux-thunk-3.1.0.tgz",
-      "integrity": "sha512-NW2r5T6ksUKXCabzhL9z+h206HQw/NJkcLm1GPImRQ8IzfXwRGqjVhKJGauHirT0DAuyy6hjdnMZaRoAcy0Klw==",
-      "license": "MIT",
-      "peer": true,
-      "peerDependencies": {
-        "redux": "^5.0.0"
-      }
-    },
     "node_modules/reflect.getprototypeof": {
       "version": "1.0.10",
       "resolved": "https://registry.npmjs.org/reflect.getprototypeof/-/reflect.getprototypeof-1.0.10.tgz",
@@ -18928,13 +18764,6 @@
       "resolved": "https://registry.npmjs.org/requires-port/-/requires-port-1.0.0.tgz",
       "integrity": "sha512-KigOCHcocU3XODJxsu8i/j8T9tzT4adHiecwORRQ0ZZFcp7ahwXuRU1m+yuO90C5ZUyGeGfocHDI14M3L3yDAQ==",
       "license": "MIT"
-    },
-    "node_modules/reselect": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/reselect/-/reselect-5.2.0.tgz",
-      "integrity": "sha512-AgZ3UOZm3YndfrJ4OYjgrT7bmCm/1iqkjvEfH/oYjzh6PD2qw4QuT3jjnXIrpdt4MTpMXclMT3lXbmRY+XRakw==",
-      "license": "MIT",
-      "peer": true
     },
     "node_modules/resolve": {
       "version": "1.22.11",
@@ -21031,20 +20860,6 @@
       "license": "MIT",
       "dependencies": {
         "is-typedarray": "^1.0.0"
-      }
-    },
-    "node_modules/typescript": {
-      "version": "4.9.5",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.5.tgz",
-      "integrity": "sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==",
-      "license": "Apache-2.0",
-      "peer": true,
-      "bin": {
-        "tsc": "bin/tsc",
-        "tsserver": "bin/tsserver"
-      },
-      "engines": {
-        "node": ">=4.2.0"
       }
     },
     "node_modules/unbox-primitive": {

--- a/install/docker-extension/ui/package.json
+++ b/install/docker-extension/ui/package.json
@@ -11,7 +11,7 @@
     "@fortawesome/fontawesome-svg-core": "^7.1.0",
     "@fortawesome/free-solid-svg-icons": "^7.1.0",
     "@fortawesome/react-fontawesome": "^3.2.0",
-    "@meshery/schemas": "^1.3.7",
+    "@meshery/schemas": "^1.3.13",
     "@mui/icons-material": "^7.3.7",
     "@mui/material": "^7.3.7",
     "@mui/styled-engine-sc": "^7.3.7",

--- a/provider-ui/package-lock.json
+++ b/provider-ui/package-lock.json
@@ -13,7 +13,7 @@
         "@emotion/react": "^11.14.0",
         "@emotion/server": "^11.11.0",
         "@emotion/styled": "^11.14.1",
-        "@meshery/schemas": "^1.3.7",
+        "@meshery/schemas": "^1.3.13",
         "@mui/icons-material": "^9.0.1",
         "@mui/material": "^9.0.1",
         "@mui/system": "^9.0.1",
@@ -1351,9 +1351,9 @@
       }
     },
     "node_modules/@meshery/schemas": {
-      "version": "1.3.7",
-      "resolved": "https://registry.npmjs.org/@meshery/schemas/-/schemas-1.3.7.tgz",
-      "integrity": "sha512-eaEwLN2krtclsCD0f3g5JhABdxBD/CsBKfiUqUN4HmKuyFeNJNK4y8kLTLzgk9G8OVC+ZS0w2nnhKNU2KCE06A==",
+      "version": "1.3.13",
+      "resolved": "https://registry.npmjs.org/@meshery/schemas/-/schemas-1.3.13.tgz",
+      "integrity": "sha512-VZw8yrKiBrxvJxFysOMQuuPJkDwGZ2DuW7ifPGJ6OxfBygAGIYuN4kofmPTglcW/WPhEYn656HM7/zahSmlcRg==",
       "license": "ISC",
       "peerDependencies": {
         "@reduxjs/toolkit": "^2.8.1",

--- a/provider-ui/package.json
+++ b/provider-ui/package.json
@@ -20,7 +20,7 @@
     "@emotion/react": "^11.14.0",
     "@emotion/server": "^11.11.0",
     "@emotion/styled": "^11.14.1",
-    "@meshery/schemas": "^1.3.7",
+    "@meshery/schemas": "^1.3.13",
     "@mui/icons-material": "^9.0.1",
     "@mui/material": "^9.0.1",
     "@mui/system": "^9.0.1",

--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -21,7 +21,7 @@
         "@emotion/react": "^11.14.0",
         "@emotion/server": "^11.11.0",
         "@emotion/styled": "^11.14.1",
-        "@meshery/schemas": "^1.3.9",
+        "@meshery/schemas": "^1.3.13",
         "@microlink/react-json-view": "^1.31.20",
         "@mui/icons-material": "^9.0.1",
         "@mui/material": "^9.0.1",
@@ -2073,9 +2073,9 @@
       "license": "MIT"
     },
     "node_modules/@meshery/schemas": {
-      "version": "1.3.9",
-      "resolved": "https://registry.npmjs.org/@meshery/schemas/-/schemas-1.3.9.tgz",
-      "integrity": "sha512-Wm8Js+Zl7KfVuhaeV8wh5fJSArdHCsZZVOupQRtx1Rdl6MMfFWSGHbTkxxnSBJkR1Yq6frn019UiaKZiUncKNA==",
+      "version": "1.3.13",
+      "resolved": "https://registry.npmjs.org/@meshery/schemas/-/schemas-1.3.13.tgz",
+      "integrity": "sha512-VZw8yrKiBrxvJxFysOMQuuPJkDwGZ2DuW7ifPGJ6OxfBygAGIYuN4kofmPTglcW/WPhEYn656HM7/zahSmlcRg==",
       "license": "ISC",
       "peerDependencies": {
         "@reduxjs/toolkit": "^2.8.1",

--- a/ui/package.json
+++ b/ui/package.json
@@ -49,7 +49,7 @@
     "@emotion/react": "^11.14.0",
     "@emotion/server": "^11.11.0",
     "@emotion/styled": "^11.14.1",
-    "@meshery/schemas": "^1.3.9",
+    "@meshery/schemas": "^1.3.13",
     "@microlink/react-json-view": "^1.31.20",
     "@mui/icons-material": "^9.0.1",
     "@mui/material": "^9.0.1",


### PR DESCRIPTION
## Description

Brings the **UI / npm** side of meshery onto `@meshery/schemas` **v1.3.13** - the version the
**Go** side already pins (`go.mod`, landed via #20177) and that `meshery-extensions`,
`meshery-cloud`, and `sistent` now consume. This closes the gap where meshery's frontend lagged
its own backend on the schemas contract, keeping the generated **RTK Query clients** and **TS
interfaces** in lockstep across the ecosystem.

schemas v1.3.13 is the release that standardizes the ecosystem on `github.com/gofrs/uuid`
(reversing the brief `google/uuid` convergence that panicked `gobuffalo/pop`). The substance is
Go-side; for TypeScript a `format: uuid` field is `string`, so this is a routine keep-current
bump of the UI dependency.

| Package | before | after |
|---|---|---|
| `ui` | `^1.3.9` | `^1.3.13` |
| `provider-ui` | `^1.3.7` | `^1.3.13` |
| `install/docker-extension/ui` | `^1.3.7` | `^1.3.13` |

The `docker-extension/ui` lockfile additionally **prunes a transitive `@reduxjs/toolkit`
subtree**: schemas 1.3.13 declares RTK as a `peerDependency` (it was previously a bundled
`dependency`), so consumers that do not use RTK directly no longer carry it. `docker-extension/ui`
neither declares nor imports RTK, so the prune is correct cleanup, not a regression. (`ui` already
declares `@reduxjs/toolkit ^2.12.0` directly, so the peer requirement is satisfied there.)

## Test plan

- [x] **`ui`** - the only TypeScript consumer (19 schemas-importing files): `tsc --noEmit
      --skipLibCheck` passes with **0 errors** at 1.3.13. The RTK clients and `v1beta*/core`
      interfaces all type-check.
- [x] **`provider-ui`** - JS app, no `tsconfig`; **0** source references to `@meshery/schemas`.
      Bump is a no-op for its code.
- [x] **`docker-extension/ui`** - **0** schemas source usage (the only match is a pre-built,
      committed bundle map); pruned RTK transitives are neither declared nor imported.
- [x] All three: `npm install @meshery/schemas@^1.3.13 --legacy-peer-deps` (repo `.npmrc`
      convention) - package.json, lockfile, and `node_modules` resolve to 1.3.13.
- [ ] CI (lint / build) - runs on this PR.

## Related

- #20177 (merged) - Go gofrs/uuid restore; pinned schemas v1.3.13 in `go.mod`.
- #19633 - Go-only schemas bump (does not touch the UI packages this PR covers).
