### PR TITLE
Add GitHub ConnectionDefinition to meshery-core model

### DIFF
--- a/server/meshmodel/meshery-core/0.7.2/v1.0.0/connections/GitHubConnection.json
+++ b/server/meshmodel/meshery-core/0.7.2/v1.0.0/connections/GitHubConnection.json
@@ -1,0 +1,91 @@
+{
+  "schemaVersion": "connections.meshery.io/v1beta3",
+  "name": "GitHub",
+  "description": "A GitHub account or organization connected to Meshery, enabling design and configuration sync with repositories - import and export designs, track changes in version control, and collaborate on infrastructure-as-code alongside Meshery's own insights.",
+  "kind": "github",
+  "type": "collaboration",
+  "subType": "git",
+  "status": "registered",
+  "transitionMap": {
+    "discovered": [
+      {
+        "nextState": "registered",
+        "description": "Are you sure you want to transition from DISCOVERED to REGISTERED? This will register the discovered GitHub connection with Meshery."
+      },
+      {
+        "nextState": "ignored",
+        "description": "Are you sure you want to transition from DISCOVERED to IGNORED? This will ignore the discovered GitHub connection."
+      }
+    ],
+    "registered": [
+      {
+        "nextState": "connected",
+        "description": "Are you sure you want to transition from REGISTERED to CONNECTED? This will connect to the GitHub connection."
+      },
+      {
+        "nextState": "ignored",
+        "description": "Are you sure you want to transition from REGISTERED to IGNORED? This will keep the GitHub registration but not connect to it."
+      }
+    ],
+    "connected": [
+      {
+        "nextState": "disconnected",
+        "description": "Are you sure you want to transition from CONNECTED to DISCONNECTED? This will disconnect the GitHub connection."
+      },
+      {
+        "nextState": "deleted",
+        "description": "Are you sure you want to transition from CONNECTED to DELETED? This will remove the GitHub connection completely."
+      }
+    ],
+    "disconnected": [
+      {
+        "nextState": "connected",
+        "description": "Are you sure you want to transition from DISCONNECTED to CONNECTED? This will reconnect the GitHub connection."
+      },
+      {
+        "nextState": "deleted",
+        "description": "Are you sure you want to transition from DISCONNECTED to DELETED? This will remove the GitHub connection completely."
+      }
+    ]
+  },
+  "connectionSchema": {
+    "type": "object",
+    "title": "GitHub Connection",
+    "required": [
+      "url"
+    ],
+    "properties": {
+      "url": {
+        "type": "string",
+        "format": "uri",
+        "title": "GitHub API URL",
+        "description": "Base URL of the GitHub API (e.g. https://api.github.com, or your GitHub Enterprise Server API endpoint)."
+      },
+      "owner": {
+        "type": "string",
+        "title": "Owner",
+        "description": "GitHub organization or username this connection is scoped to."
+      },
+      "name": {
+        "type": "string",
+        "title": "Connection Name",
+        "description": "Optional friendly name for this GitHub connection."
+      }
+    }
+  },
+  "credentialSchema": {
+    "type": "object",
+    "title": "GitHub Credential",
+    "properties": {
+      "secret": {
+        "type": "string",
+        "title": "Personal Access Token",
+        "description": "GitHub personal access token (or OAuth token) used to authenticate API requests."
+      }
+    }
+  },
+  "styles": {
+    "svgColor": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 24 24\" height=\"20\" width=\"20\"><path fill=\"#181717\" d=\"M12 .297c-6.63 0-12 5.373-12 12 0 5.303 3.438 9.8 8.205 11.385.6.113.82-.258.82-.577 0-.285-.01-1.04-.015-2.04-3.338.724-4.042-1.61-4.042-1.61-.546-1.387-1.333-1.756-1.333-1.756-1.089-.745.083-.729.083-.729 1.205.084 1.839 1.237 1.839 1.237 1.07 1.834 2.807 1.304 3.492.997.107-.775.418-1.305.762-1.604-2.665-.305-5.467-1.334-5.467-5.931 0-1.311.469-2.381 1.236-3.221-.124-.303-.535-1.524.117-3.176 0 0 1.008-.322 3.301 1.23A11.509 11.509 0 0 1 12 5.803c1.02.005 2.047.138 3.006.404 2.291-1.552 3.297-1.23 3.297-1.23.653 1.653.242 2.874.118 3.176.77.84 1.235 1.911 1.235 3.221 0 4.609-2.807 5.624-5.479 5.921.43.372.823 1.102.823 2.222 0 1.606-.014 2.898-.014 3.293 0 .322.216.694.825.576C20.565 22.092 24 17.592 24 12.297c0-6.627-5.373-12-12-12\"/></svg>",
+    "svgWhite": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 24 24\" height=\"20\" width=\"20\"><path fill=\"#fff\" d=\"M12 .297c-6.63 0-12 5.373-12 12 0 5.303 3.438 9.8 8.205 11.385.6.113.82-.258.82-.577 0-.285-.01-1.04-.015-2.04-3.338.724-4.042-1.61-4.042-1.61-.546-1.387-1.333-1.756-1.333-1.756-1.089-.745.083-.729.083-.729 1.205.084 1.839 1.237 1.839 1.237 1.07 1.834 2.807 1.304 3.492.997.107-.775.418-1.305.762-1.604-2.665-.305-5.467-1.334-5.467-5.931 0-1.311.469-2.381 1.236-3.221-.124-.303-.535-1.524.117-3.176 0 0 1.008-.322 3.301 1.23A11.509 11.509 0 0 1 12 5.803c1.02.005 2.047.138 3.006.404 2.291-1.552 3.297-1.23 3.297-1.23.653 1.653.242 2.874.118 3.176.77.84 1.235 1.911 1.235 3.221 0 4.609-2.807 5.624-5.479 5.921.43.372.823 1.102.823 2.222 0 1.606-.014 2.898-.014 3.293 0 .322.216.694.825.576C20.565 22.092 24 17.592 24 12.297c0-6.627-5.373-12-12-12\"/></svg>"
+  }
+}


