### PR TITLE
[Server] Sync wasm module to meshkit v1.0.19 (fix Build image CI)

### DIFF
--- a/server/policies/wasm/go.mod
+++ b/server/policies/wasm/go.mod
@@ -184,7 +184,7 @@ require (
 	github.com/mattn/go-shellwords v1.0.12 // indirect
 	github.com/mattn/go-sqlite3 v1.14.32 // indirect
 	github.com/meshery/meshery-operator v0.8.11 // indirect
-	github.com/meshery/meshkit v1.0.18 // indirect
+	github.com/meshery/meshkit v1.0.19 // indirect
 	github.com/meshery/meshsync v1.0.0 // indirect
 	github.com/mitchellh/copystructure v1.2.0 // indirect
 	github.com/mitchellh/go-homedir v1.1.0 // indirect

--- a/server/policies/wasm/go.sum
+++ b/server/policies/wasm/go.sum
@@ -512,8 +512,8 @@ github.com/mattn/go-sqlite3 v1.14.32 h1:JD12Ag3oLy1zQA+BNn74xRgaBbdhbNIDYvQUEuuE
 github.com/mattn/go-sqlite3 v1.14.32/go.mod h1:Uh1q+B4BYcTPb+yiD3kU8Ct7aC0hY9fxUwlHK0RXw+Y=
 github.com/meshery/meshery-operator v0.8.11 h1:eDo2Sw0jjVrXsvvhF8LenADM58pK+7Z68ROPVIejTPc=
 github.com/meshery/meshery-operator v0.8.11/go.mod h1:hQEtFKKa5Fr/Mskk6bV5ip3bQ0+3F0u1voYS3XisBp4=
-github.com/meshery/meshkit v1.0.18 h1:MzbRkwRFOUhF0753tWeMVjVzxmSnGKq8JgGnzNG/Fek=
-github.com/meshery/meshkit v1.0.18/go.mod h1:pChQu1xqvr0oNjIfVEzakaKmrqMSgiYu7wq7YPREhT4=
+github.com/meshery/meshkit v1.0.19 h1:24/JpLoPnWXKEriYhkWdaEQXfoVQlBKSQPgoe7nE4z8=
+github.com/meshery/meshkit v1.0.19/go.mod h1:pChQu1xqvr0oNjIfVEzakaKmrqMSgiYu7wq7YPREhT4=
 github.com/meshery/meshsync v1.0.0 h1:BIHEVG4BDjqOnSd3vBt9B4IfWJNTfMRAgdwLroBcCfY=
 github.com/meshery/meshsync v1.0.0/go.mod h1:mFsPXkZRiCSuk5DhxBTrkWdlo6peItRBUoIEEQCovIg=
 github.com/meshery/schemas v1.3.17 h1:vwgeqrjgXdZIkn8EWF4RhpoGJTwvMsJE2gePoK2H1aQ=


### PR DESCRIPTION
## Problem

The `build-meshery / Build image` job is failing **repo-wide** in the `meshery-wasm` stage:

```
> [meshery-wasm 4/4] RUN ... cd server/policies/wasm && GOOS=js GOARCH=wasm ... go build ...
go: updates to go.mod needed; to update it:
	go mod tidy
```

This blocks the image build (and the downstream `tests-e2e` / E2E report jobs) on every PR.

## Root cause

`server/policies/wasm` is its own Go module that pins its dependencies independently and `replace`s `github.com/meshery/meshery` with the repo root:

```
replace github.com/meshery/meshery => ../../../
```

When the root module was bumped to **meshkit v1.0.19**, the wasm module's `go.mod`/`go.sum` still pinned **meshkit v1.0.18**. Because the wasm build resolves meshkit through the replaced root module (now v1.0.19), `go build` under the default `-mod=readonly` detects the mismatch and refuses to proceed.

## Fix

Bump `github.com/meshery/meshkit` from `v1.0.18` to `v1.0.19` in the wasm module's `go.mod`/`go.sum` to match the root module. Minimal, dependency-only change — no code changes.

## Verification

Reproduced and fixed locally with the exact CI flags (go 1.26.4):

- **Before** (committed state): `cd server/policies/wasm && GOOS=js GOARCH=wasm GOFLAGS=-mod=readonly go build .` → `go: updates to go.mod needed, disabled by -mod=readonly`
- **After** (this change): same command builds `policy_engine.wasm` successfully.

Scope is intentionally limited to the wasm module; the root `go.sum` already contains the v1.0.19 checksums.