### PR TITLE
fix(docs): replace deprecated word-wrap with overflow-wrap

### DIFF
--- a/docs/assets/scss/_table.scss
+++ b/docs/assets/scss/_table.scss
@@ -26,7 +26,7 @@ table td {
   padding: 8px;
   text-align: left;
   max-width: 300px;
-  word-wrap: break-word;
+  overflow-wrap: break-word;
 }
 table td img {
   text-align: center;


### PR DESCRIPTION
## Summary

- Replaced the deprecated `word-wrap` property with the standardized `overflow-wrap` property in `docs/assets/scss/_table.scss`.

Fixes #18418
