### PR TITLE
[Docs] Align Docs scrollbar styling

### DIFF
--- a/docs/assets/scss/_elements.scss
+++ b/docs/assets/scss/_elements.scss
@@ -150,3 +150,28 @@ button {
   border: 1px solid var(--color-secondary-light);
 }
 
+/* Custom scrollbar styling aligned with Meshery.io */
+* {
+  scrollbar-width: thin;
+  scrollbar-color: var(--brand-color) transparent;
+}
+
+::-webkit-scrollbar {
+  width: 0.5rem;
+  height: 0.5rem;
+}
+
+::-webkit-scrollbar-track {
+  background: var(--background-light);
+}
+
+::-webkit-scrollbar-thumb {
+  background: var(--brand-color);
+  border-radius: 0.3rem;
+}
+
+::-webkit-scrollbar-thumb:hover {
+  background: #555;
+}
+
+

--- a/docs/assets/scss/_sidebar.scss
+++ b/docs/assets/scss/_sidebar.scss
@@ -93,21 +93,7 @@
   max-width: var(--sidebar-width);
   min-width: var(--sidebar-width);
 
-  /* Refined, modern scrollbar */
-  &::-webkit-scrollbar {
-    width: 4px;
-  }
-  &::-webkit-scrollbar-track {
-    background: transparent;
-  }
-  &::-webkit-scrollbar-thumb {
-    background: rgba(134, 142, 150, 0.3);
-    border-radius: 10px;
-    
-    &:hover {
-      background: rgba(134, 142, 150, 0.6);
-    }
-  }
+
 
  
   @media (max-width: 75em) {


### PR DESCRIPTION
Updates the custom scrollbar on the Meshery Docs site to match the styling used on Meshery.io. This includes styling for both WebKit-based browsers and Firefox, ensuring light and dark modes are handled correctly. Replaces the specific sidebar scrollbar overrides with the global scrollbar style.

**Notes for Reviewers**

- This PR fixes #

**[Signed commits](https://github.com/meshery/meshery/blob/master/CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [ ] Yes, I signed my commits.

<!--
Thank you for contributing to Meshery! 

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. Sign your commits.
4. Include before and after screenshots/terminal output.

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.
-->
