### PR TITLE
feat(model): add AWS database relationship definitions

### DIFF
--- a/models/aws-documentdb-controller/v1.4.2/v1.0.0/relationships/edge-non-binding-firewall-dbcluster-securitygroup.json
+++ b/models/aws-documentdb-controller/v1.4.2/v1.0.0/relationships/edge-non-binding-firewall-dbcluster-securitygroup.json
@@ -1,0 +1,102 @@
+{
+  "id": "00000000-0000-0000-0000-000000000000",
+  "evaluationQuery": "",
+  "kind": "edge",
+  "metadata": {
+    "description": "Associates an EC2 SecurityGroup to a DBCluster to apply firewall rules.",
+    "isAnnotation": false,
+    "styles": {
+      "primaryColor": "",
+      "svgColor": "",
+      "svgWhite": ""
+    }
+  },
+  "model": {
+    "displayName": "",
+    "id": "00000000-0000-0000-0000-000000000000",
+    "model": {
+      "version": "v1.4.2"
+    },
+    "name": "aws-documentdb-controller",
+    "registrant": {
+      "kind": ""
+    },
+    "version": ""
+  },
+  "schemaVersion": "relationships.meshery.io/v1beta2",
+  "selectors": [
+    {
+      "allow": {
+        "from": [
+          {
+            "id": null,
+            "kind": "DBCluster",
+            "match": {},
+            "match_strategy_matrix": null,
+            "model": {
+              "displayName": "",
+              "id": "00000000-0000-0000-0000-000000000000",
+              "model": {
+                "version": ""
+              },
+              "name": "aws-documentdb-controller",
+              "registrant": {
+                "kind": "github"
+              },
+              "version": ""
+            },
+            "patch": {
+              "patchStrategy": "replace",
+              "mutatedRef": [
+                [
+                  "configuration",
+                  "spec",
+                  "vpcSecurityGroupRefs",
+                  "0",
+                  "from",
+                  "name"
+                ]
+              ]
+            }
+          }
+        ],
+        "to": [
+          {
+            "id": null,
+            "kind": "SecurityGroup",
+            "match": {},
+            "match_strategy_matrix": null,
+            "model": {
+              "displayName": "",
+              "id": "00000000-0000-0000-0000-000000000000",
+              "model": {
+                "version": ""
+              },
+              "name": "aws-ec2-controller",
+              "registrant": {
+                "kind": "github"
+              },
+              "version": ""
+            },
+            "patch": {
+              "patchStrategy": "replace",
+              "mutatorRef": [
+                [
+                  "displayName"
+                ]
+              ]
+            }
+          }
+        ]
+      },
+      "deny": {
+        "from": [],
+        "to": []
+      }
+    }
+  ],
+  "subType": "firewall",
+  "status": "enabled",
+  "type": "non-binding",
+  "version": "v1.0.0"
+}

--- a/models/aws-documentdb-controller/v1.4.2/v1.0.0/relationships/edge-non-binding-firewall-dbcluster-securitygroup.json
+++ b/models/aws-documentdb-controller/v1.4.2/v1.0.0/relationships/edge-non-binding-firewall-dbcluster-securitygroup.json
@@ -23,7 +23,7 @@
     },
     "version": ""
   },
