### PR TITLE
[Docs] condense AGENTS.md and add CLAUDE.md alias

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,618 +1,278 @@
 # Project Overview
 
-Meshery is a self-service engineering platform and the open source, cloud native manager enabling the
-design and management of all Kubernetes-based infrastructure and applications. As a CNCF project, 
-Meshery offers visual and collaborative GitOps, freeing you from the chains of YAML while managing 
-Kubernetes multi-cluster deployments. With support for 300+ integrations, Meshery provides 
-infrastructure lifecycle management, workspaces for team collaboration, design pattern catalogs,
-performance management, and multi-tenancy capabilities across any cloud or on-premises environment.
+Meshery is a self-service engineering platform and open source cloud native manager for Kubernetes infrastructure. A CNCF project supporting 300+ integrations with visual GitOps, multi-cluster management, and workspace collaboration.
 
 ## Repository Structure
 
-- **/server** – Meshery Server backend written in Go; handles REST/GraphQL APIs, Kubernetes cluster
-  management, adapter orchestration, and database operations (PostgreSQL).
-- **/ui** – Meshery UI built with Next.js and React; includes Material UI components, Redux Toolkit
-  state management, and Relay for GraphQL queries.
-- **/mesheryctl** – Meshery CLI built with Go and Cobra framework; provides commands for installation,
-  lifecycle management, pattern deployment, and system validation.
-- **/docs** – Documentation site powered by Hugo; contains user guides, concepts, contributing
-  guides, and API references.
-- **/install** – Installation artifacts including Dockerfiles, Kubernetes manifests, Helm charts,
-  Docker Compose files, and platform-specific deployment scripts.
-- **/provider-ui** – Provider-specific UI extensions; isolated React application for remote provider
-  integrations.
-- **/policies** – Open Policy Agent (OPA) Rego policies for relationship evaluation and design
-  validation.
-- **/.github** – GitHub Actions workflows, issue templates, Copilot agent definitions, and community
-  health files.
+| Directory | Purpose |
+|-----------|---------|
+| `/server` | Go backend — REST/GraphQL APIs, Kubernetes management, PostgreSQL |
+| `/ui` | Next.js/React frontend — MUI, Redux Toolkit, Relay GraphQL |
+| `/mesheryctl` | Go CLI with Cobra — install, lifecycle, pattern deployment |
+| `/docs` | Hugo documentation site |
+| `/install` | Dockerfiles, Kubernetes manifests, Helm charts |
+| `/provider-ui` | Provider-specific React UI extensions |
+| `/policies` | OPA Rego policies for relationship evaluation |
+| `/.github` | GitHub Actions, issue templates, Copilot agent definitions |
 
 ## Identifier Naming Conventions — MANDATORY
 
-Full canonical directory: <https://github.com/meshery/schemas/blob/master/docs/identifier-naming-contributor-guide.md> — the reader-friendly 26-row naming table with before/after and do/don't examples. The inline per-layer forms below remain the repo-scoped authority; the guide is the ecosystem-wide reference.
+Authoritative guide: <https://github.com/meshery/schemas/blob/master/docs/identifier-naming-contributor-guide.md>
 
-This repository adheres to the canonical camelCase-wire identifier-naming contract
-defined authoritatively in `meshery/schemas/AGENTS.md § Casing rules at a
-glance`. The contract is **not optional**; deviations should be treated as
-repository policy and corrected before review or merge. The cross-repo
-consumer-audit gate lives in `meshery/schemas` and flags divergence in
-this repo's server handlers and UI slices on every PR — the migration
-that armed it is **complete (2026-04-23)** per
-`meshery/schemas/docs/identifier-naming-impact-report.md`. See
-`meshery/schemas/.github/workflows/schema-audit.yml` for the authoritative
-CI job; the consumer-audit was promoted from advisory to **blocking** in
-Phase 4.B.
-
-### The rule in one sentence
-
-*Wire is camelCase everywhere; DB is snake_case; Go fields follow Go
-idiom; the ORM layer is the sole translation boundary.*
+**Wire is camelCase; DB is snake_case; Go fields follow Go idiom; the ORM layer is the sole translation boundary.**
 
 ### Per-layer canonical forms
 
 | Layer | Form |
 |---|---|
 | DB column / `db:` tag | `snake_case` — `user_id`, `org_id`, `created_at` |
-| Go struct field | `PascalCase` with Go-idiomatic initialisms — `UserID`, `OrgID`, `CreatedAt` |
-| JSON tag | `camelCase` — `json:"userId"`, `json:"orgId"`, `json:"createdAt"` |
+| Go struct field | `PascalCase` with Go initialisms — `UserID`, `OrgID`, `CreatedAt` |
+| JSON tag | `camelCase` — `json:"userId"`, `json:"orgId"` |
 | URL query/path param | `camelCase` — `{orgId}`, `?userId=...` |
