### PR TITLE
fix(mesheryctl): wrap ValidateVersion error with ErrValidateVersion

### DIFF
--- a/mesheryctl/internal/cli/root/system/channel.go
+++ b/mesheryctl/internal/cli/root/system/channel.go
@@ -159,7 +159,7 @@ mesheryctl system channel set [stable|stable-version|edge|edge-version]
 		err = ContextContent.ValidateVersion()
 		if err != nil {
 			// TODO: Move to proper meshkit error
-			return err
+			return ErrValidateVersion(err)
 		}
 
 		mctlCfg.Contexts[focusedContext] = ContextContent

--- a/mesheryctl/internal/cli/root/system/channel.go
+++ b/mesheryctl/internal/cli/root/system/channel.go
@@ -158,7 +158,6 @@ mesheryctl system channel set [stable|stable-version|edge|edge-version]
 
 		err = ContextContent.ValidateVersion()
 		if err != nil {
-			// TODO: Move to proper meshkit error
 			return ErrValidateVersion(err)
 		}
 


### PR DESCRIPTION
## Description

This PR fixes #20134 by wrapping the raw version validation error in `mesheryctl/internal/cli/root/system/channel.go` with `ErrValidateVersion(err)`.

### Changes

* Replaced raw `return err` after `ContextContent.ValidateVersion()` with:

  ```go
  return ErrValidateVersion(err)
  ```

### Validation

* Built `mesheryctl` locally with:

  ```bash
  go build ./mesheryctl/...
  ```

**Notes for Reviewers**

* This PR fixes #20134

**Signed commits**

* [x] Yes, I signed my commits.