### PR TITLE
ci: add workflow classification to labeler.yml

### DIFF
--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -1,3 +1,14 @@
+# ##################################################################
+# Workflow Classification (ref: https://github.com/meshery/meshery/issues/18795)
+# ------------------------------------------------------------------
+# Workflow Type:    automation
+# Security Level:  write-token (requires pull-requests: write via GITHUB_TOKEN)
+# Trigger Model:   event-driven (pull_request_target)
+# CI-Gating:       no
+# Description:     Automatically labels incoming pull requests based
+#                  on changed file paths, using the rules defined in
+#                  .github/labeler.yml.
+# ##################################################################
 name: "Pull Request Labeler"
 on:
 - pull_request_target


### PR DESCRIPTION
Adds a workflow classification annotation header to `labeler.yml` as part of the [GitHub Action Workflow Cleanup and Restructure](https://github.com/meshery/meshery/issues/18795) initiative.

### Classification

| Field | Value |
|-------|-------|
| **Workflow Type** | automation |
| **Security Level** | write-token (requires `pull-requests: write` via `GITHUB_TOKEN`) |
| **Trigger Model** | event-driven (`pull_request_target`) |
| **CI-Gating** | no |

### Context

This is the first in a series of PRs to annotate every workflow with its classification (security level + type) per the acceptance criteria:

> _"Every remaining workflow is annotated with its classification (security level + type)."_

The annotation format follows a standardized comment block at the top of each workflow file, making it easy to audit and search across all workflows.

Relates to #18795



- [x] Yes, I signed my commits.