### PR TITLE
chore(ui): bump @meshery/schemas to 1.3.16

### DIFF
--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -21,7 +21,7 @@
         "@emotion/react": "^11.14.0",
         "@emotion/server": "^11.11.0",
         "@emotion/styled": "^11.14.1",
-        "@meshery/schemas": "^1.3.15",
+        "@meshery/schemas": "^1.3.16",
         "@microlink/react-json-view": "^1.31.20",
         "@mui/icons-material": "^9.1.1",
         "@mui/material": "^9.1.2",
@@ -2028,9 +2028,9 @@
       "license": "MIT"
     },
     "node_modules/@meshery/schemas": {
-      "version": "1.3.15",
-      "resolved": "https://registry.npmjs.org/@meshery/schemas/-/schemas-1.3.15.tgz",
-      "integrity": "sha512-k1x9/K5DqGLFxI8sPe2AP2886IcAcWqQ9355MjDWGfmPzgcIpl52oeVc0Rg/a3Tye4Ahe/L2ku7W+WA/cV0MBw==",
+      "version": "1.3.16",
+      "resolved": "https://registry.npmjs.org/@meshery/schemas/-/schemas-1.3.16.tgz",
+      "integrity": "sha512-rpCp3oWwRkqk6McOn8s4EzxjTcSZP0U9nUb+uopdwaN/Fsx3VtpPl0SgZa3jncTCt+QYZe65Ed/L5EA+2kWBpg==",
       "license": "ISC",
       "peerDependencies": {
         "@reduxjs/toolkit": "^2.8.1",

--- a/ui/package.json
+++ b/ui/package.json
@@ -49,7 +49,7 @@
     "@emotion/react": "^11.14.0",
     "@emotion/server": "^11.11.0",
     "@emotion/styled": "^11.14.1",
-    "@meshery/schemas": "^1.3.15",
+    "@meshery/schemas": "^1.3.16",
     "@microlink/react-json-view": "^1.31.20",
     "@mui/icons-material": "^9.1.1",
     "@mui/material": "^9.1.2",


### PR DESCRIPTION
Bumps the UI's `@meshery/schemas` dependency from 1.3.15 to 1.3.16, matching the Go module bump to v1.3.16 (already on master). Patch bump; `ui/package.json` and `ui/package-lock.json` updated. No code changes.