### PR TITLE
fix(ImportModelModal): subscribe to operations-center before HTTP req…

### DIFF
--- a/ui/components/registry/ImportModelModal.test.tsx
+++ b/ui/components/registry/ImportModelModal.test.tsx
@@ -231,4 +231,54 @@ describe('ImportModelModal', () => {
 
     expect(unsubscribe).toHaveBeenCalled();
   });
+
+  it('renders the import result when the register event is received for url', async () => {
+    const unsubscribe = vi.fn();
+    mockOn.mockReturnValue({ unsubscribe });
+    render(<ImportModelModal isImportModalOpen={true} setIsImportModalOpen={vi.fn()} />);
+    fireEvent.click(screen.getByTestId('submit-url'));
+    await Promise.resolve();
+
+    const handler = mockOn.mock.calls[0][1];
+    expect(screen.getByTestId('loading')).toBeInTheDocument();
+
+    handler({
+      data: {
+        event: {
+          action: 'register',
+          metadata: { ModelImportMessage: 'ok', ModelDetails: {} },
+        },
+      },
+    });
+
+    expect(screen.queryByTestId('loading')).not.toBeInTheDocument();
+    expect(screen.getByTestId('import-messages')).toBeInTheDocument();
+    expect(screen.getByTestId('imported-section')).toBeInTheDocument();
+    expect(unsubscribe).toHaveBeenCalled();
+  });
+
+  it('renders the import result when the register event is received for file', async () => {
+    const unsubscribe = vi.fn();
+    mockOn.mockReturnValue({ unsubscribe });
+    render(<ImportModelModal isImportModalOpen={true} setIsImportModalOpen={vi.fn()} />);
+    fireEvent.click(screen.getByTestId('submit-file'));
+    await Promise.resolve();
+
+    const handler = mockOn.mock.calls[0][1];
+    expect(screen.getByTestId('loading')).toBeInTheDocument();
+
+    handler({
+      data: {
+        event: {
+          action: 'register',
+          metadata: { ModelImportMessage: 'ok', ModelDetails: {} },
+        },
+      },
+    });
+
+    expect(screen.queryByTestId('loading')).not.toBeInTheDocument();
+    expect(screen.getByTestId('import-messages')).toBeInTheDocument();
+    expect(screen.getByTestId('imported-section')).toBeInTheDocument();
+    expect(unsubscribe).toHaveBeenCalled();
+  });
 });

--- a/ui/components/registry/ImportModelModal.test.tsx
+++ b/ui/components/registry/ImportModelModal.test.tsx
@@ -1,9 +1,11 @@
 import React from 'react';
