### PR TITLE
[Fix] Remove trailing spaces from properties to fix Kubernetes manifest generation

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -698,8 +698,6 @@ github.com/maxatome/go-testdeep v1.14.0 h1:rRlLv1+kI8eOI3OaBXZwb3O7xY3exRzdW5QyX
 github.com/maxatome/go-testdeep v1.14.0/go.mod h1:lPZc/HAcJMP92l7yI6TRz1aZN5URwUBUAfUNvrclaNM=
 github.com/meshery/meshery-operator v0.8.11 h1:eDo2Sw0jjVrXsvvhF8LenADM58pK+7Z68ROPVIejTPc=
 github.com/meshery/meshery-operator v0.8.11/go.mod h1:hQEtFKKa5Fr/Mskk6bV5ip3bQ0+3F0u1voYS3XisBp4=
-github.com/meshery/meshkit v1.0.16 h1:vnXuBSC2+Y7Q3aVI0jZGj9+P0qkkAJL9Sd1RG4XsK2w=
-github.com/meshery/meshkit v1.0.16/go.mod h1:gMPDnBpbw/nMIXd7PDDOB5Ry4QhNiF5MlcAgX0JJzPc=
 github.com/meshery/meshsync v1.0.0 h1:BIHEVG4BDjqOnSd3vBt9B4IfWJNTfMRAgdwLroBcCfY=
 github.com/meshery/meshsync v1.0.0/go.mod h1:mFsPXkZRiCSuk5DhxBTrkWdlo6peItRBUoIEEQCovIg=
 github.com/meshery/schemas v1.3.13 h1:q72IGBSYYbT3Zz7hZpprNFKTB3wQvKvjorFuHfK20s4=

--- a/server/handlers/meshery_pattern_handler.go
+++ b/server/handlers/meshery_pattern_handler.go
@@ -370,6 +370,10 @@ func (h *Handler) handlePatternPOST(
 
 	// Dehydrate the pattern before saving to the database to reduce size
 	meshkitPatternHelpers.DehydratePattern(&requestPayload.DesignFile)
+	// Sanitize the pattern to strip leading/trailing whitespace from all string
+	// keys and values in component configurations, preventing yaml.v3 from
+	// quoting them (e.g. 'storage ': 2Gi) in Kubernetes manifest export.
+	meshkitPatternHelpers.SanitizePattern(&requestPayload.DesignFile)
 
 	designFileBytes, err := encoding.Marshal(requestPayload.DesignFile)
 

--- a/ui/components/meshery-mesh-interface/PatternService/RJSFCustomComponents/WrapIfAdditionalTemplate.test.tsx
+++ b/ui/components/meshery-mesh-interface/PatternService/RJSFCustomComponents/WrapIfAdditionalTemplate.test.tsx
@@ -98,6 +98,23 @@ describe('WrapIfAdditionalTemplate', () => {
     expect(onKeyChange).toHaveBeenCalledWith('newKey');
   });
 
+  it('trims leading and trailing whitespace from key edits before forwarding to onKeyChange', () => {
+    const onKeyChange = vi.fn();
+    render(
+      <WrapIfAdditionalTemplate
+        children={<div>child</div>}
+        classNames="cls"
+        id="id1"
+        label="key1"
+        onDropPropertyClick={() => vi.fn()}
+        onKeyChange={onKeyChange}
+        schema={{ __ADDITIONAL_PROPERTY__: true }}
+      />,
+    );
+    fireEvent.change(screen.getByTestId('key-input'), { target: { value: '  storage  ' } });
+    expect(onKeyChange).toHaveBeenCalledWith('storage');
+  });
+
   it('disables the input and delete button when readonly is true', () => {
     render(
       <WrapIfAdditionalTemplate

--- a/ui/components/meshery-mesh-interface/PatternService/RJSFCustomComponents/WrapIfAdditionalTemplate.tsx
+++ b/ui/components/meshery-mesh-interface/PatternService/RJSFCustomComponents/WrapIfAdditionalTemplate.tsx
@@ -22,7 +22,7 @@ const WrapIfAdditionalTemplate = ({
   if (!additional) {
     return <div className={classNames}>{children}</div>;
   }
-  const handleChange = ({ target }) => onKeyChange(target.value);
+  const handleChange = ({ target }) => onKeyChange(target.value.trim());
 
   return (
     <Grid2


### PR DESCRIPTION
### Description
This PR eliminates trailing whitespace from design configuration maps to prevent validation errors in exported Kubernetes manifests. 

**Motivation:**
Currently, if a user accidentally types a trailing space in a dynamic key via the UI (e.g., `storage ` instead of `storage`), the design is saved with that whitespace. During export, the `yaml.v3` encoder strictly preserves it by quoting the string (generating `'storage ': 1Gi`), which causes the manifest to fail Kubernetes validation.

**Changes:**
1. **UI:** Added `.trim()` to the `target.value` in `WrapIfAdditionalTemplate` to prevent users from accidentally injecting spaces into dynamic property keys.
2. **Server:** Added `meshkitPatternHelpers.SanitizePattern(&requestPayload.DesignFile)` to `handlePatternPOST`. This acts as a defense-in-depth step to catch and scrub dirty data right at the persistence boundary.

### ⚠️ Dependency Warning
> **DO NOT MERGE yet. CI will fail on this PR.**
> This PR depends on a new utility function (`SanitizePattern`) introduced in `meshery/meshkit`. It requires [Meshkit PR #<INSERT_MESHKIT_PR_NUMBER>] to be merged and a new tag to be released. Once released, `go.mod` in this PR will be updated to point to the new tag.


- This PR fixes #20227 

**[Signed commits](https://github.com/meshery/meshery/blob/master/CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [x] Yes, I signed my commits.

<!--
Thank you for contributing to Meshery! 

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. Sign your commits.
4. Include before and after screenshots/terminal output.

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.
-->
