### PR TITLE
feat(table): persist table state in URL and add row deeplinks

### DIFF
--- a/ui/README.md
+++ b/ui/README.md
@@ -3,3 +3,74 @@
 Please do! Thank you for your help in improving Meshery! :balloon:
 
 Find the complete set of contributor guides at https://docs.meshery.io/project/contributing
+
+---
+
+## UI Development Patterns
+
+### Table State Management
+
+All data tables in Meshery UI persist their navigation state (page, page size, sort order, search, and custom filters) in the URL so that links are shareable and state survives navigation. Two hooks handle this:
+
+#### `useTableUrlState` — URL-backed table state
+
+Located at `utils/hooks/useTableUrlState.ts`. Each table gets a short, stable key (e.g. `"con"` for Connections, `"des"` for Designs, `"fil"` for Filters). State is serialised as prefixed query parameters:
+
+| Param | Description |
+|---|---|
+| `<key>_page` | Current page (omitted when 0) |
+| `<key>_ps` | Page size (omitted when equal to the default) |
+| `<key>_sort` | Sort string, e.g. `"name asc"` |
+| `<key>_q` | Search query |
+| `<key>_<field>` | Custom filter fields declared in `defaults.filters` |
+
+```tsx
+const { tableState, updateTableState, copyRowDeepLink } = useTableUrlState({
+  tableKey: 'con',          // short stable prefix — never change once deployed
+  rowParam: 'connectionId', // URL param for row deep-links (default: <key>_row)
+  defaults: {
+    page: 0,
+    pageSize: 10,
+    sortOrder: 'created_at desc',
+    filters: { status: '', kind: '' },
+  },
+});
+
+// tableState.page / .pageSize / .sortOrder / .search / .filters are read-only
+// updateTableState({ page: 2 }) writes only the changed fields to the URL
+// copyRowDeepLink(id) builds a URL pointing at that row and copies it to the clipboard
+```
+
+`updateTableState` is referentially stable across renders (uses internal refs for router and defaults), so it is safe to include in child `useCallback` dependency arrays without causing cascade re-renders.
+
+#### `useColumnVisibilityPreference` — localStorage-backed column visibility
+
+Located at `utils/hooks/useColumnVisibilityPreference.ts`. User-initiated column toggles are persisted to `localStorage` under a `meshery_cols_<tableKey>` key. Responsive-layout updates (e.g. hiding columns at narrow widths) are applied on top without overwriting saved preferences.
+
+```tsx
+const { columnVisibility, setColumnVisibilityByUser, setColumnVisibilityByResponsive } =
+  useColumnVisibilityPreference('connections', responsiveColDefaults);
+
+// In a width-change effect:
+useEffect(() => {
+  setColumnVisibilityByResponsive(responsiveColDefaults);
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+}, [width, setColumnVisibilityByResponsive]);
+```
+
+Pass `setColumnVisibilityByUser` to the table's column-visibility toolbar so toggling a column is saved. Never call `setColumnVisibilityByResponsive` from user interaction — it does not save.
+
+#### Row Deep-Links in `ResponsiveDataTable`
+
+Use `getCopyDeepLinkAction` from `@sistent/sistent` to add a copy-link action to the row action menu:
+
+```tsx
+import { getCopyDeepLinkAction } from '@sistent/sistent';
+
+const actions: TableAction[] = [
+  getCopyDeepLinkAction(() => copyRowDeepLink(row.id)),
+  // ... other actions
+];
+```
+
+The helper accepts an optional `title` argument (default: `'Copy link'`) for i18n.

--- a/ui/components/connections/ConnectionActionMenu.tsx
+++ b/ui/components/connections/ConnectionActionMenu.tsx
@@ -1,5 +1,12 @@
 import React from 'react';
-import { Button, Popover, Typography, SyncAltIcon, SettingsIcon, CopyLinkIcon } from '@sistent/sistent';
+import {
+  Button,
+  Popover,
+  Typography,
+  SyncAltIcon,
+  SettingsIcon,
+  CopyLinkIcon,
+} from '@sistent/sistent';
 import { ActionListItem } from './styles';
 import { iconMedium } from '../../css/icons.styles';
 import CAN from '@/utils/can';

--- a/ui/components/connections/ConnectionActionMenu.tsx
+++ b/ui/components/connections/ConnectionActionMenu.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Button, Popover, Typography, SyncAltIcon, SettingsIcon } from '@sistent/sistent';
+import { Button, Popover, Typography, SyncAltIcon, SettingsIcon, CopyLinkIcon } from '@sistent/sistent';
 import { ActionListItem } from './styles';
 import { iconMedium } from '../../css/icons.styles';
 import CAN from '@/utils/can';
