### PR TITLE
[UI] Fix Add Cluster crash on kubeconfig upload with errored contexts

### DIFF
--- a/ui/components/MesherySettingsEnvButtons.test.tsx
+++ b/ui/components/MesherySettingsEnvButtons.test.tsx
@@ -1,0 +1,143 @@
+import React from 'react';
+import { render, screen, act, fireEvent, waitFor } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// Shared mock state. Declared via vi.hoisted so the (hoisted) vi.mock factories
+// below can reference it without tripping the "used before initialization" rule.
+const h = vi.hoisted(() => ({
+  notifyMock: vi.fn(),
+  unwrapMock: vi.fn(),
+  addTriggerMock: vi.fn(),
+  // Resolver for the first PromptComponent.show() call (the upload modal), kept
+  // pending so the test can pick a file before "IMPORT" is confirmed — mirroring
+  // the real user flow.
+  resolveUploadModal: { current: undefined as undefined | ((value: string) => void) },
+}));
+
+vi.mock('../utils/hooks/useNotification', () => ({
+  useNotification: () => ({ notify: h.notifyMock }),
+}));
+vi.mock('../rtk-query/connection', () => ({
+  useAddKubernetesConfigMutation: () => [h.addTriggerMock],
+}));
+vi.mock('@/utils/can', () => ({ default: () => true }));
+vi.mock('@/utils/permission_constants', () => ({
+  keys: { ADD_CLUSTER: { action: 'add', subject: 'cluster' } },
+}));
+vi.mock('@/utils/hooks/useKubernetesHook', () => ({ default: () => vi.fn() }));
+vi.mock('@/utils/hooks/useTestIDs', () => ({ default: () => () => 'test-id' }));
+vi.mock('@/store/slices/mesheryUi', () => ({ updateProgress: vi.fn() }));
+vi.mock('../assets/icons/AddIconCircleBorder', () => ({ default: () => null }));
+vi.mock('../lib/event-types', () => ({
+  EVENT_TYPES: { ERROR: 'error', WARNING: 'warning', SUCCESS: 'success', INFO: 'info' },
+}));
+vi.mock('./connections/ConnectionChip', () => ({
+  TooltipWrappedConnectionChip: () => null,
+  ConnectionStateChip: () => null,
+}));
+
+// PromptComponent is imperative (ref.show()). The first call (the kubeconfig
+// upload prompt) stays pending until the test resolves it; it also renders the
+// passed subtitle so the hidden <input id="k8sfile"> mounts and can be driven.
+vi.mock('./PromptComponent', async () => {
+  const { forwardRef, useState, useImperativeHandle } = await import('react');
+  let showCount = 0;
+  const PromptComponent = forwardRef((_props: unknown, ref: React.Ref<unknown>) => {
+    const [content, setContent] = useState<React.ReactNode>(null);
+    useImperativeHandle(ref, () => ({
+      show: (args: { subtitle?: React.ReactNode }) => {
+        setContent(args?.subtitle ?? null);
+        showCount += 1;
+        if (showCount === 1) {
+          return new Promise<string>((resolve) => {
+            h.resolveUploadModal.current = resolve;
+          });
+        }
+        return Promise.resolve('OK');
+      },
+    }));
+    return <div data-testid="prompt">{content}</div>;
+  });
+  return { __esModule: true, default: PromptComponent };
+});
+
+vi.mock('@sistent/sistent', () => ({
+  Button: ({ children, onClick, disabled }: any) => (
+    <button onClick={onClick} disabled={disabled}>
+      {children}
+    </button>
+  ),
+  CloudUploadIcon: () => null,
+  Typography: ({ children }: any) => <span>{children}</span>,
+  FormGroup: ({ children }: any) => <div>{children}</div>,
+  TextField: ({ id }: any) => <input id={id} readOnly />,
+  InputAdornment: ({ children }: any) => <span>{children}</span>,
+  Tooltip: ({ children }: any) => <>{children}</>,
+  Grid2: ({ children }: any) => <div>{children}</div>,
+  Box: ({ children }: any) => <div>{children}</div>,
+  styled: () => () => ({}),
+  PROMPT_VARIANTS: { SUCCESS: 'success', WARNING: 'warning', ERROR: 'error' },
+}));
+
+import MesherySettingsEnvButtons from './MesherySettingsEnvButtons';
+
+const selectKubeconfig = () => {
+  const fileInput = document.getElementById('k8sfile') as HTMLInputElement;
+  expect(fileInput).toBeTruthy();
+  const file = new File(['apiVersion: v1'], 'config.yaml', { type: 'text/yaml' });
+  Object.defineProperty(fileInput, 'files', { value: [file], configurable: true });
+  fireEvent.change(fileInput);
+};
+
+describe('MesherySettingsEnvButtons – kubeconfig upload', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    h.resolveUploadModal.current = undefined;
+    h.addTriggerMock.mockReturnValue({ unwrap: h.unwrapMock });
+  });
+
+  it('surfaces errored contexts from a camelCase response without crashing', async () => {
+    // Mirrors the server wire format: camelCase buckets, and errored contexts are
+    // plain K8sContext objects with NO per-context `error` field (the failure is
+    // recorded server-side in event metadata). The previous implementation read
+    // snake_case keys and called `ctx.error.toString()`, throwing
+    // "Cannot read properties of undefined (reading 'toString')", which surfaced
+    // as a misleading "failed to upload kubernetes config" toast.
+    h.unwrapMock.mockResolvedValue({
+      registeredContexts: [],
+      connectedContexts: [],
+      ignoredContexts: [],
+      erroredContexts: [{ name: 'broken-ctx', server: 'https://broken.example' }],
+    });
+
+    render(<MesherySettingsEnvButtons />);
+
+    await act(async () => {
+      fireEvent.click(screen.getByText('Add Cluster'));
+    });
+
+    selectKubeconfig();
+
+    await act(async () => {
+      h.resolveUploadModal.current?.('IMPORT');
+    });
+
+    await waitFor(() =>
+      expect(h.notifyMock).toHaveBeenCalledWith(
+        expect.objectContaining({
+          message: 'Failed to add cluster "broken-ctx" at https://broken.example',
+          event_type: 'error',
+        }),
+      ),
+    );
+
+    const messages = h.notifyMock.mock.calls.map((call) => call[0]?.message);
+    // The catch-all upload-failure toast (the symptom of the old crash) must not appear.
+    expect(
+      messages.some(
+        (message) =>
+          typeof message === 'string' && message.includes('failed to upload kubernetes config'),
+      ),
+    ).toBe(false);
+  });
+});

