### PR TITLE
[UI] Fix clipped action icons in Recent Designs widget

### DIFF
--- a/ui/components/dashboard/widgets/MyDesignsWidget.test.tsx
+++ b/ui/components/dashboard/widgets/MyDesignsWidget.test.tsx
@@ -27,6 +27,13 @@ vi.mock('@/constants/endpoints', () => ({
 }));
 
 vi.mock('@sistent/sistent', () => ({
+  Box: ({
+    children,
+    sx: _sx,
+    ...rest
+  }: { children: React.ReactNode; sx?: unknown } & React.HTMLAttributes<HTMLDivElement>) => (
+    <div {...rest}>{children}</div>
+  ),
   CatalogIcon: () => <svg data-testid="catalog-icon" />,
   DesignIcon: () => <svg data-testid="design-icon" />,
   EditIcon: () => <svg data-testid="edit-icon" />,

--- a/ui/components/dashboard/widgets/MyDesignsWidget.tsx
+++ b/ui/components/dashboard/widgets/MyDesignsWidget.tsx
@@ -1,6 +1,7 @@
 import React, { useMemo, useState } from 'react';
 import { useGetLoggedInUserQuery } from '@/rtk-query/user';
 import {
+  Box,
   CatalogIcon,
   DesignIcon,
   EditIcon,
@@ -78,25 +79,34 @@ const MyDesignsWidget = ({ iconsProps }: MyDesignsWidgetProps) => {
   );
 
   return (
-    <DesignCard
-      isPatternsFetching={isPatternsFetching}
-      cardData={cardData}
-      resources={resources}
-      icon={
-        <DesignIcon
-          {...iconsProps}
-          fill={theme.palette.icon.default}
-          primaryFill={theme.palette.icon.default}
-          secondaryFill={theme.palette.icon.default}
-        />
-      }
-      title="MY RECENT DESIGNS"
-      actionButton={true}
-      href={`${MESHERY_CLOUD_PROD}/catalog/content/my-designs`}
-      btnTitle="See All Designs"
-      sortOrder={sortOrder}
-      setSortOrder={setSortOrder}
-    />
+    <Box
+      sx={{
+        height: '100%',
+        '& > .MuiPaper-root': {
+          overflow: 'auto',
+        },
+      }}
+    >
+      <DesignCard
+        isPatternsFetching={isPatternsFetching}
+        cardData={cardData}
+        resources={resources}
+        icon={
+          <DesignIcon
+            {...iconsProps}
+            fill={theme.palette.icon.default}
+            primaryFill={theme.palette.icon.default}
+            secondaryFill={theme.palette.icon.default}
+          />
+        }
+        title="MY RECENT DESIGNS"
+        actionButton={true}
+        href={`${MESHERY_CLOUD_PROD}/catalog/content/my-designs`}
+        btnTitle="See All Designs"
+        sortOrder={sortOrder}
+        setSortOrder={setSortOrder}
+      />
+    </Box>
   );
 };
 


### PR DESCRIPTION
- Wrapped DesignCard in MyDesignsWidget.tsx with a Box that sets overflow: auto on the inner MUI Card.
- This prevents the 'See All Designs' and '+' action buttons from being clipped by the fixed-height grid layout cell.
- Updated the tests mock to include Box.

Fixes #20290

**Notes for Reviewers**

## Screenshot
<img width="383" height="358" alt="Screenshot 2026-06-26 at 18 56 08" src="https://github.com/user-attachments/assets/24cf7362-288d-4ddb-a483-0a00eedb2267" />


- This PR fixes #

**[Signed commits](https://github.com/meshery/meshery/blob/master/CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [x] Yes, I signed my commits.

<!--
Thank you for contributing to Meshery! 

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. Sign your commits.
4. Include before and after screenshots/terminal output.

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.
-->
