### PR TITLE
ci: fix CodeQL Go analysis reporting

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -72,13 +72,13 @@ jobs:
         if: matrix.language == 'go'
         run: |
           # Build Meshery Server
-          go build -o ./server/cmd/meshery-server ./server/cmd/main.go ./server/cmd/error.go
+          go build -o ./server/cmd/meshery-server ./server/cmd
           
           # Build Meshery CLI
-          go build -o ./mesheryctl/mesheryctl ./mesheryctl/cmd/mesheryctl/main.go
+          go build -o ./mesheryctl/mesheryctl ./mesheryctl/cmd/mesheryctl
           
           # Build WASM Policy Engine
-          GOOS=js GOARCH=wasm go build -o ./server/policies/wasm/policy_engine.wasm ./server/policies/wasm/main.go
+          (cd server/policies/wasm && GOOS=js GOARCH=wasm go build -o policy_engine.wasm .)
 
       - name: Perform CodeQL Analysis
         uses: github/codeql-action/analyze@v4

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -50,32 +50,35 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v6
 
+      - name: Setup Go
+        if: matrix.language == 'go'
+        uses: actions/setup-go@v6
+        with:
+          go-version-file: go.mod
+
       # Initializes the CodeQL tools for scanning.
       - name: Initialize CodeQL
         uses: github/codeql-action/init@v4
         with:
           languages: ${{ matrix.language }}
           config-file: ./.github/codeql-config.yml
+          build-mode: ${{ matrix.language == 'go' && 'manual' || 'none' }}
           # If you wish to specify custom queries, you can do so here or in a config file.
           # By default, queries listed here will override any specified in a config file.
           # Prefix the list here with "+" to use these queries and those in the config file.
           # queries: ./path/to/local/query, your-org/your-repo/queries@main
 
-      # Autobuild attempts to build any compiled languages  (C/C++, C#, or Java).
-      # If this step fails, then you should remove it and run the build manually (see below)
-      - name: Autobuild
-        uses: github/codeql-action/autobuild@v4
-
-      # ℹ️ Command-line programs to run using the OS shell.
-      # 📚 https://git.io/JvXDl
-
-      # ✏️ If the Autobuild fails above, remove it and uncomment the following three lines
-      #    and modify them (or add more) to build your code if your project
-      #    uses a compiled language
-
-      #- run: |
-      #   make bootstrap
-      #   make release
+      - name: Build Go code
+        if: matrix.language == 'go'
+        run: |
+          # Build Meshery Server
+          go build -o ./server/cmd/meshery-server ./server/cmd/main.go ./server/cmd/error.go
+          
+          # Build Meshery CLI
+          go build -o ./mesheryctl/mesheryctl ./mesheryctl/cmd/mesheryctl/main.go
+          
+          # Build WASM Policy Engine
+          GOOS=js GOARCH=wasm go build -o ./server/policies/wasm/policy_engine.wasm ./server/policies/wasm/main.go
 
       - name: Perform CodeQL Analysis
         uses: github/codeql-action/analyze@v4

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -72,13 +72,13 @@ jobs:
         if: matrix.language == 'go'
         run: |
           # Build Meshery Server
-          go build -o ./server/cmd/meshery-server ./server/cmd
+          make build-server
           
           # Build Meshery CLI
-          go build -o ./mesheryctl/mesheryctl ./mesheryctl/cmd/mesheryctl
+          make -C mesheryctl build
           
           # Build WASM Policy Engine
-          (cd server/policies/wasm && GOOS=js GOARCH=wasm go build -o policy_engine.wasm .)
+          make wasm-engine
 
       - name: Perform CodeQL Analysis
         uses: github/codeql-action/analyze@v4


### PR DESCRIPTION
**Follow-up to:** #20248
**Fixes:** CodeQL Go analysis returning empty/failing to report results.

### Problem
After the consolidation of the CodeQL workflows in #20248, the remaining `codeql-analysis.yml` workflow failed to properly scan the Go source code. This happened because the workflow defaulted to `autobuild` for Go. CodeQL's autobuilder detected the `Makefile` in the root directory and ran `make` (which targets `providers-propagate`), resulting in zero Go files being compiled. Since CodeQL for Go relies on intercepting a successful compilation, no Go code was analyzed.

### Solution
This PR configures CodeQL to use a manual build mode for Go and sets up the correct build environment:
1. **Set up Go**: Added `actions/setup-go@v6` using the version specified in `go.mod`.
2. **Explicit Build Mode**: Configured `build-mode: manual` for Go and `none` for JavaScript.
3. **Manual Compilation Steps**: Replaced the default `Autobuild` step with explicit `go build` commands to compile the primary components of the repository:
   - Meshery Server (`server/cmd`)
   - Meshery CLI (`mesheryctl`)
   - WASM Policy Engine (`server/policies/wasm` with `GOOS=js GOARCH=wasm`)

By explicitly compiling these components, CodeQL can successfully observe the builds and generate the security analysis database for the Go codebase.
