### PR TITLE
fix(install): repair broken provider-drift CI gate (check-install -> providers-check) + resync stale k8s manifest

### DIFF
--- a/.github/workflows/check-install.yml
+++ b/.github/workflows/check-install.yml
@@ -32,4 +32,4 @@ jobs:
     steps:
       - uses: actions/checkout@v6
       - name: Check provider-URL artifacts are in sync
-        run: make check-install
+        run: make providers-check

--- a/install/deployment_yamls/k8s/meshery-deployment.yaml
+++ b/install/deployment_yamls/k8s/meshery-deployment.yaml
@@ -26,7 +26,7 @@ spec:
         - name: EVENT
           value: mesheryLocal
         - name: PROVIDER_BASE_URLS
-          value: https://cloud.meshery.io,https://perf.smp-spec.io,https://cloud.layer5.io,https://meshery.tcs-labs.in
+          value: https://cloud.meshery.io,https://perf.smp-spec.io,https://cloud.layer5.io,https://platform.tata-consulting.co.uk,https://collab.eti.cisco.com,https://kickstart.metabit.com,https://provider.od10.in
         - name: ADAPTER_URLS
           value: meshery-istio:10000 meshery-linkerd:10001 meshery-consul:10002 meshery-nsm:10004 meshery-app-mesh:10005 meshery-kuma:10007 meshery-nginx-sm:10010
         image: meshery/meshery:stable-latest

--- a/install/providers.env
+++ b/install/providers.env
@@ -7,7 +7,7 @@
 # chooser), URL is the provider's base URL.
 #
 # After editing, run `make providers-propagate` to propagate to all generated artifacts.
-# `make check-install` (CI) fails if anything is out of sync.
+# `make providers-check` (CI) fails if anything is out of sync.
 #
 # ACTIVE providers are registered at server startup and
 # emitted into PROVIDER_BASE_URLS. They MUST resolve in DNS: the server retries each


### PR DESCRIPTION
## Problem

The **"Install Artifacts Drift Check"** workflow (`.github/workflows/check-install.yml`) runs
`make check-install` - **a target that does not exist**. The Makefile defines `providers-check`
(and `providers-propagate`). Every run of this gate therefore failed immediately with:

```
make: *** No rule to make target 'check-install'.  Stop.
```

...**before** the drift check ever executed. The provider-URL drift gate has effectively been a
**silent no-op**, so it caught nothing.

## Consequence (masked drift)

With detection disabled, a real drift accumulated. `install/providers.env` (the canonical
source of truth) was updated - the TATA URL changed and Cisco / Metabit / OD10 were added - and
propagated to **every** generated artifact **except**
`install/deployment_yamls/k8s/meshery-deployment.yaml`, which was left on a stale single-provider
list (`meshery.tcs-labs.in`). That straggler is exactly what a working gate is meant to catch.

## Fix

1. **`.github/workflows/check-install.yml`** - `make check-install` -> `make providers-check`
   (the real target). The gate now actually runs.
2. **`install/providers.env`** - fix the identical stale target name in the header doc comment.
3. **`install/deployment_yamls/k8s/meshery-deployment.yaml`** - `make providers-propagate` resync
   so `PROVIDER_BASE_URLS` matches `providers.env` (the only out-of-sync artifact).

## Test plan

- [x] `make providers-check` **fails** before the resync (correctly reports the
      `meshery-deployment.yaml` drift) once the target name is corrected - i.e. the gate works again.
- [x] `make providers-propagate` updates **only** `meshery-deployment.yaml` (all other artifacts
      were already in sync).
- [x] `make providers-check` **passes (exit 0)** after the resync.
- [x] Diff is minimal and surgical: 3 files, 3 insertions / 3 deletions.

## Context

Surfaced by #20180 (a `@meshery/schemas` UI dependency bump that touches
`install/docker-extension/ui/**` and legitimately tripped the now-functional gate). #20180's
`check-install` job is blocked on this fix; once this lands, that job will pass on the corrected
workflow with the artifacts in sync.
