### PR TITLE
[Docs] fix: add missing Bookinfo description to adapter pages

### DIFF
--- a/docs/content/en/extensions/adapters/app-mesh/index.md
+++ b/docs/content/en/extensions/adapters/app-mesh/index.md
@@ -28,6 +28,8 @@ aliases:
 
 - [Bookinfo]({{< ref "guides/infrastructure-management/sample-apps/index.md#bookinfo" >}})
 
+  - The sample BookInfo application displays information about a book, similar to a single catalog entry of an online book store.
+
 - [Httpbin]({{< ref "guides/infrastructure-management/sample-apps/index.md#httpbin" >}})
 
   - Httpbin is a simple HTTP request and response service.

--- a/docs/content/en/extensions/adapters/app-mesh/index.md
+++ b/docs/content/en/extensions/adapters/app-mesh/index.md
@@ -28,7 +28,7 @@ aliases:
 
 - [Bookinfo]({{< ref "guides/infrastructure-management/sample-apps/index.md#bookinfo" >}})
 
-  - The sample BookInfo application displays information about a book, similar to a single catalog entry of an online book store.
+  - The sample Bookinfo application displays information about a book, similar to a single catalog entry of an online book store.
 
 - [Httpbin]({{< ref "guides/infrastructure-management/sample-apps/index.md#httpbin" >}})
 
@@ -42,3 +42,4 @@ Identify overhead involved in running the App Mesh, various App Mesh configurati
 1. Grafana integration
 
 The [Meshery Adapter for App Mesh](https://github.com/meshery-extensions/meshery-app-mesh) will connect to App Mesh’s Prometheus and Grafana instances running in the control plane.
+

--- a/docs/content/en/extensions/adapters/istio/index.md
+++ b/docs/content/en/extensions/adapters/istio/index.md
@@ -29,6 +29,7 @@ aliases:
 The Meshery Adapter for Istio includes a handful of sample applications. Use Meshery to deploy any of these sample applications:
 
 - [Bookinfo]({{< ref "guides/infrastructure-management/sample-apps/index.md#bookinfo" >}})
+  - The sample BookInfo application displays information about a book, similar to a single catalog entry of an online book store.
 - [Httpbin]({{< ref "guides/infrastructure-management/sample-apps/index.md#httpbin" >}})
   - Httpbin is a simple HTTP request and response service.
 - [Online Boutique]({{< ref "guides/infrastructure-management/sample-apps/index.md#online-boutique" >}})

--- a/docs/content/en/extensions/adapters/istio/index.md
+++ b/docs/content/en/extensions/adapters/istio/index.md
@@ -29,7 +29,7 @@ aliases:
 The Meshery Adapter for Istio includes a handful of sample applications. Use Meshery to deploy any of these sample applications:
 
 - [Bookinfo]({{< ref "guides/infrastructure-management/sample-apps/index.md#bookinfo" >}})
-  - The sample BookInfo application displays information about a book, similar to a single catalog entry of an online book store.
+  - The sample Bookinfo application displays information about a book, similar to a single catalog entry of an online book store.
 - [Httpbin]({{< ref "guides/infrastructure-management/sample-apps/index.md#httpbin" >}})
   - Httpbin is a simple HTTP request and response service.
 - [Online Boutique]({{< ref "guides/infrastructure-management/sample-apps/index.md#online-boutique" >}})

--- a/docs/content/en/extensions/adapters/nginx-sm/index.md
+++ b/docs/content/en/extensions/adapters/nginx-sm/index.md
@@ -32,7 +32,7 @@ The Meshery Adapter for NGINX Service Mesh includes a handful of sample applicat
 
 - [Bookinfo]({{< ref "guides/infrastructure-management/sample-apps/index.md" >}})
 
-  - The sample BookInfo application displays information about a book, similar to a single catalog entry of an online book store.
+  - The sample Bookinfo application displays information about a book, similar to a single catalog entry of an online book store.
 
 - [Httpbin]({{< ref "guides/infrastructure-management/sample-apps/index.md" >}})
 

--- a/docs/content/en/extensions/adapters/nginx-sm/index.md
+++ b/docs/content/en/extensions/adapters/nginx-sm/index.md
@@ -32,6 +32,8 @@ The Meshery Adapter for NGINX Service Mesh includes a handful of sample applicat
 
 - [Bookinfo]({{< ref "guides/infrastructure-management/sample-apps/index.md" >}})
 
+  - The sample BookInfo application displays information about a book, similar to a single catalog entry of an online book store.
+
 - [Httpbin]({{< ref "guides/infrastructure-management/sample-apps/index.md" >}})
 
   - Httpbin is a simple HTTP request and response service.

--- a/docs/content/en/extensions/adapters/traefik-mesh/index.md
+++ b/docs/content/en/extensions/adapters/traefik-mesh/index.md
@@ -20,7 +20,7 @@ aliases:
 The Meshery Adapter for Traefik Mesh includes some sample applications operations. Meshery can be used to deploy any of these sample applications.
 
 - [Bookinfo]({{< ref "guides/infrastructure-management/sample-apps/index.md" >}})
-  - The sample BookInfo application displays information about a book, similar to a single catalog entry of an online book store.
+  - The sample Bookinfo application displays information about a book, similar to a single catalog entry of an online book store.
 - [Httpbin]({{< ref "guides/infrastructure-management/sample-apps/index.md" >}})
   - Httpbin is a simple HTTP request and response service.
 

--- a/docs/content/en/extensions/adapters/traefik-mesh/index.md
+++ b/docs/content/en/extensions/adapters/traefik-mesh/index.md
@@ -20,6 +20,7 @@ aliases:
 The Meshery Adapter for Traefik Mesh includes some sample applications operations. Meshery can be used to deploy any of these sample applications.
 
 - [Bookinfo]({{< ref "guides/infrastructure-management/sample-apps/index.md" >}})
+  - The sample BookInfo application displays information about a book, similar to a single catalog entry of an online book store.
 - [Httpbin]({{< ref "guides/infrastructure-management/sample-apps/index.md" >}})
   - Httpbin is a simple HTTP request and response service.
 


### PR DESCRIPTION
## Description
Added missing Bookinfo sample application description to 
adapter pages that were previously showing Bookinfo without 
any description under Sample Applications section.

## Root Cause
The following adapter pages had Bookinfo listed under 
Sample Applications but were missing the short description:
- App Mesh adapter page
- Istio adapter page  
- Traefik Mesh adapter page
- NGINX service mesh adapter page

Other pages like Consul, Kuma and Linkerd already had 
the description correctly.

## Changes Made
Added the following description to all 4 missing pages:

> "The sample BookInfo application displays information 
> about a book, similar to a single catalog entry of 
> an online book store."

## Files Changed
- `docs/content/en/extensions/adapters/app-mesh/index.md`
- `docs/content/en/extensions/adapters/istio/index.md`
- `docs/content/en/extensions/adapters/traefik-mesh/index.md`
- `docs/content/en/extensions/adapters/nginx-sm/index.md`

## Screenshots
Awaiting CI preview.

Fixes #20224