### PR DESCRIPTION
## Description

Adds a new `ConnectionDefinition` for **GitHub** connections to the `meshery-core` model (version `0.7.2`), alongside the existing Grafana, Prometheus, and Kubernetes definitions.

New file:
```
server/meshmodel/meshery-core/0.7.2/v1.0.0/connections/GitHubConnection.json
```

### Definition

| Field | Value | Notes |
|---|---|---|
| `schemaVersion` | `connections.meshery.io/v1beta3` | latest canonical connection schema |
| `kind` | `github` | |
| `type` | `collaboration` | per the connection schema's documented type set (platform, telemetry, collaboration) |
| `subType` | `git` | per the documented subtype set (cloud, identity, metrics, chat, git, orchestration) |
| `status` | `registered` | GitHub is user-initiated (token/OAuth), not auto-discovered like Kubernetes - mirrors the Grafana/Prometheus initial state |

- **`connectionSchema`** - GitHub API URL (required; supports github.com and GitHub Enterprise Server), owner (org/user), optional connection name.
- **`credentialSchema`** - personal access token / OAuth token (`secret`).
- **`transitionMap`** - registered / connected / disconnected state machine mirroring the Grafana definition.
- **`styles`** - GitHub octocat mark (`svgColor` `#181717`, `svgWhite` `#fff`).

This is a data-only addition (a model artifact). It introduces no new wire/DB construct - GitHub fits the existing `collaboration`/`git` contract already defined in `meshery/schemas`, so no schema change is required. The registry picks the file up automatically via the model's `connections/` directory scan; no registration code change is needed.

## Type of change

- New feature (non-breaking change which adds functionality)

## Notes for Reviewers

JSON validated; `type`/`subType`/`status` confirmed against `connections.meshery.io/v1beta3` in `meshery/schemas`.

## Signed commits

- [x] Yes, I signed my commits.