### PR TITLE
[Server] fix(errors): dedupe ErrInvalidUUIDCode to unblock Error Codes Utility

### DIFF
--- a/server/helpers/component_info.json
+++ b/server/helpers/component_info.json
@@ -1,5 +1,5 @@
 {
   "name": "meshery-server",
   "type": "component",
-  "next_error_code": 1432
+  "next_error_code": 1433
 }

--- a/server/models/error.go
+++ b/server/models/error.go
@@ -151,7 +151,7 @@ const (
 	ErrMeshsyncStoreUpdatesCode           = "meshery-server-1380"
 	ErrRemoteProviderCapabilitiesCode     = "meshery-server-1420"
 	ErrRemoteProviderAuthExhaustedCode    = "meshery-server-1421"
-	ErrInvalidUUIDCode                    = "meshery-server-1432"
+	ErrInvalidUUIDValueCode               = "meshery-server-1432"
 )
 
 var (
@@ -368,7 +368,7 @@ func ErrGenerateUUID(err error) error {
 }
 
 func ErrInvalidUUID(err error) error {
-	return errors.New(ErrInvalidUUIDCode, errors.Alert, []string{"Invalid UUID"}, []string{err.Error()}, []string{"The provided identifier is not a valid UUID"}, []string{"Provide a valid UUID"})
+	return errors.New(ErrInvalidUUIDValueCode, errors.Alert, []string{"Invalid UUID"}, []string{err.Error()}, []string{"The provided identifier is not a valid UUID"}, []string{"Provide a valid UUID"})
 }
 
 func ErrGrafanaOrg(err error) error {


### PR DESCRIPTION
**Description**

`ErrInvalidUUIDCode` was declared in **two** packages with the **same name** but different codes:

- `server/handlers/error.go` → `meshery-server-1137`
- `server/models/error.go` → `meshery-server-1432`

This trips the MeshKit Error Codes Utility, which currently fails on `master`:

```
component_info.next_error_code '1432' is lower than or equal to highest used code '1432'
duplicate error code name 'ErrInvalidUUIDCode'
duplicate error details for error name 'ErrInvalidUUIDCode' and code '1432'
duplicate error details for error name 'ErrInvalidUUIDCode' and code '1137'
```

The newer (models) constant also grabbed `1432` = `component_info.next_error_code` without bumping it.

**Fix:** rename the models constant to `ErrInvalidUUIDValueCode` (keeping code `1432`, so there is **no client-facing error-code change** to either layer) and bump `next_error_code` to `1433`. Both `ErrInvalidUUID()` functions and their many call sites are unchanged. `errorutil analyze` is now clean (0 findings) and the server builds.

**Notes for Reviewers**

- Only two tracked files change; `server/helpers/errorutil_*.json` are gitignored artifacts regenerated by the Error Codes Utility's `update` step in CI, so they are intentionally not committed.
- Pre-existing breakage on `master`, surfaced while iterating an unrelated PR — split out as its own change per request. Unblocks the "Error codes utility" check for any PR branched off `master`.

**[Signed commits](https://github.com/meshery/meshery/blob/master/CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [x] Yes, I signed my commits.
