### PR TITLE
fix: handle null currentOrg in GetStarted widget (#20324)

### DIFF
--- a/ui/components/dashboard/widgets/getting-started/index.tsx
+++ b/ui/components/dashboard/widgets/getting-started/index.tsx
@@ -24,7 +24,7 @@ const GetStarted = (props: { iconsProps?: object }) => {
     skip: !currentUser?.id,
   });
   const { organization: currentOrg } = useSelector((state) => state.ui);
-  const { id: org_id } = currentOrg;
+  const { id: org_id } = currentOrg ?? {};
   return (
     <>
       <ActionButtonCard

--- a/ui/components/dashboard/widgets/getting-started/index.tsx
+++ b/ui/components/dashboard/widgets/getting-started/index.tsx
@@ -24,7 +24,7 @@ const GetStarted = (props: { iconsProps?: object }) => {
     skip: !currentUser?.id,
   });
   const { organization: currentOrg } = useSelector((state) => state.ui);
-  const { id: org_id } = currentOrg ?? {};
+  const org_id = currentOrg?.id;
   return (
     <>
       <ActionButtonCard

--- a/ui/components/dashboard/widgets/getting-started/index.tsx
+++ b/ui/components/dashboard/widgets/getting-started/index.tsx
@@ -24,7 +24,7 @@ const GetStarted = (props: { iconsProps?: object }) => {
     skip: !currentUser?.id,
   });
   const { organization: currentOrg } = useSelector((state) => state.ui);
-  const org_id = currentOrg?.id;
+  const org_id = currentOrg?.id ?? '00000000-0000-0000-0000-000000000000';
   return (
     <>
       <ActionButtonCard


### PR DESCRIPTION
## What this fixes
Fixes #20324 — GetStarted widget crashes with
"Cannot destructure property 'id' of 'currentOrg' as it is null"
when running Meshery locally with the Local Provider.

## Root Cause Investigation
The null check was never there to begin with. The component was written
in Feb 2025 (commit `e9762e0e9018`) assuming `currentOrg` would always
be populated — which holds true for cloud provider but not Local Provider.
Not a regression, just an unhandled edge case from day one.

## What I changed
Defaulted `org_id` to zeroed UUID when `currentOrg` is null, consistent
with how Local Provider handles org IDs across the codebase.

Before:
const { id: org_id } = currentOrg;

After:
const org_id = currentOrg?.id ?? '00000000-0000-0000-0000-000000000000';

## How to verify
1. Run Meshery locally with `make server` + `make ui`
2. Login with Local Provider
3. Navigate to Dashboard
4. Error overlay should no longer appear

## Screenshots
Before:
<img width="1472" height="743" alt="Screenshot 2026-06-27 at 9 29 08 PM" src="https://github.com/user-attachments/assets/579c3db4-19d6-4abc-8ada-1a2c0742e2aa" />

After:
<img width="1492" height="765" alt="Screenshot 2026-06-27 at 10 39 50 PM" src="https://github.com/user-attachments/assets/0f007707-74ef-4cef-b58c-2d4b2930ad2a" />

## Signed commits
- [x] Yes, I signed my commits.