### PR TITLE
test(perf): add regression tests for LoadTestUsingSMPHandler boundary checks

### DIFF
--- a/server/handlers/load_test_handler_test.go
+++ b/server/handlers/load_test_handler_test.go
@@ -1,0 +1,73 @@
+package handlers
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/meshery/meshery/server/models"
+	"github.com/meshery/meshkit/logger"
+)
+
+func TestLoadTestUsingSMPHandler_EmptyClients(t *testing.T) {
+	log, err := logger.New("test", logger.Options{})
+	if err != nil {
+		t.Fatalf("failed to create logger: %v", err)
+	}
+
+	handler := &Handler{
+		config: &models.HandlerConfig{},
+		log:    log,
+	}
+
+	body := strings.NewReader(`{
+		"test": {
+			"name": "my-test",
+			"duration": "1s",
+			"clients": []
+		}
+	}`)
+
+	req := httptest.NewRequest(http.MethodPost, "/perf/profile", body)
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+
+	handler.LoadTestUsingSMPHandler(w, req, nil, nil, nil)
+
+	if w.Code != http.StatusBadRequest {
+		t.Errorf("expected 400 for empty clients, got %d", w.Code)
+	}
+}
+
+func TestLoadTestUsingSMPHandler_EmptyEndpointUrls(t *testing.T) {
+	log, err := logger.New("test", logger.Options{})
+	if err != nil {
+		t.Fatalf("failed to create logger: %v", err)
+	}
+
+	handler := &Handler{
+		config: &models.HandlerConfig{},
+		log:    log,
+	}
+
+	body := strings.NewReader(`{
+		"test": {
+			"name": "my-test",
+			"duration": "1s",
+			"clients": [
+				{ "endpointUrls": [] }
+			]
+		}
+	}`)
+
+	req := httptest.NewRequest(http.MethodPost, "/perf/profile", body)
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+
+	handler.LoadTestUsingSMPHandler(w, req, nil, nil, nil)
+
+	if w.Code != http.StatusBadRequest {
+		t.Errorf("expected 400 for empty endpointUrls, got %d", w.Code)
+	}
+}

--- a/server/handlers/load_test_handler_test.go
+++ b/server/handlers/load_test_handler_test.go
@@ -10,7 +10,7 @@ import (
 	"github.com/meshery/meshkit/logger"
 )
 
-func TestLoadTestUsingSMPHandler_EmptyClients(t *testing.T) {
+func TestLoadTestUsingSMPHandler_BoundaryChecks(t *testing.T) {
 	log, err := logger.New("test", logger.Options{})
 	if err != nil {
 		t.Fatalf("failed to create logger: %v", err)
@@ -21,53 +21,45 @@ func TestLoadTestUsingSMPHandler_EmptyClients(t *testing.T) {
 		log:    log,
 	}
 
-	body := strings.NewReader(`{
-		"test": {
-			"name": "my-test",
-			"duration": "1s",
-			"clients": []
-		}
-	}`)
-
-	req := httptest.NewRequest(http.MethodPost, "/perf/profile", body)
-	req.Header.Set("Content-Type", "application/json")
-	w := httptest.NewRecorder()
-
-	handler.LoadTestUsingSMPHandler(w, req, nil, nil, nil)
-
-	if w.Code != http.StatusBadRequest {
-		t.Errorf("expected 400 for empty clients, got %d", w.Code)
-	}
-}
-
-func TestLoadTestUsingSMPHandler_EmptyEndpointUrls(t *testing.T) {
-	log, err := logger.New("test", logger.Options{})
-	if err != nil {
-		t.Fatalf("failed to create logger: %v", err)
-	}
-
-	handler := &Handler{
-		config: &models.HandlerConfig{},
-		log:    log,
+	tests := []struct {
+		name string
+		body string
+	}{
+		{
+			name: "EmptyClients",
+			body: `{
+				"test": {
+					"name": "my-test",
+					"duration": "1s",
+					"clients": []
+				}
+			}`,
+		},
+		{
+			name: "EmptyEndpointUrls",
+			body: `{
+				"test": {
+					"name": "my-test",
+					"duration": "1s",
+					"clients": [
+						{ "endpointUrls": [] }
+					]
+				}
+			}`,
+		},
 	}
 
-	body := strings.NewReader(`{
-		"test": {
-			"name": "my-test",
-			"duration": "1s",
-			"clients": [
-				{ "endpointUrls": [] }
-			]
-		}
-	}`)
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			req := httptest.NewRequest(http.MethodPost, "/perf/profile", strings.NewReader(tt.body))
+			req.Header.Set("Content-Type", "application/json")
+			w := httptest.NewRecorder()
 
-	req := httptest.NewRequest(http.MethodPost, "/perf/profile", body)
-	req.Header.Set("Content-Type", "application/json")
-	w := httptest.NewRecorder()
+			handler.LoadTestUsingSMPHandler(w, req, nil, nil, nil)
 
-	handler.LoadTestUsingSMPHandler(w, req, nil, nil, nil)
-
-	if w.Code != http.StatusBadRequest {
-		t.Errorf("expected 400 for empty endpointUrls, got %d", w.Code)
+			if w.Code != http.StatusBadRequest {
+				t.Errorf("expected 400 for %s, got %d", tt.name, w.Code)
+			}
+		})
 	}
 }


### PR DESCRIPTION
**Notes for Reviewers**
Adds regression tests for the two bounds-checks in `LoadTestUsingSMPHandler` 
that guard against runtime panics on malformed SMP payloads:

- Empty `clients` array → 400 Bad Request
- Empty `endpointUrls` array → 400 Bad Request

Related to #18979 

**[Signed commits](https://github.com/meshery/meshery/blob/master/CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [x] Yes, I signed my commits.

<!--
Thank you for contributing to Meshery! 

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. Sign your commits.
4. Include before and after screenshots/terminal output.

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.
-->