-| TypeScript property | `camelCase` — `response.userId`, `queryArg.orgId` |
+| TypeScript property | `camelCase` — `response.userId` |
 | OpenAPI schema property | `camelCase` |
 | OpenAPI `operationId` | `lower camelCase verbNoun` — `getWorkspaces` |
 | `components/schemas` type name | `PascalCase` — `WorkspacePayload` |
 
 ### Forbidden (MUST NOT)
 
-- MUST NOT introduce a `json:` tag that matches the `db:` tag on a new
-  DB-backed field. Wire is camel; DB is snake; they differ by design.
-- MUST NOT declare an RTK query endpoint hand-rolled when
-  `@meshery/schemas/{mesheryApi,cloudApi}` provides a canonical equivalent.
-- MUST NOT locally redeclare a Go type that has an equivalent in
-  `github.com/meshery/schemas/models/...`.
-- MUST NOT use `ID` (ALL CAPS) in URL query parameters, JSON tags, or
-  TypeScript properties. `Id` (camelCase) is canonical.
-- MUST NOT mix casing conventions within a single resource. If wire
-  format must change, introduce a new API version per
-  `meshery/schemas/AGENTS.md § Dual-Schema Pattern`.
-- MUST NOT import deprecated legacy schema versions in new code. When
-  importing from `@meshery/schemas`, consume the latest canonical-casing
-  version (v1beta3 where present, otherwise v1beta2). Deprecated
-  `v1beta1` constructs are kept for backward compatibility only; do not
-  reach for them in new server handlers, `mesheryctl` commands, or UI
-  RTK slices.
+- MUST NOT use a `json:` tag matching the `db:` tag — wire is camel, DB is snake.
+- MUST NOT hand-roll an RTK query endpoint when `@meshery/schemas/{mesheryApi,cloudApi}` provides one.
+- MUST NOT locally redeclare a Go type with an equivalent in `github.com/meshery/schemas/models/...`.
+- MUST NOT use `ID` (ALL CAPS) in URL params, JSON tags, or TypeScript properties — use `Id`.
+- MUST NOT mix casing within a single resource; introduce a new API version to change wire format.
+- MUST NOT import deprecated `v1beta1` in new code; use `v1beta3` (or `v1beta2` where v1beta3 absent).
 
 ### Required on every PR
 
-- MUST run the schemas validator locally before pushing. This command
-  assumes `meshery` and `schemas` are checked out as sibling directories
-  (for example, `../meshery` and `../schemas`):
-  `cd ../schemas && make validate-schemas && make consumer-audit`. If
-  `meshery/schemas` is cloned elsewhere, run the same targets from that
-  checkout instead — e.g. `cd /path/to/schemas && make validate-schemas && make consumer-audit`.
-- MUST include test updates for any casing or tag change.
-- MUST include doc updates for any user-visible API change.
-- MUST sign off commits (`git commit -s`).
+- Run schemas validator: `cd ../schemas && make validate-schemas && make consumer-audit`
+- Include test updates for casing/tag changes.
+- Include doc updates for user-visible API changes.
+- Sign off commits: `git commit -s`
 
