### PR TITLE
docs: add Meshery Operator contributing guide

### DIFF
--- a/docs/content/en/project/contributing/contributing-operator.md
+++ b/docs/content/en/project/contributing/contributing-operator.md
@@ -72,4 +72,10 @@ Follow the conventions in
 [How to write MeshKit compatible errors]({{< ref "project/contributing/contributing-error.md" >}}) -
 declare the code constant and factory function in an `error.go` file, and use
 `errors.New(...)` from MeshKit rather than `fmt.Errorf` or the standard-library `errors`
-package.
+package. Error names and codes must be unique across the whole component, so give each
+constructor a distinct name (for example `ErrGettingBrokerResource` and
+`ErrGettingMeshsyncResource`).
+
+After adding or changing an error, run `make error` to validate that codes and names are
+unique and to regenerate the error reference; `make error-util` assigns codes to new
+placeholder constants and bumps `next_error_code` in `helpers/component_info.json`.

--- a/docs/content/en/project/contributing/contributing-operator.md
+++ b/docs/content/en/project/contributing/contributing-operator.md
@@ -1,0 +1,75 @@
+---
+title: Contributing to Meshery Operator
+description: How to build, test, and deploy Meshery Operator from source
+categories: [contributing]
+---
+
+[Meshery Operator]({{< ref "concepts/architecture/operator/index.md" >}}) is a
+Kubernetes operator that manages the lifecycle of
+[MeshSync]({{< ref "concepts/architecture/meshsync.md" >}}) and the
+[Meshery Broker]({{< ref "concepts/architecture/broker/index.md" >}}). It is built with
+[Kubebuilder](https://book.kubebuilder.io/) and the Operator SDK, and follows the standard
+Kubebuilder `go/v4` project layout - the manager entrypoint lives at `cmd/main.go`.
+
+Development follows the usual fork-and-pull-request workflow. Every commit must be signed
+off; see the [Contributing Overview]({{< ref "project/contributing/_index.md" >}}) and the
+[Git workflow guide]({{< ref "project/contributing/contributing-gitflow.md" >}}).
+
+## Prerequisites
+
+You only need Go and Docker installed locally. The `Makefile` downloads its pinned build
+tools into `bin/` on demand (kustomize, controller-gen, setup-envtest, kind, operator-sdk,
+opm), so their versions are reproducible and you do not install them globally. A running
+Kubernetes cluster - or `make kind` to provision one with kind - is required for the deploy
+and integration-test targets.
+
+## Building and testing
+
+Generate manifests and deepcopy code, then build the manager binary:
+
+{{< code code=`make build` >}}
+
+Run the controller against the cluster in your current `~/.kube/config`:
+
+{{< code code=`make run` >}}
+
+Run the unit and envtest suites. `make test` provisions an envtest control plane
+automatically, so no cluster is required:
+
+{{< code code=`make test` >}}
+
+Lint the codebase (and auto-fix where possible with `make lint-fix`):
+
+{{< code code=`make lint` >}}
+
+## Building the container image
+
+{{< code code=`make docker-build docker-push IMG=<registry>/meshery-operator:<tag>` >}}
+
+## Deploying to a cluster
+
+Install the CRDs and deploy the operator into your current kube context:
+
+{{< code code=`make install
+make deploy IMG=<registry>/meshery-operator:<tag>` >}}
+
+To remove it:
+
+{{< code code=`make undeploy
+make uninstall` >}}
+
+## Building the OLM bundle
+
+To generate and build the Operator Lifecycle Manager bundle image:
+
+{{< code code=`make bundle bundle-build bundle-push BUNDLE_IMG=<registry>/meshery-operator-bundle:<tag>` >}}
+
+## Error handling
+
+New errors returned from a controller or package must be declared as MeshKit structured
+errors so they carry a stable code, severity, probable cause, and suggested remediation.
+Follow the conventions in
+[How to write MeshKit compatible errors]({{< ref "project/contributing/contributing-error.md" >}}) -
+declare the code constant and factory function in an `error.go` file, and use
+`errors.New(...)` from MeshKit rather than `fmt.Errorf` or the standard-library `errors`
+package.


### PR DESCRIPTION
## Description

Adds a contributing guide for **Meshery Operator** at `project/contributing/contributing-operator.md`, covering the build, test, deploy, and OLM bundle workflow now standardized on the Kubebuilder `go/v4` layout.

This fills a real gap: Meshery Server and Adapters each have a contributing guide, but the operator had none. The page mirrors the conventions of the existing component guides (frontmatter `categories: [contributing]`, `{{< code >}}` and `{{< ref >}}` shortcodes), so it surfaces automatically in the Specific Contribution Guides section - no navigation edits needed.

It documents the workflow standardized in meshery-operator **WS-1** ([meshery/meshery-operator#792](https://github.com/meshery/meshery-operator/pull/792)):
- Kubebuilder `go/v4` layout with the manager entrypoint at `cmd/main.go`
- `make build` / `run` / `test` (envtest auto-provisioned) / `lint`
- `make docker-build` / `docker-push`
- `make install` / `deploy` / `undeploy` / `uninstall`
- `make bundle` / `bundle-build` / `bundle-push` for the OLM bundle
- An error-handling section linking to the canonical [How to write MeshKit compatible errors]({{< ref "project/contributing/contributing-error.md" >}}) guide

All `make` targets referenced were verified against the current operator `Makefile`.

## Notes for Reviewers

User-facing docs counterpart to the operator modernization program. The internal/contributor docs live in the `meshery-operator` repo under `docs/`.

## Signed commits

- [x] Yes, I signed my commits.