### PR TITLE
[UI] Guard dashboard widgets against null data and add consistent error/empty states

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -642,8 +642,6 @@ github.com/maxatome/go-testdeep v1.14.0 h1:rRlLv1+kI8eOI3OaBXZwb3O7xY3exRzdW5QyX
 github.com/maxatome/go-testdeep v1.14.0/go.mod h1:lPZc/HAcJMP92l7yI6TRz1aZN5URwUBUAfUNvrclaNM=
 github.com/meshery/meshery-operator v0.8.11 h1:eDo2Sw0jjVrXsvvhF8LenADM58pK+7Z68ROPVIejTPc=
 github.com/meshery/meshery-operator v0.8.11/go.mod h1:hQEtFKKa5Fr/Mskk6bV5ip3bQ0+3F0u1voYS3XisBp4=
-github.com/meshery/meshkit v1.0.18 h1:MzbRkwRFOUhF0753tWeMVjVzxmSnGKq8JgGnzNG/Fek=
-github.com/meshery/meshkit v1.0.18/go.mod h1:pChQu1xqvr0oNjIfVEzakaKmrqMSgiYu7wq7YPREhT4=
 github.com/meshery/meshkit v1.0.19 h1:24/JpLoPnWXKEriYhkWdaEQXfoVQlBKSQPgoe7nE4z8=
 github.com/meshery/meshkit v1.0.19/go.mod h1:pChQu1xqvr0oNjIfVEzakaKmrqMSgiYu7wq7YPREhT4=
 github.com/meshery/meshsync v1.0.0 h1:BIHEVG4BDjqOnSd3vBt9B4IfWJNTfMRAgdwLroBcCfY=

--- a/ui/components/ExtensionSandbox.tsx
+++ b/ui/components/ExtensionSandbox.tsx
@@ -11,7 +11,7 @@ import type {
   CollaboratorSchema,
   FullPageExtensionSchema,
 } from '../utils/ExtensionPointSchemaValidator';
