### PR TITLE
fix(error-404): show the user's assigned organization roles in Current Session

### DIFF
--- a/ui/components/general/error-404/CurrentSession.tsx
+++ b/ui/components/general/error-404/CurrentSession.tsx
@@ -1,5 +1,4 @@
 import React from 'react';
-import { useGetUserOrgRolesQuery } from '@/rtk-query/orgRoles';
 import { useGetUserProviderRolesQuery } from '@/rtk-query/providerRoles';
 import {
   StyledBox,
@@ -24,22 +23,18 @@ import { useGetSelectedOrganization } from '@/rtk-query/user';
 const CurrentSessionInfo = () => {
   const { selectedOrganization } = useGetSelectedOrganization();
 
-  const {
-    data: rolesRes,
-    // isSuccess: isRolesSuccess,
-    // isError: isRolesError,
-    // error: rolesError,
-  } = useGetUserOrgRolesQuery(
-    { orgId: selectedOrganization?.id },
-    { skip: !selectedOrganization?.id },
-  );
+  // The logged-in user profile (/api/user) already carries the user's
+  // per-organization role assignments under organizations.organizationsWithRoles,
+  // so this single profile query powers both the provider (global) roles and the
+  // organization roles rendered below — no separate org-roles request is needed.
+  const { data: providerRolesRes } = useGetUserProviderRolesQuery();
 
-  const {
-    data: providerRolesRes,
-    // isSuccess: isProviderRolesSuccess,
-    // isError: isProviderRolesError,
-    // error: providerRolesError,
-  } = useGetUserProviderRolesQuery();
+  // Roles assigned to the signed-in user within the currently selected
+  // organization (as opposed to every role defined in that organization).
+  const organizationRoleNames =
+    providerRolesRes?.organizations?.organizationsWithRoles?.find(
+      (org) => org.id === selectedOrganization?.id,
+    )?.roleNames ?? [];
 
   const theme = useTheme();
 
@@ -70,8 +65,8 @@ const CurrentSessionInfo = () => {
           </CustomTooltip>
         </HeaderContainer>
         <StyledBox>
-          {rolesRes
-            ? rolesRes?.roles?.map?.((role) => <StyledChip key={role.id} label={role.roleName} />)
+          {organizationRoleNames.length > 0
+            ? organizationRoleNames.map((role, index) => <StyledChip key={index} label={role} />)
             : 'No roles found'}
         </StyledBox>
       </div>


### PR DESCRIPTION
## Problem

The "Current Session" panel on the error-404 page sourced its **Organization Role(s)**
from `useGetUserOrgRolesQuery`, a locally-defined query that calls
`GET /identity/orgs/{orgId}/roles` (`getAllRoles`). That endpoint returns **every role
defined in the organization**, not the roles assigned to the signed-in user — so the
panel displayed a misleading role set, and did so through a hand-rolled query that
bypasses schema-driven typing.

## Fix

Reuse the logged-in-user profile query (`/api/user`) that the component **already
calls** for provider roles. That response (`models.User`) carries
`organizations.organizationsWithRoles`, where each membership entry holds the user's
assigned `roleNames` for that organization. The panel now selects the entry for the
currently selected organization and renders those role names.

- One profile request now powers **both** the provider (global) and organization role
  sections — the extra `getAllRoles` request is gone.
- The displayed roles are the user's **actual** assigned organization roles.

`useGetUserOrgRolesQuery` / `rtk-query/orgRoles.ts` is intentionally **kept**: the
getting-started onboarding flow (`GetStartedModal`) still uses it — correctly — to list
*assignable* organization roles when inviting users. Only the Current-Session misuse is
removed.

## Related

Backed by meshery/schemas#947, which types `User.organizations.organizationsWithRoles`
(and `teams.teamsWithRoles`) so the assigned role names are strongly typed once that
release is consumed here. This UI change is runtime-correct with the current
`@meshery/schemas` as well (the field is already present on the wire).

## Test plan
- [x] `eslint components/general/error-404/CurrentSession.tsx` — clean
- [x] `tsc --noEmit` — no type errors referencing the changed file
- [ ] Manual: open the error page with a user who holds specific org roles; confirm the
      Organization Role(s) chips match the user's assigned roles in the selected org
      (and update on org switch). *(requires a running session; not run here)*
