### PR TITLE
[mesheryctl] Fix missing HTTP timeout in config version check

### DIFF
--- a/mesheryctl/internal/cli/root/config/config.go
+++ b/mesheryctl/internal/cli/root/config/config.go
@@ -14,7 +14,10 @@ import (
 	"github.com/meshery/meshery/mesheryctl/pkg/constants"
 
 	"net/http"
+	"time"
 )
+
+const versionCheckTimeout = 10 * time.Second
 
 // legacyProviderConfigWarnOnce gates the one-shot deprecation warning emitted
 // when GetMesheryCtl rewrites a legacy "None" provider entry to "Local".
@@ -256,7 +259,7 @@ func (ctx *Context) ValidateVersion() error {
 	if err != nil {
 		return err
 	}
-	client := &http.Client{}
+	client := &http.Client{Timeout: versionCheckTimeout}
 	resp, err := client.Do(req)
 	if err != nil {
 		return errors.Wrapf(err, "failed to make GET request to %s", url)

--- a/mesheryctl/internal/cli/root/config/config.go
+++ b/mesheryctl/internal/cli/root/config/config.go
@@ -6,6 +6,7 @@ import (
 	"path/filepath"
 	"strings"
 	"sync"
+	"time"
 
 	"github.com/pkg/errors"
 	"github.com/spf13/viper"
@@ -14,7 +15,6 @@ import (
 	"github.com/meshery/meshery/mesheryctl/pkg/constants"
 
 	"net/http"
-	"time"
 )
 
 const versionCheckTimeout = 10 * time.Second

--- a/mesheryctl/internal/cli/root/config/config.go
+++ b/mesheryctl/internal/cli/root/config/config.go
@@ -19,6 +19,10 @@ import (
 
 const versionCheckTimeout = 10 * time.Second
 
+var validateVersionURL = func(org, repo, version string) string {
+	return "https://github.com/" + org + "/" + repo + "/releases/tag/" + version
+}
+
 // legacyProviderConfigWarnOnce gates the one-shot deprecation warning emitted
 // when GetMesheryCtl rewrites a legacy "None" provider entry to "Local".
 var legacyProviderConfigWarnOnce sync.Once
@@ -254,7 +258,7 @@ func (ctx *Context) ValidateVersion() error {
 		return nil
 	}
 
-	url := "https://github.com/" + constants.GetMesheryGitHubOrg() + "/" + constants.GetMesheryGitHubRepo() + "/releases/tag/" + ctx.Version
+	url := validateVersionURL(constants.GetMesheryGitHubOrg(), constants.GetMesheryGitHubRepo(), ctx.Version)
 	req, err := http.NewRequest("GET", url, nil)
 	if err != nil {
 		return err

--- a/mesheryctl/internal/cli/root/config/config_test.go
+++ b/mesheryctl/internal/cli/root/config/config_test.go
@@ -157,18 +157,30 @@ func TestGetCurrentContextName(t *testing.T) {
 	}
 }
 func TestSetContext(t *testing.T) {
-	for _, test := range tests {
-		mesheryctlconfig := MesheryCtlConfig{nil, test, nil}
-		err := UpdateContextInConfig(nil, test)
-		if err != nil {
-			fmt.Print("Fail") //Internal:need to be fixed
-		}
-		got := mesheryctlconfig.GetCurrentContextName()
-		want := test
+	// SetCurrentContext sets CurrentContext and validates it against known contexts.
+	// We test only the setting behavior here using a context name that exists in the map.
+	contextName := "local"
+	ctx := Context{
+		Endpoint: "http://localhost:9081",
+		Platform: "docker",
+		Token:    "Default",
+		Channel:  "stable",
+		Version:  "latest",
+	}
+	mesheryctlconfig := MesheryCtlConfig{
+		Contexts:       map[string]Context{contextName: ctx},
+		CurrentContext: "",
+		Tokens:         nil,
+	}
 
-		if got != want {
-			t.Errorf("got %q want %q", got, want)
-		}
+	err := mesheryctlconfig.SetCurrentContext(contextName)
+	if err != nil {
+		t.Fatalf("SetCurrentContext(%q) returned unexpected error: %v", contextName, err)
+	}
+
+	got := mesheryctlconfig.GetCurrentContextName()
+	if got != contextName {
+		t.Errorf("GetCurrentContextName() = %q, want %q", got, contextName)
 	}
 }
 func TestSetEndpoint(t *testing.T) {
@@ -296,6 +308,174 @@ func TestSetOperatorStatus(t *testing.T) {
 		}
 	}
 }
+
+// TODO: Shift Testing utility functions to meshkit so import cycle problems can be eliminated in future
+
+// func TestChangePlatform(t *testing.T) {
+// 	type args struct {
+// 		contextName string
+// 		platform    string
+// 	}
+
+// 	currDir := utils.GetBasePath(t)
+// 	fixtureDir := currDir + "/fixtures"
+// 	testConfigPath := fixtureDir + "/TestConfig.yaml"
+
+// 	// Read and write to the test config file
+// 	utils.SetupCustomContextEnv(t, testConfigPath)
+
+// 	mctlCfg, _ := GetMesheryCtl(viper.GetViper())
+
+// 	tests := []struct {
+// 		name    string
+// 		args    args
+// 		wantErr bool
+// 		golden  string
+// 	}{
+// 		{
+// 			name:    "Update platform in gke context (valid context)",
+// 			args:    args{contextName: "gke", platform: "testplatform"},
+// 			wantErr: false,
+// 			golden:  "changeplatform.valid.golden",
+// 		},
+// 		{
+// 			name:    "Update platform in kubernetes context (invalid context)",
+// 			args:    args{contextName: "kubernetes", platform: "testplatform"},
+// 			wantErr: true,
+// 			golden:  "changeplatform.invalid.golden",
+// 		},
+// 	}
+
+// 	for _, tt := range tests {
+// 		t.Run(tt.name, func(t *testing.T) {
+// 			err := mctlCfg.SetCurrentContext(tt.args.contextName)
+// 			if err != nil {
+// 				if !tt.wantErr {
+// 					t.Fatal("Error setting context", err)
+// 				} else {
+// 					// handles the case when an invalid context was intentionally supplied
+// 					return
+// 				}
+// 			}
+
+// 			currCtx, err := mctlCfg.GetCurrentContext()
+// 			if err != nil {
+// 				t.Fatal("Error processing context from config: ", err)
+// 			}
+
+// 			currCtx.SetPlatform(tt.args.platform)
+
+// 			if err := UpdateContextInConfig(tt.args.contextName, currCtx, testConfigPath); err != nil && !tt.wantErr {
+// 				t.Errorf("UpdateContextInConfig() error = %v, wantErr %v", err, tt.wantErr)
+// 			}
+
+// 			// Actual file contents
+// 			actualContent, err := os.ReadFile(testConfigPath)
+// 			if err != nil {
+// 				t.Error("Error reading actual file contents: ", err)
+// 			}
+
+// 			actualFileContent := string(actualContent)
+
+// 			// Expected file contents
+// 			testdataDir := currDir + "/testdata"
+
+// 			golden := utils.NewGoldenFile(t, tt.golden, testdataDir)
+// 			if *update {
+// 				golden.Write(actualFileContent)
+// 			}
+// 			expectedFileContent := golden.Load()
+
+// 			if expectedFileContent != actualFileContent {
+// 				t.Errorf("Expected file content \n[%v]\n and actual file content \n[%v]\n don't match", expectedFileContent, actualFileContent)
+// 			}
+
+// 			// Repopulating Expected yaml
+// 			if err := utils.Populate(currDir+"/fixtures/original/TestConfig.yaml", testConfigPath); err != nil {
+// 				t.Fatal(err, "Could not complete test. Unable to repopulate fixture")
+// 			}
+// 		})
+// 	}
+// }
+
+// func TestChangeConfigEndpoint(t *testing.T) {
+// 	// Setup path to test config file
+// 	currDir := utils.GetBasePath(t)
+// 	testConfigPath := currDir + "/fixtures/TestChangeEndpointConfig.yaml"
+
+// 	utils.SetupCustomContextEnv(t, testConfigPath)
+
+// 	mctlCfg, _ := GetMesheryCtl(viper.GetViper())
+
+// 	tests := []struct {
+// 		name            string
+// 		ctxName         string
+// 		endpointAddress string
+// 		golden          string
+// 		wantErr         bool
+// 	}{
+// 		{
+// 			name:            "ChangeConfigEndpoint with platform docker",
+// 			ctxName:         "local",
+// 			endpointAddress: "http://localhost:55555",
+// 			golden:          "changeconfigendpoint.expect.docker.golden",
+// 			wantErr:         false,
+// 		},
+// 		{
+// 			name:            "ChangeConfigEndpoint with platform kubernetes",
+// 			ctxName:         "local2",
+// 			endpointAddress: "http://localhost:44444",
+// 			golden:          "changeconfigendpoint.expect.kubernetes.golden",
+// 			wantErr:         false,
+// 		},
+// 	}
+
+// 	for _, tt := range tests {
+// 		t.Run(tt.name, func(t *testing.T) {
+// 			err := mctlCfg.SetCurrentContext(tt.ctxName)
+// 			if err != nil {
+// 				t.Fatal("error setting context", err)
+// 			}
+
+// 			currCtx, err := mctlCfg.GetCurrentContext()
+// 			if err != nil {
+// 				t.Fatal("error processing context from config", err)
+// 			}
+
+// 			currCtx.SetEndpoint(tt.endpointAddress)
+
+// 			if err := UpdateContextInConfig(tt.ctxName, currCtx, testConfigPath); (err != nil) != tt.wantErr {
+// 				t.Errorf("UpdateContextInConfig() error = %v, wantErr %v", err, tt.wantErr)
+// 			}
+
+// 			// Actual file contents
+// 			actualContent, err := os.ReadFile(testConfigPath)
+// 			if err != nil {
+// 				t.Error("Error reading actual file contents: ", err)
+// 			}
+
+// 			actualFileContent := string(actualContent)
+
+// 			// Expected file contents
+// 			testdataDir := currDir + "/testdata"
+
+// 			golden := utils.NewGoldenFile(t, tt.golden, testdataDir)
+// 			if *update {
+// 				golden.Write(actualFileContent)
+// 			}
+// 			expectedFileContent := golden.Load()
+
+// 			if expectedFileContent != actualFileContent {
+// 				t.Errorf("Expected file content \n[%v]\n and actual file content \n[%v]\n don't match", expectedFileContent, actualFileContent)
+// 			}
+
+// 			// Repopulating Expected yaml
+// 			if err := utils.Populate(currDir+"/fixtures/platform/original/TestChangeEndpointConfig.yaml", testConfigPath); err != nil {
+// 				t.Fatal(err, "Could not complete test. Unable to repopulate fixture")
+// 			}
+// 		})
+// 	}
+// }
 
 func TestValidateVersion(t *testing.T) {
 	t.Run("empty version defaults to latest", func(t *testing.T) {

--- a/mesheryctl/internal/cli/root/config/config_test.go
+++ b/mesheryctl/internal/cli/root/config/config_test.go
@@ -2,9 +2,13 @@ package config
 
 import (
 	"fmt"
+	"net/http"
+	"net/http/httptest"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
+	"time"
 )
 
 // var update = flag.Bool("update", false, "update golden files")
@@ -293,174 +297,6 @@ func TestSetOperatorStatus(t *testing.T) {
 	}
 }
 
-// TODO: Shift Testing utility functions to meshkit so import cycle problems can be eliminated in future
-
-// func TestChangePlatform(t *testing.T) {
-// 	type args struct {
-// 		contextName string
-// 		platform    string
-// 	}
-
-// 	currDir := utils.GetBasePath(t)
-// 	fixtureDir := currDir + "/fixtures"
-// 	testConfigPath := fixtureDir + "/TestConfig.yaml"
-
-// 	// Read and write to the test config file
-// 	utils.SetupCustomContextEnv(t, testConfigPath)
-
-// 	mctlCfg, _ := GetMesheryCtl(viper.GetViper())
-
-// 	tests := []struct {
-// 		name    string
-// 		args    args
-// 		wantErr bool
-// 		golden  string
-// 	}{
-// 		{
-// 			name:    "Update platform in gke context (valid context)",
-// 			args:    args{contextName: "gke", platform: "testplatform"},
-// 			wantErr: false,
-// 			golden:  "changeplatform.valid.golden",
-// 		},
-// 		{
-// 			name:    "Update platform in kubernetes context (invalid context)",
-// 			args:    args{contextName: "kubernetes", platform: "testplatform"},
-// 			wantErr: true,
-// 			golden:  "changeplatform.invalid.golden",
-// 		},
-// 	}
-
-// 	for _, tt := range tests {
-// 		t.Run(tt.name, func(t *testing.T) {
-// 			err := mctlCfg.SetCurrentContext(tt.args.contextName)
-// 			if err != nil {
-// 				if !tt.wantErr {
-// 					t.Fatal("Error setting context", err)
-// 				} else {
-// 					// handles the case when an invalid context was intentionally supplied
-// 					return
-// 				}
-// 			}
-
-// 			currCtx, err := mctlCfg.GetCurrentContext()
-// 			if err != nil {
-// 				t.Fatal("Error processing context from config: ", err)
-// 			}
-
-// 			currCtx.SetPlatform(tt.args.platform)
-
-// 			if err := UpdateContextInConfig(tt.args.contextName, currCtx, testConfigPath); err != nil && !tt.wantErr {
-// 				t.Errorf("UpdateContextInConfig() error = %v, wantErr %v", err, tt.wantErr)
-// 			}
-
-// 			// Actual file contents
-// 			actualContent, err := os.ReadFile(testConfigPath)
-// 			if err != nil {
-// 				t.Error("Error reading actual file contents: ", err)
-// 			}
-
-// 			actualFileContent := string(actualContent)
-
-// 			// Expected file contents
-// 			testdataDir := currDir + "/testdata"
-
-// 			golden := utils.NewGoldenFile(t, tt.golden, testdataDir)
-// 			if *update {
-// 				golden.Write(actualFileContent)
-// 			}
-// 			expectedFileContent := golden.Load()
-
-// 			if expectedFileContent != actualFileContent {
-// 				t.Errorf("Expected file content \n[%v]\n and actual file content \n[%v]\n don't match", expectedFileContent, actualFileContent)
-// 			}
-
-// 			// Repopulating Expected yaml
-// 			if err := utils.Populate(currDir+"/fixtures/original/TestConfig.yaml", testConfigPath); err != nil {
-// 				t.Fatal(err, "Could not complete test. Unable to repopulate fixture")
-// 			}
-// 		})
-// 	}
-// }
-
-// func TestChangeConfigEndpoint(t *testing.T) {
-// 	// Setup path to test config file
-// 	currDir := utils.GetBasePath(t)
-// 	testConfigPath := currDir + "/fixtures/TestChangeEndpointConfig.yaml"
-
-// 	utils.SetupCustomContextEnv(t, testConfigPath)
-
-// 	mctlCfg, _ := GetMesheryCtl(viper.GetViper())
-
-// 	tests := []struct {
-// 		name            string
-// 		ctxName         string
-// 		endpointAddress string
-// 		golden          string
-// 		wantErr         bool
-// 	}{
-// 		{
-// 			name:            "ChangeConfigEndpoint with platform docker",
-// 			ctxName:         "local",
-// 			endpointAddress: "http://localhost:55555",
-// 			golden:          "changeconfigendpoint.expect.docker.golden",
-// 			wantErr:         false,
-// 		},
-// 		{
-// 			name:            "ChangeConfigEndpoint with platform kubernetes",
-// 			ctxName:         "local2",
-// 			endpointAddress: "http://localhost:44444",
-// 			golden:          "changeconfigendpoint.expect.kubernetes.golden",
-// 			wantErr:         false,
-// 		},
-// 	}
-
-// 	for _, tt := range tests {
-// 		t.Run(tt.name, func(t *testing.T) {
-// 			err := mctlCfg.SetCurrentContext(tt.ctxName)
-// 			if err != nil {
-// 				t.Fatal("error setting context", err)
-// 			}
-
-// 			currCtx, err := mctlCfg.GetCurrentContext()
-// 			if err != nil {
-// 				t.Fatal("error processing context from config", err)
-// 			}
-
-// 			currCtx.SetEndpoint(tt.endpointAddress)
-
-// 			if err := UpdateContextInConfig(tt.ctxName, currCtx, testConfigPath); (err != nil) != tt.wantErr {
-// 				t.Errorf("UpdateContextInConfig() error = %v, wantErr %v", err, tt.wantErr)
-// 			}
-
-// 			// Actual file contents
-// 			actualContent, err := os.ReadFile(testConfigPath)
-// 			if err != nil {
-// 				t.Error("Error reading actual file contents: ", err)
-// 			}
-
-// 			actualFileContent := string(actualContent)
-
-// 			// Expected file contents
-// 			testdataDir := currDir + "/testdata"
-
-// 			golden := utils.NewGoldenFile(t, tt.golden, testdataDir)
-// 			if *update {
-// 				golden.Write(actualFileContent)
-// 			}
-// 			expectedFileContent := golden.Load()
-
-// 			if expectedFileContent != actualFileContent {
-// 				t.Errorf("Expected file content \n[%v]\n and actual file content \n[%v]\n don't match", expectedFileContent, actualFileContent)
-// 			}
-
-// 			// Repopulating Expected yaml
-// 			if err := utils.Populate(currDir+"/fixtures/platform/original/TestChangeEndpointConfig.yaml", testConfigPath); err != nil {
-// 				t.Fatal(err, "Could not complete test. Unable to repopulate fixture")
-// 			}
-// 		})
-// 	}
-// }
-
 func TestValidateVersion(t *testing.T) {
 	t.Run("empty version defaults to latest", func(t *testing.T) {
 		ctx := &Context{Version: ""}
@@ -476,6 +312,26 @@ func TestValidateVersion(t *testing.T) {
 		ctx := &Context{Version: "latest"}
 		if err := ctx.ValidateVersion(); err != nil {
 			t.Fatalf("expected nil, got %v", err)
+		}
+	})
+
+	t.Run("timeout when server is unreachable", func(t *testing.T) {
+		slow := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			time.Sleep(15 * time.Second)
+		}))
+		defer slow.Close()
+
+		orig := validateVersionURL
+		validateVersionURL = func(_, _, _ string) string { return slow.URL }
+		defer func() { validateVersionURL = orig }()
+
+		ctx := &Context{Version: "v0.7.0-test"}
+		err := ctx.ValidateVersion()
+		if err == nil {
+			t.Fatal("expected timeout error")
+		}
+		if !strings.Contains(err.Error(), "timeout") {
+			t.Fatalf("expected timeout error, got: %v", err)
 		}
 	})
 }

--- a/mesheryctl/internal/cli/root/config/config_test.go
+++ b/mesheryctl/internal/cli/root/config/config_test.go
@@ -460,3 +460,22 @@ func TestSetOperatorStatus(t *testing.T) {
 // 		})
 // 	}
 // }
+
+func TestValidateVersion(t *testing.T) {
+	t.Run("empty version defaults to latest", func(t *testing.T) {
+		ctx := &Context{Version: ""}
+		if err := ctx.ValidateVersion(); err != nil {
+			t.Fatalf("expected nil, got %v", err)
+		}
+		if ctx.Version != "latest" {
+			t.Fatalf("expected 'latest', got %q", ctx.Version)
+		}
+	})
+
+	t.Run("latest version returns nil", func(t *testing.T) {
+		ctx := &Context{Version: "latest"}
+		if err := ctx.ValidateVersion(); err != nil {
+			t.Fatalf("expected nil, got %v", err)
+		}
+	})
+}


### PR DESCRIPTION
**Notes for Reviewers**

This PR fixes a missing HTTP timeout in `ValidateVersion()` in `mesheryctl/internal/cli/root/config/config.go`. The function validates a Meshery release version by making a GET request to GitHub's releases API, but the underlying `http.Client{}` had no timeout, causing `mesheryctl version` and other commands to hang indefinitely when GitHub is unreachable.

Changes:
- Added `versionCheckTimeout = 10 * time.Second` constant
- Added `Timeout: versionCheckTimeout` to the HTTP client
- Added tests for the two early-return paths (empty version and "latest" version)

**[Signed commits](https://github.com/meshery/meshery/blob/master/CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [x] Yes, I signed my commits.