### PR TITLE
[Relationships] Enforce strict Kubernetes binding semantics for PV to PVC edge

### DIFF
--- a/models/kubernetes/v1.37.0-alpha.1/v1.0.0/relationships/pv-to-pvc-reference.json
+++ b/models/kubernetes/v1.37.0-alpha.1/v1.0.0/relationships/pv-to-pvc-reference.json
@@ -3,7 +3,7 @@
   "evaluationQuery": "",
   "kind": "edge",
   "metadata": {
-    "description": "Reference relationship between PersistentVolume and PersistentVolumeClaim. Automatically configures the PVC to reference the PV by name, and syncs storageClassName and volumeMode when an edge is drawn.",
+    "description": "Automatically configures the PersistentVolumeClaim to reference the PersistentVolume by name, and syncs storageClassName and volumeMode when an edge is drawn.",
     "isAnnotation": false,
     "styles": {
       "primaryColor": "",

--- a/models/kubernetes/v1.37.0-alpha.1/v1.0.0/relationships/pv-to-pvc-reference.json
+++ b/models/kubernetes/v1.37.0-alpha.1/v1.0.0/relationships/pv-to-pvc-reference.json
@@ -3,7 +3,7 @@
   "evaluationQuery": "",
   "kind": "edge",
   "metadata": {
-    "description": "",
+    "description": "Reference relationship between PersistentVolume and PersistentVolumeClaim. Automatically configures the PVC to reference the PV by name, and syncs storageClassName and volumeMode when an edge is drawn.",
     "isAnnotation": false,
     "styles": {
       "primaryColor": "",
@@ -36,6 +36,12 @@
               [
                 "equal_as_strings",
                 "not_null"
+              ],
+              [
+                "equal_as_strings"
+              ],
+              [
+                "equal"
               ]
             ],
             "model": {
@@ -53,9 +59,17 @@
             "patch": {
               "mutatorRef": [
                 [
+                  "displayName"
+                ],
+                [
                   "configuration",
-                  "metadata",
-                  "name"
+                  "spec",
+                  "storageClassName"
+                ],
+                [
+                  "configuration",
+                  "spec",
+                  "volumeMode"
                 ]
               ],
               "patchStrategy": "replace"
@@ -86,6 +100,16 @@
                   "configuration",
                   "spec",
                   "volumeName"
+                ],
+                [
+                  "configuration",
+                  "spec",
+                  "storageClassName"
+                ],
+                [
+                  "configuration",
+                  "spec",
+                  "volumeMode"
                 ]
               ],
               "patchStrategy": "replace"

--- a/models/kubernetes/v1.37.0-alpha.2/v1.0.0/relationships/pv-to-pvc-reference.json
+++ b/models/kubernetes/v1.37.0-alpha.2/v1.0.0/relationships/pv-to-pvc-reference.json
@@ -3,7 +3,7 @@
   "evaluationQuery": "",
   "kind": "edge",
   "metadata": {
-    "description": "",
+    "description": "Automatically configures the PersistentVolumeClaim to reference the PersistentVolume by name, and syncs storageClassName and volumeMode when an edge is drawn.",
     "isAnnotation": false,
     "styles": {
       "primaryColor": "",
@@ -36,6 +36,12 @@
               [
                 "equal_as_strings",
                 "not_null"
+              ],
+              [
+                "equal_as_strings"
+              ],
+              [
+                "equal"
               ]
             ],
             "model": {
@@ -53,9 +59,17 @@
             "patch": {
               "mutatorRef": [
                 [
+                  "displayName"
+                ],
+                [
                   "configuration",
-                  "metadata",
-                  "name"
+                  "spec",
+                  "storageClassName"
+                ],
+                [
+                  "configuration",
+                  "spec",
+                  "volumeMode"
                 ]
               ],
               "patchStrategy": "replace"
@@ -86,6 +100,16 @@
                   "configuration",
                   "spec",
                   "volumeName"
+                ],
+                [
+                  "configuration",
+                  "spec",
+                  "storageClassName"
+                ],
+                [
+                  "configuration",
+                  "spec",
+                  "volumeMode"
                 ]
               ],
               "patchStrategy": "replace"


### PR DESCRIPTION
## Description
This PR refines and strictly enforces the binding semantics for the `PersistentVolume` to `PersistentVolumeClaim` reference relationship (`pv-to-pvc-reference.json`) within the Kubernetes model. 

Previously, the relationship only synchronized the volume name. This update expands the relationship to automatically detect and synchronize critical Kubernetes binding properties, ensuring that auto-generated edges are semantically valid according to Kubernetes constraints.

### Changes Made:
- **Fixed `mutatorRef` Path:** Updated the primary `mutatorRef` path from `configuration.metadata.name` to `displayName` to correctly capture and inject the `PersistentVolume`'s canvas name into the PVC's `volumeName` field.
- **Added `storageClassName` Synchronization:** Added a new path pair to map `PV.spec.storageClassName` to `PVC.spec.storageClassName`. The engine now utilizes the `equal_as_strings`  strategies to ensure storage classes match before an edge is auto-detected.
- **Added `volumeMode` Synchronization:** Added a path pair to map `PV.spec.volumeMode` to `PVC.spec.volumeMode` utilizing the `equal` and  strategies.
- **Improved Auto-Detection:** Auto-detection for PV-to-PVC bindings is now significantly stricter and more accurate. The engine will now require the Name, StorageClass, and VolumeMode to all match simultaneously before an edge is automatically drawn on the canvas.

These additions ensure that when users manually connect a PV to a PVC (or when auto-detection runs), the components remain strictly aligned with Kubernetes binding prerequisites.

---
Design Link - http://playground.meshery.io/extension/meshmap?mode=design&design=fec96cfc-4bc6-4882-8094-fa623418fdd3

---

**[Signed commits](https://github.com/meshery/meshery/blob/master/CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [x] Yes, I signed my commits.

<!--
Thank you for contributing to Meshery! 

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. Sign your commits.
4. Include before and after screenshots/terminal output.

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.
-->
