### PR TITLE
[Docs] Sidebar TOC: render leaf pages with normal font weight

### DIFF
--- a/docs/assets/scss/_sidebar.scss
+++ b/docs/assets/scss/_sidebar.scss
@@ -351,7 +351,7 @@
   }
 
   & .td-sidebar-nav__section.without-child > a.td-sidebar-link {
-    font-weight: 600;
+    font-weight: 400;
   }
 
   & .td-sidebar-link:hover,


### PR DESCRIPTION
**Notes for Reviewers**

Fixes #20242

### Symptom
Leaf pages in the documentation sidebar Table of Contents - e.g. "Quick Start Guide" and "Using Meshery Playground" under Installation - render in semi-bold, visually indistinguishable from parent section links.

### Root cause
In `docs/assets/scss/_sidebar.scss`, the rule for leaf nav items sets the wrong weight:

```scss
& .td-sidebar-nav__section.without-child > a.td-sidebar-link {
  font-weight: 600;
}
```

Leaf pages carry the `without-child` class (verified against `layouts/partials/sidebar-tree.html`, which emits `with-child`/`without-child` based on whether a section has children). The adjacent comment already states leaf pages should be de-emphasised relative to sections with children - the `600` value contradicted that intent.

Note: PR #20275 ("TOC Sidebar uplift") was merged referencing this issue, but it only landed the visual refresh (gradient, scrollbar, padding) and left this `font-weight` at `600`, so the issue remained unresolved.

### Fix
Set `font-weight: 400` (normal) for `without-child` leaf links. Sections with children remain bold (`with-child` -> `800`), producing a clear, scannable hierarchy.

### Scope / correctness
- Cascade verified: at the nested (ul-2+) level where these leaf pages live, `without-child` (4 classes) wins over the `ul:not(.ul-1)` rule on a source-order tie, so `400` now applies cleanly.
- All top-level nav items are sections (`with-child`), so no top-level leaf pages are affected by this change.

### Before / After
- **Before:** "Quick Start Guide" / "Using Meshery Playground" appear semi-bold, same weight as parent sections.
- **After:** Leaf pages render in normal weight; parent sections with children stay bold.

**[Signed commits](https://github.com/meshery/meshery/blob/master/CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [x] Yes, I signed my commits.
