### PR TITLE
[Docs] Add Connection Wizard user and contributor guides

### DIFF
--- a/docs/content/en/concepts/logical/connections/index.md
+++ b/docs/content/en/concepts/logical/connections/index.md
@@ -86,6 +86,10 @@ _Connections like **Registration of Meshery server with remote provider** (and f
 
 ## Registering Connections with Remote Providers
 
+{{% alert color="info" title="Use the Connection Wizard" %}}
+The [Connection Wizard]({{< ref "guides/infrastructure-management/registering-a-connection.md" >}}) is the canonical, guided way to register or update any Connection from the Meshery UI. The summary below describes the same flow conceptually.
+{{% /alert %}}
+
 To register a connection with a remote provider, you need to follow these steps:
 
 1. Obtain the necessary credentials or access tokens from the remote provider.

--- a/docs/content/en/extensions/extensions/helm-snapshot/index.md
+++ b/docs/content/en/extensions/extensions/helm-snapshot/index.md
@@ -84,6 +84,6 @@ To generate a snapshot for a Helm chart located at `https://meshery.io/charts/v0
 
 - [Adapters]({{< ref "concepts/architecture/adapters.md" >}}): Adapters allow Meshery to interface with the different cloud native infrastructure.
 - [Load Generators]({{< ref "reference/extensibility/load-generators.md" >}}): for performance characterization and benchmarking
-- [Integrations]({{< ref "reference/extensibility/api.md" >}}): model-based support for a broad variety of design and orchestration of cloud and cloud native platforms, tools, and technologies.
+- [Integrations]({{< ref "extensions/models/_index.md" >}}): model-based support for a broad variety of design and orchestration of cloud and cloud native platforms, tools, and technologies.
 - [Providers]({{< ref "reference/extensibility/providers/index.md" >}}): for connecting to different cloud providers and infrastructure platforms
 - [UI Plugins]({{< ref "reference/extensibility/ui.md" >}}): Meshery UI has a number of extension points that allow users to customize their experience with third-party plugins.

--- a/docs/content/en/extensions/extensions/kubectl-meshsync-snapshot/index.md
+++ b/docs/content/en/extensions/extensions/kubectl-meshsync-snapshot/index.md
@@ -18,6 +18,6 @@ A `kubectl` plugin for performing an ad hoc collection of resource information f
 
 - [Adapters]({{< ref "concepts/architecture/adapters.md" >}}): Adapters allow Meshery to interface with the different cloud native infrastructure.
 - [Load Generators]({{< ref "reference/extensibility/load-generators.md" >}}): for performance characterization and benchmarking
-- [Integrations]({{< ref "reference/extensibility/api.md" >}}): model-based support for a broad variety of design and orchestration of cloud and cloud native platforms, tools, and technologies.
+- [Integrations]({{< ref "extensions/models/_index.md" >}}): model-based support for a broad variety of design and orchestration of cloud and cloud native platforms, tools, and technologies.
 - [Providers]({{< ref "reference/extensibility/providers/index.md" >}}): for connecting to different cloud providers and infrastructure platforms
 - [UI Plugins]({{< ref "reference/extensibility/ui.md" >}}): Meshery UI has a number of extension points that allow users to customize their experience with third-party plugins.

--- a/docs/content/en/guides/infrastructure-management/lifecycle-management/index.md
+++ b/docs/content/en/guides/infrastructure-management/lifecycle-management/index.md
@@ -9,7 +9,7 @@ description: Manage the lifecycle of your infrastructure by registering each inf
 
 <a name="lifecycle-management"></a>
 
-Meshery manages hundreds of different types of cloud native infrastructure. See the [full set of integrations]({{< ref "reference/extensibility/api.md" >}}).
+Meshery manages hundreds of different types of cloud native infrastructure. See the [full set of integrations]({{< ref "extensions/models/_index.md" >}}).
 
 ## Cloud Native Infrastructure Lifecycle Management
 

--- a/docs/content/en/guides/infrastructure-management/registering-a-connection.md
+++ b/docs/content/en/guides/infrastructure-management/registering-a-connection.md
@@ -9,7 +9,7 @@ weight: -5
 description: Use the Connection Wizard to create and update Connections - Kubernetes clusters, Grafana, Prometheus, and more - in your Meshery deployment.
 ---
 
-A [Connection]({{< ref "concepts/logical/connections/index.md" >}}) is how Meshery tracks and manages a resource - a Kubernetes cluster, a Grafana instance, a Prometheus server, and [many more]({{< ref "reference/extensibility/api.md" >}}). The **Connection Wizard** is the guided, in-UI way to register a new Connection or reconfigure an existing one, without hand-editing YAML or memorizing API payloads.
+A [Connection]({{< ref "concepts/logical/connections/index.md" >}}) is how Meshery tracks and manages a resource - a Kubernetes cluster, a Grafana instance, a Prometheus server, and [many more]({{< ref "extensions/models/_index.md" >}}). The **Connection Wizard** is the guided, in-UI way to register a new Connection or reconfigure an existing one, without hand-editing YAML or memorizing API payloads.
 
 This guide covers creating and updating Connections with the wizard. For what a Connection _is_, the states it moves through, and how it is managed over time, see the canonical references:
 

--- a/docs/content/en/guides/infrastructure-management/registering-a-connection.md
+++ b/docs/content/en/guides/infrastructure-management/registering-a-connection.md
@@ -1,68 +1,116 @@
 ---
-title: Infrastructure Discovery
+title: Registering a Connection
+aliases:
+- /guides/infrastructure-management/connection-wizard
+- /guides/infrastructure-management/infrastructure-discovery
+- /connection-wizard
 categories: [infrastructure]
-description: MeshSync supports both greenfield and brownfield discovery of infrastructure. Greenfield discovery manages infrastructure created and managed entirely by Meshery, while brownfield discovery identifies separately created infrastructure.
+weight: -5
+description: Use the Connection Wizard to create and update Connections - Kubernetes clusters, Grafana, Prometheus, and more - in your Meshery deployment.
 ---
 
-{{% alert color="info" title="MeshSync" %}}
-Managed by the <a href='{{< ref "concepts/architecture/operator/index.md" >}}'>Meshery Operator</a>, MeshSync is a custom Kubernetes controller that provides tiered discovery and continual synchronization with Meshery Server as to the state of the Kubernetes clusters and their workloads. Learn more about <a href='{{< ref "concepts/architecture/meshsync.md" >}}'>MeshSync</a>.
+A [Connection]({{< ref "concepts/logical/connections/index.md" >}}) is how Meshery tracks and manages a resource - a Kubernetes cluster, a Grafana instance, a Prometheus server, and [many more]({{< ref "reference/extensibility/api.md" >}}). The **Connection Wizard** is the guided, in-UI way to register a new Connection or reconfigure an existing one, without hand-editing YAML or memorizing API payloads.
+
+This guide covers creating and updating Connections with the wizard. For what a Connection _is_, the states it moves through, and how it is managed over time, see the canonical references:
+
+- [Connections]({{< ref "concepts/logical/connections/index.md" >}}) - what Connections are and their full state lifecycle.
+- [Credentials]({{< ref "concepts/logical/credentials.md" >}}) - how Meshery authenticates to a Connection.
+- [Managing Connections]({{< ref "guides/infrastructure-management/lifecycle-management/index.md" >}}) - operating Connections after they are registered.
+
+{{% alert color="info" title="Discovered vs. manually registered Connections" %}}
+Meshery learns about Connections two ways. **Managed** Connections (for example, the resources inside a Kubernetes cluster) are auto-discovered by [MeshSync]({{< ref "concepts/architecture/meshsync.md" >}}) and arrive already in the [Discovered]({{< ref "concepts/logical/connections/index.md#state-discovered" >}}) state. **Unmanaged** Connections (for example, a standalone Grafana or Prometheus) are added by you. The Connection Wizard is how you do the latter - and how you bring a Kubernetes cluster under management in the first place.
 {{% /alert %}}
 
-MeshSync is your tool for efficient management and synchronization of Kubernetes clusters! This user guide will walk you through how to establish a connection with any element that Meshery is able to connect to and manage. Use the MeshSync page to register connections, view connection metadata, and perform connectivity tests, as weel as to manage credentials and environments.
+## Before you begin
 
-## MeshSync Discovery
+- A running Meshery deployment. See the [Quick Start]({{< ref "installation/quick-start/index.md" >}}) if you do not have one yet.
+- Permission to add Connections. The wizard is permission-gated: adding a Kubernetes cluster requires the **add cluster** permission, and other Connection kinds require the **connect metrics** permission. If you lack both, the **Create Connection** button is disabled. See [Roles and Permissions]({{< ref "reference/extensibility/authorization/index.md" >}}).
+- For an authenticated Connection (most Grafana/Prometheus instances), the access token or credential you intend to use. You can paste it during the wizard or reuse an existing [Credential]({{< ref "concepts/logical/credentials.md" >}}).
 
-MeshSync involves the discovery and registration of elements in your infrastructure. Follow these steps to seamlessly integrate and manage your connections:
+## Launching the Connection Wizard
 
-1. **Discovered**: Fill out the registration form, specifying metrics to listen to for Prometheus.
-2. **Register**: Your object will now appear on the connection page.
+1. Open the **Connections** page in Meshery (**Lifecycle → Connections**).
+2. Click **Create Connection**.
 
-Tasks performed during registration:
+The wizard opens as a modal. The set of Connection kinds you can create is driven by the [connection definitions]({{< ref "project/contributing/contributing-connections.md" >}}) registered in your Meshery Server's [Registry]({{< ref "concepts/logical/registry.md" >}}). Out of the box this includes **Kubernetes**, **Grafana**, and **Prometheus**; your deployment may offer more. If a kind you need is missing, a contributor can add it - see [Contributing a Connection]({{< ref "project/contributing/contributing-connections.md" >}}).
 
-- Enrich connections with more information about your infrastructure.
-- Offload fingerprinting process to MeshSync.
-- Connect with KubeAPI for connections management.
-- Handle curated list of connections (port, protocol, etc.).
-- Display Meshery Models icons/colors for every discovered object with connection definitions pointing to components.
+## Creating a Connection
 
-### Meshery Server Database Updates
+Most Connections follow the same generic flow. Each step is rendered from the connection definition itself, so the exact fields you see depend on the kind you choose.
 
-Meshery Server writes updates from MeshSync to the server database:
+1. **Choose Connection.** Pick the kind of Connection to create (for example, Grafana). Kinds you do not have permission to add are shown but cannot be selected.
+2. **Configure Connection.** Fill in the Connection's details - typically the endpoint URL and an optional friendly name. Required fields are validated before you can continue. For a Grafana Connection, for instance, you supply the Grafana endpoint (e.g. `http://grafana.example:3000`).
+3. **Associate Credential.** Provide the secret Meshery will use to authenticate. You can either:
+   - **Reuse an existing credential** - the list is filtered to credentials that match the Connection's kind, or
+   - **Create a new credential** - enter the token, API key, or `username:password` and give it a name (it defaults to the Connection's name).
 
-Meshery uses the component's Group, Version, Kind to perform the initial tier of fingerprinting. 
+   You may also choose to **skip credential verification**, which registers the Connection without first probing reachability - useful when the target is not reachable yet but you still want it on record. This step is omitted entirely for kinds that do not define a credential (and for Kubernetes, whose kubeconfig _is_ its credential - see below).
+4. **Review & Create.** Confirm the summary and click **Create Connection**. Meshery registers the Connection and immediately attempts to connect to it.
+5. **Done.** On success, the Connection becomes a first-class resource, listed in the [Connections]({{< ref "concepts/logical/connections/index.md" >}}) table and ready to use.
 
-### MeshSync Endpoint
+{{% alert color="info" title="What 'Create' actually does" %}}
+Creating a Connection performs two transitions in sequence: it **registers** the Connection (recording it and its credential) and then **connects** to it (verifying reachability and beginning management). A reachable Connection lands in the [Connected]({{< ref "concepts/logical/connections/index.md#state-connected" >}}) state; if Meshery cannot reach it - or you skipped verification - it remains [Registered]({{< ref "concepts/logical/connections/index.md#state-registered" >}}). You can drive further transitions later from the Connections table.
+{{% /alert %}}
 
-The Meshery Server endpoint performs a simple JOIN of GVKs to enrich responses with Component Metadata. Key points to note:
+### Credentials
 
-## Connection Management
+Credentials entered in the wizard are persisted as first-class, named [Credentials]({{< ref "concepts/logical/credentials.md" >}}), encrypted at rest, and reusable across other Connections. Meshery never exposes them in logs or API responses. To learn how Meshery interprets a credential's secret (Basic auth vs. bearer token vs. anonymous), see [Credentials]({{< ref "concepts/logical/credentials.md" >}}) and the [Telemetry authentication note](https://docs.meshery.io/guides/telemetry/).
 
-### During Connection Registration
+## Importing a Kubernetes cluster
 
-Upon registration, the MeshSync object should have a status of "REGISTERED." Follow these steps:
+Kubernetes uses a dedicated flow because a single kubeconfig can describe many clusters and its kubeconfig also serves as its credential.
 
-1. Create a new entry in the Connections table with either "REGISTERED" or "CONNECTED," based on the Meshery Server's ability to establish a connection.
-2. Use the Registration Modal to assign the connection to an environment.
-3. Confirm connection metadata details, including the assigned model and component.
-4. Perform a connectivity test to determine the status: "REGISTERED" (administratively connected) or "CONNECTED" (both administratively and actually connected).
+1. **Choose Connection** → **Kubernetes**.
+2. **Import Kubeconfig.** Upload a kubeconfig file. Meshery parses it and lists the contexts it contains, indicating which are reachable - nothing is persisted yet.
+3. **Select contexts.** Choose which contexts to import. For each, you can override the Connection name and choose a [MeshSync deployment mode](#meshsync-deployment-mode).
+4. **Review Import.** Confirm your selection and import. Meshery creates one Connection per selected context and reports the outcome, grouped into connected, registered, ignored, and errored buckets.
 
-### Registration Modal
+Each imported cluster is created as a Kubernetes Connection that [MeshSync]({{< ref "concepts/architecture/meshsync.md" >}}) keeps in sync. From there, Meshery can deploy and operate workloads, visualize the cluster, and more. See [Managing Connections]({{< ref "guides/infrastructure-management/lifecycle-management/index.md" >}}).
 
-The Registration Modal allows users to assign connections to environments, view connection metadata, and perform connectivity tests. Key features include:
+{{% alert color="dark" title="Who can access an imported cluster?" %}}
+A Kubernetes Connection is owned by the user who imported it and is private until you explicitly share it - by assigning it to an [Environment]({{< ref "concepts/logical/environments.md" >}}) and that environment to a [Workspace]({{< ref "concepts/logical/workspaces.md" >}}). See the sharing FAQ under [Managing Connections]({{< ref "guides/infrastructure-management/lifecycle-management/index.md" >}}).
+{{% /alert %}}
 
-- Connectivity test to determine registration status.
-- Identification of credentials to be used, with a selection based on CredentialDefinition for the ConnectionDefinition being registered.
-- Future options to offer generic CredentialDefinitions for various authentication methods.
+### MeshSync deployment mode
 
-### Credential Registration
+When you import or reconfigure a Kubernetes cluster, you choose how [MeshSync]({{< ref "concepts/architecture/meshsync.md" >}}) - the component that keeps Meshery's view of the cluster's resources up to date - runs:
 
-During credential registration, users can assign credentials to one or more connections and perform ad hoc connectivity tests. UI buttons include "Test" and "Register."
+- **Operator** - installs the [Meshery Operator]({{< ref "concepts/architecture/operator/index.md" >}}) into the cluster. MeshSync runs in-cluster and streams resource changes to Meshery in real time.
+- **Embedded** - runs MeshSync from within Meshery Server. Nothing is installed into the cluster; discovery happens out-of-cluster. This is the default.
 
-## Connection Configuration
+Switching the mode later makes Meshery redeploy MeshSync accordingly (see [Updating a Connection](#updating-a-connection)).
 
-The benefit of normalizing and extracting the status of a component as a direct property of the connection is to allow different systems to connect to the same component with different states. For example, multiple Meshery servers can connect to the same Kubernetes cluster, each having its own individual connection with a unique status.
+## Updating a Connection
 
-Now that you are familiar with MeshSync and its powerful features, you are ready to streamline your Kubernetes cluster management. 
+The wizard also reconfigures an already-registered Connection. From the [Connections]({{< ref "concepts/logical/connections/index.md" >}}) table, open a Connection's action menu and choose **Configure**. The wizard opens in configure mode and presents only the post-registration steps relevant to that kind.
 
+For a Kubernetes Connection, this is where you change the [MeshSync deployment mode](#meshsync-deployment-mode). Selecting a different mode and clicking **Apply** makes Meshery undeploy MeshSync and redeploy it in the newly selected mode (Operator or Embedded) for that cluster.
 
+{{% alert color="info" title="Changing a Connection's state" %}}
+Configuring a Connection is distinct from transitioning its **state** (Connected, Ignored, Disconnected, and so on). State transitions - and the rules governing which are allowed - are driven by the connection definition and performed from the status control on the Connections table. See [States and the Lifecycle of Connections]({{< ref "concepts/logical/connections/index.md#states-and-the-lifecycle-of-connections" >}}).
+{{% /alert %}}
 
+<!-- The Telemetry pages (guides/telemetry/*) ship in meshery/meshery#20161. Until that
+     merges, these are absolute docs.meshery.io links so this page does not break the Hugo
+     build, since an unresolved ref shortcode fails the build. Convert them to ref-shortcode
+     links once the Telemetry pages exist on master. -->
+## Using Connections for Telemetry
+
+Grafana and Prometheus Connections you register with the wizard power Meshery's [Telemetry](https://docs.meshery.io/guides/telemetry/) views. Once such a Connection reaches the **Connected** or **Registered** state, it becomes selectable in the Telemetry connection picker, where you can:
+
+- Browse and render your existing dashboards - see [Grafana Dashboards](https://docs.meshery.io/guides/telemetry/grafana-dashboards).
+- Explore metrics and save PromQL panels - see [Prometheus Metrics](https://docs.meshery.io/guides/telemetry/prometheus-metrics).
+
+## Registering Connections from the CLI
+
+Prefer the terminal? `mesheryctl` can create, list, view, and delete Connections too. See [`mesheryctl connection`]({{< ref "reference/references/mesheryctl/connection/_index.md" >}}).
+
+## Related
+
+- [Connections]({{< ref "concepts/logical/connections/index.md" >}}) - concepts and state lifecycle.
+- [Credentials]({{< ref "concepts/logical/credentials.md" >}}) - authentication for Connections.
+- [Environments]({{< ref "concepts/logical/environments.md" >}}) and [Workspaces]({{< ref "concepts/logical/workspaces.md" >}}) - grouping and sharing Connections.
+- [Managing Connections]({{< ref "guides/infrastructure-management/lifecycle-management/index.md" >}}) - lifecycle operations.
+- [Contributing a Connection]({{< ref "project/contributing/contributing-connections.md" >}}) - add a new Connection kind to the wizard.
+
+{{< discuss >}}

--- a/docs/content/en/installation/quick-start/index.md
+++ b/docs/content/en/installation/quick-start/index.md
@@ -85,7 +85,7 @@ Run connectivity tests and verify the health of your Meshery system. Verify Mesh
 
 ## 6. Design and operate Kubernetes clusters and their workloads
 
-You may now proceed to manage any cloud native infrastructure supported by Meshery. See all [integrations]({{< ref "reference/extensibility/api.md" >}}) for a complete list of supported infrastructure.
+You may now proceed to manage any cloud native infrastructure supported by Meshery. See all [integrations]({{< ref "extensions/models/_index.md" >}}) for a complete list of supported infrastructure.
 
 <a href="./images/meshery-designs.png">
   <img class="center" style="width:min(100%,650px);" src="./images/meshery-designs.png" />

--- a/docs/content/en/project/contributing/contributing-connections.md
+++ b/docs/content/en/project/contributing/contributing-connections.md
@@ -127,7 +127,7 @@ Two optional `metadata` keys tune wizard behavior:
 Place the definition as a JSON file in a `connections/` folder inside its Model, alongside that Model's `components/` and `relationships/`:
 
 ```
-server/meshmodel/<model>/<version>/<schemaVersion>/connections/<Name>Connection.json
+server/meshmodel/<model>/<version>/connections/<Name>Connection.json
 ```
 
 For example, the shipped definitions live under [`server/meshmodel/meshery-core/.../connections/`](https://github.com/meshery/meshery/tree/master/server/meshmodel) as `KubernetesConnection.json`, `GrafanaConnection.json`, and `PrometheusConnection.json`. A Model may include any number of connection definitions. Use these existing files as templates.

--- a/docs/content/en/project/contributing/contributing-connections.md
+++ b/docs/content/en/project/contributing/contributing-connections.md
@@ -1,0 +1,184 @@
+---
+title: Contributing to Connections
+description: How to define a new Connection and register it so Meshery understands it and includes it in the Connection Wizard.
+categories: [contributing]
+aliases:
+- /project/contributing/contributing-connection-definitions
+---
+
+**Connections are schema-driven.** A Connection's structure, identity, lifecycle, and the forms Meshery renders for it are declared in a **connection definition** that conforms to the [Connection schema](https://github.com/meshery/schemas/tree/master/schemas/constructs/v1beta3/connection) (`connections.meshery.io/v1beta3`) in [`meshery/schemas`](https://github.com/meshery/schemas). Before contributing, familiarize yourself with that schema and read [Contributing to Schemas]({{< ref "project/contributing/contributing-schemas.md" >}}) for the development workflow.
+
+This guide explains how to author a connection definition so that Meshery understands a new kind of [Connection]({{< ref "concepts/logical/connections/index.md" >}}) and offers it in the [Connection Wizard]({{< ref "guides/infrastructure-management/registering-a-connection.md" >}}). In most cases, **authoring a JSON definition is all you need** - no UI or server code.
+
+## What is a connection definition?
+
+A connection definition is a first-class [Registry]({{< ref "concepts/logical/registry.md" >}}) entity, authored per [Model]({{< ref "concepts/logical/models/index.md" >}}) - exactly like [Components]({{< ref "project/contributing/contributing-components.md" >}}) and [Relationships]({{< ref "project/contributing/contributing-relationships.md" >}}). It declares everything Meshery needs to register, render, and manage a kind of Connection:
+
+- its **identity** (`kind`, `type`, `subType`),
+- its **lifecycle** (initial `status` and a `transitionMap` of allowed [state transitions]({{< ref "concepts/logical/connections/index.md#states-and-the-lifecycle-of-connections" >}})),
+- the **forms** the Connection Wizard renders (`connectionSchema` and `credentialSchema`), and
+- its **visual identity** (`styles`).
+
+{{% alert color="warning" title="Prerequisite reading" %}}
+Connection definitions are packaged in the context of a Model. Be sure you understand <a href='{{< ref "project/contributing/contributing-models.md" >}}'>how Models are created and packaged</a> first - without a Model to belong to, your connection definition is homeless.
+{{% /alert %}}
+
+## Anatomy of a connection definition
+
+Below is a complete, minimal definition for a hypothetical telemetry backend. It uses the **generic** wizard flow, which is what most contributions should use.
+
+{{< code code=`{
+  "schemaVersion": "connections.meshery.io/v1beta3",
+  "name": "Grafana",
+  "description": "A Grafana instance that brings its dashboards and panels into Meshery.",
+  "kind": "grafana",
+  "type": "telemetry",
+  "subType": "metrics",
+  "status": "registered",
+  "transitionMap": {
+    "registered": [
+      { "nextState": "connected", "description": "Connect to the Grafana instance." },
+      { "nextState": "ignored", "description": "Keep the registration but do not connect." }
+    ],
+    "connected": [
+      { "nextState": "disconnected", "description": "Disconnect the Grafana connection." },
+      { "nextState": "deleted", "description": "Remove the Grafana connection completely." }
+    ]
+  },
+  "connectionSchema": {
+    "type": "object",
+    "title": "Grafana Connection",
+    "required": ["url"],
+    "properties": {
+      "url": {
+        "type": "string", "format": "uri", "title": "Grafana Endpoint",
+        "description": "Base URL of the Grafana instance (e.g. http://grafana.example:3000)."
+      },
+      "name": {
+        "type": "string", "title": "Connection Name",
+        "description": "Optional friendly name for this Grafana connection."
+      }
+    }
+  },
+  "credentialSchema": {
+    "type": "object",
+    "title": "Grafana Credential",
+    "properties": {
+      "secret": {
+        "type": "string", "title": "API Key or Basic Auth",
+        "description": "API key, or basic-auth credential formatted as username:password."
+      }
+    }
+  },
+  "styles": {
+    "svgColor": "<svg ...>...</svg>",
+    "svgWhite": "<svg ...>...</svg>"
+  }
+}` >}}
+
+### Identity: `kind`, `type`, `subType`
+
+These three fields identify the Connection and determine how the wizard treats it:
+
+- **`kind`** - the genre of Connection (e.g. `grafana`, `prometheus`, `kubernetes`). The wizard groups credentials and renders icons by `kind`.
+- **`type`** - a broad classification: `platform`, `telemetry`, `collaboration`, and so on.
+- **`subType`** - a finer classification: `orchestration`, `metrics`, `git`, `chat`, and so on.
+
+Together they let the UI target a specific Connection with a [custom wizard extension](#advanced-customizing-the-wizard) when the generic flow is not enough. For reference, the definitions Meshery ships with:
+
+| Connection | `kind`       | `type`      | `subType`       | initial `status` |
+| ---------- | ------------ | ----------- | --------------- | ---------------- |
+| Kubernetes | `kubernetes` | `platform`  | `orchestration` | `discovered`     |
+| Grafana    | `grafana`    | `telemetry` | `metrics`       | `registered`     |
+| Prometheus | `prometheus` | `telemetry` | `metrics`       | `registered`     |
+
+### Lifecycle: `status` and `transitionMap`
+
+`status` is the state a freshly created Connection starts in. Manually registered Connections typically start at `registered`; resources that Meshery discovers (like Kubernetes) start at `discovered`.
+
+`transitionMap` declares the **state machine** for the Connection: for each state, the list of states it may move to, each with a human-readable `description` shown as a confirmation prompt in the UI. Use only the canonical states - `discovered`, `registered`, `connected`, `disconnected`, `ignored`, `maintenance`, `deleted`, and `not found` - and keep the transitions consistent with their documented meanings. See [States and the Lifecycle of Connections]({{< ref "concepts/logical/connections/index.md#states-and-the-lifecycle-of-connections" >}}) for what each state means and which transitions make sense.
+
+{{% alert color="info" title="The transition map drives the UI" %}}
+The set of transitions Meshery offers a user for a given Connection comes directly from its definition's `transitionMap`. If a transition is not declared, it is not offered. Model the lifecycle deliberately.
+{{% /alert %}}
+
+### Forms: `connectionSchema` and `credentialSchema`
+
+Both are [JSON Schemas](https://json-schema.org/). The Connection Wizard renders them directly with [`react-jsonschema-form`](https://rjsf-team.github.io/react-jsonschema-form/docs/) - the same library used for [Component]({{< ref "project/contributing/contributing-components.md" >}}) forms:
+
+- **`connectionSchema`** becomes the **Configure Connection** step. Mark the fields a Connection cannot exist without (such as `url`) as `required`. A `name` property, if present, is used as the Connection's display name.
+- **`credentialSchema`** becomes the **Associate Credential** step. **Omit it** for a Connection that needs no secret - the wizard then skips the credential step entirely.
+
+Because these schemas live on the definition, the wizard needs no per-kind UI code to render them. Adding a property to the schema adds a field to the form.
+
+### Visual identity: `styles`
+
+`styles` carries inline SVG markup for the kind's icon: `svgColor` (for light backgrounds), `svgWhite` (for dark backgrounds), and optionally `svgComplete`. Follow the same icon conventions as [Components]({{< ref "project/contributing/contributing-components.md" >}}).
+
+### Optional `metadata`
+
+Two optional `metadata` keys tune wizard behavior:
+
+- **`metadata.flow`** - force a wizard flow: `generic` (the default for every kind except Kubernetes) or `kubernetes`. You rarely need to set this.
+- **`metadata.docsURL`** - a documentation link surfaced for the kind in the wizard. Defaults to the [Connections]({{< ref "concepts/logical/connections/index.md" >}}) concept page.
+
+## Where the definition lives
+
+Place the definition as a JSON file in a `connections/` folder inside its Model, alongside that Model's `components/` and `relationships/`:
+
+```
+server/meshmodel/<model>/<version>/<schemaVersion>/connections/<Name>Connection.json
+```
+
+For example, the shipped definitions live under [`server/meshmodel/meshery-core/.../connections/`](https://github.com/meshery/meshery/tree/master/server/meshmodel) as `KubernetesConnection.json`, `GrafanaConnection.json`, and `PrometheusConnection.json`. A Model may include any number of connection definitions. Use these existing files as templates.
+
+## How the definition is registered and consumed
+
+1. **Registration.** On Model registration, Meshery registers the connection definition into the [Registry]({{< ref "concepts/logical/registry.md" >}}) under its Model and registrant - the same path as Components and Relationships. A Model (carrying a registrant) is required. Definitions can also be managed over the registry API:
+
+   | Method   | Endpoint                                          | Purpose                                |
+   | -------- | ------------------------------------------------- | -------------------------------------- |
+   | `GET`    | `/api/meshmodels/connections`                     | List connection definitions            |
+   | `GET`    | `/api/meshmodels/connections/{id}`                | Fetch one definition                   |
+   | `POST`   | `/api/meshmodels/connections`                     | Register a definition (needs a Model)  |
+   | `PUT`    | `/api/meshmodels/connections/{id}`                | Update a definition                    |
+   | `DELETE` | `/api/meshmodels/connections/{id}`                | Remove a definition                    |
+
+2. **Consumption.** The [Connection Wizard]({{< ref "guides/infrastructure-management/registering-a-connection.md" >}}) lists every registered definition as a creatable kind and renders its `connectionSchema` and `credentialSchema` as wizard steps. **Register your definition and it appears in the wizard automatically** - no UI changes required.
+
+{{% alert color="info" title="Verify it appears" %}}
+After registering, open the Connection Wizard (**Connections → Create Connection**) and confirm your kind is listed with its icon, that the Configure and Associate Credential steps render your schemas, and that creating a Connection drives the states you declared in the `transitionMap`.
+{{% /alert %}}
+
+## Advanced: customizing the wizard
+
+The generic flow - choose → configure → credential → review → done, all derived from your schemas - covers most Connections. When a Connection needs bespoke steps (Kubernetes, for example, imports clusters from a kubeconfig and offers a MeshSync deployment-mode step), register a **connection extension** in the Meshery UI at `ui/components/connections/wizard/registry.ts`.
+
+An extension matches a Connection by `kind` (optionally narrowed by `type`/`subType`) and may override any step; the most specific match wins, and any step left unset falls back to the generic default:
+
+- `detailsStep`, `credentialStep`, `registerStep`, `receiptStep` - override individual steps. Set `credentialStep: null` to remove the credential step (Kubernetes carries its credential inline as a kubeconfig).
+- `postConfigSteps` - extra steps appended after registration; these also drive the wizard's **configure** mode for an already-registered Connection.
+
+Each step implements a small contract - an `id` and `label`, a `Component` to render, and optional `canProceed`, `onNext`, `nextLabel`, and `hidden` hooks. Use the existing `kubernetesExtension` as a worked example, and see [Contributing to the Meshery UI]({{< ref "project/contributing/contributing-ui.md" >}}) for building and testing UI changes.
+
+{{% alert color="warning" title="Prefer schemas over code" %}}
+Reach for a custom extension only when the generic, schema-driven flow genuinely cannot express what your Connection needs. A definition-only contribution is easier to review, ships without a UI release, and stays consistent with every other Connection in the wizard.
+{{% /alert %}}
+
+## Authoring best practices
+
+1. Use `camelCase` for property names, matching the rest of Meshery's schemas.
+2. Keep the `transitionMap` consistent with the [documented Connection states]({{< ref "concepts/logical/connections/index.md#states-and-the-lifecycle-of-connections" >}}); do not invent states.
+3. Mark only genuinely required fields as `required` in `connectionSchema`, and omit `credentialSchema` when no secret is needed.
+4. Start from a [shipped definition](https://github.com/meshery/meshery/tree/master/server/meshmodel) rather than from scratch.
+5. Provide both `svgColor` and `svgWhite` icons so the kind renders well on light and dark backgrounds.
+
+## Contribute your Connection
+
+Submit a pull request to the [Meshery repository](https://github.com/meshery/meshery) adding your connection definition to its Model's `connections/` folder, so every user benefits from the new Connection kind. Follow the [contribution gitflow]({{< ref "project/contributing/contributing-gitflow.md" >}}) and sign off your commits.
+
+{{% alert color="info" title="Keeping your Connection private" %}}
+Prefer to keep a Connection definition private? Bundle it in a custom [Model]({{< ref "concepts/logical/models/index.md" >}}) and [import that Model]({{< ref "guides/configuration-management/importing-models/index.md" >}}) into your Meshery deployment. Your definition is registered in your Meshery Server's [Registry]({{< ref "concepts/logical/registry.md" >}}) and offered in your Connection Wizard, without being published upstream.
+{{% /alert %}}
+
+{{< discuss >}}

--- a/docs/content/en/project/contributing/contributing-models.md
+++ b/docs/content/en/project/contributing/contributing-models.md
@@ -13,10 +13,11 @@ Meshery uses a logical object model to describe the infrastructure and capabilit
 
 #### What Are Meshery Models?
 
-At the core of this system are **Meshery Models** — packages that define a specific type of infrastructure, application, or capability. These models include:
+At the core of this system are **Meshery Models** - packages that define a specific type of infrastructure, application, or capability. These models include:
 
 - **[Components]({{< ref "concepts/logical/components.md" >}})**: Individual parts of a system (e.g., services, databases).
 - **[Relationships]({{< ref "concepts/logical/relationships/index.md" >}})**: How those parts interact.
+- **[Connections]({{< ref "concepts/logical/connections/index.md" >}})**: How Meshery reaches and manages the resource a model represents. See [Contributing to Connections]({{< ref "project/contributing/contributing-connections.md" >}}).
 - **Metadata**: Visual and behavioral traits, such as icons or capabilities.
 
 Models can describe traditional technologies (like Kubernetes workloads), or more abstract entities (like annotations or diagrams).
@@ -187,7 +188,7 @@ Meshery automatically generates models and components by parsing schemas from va
 When generating components, Meshery processes input schemas and automatically organizes them into **Models**. This grouping process logically binds related components together based on their source.
 
 **Source-Based Grouping:**  
-Components are grouped based on their origin—such as a specific GitHub repository, Helm chart, or Kubernetes cluster. For example:
+Components are grouped based on their origin - such as a specific GitHub repository, Helm chart, or Kubernetes cluster. For example:
 
 - Importing a Helm chart for Prometheus from ArtifactHub creates a "Prometheus" Model containing all resources defined in that chart (Services, Deployments, ConfigMaps, etc.) as components
 - Connecting to a Kubernetes cluster creates a "Kubernetes" Model containing all discovered CRDs as components


### PR DESCRIPTION
## Notes for Reviewers

This PR adds the two Meshery Docs pages for the **Connection Wizard** feature - one for users and one for contributors.

### User guide - "Registering a Connection"

`guides/infrastructure-management/registering-a-connection.md` is rewritten into the user guide for the Connection Wizard. The page previously titled "Infrastructure Discovery" described the superseded Registration Modal; the Telemetry docs (#20161) already link to this path 4× as "Registering a Connection," so this makes those inbound links resolve to current content rather than stale content.

It covers:
- Launching the wizard and the permissions it requires.
- The generic create flow (choose → configure → associate credential → review & create).
- The Kubernetes kubeconfig import flow (context discovery/selection, per-context naming).
- MeshSync deployment mode (Operator vs Embedded), and reconfiguring it via the configure/update flow.
- Using Grafana/Prometheus connections for Telemetry.

### Contributor guide - "Contributing to Connections"

`project/contributing/contributing-connections.md` (new) explains how to make Meshery understand a new Connection and include it in the wizard by authoring a connection definition (`connections.meshery.io/v1beta3`):
- Identity (`kind`/`type`/`subType`), `status` + `transitionMap`, `connectionSchema`/`credentialSchema`, `styles`, and optional `metadata`.
- Where the definition lives (per-model `connections/` folder) and how it is registered in the registry and consumed by the wizard - definition-only, no UI code for the generic flow.
- The advanced path: registering a custom wizard extension for non-generic flows (the Kubernetes pattern).

### Interlinking

Both pages redirect to canonical coverage (Connections lifecycle, Credentials, Environments, Workspaces, Registry, MeshSync, Models) rather than duplicating it. Added inbound links from the Connections concept page and the "Contributing to Models" page, and fixed two pre-existing em-dashes in the latter.

### Functionality covered from referenced PRs

- Connection Wizard backend and UX: #20089
- Telemetry connections (Grafana/Prometheus): #20161

The Telemetry pages ship in #20161 (still open). To keep the docs build green regardless of merge order, the forward-links to those three pages use absolute `docs.meshery.io` URLs (an unresolved `ref` shortcode fails the Hugo build). A code comment flags them to be tightened to `ref` once #20161 lands. Everything else uses `ref`.

### Verification

- Built the changed pages in an isolated Hugo site (the full local build is blocked on SCSS in this environment): build succeeds, all `ref` cross-references resolve, all anchors resolve, and shortcodes/tables/code blocks render.
- All new content is em-dash-free per project convention.

## This PR fixes #

N/A - documentation for an already-merged feature (#20089).

**[Signed commits](https://github.com/meshery/meshery/blob/master/CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [x] Yes, I signed my commits.
