### PR TITLE
[UI] Replace hardcoded hex fills with sistent tokens in environments

### DIFF
--- a/ui/components/environments/index.tsx
+++ b/ui/components/environments/index.tsx
@@ -6,6 +6,7 @@ import {
   NoSsr,
   Pagination,
   PaginationItem,
+  useTheme,
 } from '@sistent/sistent';
 import { withRouter } from 'next/router';
 import { debounce } from 'lodash';
@@ -57,6 +58,7 @@ const ACTION_TYPES = {
 };
 
 const Environments = () => {
+  const theme = useTheme();
   const { organization } = useSelector((state) => state.ui);
   const [environmentModal, setEnvironmentModal] = useState({
     open: false,
@@ -549,10 +551,9 @@ const Environments = () => {
                 <EnvironmentIcon
                   height="6rem"
                   width="6rem"
-                  fill="#808080"
-                  secondaryFill="#979797"
+                  fill={theme.palette.icon.default}
+                  secondaryFill={theme.palette.icon.secondary}
                 />
-                // TODO: replace all fill and secondary fill hex values with sistent tokens
               }
               message="No environment available"
               pointerLabel="Click “Create” to establish your first environment."
@@ -596,11 +597,19 @@ const Environments = () => {
                 assignedData={handleAssignConnectionData}
                 originalAssignedData={environmentConnectionsData}
                 emptyStateIconLeft={
-                  <ConnectionIcon width="120" primaryFill="#808080" secondaryFill="#979797" />
+                  <ConnectionIcon
+                    width="120"
+                    primaryFill={theme.palette.icon.default}
+                    secondaryFill={theme.palette.icon.secondary}
+                  />
                 }
                 emtyStateMessageLeft="No connections available"
                 emptyStateIconRight={
-                  <ConnectionIcon width="120" primaryFill="#808080" secondaryFill="#979797" />
+                  <ConnectionIcon
+                    width="120"
+                    primaryFill={theme.palette.icon.default}
+                    secondaryFill={theme.palette.icon.secondary}
+                  />
                 }
                 emtyStateMessageRight="No connections assigned"
                 transferComponentType={TRANSFER_COMPONENT.CHIP}


### PR DESCRIPTION
**Notes for Reviewers**

This PR fixes #20280 .
- Replaces hardcoded icon color hex values in `ui/components/environments/index.tsx` with Sistent theme tokens.
- Updates the empty state `EnvironmentIcon `and both `ConnectionIcon `instances used in the transfer list to use theme-provided icon colors.

#### Before
- Icons used hardcoded colors (#808080 and #979797).

#### After
- Icons use Sistent theme tokens (`theme.palette.icon.default` and `theme.palette.icon.secondary`) for consistent theming across the UI.

**[Signed commits](https://github.com/meshery/meshery/blob/master/CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [x] Yes, I signed my commits.

<!--
Thank you for contributing to Meshery! 

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. Sign your commits.
4. Include before and after screenshots/terminal output.

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.
-->
