### PR TITLE
[Server] Fix Broadcast concurrency: panic, dropped events, data race

### DIFF
--- a/server/models/event_broadcast.go
+++ b/server/models/event_broadcast.go
@@ -3,14 +3,16 @@ package models
 import (
 	"sync"
 
-	"github.com/meshery/meshery/server/helpers/utils"
 	"github.com/meshery/schemas/models/core"
-	"github.com/sirupsen/logrus"
 )
 
+// clients holds the set of subscriber channels registered for a single id
+// together with the mutex that guards that set. It is always stored in
+// Broadcast.clients as a *pointer* so the mutex and the listeners slice are
+// shared (never copied) across Subscribe/Publish/unsubscribe for the same id.
 type clients struct {
+	mu        sync.Mutex
 	listeners []chan interface{}
-	mu        *sync.Mutex
 }
 
 type Broadcast struct {
@@ -18,64 +20,65 @@ type Broadcast struct {
 	Name    string
 }
 
+// Subscribe registers a new listener channel for id and returns it along with
+// an unsubscribe function that removes and closes the channel. unsubscribe is
+// safe to call multiple times: once the channel has been removed subsequent
+// calls are no-ops (so the channel is never double-closed).
 func (c *Broadcast) Subscribe(id core.Uuid) (chan interface{}, func()) {
-	clientMap, err := c.clients.LoadOrStore(id, clients{mu: &sync.Mutex{}})
-	if err {
-		logrus.Infof("Client for id %s does not exist in clients map", id)
-	}
+	actual, _ := c.clients.LoadOrStore(id, &clients{})
+	client := actual.(*clients)
+
 	ch := make(chan interface{}, 1)
-	connectedClient, err := clientMap.(clients)
 
-	if err {
-		logrus.Infof("Client for id %s is not connected. Attempting to connect to client %s.", id, id)
-	}
+	client.mu.Lock()
+	client.listeners = append(client.listeners, ch)
+	client.mu.Unlock()
 
-	connectedClient.mu.Lock()
-	connectedClient.listeners = append(connectedClient.listeners, ch)
-	connectedClient.mu.Unlock()
-
-	c.clients.Store(id, connectedClient)
 	unsubscribe := func() {
-		cclient, ok := c.clients.Load(id)
-		var client clients
-		if ok {
-			client, ok = cclient.(clients)
-			if !ok {
-				return
-			}
-		}
 		client.mu.Lock()
 		defer client.mu.Unlock()
 
-		listeners := client.listeners
-		updatedListeners := []chan interface{}{}
-		for _, client := range listeners {
-			if client == ch {
-				close(client)
-				// break
+		updated := make([]chan interface{}, 0, len(client.listeners))
+		for _, listener := range client.listeners {
+			if listener == ch {
+				close(listener)
 			} else {
-				updatedListeners = append(updatedListeners, client)
+				updated = append(updated, listener)
 			}
 		}
-		client.listeners = updatedListeners
-		c.clients.Store(id, client)
+		client.listeners = updated
 	}
 	return ch, unsubscribe
 }
 
+// Publish delivers data to every listener currently subscribed to id.
+//
+// The per-id lock is held for the whole fan-out. Because unsubscribe closes a
+// channel only while holding the same lock, no channel can be closed
+// mid-send, so Publish can never panic with "send on closed channel" even
+// during a concurrent unsubscribe. Holding the lock also makes the iteration
+// over listeners race-free.
+//
+// The send is non-blocking: if a listener's buffer is full the event is
+// skipped for that listener rather than blocking the publishing goroutine (and
+// every other subscriber) behind a single slow consumer, which would otherwise
+// stall the broadcaster and leak goroutines under load.
 func (c *Broadcast) Publish(id core.Uuid, data interface{}) {
-	clientMap, ok := c.clients.Load(id)
+	actual, ok := c.clients.Load(id)
+	if !ok {
+		return
+	}
+	client, ok := actual.(*clients)
 	if !ok {
 		return
 	}
 
-	clientToPublish, ok := clientMap.(clients)
-	if !ok {
-		return
-	}
-	for _, client := range clientToPublish.listeners {
-		if !utils.IsClosed(client) {
-			client <- data
+	client.mu.Lock()
+	defer client.mu.Unlock()
+	for _, listener := range client.listeners {
+		select {
+		case listener <- data:
+		default:
 		}
 	}
 }

--- a/server/models/event_broadcast.go
+++ b/server/models/event_broadcast.go
@@ -25,14 +25,29 @@ type Broadcast struct {
 // safe to call multiple times: once the channel has been removed subsequent
 // calls are no-ops (so the channel is never double-closed).
 func (c *Broadcast) Subscribe(id core.Uuid) (chan interface{}, func()) {
-	actual, _ := c.clients.LoadOrStore(id, &clients{})
-	client := actual.(*clients)
-
 	ch := make(chan interface{}, 1)
 
-	client.mu.Lock()
-	client.listeners = append(client.listeners, ch)
-	client.mu.Unlock()
+	// Attach ch to whichever entry is currently active in the map. If a
+	// concurrent unsubscribe removed the entry we loaded (see unsubscribe
+	// below) we must retry, otherwise we would register on an orphaned
+	// *clients that Publish can no longer reach and the listener would never
+	// receive events.
+	var client *clients
+	for {
+		actual, _ := c.clients.LoadOrStore(id, &clients{})
+		client = actual.(*clients)
+
+		client.mu.Lock()
+		if cur, ok := c.clients.Load(id); !ok || cur != actual {
+			// The entry was deleted or replaced after our load; drop it and
+			// try again with the fresh entry.
+			client.mu.Unlock()
+			continue
+		}
+		client.listeners = append(client.listeners, ch)
+		client.mu.Unlock()
+		break
+	}
 
 	unsubscribe := func() {
 		client.mu.Lock()
@@ -47,6 +62,17 @@ func (c *Broadcast) Subscribe(id core.Uuid) (chan interface{}, func()) {
 			}
 		}
 		client.listeners = updated
+
+		// Drop the map entry once its last listener leaves so ids that are no
+		// longer subscribed don't accumulate empty entries forever. The
+		// CompareAndDelete runs under the same lock that guards the listener
+		// set and only removes this exact *clients, so it can never delete an
+		// entry a concurrent Subscribe has already attached to: that Subscribe
+		// either observes a non-empty slice here (no delete) or fails its
+		// post-lock validation above and retries with a fresh entry.
+		if len(updated) == 0 {
+			c.clients.CompareAndDelete(id, client)
+		}
 	}
 	return ch, unsubscribe
 }

--- a/server/models/event_broadcast_test.go
+++ b/server/models/event_broadcast_test.go
@@ -135,18 +135,64 @@ func TestBroadcast_ConcurrentPublishAndUnsubscribe(t *testing.T) {
 
 	wg.Wait()
 
-	// Every Subscribe was paired with an unsubscribe, so no listeners should
-	// remain leaked in the slice.
-	if actual, ok := b.clients.Load(id); ok {
-		cl := actual.(*clients)
-		cl.mu.Lock()
-		n := len(cl.listeners)
-		cl.mu.Unlock()
-		if n != 0 {
-			t.Fatalf("expected no listeners after all unsubscribes, got %d", n)
-		}
+	// Every Subscribe was paired with an unsubscribe, so the map entry must be
+	// gone rather than left behind as an empty (leaked) entry.
+	if _, ok := b.clients.Load(id); ok {
+		t.Fatalf("expected the map entry to be removed after all unsubscribes")
 	}
 
 	// A final publish after all the churn must still be safe.
 	b.Publish(id, "final")
+}
+
+// TestBroadcast_MapEntryRemovedAfterLastUnsubscribe verifies the map entry for
+// an id is reclaimed once its last listener unsubscribes, preventing unbounded
+// growth as unique ids come and go.
+func TestBroadcast_MapEntryRemovedAfterLastUnsubscribe(t *testing.T) {
+	b := NewBroadcaster("test")
+	id := newBroadcastTestID(t)
+
+	_, unsubscribe := b.Subscribe(id)
+	if _, ok := b.clients.Load(id); !ok {
+		t.Fatal("expected a map entry to exist while subscribed")
+	}
+
+	unsubscribe()
+	if _, ok := b.clients.Load(id); ok {
+		t.Fatal("expected the map entry to be removed after the last unsubscribe")
+	}
+
+	// Subscribing again after cleanup must still work and deliver events.
+	ch, unsubscribe2 := b.Subscribe(id)
+	defer unsubscribe2()
+	b.Publish(id, "again")
+	if got := <-ch; got != "again" {
+		t.Fatalf("got %v, want %q", got, "again")
+	}
+}
+
+// TestBroadcast_MapEntryRetainedWhileSubscribersRemain verifies the entry is
+// only removed once the *last* listener leaves, not on the first unsubscribe.
+func TestBroadcast_MapEntryRetainedWhileSubscribersRemain(t *testing.T) {
+	b := NewBroadcaster("test")
+	id := newBroadcastTestID(t)
+
+	_, unsubscribe1 := b.Subscribe(id)
+	ch2, unsubscribe2 := b.Subscribe(id)
+
+	unsubscribe1()
+	if _, ok := b.clients.Load(id); !ok {
+		t.Fatal("expected the map entry to remain while a listener is still subscribed")
+	}
+
+	// The surviving listener must still receive events.
+	b.Publish(id, "still-here")
+	if got := <-ch2; got != "still-here" {
+		t.Fatalf("got %v, want %q", got, "still-here")
+	}
+
+	unsubscribe2()
+	if _, ok := b.clients.Load(id); ok {
+		t.Fatal("expected the map entry to be removed after the last unsubscribe")
+	}
 }

--- a/server/models/event_broadcast_test.go
+++ b/server/models/event_broadcast_test.go
@@ -1,0 +1,152 @@
+package models
+
+import (
+	"sync"
+	"testing"
+
+	"github.com/gofrs/uuid"
+)
+
+// newBroadcastTestID returns a fresh random id for broadcaster tests.
+// core.Uuid is an alias for uuid.UUID, so this value is usable directly as the
+// id argument to Subscribe/Publish.
+func newBroadcastTestID(t *testing.T) uuid.UUID {
+	t.Helper()
+	id, err := uuid.NewV4()
+	if err != nil {
+		t.Fatalf("failed to generate uuid: %v", err)
+	}
+	return id
+}
+
+// TestBroadcast_PublishDeliversToSubscriber verifies the basic contract: an
+// event published for an id is delivered to that id's subscriber.
+func TestBroadcast_PublishDeliversToSubscriber(t *testing.T) {
+	b := NewBroadcaster("test")
+	id := newBroadcastTestID(t)
+
+	ch, unsubscribe := b.Subscribe(id)
+	defer unsubscribe()
+
+	b.Publish(id, "hello")
+
+	select {
+	case got := <-ch:
+		if got != "hello" {
+			t.Fatalf("got %v, want %q", got, "hello")
+		}
+	default:
+		t.Fatal("expected the published event to be buffered, channel was empty")
+	}
+}
+
+// TestBroadcast_BufferedEventNotDrained guards against the regression where the
+// closed-channel check consumed the buffered event: the first event must remain
+// queued for the subscriber. Because the buffer has capacity 1, the second
+// event is intentionally dropped (back-pressure) rather than replacing the
+// first or being silently drained out-of-band.
+func TestBroadcast_BufferedEventNotDrained(t *testing.T) {
+	b := NewBroadcaster("test")
+	id := newBroadcastTestID(t)
+
+	ch, unsubscribe := b.Subscribe(id)
+	defer unsubscribe()
+
+	b.Publish(id, "first")  // buffered (capacity 1)
+	b.Publish(id, "second") // buffer full -> dropped, must not drain "first"
+
+	got := <-ch
+	if got != "first" {
+		t.Fatalf("buffered event was lost or replaced: got %v, want %q", got, "first")
+	}
+}
+
+// TestBroadcast_UnsubscribeClosesChannelAndPublishIsSafe verifies unsubscribe
+// closes the listener channel and that publishing afterwards (with no
+// listeners) does not panic.
+func TestBroadcast_UnsubscribeClosesChannelAndPublishIsSafe(t *testing.T) {
+	b := NewBroadcaster("test")
+	id := newBroadcastTestID(t)
+
+	ch, unsubscribe := b.Subscribe(id)
+	unsubscribe()
+
+	if _, open := <-ch; open {
+		t.Fatal("expected channel to be closed after unsubscribe")
+	}
+
+	b.Publish(id, "after-unsub") // must be a no-op, not a panic
+}
+
+// TestBroadcast_DoubleUnsubscribeDoesNotPanic verifies unsubscribe is
+// idempotent and never double-closes the channel.
+func TestBroadcast_DoubleUnsubscribeDoesNotPanic(t *testing.T) {
+	b := NewBroadcaster("test")
+	id := newBroadcastTestID(t)
+
+	_, unsubscribe := b.Subscribe(id)
+	unsubscribe()
+	unsubscribe() // must be a no-op
+}
+
+// TestBroadcast_ConcurrentPublishAndUnsubscribe drives publishers and
+// subscribing/unsubscribing goroutines against the same id simultaneously.
+// Before the fix this panicked with "send on closed channel" and tripped the
+// race detector while iterating the listeners slice. It must now run clean
+// under `go test -race`.
+func TestBroadcast_ConcurrentPublishAndUnsubscribe(t *testing.T) {
+	b := NewBroadcaster("test")
+	id := newBroadcastTestID(t)
+
+	const (
+		publishers  = 8
+		subscribers = 8
+		iterations  = 500
+	)
+
+	var wg sync.WaitGroup
+
+	for p := 0; p < publishers; p++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for i := 0; i < iterations; i++ {
+				b.Publish(id, i) // must never panic sending to a closed channel
+			}
+		}()
+	}
+
+	for s := 0; s < subscribers; s++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for i := 0; i < iterations; i++ {
+				ch, unsubscribe := b.Subscribe(id)
+				// Drain whatever happens to be buffered without blocking, then
+				// unsubscribe (closing the channel) concurrently with publishers.
+				select {
+				case <-ch:
+				default:
+				}
+				unsubscribe()
+			}
+		}()
+	}
+
+	wg.Wait()
+
+	// Every Subscribe was paired with an unsubscribe, so no listeners should
+	// remain leaked in the slice.
+	if actual, ok := b.clients.Load(id); ok {
+		cl := actual.(*clients)
+		cl.mu.Lock()
+		n := len(cl.listeners)
+		cl.mu.Unlock()
+		if n != 0 {
+			t.Fatalf("expected no listeners after all unsubscribes, got %d", n)
+		}
+	}
+
+	// A final publish after all the churn must still be safe.
+	b.Publish(id, "final")
+}

--- a/server/models/event_broadcast_test.go
+++ b/server/models/event_broadcast_test.go
@@ -5,18 +5,20 @@ import (
 	"testing"
 
 	"github.com/gofrs/uuid"
+	"github.com/meshery/schemas/models/core"
 )
 
-// newBroadcastTestID returns a fresh random id for broadcaster tests.
-// core.Uuid is an alias for uuid.UUID, so this value is usable directly as the
-// id argument to Subscribe/Publish.
-func newBroadcastTestID(t *testing.T) uuid.UUID {
+// newBroadcastTestID returns a fresh random id for broadcaster tests. It
+// returns core.Uuid (converting explicitly) so callers match the
+// Subscribe/Publish signature regardless of whether core.Uuid stays a type
+// alias for uuid.UUID.
+func newBroadcastTestID(t *testing.T) core.Uuid {
 	t.Helper()
 	id, err := uuid.NewV4()
 	if err != nil {
 		t.Fatalf("failed to generate uuid: %v", err)
 	}
-	return id
+	return core.Uuid(id)
 }
 
 // TestBroadcast_PublishDeliversToSubscriber verifies the basic contract: an


### PR DESCRIPTION
**Notes for Reviewers**

- This PR fixes #20391 

**[Signed commits](https://github.com/meshery/meshery/blob/master/CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [x] Yes, I signed my commits.

<!--
Thank you for contributing to Meshery! 

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. Sign your commits.
4. Include before and after screenshots/terminal output.

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.
-->
