### PR TITLE
[Server][UI] Fix API error when cloning designs and filters

### DIFF
--- a/server/models/remote_provider.go
+++ b/server/models/remote_provider.go
@@ -2631,7 +2631,12 @@ func (l *RemoteProvider) CloneMesheryPattern(req *http.Request, patternID string
 
 	bf := bytes.NewBuffer(data)
 
-	cReq, _ := http.NewRequest(http.MethodPost, remoteProviderURL.String(), bf)
+	cReq, err := http.NewRequest(http.MethodPost, remoteProviderURL.String(), bf)
+	if err != nil {
+		err = ErrClone(err, "design")
+		l.Log.Error(err)
+		return nil, err
+	}
 	cReq.Header.Set("Content-Type", "application/json")
 
 	tokenString, err := l.GetToken(req)
@@ -3211,7 +3216,12 @@ func (l *RemoteProvider) CloneMesheryFilter(req *http.Request, filterID string, 
 
 	bf := bytes.NewBuffer(data)
 
-	cReq, _ := http.NewRequest(http.MethodPost, remoteProviderURL.String(), bf)
+	cReq, err := http.NewRequest(http.MethodPost, remoteProviderURL.String(), bf)
+	if err != nil {
+		err = ErrClone(err, "filter")
+		l.Log.Error(err)
+		return nil, err
+	}
 	cReq.Header.Set("Content-Type", "application/json")
 
 	tokenString, err := l.GetToken(req)

--- a/server/models/remote_provider.go
+++ b/server/models/remote_provider.go
@@ -2632,6 +2632,7 @@ func (l *RemoteProvider) CloneMesheryPattern(req *http.Request, patternID string
 	bf := bytes.NewBuffer(data)
 
 	cReq, _ := http.NewRequest(http.MethodPost, remoteProviderURL.String(), bf)
+	cReq.Header.Set("Content-Type", "application/json")
 
 	tokenString, err := l.GetToken(req)
 	if err != nil {
@@ -3211,6 +3212,7 @@ func (l *RemoteProvider) CloneMesheryFilter(req *http.Request, filterID string, 
 	bf := bytes.NewBuffer(data)
 
 	cReq, _ := http.NewRequest(http.MethodPost, remoteProviderURL.String(), bf)
+	cReq.Header.Set("Content-Type", "application/json")
 
 	tokenString, err := l.GetToken(req)
 	if err != nil {

--- a/ui/components/designs/patterns/patterns-actions.test.tsx
+++ b/ui/components/designs/patterns/patterns-actions.test.tsx
@@ -271,4 +271,21 @@ describe('createPatternsActions', () => {
       event_type: 'error',
     });
   });
+
+  it('handleClone clones a pattern and notifies on success', async () => {
+    const deps = baseDeps();
+    deps.clonePattern.mockReturnValue({ unwrap: () => Promise.resolve({}) });
+
+    const actions = createPatternsActions(deps);
+    await actions.handleClone('p-1', 'My Pattern');
+
+    expect(deps.clonePattern).toHaveBeenCalledWith({
+      body: { name: 'My Pattern (Copy)' },
+      patternID: 'p-1',
+    });
+    expect(deps.notify).toHaveBeenCalledWith({
+      message: '"My Pattern" Design cloned',
+      event_type: 'success',
+    });
+  });
 });

--- a/ui/components/designs/patterns/patterns-actions.ts
+++ b/ui/components/designs/patterns/patterns-actions.ts
@@ -196,7 +196,7 @@ export function createPatternsActions(deps) {
   function handleClone(patternID, name) {
     updateProgress({ showProgress: true });
     clonePattern({
-      body: JSON.stringify({ name: name + ' (Copy)' }),
+      body: { name: name + ' (Copy)' },
       patternID: patternID,
     })
       .unwrap()

--- a/ui/components/filters/Filters.fileActions.test.tsx
+++ b/ui/components/filters/Filters.fileActions.test.tsx
@@ -438,7 +438,7 @@ describe('createHandleClone', () => {
     clone('f-1', 'flt');
     await flush();
     expect(cloneFilter).toHaveBeenCalledWith({
-      body: JSON.stringify({ name: 'flt (Copy)' }),
+      body: { name: 'flt (Copy)' },
       filterID: 'f-1',
     });
     expect(notify).toHaveBeenCalledWith({

--- a/ui/components/filters/Filters.fileActions.ts
+++ b/ui/components/filters/Filters.fileActions.ts
@@ -332,7 +332,7 @@ export function createHandleClone({ cloneFilter, notify, handleError }: CreateHa
   return function handleClone(filterID: string, name: string) {
     updateProgress({ showProgress: true });
     cloneFilter({
-      body: JSON.stringify({ name: name + ' (Copy)' }),
+      body: { name: name + ' (Copy)' },
       filterID: filterID,
     })
       .unwrap()

--- a/ui/components/filters/Filters.fileActions.ts
+++ b/ui/components/filters/Filters.fileActions.ts
@@ -323,7 +323,7 @@ export function createHandlePublish({
 }
 
 type CreateHandleCloneArgs = {
-  cloneFilter: (_args: { body: string; filterID: string }) => { unwrap: () => Promise<any> };
+  cloneFilter: (_args: { body: any; filterID: string }) => { unwrap: () => Promise<any> };
   notify: Notify;
   handleError: ErrorHandler;
 };


### PR DESCRIPTION
**Notes for Reviewers**

- This PR fixes #18060

This PR resolves an issue where cloning a design (and filter) resulted in an API error from the remote provider (`1 error while cloning design file...`).

### Changes made
1. **[UI]**: Removed premature `JSON.stringify` on the mutation payload in `patterns-actions.ts` and `Filters.fileActions.ts`. This allows RTK Query to properly serialize the payload and automatically apply the required `Content-Type: application/json` header, instead of defaulting to `text/plain`.
2. **[Server]**: Added explicit `Content-Type: application/json` headers to the upstream requests constructed by `CloneMesheryPattern` and `CloneMesheryFilter` in the `RemoteProvider` backend handler (`remote_provider.go`).

These changes ensure the cloning requests are properly formatted across the entire stack while keeping the footprint minimal and preserving existing architecture.

**[Signed commits](https://github.com/meshery/meshery/blob/master/CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [x] Yes, I signed my commits.
