### PR TITLE
[Docs] feat: add Bluesky social shield to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,9 @@ alt="Meshery Logo" width="70%" /></picture></a><br /><br /></p>
   <img src="https://img.shields.io/badge/Slack-@meshery.svg?logo=slack" /></a>
 <a href="https://x.com/intent/follow?screen_name=mesheryio" alt="X Follow">
   <img src="https://img.shields.io/twitter/follow/mesheryio.svg?label=Follow+Meshery&style=social" /></a>
+<a href="https://bsky.app/profile/mesheryio.bsky.social">
+  <img src="https://img.shields.io/badge/Bluesky-Follow-0285FF?logo=bluesky&logoColor=white" alt="Bluesky Follow" />
+</a>
 <a href="https://github.com/meshery/meshery/releases" alt="Meshery Downloads">
   <img src="https://img.shields.io/github/downloads/meshery/meshery/total" /></a>
 <a href="https://scorecard.dev/viewer/?uri=github.com/meshery/meshery" alt="OpenSSF Scorecard">


### PR DESCRIPTION
## Description
Added a Bluesky social shield/badge to the README.md for 
Meshery's Bluesky account @mesheryio.bsky.social, alongside 
the existing Twitter/X and Slack social badges.

## Root Cause
The README had social shields for Twitter/X and Slack but 
was missing a Bluesky badge despite Meshery having an 
active Bluesky account.

## Changes Made
- Added Bluesky shield badge in the social links section 
  of README.md after the existing X/Twitter badge

## Badge Preview
[![Bluesky](https://img.shields.io/badge/Bluesky-Follow-0285FF?logo=bluesky&logoColor=white)](https://bsky.app/profile/mesheryio.bsky.social)

## Screenshots
Awaiting CI preview.

Fixes #20218