### PR TITLE
[mesheryctl] Fix minimum() returning max on argument ties

### DIFF
--- a/mesheryctl/pkg/utils/closest_arg.go
+++ b/mesheryctl/pkg/utils/closest_arg.go
@@ -26,13 +26,14 @@ func levenshtein(str1, str2 []rune) int {
 }
 
 func minimum(a, b, c int) int {
-	if a < b && a < c {
-		return a
-	} else if b < a && b < c {
-		return b
-	} else {
-		return c
+	m := a
+	if b < m {
+		m = b
 	}
+	if c < m {
+		m = c
+	}
+	return m
 }
 
 func minIntSlice(values []int) (int, int) {

--- a/mesheryctl/pkg/utils/closest_arg_test.go
+++ b/mesheryctl/pkg/utils/closest_arg_test.go
@@ -48,6 +48,11 @@ func TestClosestArgs(t *testing.T) {
 		if min != 1 {
 			t.Errorf("Expected 1, got %d", min)
 		}
+
+		min = minimum(1, 1, 2)
+		if min != 1 {
+			t.Errorf("Expected 1, got %d", min)
+		}
 	})
 
 	t.Run("Test levenshtein", func(t *testing.T) {


### PR DESCRIPTION
Fixes #20283

**Notes for Reviewers**

- This PR fixes #20283

`minimum(a, b, c)` in `mesheryctl/pkg/utils/closest_arg.go` returned the
largest value when two arguments tied for the minimum (`a == b < c`),
since neither strict `<` branch matched and it fell through to `return c`.
Rewrote it as a straightforward min-reduction and added a tie-case
regression assertion to the existing `Test minimum` subtest.

**[Signed commits](https://github.com/meshery/meshery/blob/master/CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [x] Yes, I signed my commits.

<!--
Thank you for contributing to Meshery! 

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. Sign your commits.
4. Include before and after screenshots/terminal output.

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.
-->