-import { render, screen, fireEvent } from '@testing-library/react';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
-const importModelReq = vi.fn();
-const mockOn = vi.fn().mockReturnValue({ unsubscribe: vi.fn() });
+const { importModelReq, mockOn } = vi.hoisted(() => ({
+  importModelReq: vi.fn(),
+  mockOn: vi.fn().mockReturnValue({ unsubscribe: vi.fn() }),
+}));
 
 vi.mock('@sistent/sistent', () => ({
   FormControlLabel: ({ label, control }: any) => (
@@ -237,10 +239,9 @@ describe('ImportModelModal', () => {
     mockOn.mockReturnValue({ unsubscribe });
     render(<ImportModelModal isImportModalOpen={true} setIsImportModalOpen={vi.fn()} />);
     fireEvent.click(screen.getByTestId('submit-url'));
-    await Promise.resolve();
+    await waitFor(() => expect(screen.getByTestId('loading')).toBeInTheDocument());
 
     const handler = mockOn.mock.calls[0][1];
-    expect(screen.getByTestId('loading')).toBeInTheDocument();
 
     handler({
       data: {
@@ -250,8 +251,8 @@ describe('ImportModelModal', () => {
         },
       },
     });
+    await waitFor(() => expect(screen.queryByTestId('loading')).not.toBeInTheDocument());
 
-    expect(screen.queryByTestId('loading')).not.toBeInTheDocument();
     expect(screen.getByTestId('import-messages')).toBeInTheDocument();
     expect(screen.getByTestId('imported-section')).toBeInTheDocument();
     expect(unsubscribe).toHaveBeenCalled();
@@ -262,10 +263,9 @@ describe('ImportModelModal', () => {
     mockOn.mockReturnValue({ unsubscribe });
     render(<ImportModelModal isImportModalOpen={true} setIsImportModalOpen={vi.fn()} />);
     fireEvent.click(screen.getByTestId('submit-file'));
-    await Promise.resolve();
+    await waitFor(() => expect(screen.getByTestId('loading')).toBeInTheDocument());
 
     const handler = mockOn.mock.calls[0][1];
-    expect(screen.getByTestId('loading')).toBeInTheDocument();
 
     handler({
       data: {
@@ -276,7 +276,7 @@ describe('ImportModelModal', () => {
       },
     });
 
-    expect(screen.queryByTestId('loading')).not.toBeInTheDocument();
+    await waitFor(() => expect(screen.queryByTestId('loading')).not.toBeInTheDocument());
     expect(screen.getByTestId('import-messages')).toBeInTheDocument();
     expect(screen.getByTestId('imported-section')).toBeInTheDocument();
     expect(unsubscribe).toHaveBeenCalled();

--- a/ui/components/registry/ImportModelModal.test.tsx
+++ b/ui/components/registry/ImportModelModal.test.tsx
@@ -3,6 +3,7 @@ import { render, screen, fireEvent } from '@testing-library/react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 const importModelReq = vi.fn();
+const mockOn = vi.fn().mockReturnValue({ unsubscribe: vi.fn() });
 
 vi.mock('@sistent/sistent', () => ({
   FormControlLabel: ({ label, control }: any) => (
@@ -26,6 +27,12 @@ vi.mock('@/components/shared/Modal', () => ({
     isOpen ? (
       <div data-testid={`modal-${title}`}>
         <div data-testid="rjsf-wrapper">{helpText}</div>
+        <button
+          data-testid="submit-file"
+          onClick={() => onSubmit({ uploadType: 'file', modelFile: 'mockFile' })}
+        >
+          submit-file
+        </button>
         <button
           data-testid="submit-url"
           onClick={() => onSubmit({ uploadType: 'urlImport', url: 'https://x.com' })}
@@ -76,9 +83,7 @@ vi.mock('@/components/designs/lifecycle/common', () => ({
 
 vi.mock('@/components/layout/NotificationCenter', () => {
   const Ctx = (require('react') as typeof import('react')).createContext({
-    operationsCenterActorRef: {
-      on: () => ({ unsubscribe: () => {} }),
-    },
+    operationsCenterActorRef: { on: mockOn },
   });
   return { NotificationCenterContext: Ctx };
 });
@@ -125,6 +130,8 @@ describe('ImportModelModal', () => {
   beforeEach(() => {
     importModelReq.mockReset();
     importModelReq.mockReturnValue({ unwrap: () => Promise.resolve({}) });
+    mockOn.mockReset();
+    mockOn.mockReturnValue({ unsubscribe: vi.fn() });
   });
 
   it('renders the main Import Model modal when open', () => {
@@ -155,6 +162,13 @@ describe('ImportModelModal', () => {
     consoleSpy.mockRestore();
   });
 
+  it('calls importModelReq on file submission with a valid file', async () => {
+    render(<ImportModelModal isImportModalOpen={true} setIsImportModalOpen={vi.fn()} />);
+    fireEvent.click(screen.getByTestId('submit-file'));
+    await Promise.resolve();
+    expect(importModelReq).toHaveBeenCalled();
+  });
+
   it('does not call importModelReq for an invalid upload type', () => {
     const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
     render(<ImportModelModal isImportModalOpen={true} setIsImportModalOpen={vi.fn()} />);
@@ -172,5 +186,49 @@ describe('ImportModelModal', () => {
     fireEvent.click(screen.getByTestId('submit-csv'));
     expect(setIsImportModalOpen).toHaveBeenCalledWith(false);
     expect(screen.getByTestId('modal-Import CSV')).toBeInTheDocument();
+  });
+
+  it('subscribes to operations-center before firing the import request for url', async () => {
+    render(<ImportModelModal isImportModalOpen={true} setIsImportModalOpen={vi.fn()} />);
+    fireEvent.click(screen.getByTestId('submit-url'));
+    await Promise.resolve();
+
+    const onCallOrder = mockOn.mock.invocationCallOrder[0];
+    const reqCallOrder = importModelReq.mock.invocationCallOrder[0];
+    expect(onCallOrder).toBeLessThan(reqCallOrder);
+  });
+
+  it('subscribes to operations-center before firing the import request for file', async () => {
+    render(<ImportModelModal isImportModalOpen={true} setIsImportModalOpen={vi.fn()} />);
+    fireEvent.click(screen.getByTestId('submit-file'));
+    await Promise.resolve();
+
+    const onCallOrder = mockOn.mock.invocationCallOrder[0];
+    const reqCallOrder = importModelReq.mock.invocationCallOrder[0];
+    expect(onCallOrder).toBeLessThan(reqCallOrder);
+  });
+
+  it('unsubscribes from operations-center on import request failure for url', async () => {
+    const unsubscribe = vi.fn();
+    mockOn.mockReturnValue({ unsubscribe });
+    importModelReq.mockReturnValue({ unwrap: () => Promise.reject(new Error('failed')) });
+
+    render(<ImportModelModal isImportModalOpen={true} setIsImportModalOpen={vi.fn()} />);
+    fireEvent.click(screen.getByTestId('submit-url'));
+    await Promise.resolve();
+
+    expect(unsubscribe).toHaveBeenCalled();
+  });
+
+  it('unsubscribes from operations-center on import request failure for file', async () => {
+    const unsubscribe = vi.fn();
+    mockOn.mockReturnValue({ unsubscribe });
+    importModelReq.mockReturnValue({ unwrap: () => Promise.reject(new Error('failed')) });
+
+    render(<ImportModelModal isImportModalOpen={true} setIsImportModalOpen={vi.fn()} />);
+    fireEvent.click(screen.getByTestId('submit-file'));
+    await Promise.resolve();
+
+    expect(unsubscribe).toHaveBeenCalled();
   });
 });

--- a/ui/components/registry/ImportModelModal.test.tsx
+++ b/ui/components/registry/ImportModelModal.test.tsx
@@ -217,9 +217,7 @@ describe('ImportModelModal', () => {
 
     render(<ImportModelModal isImportModalOpen={true} setIsImportModalOpen={vi.fn()} />);
     fireEvent.click(screen.getByTestId('submit-url'));
-    await Promise.resolve();
-
-    expect(unsubscribe).toHaveBeenCalled();
+    await waitFor(() => expect(unsubscribe).toHaveBeenCalled());
   });
 
   it('unsubscribes from operations-center on import request failure for file', async () => {
@@ -229,9 +227,7 @@ describe('ImportModelModal', () => {
 
     render(<ImportModelModal isImportModalOpen={true} setIsImportModalOpen={vi.fn()} />);
     fireEvent.click(screen.getByTestId('submit-file'));
-    await Promise.resolve();
-
-    expect(unsubscribe).toHaveBeenCalled();
+    await waitFor(() => expect(unsubscribe).toHaveBeenCalled());
   });
 
   it('renders the import result when the register event is received for url', async () => {

--- a/ui/components/registry/ImportModelModal.tsx
+++ b/ui/components/registry/ImportModelModal.tsx
@@ -167,6 +167,10 @@ const ImportModelModal = memo<ImportModelModalProps>(
       if (!isImportModalOpen) {
         subscriptionRef.current?.unsubscribe();
         subscriptionRef.current = null;
+        setIsCsvModalOpen(false);
+        setActiveStep(0);
+        setIsDeploying(true);
+        setDeployEvent(undefined);
       }
       return () => {
         subscriptionRef.current?.unsubscribe();

--- a/ui/components/registry/ImportModelModal.tsx
+++ b/ui/components/registry/ImportModelModal.tsx
@@ -32,7 +32,7 @@ import { Modal, FormModal } from '@/components/shared/Modal';
 import CsvStepper from './Stepper/CSVStepper';
 import { MESHERY_DOCS_URL } from '@/constants/endpoints';
 import { useImportMeshModelMutation } from '@/rtk-query/meshModel';
-import { useState, useEffect, useContext, memo } from 'react';
+import { useState, useContext, useRef, useEffect, memo } from 'react';
 import { capitalize } from 'lodash';
 import { Loading } from '@/components/designs/lifecycle/common';
 import { NotificationCenterContext } from '@/components/layout/NotificationCenter';
@@ -57,25 +57,16 @@ import {
   importModelUiSchema,
 } from './importModelSchema';
 
-const FinishDeploymentStep = ({ deploymentType }: { deploymentType: string }) => {
-  const { operationsCenterActorRef } = useContext(NotificationCenterContext);
-  const [isDeploying, setIsDeploying] = useState(true);
-  const [deployEvent, setDeployEvent] = useState<any>();
+const FinishDeploymentStep = ({
+  deploymentType,
+  isDeploying,
+  deployEvent,
+}: {
+  deploymentType: string;
+  isDeploying: boolean;
+  deployEvent: any;
+}) => {
   const theme = useTheme();
-
-  useEffect(() => {
-    const subscription = operationsCenterActorRef.on(
-      OPERATION_CENTER_EVENTS.EVENT_RECEIVED_FROM_SERVER,
-      (event) => {
-        const serverEvent = event.data.event;
-        if (serverEvent.action === deploymentType) {
-          setIsDeploying(false);
-          setDeployEvent(serverEvent);
-        }
-      },
-    );
-    return () => subscription.unsubscribe();
-  }, []);
 
   const progressMessage = `${capitalize(deploymentType)}ing model`;
 
@@ -167,6 +158,26 @@ const ImportModelModal = memo<ImportModelModalProps>(
     const [importModelReq] = useImportMeshModelMutation();
     const [activeStep, setActiveStep] = useState(0);
     const { notify } = useNotification();
+    const { operationsCenterActorRef } = useContext(NotificationCenterContext);
+    const [isDeploying, setIsDeploying] = useState(true);
+    const [deployEvent, setDeployEvent] = useState<any>();
+
+    const subscriptionRef = useRef<{ unsubscribe: () => void } | null>(null);
+
+useEffect(() => {
+  if (!isImportModalOpen) {
+    subscriptionRef.current?.unsubscribe();
+    subscriptionRef.current = null;
+    setActiveStep(0);
+    setIsCsvModalOpen(false);
+    setIsDeploying(true);
+    setDeployEvent(undefined);
+  }
+  return () => {
+    subscriptionRef.current?.unsubscribe();
+    subscriptionRef.current = null;
+  };
+}, [isImportModalOpen]);
 
     const handleClose = () => {
       setIsImportModalOpen(false);
@@ -273,6 +284,31 @@ const ImportModelModal = memo<ImportModelModalProps>(
         }
       }
 
+// Subscribe to the operations-center bus before firing the request to avoid
+      // the race where the server emits the event before FinishDeploymentStep mounts.
+      // The loader stops on the first matching `register` event regardless of severity.
+      setIsDeploying(true);
+      setDeployEvent(undefined);
+      subscriptionRef.current?.unsubscribe();
+
+      const subscription = operationsCenterActorRef.on(
+        OPERATION_CENTER_EVENTS.EVENT_RECEIVED_FROM_SERVER,
+        (event) => {
+          const serverEvent = event?.data?.event;
+          if (
+            serverEvent?.action === 'register' &&
+            (serverEvent?.metadata?.ModelImportMessage !== undefined ||
+              serverEvent?.metadata?.ModelDetails !== undefined)
+          ) {
+            setIsDeploying(false);
+            setDeployEvent(serverEvent);
+            subscription.unsubscribe();
+            subscriptionRef.current = null;
+          }
+        },
+      );
+
+      subscriptionRef.current = subscription;
       updateProgress({ showProgress: true });
       setActiveStep(1);
 
@@ -280,12 +316,14 @@ const ImportModelModal = memo<ImportModelModalProps>(
         try {
           await importModelReq({ importBody: requestBody }).unwrap();
         } catch (err) {
-          console.error('Failed to import model:', err);
-          notify({
-            message: 'Model import failed. Please verify the file or URL and try again.',
-            event_type: EVENT_TYPES.ERROR,
-          });
-          setActiveStep(0); // Move back on failure
+ subscriptionRef.current?.unsubscribe();
+  subscriptionRef.current = null;
+  console.error('Failed to import model:', err);
+  notify({
+    message: 'Model import failed. Please verify the file or URL and try again.',
+    event_type: EVENT_TYPES.ERROR,
+  });
+  setActiveStep(0);
         } finally {
           updateProgress({ showProgress: false });
         }
@@ -333,7 +371,11 @@ const ImportModelModal = memo<ImportModelModalProps>(
             actions={<ModalButtonPrimary onClick={handleClose}>Finish</ModalButtonPrimary>}
             sx={{ zIndex: 1600 }}
           >
-            <FinishDeploymentStep deploymentType="register" />
+            <FinishDeploymentStep
+              deploymentType="register"
+              isDeploying={isDeploying}
+              deployEvent={deployEvent}
+            />
           </Modal>
         )}
 

--- a/ui/components/registry/ImportModelModal.tsx
+++ b/ui/components/registry/ImportModelModal.tsx
@@ -161,6 +161,13 @@ const ImportModelModal = memo<ImportModelModalProps>(
     const { operationsCenterActorRef } = useContext(NotificationCenterContext);
     const [isDeploying, setIsDeploying] = useState(true);
     const [deployEvent, setDeployEvent] = useState<any>();
+    const subscriptionRef = useRef<{ unsubscribe: () => void } | null>(null);
+
+    useEffect(() => {
+      return () => {
+        subscriptionRef.current?.unsubscribe();
+      };
+    }, []);
 
     const subscriptionRef = useRef<{ unsubscribe: () => void } | null>(null);
 
@@ -309,25 +316,22 @@ useEffect(() => {
       );
 
       subscriptionRef.current = subscription;
-      updateProgress({ showProgress: true });
-      setActiveStep(1);
 
-      (async () => {
-        try {
-          await importModelReq({ importBody: requestBody }).unwrap();
-        } catch (err) {
- subscriptionRef.current?.unsubscribe();
-  subscriptionRef.current = null;
-  console.error('Failed to import model:', err);
-  notify({
-    message: 'Model import failed. Please verify the file or URL and try again.',
-    event_type: EVENT_TYPES.ERROR,
-  });
-  setActiveStep(0);
-        } finally {
-          updateProgress({ showProgress: false });
-        }
-      })();
+      updateProgress({ showProgress: true });
+      try {
+        await importModelReq({ importBody: requestBody }).unwrap();
+        setActiveStep(1);
+      } catch (err) {
+        subscriptionRef.current?.unsubscribe();
+        subscriptionRef.current = null;
+        console.error('Failed to import model:', err);
+        notify({
+          message: 'Model import failed. Please verify the file or URL and try again.',
+          event_type: EVENT_TYPES.ERROR,
+        });
+      } finally {
+        updateProgress({ showProgress: false });
+      }
     };
 
     const helpText = (

--- a/ui/components/registry/ImportModelModal.tsx
+++ b/ui/components/registry/ImportModelModal.tsx
@@ -178,23 +178,6 @@ const ImportModelModal = memo<ImportModelModalProps>(
       };
     }, [isImportModalOpen]);
 
-    const subscriptionRef = useRef<{ unsubscribe: () => void } | null>(null);
-
-useEffect(() => {
-  if (!isImportModalOpen) {
-    subscriptionRef.current?.unsubscribe();
-    subscriptionRef.current = null;
-    setActiveStep(0);
-    setIsCsvModalOpen(false);
-    setIsDeploying(true);
-    setDeployEvent(undefined);
-  }
-  return () => {
-    subscriptionRef.current?.unsubscribe();
-    subscriptionRef.current = null;
-  };
-}, [isImportModalOpen]);
-
     const handleClose = () => {
       setIsImportModalOpen(false);
       setIsCsvModalOpen(false);
@@ -300,7 +283,7 @@ useEffect(() => {
         }
       }
 
-// Subscribe to the operations-center bus before firing the request to avoid
+      // Subscribe to the operations-center bus before firing the request to avoid
       // the race where the server emits the event before FinishDeploymentStep mounts.
       // The loader stops on the first matching `register` event regardless of severity.
       setIsDeploying(true);

--- a/ui/components/registry/ImportModelModal.tsx
+++ b/ui/components/registry/ImportModelModal.tsx
@@ -310,12 +310,13 @@ const ImportModelModal = memo<ImportModelModalProps>(
       subscriptionRef.current = subscription;
 
       updateProgress({ showProgress: true });
+      setActiveStep(1);
       try {
         await importModelReq({ importBody: requestBody }).unwrap();
-        setActiveStep(1);
       } catch (err) {
         subscriptionRef.current?.unsubscribe();
         subscriptionRef.current = null;
+        setActiveStep(0);
         console.error('Failed to import model:', err);
         notify({
           message: 'Model import failed. Please verify the file or URL and try again.',

--- a/ui/components/registry/ImportModelModal.tsx
+++ b/ui/components/registry/ImportModelModal.tsx
@@ -164,10 +164,15 @@ const ImportModelModal = memo<ImportModelModalProps>(
     const subscriptionRef = useRef<{ unsubscribe: () => void } | null>(null);
 
     useEffect(() => {
+      if (!isImportModalOpen) {
+        subscriptionRef.current?.unsubscribe();
+        subscriptionRef.current = null;
+      }
       return () => {
         subscriptionRef.current?.unsubscribe();
+        subscriptionRef.current = null;
       };
-    }, []);
+    }, [isImportModalOpen]);
 
     const subscriptionRef = useRef<{ unsubscribe: () => void } | null>(null);
 

--- a/ui/vitest.config.ts
+++ b/ui/vitest.config.ts
@@ -21,7 +21,6 @@ export default defineConfig({
       // in SistentThemeProvider, or (b) exhaustively stubbing the imported
       // exports. Tracked separately from the Nighthawk removal.
       'components/layout/Header/Header.test.tsx',
-      'components/registry/ImportModelModal.test.tsx',
       'components/registry/CreateModelModal.test.tsx',
       'components/registry/MeshModelComponent.test.tsx',
     ],


### PR DESCRIPTION
…uest to avoid missing server event

**Notes for Reviewers**

- This PR fixes #20191 
- Fixed a race condition where FinishDeploymentStep missed the server-emitted import event because the subscription was set up after the component mounted, by which point the event had already fired.
- Moved the operations-center subscription into ImportModelModal so it is active before the HTTP request is fired, and passed isDeploying/deployEvent as props to FinishDeploymentStep which is now a pure display component

**[Signed commits](https://github.com/meshery/meshery/blob/master/CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [x] Yes, I signed my commits.