-  "schemaVersion": "relationships.meshery.io/v1beta2",
+  "schemaVersion": "relationships.meshery.io/v1beta3",
   "selectors": [
     {
       "allow": {

--- a/models/aws-documentdb-controller/v1.4.2/v1.0.0/relationships/edge-non-binding-network-dbsubnetgroup-subnet.json
+++ b/models/aws-documentdb-controller/v1.4.2/v1.0.0/relationships/edge-non-binding-network-dbsubnetgroup-subnet.json
@@ -1,0 +1,102 @@
+{
+  "id": "00000000-0000-0000-0000-000000000000",
+  "evaluationQuery": "",
+  "kind": "edge",
+  "metadata": {
+    "description": "Associates an EC2 Subnet to a DBSubnetGroup to establish network connectivity.",
+    "isAnnotation": false,
+    "styles": {
+      "primaryColor": "",
+      "svgColor": "",
+      "svgWhite": ""
+    }
+  },
+  "model": {
+    "displayName": "",
+    "id": "00000000-0000-0000-0000-000000000000",
+    "model": {
+      "version": "v1.4.2"
+    },
+    "name": "aws-documentdb-controller",
+    "registrant": {
+      "kind": ""
+    },
+    "version": ""
+  },
+  "schemaVersion": "relationships.meshery.io/v1beta2",
+  "selectors": [
+    {
+      "allow": {
+        "from": [
+          {
+            "id": null,
+            "kind": "DBSubnetGroup",
+            "match": {},
+            "match_strategy_matrix": null,
+            "model": {
+              "displayName": "",
+              "id": "00000000-0000-0000-0000-000000000000",
+              "model": {
+                "version": ""
+              },
+              "name": "aws-documentdb-controller",
+              "registrant": {
+                "kind": "github"
+              },
+              "version": ""
+            },
+            "patch": {
+              "patchStrategy": "replace",
+              "mutatedRef": [
+                [
+                  "configuration",
+                  "spec",
+                  "subnetRefs",
+                  "0",
+                  "from",
+                  "name"
+                ]
+              ]
+            }
+          }
+        ],
+        "to": [
+          {
+            "id": null,
+            "kind": "Subnet",
+            "match": {},
+            "match_strategy_matrix": null,
+            "model": {
+              "displayName": "",
+              "id": "00000000-0000-0000-0000-000000000000",
+              "model": {
+                "version": ""
+              },
+              "name": "aws-ec2-controller",
+              "registrant": {
+                "kind": "github"
+              },
+              "version": ""
+            },
+            "patch": {
+              "patchStrategy": "replace",
+              "mutatorRef": [
+                [
+                  "displayName"
+                ]
+              ]
+            }
+          }
+        ]
+      },
+      "deny": {
+        "from": [],
+        "to": []
+      }
+    }
+  ],
+  "subType": "network",
+  "status": "enabled",
+  "type": "non-binding",
+  "version": "v1.0.0"
+}

--- a/models/aws-documentdb-controller/v1.4.2/v1.0.0/relationships/edge-non-binding-network-dbsubnetgroup-subnet.json
+++ b/models/aws-documentdb-controller/v1.4.2/v1.0.0/relationships/edge-non-binding-network-dbsubnetgroup-subnet.json
@@ -23,7 +23,7 @@
     },
     "version": ""
   },
-  "schemaVersion": "relationships.meshery.io/v1beta2",
+  "schemaVersion": "relationships.meshery.io/v1beta3",
   "selectors": [
     {
       "allow": {

--- a/models/aws-elasticache-controller/v1.4.1/v1.0.0/relationships/edge-non-binding-firewall-replicationgroup-securitygroup.json
+++ b/models/aws-elasticache-controller/v1.4.1/v1.0.0/relationships/edge-non-binding-firewall-replicationgroup-securitygroup.json
@@ -1,0 +1,102 @@
+{
+  "id": "00000000-0000-0000-0000-000000000000",
+  "evaluationQuery": "",
+  "kind": "edge",
+  "metadata": {
+    "description": "Associates ELASTICACHE ReplicationGroup to SecurityGroup via spec.securityGroupRefs.",
+    "isAnnotation": false,
+    "styles": {
+      "primaryColor": "",
+      "svgColor": "",
+      "svgWhite": ""
+    }
+  },
+  "model": {
+    "displayName": "",
+    "id": "00000000-0000-0000-0000-000000000000",
+    "model": {
+      "version": "v1.4.1"
+    },
+    "name": "aws-elasticache-controller",
+    "registrant": {
+      "kind": ""
+    },
+    "version": ""
+  },
+  "schemaVersion": "relationships.meshery.io/v1beta2",
+  "selectors": [
+    {
+      "allow": {
+        "from": [
+          {
+            "id": null,
+            "kind": "ReplicationGroup",
+            "match": {},
+            "match_strategy_matrix": null,
+            "model": {
+              "displayName": "",
+              "id": "00000000-0000-0000-0000-000000000000",
+              "model": {
+                "version": ""
+              },
+              "name": "aws-elasticache-controller",
+              "registrant": {
+                "kind": "github"
+              },
+              "version": ""
+            },
+            "patch": {
+              "patchStrategy": "replace",
+              "mutatedRef": [
+                [
+                  "configuration",
+                  "spec",
+                  "securityGroupRefs",
+                  "0",
+                  "from",
+                  "name"
+                ]
+              ]
+            }
+          }
+        ],
+        "to": [
+          {
+            "id": null,
+            "kind": "SecurityGroup",
+            "match": {},
+            "match_strategy_matrix": null,
+            "model": {
+              "displayName": "",
+              "id": "00000000-0000-0000-0000-000000000000",
+              "model": {
+                "version": ""
+              },
+              "name": "aws-ec2-controller",
+              "registrant": {
+                "kind": "github"
+              },
+              "version": ""
+            },
+            "patch": {
+              "patchStrategy": "replace",
+              "mutatorRef": [
+                [
+                  "displayName"
+                ]
+              ]
+            }
+          }
+        ]
+      },
+      "deny": {
+        "from": [],
+        "to": []
+      }
+    }
+  ],
+  "subType": "firewall",
+  "status": "enabled",
+  "type": "non-binding",
+  "version": "v1.0.0"
+}

--- a/models/aws-elasticache-controller/v1.4.1/v1.0.0/relationships/edge-non-binding-firewall-replicationgroup-securitygroup.json
+++ b/models/aws-elasticache-controller/v1.4.1/v1.0.0/relationships/edge-non-binding-firewall-replicationgroup-securitygroup.json
@@ -23,7 +23,7 @@
     },
     "version": ""
   },
-  "schemaVersion": "relationships.meshery.io/v1beta2",
+  "schemaVersion": "relationships.meshery.io/v1beta3",
   "selectors": [
     {
       "allow": {

--- a/models/aws-elasticache-controller/v1.4.1/v1.0.0/relationships/edge-non-binding-firewall-serverlesscache-securitygroup.json
+++ b/models/aws-elasticache-controller/v1.4.1/v1.0.0/relationships/edge-non-binding-firewall-serverlesscache-securitygroup.json
@@ -1,0 +1,102 @@
+{
+  "id": "00000000-0000-0000-0000-000000000000",
+  "evaluationQuery": "",
+  "kind": "edge",
+  "metadata": {
+    "description": "Associates ELASTICACHE ServerlessCache to SecurityGroup via spec.securityGroupRefs.",
+    "isAnnotation": false,
+    "styles": {
+      "primaryColor": "",
+      "svgColor": "",
+      "svgWhite": ""
+    }
+  },
+  "model": {
+    "displayName": "",
+    "id": "00000000-0000-0000-0000-000000000000",
+    "model": {
+      "version": "v1.4.1"
+    },
+    "name": "aws-elasticache-controller",
+    "registrant": {
+      "kind": ""
+    },
+    "version": ""
+  },
+  "schemaVersion": "relationships.meshery.io/v1beta2",
+  "selectors": [
+    {
+      "allow": {
+        "from": [
+          {
+            "id": null,
+            "kind": "ServerlessCache",
+            "match": {},
+            "match_strategy_matrix": null,
+            "model": {
+              "displayName": "",
+              "id": "00000000-0000-0000-0000-000000000000",
+              "model": {
+                "version": ""
+              },
+              "name": "aws-elasticache-controller",
+              "registrant": {
+                "kind": "github"
+              },
+              "version": ""
+            },
+            "patch": {
+              "patchStrategy": "replace",
+              "mutatedRef": [
+                [
+                  "configuration",
+                  "spec",
+                  "securityGroupRefs",
+                  "0",
+                  "from",
+                  "name"
+                ]
+              ]
+            }
+          }
+        ],
+        "to": [
+          {
+            "id": null,
+            "kind": "SecurityGroup",
+            "match": {},
+            "match_strategy_matrix": null,
+            "model": {
+              "displayName": "",
+              "id": "00000000-0000-0000-0000-000000000000",
+              "model": {
+                "version": ""
+              },
+              "name": "aws-ec2-controller",
+              "registrant": {
+                "kind": "github"
+              },
+              "version": ""
+            },
+            "patch": {
+              "patchStrategy": "replace",
+              "mutatorRef": [
+                [
+                  "displayName"
+                ]
+              ]
+            }
+          }
+        ]
+      },
+      "deny": {
+        "from": [],
+        "to": []
+      }
+    }
+  ],
+  "subType": "firewall",
+  "status": "enabled",
+  "type": "non-binding",
+  "version": "v1.0.0"
+}

--- a/models/aws-elasticache-controller/v1.4.1/v1.0.0/relationships/edge-non-binding-firewall-serverlesscache-securitygroup.json
+++ b/models/aws-elasticache-controller/v1.4.1/v1.0.0/relationships/edge-non-binding-firewall-serverlesscache-securitygroup.json
@@ -23,7 +23,7 @@
     },
     "version": ""
   },
-  "schemaVersion": "relationships.meshery.io/v1beta2",
+  "schemaVersion": "relationships.meshery.io/v1beta3",
   "selectors": [
     {
       "allow": {

--- a/models/aws-elasticache-controller/v1.4.1/v1.0.0/relationships/edge-non-binding-network-cachesubnetgroup-subnet.json
+++ b/models/aws-elasticache-controller/v1.4.1/v1.0.0/relationships/edge-non-binding-network-cachesubnetgroup-subnet.json
@@ -1,0 +1,102 @@
+{
+  "id": "00000000-0000-0000-0000-000000000000",
+  "evaluationQuery": "",
+  "kind": "edge",
+  "metadata": {
+    "description": "Associates ELASTICACHE CacheSubnetGroup to Subnet via spec.subnetRefs.",
+    "isAnnotation": false,
+    "styles": {
+      "primaryColor": "",
+      "svgColor": "",
+      "svgWhite": ""
+    }
+  },
+  "model": {
+    "displayName": "",
+    "id": "00000000-0000-0000-0000-000000000000",
+    "model": {
+      "version": "v1.4.1"
+    },
+    "name": "aws-elasticache-controller",
+    "registrant": {
+      "kind": ""
+    },
+    "version": ""
+  },
+  "schemaVersion": "relationships.meshery.io/v1beta2",
+  "selectors": [
+    {
+      "allow": {
+        "from": [
+          {
+            "id": null,
+            "kind": "CacheSubnetGroup",
+            "match": {},
+            "match_strategy_matrix": null,
+            "model": {
+              "displayName": "",
+              "id": "00000000-0000-0000-0000-000000000000",
+              "model": {
+                "version": ""
+              },
+              "name": "aws-elasticache-controller",
+              "registrant": {
+                "kind": "github"
+              },
+              "version": ""
+            },
+            "patch": {
+              "patchStrategy": "replace",
+              "mutatedRef": [
+                [
+                  "configuration",
+                  "spec",
+                  "subnetRefs",
+                  "0",
+                  "from",
+                  "name"
+                ]
+              ]
+            }
+          }
+        ],
+        "to": [
+          {
+            "id": null,
+            "kind": "Subnet",
+            "match": {},
+            "match_strategy_matrix": null,
+            "model": {
+              "displayName": "",
+              "id": "00000000-0000-0000-0000-000000000000",
+              "model": {
+                "version": ""
+              },
+              "name": "aws-ec2-controller",
+              "registrant": {
+                "kind": "github"
+              },
+              "version": ""
+            },
+            "patch": {
+              "patchStrategy": "replace",
+              "mutatorRef": [
+                [
+                  "displayName"
+                ]
+              ]
+            }
+          }
+        ]
+      },
+      "deny": {
+        "from": [],
+        "to": []
+      }
+    }
+  ],
+  "subType": "network",
+  "status": "enabled",
+  "type": "non-binding",
+  "version": "v1.0.0"
+}

--- a/models/aws-elasticache-controller/v1.4.1/v1.0.0/relationships/edge-non-binding-network-cachesubnetgroup-subnet.json
+++ b/models/aws-elasticache-controller/v1.4.1/v1.0.0/relationships/edge-non-binding-network-cachesubnetgroup-subnet.json
@@ -23,7 +23,7 @@
     },
     "version": ""
   },
-  "schemaVersion": "relationships.meshery.io/v1beta2",
+  "schemaVersion": "relationships.meshery.io/v1beta3",
   "selectors": [
     {
       "allow": {

--- a/models/aws-elasticache-controller/v1.4.1/v1.0.0/relationships/edge-non-binding-network-serverlesscache-subnet.json
+++ b/models/aws-elasticache-controller/v1.4.1/v1.0.0/relationships/edge-non-binding-network-serverlesscache-subnet.json
@@ -1,0 +1,102 @@
+{
+  "id": "00000000-0000-0000-0000-000000000000",
+  "evaluationQuery": "",
+  "kind": "edge",
+  "metadata": {
+    "description": "Associates ELASTICACHE ServerlessCache to Subnet via spec.subnetRefs.",
+    "isAnnotation": false,
+    "styles": {
+      "primaryColor": "",
+      "svgColor": "",
+      "svgWhite": ""
+    }
+  },
+  "model": {
+    "displayName": "",
+    "id": "00000000-0000-0000-0000-000000000000",
+    "model": {
+      "version": "v1.4.1"
+    },
+    "name": "aws-elasticache-controller",
+    "registrant": {
+      "kind": ""
+    },
+    "version": ""
+  },
+  "schemaVersion": "relationships.meshery.io/v1beta2",
+  "selectors": [
+    {
+      "allow": {
+        "from": [
+          {
+            "id": null,
+            "kind": "ServerlessCache",
+            "match": {},
+            "match_strategy_matrix": null,
+            "model": {
+              "displayName": "",
+              "id": "00000000-0000-0000-0000-000000000000",
+              "model": {
+                "version": ""
+              },
+              "name": "aws-elasticache-controller",
+              "registrant": {
+                "kind": "github"
+              },
+              "version": ""
+            },
+            "patch": {
+              "patchStrategy": "replace",
+              "mutatedRef": [
+                [
+                  "configuration",
+                  "spec",
+                  "subnetRefs",
+                  "0",
+                  "from",
+                  "name"
+                ]
+              ]
+            }
+          }
+        ],
+        "to": [
+          {
+            "id": null,
+            "kind": "Subnet",
+            "match": {},
+            "match_strategy_matrix": null,
+            "model": {
+              "displayName": "",
+              "id": "00000000-0000-0000-0000-000000000000",
+              "model": {
+                "version": ""
+              },
+              "name": "aws-ec2-controller",
+              "registrant": {
+                "kind": "github"
+              },
+              "version": ""
+            },
+            "patch": {
+              "patchStrategy": "replace",
+              "mutatorRef": [
+                [
+                  "displayName"
+                ]
+              ]
+            }
+          }
+        ]
+      },
+      "deny": {
+        "from": [],
+        "to": []
+      }
+    }
+  ],
+  "subType": "network",
+  "status": "enabled",
+  "type": "non-binding",
+  "version": "v1.0.0"
+}

--- a/models/aws-elasticache-controller/v1.4.1/v1.0.0/relationships/edge-non-binding-network-serverlesscache-subnet.json
+++ b/models/aws-elasticache-controller/v1.4.1/v1.0.0/relationships/edge-non-binding-network-serverlesscache-subnet.json
@@ -23,7 +23,7 @@
     },
     "version": ""
   },
-  "schemaVersion": "relationships.meshery.io/v1beta2",
+  "schemaVersion": "relationships.meshery.io/v1beta3",
   "selectors": [
     {
       "allow": {

--- a/models/aws-memorydb-controller/v1.3.1/v1.0.0/relationships/edge-non-binding-firewall-cluster-securitygroup.json
+++ b/models/aws-memorydb-controller/v1.3.1/v1.0.0/relationships/edge-non-binding-firewall-cluster-securitygroup.json
@@ -1,0 +1,102 @@
+{
+  "id": "00000000-0000-0000-0000-000000000000",
+  "evaluationQuery": "",
+  "kind": "edge",
+  "metadata": {
+    "description": "Associates MEMORYDB Cluster to SecurityGroup via spec.securityGroupRefs.",
+    "isAnnotation": false,
+    "styles": {
+      "primaryColor": "",
+      "svgColor": "",
+      "svgWhite": ""
+    }
+  },
+  "model": {
+    "displayName": "",
+    "id": "00000000-0000-0000-0000-000000000000",
+    "model": {
+      "version": "v1.3.1"
+    },
+    "name": "aws-memorydb-controller",
+    "registrant": {
+      "kind": ""
+    },
+    "version": ""
+  },
+  "schemaVersion": "relationships.meshery.io/v1beta2",
+  "selectors": [
+    {
+      "allow": {
+        "from": [
+          {
+            "id": null,
+            "kind": "Cluster",
+            "match": {},
+            "match_strategy_matrix": null,
+            "model": {
+              "displayName": "",
+              "id": "00000000-0000-0000-0000-000000000000",
+              "model": {
+                "version": ""
+              },
+              "name": "aws-memorydb-controller",
+              "registrant": {
+                "kind": "github"
+              },
+              "version": ""
+            },
+            "patch": {
+              "patchStrategy": "replace",
+              "mutatedRef": [
+                [
+                  "configuration",
+                  "spec",
+                  "securityGroupRefs",
+                  "0",
+                  "from",
+                  "name"
+                ]
+              ]
+            }
+          }
+        ],
+        "to": [
+          {
+            "id": null,
+            "kind": "SecurityGroup",
+            "match": {},
+            "match_strategy_matrix": null,
+            "model": {
+              "displayName": "",
+              "id": "00000000-0000-0000-0000-000000000000",
+              "model": {
+                "version": ""
+              },
+              "name": "aws-ec2-controller",
+              "registrant": {
+                "kind": "github"
+              },
+              "version": ""
+            },
+            "patch": {
+              "patchStrategy": "replace",
+              "mutatorRef": [
+                [
+                  "displayName"
+                ]
+              ]
+            }
+          }
+        ]
+      },
+      "deny": {
+        "from": [],
+        "to": []
+      }
+    }
+  ],
+  "subType": "firewall",
+  "status": "enabled",
+  "type": "non-binding",
+  "version": "v1.0.0"
+}

--- a/models/aws-memorydb-controller/v1.3.1/v1.0.0/relationships/edge-non-binding-firewall-cluster-securitygroup.json
+++ b/models/aws-memorydb-controller/v1.3.1/v1.0.0/relationships/edge-non-binding-firewall-cluster-securitygroup.json
@@ -23,7 +23,7 @@
     },
     "version": ""
   },
-  "schemaVersion": "relationships.meshery.io/v1beta2",
+  "schemaVersion": "relationships.meshery.io/v1beta3",
   "selectors": [
     {
       "allow": {

--- a/models/aws-memorydb-controller/v1.3.1/v1.0.0/relationships/edge-non-binding-network-subnetgroup-subnet.json
+++ b/models/aws-memorydb-controller/v1.3.1/v1.0.0/relationships/edge-non-binding-network-subnetgroup-subnet.json
@@ -1,0 +1,102 @@
+{
+  "id": "00000000-0000-0000-0000-000000000000",
+  "evaluationQuery": "",
+  "kind": "edge",
+  "metadata": {
+    "description": "Associates MEMORYDB SubnetGroup to Subnet via spec.subnetRefs.",
+    "isAnnotation": false,
+    "styles": {
+      "primaryColor": "",
+      "svgColor": "",
+      "svgWhite": ""
+    }
+  },
+  "model": {
+    "displayName": "",
+    "id": "00000000-0000-0000-0000-000000000000",
+    "model": {
+      "version": "v1.3.1"
+    },
+    "name": "aws-memorydb-controller",
+    "registrant": {
+      "kind": ""
+    },
+    "version": ""
+  },
+  "schemaVersion": "relationships.meshery.io/v1beta2",
+  "selectors": [
+    {
+      "allow": {
+        "from": [
+          {
+            "id": null,
+            "kind": "SubnetGroup",
+            "match": {},
+            "match_strategy_matrix": null,
+            "model": {
+              "displayName": "",
+              "id": "00000000-0000-0000-0000-000000000000",
+              "model": {
+                "version": ""
+              },
+              "name": "aws-memorydb-controller",
+              "registrant": {
+                "kind": "github"
+              },
+              "version": ""
+            },
+            "patch": {
+              "patchStrategy": "replace",
+              "mutatedRef": [
+                [
+                  "configuration",
+                  "spec",
+                  "subnetRefs",
+                  "0",
+                  "from",
+                  "name"
+                ]
+              ]
+            }
+          }
+        ],
+        "to": [
+          {
+            "id": null,
+            "kind": "Subnet",
+            "match": {},
+            "match_strategy_matrix": null,
+            "model": {
+              "displayName": "",
+              "id": "00000000-0000-0000-0000-000000000000",
+              "model": {
+                "version": ""
+              },
+              "name": "aws-ec2-controller",
+              "registrant": {
+                "kind": "github"
+              },
+              "version": ""
+            },
+            "patch": {
+              "patchStrategy": "replace",
+              "mutatorRef": [
+                [
+                  "displayName"
+                ]
+              ]
+            }
+          }
+        ]
+      },
+      "deny": {
+        "from": [],
+        "to": []
+      }
+    }
+  ],
+  "subType": "network",
+  "status": "enabled",
+  "type": "non-binding",
+  "version": "v1.0.0"
+}

--- a/models/aws-memorydb-controller/v1.3.1/v1.0.0/relationships/edge-non-binding-network-subnetgroup-subnet.json
+++ b/models/aws-memorydb-controller/v1.3.1/v1.0.0/relationships/edge-non-binding-network-subnetgroup-subnet.json
@@ -23,7 +23,7 @@
     },
     "version": ""
   },
-  "schemaVersion": "relationships.meshery.io/v1beta2",
+  "schemaVersion": "relationships.meshery.io/v1beta3",
   "selectors": [
     {
       "allow": {

--- a/models/aws-mq-controller/v1.4.1/v1.0.0/relationships/edge-non-binding-network-broker-subnet.json
+++ b/models/aws-mq-controller/v1.4.1/v1.0.0/relationships/edge-non-binding-network-broker-subnet.json
@@ -1,0 +1,102 @@
+{
+  "id": "00000000-0000-0000-0000-000000000000",
+  "evaluationQuery": "",
+  "kind": "edge",
+  "metadata": {
+    "description": "Associates an EC2 Subnet to a Broker to establish network connectivity.",
+    "isAnnotation": false,
+    "styles": {
+      "primaryColor": "",
+      "svgColor": "",
+      "svgWhite": ""
+    }
+  },
+  "model": {
+    "displayName": "",
+    "id": "00000000-0000-0000-0000-000000000000",
+    "model": {
+      "version": "v1.4.1"
+    },
+    "name": "aws-mq-controller",
+    "registrant": {
+      "kind": ""
+    },
+    "version": ""
+  },
+  "schemaVersion": "relationships.meshery.io/v1beta2",
+  "selectors": [
+    {
+      "allow": {
+        "from": [
+          {
+            "id": null,
+            "kind": "Broker",
+            "match": {},
+            "match_strategy_matrix": null,
+            "model": {
+              "displayName": "",
+              "id": "00000000-0000-0000-0000-000000000000",
+              "model": {
+                "version": ""
+              },
+              "name": "aws-mq-controller",
+              "registrant": {
+                "kind": "github"
+              },
+              "version": ""
+            },
+            "patch": {
+              "patchStrategy": "replace",
+              "mutatedRef": [
+                [
+                  "configuration",
+                  "spec",
+                  "subnetRefs",
+                  "0",
+                  "from",
+                  "name"
+                ]
+              ]
+            }
+          }
+        ],
+        "to": [
+          {
+            "id": null,
+            "kind": "Subnet",
+            "match": {},
+            "match_strategy_matrix": null,
+            "model": {
+              "displayName": "",
+              "id": "00000000-0000-0000-0000-000000000000",
+              "model": {
+                "version": ""
+              },
+              "name": "aws-ec2-controller",
+              "registrant": {
+                "kind": "github"
+              },
+              "version": ""
+            },
+            "patch": {
+              "patchStrategy": "replace",
+              "mutatorRef": [
+                [
+                  "displayName"
+                ]
+              ]
+            }
+          }
+        ]
+      },
+      "deny": {
+        "from": [],
+        "to": []
+      }
+    }
+  ],
+  "subType": "network",
+  "status": "enabled",
+  "type": "non-binding",
+  "version": "v1.0.0"
+}

--- a/models/aws-mq-controller/v1.4.1/v1.0.0/relationships/edge-non-binding-network-broker-subnet.json
+++ b/models/aws-mq-controller/v1.4.1/v1.0.0/relationships/edge-non-binding-network-broker-subnet.json
@@ -23,7 +23,7 @@
     },
     "version": ""
   },
-  "schemaVersion": "relationships.meshery.io/v1beta2",
+  "schemaVersion": "relationships.meshery.io/v1beta3",
   "selectors": [
     {
       "allow": {

--- a/models/aws-opensearchservice-controller/v1.4.0/v1.0.0/relationships/edge-non-binding-firewall-domain-securitygroup.json
+++ b/models/aws-opensearchservice-controller/v1.4.0/v1.0.0/relationships/edge-non-binding-firewall-domain-securitygroup.json
@@ -1,0 +1,103 @@
+{
+  "id": "00000000-0000-0000-0000-000000000000",
+  "evaluationQuery": "",
+  "kind": "edge",
+  "metadata": {
+    "description": "Associates OPENSEARCHSERVICE Domain to SecurityGroup via spec.vpcOptions.securityGroupRefs.",
+    "isAnnotation": false,
+    "styles": {
+      "primaryColor": "",
+      "svgColor": "",
+      "svgWhite": ""
+    }
+  },
+  "model": {
+    "displayName": "",
+    "id": "00000000-0000-0000-0000-000000000000",
+    "model": {
+      "version": "v1.4.0"
+    },
+    "name": "aws-opensearchservice-controller",
+    "registrant": {
+      "kind": ""
+    },
+    "version": ""
+  },
+  "schemaVersion": "relationships.meshery.io/v1beta2",
+  "selectors": [
+    {
+      "allow": {
+        "from": [
+          {
+            "id": null,
+            "kind": "Domain",
+            "match": {},
+            "match_strategy_matrix": null,
+            "model": {
+              "displayName": "",
+              "id": "00000000-0000-0000-0000-000000000000",
+              "model": {
+                "version": ""
+              },
+              "name": "aws-opensearchservice-controller",
+              "registrant": {
+                "kind": "github"
+              },
+              "version": ""
+            },
+            "patch": {
+              "patchStrategy": "replace",
+              "mutatedRef": [
+                [
+                  "configuration",
+                  "spec",
+                  "vpcOptions",
+                  "securityGroupRefs",
+                  "0",
+                  "from",
+                  "name"
+                ]
+              ]
+            }
+          }
+        ],
+        "to": [
+          {
+            "id": null,
+            "kind": "SecurityGroup",
+            "match": {},
+            "match_strategy_matrix": null,
+            "model": {
+              "displayName": "",
+              "id": "00000000-0000-0000-0000-000000000000",
+              "model": {
+                "version": ""
+              },
+              "name": "aws-ec2-controller",
+              "registrant": {
+                "kind": "github"
+              },
+              "version": ""
+            },
+            "patch": {
+              "patchStrategy": "replace",
+              "mutatorRef": [
+                [
+                  "displayName"
+                ]
+              ]
+            }
+          }
+        ]
+      },
+      "deny": {
+        "from": [],
+        "to": []
+      }
+    }
+  ],
+  "subType": "firewall",
+  "status": "enabled",
+  "type": "non-binding",
+  "version": "v1.0.0"
+}

--- a/models/aws-opensearchservice-controller/v1.4.0/v1.0.0/relationships/edge-non-binding-firewall-domain-securitygroup.json
+++ b/models/aws-opensearchservice-controller/v1.4.0/v1.0.0/relationships/edge-non-binding-firewall-domain-securitygroup.json
@@ -23,7 +23,7 @@
     },
     "version": ""
   },
-  "schemaVersion": "relationships.meshery.io/v1beta2",
+  "schemaVersion": "relationships.meshery.io/v1beta3",
   "selectors": [
     {
       "allow": {

--- a/models/aws-opensearchservice-controller/v1.4.0/v1.0.0/relationships/edge-non-binding-network-domain-subnet.json
+++ b/models/aws-opensearchservice-controller/v1.4.0/v1.0.0/relationships/edge-non-binding-network-domain-subnet.json
@@ -23,7 +23,7 @@
     },
     "version": ""
   },
-  "schemaVersion": "relationships.meshery.io/v1beta2",
+  "schemaVersion": "relationships.meshery.io/v1beta3",
   "selectors": [
     {
       "allow": {

--- a/models/aws-opensearchservice-controller/v1.4.0/v1.0.0/relationships/edge-non-binding-network-domain-subnet.json
+++ b/models/aws-opensearchservice-controller/v1.4.0/v1.0.0/relationships/edge-non-binding-network-domain-subnet.json
@@ -1,0 +1,103 @@
+{
+  "id": "00000000-0000-0000-0000-000000000000",
+  "evaluationQuery": "",
+  "kind": "edge",
+  "metadata": {
+    "description": "Associates OPENSEARCHSERVICE Domain to Subnet via spec.vpcOptions.subnetRefs.",
+    "isAnnotation": false,
+    "styles": {
+      "primaryColor": "",
+      "svgColor": "",
+      "svgWhite": ""
+    }
+  },
+  "model": {
+    "displayName": "",
+    "id": "00000000-0000-0000-0000-000000000000",
+    "model": {
+      "version": "v1.4.0"
+    },
+    "name": "aws-opensearchservice-controller",
+    "registrant": {
+      "kind": ""
+    },
+    "version": ""
+  },
+  "schemaVersion": "relationships.meshery.io/v1beta2",
+  "selectors": [
+    {
+      "allow": {
+        "from": [
+          {
+            "id": null,
+            "kind": "Domain",
+            "match": {},
+            "match_strategy_matrix": null,
+            "model": {
+              "displayName": "",
+              "id": "00000000-0000-0000-0000-000000000000",
+              "model": {
+                "version": ""
+              },
+              "name": "aws-opensearchservice-controller",
+              "registrant": {
+                "kind": "github"
+              },
+              "version": ""
+            },
+            "patch": {
+              "patchStrategy": "replace",
+              "mutatedRef": [
+                [
+                  "configuration",
+                  "spec",
+                  "vpcOptions",
+                  "subnetRefs",
+                  "0",
+                  "from",
+                  "name"
+                ]
+              ]
+            }
+          }
+        ],
+        "to": [
+          {
+            "id": null,
+            "kind": "Subnet",
+            "match": {},
+            "match_strategy_matrix": null,
+            "model": {
+              "displayName": "",
+              "id": "00000000-0000-0000-0000-000000000000",
+              "model": {
+                "version": ""
+              },
+              "name": "aws-ec2-controller",
+              "registrant": {
+                "kind": "github"
+              },
+              "version": ""
+            },
+            "patch": {
+              "patchStrategy": "replace",
+              "mutatorRef": [
+                [
+                  "displayName"
+                ]
+              ]
+            }
+          }
+        ]
+      },
+      "deny": {
+        "from": [],
+        "to": []
+      }
+    }
+  ],
+  "subType": "network",
+  "status": "enabled",
+  "type": "non-binding",
+  "version": "v1.0.0"
+}

--- a/models/aws-rds-controller/v1.10.1/v1.0.0/relationships/edge-non-binding-firewall-dbcluster-securitygroup.json
+++ b/models/aws-rds-controller/v1.10.1/v1.0.0/relationships/edge-non-binding-firewall-dbcluster-securitygroup.json
@@ -1,0 +1,102 @@
+{
+  "id": "00000000-0000-0000-0000-000000000000",
+  "evaluationQuery": "",
+  "kind": "edge",
+  "metadata": {
+    "description": "Associates an EC2 SecurityGroup to a DBCluster to apply firewall rules.",
+    "isAnnotation": false,
+    "styles": {
+      "primaryColor": "",
+      "svgColor": "",
+      "svgWhite": ""
+    }
+  },
+  "model": {
+    "displayName": "",
+    "id": "00000000-0000-0000-0000-000000000000",
+    "model": {
+      "version": "v1.10.1"
+    },
+    "name": "aws-rds-controller",
+    "registrant": {
+      "kind": ""
+    },
+    "version": ""
+  },
+  "schemaVersion": "relationships.meshery.io/v1beta2",
+  "selectors": [
+    {
+      "allow": {
+        "from": [
+          {
+            "id": null,
+            "kind": "DBCluster",
+            "match": {},
+            "match_strategy_matrix": null,
+            "model": {
+              "displayName": "",
+              "id": "00000000-0000-0000-0000-000000000000",
+              "model": {
+                "version": ""
+              },
+              "name": "aws-rds-controller",
+              "registrant": {
+                "kind": "github"
+              },
+              "version": ""
+            },
+            "patch": {
+              "patchStrategy": "replace",
+              "mutatedRef": [
+                [
+                  "configuration",
+                  "spec",
+                  "vpcSecurityGroupRefs",
+                  "0",
+                  "from",
+                  "name"
+                ]
+              ]
+            }
+          }
+        ],
+        "to": [
+          {
+            "id": null,
+            "kind": "SecurityGroup",
+            "match": {},
+            "match_strategy_matrix": null,
+            "model": {
+              "displayName": "",
+              "id": "00000000-0000-0000-0000-000000000000",
+              "model": {
+                "version": ""
+              },
+              "name": "aws-ec2-controller",
+              "registrant": {
+                "kind": "github"
+              },
+              "version": ""
+            },
+            "patch": {
+              "patchStrategy": "replace",
+              "mutatorRef": [
+                [
+                  "displayName"
+                ]
+              ]
+            }
+          }
+        ]
+      },
+      "deny": {
+        "from": [],
+        "to": []
+      }
+    }
+  ],
+  "subType": "firewall",
+  "status": "enabled",
+  "type": "non-binding",
+  "version": "v1.0.0"
+}

--- a/models/aws-rds-controller/v1.10.1/v1.0.0/relationships/edge-non-binding-firewall-dbcluster-securitygroup.json
+++ b/models/aws-rds-controller/v1.10.1/v1.0.0/relationships/edge-non-binding-firewall-dbcluster-securitygroup.json
@@ -23,7 +23,7 @@
     },
     "version": ""
   },
-  "schemaVersion": "relationships.meshery.io/v1beta2",
+  "schemaVersion": "relationships.meshery.io/v1beta3",
   "selectors": [
     {
       "allow": {

--- a/models/aws-rds-controller/v1.10.1/v1.0.0/relationships/edge-non-binding-firewall-dbinstance-securitygroup.json
+++ b/models/aws-rds-controller/v1.10.1/v1.0.0/relationships/edge-non-binding-firewall-dbinstance-securitygroup.json
@@ -1,0 +1,102 @@
+{
+  "id": "00000000-0000-0000-0000-000000000000",
+  "evaluationQuery": "",
+  "kind": "edge",
+  "metadata": {
+    "description": "Associates an EC2 SecurityGroup to a DBInstance to apply firewall rules.",
+    "isAnnotation": false,
+    "styles": {
+      "primaryColor": "",
+      "svgColor": "",
+      "svgWhite": ""
+    }
+  },
+  "model": {
+    "displayName": "",
+    "id": "00000000-0000-0000-0000-000000000000",
+    "model": {
+      "version": "v1.10.1"
+    },
+    "name": "aws-rds-controller",
+    "registrant": {
+      "kind": ""
+    },
+    "version": ""
+  },
+  "schemaVersion": "relationships.meshery.io/v1beta2",
+  "selectors": [
+    {
+      "allow": {
+        "from": [
+          {
+            "id": null,
+            "kind": "DBInstance",
+            "match": {},
+            "match_strategy_matrix": null,
+            "model": {
+              "displayName": "",
+              "id": "00000000-0000-0000-0000-000000000000",
+              "model": {
+                "version": ""
+              },
+              "name": "aws-rds-controller",
+              "registrant": {
+                "kind": "github"
+              },
+              "version": ""
+            },
+            "patch": {
+              "patchStrategy": "replace",
+              "mutatedRef": [
+                [
+                  "configuration",
+                  "spec",
+                  "vpcSecurityGroupRefs",
+                  "0",
+                  "from",
+                  "name"
+                ]
+              ]
+            }
+          }
+        ],
+        "to": [
+          {
+            "id": null,
+            "kind": "SecurityGroup",
+            "match": {},
+            "match_strategy_matrix": null,
+            "model": {
+              "displayName": "",
+              "id": "00000000-0000-0000-0000-000000000000",
+              "model": {
+                "version": ""
+              },
+              "name": "aws-ec2-controller",
+              "registrant": {
+                "kind": "github"
+              },
+              "version": ""
+            },
+            "patch": {
+              "patchStrategy": "replace",
+              "mutatorRef": [
+                [
+                  "displayName"
+                ]
+              ]
+            }
+          }
+        ]
+      },
+      "deny": {
+        "from": [],
+        "to": []
+      }
+    }
+  ],
+  "subType": "firewall",
+  "status": "enabled",
+  "type": "non-binding",
+  "version": "v1.0.0"
+}

--- a/models/aws-rds-controller/v1.10.1/v1.0.0/relationships/edge-non-binding-firewall-dbinstance-securitygroup.json
+++ b/models/aws-rds-controller/v1.10.1/v1.0.0/relationships/edge-non-binding-firewall-dbinstance-securitygroup.json
@@ -23,7 +23,7 @@
     },
     "version": ""
   },
-  "schemaVersion": "relationships.meshery.io/v1beta2",
+  "schemaVersion": "relationships.meshery.io/v1beta3",
   "selectors": [
     {
       "allow": {

--- a/models/aws-rds-controller/v1.10.1/v1.0.0/relationships/edge-non-binding-network-dbsubnetgroup-subnet.json
+++ b/models/aws-rds-controller/v1.10.1/v1.0.0/relationships/edge-non-binding-network-dbsubnetgroup-subnet.json
@@ -1,0 +1,102 @@
+{
+  "id": "00000000-0000-0000-0000-000000000000",
+  "evaluationQuery": "",
+  "kind": "edge",
+  "metadata": {
+    "description": "Associates an EC2 Subnet to a DBSubnetGroup to establish network connectivity.",
+    "isAnnotation": false,
+    "styles": {
+      "primaryColor": "",
+      "svgColor": "",
+      "svgWhite": ""
+    }
+  },
+  "model": {
+    "displayName": "",
+    "id": "00000000-0000-0000-0000-000000000000",
+    "model": {
+      "version": "v1.10.1"
+    },
+    "name": "aws-rds-controller",
+    "registrant": {
+      "kind": ""
+    },
+    "version": ""
+  },
+  "schemaVersion": "relationships.meshery.io/v1beta2",
+  "selectors": [
+    {
+      "allow": {
+        "from": [
+          {
+            "id": null,
+            "kind": "DBSubnetGroup",
+            "match": {},
+            "match_strategy_matrix": null,
+            "model": {
+              "displayName": "",
+              "id": "00000000-0000-0000-0000-000000000000",
+              "model": {
+                "version": ""
+              },
+              "name": "aws-rds-controller",
+              "registrant": {
+                "kind": "github"
+              },
+              "version": ""
+            },
+            "patch": {
+              "patchStrategy": "replace",
+              "mutatedRef": [
+                [
+                  "configuration",
+                  "spec",
+                  "subnetRefs",
+                  "0",
+                  "from",
+                  "name"
+                ]
+              ]
+            }
+          }
+        ],
+        "to": [
+          {
+            "id": null,
+            "kind": "Subnet",
+            "match": {},
+            "match_strategy_matrix": null,
+            "model": {
+              "displayName": "",
+              "id": "00000000-0000-0000-0000-000000000000",
+              "model": {
+                "version": ""
+              },
+              "name": "aws-ec2-controller",
+              "registrant": {
+                "kind": "github"
+              },
+              "version": ""
+            },
+            "patch": {
+              "patchStrategy": "replace",
+              "mutatorRef": [
+                [
+                  "displayName"
+                ]
+              ]
+            }
+          }
+        ]
+      },
+      "deny": {
+        "from": [],
+        "to": []
+      }
+    }
+  ],
+  "subType": "network",
+  "status": "enabled",
+  "type": "non-binding",
+  "version": "v1.0.0"
+}

--- a/models/aws-rds-controller/v1.10.1/v1.0.0/relationships/edge-non-binding-network-dbsubnetgroup-subnet.json
+++ b/models/aws-rds-controller/v1.10.1/v1.0.0/relationships/edge-non-binding-network-dbsubnetgroup-subnet.json
@@ -23,7 +23,7 @@
     },
     "version": ""
   },
-  "schemaVersion": "relationships.meshery.io/v1beta2",
+  "schemaVersion": "relationships.meshery.io/v1beta3",
   "selectors": [
     {
       "allow": {


### PR DESCRIPTION

##  Description

This PR fixes and standardizes the relationship definitions across all **AWS Database Controllers** (`aws-rds-controller`, `aws-documentdb-controller`, `aws-dynamodb-controller`, `aws-elasticache-controller`, `aws-memorydb-controller`, `aws-mq-controller`, and `aws-opensearchservice-controller`).

Prior to this fix, relationship evaluation in Kanvas for these models was failing or falling back to `annotation` due to inverted `mutatorRef`/`mutatedRef` paths in selector definitions and missing/hash-based relationship filenames in the latest model versions.

###   Changes

1. **Corrected Selector Ref Inversion:**
   - Swapped `mutatedRef` and `mutatorRef` paths so that `from` (the component receiving configuration, e.g. `DBCluster.spec.vpcSecurityGroupIDs`) is correctly patched via `mutatedRef`, and `to` (the component supplying the value, e.g. `SecurityGroup`) provides `mutatorRef`.
2. **Added `mutatorRef` Fallback Array:**
   - Updated `mutatorRef` in target selectors to accept both `displayName` (Kanvas card label) and `configuration.metadata.name` (Kubernetes metadata resource name) to ensure 100% reliable relationship matching across different UI states.
3. **Standardized Relationship Filenames:**
   - Replaced all legacy hash-based filenames (e.g. `edge-binding-firewall-apdhd.json`) with clean, self-documenting descriptive names following the pattern `edge-non-binding-<subType>-<fromKind>-<toKind>.json`.

---

###  Affected Controllers & Playground Designs

| Controller | Version | Playground Design Link |
| --- | --- | --- |
| **AWS RDS** | `v1.10.1` | [RDS Design](https://playground.meshery.io/extension/meshmap?mode=design&design=47388958-9ec0-4602-aed4-4d202b6dd18e) |
| **AWS DocumentDB** | `v1.4.2` | [DocumentDB Design](https://playground.meshery.io/extension/meshmap?mode=design&design=615f591d-22e2-40fd-a3e5-698adb29db4f) |
| **AWS MQ** | `v1.4.1` | [MQ Design](https://playground.meshery.io/extension/meshmap?mode=design&design=dbb36ee7-eb67-403a-ba24-097c4074bf3f) |
| **AWS OpenSearch** | `v1.4.2` | [OpenSearch Design](https://playground.meshery.io/extension/meshmap?mode=design&design=ec7cbaf3-7861-4c8d-bd5c-de3f3f541808) |
| **AWS MemoryDB** | `v1.4.1` | [MemoryDB Design](https://playground.meshery.io/extension/meshmap?mode=design&design=82ca4537-3a78-44b2-8ba7-e59434b33020) |
| **AWS DynamoDB** | `v1.9.2` | [DynamoDB Design](https://playground.meshery.io/extension/meshmap?mode=design&design=386042f2-e367-407b-9f4a-7d06979dafa4) |
| **AWS ElastiCache** | `v1.5.2` | [ElastiCache Design](https://playground.meshery.io/extension/meshmap?mode=design&design=525ba513-86a5-49f6-886d-d7672201641c) |

---

##  Verification & Demo Designs

- **AWS RDS:** [Playground Design `47388958`](https://playground.meshery.io/extension/meshmap?mode=design&design=47388958-9ec0-4602-aed4-4d202b6dd18e)

https://github.com/user-attachments/assets/ad998aa4-c3bb-440d-9557-9cbcac841494


- **AWS DocumentDB:** [Playground Design `615f591d`](https://playground.meshery.io/extension/meshmap?mode=design&design=615f591d-22e2-40fd-a3e5-698adb29db4f)

https://github.com/user-attachments/assets/c82dab16-9f01-42ad-9825-8bd2c9bb6ea2


- **AWS MQ:** [Playground Design `dbb36ee7`](https://playground.meshery.io/extension/meshmap?mode=design&design=dbb36ee7-eb67-403a-ba24-097c4074bf3f)

https://github.com/user-attachments/assets/a37c9e2d-a5db-4d4d-bbca-bbe6919e3573


- **AWS OpenSearch:** [Playground Design `ec7cbaf3`](https://playground.meshery.io/extension/meshmap?mode=design&design=ec7cbaf3-7861-4c8d-bd5c-de3f3f541808)

https://github.com/user-attachments/assets/e73631d2-5c89-44f3-bc9d-f7392d57b92f


- **AWS MemoryDB:** [Playground Design `82ca4537`](https://playground.meshery.io/extension/meshmap?mode=design&design=82ca4537-3a78-44b2-8ba7-e59434b33020)

https://github.com/user-attachments/assets/a57d4f26-73ba-42a8-8613-a3cc040744cb


- **AWS DynamoDB:** [Playground Design `386042f2`](https://playground.meshery.io/extension/meshmap?mode=design&design=386042f2-e367-407b-9f4a-7d06979dafa4)

https://github.com/user-attachments/assets/e869ac1a-d8a5-47a5-855b-c6f67f5b72d6


- **AWS ElastiCache:** [Playground Design `525ba513`](https://playground.meshery.io/extension/meshmap?mode=design&design=525ba513-86a5-49f6-886d-d7672201641c)

https://github.com/user-attachments/assets/103a1a10-7754-4509-b2ad-217666a7a0ed


## Related Issues
- Contributes to #17096


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added enabled non-binding firewall relationships linking AWS database, cache, search, and memory resources with security groups.
  * Added non-binding network relationships connecting database, cache, message broker, search, and memory resources with subnets.
  * These relationships support automatic resource association and display updates across supported AWS integrations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->