--- a/ui/components/MesherySettingsEnvButtons.test.tsx
+++ b/ui/components/MesherySettingsEnvButtons.test.tsx
@@ -12,6 +12,9 @@ const h = vi.hoisted(() => ({
   // pending so the test can pick a file before "IMPORT" is confirmed — mirroring
   // the real user flow.
   resolveUploadModal: { current: undefined as undefined | ((value: string) => void) },
+  // Counts show() calls so only the first (upload) modal stays pending. Held in
+  // hoisted state (not a factory-local) so beforeEach can reset it per test.
+  showCount: { current: 0 },
 }));
 
 vi.mock('../utils/hooks/useNotification', () => ({
@@ -41,14 +44,13 @@ vi.mock('./connections/ConnectionChip', () => ({
 // passed subtitle so the hidden <input id="k8sfile"> mounts and can be driven.
 vi.mock('./PromptComponent', async () => {
   const { forwardRef, useState, useImperativeHandle } = await import('react');
-  let showCount = 0;
   const PromptComponent = forwardRef((_props: unknown, ref: React.Ref<unknown>) => {
     const [content, setContent] = useState<React.ReactNode>(null);
     useImperativeHandle(ref, () => ({
       show: (args: { subtitle?: React.ReactNode }) => {
         setContent(args?.subtitle ?? null);
-        showCount += 1;
-        if (showCount === 1) {
+        h.showCount.current += 1;
+        if (h.showCount.current === 1) {
           return new Promise<string>((resolve) => {
             h.resolveUploadModal.current = resolve;
           });
@@ -93,6 +95,7 @@ describe('MesherySettingsEnvButtons – kubeconfig upload', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     h.resolveUploadModal.current = undefined;
+    h.showCount.current = 0;
     h.addTriggerMock.mockReturnValue({ unwrap: h.unwrapMock });
   });
 

--- a/ui/components/MesherySettingsEnvButtons.tsx
+++ b/ui/components/MesherySettingsEnvButtons.tsx
@@ -19,6 +19,7 @@ import { useNotification } from '../utils/hooks/useNotification';
 import { EVENT_TYPES } from '../lib/event-types';
 import { CONNECTION_STATES } from '../utils/Enum';
 import { TooltipWrappedConnectionChip, ConnectionStateChip } from './connections/ConnectionChip';
+import { getKubernetesContexts } from './connections/ConnectionWizard.helpers';
 import useKubernetesHook from '@/utils/hooks/useKubernetesHook';
 import { keys } from '@/utils/permission_constants';
 import useTestIDsGenerator from '@/utils/hooks/useTestIDs';
@@ -56,9 +57,14 @@ const MesherySettingsEnvButtons = () => {
 
   const handleConfigSnackbars = (ctxs) => {
     updateProgress({ showProgress: false });
-    for (let ctx of ctxs.errored_contexts) {
+    // Errored contexts are plain K8sContext objects (no per-context `error`
+    // field — the failure is recorded server-side in event metadata), so build
+    // the message from the data that is actually present. Read the bucket via
+    // the shared helper which tolerates both camelCase (current wire format) and
+    // legacy snake_case payloads.
+    for (let ctx of getKubernetesContexts(ctxs, 'errored')) {
       const msg = `Failed to add cluster "${ctx.name}" at ${ctx.server}`;
-      notify({ message: msg, event_type: EVENT_TYPES.ERROR, details: ctx.error.toString() });
+      notify({ message: msg, event_type: EVENT_TYPES.ERROR });
     }
   };
 
@@ -90,9 +96,9 @@ const MesherySettingsEnvButtons = () => {
 
   const showUploadedContexts = async (inputFileName) => {
     const modal = ref.current;
-    const registeredContexts = contextsRef.current.registered_contexts;
-    const connectedContexts = contextsRef.current.connected_contexts;
-    const ignoredContexts = contextsRef.current.ignored_contexts;
+    const registeredContexts = getKubernetesContexts(contextsRef.current, 'registered');
+    const connectedContexts = getKubernetesContexts(contextsRef.current, 'connected');
+    const ignoredContexts = getKubernetesContexts(contextsRef.current, 'ignored');
     if (
       registeredContexts.length === 0 &&
       connectedContexts.length == 0 &&


### PR DESCRIPTION
## Description

Uploading a kubeconfig via **Add Cluster** (the button in the header, reachable from any page including `/performance`) could fail with a misleading toast:

> failed to upload kubernetes config: TypeError: Cannot read properties of undefined (reading 'toString')

The upload itself wasn't the problem — the crash happened in the UI's post-upload handling, was caught, and re-displayed as an upload failure.

## Root cause

`ui/components/MesherySettingsEnvButtons.tsx` read the upload response with **snake_case** keys (`errored_contexts`, `registered_contexts`, …) and called `ctx.error.toString()` on each errored context. Two problems:

1. The server response (`SaveK8sContextResponse`) returns **camelCase** buckets (`erroredContexts`, …) since the wire-format canonicalization. The snake_case reads resolved to `undefined`.
2. Errored contexts are plain `K8sContext` objects that have **no `error` field** — the failure detail is recorded server-side in event metadata, not on the returned context. So `ctx.error.toString()` threw on `undefined`.

This fired whenever a kubeconfig contained any unreachable/unsavable context.

## Fix

- Read all four context buckets through the existing shared `getKubernetesContexts` helper (`ConnectionWizard.helpers.ts`), which tolerates both camelCase (current wire format) and legacy snake_case payloads.
- Drop the non-existent per-context `error` field from the errored-context notification; build the message from the data that is actually present (name + server).

This brings `MesherySettingsEnvButtons` in line with the ConnectionWizard, which already uses the same helper.

## Testing

- Added `MesherySettingsEnvButtons.test.tsx` covering the errored-context path with a realistic camelCase response (errored context with no `error` field). Verified red/green: it fails against the previous code and passes with the fix.
- `eslint` and `prettier` clean on the changed files.

## Notes

No API/wire changes; UI-only. Per the schemas identifier-naming guidance, wire is camelCase — this aligns the consumer with that.