### PR TITLE
ci: pin actions/checkout from @master to @v6

### DIFF
--- a/.github/workflows/badge-award.yml
+++ b/.github/workflows/badge-award.yml
@@ -19,7 +19,7 @@ jobs:
     
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       
       - name: Process issues and extract emails
         id: extract

--- a/.github/workflows/helm-chart-releaser.yml
+++ b/.github/workflows/helm-chart-releaser.yml
@@ -34,7 +34,7 @@ jobs:
     runs-on: ubuntu-24.04
     if: ${{github.event_name == 'pull_request'}}
     steps:
-    - uses: actions/checkout@master
+    - uses: actions/checkout@v6
     - uses: azure/setup-helm@v3.5
       with:
         version: 'v3.6.0' # default is latest stable
@@ -47,7 +47,7 @@ jobs:
     runs-on: ubuntu-24.04
     if: ${{ github.event_name != 'pull_request' }}
     steps:
-      - uses: actions/checkout@master
+      - uses: actions/checkout@v6
       - name: set env
         id: vars
         # https://github.community/t/how-to-get-just-the-tag-name/16241/7

--- a/.github/workflows/label-commenter.yml
+++ b/.github/workflows/label-commenter.yml
@@ -19,7 +19,7 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - name: Checkout repo 🛎️
-        uses: actions/checkout@master
+        uses: actions/checkout@v6
         with:
           ref: master # Set your default branch
         env:

--- a/.github/workflows/test_adapters.yaml
+++ b/.github/workflows/test_adapters.yaml
@@ -71,7 +71,7 @@ jobs:
           driver: docker
           start args: --cni "${{ inputs.k8s_cni }}"
       - name: Checkout Code
-        uses: actions/checkout@master
+        uses: actions/checkout@v6
 
       # Build the image by setting appropriate environmental variables in order to access the image from minikube
       - name: Build the tagged Docker image

--- a/.github/workflows/test_adaptersv2.yaml
+++ b/.github/workflows/test_adaptersv2.yaml
@@ -77,7 +77,7 @@ jobs:
           driver: docker
           start args: --cni "${{ inputs.k8s_cni }}"
       - name: Checkout Code
-        uses: actions/checkout@master
+        uses: actions/checkout@v6
 
       # Build the image by setting appropriate environmental variables in order to access the image from minikube
       - name: Build the tagged Docker image


### PR DESCRIPTION
### Description

Upgrade `actions/checkout` from the unpinned `@master` ref to the stable `@v6` tag
across 5 workflow files (6 action references).

**Why:** Using `@master` tracks the default branch of the upstream action repository.
If the upstream repo is compromised or undergoes a breaking change, every CI run
using `@master` will silently execute the new code. Pinning to `@v6` ensures we get
only reviewed, tagged releases and aligns with the repo standard (52 existing usages).

Also upgrades 1 remaining `@v4` reference in `badge-award.yml` to `@v6` for consistency.

SHA-pinned files (`bom.yaml`, `scorecard.yml`) and the auto-generated
`pull-request-reviewer.lock.yml` are intentionally excluded.

Relates to #18795

### Changes

| File | Jobs | Change |
|------|------|--------|
| `label-commenter.yml` | `comment` | `@master` → `@v6` |
| `test_adapters.yaml` | `TestAdapter` | `@master` → `@v6` |
| `test_adaptersv2.yaml` | `TestAdapter` | `@master` → `@v6` |
| `helm-chart-releaser.yml` | `validate`, `release-chart` | `@master` → `@v6` (2 refs) |
| `badge-award.yml` | `award-badges` | `@v4` → `@v6` |
