### PR TITLE
[CI] Fix Rego workflow: setup-regal action moved to open-policy-agent org

### DIFF
--- a/.github/workflows/rego-lint-and-test.yml
+++ b/.github/workflows/rego-lint-and-test.yml
@@ -59,7 +59,7 @@ jobs:
           commit_options: "--no-verify"
 
       - name: Setup Regal
-        uses: StyraInc/setup-regal@v1
+        uses: open-policy-agent/setup-regal@v1
         with:
           version: 0.25.0
 


### PR DESCRIPTION
**Notes for Reviewers**

The `Rego Lint and Test` workflow fails at job setup on every PR since 2026-07-01 with:

```
##[error]Unable to resolve action styrainc/setup-regal, not found
```

- **Symptom** - all PRs show a failing `Lint and Test Rego Policies` check regardless of content (e.g. #20395, the policies-cleanup PRs).
- **Root cause** - the Regal project moved from the StyraInc GitHub org to open-policy-agent; `StyraInc/setup-regal` now 404s, and org-rename redirects do not apply to Actions resolution.
- **Fix** - repoint to `open-policy-agent/setup-regal@v1` (the transferred action publishes the same `v1` tag; the pinned regal `version: 0.25.0` input is unchanged).
- **Watch for** - any other workflows referencing StyraInc actions (none found in `.github/workflows/`).

**[Signed commits](https://github.com/meshery/meshery/blob/master/CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [x] Yes, I signed my commits.