@@ -13,6 +13,7 @@ type ConnectionActionMenuProps = {
   onFlushMeshSync: () => void;
   onDeploymentModeAnchor: (event: React.MouseEvent<HTMLElement>) => void;
   onConfigure?: () => void;
+  onCopyLink?: () => void;
 };
 
 export const ConnectionActionMenu = ({
@@ -22,6 +23,7 @@ export const ConnectionActionMenu = ({
   onFlushMeshSync,
   onDeploymentModeAnchor,
   onConfigure,
+  onCopyLink,
 }: ConnectionActionMenuProps) => {
   return (
     <Popover
@@ -39,6 +41,23 @@ export const ConnectionActionMenu = ({
             <SettingsIcon {...iconMedium} />
             <Typography variant="body1" style={{ marginLeft: '0.5rem' }}>
               Configure
+            </Typography>
+          </Button>
+        </ActionListItem>
+      )}
+      {onCopyLink && (
+        <ActionListItem>
+          <Button
+            type="button"
+            onClick={() => {
+              onCopyLink();
+              onClose();
+            }}
+            data-cy="btnCopyConnectionLink"
+          >
+            <CopyLinkIcon {...iconMedium} />
+            <Typography variant="body1" style={{ marginLeft: '0.5rem' }}>
+              Copy link
             </Typography>
           </Button>
         </ActionListItem>

--- a/ui/components/connections/ConnectionTable.test.tsx
+++ b/ui/components/connections/ConnectionTable.test.tsx
@@ -316,7 +316,7 @@ describe('ConnectionTable', () => {
   });
 
   it('hydrates search from a string router query and passes it to the connections query', async () => {
-    router.query = { searchText: 'cluster-a' };
+    router.query = { con_q: 'cluster-a' };
 
     render(<ConnectionTable />);
 

--- a/ui/components/connections/ConnectionTable.tsx
+++ b/ui/components/connections/ConnectionTable.tsx
@@ -1,5 +1,4 @@
 import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
-import { useRouter } from 'next/router';
 import { PROMPT_VARIANTS, ResponsiveDataTable } from '@sistent/sistent';
 import LoadingScreen from '../shared/LoadingState/LoadingComponent';
 import { EVENT_TYPES } from '../../lib/event-types';
@@ -12,6 +11,8 @@ import { getResponsiveColumnVisibility } from '../../utils/responsive-column';
 import { useWindowDimensions } from '../../utils/dimension';
 import { useGetEnvironmentsQuery } from '../../rtk-query/environments';
 import { useGetConnectionsQuery } from '@/rtk-query/connection';
+import { useTableUrlState } from '@/utils/hooks/useTableUrlState';
+import { useColumnVisibilityPreference } from '@/utils/hooks/useColumnVisibilityPreference';
 
 import { useSelector } from 'react-redux';
 import { updateProgress } from '@/store/slices/mesheryUi';
@@ -52,7 +53,6 @@ const ConnectionTable = ({
   selectedConnectionId,
   updateUrlWithConnectionId,
 }: ConnectionTableProps) => {
-  const router = useRouter();
   const {
     organization,
     connectionMetadataState,
@@ -75,19 +75,38 @@ const ConnectionTable = ({
   );
   const ping = useKubernetesHook();
   const { width } = useWindowDimensions();
-  const [page, setPage] = useState(0);
-  const [pageSize, setPageSize] = useState(10);
-  const [sortOrder, setSortOrder] = useState('created_at desc');
+
+  const { tableState, updateTableState, copyRowDeepLink } = useTableUrlState({
+    tableKey: 'con',
+    // Row deeplinks reuse the existing `connectionId` param so the parent's
+    // expansion logic keeps working without changes.
+    rowParam: 'connectionId',
+    defaults: {
+      page: 0,
+      pageSize: 10,
+      sortOrder: 'created_at desc',
+      search: '',
+      filters: { status: '', kind: '' },
+    },
+  });
+
+  const { page, pageSize, sortOrder, search } = tableState;
+  const setPage = useCallback((p: number) => updateTableState({ page: p }), [updateTableState]);
+  const setPageSize = useCallback((ps: number) => updateTableState({ pageSize: ps }), [updateTableState]);
+  const setSortOrder = useCallback((so: string) => updateTableState({ sortOrder: so }), [updateTableState]);
+  const setSearch = useCallback((s: string) => updateTableState({ search: s, page: 0 }), [updateTableState]);
+
+  // Applied filters come from URL state so they survive navigation.
+  const statusFilter = tableState.filters.status || null;
+  const kindFilter = tableState.filters.kind || null;
+
   const [rowData, setRowData] = useState<RowData | null>(null);
   const [rowsExpanded, setRowsExpanded] = useState<number[]>([]);
   const [isSearchExpanded, setIsSearchExpanded] = useState(false);
-  const [selectedFilters, setSelectedFilters] = useState<SelectedFilters>({
-    status: 'All',
-    kind: 'All',
-  });
-  const [search, setSearch] = useState('');
-  const [statusFilter, setStatusFilter] = useState<string | null>(null);
-  const [kindFilter, setKindFilter] = useState<string | null>(null);
+  const [selectedFilters, setSelectedFilters] = useState<SelectedFilters>(() => ({
+    status: tableState.filters.status || 'All',
+    kind: tableState.filters.kind || 'All',
+  }));
   const {
     notify,
     updateConnectionByIdMutator,
@@ -108,12 +127,6 @@ const ConnectionTable = ({
     environments: '',
     connections: '',
   });
-
-  useEffect(() => {
-    if (typeof router.query.searchText === 'string') {
-      setSearch(router.query.searchText);
-    }
-  }, [router.query.searchText]);
 
   const filters = useMemo(
     () => ({
@@ -139,11 +152,13 @@ const ConnectionTable = ({
   );
 
   const handleApplyFilter = () => {
-    const statusFilter = selectedFilters.status === 'All' ? null : selectedFilters.status;
-    const kindFilter = selectedFilters.kind === 'All' ? null : selectedFilters.kind;
-
-    setKindFilter(kindFilter);
-    setStatusFilter(statusFilter);
+    updateTableState({
+      filters: {
+        status: selectedFilters.status === 'All' ? '' : selectedFilters.status,
+        kind: selectedFilters.kind === 'All' ? '' : selectedFilters.kind,
+      },
+      page: 0,
+    });
   };
   // lock for not allowing multiple updates at the same time
   // needs to be a ref because it needs to be shared between renders
@@ -682,28 +697,19 @@ const ConnectionTable = ({
     setTableCols(columnsRef.current);
   }, [isEnvironmentsSuccess, environmentOptions]);
 
-  const [columnVisibility, setColumnVisibility] = useState<Record<string, boolean | undefined>>(
-    () => getResponsiveColumnVisibility(columnNames, colViews, width),
-  );
+  const { columnVisibility, setColumnVisibilityByUser, setColumnVisibilityByResponsive } =
+    useColumnVisibilityPreference(
+      'connections',
+      getResponsiveColumnVisibility(columnNames, colViews, width),
+    );
 
   useEffect(() => {
-    setColumnVisibility((previous) => {
-      const next = getResponsiveColumnVisibility(columnNames, colViews, width);
+    const next = getResponsiveColumnVisibility(columnNames, colViews, width);
 
-      // `getResponsiveColumnVisibility` always allocates a new object, so a
-      // plain `setColumnVisibility(next)` queues a commit even when the
-      // computed visibility matches the prior commit. Bail out on a
-      // value-equal computation to keep the table from re-rendering on every
-      // unrelated parent re-render that recomputes `columnNames`.
-      const keys = new Set([...Object.keys(previous), ...Object.keys(next)]);
-      for (const key of keys) {
-        if (previous[key] !== next[key]) {
-          return next;
-        }
-      }
-      return previous;
-    });
-  }, [colViews, columnNames, width]);
+    // Only apply responsive update when the computed layout actually changed so
+    // we avoid flushing user-preference overrides on every unrelated re-render.
+    setColumnVisibilityByResponsive(next);
+  }, [colViews, columnNames, width, setColumnVisibilityByResponsive]);
 
   if (isConnectionLoading) {
     return <LoadingScreen animatedIcon="AnimatedMeshery" message="Loading Connections" />;
@@ -721,7 +727,7 @@ const ConnectionTable = ({
         handleApplyFilter={handleApplyFilter}
         columns={columns}
         columnVisibility={columnVisibility}
-        setColumnVisibility={setColumnVisibility}
+        setColumnVisibility={setColumnVisibilityByUser}
       />
 
       <ResponsiveDataTable
@@ -741,6 +747,14 @@ const ConnectionTable = ({
         onFlushMeshSync={handleFlushMeshSync}
         onDeploymentModeAnchor={handleDeploymentModeAnchorOpen}
         onConfigure={handleConfigureConnection}
+        onCopyLink={
+          rowData?.rowIndex != null
+            ? () => {
+                const connection = filteredConnections[rowData.rowIndex];
+                if (connection?.id) copyRowDeepLink(connection.id);
+              }
+            : undefined
+        }
       />
 
       {/* Only mount (and thus load) the configure modal once a row is chosen. */}

--- a/ui/components/connections/ConnectionTable.tsx
+++ b/ui/components/connections/ConnectionTable.tsx
@@ -92,9 +92,18 @@ const ConnectionTable = ({
 
   const { page, pageSize, sortOrder, search } = tableState;
   const setPage = useCallback((p: number) => updateTableState({ page: p }), [updateTableState]);
-  const setPageSize = useCallback((ps: number) => updateTableState({ pageSize: ps }), [updateTableState]);
-  const setSortOrder = useCallback((so: string) => updateTableState({ sortOrder: so }), [updateTableState]);
-  const setSearch = useCallback((s: string) => updateTableState({ search: s, page: 0 }), [updateTableState]);
+  const setPageSize = useCallback(
+    (ps: number) => updateTableState({ pageSize: ps }),
+    [updateTableState],
+  );
+  const setSortOrder = useCallback(
+    (so: string) => updateTableState({ sortOrder: so }),
+    [updateTableState],
+  );
+  const setSearch = useCallback(
+    (s: string) => updateTableState({ search: s, page: 0 }),
+    [updateTableState],
+  );
 
   // Applied filters come from URL state so they survive navigation.
   const statusFilter = tableState.filters.status || null;

--- a/ui/components/designs/patterns/MesheryPatterns.tsx
+++ b/ui/components/designs/patterns/MesheryPatterns.tsx
@@ -5,7 +5,7 @@ import {
   ResponsiveDataTable,
 } from '@sistent/sistent';
 import { NoSsr } from '@sistent/sistent';
-import React, { useEffect, useRef, useState } from 'react';
+import React, { useCallback, useEffect, useRef, useState } from 'react';
 import MesheryPatternGrid from './MesheryPatternGridView';
 import _PromptComponent from '../../PromptComponent';
 import LoadingScreen from '../../shared/LoadingState/LoadingComponent';
@@ -18,6 +18,8 @@ import { getMeshModels } from '../../../api/meshmodel';
 import { modifyRJSFSchema } from '../../../utils/utils';
 import { updateVisibleColumns } from '../../../utils/responsive-column';
 import { useWindowDimensions } from '../../../utils/dimension';
+import { useTableUrlState } from '@/utils/hooks/useTableUrlState';
+import { useColumnVisibilityPreference } from '@/utils/hooks/useColumnVisibilityPreference';
 import InfoModal from '../../shared/Modal/Information/InfoModal';
 import DefaultError from '../../general/error-404/index';
 import CAN from '@/utils/can';
@@ -65,16 +67,33 @@ function MesheryPatterns({
   pageTitle = 'Designs',
   arePatternsReadOnly = false,
 }) {
-  const [page, setPage] = useState(0);
-  const [search, setSearch] = useState('');
-  const [sortOrder, setSortOrder] = useState('updated_at desc');
+  const router = useRouter();
+
+  const { tableState, updateTableState } = useTableUrlState({
+    tableKey: 'des',
+    defaults: {
+      page: 0,
+      pageSize: 10,
+      sortOrder: 'updated_at desc',
+      search: '',
+      filters: { vis: '' },
+    },
+  });
+
+  const { page, pageSize, sortOrder, search } = tableState;
+  const setPage = useCallback((p) => updateTableState({ page: p }), [updateTableState]);
+  const setPageSize = useCallback((ps) => updateTableState({ pageSize: ps }), [updateTableState]);
+  const setSortOrder = useCallback((so) => updateTableState({ sortOrder: so }), [updateTableState]);
+  const setSearch = useCallback((s) => updateTableState({ search: s, page: 0 }), [updateTableState]);
+
+  // visibilityFilter is persisted in URL — no separate useState needed.
+  const visibilityFilter = tableState.filters.vis || null;
+
   const [count, setCount] = useState(0);
-  const [pageSize, setPageSize] = useState(10);
   const modalRef = useRef();
   const [patterns, setPatterns] = useState([]);
   const [selectedRowData, setSelectedRowData] = useState(null);
   const [selectedPattern, setSelectedPattern] = useState(resetSelectedPattern());
-  const router = useRouter();
   const [meshModels, setMeshModels] = useState([]);
   const [selectedFilters, setSelectedFilters] = useState(initialFilters);
   const [canPublishPattern, setCanPublishPattern] = useState(false);
@@ -88,7 +107,6 @@ function MesheryPatterns({
   const { view } = router.query;
   const [viewType, setViewType] = useState(view === 'table' ? 'table' : 'grid');
   const { notify } = useNotification();
-  const [visibilityFilter, setVisibilityFilter] = useState(null);
   const { selectedK8sContexts, catalogVisibility, user } = useSelector((state) => state.ui);
   const [deployPatternMutation] = useDeployPatternMutation();
   const [undeployPatternMutation] = useUndeployPatternMutation();
@@ -124,7 +142,6 @@ function MesheryPatterns({
       });
       setCount(patternsData.totalCount || 0);
       handleSetPatterns(filteredPatterns);
-      setVisibilityFilter(visibilityFilter);
       setPatterns(patternsData.patterns || []);
     }
   }, [patternsData]);
@@ -241,14 +258,12 @@ function MesheryPatterns({
   /**
    * fetch patterns when the page loads
    */
-  // @ts-ignore
   useEffect(() => {
     document.body.style.overflowX = 'hidden';
-    const visibilityFilter =
-      selectedFilters.visibility === 'All' ? null : selectedFilters.visibility;
-    setVisibilityFilter(visibilityFilter);
-    return () => (document.body.style.overflowX = 'auto');
-  }, [visibilityFilter]);
+    return () => {
+      document.body.style.overflowX = 'auto';
+    };
+  }, []);
 
   useEffect(() => {
     if (viewType === 'grid') {
@@ -429,9 +444,8 @@ function MesheryPatterns({
 
   const [tableCols, updateCols] = useState(columns);
 
-  const [columnVisibility, setColumnVisibility] = useState(() => {
-    let showCols = updateVisibleColumns(PATTERN_COL_VIEWS, width);
-    // Initialize column visibility based on the original columns' visibility
+  const responsiveColDefaults = (() => {
+    const showCols = updateVisibleColumns(PATTERN_COL_VIEWS, width);
     const initialVisibility = {};
     columns.forEach((col) => {
       if (!(hideVisibility && col.name === 'visibility')) {
@@ -439,7 +453,10 @@ function MesheryPatterns({
       }
     });
     return initialVisibility;
-  });
+  })();
+
+  const { columnVisibility, setColumnVisibilityByUser, setColumnVisibilityByResponsive } =
+    useColumnVisibilityPreference('designs', responsiveColDefaults);
 
   const options = buildPatternsTableOptions({
     patterns,
@@ -487,9 +504,10 @@ function MesheryPatterns({
   };
 
   const handleApplyFilter = () => {
-    const visibilityFilter =
-      selectedFilters.visibility === 'All' ? null : selectedFilters.visibility;
-    setVisibilityFilter(visibilityFilter);
+    updateTableState({
+      filters: { vis: selectedFilters.visibility === 'All' ? '' : selectedFilters.visibility },
+      page: 0,
+    });
   };
 
   return (
@@ -529,7 +547,7 @@ function MesheryPatterns({
               handleApplyFilter={handleApplyFilter}
               columns={columns}
               columnVisibility={columnVisibility}
-              setColumnVisibility={setColumnVisibility}
+              setColumnVisibility={setColumnVisibilityByUser}
             />
             {!selectedPattern.show && viewType === 'table' && (
               <>

--- a/ui/components/designs/patterns/MesheryPatterns.tsx
+++ b/ui/components/designs/patterns/MesheryPatterns.tsx
@@ -461,6 +461,11 @@ function MesheryPatterns({
   const { columnVisibility, setColumnVisibilityByUser, setColumnVisibilityByResponsive } =
     useColumnVisibilityPreference('designs', responsiveColDefaults);
 
+  useEffect(() => {
+    setColumnVisibilityByResponsive(responsiveColDefaults);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [width, setColumnVisibilityByResponsive]);
+
   const options = buildPatternsTableOptions({
     patterns,
     columns,

--- a/ui/components/designs/patterns/MesheryPatterns.tsx
+++ b/ui/components/designs/patterns/MesheryPatterns.tsx
@@ -84,7 +84,10 @@ function MesheryPatterns({
   const setPage = useCallback((p) => updateTableState({ page: p }), [updateTableState]);
   const setPageSize = useCallback((ps) => updateTableState({ pageSize: ps }), [updateTableState]);
   const setSortOrder = useCallback((so) => updateTableState({ sortOrder: so }), [updateTableState]);
-  const setSearch = useCallback((s) => updateTableState({ search: s, page: 0 }), [updateTableState]);
+  const setSearch = useCallback(
+    (s) => updateTableState({ search: s, page: 0 }),
+    [updateTableState],
+  );
 
   // visibilityFilter is persisted in URL — no separate useState needed.
   const visibilityFilter = tableState.filters.vis || null;

--- a/ui/components/filters/Filters.tsx
+++ b/ui/components/filters/Filters.tsx
@@ -401,8 +401,16 @@ function MesheryFilters() {
     return initialVisibility;
   })();
 
-  const { columnVisibility, setColumnVisibilityByUser: setColumnVisibility } =
-    useColumnVisibilityPreference('filters', responsiveColDefaults);
+  const {
+    columnVisibility,
+    setColumnVisibilityByUser: setColumnVisibility,
+    setColumnVisibilityByResponsive,
+  } = useColumnVisibilityPreference('filters', responsiveColDefaults);
+
+  useEffect(() => {
+    setColumnVisibilityByResponsive(responsiveColDefaults);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [width, setColumnVisibilityByResponsive]);
 
   const filter = {
     visibility: {

--- a/ui/components/filters/Filters.tsx
+++ b/ui/components/filters/Filters.tsx
@@ -1,4 +1,6 @@
-import React, { useState, useEffect, useRef } from 'react';
+import React, { useState, useEffect, useRef, useCallback } from 'react';
+import { useTableUrlState } from '@/utils/hooks/useTableUrlState';
+import { useColumnVisibilityPreference } from '@/utils/hooks/useColumnVisibilityPreference';
 import { NoSsr } from '@sistent/sistent';
 import { Publish as PublishIcon } from '@/assets/icons';
 import _PromptComponent from '../PromptComponent';
@@ -67,12 +69,27 @@ function resetSelectedFilter() {
 }
 
 function MesheryFilters() {
-  const [page, setPage] = useState(0);
-  const [search, setSearch] = useState('');
-  const [sortOrder, setSortOrder] = useState('');
+  const { tableState, updateTableState } = useTableUrlState({
+    tableKey: 'fil',
+    defaults: {
+      page: 0,
+      pageSize: 10,
+      sortOrder: '',
+      search: '',
+      filters: { vis: '' },
+    },
+  });
+
+  const { page, pageSize, sortOrder, search } = tableState;
+  const setPage = useCallback((p) => updateTableState({ page: p }), [updateTableState]);
+  const setPageSize = useCallback((ps) => updateTableState({ pageSize: ps }), [updateTableState]);
+  const setSortOrder = useCallback((so) => updateTableState({ sortOrder: so }), [updateTableState]);
+  const setSearch = useCallback((s) => updateTableState({ search: s, page: 0 }), [updateTableState]);
+
+  const visibilityFilter = tableState.filters.vis || null;
+
   const [count, setCount] = useState(0);
   const modalRef = useRef<{ show: (_args: any) => Promise<string> } | null>(null);
-  const [pageSize, setPageSize] = useState(10);
   const [filters, setFilters] = useState<any[]>([]);
   const [selectedFilter, setSelectedFilter] = useState(resetSelectedFilter());
   const [selectedRowData, setSelectedRowData] = useState<any | null>(null);
@@ -109,11 +126,9 @@ function MesheryFilters() {
   const catalogContentRef = useRef<any[]>([]);
   const catalogVisibilityRef = useRef<boolean>(false);
   const disposeConfSubscriptionRef = useRef<{ dispose: () => void } | null>(null);
-  const [visibilityFilter, setVisibilityFilter] = useState<string | null>(null);
-
-  const [selectedFilters, setSelectedFilters] = useState<{ visibility: string }>({
-    visibility: 'All',
-  });
+  const [selectedFilters, setSelectedFilters] = useState<{ visibility: string }>(() => ({
+    visibility: tableState.filters.vis || 'All',
+  }));
 
   const {
     data: filtersData,
@@ -199,9 +214,10 @@ function MesheryFilters() {
   };
 
   const handleApplyFilter = () => {
-    const visibilityFilter =
-      selectedFilters.visibility === 'All' ? null : selectedFilters.visibility;
-    setVisibilityFilter(visibilityFilter);
+    updateTableState({
+      filters: { vis: selectedFilters.visibility === 'All' ? '' : selectedFilters.visibility },
+      page: 0,
+    });
   };
 
   function resetSelectedRowData() {
@@ -274,7 +290,6 @@ function MesheryFilters() {
       });
       setCount(filtersData.totalCount || 0);
       handleSetFilters(filteredWasmFilters);
-      setVisibilityFilter(visibilityFilter);
       setFilters(filtersData.filters || []);
     }
   }, [filtersData]);
@@ -374,15 +389,17 @@ function MesheryFilters() {
 
   const [tableCols, updateCols] = useState(columns);
 
-  const [columnVisibility, setColumnVisibility] = useState(() => {
-    let showCols = updateVisibleColumns(COLUMN_VIEWS, width);
-    // Initialize column visibility based on the original columns' visibility
-    const initialVisibility = {};
+  const responsiveColDefaults = (() => {
+    const showCols = updateVisibleColumns(COLUMN_VIEWS, width);
+    const initialVisibility: Record<string, boolean> = {};
     columns.forEach((col) => {
       initialVisibility[col.name] = showCols[col.name];
     });
     return initialVisibility;
-  });
+  })();
+
+  const { columnVisibility, setColumnVisibilityByUser: setColumnVisibility } =
+    useColumnVisibilityPreference('filters', responsiveColDefaults);
 
   const filter = {
     visibility: {

--- a/ui/components/filters/Filters.tsx
+++ b/ui/components/filters/Filters.tsx
@@ -84,7 +84,10 @@ function MesheryFilters() {
   const setPage = useCallback((p) => updateTableState({ page: p }), [updateTableState]);
   const setPageSize = useCallback((ps) => updateTableState({ pageSize: ps }), [updateTableState]);
   const setSortOrder = useCallback((so) => updateTableState({ sortOrder: so }), [updateTableState]);
-  const setSearch = useCallback((s) => updateTableState({ search: s, page: 0 }), [updateTableState]);
+  const setSearch = useCallback(
+    (s) => updateTableState({ search: s, page: 0 }),
+    [updateTableState],
+  );
 
   const visibilityFilter = tableState.filters.vis || null;
 

--- a/ui/utils/hooks/index.ts
+++ b/ui/utils/hooks/index.ts
@@ -1,4 +1,6 @@
 export { useNotification, withNotify, useNotificationHandlers } from './useNotification';
+export { useTableUrlState } from './useTableUrlState';
+export { useColumnVisibilityPreference } from './useColumnVisibilityPreference';
 export { default as useDebounce } from './useDebounce';
 export { useMeshModelComponents } from './useMeshModelComponents';
 export { default as usePreventUserFromLeavingPage } from './usePreventUserFromLeavingPage';

--- a/ui/utils/hooks/useColumnVisibilityPreference.ts
+++ b/ui/utils/hooks/useColumnVisibilityPreference.ts
@@ -71,8 +71,14 @@ export function useColumnVisibilityPreference(
 
   const setColumnVisibilityByResponsive = useCallback(
     (next: Record<string, boolean | undefined>) => {
-      // Re-merge: responsive defaults first, then stored user overrides on top.
-      setColumnVisibility({ ...next, ...storedPrefs.current });
+      setColumnVisibility((prev) => {
+        const merged = { ...next, ...storedPrefs.current };
+        const keys = new Set([...Object.keys(prev), ...Object.keys(merged)]);
+        for (const key of keys) {
+          if (prev[key] !== merged[key]) return merged;
+        }
+        return prev;
+      });
     },
     [],
   );

--- a/ui/utils/hooks/useColumnVisibilityPreference.ts
+++ b/ui/utils/hooks/useColumnVisibilityPreference.ts
@@ -1,4 +1,4 @@
-import { useCallback, useRef, useState } from 'react';
+import { useCallback, useRef, useState, type SetStateAction } from 'react';
 
 const STORAGE_KEY_PREFIX = 'meshery_cols_';
 
@@ -40,7 +40,7 @@ export function useColumnVisibilityPreference(
   columnVisibility: Record<string, boolean | undefined>;
   /** Call from the column-visibility toolbar. Persists to localStorage. */
   setColumnVisibilityByUser: (
-    updater: React.SetStateAction<Record<string, boolean | undefined>>,
+    updater: SetStateAction<Record<string, boolean | undefined>>,
   ) => void;
   /** Call from width-change effects. Merges responsive defaults with stored user prefs. */
   setColumnVisibilityByResponsive: (next: Record<string, boolean | undefined>) => void;
@@ -53,7 +53,7 @@ export function useColumnVisibilityPreference(
   );
 
   const setColumnVisibilityByUser = useCallback(
-    (updater: React.SetStateAction<Record<string, boolean | undefined>>) => {
+    (updater: SetStateAction<Record<string, boolean | undefined>>) => {
       setColumnVisibility((prev) => {
         const next = typeof updater === 'function' ? updater(prev) : updater;
         // Persist only defined (non-undefined) values.
@@ -69,10 +69,13 @@ export function useColumnVisibilityPreference(
     [tableKey],
   );
 
-  const setColumnVisibilityByResponsive = useCallback((next: Record<string, boolean | undefined>) => {
-    // Re-merge: responsive defaults first, then stored user overrides on top.
-    setColumnVisibility({ ...next, ...storedPrefs.current });
-  }, []);
+  const setColumnVisibilityByResponsive = useCallback(
+    (next: Record<string, boolean | undefined>) => {
+      // Re-merge: responsive defaults first, then stored user overrides on top.
+      setColumnVisibility({ ...next, ...storedPrefs.current });
+    },
+    [],
+  );
 
   return { columnVisibility, setColumnVisibilityByUser, setColumnVisibilityByResponsive };
 }

--- a/ui/utils/hooks/useColumnVisibilityPreference.ts
+++ b/ui/utils/hooks/useColumnVisibilityPreference.ts
@@ -1,0 +1,78 @@
+import { useCallback, useRef, useState } from 'react';
+
+const STORAGE_KEY_PREFIX = 'meshery_cols_';
+
+function loadFromStorage(tableKey: string): Record<string, boolean> {
+  if (typeof window === 'undefined') return {};
+  try {
+    const raw = window.localStorage.getItem(`${STORAGE_KEY_PREFIX}${tableKey}`);
+    return raw ? (JSON.parse(raw) as Record<string, boolean>) : {};
+  } catch {
+    return {};
+  }
+}
+
+function saveToStorage(tableKey: string, prefs: Record<string, boolean>): void {
+  if (typeof window === 'undefined') return;
+  try {
+    window.localStorage.setItem(`${STORAGE_KEY_PREFIX}${tableKey}`, JSON.stringify(prefs));
+  } catch {
+    // Quota exceeded or private browsing — degrade silently.
+  }
+}
+
+/**
+ * Persistent column visibility for data tables.
+ *
+ * User-initiated column toggles (via `setColumnVisibilityByUser`) are saved to
+ * localStorage so they survive navigation and refresh. Responsive-layout
+ * updates (via `setColumnVisibilityByResponsive`) are NOT saved — the
+ * user's explicit overrides are layered on top of each responsive update.
+ *
+ * @param tableKey - Stable, unique key for this table (e.g. "connections").
+ * @param responsiveDefaults - Breakpoint-computed defaults from
+ *   `getResponsiveColumnVisibility` / `updateVisibleColumns`.
+ */
+export function useColumnVisibilityPreference(
+  tableKey: string,
+  responsiveDefaults: Record<string, boolean | undefined>,
+): {
+  columnVisibility: Record<string, boolean | undefined>;
+  /** Call from the column-visibility toolbar. Persists to localStorage. */
+  setColumnVisibilityByUser: (
+    updater: React.SetStateAction<Record<string, boolean | undefined>>,
+  ) => void;
+  /** Call from width-change effects. Merges responsive defaults with stored user prefs. */
+  setColumnVisibilityByResponsive: (next: Record<string, boolean | undefined>) => void;
+} {
+  // Stored user preferences — only the columns the user explicitly toggled.
+  const storedPrefs = useRef<Record<string, boolean>>(loadFromStorage(tableKey));
+
+  const [columnVisibility, setColumnVisibility] = useState<Record<string, boolean | undefined>>(
+    () => ({ ...responsiveDefaults, ...storedPrefs.current }),
+  );
+
+  const setColumnVisibilityByUser = useCallback(
+    (updater: React.SetStateAction<Record<string, boolean | undefined>>) => {
+      setColumnVisibility((prev) => {
+        const next = typeof updater === 'function' ? updater(prev) : updater;
+        // Persist only defined (non-undefined) values.
+        const toStore: Record<string, boolean> = {};
+        for (const [col, val] of Object.entries(next)) {
+          if (val !== undefined) toStore[col] = val;
+        }
+        storedPrefs.current = toStore;
+        saveToStorage(tableKey, toStore);
+        return next;
+      });
+    },
+    [tableKey],
+  );
+
+  const setColumnVisibilityByResponsive = useCallback((next: Record<string, boolean | undefined>) => {
+    // Re-merge: responsive defaults first, then stored user overrides on top.
+    setColumnVisibility({ ...next, ...storedPrefs.current });
+  }, []);
+
+  return { columnVisibility, setColumnVisibilityByUser, setColumnVisibilityByResponsive };
+}

--- a/ui/utils/hooks/useColumnVisibilityPreference.ts
+++ b/ui/utils/hooks/useColumnVisibilityPreference.ts
@@ -39,9 +39,7 @@ export function useColumnVisibilityPreference(
 ): {
   columnVisibility: Record<string, boolean | undefined>;
   /** Call from the column-visibility toolbar. Persists to localStorage. */
-  setColumnVisibilityByUser: (
-    updater: SetStateAction<Record<string, boolean | undefined>>,
-  ) => void;
+  setColumnVisibilityByUser: (updater: SetStateAction<Record<string, boolean | undefined>>) => void;
   /** Call from width-change effects. Merges responsive defaults with stored user prefs. */
   setColumnVisibilityByResponsive: (next: Record<string, boolean | undefined>) => void;
 } {

--- a/ui/utils/hooks/useTableUrlState.ts
+++ b/ui/utils/hooks/useTableUrlState.ts
@@ -1,5 +1,7 @@
 import { useCallback, useMemo, useRef } from 'react';
 import { useRouter } from 'next/router';
+import { useNotification } from './useNotification';
+import { EVENT_TYPES } from '../../lib/event-types';
 
 /**
  * Persistent table state backed by URL query parameters.
@@ -60,6 +62,7 @@ export function useTableUrlState<F extends Record<string, string> = Record<strin
   options: UseTableUrlStateOptions<F>,
 ) {
   const router = useRouter();
+  const { notify } = useNotification();
   const { tableKey, defaults, rowParam } = options;
   const prefix = `${tableKey}_`;
   const resolvedRowParam = rowParam ?? `${prefix}row`;
@@ -130,7 +133,11 @@ export function useTableUrlState<F extends Record<string, string> = Record<strin
         Object.entries(next).filter(([, v]) => v !== undefined),
       );
 
-      routerRef.current.replace({ query: cleanQuery }, undefined, { shallow: true });
+      routerRef.current.replace(
+        { pathname: routerRef.current.pathname, query: cleanQuery },
+        undefined,
+        { shallow: true },
+      );
     },
     [prefix, defaults],
   );
@@ -143,15 +150,20 @@ export function useTableUrlState<F extends Record<string, string> = Record<strin
   const buildRowDeepLink = useCallback(
     (rowId: string): string => {
       const { query } = routerRef.current;
-      const next: Record<string, string> = {};
+      const params = new URLSearchParams();
       for (const [k, v] of Object.entries(query)) {
-        if (typeof v === 'string') next[k] = v;
+        if (v === undefined) continue;
+        if (Array.isArray(v)) {
+          v.forEach((val) => params.append(k, val));
+        } else {
+          params.set(k, v);
+        }
       }
-      if (rowId) next[resolvedRowParam] = rowId;
-      else delete next[resolvedRowParam];
+      if (rowId) params.set(resolvedRowParam, rowId);
+      else params.delete(resolvedRowParam);
 
       const url = new URL(window.location.href);
-      url.search = new URLSearchParams(next).toString();
+      url.search = params.toString();
       return url.toString();
     },
     [resolvedRowParam],
@@ -161,19 +173,27 @@ export function useTableUrlState<F extends Record<string, string> = Record<strin
    * Copies a deeplink for the given row to the clipboard.
    */
   const copyRowDeepLink = useCallback(
-    (rowId: string) => {
+    async (rowId: string) => {
       const url = buildRowDeepLink(rowId);
-      navigator.clipboard.writeText(url).catch(() => {
+      try {
+        await navigator.clipboard.writeText(url);
+        notify({ message: 'Link copied to clipboard', event_type: EVENT_TYPES.SUCCESS });
+      } catch (err: unknown) {
         // Fallback for non-secure contexts (http in dev)
-        const ta = document.createElement('textarea');
-        ta.value = url;
-        document.body.appendChild(ta);
-        ta.select();
-        document.execCommand('copy');
-        document.body.removeChild(ta);
-      });
+        try {
+          const ta = document.createElement('textarea');
+          ta.value = url;
+          document.body.appendChild(ta);
+          ta.select();
+          document.execCommand('copy');
+          document.body.removeChild(ta);
+          notify({ message: 'Link copied to clipboard', event_type: EVENT_TYPES.SUCCESS });
+        } catch (fallbackErr: unknown) {
+          notify({ message: 'Failed to copy link', event_type: EVENT_TYPES.ERROR });
+        }
+      }
     },
-    [buildRowDeepLink],
+    [buildRowDeepLink, notify],
   );
 
   return { tableState, updateTableState, copyRowDeepLink, buildRowDeepLink };

--- a/ui/utils/hooks/useTableUrlState.ts
+++ b/ui/utils/hooks/useTableUrlState.ts
@@ -85,7 +85,6 @@ export function useTableUrlState<F extends Record<string, string> = Record<strin
     }
 
     return { page, pageSize, sortOrder, search, filters: filters as F };
-    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [router.query, tableKey]);
 
   const updateTableState = useCallback(

--- a/ui/utils/hooks/useTableUrlState.ts
+++ b/ui/utils/hooks/useTableUrlState.ts
@@ -67,9 +67,11 @@ export function useTableUrlState<F extends Record<string, string> = Record<strin
   const prefix = `${tableKey}_`;
   const resolvedRowParam = rowParam ?? `${prefix}row`;
 
-  // Keep a stable ref of the router so callbacks don't re-create on every render.
+  // Keep stable refs so callbacks don't re-create when router or defaults change.
   const routerRef = useRef(router);
   routerRef.current = router;
+  const defaultsRef = useRef(defaults);
+  defaultsRef.current = defaults;
 
   const tableState = useMemo<TableUrlState<F>>(() => {
     const { query } = router;
@@ -104,12 +106,12 @@ export function useTableUrlState<F extends Record<string, string> = Record<strin
       }
 
       if (updates.pageSize !== undefined) {
-        if (updates.pageSize === (defaults.pageSize ?? 10)) delete next[`${prefix}ps`];
+        if (updates.pageSize === (defaultsRef.current.pageSize ?? 10)) delete next[`${prefix}ps`];
         else next[`${prefix}ps`] = String(updates.pageSize);
       }
 
       if (updates.sortOrder !== undefined) {
-        if (!updates.sortOrder || updates.sortOrder === defaults.sortOrder)
+        if (!updates.sortOrder || updates.sortOrder === defaultsRef.current.sortOrder)
           delete next[`${prefix}sort`];
         else next[`${prefix}sort`] = updates.sortOrder;
       }
@@ -122,7 +124,7 @@ export function useTableUrlState<F extends Record<string, string> = Record<strin
       if (updates.filters) {
         for (const [key, value] of Object.entries(updates.filters)) {
           const paramKey = `${prefix}${key}`;
-          if (!value || value === (defaults.filters as Record<string, string>)?.[key])
+          if (!value || value === (defaultsRef.current.filters as Record<string, string>)?.[key])
             delete next[paramKey];
           else next[paramKey] = value;
         }
@@ -139,7 +141,7 @@ export function useTableUrlState<F extends Record<string, string> = Record<strin
         { shallow: true },
       );
     },
-    [prefix, defaults],
+    [prefix],
   );
 
   /**

--- a/ui/utils/hooks/useTableUrlState.ts
+++ b/ui/utils/hooks/useTableUrlState.ts
@@ -1,0 +1,181 @@
+import { useCallback, useMemo, useRef } from 'react';
+import { useRouter } from 'next/router';
+
+/**
+ * Persistent table state backed by URL query parameters.
+ *
+ * Each table gets a short `tableKey` prefix (e.g. "con" for connections,
+ * "des" for designs) so multiple tables can co-exist on the same page without
+ * colliding. Pagination, sort, and search are serialised as:
+ *
+ *   <key>_page  – current page (omitted when 0)
+ *   <key>_ps    – page size   (omitted when equal to the default)
+ *   <key>_sort  – sort string, e.g. "name asc"
+ *   <key>_q     – search query
+ *
+ * Additional per-table filter fields are passed through `defaults.filters`
+ * and appear as `<key>_<fieldName>` params.
+ *
+ * Deep-links to a specific row use a caller-provided `rowParam` (defaults to
+ * `<key>_row`). The parent component writes the param when a row is expanded;
+ * `copyRowDeepLink` writes the URL to the clipboard.
+ */
+
+export interface TableUrlState<F extends Record<string, string> = Record<string, string>> {
+  page: number;
+  pageSize: number;
+  sortOrder: string;
+  search: string;
+  filters: F;
+}
+
+interface UseTableUrlStateOptions<F extends Record<string, string>> {
+  /** Short, stable identifier, e.g. "con", "des", "fil". */
+  tableKey: string;
+  /**
+   * Optional name for the row-id URL parameter used by deeplinks.
+   * Defaults to `<tableKey>_row`.
+   */
+  rowParam?: string;
+  defaults: {
+    page?: number;
+    pageSize?: number;
+    sortOrder?: string;
+    search?: string;
+    /** Default values for each custom filter field. */
+    filters?: F;
+  };
+}
+
+function parseIntSafe(value: string | string[] | undefined, fallback: number): number {
+  const n = parseInt(value as string, 10);
+  return Number.isFinite(n) ? n : fallback;
+}
+
+function decodeParam(value: string | string[] | undefined): string {
+  return typeof value === 'string' ? decodeURIComponent(value) : '';
+}
+
+export function useTableUrlState<F extends Record<string, string> = Record<string, string>>(
+  options: UseTableUrlStateOptions<F>,
+) {
+  const router = useRouter();
+  const { tableKey, defaults, rowParam } = options;
+  const prefix = `${tableKey}_`;
+  const resolvedRowParam = rowParam ?? `${prefix}row`;
+
+  // Keep a stable ref of the router so callbacks don't re-create on every render.
+  const routerRef = useRef(router);
+  routerRef.current = router;
+
+  const tableState = useMemo<TableUrlState<F>>(() => {
+    const { query } = router;
+
+    const page = parseIntSafe(query[`${prefix}page`], defaults.page ?? 0);
+    const pageSize = parseIntSafe(query[`${prefix}ps`], defaults.pageSize ?? 10);
+    const sortOrder = decodeParam(query[`${prefix}sort`]) || defaults.sortOrder || '';
+    const search = decodeParam(query[`${prefix}q`]) || '';
+
+    const filters: Record<string, string> = {};
+    if (defaults.filters) {
+      for (const key of Object.keys(defaults.filters)) {
+        const raw = decodeParam(query[`${prefix}${key}`]);
+        filters[key] = raw || defaults.filters[key] || '';
+      }
+    }
+
+    return { page, pageSize, sortOrder, search, filters: filters as F };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [router.query, tableKey]);
+
+  const updateTableState = useCallback(
+    (updates: Partial<TableUrlState<F>>) => {
+      const { query: currentQuery } = routerRef.current;
+      const next: Record<string, string | undefined> = { ...currentQuery } as Record<
+        string,
+        string | undefined
+      >;
+
+      if (updates.page !== undefined) {
+        if (updates.page === 0) delete next[`${prefix}page`];
+        else next[`${prefix}page`] = String(updates.page);
+      }
+
+      if (updates.pageSize !== undefined) {
+        if (updates.pageSize === (defaults.pageSize ?? 10)) delete next[`${prefix}ps`];
+        else next[`${prefix}ps`] = String(updates.pageSize);
+      }
+
+      if (updates.sortOrder !== undefined) {
+        if (!updates.sortOrder || updates.sortOrder === defaults.sortOrder)
+          delete next[`${prefix}sort`];
+        else next[`${prefix}sort`] = updates.sortOrder;
+      }
+
+      if (updates.search !== undefined) {
+        if (!updates.search) delete next[`${prefix}q`];
+        else next[`${prefix}q`] = updates.search;
+      }
+
+      if (updates.filters) {
+        for (const [key, value] of Object.entries(updates.filters)) {
+          const paramKey = `${prefix}${key}`;
+          if (!value || value === (defaults.filters as Record<string, string>)?.[key])
+            delete next[paramKey];
+          else next[paramKey] = value;
+        }
+      }
+
+      // Remove undefined entries so router.replace gets a clean query object.
+      const cleanQuery = Object.fromEntries(
+        Object.entries(next).filter(([, v]) => v !== undefined),
+      );
+
+      routerRef.current.replace({ query: cleanQuery }, undefined, { shallow: true });
+    },
+    [prefix, defaults],
+  );
+
+  /**
+   * Builds a shareable URL that points directly to `rowId` in this table.
+   * All current table-state params are preserved so the recipient lands on
+   * the same view, with just the row expanded.
+   */
+  const buildRowDeepLink = useCallback(
+    (rowId: string): string => {
+      const { query } = routerRef.current;
+      const next: Record<string, string> = {};
+      for (const [k, v] of Object.entries(query)) {
+        if (typeof v === 'string') next[k] = v;
+      }
+      if (rowId) next[resolvedRowParam] = rowId;
+      else delete next[resolvedRowParam];
+
+      const url = new URL(window.location.href);
+      url.search = new URLSearchParams(next).toString();
+      return url.toString();
+    },
+    [resolvedRowParam],
+  );
+
+  /**
+   * Copies a deeplink for the given row to the clipboard.
+   */
+  const copyRowDeepLink = useCallback(
+    (rowId: string) => {
+      const url = buildRowDeepLink(rowId);
+      navigator.clipboard.writeText(url).catch(() => {
+        // Fallback for non-secure contexts (http in dev)
+        const ta = document.createElement('textarea');
+        ta.value = url;
+        document.body.appendChild(ta);
+        ta.select();
+        document.execCommand('copy');
+        document.body.removeChild(ta);
+      });
+    },
+    [buildRowDeepLink],
+  );
+
+  return { tableState, updateTableState, copyRowDeepLink, buildRowDeepLink };
+}


### PR DESCRIPTION
## Summary

Addresses two UX gaps in Meshery's datatable usage:

1. **State persistence** — table navigation state (page, page size, sort, search, filters) is now serialized into URL query parameters. Navigating away and returning restores the exact same view.
2. **Row deeplinks** — users can copy a direct link to any specific connection row from the connection table's action menu. Sharing the link lands the recipient on that row.

## New hooks (`ui/utils/hooks/`)

### `useTableUrlState`
Reads and writes table navigation state (page, pageSize, sortOrder, search, filters) as URL query parameters using per-table prefixes (`con_`, `des_`, `fil_`). Uses `router.replace` with `shallow: true` so no full navigation occurs and browser history is not polluted. Returns `tableState`, `updateTableState`, `copyRowDeepLink`, and `buildRowDeepLink`.

### `useColumnVisibilityPreference`
Persists column visibility to `localStorage` under key `meshery_cols_<tableKey>`, distinguishing between user-initiated toggles (persisted) and responsive-layout updates (not persisted, but user overrides win). Exposes `setColumnVisibilityByUser` and `setColumnVisibilityByResponsive`.

## Tables migrated

| Table | Key | Filter params |
|---|---|---|
| Connections | `con` | `con_status`, `con_kind` |
| Designs | `des` | `des_vis` |
| Filters | `fil` | `fil_vis` |

## Changes

- `ui/utils/hooks/useTableUrlState.ts` — new hook
- `ui/utils/hooks/useColumnVisibilityPreference.ts` — new hook
- `ui/utils/hooks/index.ts` — export both new hooks
- `ui/components/connections/ConnectionTable.tsx` — migrate to hooks; wire Copy link into action menu
- `ui/components/connections/ConnectionActionMenu.tsx` — add optional Copy link button
- `ui/components/designs/patterns/MesheryPatterns.tsx` — migrate to hooks
- `ui/components/filters/Filters.tsx` — migrate to hooks

## Test plan

- [ ] Navigate to Connections, set filters/sort/search/page, go to another page and return — state is preserved
- [ ] Open the action menu on a connection row, click "Copy link", paste in a new tab — row is highlighted/expanded
- [ ] Toggle column visibility, navigate away and return — visibility is preserved
- [ ] Resize viewport to narrow width — responsive column hiding works and does not override saved user visibility prefs
- [ ] Repeat state-persistence and deeplink checks on Designs and Filters tables