-### Authority
-
-`meshery/schemas/AGENTS.md` is authoritative. On any conflict between
-this repo's documentation and the schemas AGENTS.md, schemas wins. File
-discrepancies as issues against `meshery/schemas`, not locally. All
-wire-format questions are resolved against `meshery/schemas`, not this
-downstream repo.
-
-### Migration
-
-The identifier-naming migration is tracked at
-`meshery/schemas/docs/identifier-naming-migration.md`. All
-contributors — human and AI agents — MUST read this plan before making
-any schema-aware change.
-
-**Status: complete (2026-04-23).** Per
-`meshery/schemas/docs/identifier-naming-impact-report.md`, all 22
-in-scope resources have been migrated to canonical camelCase-on-wire
-versions, the consumer-audit CI gate has been promoted to blocking
-(Phase 4.B), and consumer-audit TypeScript findings against this repo
-are at zero (Phase 2 tail PR #18904 + the per-resource Phase 3 repoint
-PRs #18886, #18888, #18889, #18890, #18894, #18900). This repository's
-side of the migration is therefore **closed**; new work should not
-introduce snake_case wire properties or hand-rolled local Go types
-duplicating canonical schemas types.
-
-#### Server-side post-migration audit (2026-04-23)
-
-A retrospective canonical-conformance audit confirmed that this repo's
-server side is conformant with the contract:
-
-- **Local Go duplicates of canonical schemas types — none requiring
-  retirement.** The named candidates from the migration plan (§2.3) are
-  resolved as follows:
-  - `MesheryPattern` (`server/models/meshery_pattern.go`) — retained as
-    a deliberate **persistence/storage adapter shim**, not a duplicate.
-    The canonical `v1beta3/design.MesheryPattern` expresses the design
-    body as a typed `*PatternFile` struct; the server's storage model
-    persists the design as a YAML/JSON string in a single `pattern_file`
-    column. The local struct is the adapter that bridges the canonical
-    design representation and the server's persisted storage model and
-    cannot be displaced without first restructuring server-side
-    persistence — out of scope for an identifier-naming migration. The
-    five count fields (`viewCount`, `shareCount`, `downloadCount`,
-    `cloneCount`, `deploymentCount`) and `orgId` already wear canonical
-    camelCase JSON tags, and `UnmarshalJSON` dual-accepts the legacy
-    snake_case spellings for the deprecation window per the Phase 2.K
-    cascade contract.
-  - `MesheryPatternRequestBody` — not present locally. Of the two
-    locally defined wrappers, only `MesheryPatternUPDATERequestBody`
-    remains on an active request path; the POST handler uses
-    `DesignPostPayload`, which contains `design.PatternFile`, while
-    `MesheryPatternPOSTRequestBody` is deprecated. These local request
-    shapes dual-accept `patternData` / `pattern_data` wrapper keys per
-    the cascade contract.
-  - `MesheryFilter` (`server/models/meshery_filter.go`) — canonical
-    schemas `v1beta3/design.MesheryFilter` is a placeholder
-    (`map[string]interface{}`), not a typed struct. Local retention is
-    correct until schemas authors a structured filter resource.
-  - `MesheryApplication` (`server/models/meshery_application.go`) — no
-    canonical equivalent exists in `meshery/schemas`. Local retention
-    is correct.
-  - `PerformanceProfile` (`server/models/performance_profiles.go`) — no
-    canonical equivalent exists in `meshery/schemas`. Local retention
-    is correct.
-- **DB-column conformance — all canonical-declared `db:` tags
-  present.** Every column declared via `db:` on
-  `v1beta3/design.MesheryPattern` (`clone_count`, `created_at`,
-  `deployment_count`, `download_count`, `pattern_file`, `share_count`,
-  `updated_at`, `user_id`, `view_count`) has a corresponding gorm-mapped
-  column in `models.MesheryPattern`'s `AutoMigrate` registration in
-  `server/cmd/main.go`. No migration action required.
-- **Consumer audit clean.** The `consumer-audit` blocking CI in
-  `meshery/schemas` reports zero TypeScript findings against this repo
-  post-merge of PR #18904.
-
-**Reviewer guardrail: the residual local types listed above are
-intentional and MUST NOT be flagged as canonical-duplicate violations
-in code review.** They are documented as "intentional request-wrapper
-shims" in the impact report's row 42. If a future change makes
-displacement feasible (e.g., schemas adds a structured `MesheryFilter`
-or the server's persistence model is refactored), the displacement
-should be coordinated cross-repo per `meshery/schemas/AGENTS.md`'s
-"Source of Truth" directive — not unilaterally in this repo.
+> `meshery/schemas/AGENTS.md` is authoritative. On conflicts, schemas wins.
 
 ## Build & Development Commands
 
 ### Server (Go)
 
 ```bash
-# Run Meshery Server locally (port 9081)
-make server
-
-# Run with local provider for testing
-make server-local
-
-# Build server binary
-make build-server
-
-# Run server binary
-make server-binary
-
-# Lint Go code
-make golangci
-
-# Run server without Kubernetes components
-make server-skip-compgen
-
-# Run server without operator deployment
-make server-without-operator
-
-# Generate error codes and update helpers
-make error
+make server                    # Run server locally (port 9081)
+make server-local              # Run with local provider
+make build-server              # Build binary
+make golangci                  # Lint Go code
+make server-skip-compgen       # Run without Kubernetes components
+make server-without-operator   # Run without operator deployment
+make error                     # Generate error codes
 ```
 
 ### UI (Next.js/React)
 
 ```bash
-# Install UI dependencies
-make ui-setup
-
-# Run UI development server (port 3000)
-make ui
-
-# Build and export UI
-make ui-build
-
-# Build only Meshery UI
-make ui-meshery-build
-
-# Lint UI code
-make ui-lint
-
-# Run end-to-end tests
-make ui-integration-tests
+make ui-setup              # Install dependencies
+make ui                    # Dev server (port 3000)
+make ui-build              # Build and export
+make ui-lint               # Lint UI code
+make ui-integration-tests  # Run E2E tests
 ```
 
 ### CLI (mesheryctl)
 
 ```bash
-# Build mesheryctl binary
-cd mesheryctl && make
-
-# Run unit tests
-cd mesheryctl && go test --short ./...
-
-# Run integration tests
-cd mesheryctl && go test -run Integration ./...
-
-# Generate CLI documentation
-make docs-mesheryctl
+cd mesheryctl && make                       # Build binary
+cd mesheryctl && go test --short ./...      # Unit tests
+cd mesheryctl && go test -run Integration ./...  # Integration tests
+make docs-mesheryctl                        # Generate CLI docs
 ```
 
 ### Docker
 
 ```bash
-# Build Meshery container
-make docker-build
-
-# Build playground mode container
-make docker-playground-build
-
-# Run Meshery with Docker pointing to production Remote Provider
-make docker-cloud
-
-# Run Meshery with Docker pointing to local Remote Provider
-make docker-local-cloud
+make docker-build           # Build container
+make docker-cloud           # Run with production Remote Provider
+make docker-local-cloud     # Run with local Remote Provider
 ```
 
 ### Documentation
 
 ```bash
-# Run docs site with and listen for changes (port 1313)
-make docs
-
-# Build docs site
-make docs-build
-
-# Run docs in Docker container
-make docs-docker
+make docs        # Run docs site (port 1313)
+make docs-build  # Build docs site
 ```
 
-### API Specifications
+### API & Helm
 
 ```bash
-# REST API docs consume the published OpenAPI spec at docs/data/openapi.yml
-
-# Build GraphQL schema
-make graphql-build
-
-# GraphQL is self-documenting via the introspection endpoint and the GraphQL
-# Playground at http://localhost:9081/api/system/graphql/playground.
-# A static reference snapshot lives at docs/content/en/reference/graphql-apis.md.
-```
-
-### Helm Charts
-
-```bash
-# Lint all Helm charts
-make helm-lint
-
-# Generate Helm chart documentation
-make helm-docs
+make graphql-build  # Build GraphQL schema
+make helm-lint      # Lint Helm charts
+make helm-docs      # Generate Helm chart docs
 ```
 
 ## Code Style & Conventions
 
-### Go Code
+### Go
 
-- **Formatting**: Use `gofmt` and `goimports`; enforced via `golangci-lint`.
-- **Linting**: Run `make golangci` before committing; config in `.golangci.yml`.
-- **Error Handling**: Use MeshKit's error utilities (`github.com/meshery/meshkit/errors`); run
-  `make error` to analyze error codes.
-- **Package Structure**: Follow Go project layout standards; keep packages focused and cohesive.
-- **Testing**: Use Go's standard testing library; place tests in `*_test.go` files; run with 
-  `go test`.
-- **Dependencies**: Manage with Go modules; run `go mod tidy` regularly.
+- Format with `gofmt`/`goimports`; lint with `make golangci` (config: `.golangci.yml`).
+- Use MeshKit error utilities (`github.com/meshery/meshkit/errors`); run `make error` for codes.
+- Tests in `*_test.go`; manage deps with `go mod tidy`.
 
-### JavaScript/React Code
+### JavaScript/React
 
-- **Formatting**: ESLint with Prettier; config in `ui/.eslintrc.js`.
-- **Component Style**: Use functional components with React hooks; avoid class components.
-- **Styling**: Prefer Sistent design system components (`@sistent/sistent`); fall back to Material
-  UI (MUI) when components unavailable.
-- **State Management**: Redux Toolkit for global state; local state with `useState`/`useReducer`.
-- **API Integration**: GraphQL via Relay; REST via Axios.
-- **Testing**: Playwright for E2E tests; run with `make ui-integration-tests`.
-- **Schema-Driven Development**: Use JSON schemas to define component props and validation.
+- ESLint + Prettier (config: `ui/.eslintrc.js`).
+- Functional components with hooks; no class components.
+- Use `@sistent/sistent` design system; fall back to MUI.
+- Redux Toolkit for global state; GraphQL via Relay; REST via Axios.
+- Playwright for E2E tests.
 
-### Commit Messages
+### Commits
 
-- **Format**: `[component] descriptive message` (e.g., `[UI] Add workspace filter dropdown`).
-- **Sign-Off**: All commits must be signed with DCO (`git commit -s`).
-- **References**: Link to issues/PRs when applicable (`Fixes #1234`, `Relates to #5678`).
+- Format: `[component] descriptive message` (e.g., `[UI] Add workspace filter dropdown`)
+- Sign off: `git commit -s`
+- Reference issues: `Fixes #1234`
 
-### Git Workflow
-
-- Fork the repository and create feature branches from `master`.
-- Keep commits atomic and focused on single changes.
-- Squash commits before merging unless history provides value.
-
-## Architecture Notes
+## Architecture
 
 ```
-┌─────────────────────────────────────────────────────────────────────┐
-│                         Meshery UI (Next.js)                        │
-│  ┌───────────────┐  ┌──────────────┐  ┌──────────────────────────┐ │
-│  │   Material UI │  │ Redux Toolkit│  │  Relay (GraphQL Client)  │ │
-│  │   Components  │  │  State Mgmt  │  │  + REST (Axios)          │ │
-│  └───────────────┘  └──────────────┘  └──────────────────────────┘ │
-└─────────────────────────────────────────────────────────────────────┘
-                              │
-                         HTTP/WebSocket
-                              │
-┌─────────────────────────────────────────────────────────────────────┐
-│                      Meshery Server (Go)                            │
-│  ┌─────────────┐  ┌──────────────┐  ┌────────────┐ ┌────────────┐ │
-│  │  REST API   │  │  GraphQL API │  │ PostgreSQL │ │   NATS     │ │
-│  │  (Gorilla)  │  │   (gqlgen)   │  │     DB     │ │  Messaging │ │
-│  └─────────────┘  └──────────────┘  └────────────┘ └────────────┘ │
-│  ┌──────────────────────────────────────────────────────────────┐ │
-│  │           Provider Plugins (gRPC/Remote Providers)           │ │
-│  └──────────────────────────────────────────────────────────────┘ │
-└─────────────────────────────────────────────────────────────────────┘
-                              │
-                    gRPC / Kubernetes API
-                              │
-┌─────────────────────────────────────────────────────────────────────┐
-│                     Kubernetes Clusters                             │
-│  ┌─────────────┐  ┌──────────────┐  ┌────────────────────────────┐ │
-│  │   Meshery   │  │   MeshSync   │  │  Adapters (Istio, Linkerd, │ │
-│  │  Operator   │  │ (Discovery)  │  │   Consul, NSM, etc.)       │ │
-│  └─────────────┘  └──────────────┘  └────────────────────────────┘ │
-└─────────────────────────────────────────────────────────────────────┘
+┌──────────────────────────────────────────────────────┐
+│                  Meshery UI (Next.js)                │
+│   MUI Components │ Redux Toolkit │ Relay + Axios     │
+└──────────────────────────┬───────────────────────────┘
+                     HTTP/WebSocket
+┌──────────────────────────┴───────────────────────────┐
+│                 Meshery Server (Go)                  │
+│   REST (9081) │ GraphQL │ PostgreSQL │ NATS          │
+│         Provider Plugins (gRPC/Remote)               │
+└──────────────────────────┬───────────────────────────┘
+                  gRPC / Kubernetes API
+┌──────────────────────────┴───────────────────────────┐
+│              Kubernetes Clusters                     │
+│  Meshery Operator │ MeshSync │ Adapters (gRPC)       │
+└──────────────────────────────────────────────────────┘
 ```
 
-### Component Interactions
+**Data flow**: UI → REST/GraphQL → Server → PostgreSQL + Kubernetes API → NATS → MeshSync → GraphQL subscriptions → UI.
 
-**Meshery UI** serves as the primary user interface, communicating with Meshery Server via REST and
-GraphQL APIs. The UI uses Relay for GraphQL subscriptions (real-time updates) and Axios for REST
-endpoints. Redux Toolkit manages application state including user sessions, workspace data, and
-connection configurations.
+## Testing
 
-**Meshery Server** is the core orchestration engine written in Go. It exposes REST (port 9081) and
-GraphQL APIs, manages connections to Kubernetes clusters, handles user authentication via provider
-plugins, stores data in PostgreSQL, and publishes events to NATS. The server uses MeshKit for common
-utilities, error handling, and database abstractions.
+### Go
 
-**Meshery Operator** runs inside Kubernetes clusters to manage lifecycle of Meshery components
-including MeshSync (for cluster discovery and state synchronization) and Meshery Broker (NATS for
-event streaming).
+- Unit: `go test ./...` or `go test --short ./...`
+- Integration setup: `make server-integration-tests-meshsync-setup` (requires Docker, kind, kubectl, helm)
+- Integration run: `make server-integration-tests-meshsync-run`
+- Target ≥70% coverage on business logic.
 
-**Adapters** are gRPC services that provide integration with specific service meshes and cloud native
-infrastructure. They run as separate containers and communicate with Meshery Server over gRPC.
+### UI
 
-**mesheryctl** is the CLI tool for local development, deployment, and operations. It communicates
-directly with Meshery Server APIs and can manage local Docker containers or Kubernetes deployments.
+- E2E (Playwright): `make ui-integration-tests` or `npm run test:e2e` in `ui/`
+- Setup: `make test-setup-ui`
 
-### Data Flow
+### Local Validation
 
-1. User interacts with Meshery UI (design canvas, configuration forms, performance tests).
-2. UI sends GraphQL mutations/queries or REST requests to Meshery Server.
-3. Server processes requests, applies business logic, and persists to PostgreSQL.
-4. Server communicates with Kubernetes API or adapter gRPC endpoints to deploy resources.
-5. MeshSync discovers cluster state changes and publishes to NATS.
-6. Server receives NATS events and updates database.
-7. UI receives real-time updates via GraphQL subscriptions.
-
-## Testing Strategy
-
-### Unit Tests (Go)
-
-- **Location**: `*_test.go` files alongside source code.
-- **Framework**: Go standard library `testing` package.
-- **Run**: `go test ./...` or `go test --short ./...` (skip integration tests).
-- **Coverage**: Aim for ≥ 70% coverage on business logic.
-
-### Unit Tests (JavaScript)
-
-> TODO: Expand JavaScript unit testing infrastructure.
-
-### Integration Tests (Go)
-
-- **Location**: `server/integration-tests/`
-- **Setup**: `make server-integration-tests-meshsync-setup` (creates kind cluster, deploys
-  operator).
-- **Run**: `make server-integration-tests-meshsync-run`
-- **Cleanup**: `make server-integration-tests-meshsync-cleanup`
-- **Requirements**: Docker, kind, kubectl, helm.
-
-### End-to-End Tests (UI)
-
-- **Location**: `ui/` (Playwright tests).
-- **Framework**: Playwright.
-- **Setup**: `make test-setup-ui` (installs Playwright browsers with dependencies).
-- **Run**: `make ui-integration-tests` or `npm run test:e2e` in `ui/`.
-- **CI**: `make test-e2e-ci` runs in non-interactive mode.
-
-### CI/CD Testing
-
-- **Workflows**: `.github/workflows/` contains GitHub Actions for PR checks, release builds, and
-  deployments.
-- **Automated Tests**: `build-ui-and-server.yml` runs on PRs; includes linting, builds, and test
-  execution.
-- **CodeQL**: `codeql-analysis.yml` performs security scanning.
-
-### Local Testing Best Practices
-
-- Run `make golangci` before committing Go code.
-- Run `make ui-lint` before committing UI code.
-- Test server changes with `make server` and verify on `http://localhost:9081`.
-- Test UI changes with `make ui` and verify on `http://localhost:3000`.
-- Run integration tests when modifying Kubernetes or MeshSync interactions.
+```bash
+make golangci    # before Go commits
+make ui-lint     # before UI commits
+```
 
 ## Security & Compliance
 
-### Reporting Vulnerabilities
-
-- **Email**: [security@meshery.dev](mailto:security@meshery.dev)
-- **Response Time**: Acknowledged within 10 business days.
-- **Full Policy**: [SECURITY.md](./SECURITY.md)
-
-### Secrets Management
-
-- **Never commit secrets**: API keys, tokens, passwords, certificates.
-- **Use environment variables**: Server accepts secrets via env vars (e.g., `PROVIDER_BASE_URLS`,
-  `KEYS_PATH`).
-- **GitHub Secrets**: Store in repository secrets for CI/CD; access via `${{ secrets.VAR_NAME }}`.
-
-### Dependency Scanning
-
-- **Go**: Dependabot enabled; monitors `go.mod` and `go.sum`.
-- **JavaScript**: Dependabot monitors `ui/package.json` and `provider-ui/package.json`.
-- **SBOM**: Software Bill of Materials generated via `.github/workflows/bom.yaml`.
-
-### Security Scanning
-
-- **CodeQL**: Automated security analysis runs on every PR and push to `master`.
-- **OpenSSF Scorecard**: Tracks security posture; badge in README.
-- **License Compliance**: Apache 2.0; verify dependencies are compatible.
-
-### Best Practices
-
-- Run `make golangci` to catch security lints (e.g., SQL injection, command injection).
-- Validate all user inputs; sanitize data before rendering in UI.
-- Use parameterized queries for database operations.
-- Limit permissions on Kubernetes service accounts and RBAC roles.
+- Report vulnerabilities: [security@meshery.dev](mailto:security@meshery.dev) — acknowledged in 10 business days.
+- Never commit secrets; use env vars (`PROVIDER_BASE_URLS`, `KEYS_PATH`) and GitHub Secrets.
+- CodeQL runs on every PR; OpenSSF Scorecard tracks security posture.
+- Apache 2.0 license — verify dependency compatibility.
+- Use parameterized queries; validate/sanitize all user inputs.
 
 ## Agent Guardrails
 
-### Files That Should Not Be Modified by Agents
+### Do Not Modify
 
-- **LICENSE** – Apache 2.0 license text; do not edit.
-- **CODE_OF_CONDUCT.md** – Community standards; changes require human review.
-- **GOVERNANCE.md** – Project governance; changes require maintainer consensus.
-- **MAINTAINERS.md** – Maintainer list; requires verification of identity.
-- **.github/copilot-instructions.md** – Base Copilot instructions; changes require careful review.
-- **.github/agents/** – Agent definition files; self-modification risks infinite loops.
-- **go.sum**, **ui/package-lock.json**, **provider-ui/package-lock.json** – Lock files; only update
-  via package managers.
+`LICENSE`, `CODE_OF_CONDUCT.md`, `GOVERNANCE.md`, `MAINTAINERS.md`, `.github/copilot-instructions.md`, `.github/agents/`, `go.sum`, `ui/package-lock.json`, `provider-ui/package-lock.json`
 
-### Required Human Reviews
+### Require Human Review
 
-- **Security changes**: All changes touching authentication, authorization, secrets, or encryption.
-- **Database migrations**: Schema changes require careful review to avoid data loss.
-- **API breaking changes**: REST/GraphQL API modifications that break backward compatibility.
-- **Helm chart templates**: Changes to `install/kubernetes/helm/` require validation in test clusters.
-- **CI/CD workflows**: `.github/workflows/` changes may affect release process.
+- Security changes (auth, secrets, encryption)
+- Database migrations
+- API breaking changes
+- Helm chart templates (`install/kubernetes/helm/`)
+- CI/CD workflows (`.github/workflows/`)
 
-### Rate Limits & Constraints
+### Quality Gates
 
-- **PR size**: Keep PRs focused and under 500 lines changed when possible.
-- **Commit frequency**: Batch related changes; avoid excessive micro-commits.
-- **Build failures**: Do not merge if CI checks fail; investigate and fix root cause.
+- Go: `make golangci` must pass
+- JS: `make ui-lint` must pass
+- New features need docs; breaking changes need deprecation notices
+- Keep PRs under 500 lines; don't merge on CI failure
 
-### Quality Standards
-
-- All Go code must pass `make golangci`.
-- All JavaScript code must pass `make ui-lint`.
-- New features require corresponding documentation updates.
-- Breaking changes require deprecation notices and migration guides.
-
-## Extensibility Hooks
+## Extensibility
 
 ### Provider Plugins
 
-- **Interface**: `server/models/provider.go` defines the provider contract.
-- **Remote Providers**: Implement authentication, preferences, and sync logic externally.
-- **Example**: Meshery Cloud provider integrates via HTTPS/gRPC.
+Interface: `server/models/provider.go` — implement auth, preferences, and sync externally.
 
 ### Adapters (gRPC)
 
-- **Protocol**: Defined in `server/meshes/meshops.proto`.
-- **Examples**: meshery-istio, meshery-linkerd, meshery-consul (separate repositories).
-- **Registration**: Adapters self-register with Meshery Server on startup.
+Protocol: `server/meshes/meshops.proto` — adapters self-register on startup. Examples: meshery-istio, meshery-linkerd, meshery-consul.
 
 ### UI Extensions
 
-- **Remote Components**: Load React components from URLs at runtime via `@paciolan/remote-component`.
-  - **Export contract**: the host evaluates the fetched bundle as a CommonJS module
-    and reads `module.exports.default` (the loader's `imports` arg defaults to
-    `"default"`). The remote bundle **must** expose the component as a CommonJS
-    default export — i.e. `module.exports = { default: Component, __esModule: true }`.
-    A bundle built as ESM-only, as a bare IIFE, or with the component on a named
-    export will not be found.
-  - **Silent-undefined gotcha**: `useRemoteComponent` does **not** throw when
-    `module.exports.default` is missing — it returns `[loading=false, err=undefined,
-    Component=undefined]`. So a mis-built bundle renders as `undefined` with **no
-    console error** from the loader (React then throws "Element type is invalid …
-    got: undefined" at render). When debugging "extension is undefined, no error",
-    check the bundle's export shape first: it should end with a `module.exports = …`
-    assignment exposing `.default`. See `ui/components/layout/Navigator/NavigatorExtension.tsx`.
-  - On the extension-author side this is a real footgun under bundler upgrades; see
-    `meshery-extensions/docs/troubleshoot.md` ("Extension loads as `undefined` with
-    no error").
-- **Provider UI**: `provider-ui/` directory for provider-specific UI extensions.
+Remote Components loaded via `@paciolan/remote-component`. Bundle **must** expose `module.exports = { default: Component, __esModule: true }`. Silent-undefined gotcha: a mis-built bundle renders as `undefined` with no loader error — React throws "Element type is invalid" at render. Check bundle export shape first. See `ui/components/layout/Navigator/NavigatorExtension.tsx`.
 
-### GraphQL Subscriptions
+### GraphQL
 
-- **Location**: `server/internal/graphql/schema.graphql`
-- **Extend**: Add new queries, mutations, or subscriptions; run `make graphql-build`.
+Schema: `server/internal/graphql/schema.graphql`. Add queries/mutations/subscriptions then run `make graphql-build`.
 
 ### Feature Flags
 
-- **Environment Variables**: Control behavior via env vars (e.g., `PLAYGROUND`, `DEBUG`,
-  `SKIP_COMP_GEN`).
-- **Runtime Config**: Server reads config from `~/.meshery/config.yaml`.
+Env vars: `PLAYGROUND`, `DEBUG`, `SKIP_COMP_GEN`. Runtime config: `~/.meshery/config.yaml`.
 
 ### Event System
 
-- **NATS Topics**: Publish/subscribe to topics like `meshsync.request`, `meshery.broker`.
-- **MeshSync Events**: Listen for cluster state changes and trigger workflows.
+NATS topics: `meshsync.request`, `meshery.broker`. MeshSync publishes cluster state changes.
 
 ### Hooks & Scripts
 
-- **Pre-commit**: Husky hooks in `ui/.husky/` run linting before commits.
-- **Makefile Targets**: Extend `Makefile` or `install/Makefile.core.mk` for custom build steps.
+- Pre-commit: Husky hooks in `ui/.husky/`
+- Build: extend `Makefile` or `install/Makefile.core.mk`
 
 ## Coding Agents
 
-Reusable agent definitions live in `.agents/`. These are LLM-agnostic — any coding assistant can use them.
+Agent definitions in `.agents/` (LLM-agnostic):
 
 | Agent | File | Purpose |
 |-------|------|---------|
-| Code Reviewer | `.agents/code-reviewer.md` | Parallel code review across Go + frontend |
-| Security Reviewer | `.agents/security-reviewer.md` | Security audit for infrastructure-managing code |
-| Meshery Code Contributor | `.agents/meshery-code-contributor.md` | Full-stack code contributions (Go, React, CLI) |
-| Meshery Docs Contributor | `.agents/meshery-docs-contributor.md` | Hugo-based documentation contributions |
-| GitHub Actions Engineer | `.agents/github-actions-engineer.md` | CI/CD workflow design and debugging |
-| Relationship Fixture Agent | `.agents/relationship-fixture-agent.md` | Create relationship test fixture designs |
+| Code Reviewer | `.agents/code-reviewer.md` | Parallel review across Go + frontend |
+| Security Reviewer | `.agents/security-reviewer.md` | Security audit |
+| Meshery Code Contributor | `.agents/meshery-code-contributor.md` | Full-stack contributions |
+| Meshery Docs Contributor | `.agents/meshery-docs-contributor.md` | Hugo docs contributions |
+| GitHub Actions Engineer | `.agents/github-actions-engineer.md` | CI/CD design and debugging |
+| Relationship Fixture Agent | `.agents/relationship-fixture-agent.md` | Relationship test fixtures |
 
 ## Skills
 
-Packaged, repeatable workflows live in `.agents/skills/`. Each skill has a `SKILL.md` with instructions.
+Packaged workflows in `.agents/skills/`:
 
-| Skill | Directory | Invocation | Purpose |
-|-------|-----------|------------|---------|
-| gen-test | `.agents/skills/gen-test/` | User-invoked | Generate idiomatic Go tests |
-| api-doc | `.agents/skills/api-doc/` | User or agent | Document REST/GraphQL endpoints |
-| gen-relationship | `.agents/skills/gen-relationship/` | User or agent | Generate schema-backed relationships |
+| Skill | Directory | Purpose |
+|-------|-----------|---------|
+| gen-test | `.agents/skills/gen-test/` | Generate idiomatic Go tests |
+| api-doc | `.agents/skills/api-doc/` | Document REST/GraphQL endpoints |
+| gen-relationship | `.agents/skills/gen-relationship/` | Generate schema-backed relationships |
 
 ## Automation Hooks
 
-Standalone hook scripts in `.agents/hooks/` can be wired into any coding agent's hook system or run manually:
+Scripts in `.agents/hooks/`:
 
 | Hook | Script | Trigger | Purpose |
 |------|--------|---------|---------|
-| Format Frontend | `.agents/hooks/format-frontend.sh` | Post-edit | Auto-format JS/TS files with Prettier |
+| Format Frontend | `.agents/hooks/format-frontend.sh` | Post-edit | Auto-format JS/TS with Prettier |
 | Block Lock Files | `.agents/hooks/block-lockfiles.sh` | Pre-edit | Prevent direct edits to lock files |
 
 ## Further Reading
 
-- [Contributing Guide](./CONTRIBUTING.md) – Start here for onboarding.
-- [Meshery Documentation](https://docs.meshery.io) – Full user and contributor guides.
-- [Architecture Overview](https://docs.meshery.io/concepts/architecture) – Detailed component
-  diagrams and explanations.
-- [API Documentation](https://docs.meshery.io/extensibility/api) – REST and GraphQL API references.
-- [CLI Guide](https://docs.meshery.io/guides/mesheryctl) – mesheryctl command reference.
-- [Extensibility](https://docs.meshery.io/extensibility) – Provider plugins, adapters, and extension
-  points.
-- [Community Handbook](https://meshery.io/community#handbook) – Community processes and resources.
-- [Roadmap](./ROADMAP.md) – Upcoming features and milestones.
-- [Security Policy](./SECURITY.md) – Vulnerability reporting and disclosure process.
-- [Governance](./GOVERNANCE.md) – Project decision-making and maintainer responsibilities.
+- [Contributing Guide](./CONTRIBUTING.md)
+- [Meshery Documentation](https://docs.meshery.io)
+- [Architecture Overview](https://docs.meshery.io/concepts/architecture)
+- [API Documentation](https://docs.meshery.io/extensibility/api)
+- [CLI Guide](https://docs.meshery.io/guides/mesheryctl)
+- [Extensibility](https://docs.meshery.io/extensibility)
+- [Community Handbook](https://meshery.io/community#handbook)
+- [Security Policy](./SECURITY.md)
+- [Governance](./GOVERNANCE.md)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,1 @@
+@AGENTS.md


### PR DESCRIPTION
## Summary

- Condensed `AGENTS.md` from 619 → 278 lines (55% reduction) by removing completed migration history, verbose post-migration audit details, and redundant prose while keeping all actionable rules, build commands, and guardrails intact
- Added `CLAUDE.md` as a single-line `@AGENTS.md` import so Claude Code (and any other tooling that looks for `CLAUDE.md`) resolves to the same authoritative source without duplication

## Test plan

- [ ] Verify `AGENTS.md` still contains all identifier naming rules, build commands, and agent guardrails
- [ ] Verify `CLAUDE.md` contains only `@AGENTS.md` and that Claude Code resolves it correctly