-import type { RootState } from '@/store/store';
+import type { RootState } from '../store';
 
 /**
  * getPath returns the current pathname

--- a/ui/components/MesheryCredentialComponent.tsx
+++ b/ui/components/MesheryCredentialComponent.tsx
@@ -27,7 +27,7 @@ import {
 } from '@/rtk-query/credentials';
 import { useSelector } from 'react-redux';
 import { updateProgress } from '@/store/slices/mesheryUi';
-import type { RootState } from '@/store/store';
+import type { RootState } from '../store';
 import type { MUIDataTableColumn, MUIDataTableMeta } from '@sistent/mui-datatables';
 
 const CredentialIcon = styled('img')({

--- a/ui/components/connections/ConnectionWizardModal.tsx
+++ b/ui/components/connections/ConnectionWizardModal.tsx
@@ -11,7 +11,7 @@ import {
 import { useSelector } from 'react-redux';
 import { Modal } from '@/components/shared/Modal';
 import ConnectionIcon from '@/assets/icons/Connection';
-import type { RootState } from '@/store/store';
+import type { RootState } from '../../store';
 import { useListConnectionDefinitionsQuery } from '@meshery/schemas/mesheryApi';
 import { buildConnectionWizardKindConfigs } from './ConnectionWizard.helpers';
 import { useConnectionWizard } from './wizard/useConnectionWizard';

--- a/ui/components/dashboard/charts/KubernetesConnectionChart.test.tsx
+++ b/ui/components/dashboard/charts/KubernetesConnectionChart.test.tsx
@@ -169,12 +169,23 @@ describe('KubernetesConnectionStatsChart', () => {
     expect(screen.getByText('KUBERNETES CLUSTER STATUS')).toBeInTheDocument();
   });
 
-  it('shows a loading indicator while connections are being fetched', () => {
+  it('shows a loading indicator on the initial load', () => {
     connectionsQueryReturn = { isFetching: true, isLoading: true };
     render(<KubernetesConnectionStatsChart />);
     expect(screen.getByTestId('loading-container')).toBeInTheDocument();
     expect(screen.getByTestId('circular-progress')).toBeInTheDocument();
     expect(screen.queryByTestId('connect-cluster')).not.toBeInTheDocument();
+  });
+
+  it('keeps showing the chart during a background refetch instead of the loading indicator', () => {
+    connectionsQueryReturn = {
+      data: { connections: [{ status: 'connected' }] },
+      isFetching: true,
+      isLoading: false,
+    };
+    render(<KubernetesConnectionStatsChart />);
+    expect(screen.queryByTestId('loading-container')).not.toBeInTheDocument();
+    expect(screen.getByTestId('bb-chart')).toBeInTheDocument();
   });
 
   it('shows the error fallback when the connections query fails', () => {

--- a/ui/components/dashboard/charts/KubernetesConnectionChart.test.tsx
+++ b/ui/components/dashboard/charts/KubernetesConnectionChart.test.tsx
@@ -2,8 +2,16 @@ import React from 'react';
 import { render, screen } from '@testing-library/react';
 import { describe, expect, it, vi, beforeEach } from 'vitest';
 
-let connectionsQueryReturn: { data?: { connections?: Array<{ status?: string }> } } = {
+let connectionsQueryReturn: {
+  data?: { connections?: Array<{ status?: string }> };
+  isFetching?: boolean;
+  isLoading?: boolean;
+  isError?: boolean;
+} = {
   data: { connections: [] },
+  isFetching: false,
+  isLoading: false,
+  isError: false,
 };
 const canSpy = vi.fn(() => true);
 const bbChartSpy = vi.fn();
@@ -64,20 +72,32 @@ vi.mock('next/router', () => ({
   useRouter: () => ({ push: vi.fn() }),
 }));
 
-vi.mock('../style', () => ({
-  DashboardSection: ({ children }: { children?: React.ReactNode }) => (
-    <section data-testid="dashboard-section">{children}</section>
-  ),
-}));
-
 vi.mock('./ConnectCluster', () => ({
   default: ({ message }: { message: React.ReactNode }) => (
     <div data-testid="connect-cluster">{message}</div>
   ),
 }));
 
+vi.mock('../widgets/WidgetErrorFallback', () => ({
+  default: ({ widgetTitle, message }: { widgetTitle: string; message?: string }) => (
+    <div data-testid="widget-error-fallback" data-title={widgetTitle}>
+      {message}
+    </div>
+  ),
+}));
+
+vi.mock('../style', () => ({
+  DashboardSection: ({ children }: { children?: React.ReactNode }) => (
+    <section data-testid="dashboard-section">{children}</section>
+  ),
+  LoadingContainer: ({ children }: { children?: React.ReactNode }) => (
+    <div data-testid="loading-container">{children}</div>
+  ),
+}));
+
 vi.mock('@sistent/sistent', () => ({
   Box: ({ children }: { children?: React.ReactNode }) => <div>{children}</div>,
+  CircularProgress: () => <div data-testid="circular-progress" />,
   InfoOutlinedIcon: () => <svg data-testid="info-icon" />,
   KubernetesIcon: () => <svg data-testid="k8s-icon" />,
   Typography: ({ children }: { children?: React.ReactNode }) => <p>{children}</p>,
@@ -93,7 +113,12 @@ describe('KubernetesConnectionStatsChart', () => {
     bbChartSpy.mockReset();
     canSpy.mockClear();
     canSpy.mockReturnValue(true);
-    connectionsQueryReturn = { data: { connections: [] } };
+    connectionsQueryReturn = {
+      data: { connections: [] },
+      isFetching: false,
+      isLoading: false,
+      isError: false,
+    };
   });
 
   it('shows ConnectCluster fallback when there are no kubernetes connections', () => {
@@ -142,5 +167,23 @@ describe('KubernetesConnectionStatsChart', () => {
     render(<KubernetesConnectionStatsChart />);
     expect(screen.getByTestId('k8s-icon')).toBeInTheDocument();
     expect(screen.getByText('KUBERNETES CLUSTER STATUS')).toBeInTheDocument();
+  });
+
+  it('shows a loading indicator while connections are being fetched', () => {
+    connectionsQueryReturn = { isFetching: true, isLoading: true };
+    render(<KubernetesConnectionStatsChart />);
+    expect(screen.getByTestId('loading-container')).toBeInTheDocument();
+    expect(screen.getByTestId('circular-progress')).toBeInTheDocument();
+    expect(screen.queryByTestId('connect-cluster')).not.toBeInTheDocument();
+  });
+
+  it('shows the error fallback when the connections query fails', () => {
+    connectionsQueryReturn = { isError: true };
+    render(<KubernetesConnectionStatsChart />);
+    expect(screen.getByTestId('widget-error-fallback')).toHaveAttribute(
+      'data-title',
+      'Kubernetes Cluster Status',
+    );
+    expect(screen.queryByTestId('connect-cluster')).not.toBeInTheDocument();
   });
 });

--- a/ui/components/dashboard/charts/KubernetesConnectionChart.tsx
+++ b/ui/components/dashboard/charts/KubernetesConnectionChart.tsx
@@ -9,12 +9,25 @@ import { useGetConnectionsQuery } from '@/rtk-query/connection';
 import CAN from '@/utils/can';
 import { keys } from '@/utils/permission_constants';
 import { useRouter } from 'next/router';
-import { DashboardSection } from '../style';
+import { DashboardSection, LoadingContainer } from '../style';
 import ConnectCluster from './ConnectCluster';
-import { Box, InfoOutlinedIcon, KubernetesIcon, Typography, useTheme } from '@sistent/sistent';
+import {
+  Box,
+  CircularProgress,
+  InfoOutlinedIcon,
+  KubernetesIcon,
+  Typography,
+  useTheme,
+} from '@sistent/sistent';
+import WidgetErrorFallback from '../widgets/WidgetErrorFallback';
 
 export default function KubernetesConnectionStatsChart() {
-  const { data: connectionData } = useGetConnectionsQuery({
+  const {
+    data: connectionData,
+    isFetching,
+    isLoading,
+    isError,
+  } = useGetConnectionsQuery({
     page: 0,
     pagesize: 'all',
     kind: JSON.stringify(['kubernetes']),
@@ -106,6 +119,29 @@ export default function KubernetesConnectionStatsChart() {
       </div>
     </div>
   );
+
+  if (isFetching || isLoading) {
+    return (
+      <DashboardSection>
+        {header}
+        <LoadingContainer>
+          <CircularProgress />
+        </LoadingContainer>
+      </DashboardSection>
+    );
+  }
+
+  if (isError) {
+    return (
+      <DashboardSection>
+        {header}
+        <WidgetErrorFallback
+          widgetTitle="Kubernetes Cluster Status"
+          message="Unable to load your cluster connections. Please try again later."
+        />
+      </DashboardSection>
+    );
+  }
 
   if (chartData.length === 0) {
     return (

--- a/ui/components/dashboard/charts/KubernetesConnectionChart.tsx
+++ b/ui/components/dashboard/charts/KubernetesConnectionChart.tsx
@@ -24,7 +24,6 @@ import WidgetErrorFallback from '../widgets/WidgetErrorFallback';
 export default function KubernetesConnectionStatsChart() {
   const {
     data: connectionData,
-    isFetching,
     isLoading,
     isError,
   } = useGetConnectionsQuery({
@@ -120,7 +119,7 @@ export default function KubernetesConnectionStatsChart() {
     </div>
   );
 
-  if (isFetching || isLoading) {
+  if (isLoading) {
     return (
       <DashboardSection>
         {header}

--- a/ui/components/dashboard/index.tsx
+++ b/ui/components/dashboard/index.tsx
@@ -32,6 +32,7 @@ import { DEFAULT_LAYOUT, LOCAL_PROVIDER_LAYOUT, OVERVIEW_LAYOUT } from './defaul
 import { applyMinSizeConstraints } from './layoutConstraints';
 import { useGetUserPrefQuery, useUpdateUserPrefMutation } from '@/rtk-query/user';
 import getWidgets from './widgets/getWidgets';
+import WidgetErrorFallback from './widgets/WidgetErrorFallback';
 import { TABS_SCROLL_BUTTONS_CLASS } from './constants';
 import { useSelector } from 'react-redux';
 import useUnsavedChanges from './useUnsavedChanges';
@@ -419,7 +420,11 @@ const Dashboard = () => {
                 {widgetsToRenderForLayout(dashboardLayout, currentBreakPoint).map((widget) => {
                   return (
                     <div key={widget.key} style={isEditMode ? editModeStyles : {}}>
-                      <ErrorBoundary>
+                      <ErrorBoundary
+                        customFallback={(fallbackProps) => (
+                          <WidgetErrorFallback {...fallbackProps} widgetTitle={widget.title} />
+                        )}
+                      >
                         <LayoutWidget
                           isEditMode={isEditMode}
                           key={widget.key}

--- a/ui/components/dashboard/overview.tsx
+++ b/ui/components/dashboard/overview.tsx
@@ -7,6 +7,7 @@ import ConnectCluster from './charts/ConnectCluster';
 import { ErrorContainer, HoneycombRoot } from './style';
 import { ErrorIcon, Typography, useTheme, type Theme } from '@sistent/sistent';
 import { useSelector } from 'react-redux';
+import type { RootState } from '../../store';
 
 const ErrorDisplay = ({ theme }: { theme: Theme }) => (
   <ErrorContainer>
@@ -26,7 +27,7 @@ const ErrorDisplay = ({ theme }: { theme: Theme }) => (
 );
 
 const Overview = ({ isEditMode }: { isEditMode?: boolean }) => {
-  const { k8sConfig, selectedK8sContexts } = useSelector((state) => state.ui);
+  const { k8sConfig, selectedK8sContexts } = useSelector((state: RootState) => state.ui);
   const clusterIds = useMemo(
     () => getK8sClusterIdsFromCtxId(selectedK8sContexts, k8sConfig),
     [k8sConfig, selectedK8sContexts],

--- a/ui/components/dashboard/widgets/HoneyComb/HoneyCombComponent.tsx
+++ b/ui/components/dashboard/widgets/HoneyComb/HoneyCombComponent.tsx
@@ -34,6 +34,7 @@ import {
   useResourceOptions,
 } from './useResourceOptions';
 import GetKubernetesNodeIcon from '../../utils';
+import WidgetErrorFallback from '../WidgetErrorFallback';
 
 type HoneycombComponentProps = {
   kinds?: ResourceKind[];
@@ -113,7 +114,11 @@ const HoneycombComponent = ({
   const hasFilteredKinds = filteredKinds.length > 0;
 
   return (
-    <ErrorBoundary>
+    <ErrorBoundary
+      customFallback={(fallbackProps) => (
+        <WidgetErrorFallback {...fallbackProps} widgetTitle="Cluster Resource Overview" />
+      )}
+    >
       <HoneycombRoot isEditMode={isEditMode}>
         <HeaderContainer>
           <Typography variant="h6" fontWeight="700">

--- a/ui/components/dashboard/widgets/LatestBlogs.test.tsx
+++ b/ui/components/dashboard/widgets/LatestBlogs.test.tsx
@@ -38,11 +38,25 @@ vi.mock('@sistent/sistent', () => ({
   DesignIcon: () => <svg data-testid="design-icon" />,
 }));
 
+const widgetErrorFallbackSpy = vi.fn();
+
+vi.mock('./WidgetErrorFallback', () => ({
+  default: (props: { widgetTitle: string; message?: string }) => {
+    widgetErrorFallbackSpy(props);
+    return (
+      <div data-testid="widget-error-fallback" data-title={props.widgetTitle}>
+        {props.message}
+      </div>
+    );
+  },
+}));
+
 import LatestBlogs from './LatestBlogs';
 
 describe('LatestBlogs', () => {
   beforeEach(() => {
     plainCardSpy.mockReset();
+    widgetErrorFallbackSpy.mockReset();
     vi.restoreAllMocks();
   });
 
@@ -124,13 +138,49 @@ describe('LatestBlogs', () => {
     });
   });
 
-  it('logs the error and stops loading on fetch failure', async () => {
+  it('logs the error and shows the error fallback on fetch failure', async () => {
     const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
     global.fetch = vi.fn().mockRejectedValue(new Error('network down')) as never;
 
     render(<LatestBlogs />);
     await waitFor(() => {
       expect(errorSpy).toHaveBeenCalled();
+      expect(screen.getByTestId('widget-error-fallback')).toHaveAttribute(
+        'data-title',
+        'Latest Blogs',
+      );
     });
+    expect(screen.queryByTestId('plain-card')).not.toBeInTheDocument();
+  });
+
+  it('shows the error fallback when the feed responds with a non-ok status', async () => {
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    global.fetch = vi.fn().mockResolvedValue({
+      ok: false,
+      status: 500,
+      text: () => Promise.resolve(''),
+    }) as never;
+
+    render(<LatestBlogs />);
+    await waitFor(() => {
+      expect(errorSpy).toHaveBeenCalled();
+      expect(screen.getByTestId('widget-error-fallback')).toBeInTheDocument();
+    });
+  });
+
+  it('shows an empty-state message when the feed returns zero entries', async () => {
+    const feedXml = `<?xml version="1.0"?>
+<feed xmlns="http://www.w3.org/2005/Atom"></feed>`;
+
+    global.fetch = vi.fn().mockResolvedValue({
+      ok: true,
+      text: () => Promise.resolve(feedXml),
+    }) as never;
+
+    render(<LatestBlogs />);
+    await waitFor(() => {
+      expect(screen.getByText('No blog posts found.')).toBeInTheDocument();
+    });
+    expect(screen.queryByTestId('widget-error-fallback')).not.toBeInTheDocument();
   });
 });

--- a/ui/components/dashboard/widgets/LatestBlogs.tsx
+++ b/ui/components/dashboard/widgets/LatestBlogs.tsx
@@ -1,5 +1,6 @@
 import React, { useEffect, useMemo, useState } from 'react';
 import { useTheme, PlainCard, BellIcon, DesignIcon } from '@sistent/sistent';
+import WidgetErrorFallback from './WidgetErrorFallback';
 
 type DashboardIconProps = {
   fill?: string;
@@ -17,11 +18,13 @@ type Resource = { name: string; link: string; external: true };
 
 const BLOG_FEED_URL = 'https://meshery.io/feed.xml';
 const LOADING_RESOURCES = [{ name: 'Loading...' }];
+const EMPTY_RESOURCES = [{ name: 'No blog posts found.' }];
 
 const LatestBlogs = ({ iconsProps }: LatestBlogsProps) => {
   const theme = useTheme();
   const [resources, setResources] = useState<Resource[]>([]);
   const [loading, setLoading] = useState(true);
+  const [hasError, setHasError] = useState(false);
 
   useEffect(() => {
     let isActive = true;
@@ -29,6 +32,9 @@ const LatestBlogs = ({ iconsProps }: LatestBlogsProps) => {
     const fetchBlogFeed = async () => {
       try {
         const response = await fetch(BLOG_FEED_URL);
+        if (!response.ok) {
+          throw new Error(`Unexpected response status: ${response.status}`);
+        }
         const text = await response.text();
         const xmlDoc = new DOMParser().parseFromString(text, 'application/xml');
         const items = Array.from(xmlDoc.getElementsByTagName('entry'));
@@ -50,6 +56,7 @@ const LatestBlogs = ({ iconsProps }: LatestBlogsProps) => {
       } catch (error) {
         if (isActive) {
           console.error('Error fetching latest blogs:', error);
+          setHasError(true);
         }
       } finally {
         if (isActive) {
@@ -81,9 +88,20 @@ const LatestBlogs = ({ iconsProps }: LatestBlogsProps) => {
     [resources],
   );
 
+  if (!loading && hasError) {
+    return (
+      <WidgetErrorFallback
+        widgetTitle="Latest Blogs"
+        message="Unable to load the latest blog posts. Please try again later."
+      />
+    );
+  }
+
   return (
     <PlainCard
-      resources={loading ? LOADING_RESOURCES : cardResources}
+      resources={
+        loading ? LOADING_RESOURCES : cardResources.length > 0 ? cardResources : EMPTY_RESOURCES
+      }
       icon={
         <BellIcon
           {...iconsProps}

--- a/ui/components/dashboard/widgets/LatestBlogs.tsx
+++ b/ui/components/dashboard/widgets/LatestBlogs.tsx
@@ -17,8 +17,8 @@ type LatestBlogsProps = {
 type Resource = { name: string; link: string; external: true };
 
 const BLOG_FEED_URL = 'https://meshery.io/feed.xml';
-const LOADING_RESOURCES = [{ name: 'Loading...' }];
-const EMPTY_RESOURCES = [{ name: 'No blog posts found.' }];
+const LOADING_RESOURCES: Resource[] = [{ name: 'Loading...', link: '#', external: true }];
+const EMPTY_RESOURCES: Resource[] = [{ name: 'No blog posts found.', link: '#', external: true }];
 
 const LatestBlogs = ({ iconsProps }: LatestBlogsProps) => {
   const theme = useTheme();

--- a/ui/components/dashboard/widgets/MyDesignsWidget.test.tsx
+++ b/ui/components/dashboard/widgets/MyDesignsWidget.test.tsx
@@ -7,7 +7,8 @@ let loggedInReturn: { data?: { id?: string } } = { data: { id: 'user-1' } };
 let patternsReturn: {
   data?: { patterns?: Array<{ name: string; id: string; updatedAt?: string }> };
   isFetching?: boolean;
-} = { data: { patterns: [] }, isFetching: false };
+  isError?: boolean;
+} = { data: { patterns: [] }, isFetching: false, isError: false };
 
 const designCardSpy = vi.fn();
 const useGetUserDesignsQuerySpy = vi.fn();
@@ -85,14 +86,28 @@ vi.mock('@sistent/sistent', () => ({
   },
 }));
 
+const widgetErrorFallbackSpy = vi.fn();
+
+vi.mock('./WidgetErrorFallback', () => ({
+  default: (props: { widgetTitle: string; message?: string }) => {
+    widgetErrorFallbackSpy(props);
+    return (
+      <div data-testid="widget-error-fallback" data-title={props.widgetTitle}>
+        {props.message}
+      </div>
+    );
+  },
+}));
+
 import MyDesignsWidget from './MyDesignsWidget';
 
 describe('MyDesignsWidget', () => {
   beforeEach(() => {
     designCardSpy.mockReset();
     useGetUserDesignsQuerySpy.mockReset();
+    widgetErrorFallbackSpy.mockReset();
     loggedInReturn = { data: { id: 'user-1' } };
-    patternsReturn = { data: { patterns: [] }, isFetching: false };
+    patternsReturn = { data: { patterns: [] }, isFetching: false, isError: false };
   });
 
   it('renders the DesignCard with default props', () => {
@@ -158,5 +173,15 @@ describe('MyDesignsWidget', () => {
     render(<MyDesignsWidget />);
     const [, options] = useGetUserDesignsQuerySpy.mock.calls[0];
     expect(options).toEqual({ skip: false });
+  });
+
+  it('shows the error fallback when the designs query fails', () => {
+    patternsReturn = { isError: true };
+    render(<MyDesignsWidget />);
+    expect(screen.getByTestId('widget-error-fallback')).toHaveAttribute(
+      'data-title',
+      'My Recent Designs',
+    );
+    expect(screen.queryByTestId('design-card')).not.toBeInTheDocument();
   });
 });

--- a/ui/components/dashboard/widgets/MyDesignsWidget.test.tsx
+++ b/ui/components/dashboard/widgets/MyDesignsWidget.test.tsx
@@ -10,14 +10,15 @@ let patternsReturn: {
 } = { data: { patterns: [] }, isFetching: false };
 
 const designCardSpy = vi.fn();
+const useGetUserDesignsQuerySpy = vi.fn();
 
 vi.mock('@/rtk-query/user', () => ({
   useGetLoggedInUserQuery: () => loggedInReturn,
 }));
 
 vi.mock('@/rtk-query/design', () => ({
-  useGetUserDesignsQuery: (args: unknown) => {
-    (useGetUserDesignsQuery as { lastArgs?: unknown }).lastArgs = args;
+  useGetUserDesignsQuery: (...args: unknown[]) => {
+    useGetUserDesignsQuerySpy(...args);
     return patternsReturn;
   },
 }));
@@ -84,13 +85,12 @@ vi.mock('@sistent/sistent', () => ({
   },
 }));
 
-const useGetUserDesignsQuery = () => patternsReturn;
-
 import MyDesignsWidget from './MyDesignsWidget';
 
 describe('MyDesignsWidget', () => {
   beforeEach(() => {
     designCardSpy.mockReset();
+    useGetUserDesignsQuerySpy.mockReset();
     loggedInReturn = { data: { id: 'user-1' } };
     patternsReturn = { data: { patterns: [] }, isFetching: false };
   });
@@ -145,5 +145,18 @@ describe('MyDesignsWidget', () => {
     expect(screen.getByTestId('design-card')).toHaveAttribute('data-sort', 'updated_at desc');
     await userEvent.click(screen.getByRole('button', { name: 'changeOrder' }));
     expect(screen.getByTestId('design-card')).toHaveAttribute('data-sort', 'created_at desc');
+  });
+
+  it('skips fetching designs until the logged-in user id is available', () => {
+    loggedInReturn = {};
+    render(<MyDesignsWidget />);
+    const [, options] = useGetUserDesignsQuerySpy.mock.calls[0];
+    expect(options).toEqual({ skip: true });
+  });
+
+  it('does not skip fetching designs once the logged-in user id is available', () => {
+    render(<MyDesignsWidget />);
+    const [, options] = useGetUserDesignsQuerySpy.mock.calls[0];
+    expect(options).toEqual({ skip: false });
   });
 });

--- a/ui/components/dashboard/widgets/MyDesignsWidget.tsx
+++ b/ui/components/dashboard/widgets/MyDesignsWidget.tsx
@@ -11,6 +11,7 @@ import {
 } from '@sistent/sistent';
 import { useGetUserDesignsQuery } from '@/rtk-query/design';
 import { MESHERY_CLOUD_PROD } from '@/constants/endpoints';
+import WidgetErrorFallback from './WidgetErrorFallback';
 
 type DashboardIconProps = {
   fill?: string;
@@ -50,7 +51,11 @@ const cardData = [
 const MyDesignsWidget = ({ iconsProps }: MyDesignsWidgetProps) => {
   const [sortOrder, setSortOrder] = useState(DEFAULT_SORT_ORDER);
   const { data: userData } = useGetLoggedInUserQuery();
-  const { data: patternsData, isFetching: isPatternsFetching } = useGetUserDesignsQuery(
+  const {
+    data: patternsData,
+    isFetching: isPatternsFetching,
+    isError: isPatternsError,
+  } = useGetUserDesignsQuery(
     {
       expandUser: true,
       page: 0,
@@ -80,6 +85,15 @@ const MyDesignsWidget = ({ iconsProps }: MyDesignsWidgetProps) => {
       })) ?? [],
     [patternsData?.patterns],
   );
+
+  if (isPatternsError) {
+    return (
+      <WidgetErrorFallback
+        widgetTitle="My Recent Designs"
+        message="Unable to load your designs. Please try again later."
+      />
+    );
+  }
 
   return (
     <Box

--- a/ui/components/dashboard/widgets/MyDesignsWidget.tsx
+++ b/ui/components/dashboard/widgets/MyDesignsWidget.tsx
@@ -50,14 +50,17 @@ const cardData = [
 const MyDesignsWidget = ({ iconsProps }: MyDesignsWidgetProps) => {
   const [sortOrder, setSortOrder] = useState(DEFAULT_SORT_ORDER);
   const { data: userData } = useGetLoggedInUserQuery();
-  const { data: patternsData, isFetching: isPatternsFetching } = useGetUserDesignsQuery({
-    expandUser: true,
-    page: 0,
-    pagesize: 7,
-    order: sortOrder,
-    userId: userData?.id,
-    metrics: true,
-  });
+  const { data: patternsData, isFetching: isPatternsFetching } = useGetUserDesignsQuery(
+    {
+      expandUser: true,
+      page: 0,
+      pagesize: 7,
+      order: sortOrder,
+      userId: userData?.id,
+      metrics: true,
+    },
+    { skip: !userData?.id },
+  );
   const theme = useTheme();
 
   const resources = useMemo(

--- a/ui/components/dashboard/widgets/WidgetErrorFallback.test.tsx
+++ b/ui/components/dashboard/widgets/WidgetErrorFallback.test.tsx
@@ -1,0 +1,63 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { describe, expect, it, vi } from 'vitest';
+
+vi.mock('@sistent/sistent', () => ({
+  useTheme: () => ({
+    palette: {
+      text: { error: '#b00020' },
+      background: { error: { default: '#fdecea' } },
+    },
+  }),
+  ErrorIcon: ({ fill }: { fill?: string }) => <svg data-testid="error-icon" data-fill={fill} />,
+  Typography: ({ children, variant }: { children?: React.ReactNode; variant?: string }) => (
+    <p data-variant={variant}>{children}</p>
+  ),
+  Button: ({ children, onClick }: { children?: React.ReactNode; onClick?: () => void }) => (
+    <button type="button" onClick={onClick}>
+      {children}
+    </button>
+  ),
+}));
+
+vi.mock('../style', () => ({
+  ErrorContainer: ({ children }: { children?: React.ReactNode }) => (
+    <div data-testid="error-container">{children}</div>
+  ),
+}));
+
+import WidgetErrorFallback from './WidgetErrorFallback';
+
+describe('WidgetErrorFallback', () => {
+  it('renders the widget title in the message', () => {
+    render(<WidgetErrorFallback widgetTitle="Getting Started" />);
+    expect(screen.getByText('Unable to load Getting Started')).toBeInTheDocument();
+  });
+
+  it('renders a default message when none is provided', () => {
+    render(<WidgetErrorFallback widgetTitle="My Designs" />);
+    expect(
+      screen.getByText('Something went wrong while loading this widget. Please try again.'),
+    ).toBeInTheDocument();
+  });
+
+  it('renders a custom message when provided', () => {
+    render(<WidgetErrorFallback widgetTitle="Latest Blogs" message="Unable to reach the feed." />);
+    expect(screen.getByText('Unable to reach the feed.')).toBeInTheDocument();
+  });
+
+  it('does not render a retry button when resetErrorBoundary is not provided', () => {
+    render(<WidgetErrorFallback widgetTitle="My Designs" />);
+    expect(screen.queryByRole('button')).not.toBeInTheDocument();
+  });
+
+  it('calls resetErrorBoundary when Try Again is clicked', async () => {
+    const resetErrorBoundary = vi.fn();
+    render(
+      <WidgetErrorFallback widgetTitle="My Designs" resetErrorBoundary={resetErrorBoundary} />,
+    );
+    await userEvent.click(screen.getByRole('button', { name: 'Try Again' }));
+    expect(resetErrorBoundary).toHaveBeenCalledTimes(1);
+  });
+});

--- a/ui/components/dashboard/widgets/WidgetErrorFallback.test.tsx
+++ b/ui/components/dashboard/widgets/WidgetErrorFallback.test.tsx
@@ -38,7 +38,9 @@ describe('WidgetErrorFallback', () => {
   it('renders a default message when none is provided', () => {
     render(<WidgetErrorFallback widgetTitle="My Designs" />);
     expect(
-      screen.getByText('Something went wrong while loading this widget. Please try again.'),
+      screen.getByText(
+        'Unable to load. Confirm your organization selection and role assignments are appropriate and try again.',
+      ),
     ).toBeInTheDocument();
   });
 

--- a/ui/components/dashboard/widgets/WidgetErrorFallback.tsx
+++ b/ui/components/dashboard/widgets/WidgetErrorFallback.tsx
@@ -1,0 +1,40 @@
+import { Button, ErrorIcon, Typography, useTheme } from '@sistent/sistent';
+import { ErrorContainer } from '../style';
+
+type WidgetErrorFallbackProps = {
+  widgetTitle: string;
+  message?: string;
+  resetErrorBoundary?: () => void;
+};
+
+const WidgetErrorFallback = ({
+  widgetTitle,
+  message,
+  resetErrorBoundary,
+}: WidgetErrorFallbackProps) => {
+  const theme = useTheme();
+
+  return (
+    <ErrorContainer>
+      <ErrorIcon fill={theme.palette.background.error.default} />
+      <Typography variant="h6" sx={{ color: theme.palette.text.error }}>
+        Unable to load {widgetTitle}
+      </Typography>
+      <Typography variant="body1">
+        {message ?? 'Something went wrong while loading this widget. Please try again.'}
+      </Typography>
+      {resetErrorBoundary && (
+        <Button
+          variant="outlined"
+          size="small"
+          sx={{ marginTop: '1rem' }}
+          onClick={resetErrorBoundary}
+        >
+          Try Again
+        </Button>
+      )}
+    </ErrorContainer>
+  );
+};
+
+export default WidgetErrorFallback;

--- a/ui/components/dashboard/widgets/WidgetErrorFallback.tsx
+++ b/ui/components/dashboard/widgets/WidgetErrorFallback.tsx
@@ -21,7 +21,8 @@ const WidgetErrorFallback = ({
         Unable to load {widgetTitle}
       </Typography>
       <Typography variant="body1">
-        {message ?? 'Something went wrong while loading this widget. Please try again.'}
+        {message ??
+          'Unable to load. Confirm your organization selection and role assignments are appropriate and try again.'}
       </Typography>
       {resetErrorBoundary && (
         <Button

--- a/ui/components/dashboard/widgets/WorkspaceActivityWidget.test.tsx
+++ b/ui/components/dashboard/widgets/WorkspaceActivityWidget.test.tsx
@@ -5,6 +5,8 @@ import { describe, expect, it, vi, beforeEach } from 'vitest';
 
 let workspacesQueryReturn: {
   data?: { workspaces?: Array<{ id: string; name: string }> };
+  isError?: boolean;
+  isLoading?: boolean;
 } = { data: { workspaces: [] } };
 
 let eventsQueryReturn: {
@@ -59,11 +61,25 @@ vi.mock('@sistent/sistent', () => ({
   },
 }));
 
+const widgetErrorFallbackSpy = vi.fn();
+
+vi.mock('./WidgetErrorFallback', () => ({
+  default: (props: { widgetTitle: string; message?: string }) => {
+    widgetErrorFallbackSpy(props);
+    return (
+      <div data-testid="widget-error-fallback" data-title={props.widgetTitle}>
+        {props.message}
+      </div>
+    );
+  },
+}));
+
 import WorkspaceActivityWidget from './WorkspaceActivityWidget';
 
 describe('WorkspaceActivityWidget', () => {
   beforeEach(() => {
     activityCardSpy.mockReset();
+    widgetErrorFallbackSpy.mockReset();
     workspacesQueryReturn = {
       data: {
         workspaces: [
@@ -71,6 +87,8 @@ describe('WorkspaceActivityWidget', () => {
           { id: 'ws-2', name: 'WS Two' },
         ],
       },
+      isError: false,
+      isLoading: false,
     };
     eventsQueryReturn = {
       data: { data: [{ id: 'evt-1' }, { id: 'evt-2' }] },
@@ -117,5 +135,15 @@ describe('WorkspaceActivityWidget', () => {
     workspacesQueryReturn = { data: { workspaces: [] } };
     render(<WorkspaceActivityWidget />);
     expect(screen.getByTestId('activity-card')).toBeInTheDocument();
+  });
+
+  it('shows the error fallback when the workspaces query fails', () => {
+    workspacesQueryReturn = { isError: true };
+    render(<WorkspaceActivityWidget />);
+    expect(screen.getByTestId('widget-error-fallback')).toHaveAttribute(
+      'data-title',
+      'Workspace Activity',
+    );
+    expect(screen.queryByTestId('activity-card')).not.toBeInTheDocument();
   });
 });

--- a/ui/components/dashboard/widgets/WorkspaceActivityWidget.tsx
+++ b/ui/components/dashboard/widgets/WorkspaceActivityWidget.tsx
@@ -2,7 +2,8 @@ import React, { useCallback, useMemo, useState } from 'react';
 import { WorkspaceActivityCard } from '@sistent/sistent';
 import { useGetEventsOfWorkspaceQuery, useGetWorkspacesQuery } from '@/rtk-query/workspace';
 import { useSelector } from 'react-redux';
-import type { RootState } from '@/store/store';
+import type { RootState } from '../../../store';
+import WidgetErrorFallback from './WidgetErrorFallback';
 
 type WorkspaceChangeHandler = NonNullable<
   React.ComponentProps<typeof WorkspaceActivityCard>['handleWorkspaceChange']
@@ -10,10 +11,11 @@ type WorkspaceChangeHandler = NonNullable<
 
 const WorkspaceActivityWidget = () => {
   const { organization: currentOrg } = useSelector((state: RootState) => state.ui);
-  const { data: workspaces } = useGetWorkspacesQuery(
-    { orgId: currentOrg?.id },
-    { skip: !currentOrg?.id },
-  );
+  const {
+    data: workspaces,
+    isError: isWorkspacesError,
+    isLoading: isWorkspacesLoading,
+  } = useGetWorkspacesQuery({ orgId: currentOrg?.id }, { skip: !currentOrg?.id });
 
   const workspaceOptions = workspaces?.workspaces ?? [];
   const [selectedWorkspace, setSelectedWorkspace] = useState('');
@@ -46,13 +48,22 @@ const WorkspaceActivityWidget = () => {
     setSelectedWorkspace(String(event.target.value));
   }, []);
 
+  if (isWorkspacesError) {
+    return (
+      <WidgetErrorFallback
+        widgetTitle="Workspace Activity"
+        message="Unable to load your workspaces. Please try again later."
+      />
+    );
+  }
+
   return (
     <WorkspaceActivityCard
       selectedWorkspace={activeWorkspaceId}
       handleWorkspaceChange={handleWorkspaceChange}
       activities={isEventsError ? [] : (events?.data ?? [])}
       workspaces={workspaceOptions}
-      isEventsLoading={isEventsLoading}
+      isEventsLoading={isEventsLoading || isWorkspacesLoading}
       workspacePagePath="/management/workspaces"
     />
   );

--- a/ui/components/dashboard/widgets/getting-started/index.test.tsx
+++ b/ui/components/dashboard/widgets/getting-started/index.test.tsx
@@ -9,7 +9,7 @@ let profile: {
 } = {
   data: { preferences: { remoteProviderPreferences: { getstarted: ['step-1'] } } },
 };
-let currentOrg: { id?: string } = { id: 'org-1' };
+let currentOrg: { id?: string } | null = { id: 'org-1' };
 
 const actionCardSpy = vi.fn();
 const modalSpy = vi.fn();
@@ -139,5 +139,13 @@ describe('GetStarted', () => {
     render(<GetStarted />);
     const props = actionCardSpy.mock.calls[0][0];
     expect(props.completedSteps).toEqual([]);
+  });
+
+  it('does not crash and passes an undefined currentOrgId when the organization is null', () => {
+    currentOrg = null;
+    render(<GetStarted />);
+    expect(screen.getByTestId('action-card')).toBeInTheDocument();
+    const modalProps = modalSpy.mock.calls[0][0];
+    expect(modalProps.currentOrgId).toBeUndefined();
   });
 });

--- a/ui/components/dashboard/widgets/getting-started/index.tsx
+++ b/ui/components/dashboard/widgets/getting-started/index.tsx
@@ -15,6 +15,7 @@ import { useGetOrgsQuery } from '@/rtk-query/organization';
 import CAN from '@/utils/can';
 import { keys } from '@/utils/permission_constants';
 import { useSelector } from 'react-redux';
+import type { RootState } from '../../../../store';
 
 const GetStarted = (props: { iconsProps?: object }) => {
   const [openModal, setOpenModal] = useState(false);
@@ -23,8 +24,8 @@ const GetStarted = (props: { iconsProps?: object }) => {
   const { data: profileData } = useGetUserByIdQuery(currentUser?.id, {
     skip: !currentUser?.id,
   });
-  const { organization: currentOrg } = useSelector((state) => state.ui);
-  const { id: org_id } = currentOrg;
+  const { organization: currentOrg } = useSelector((state: RootState) => state.ui);
+  const org_id = currentOrg?.id;
   return (
     <>
       <ActionButtonCard

--- a/ui/store/index.ts
+++ b/ui/store/index.ts
@@ -21,6 +21,8 @@ export const store = configureStore({
     getDefaultMiddleware().concat(api.middleware).concat(rtkErrorMiddleware),
 });
 
+export type RootState = ReturnType<typeof store.getState>;
+
 mesheryEventBus.on('DISPATCH_TO_MESHERY_STORE').subscribe((event) => {
   console.log('Dispatching to Meshery Store:', event.data);
   store.dispatch(event.data);


### PR DESCRIPTION
**Notes for Reviewers**

- This PR fixes #20324

## Summary

The Getting Started dashboard widget crashed on every fresh dashboard load with `Cannot destructure property 'id' of 'currentOrg' as it is null`, because `state.ui.organization` is `null` until `_app.tsx`'s async `loadOrg()` resolves - not a rare race, but the deterministic default on every load.

Root cause: the widget's `useSelector` callback had no `RootState` type annotation, so TypeScript couldn't apply `strictNullChecks` here at all. Restoring that safety net surfaced an adjacent bug: `WorkspaceActivityWidget.tsx` already tried `import type { RootState } from '@/store/store'`, but that module doesn't exist anywhere in the repo - `RootState` was never actually exported from the store.

## Changes

1. **Crash fix** - `getting-started/index.tsx` now uses `currentOrg?.id`; selector is properly typed via a new `RootState` export added to `store/index.ts`. Fixed the broken `@/store/store` import in `WorkspaceActivityWidget.tsx` to point at the real module, and typed `overview.tsx`'s selector the same way for consistency.
2. **Shared, per-widget error fallback** - every dashboard widget was already wrapped in a sistent `ErrorBoundary`, but with no `customFallback` it fell back to a generic default UI with no indication of which widget failed. Added `WidgetErrorFallback` (reusing the existing `ErrorContainer`/`ErrorIcon` styling already used by `overview.tsx`) and wired it into the per-widget boundary in `dashboard/index.tsx` (parameterized by `widget.title`, so it covers every current and future widget) and into `HoneyCombComponent`'s own nested boundary.
3. **Widget-by-widget defensive audit**:
   - `MyDesignsWidget`: added the missing `skip: !userData?.id` guard on `useGetUserDesignsQuery` (it fired once with `userId: undefined` before the logged-in user resolved).
   - `WorkspaceActivityWidget`: the workspaces query's own error was silently swallowed into an empty list (unlike the events query, which already handled its error) - now shows `WidgetErrorFallback`.
   - `LatestBlogs`: a failed fetch, or a non-2xx response (which `fetch()` does not treat as an error on its own), fell through to an empty list indistinguishable from "no posts." Now checks `response.ok`, tracks error state explicitly, and distinguishes error vs. genuine empty.
   - `KubernetesConnectionChart`: had no loading or error handling at all - a still-in-flight query rendered the same "no connections" empty state as a real empty result. Added the same `LoadingContainer`/`CircularProgress` idiom already used by its sibling charts (`NodeStatusChart`, `PodStatusChart`, `ResourceUtilizationChart`).
   - `HelpCenterWidget`, `HoneyCombComponent`, `Overview` were already defensive (static data, or existing loading/empty/error handling) and needed no changes.

## Flagged, out of scope

While root-causing why `strictNullChecks` never caught this, I found `ui/tsconfig.json`'s `include` field (`"ui/**/*.ts", "ui/**/*.tsx"`) is resolved relative to the config file's own directory - since the config already lives in `ui/`, this looks for a nonexistent `ui/ui/` folder. A plain `tsc --noEmit -p tsconfig.json` run confirms it currently type-checks almost nothing. With the path corrected in a throwaway local copy (never committed), 3,812 errors surface across 465 files - a large, pre-existing type-debt backlog well outside this PR's scope. Fix direction: change `include` to `["next-env.d.ts", "**/*.ts", "**/*.tsx"]`, then triage the resulting errors incrementally (likely several follow-up PRs). Separately, `@sistent/sistent`'s shipped type declarations don't include most of its actual component exports (e.g. `ErrorBoundary`, `DesignCard`, `WorkspaceActivityCard` all report "no exported member" once the include bug is fixed) - that's an upstream fix in the `sistent` package, not something to patch locally.

## Test plan

- [x] `getting-started/index.test.tsx`: added a regression test rendering with `currentOrg = null`, asserting no crash and `currentOrgId` is `undefined`.
- [x] Added/extended tests for `WidgetErrorFallback`, `MyDesignsWidget` (skip guard), `LatestBlogs` (non-ok response, error fallback, empty state), `WorkspaceActivityWidget` (workspaces-query error), `KubernetesConnectionChart` (loading + error states).
- [x] Full `ui` unit test suite: 2552 passed, 18 skipped (pre-existing), 0 failed.
- [x] `npm run lint` clean on all touched files.
- [x] Manually verified: booted the Next.js dev server with no backend (so `organization` stays `null` indefinitely, the exact bug condition) and drove it with a headless browser - zero uncaught exceptions during the full app bootstrap. Could not visually exercise the widgets' live-data rendering without a running `meshery-server` backend in this environment.

**[Signed commits](https://github.com/meshery/meshery/blob/master/CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [x] Yes, I signed my commits.