### PR TITLE
[mesheryctl] Fix error string formatting to use newlines instead of pipes

### DIFF
--- a/mesheryctl/internal/cli/root/root.go
+++ b/mesheryctl/internal/cli/root/root.go
@@ -99,7 +99,12 @@ func Execute() error {
 	RootCmd.SilenceErrors = true
 	err := RootCmd.Execute()
 	if err != nil {
-		utils.Log.Errorf("%s", strings.ReplaceAll(err.Error(), " | ", "\n"))
+		errMsg := strings.ReplaceAll(err.Error(), " | ", "\n")
+		if utils.Log != nil {
+			utils.Log.Errorf("%s", errMsg)
+		} else {
+			fmt.Fprintf(os.Stderr, "Error: %s\n", errMsg)
+		}
 	}
 	return err
 }

--- a/mesheryctl/internal/cli/root/root.go
+++ b/mesheryctl/internal/cli/root/root.go
@@ -19,6 +19,7 @@ import (
 	"fmt"
 	"log"
 	"os"
+	"strings"
 
 	mesheryctlflags "github.com/meshery/meshery/mesheryctl/internal/cli/pkg/flags"
 	mesheryctllogger "github.com/meshery/meshery/mesheryctl/internal/cli/pkg/logger"
@@ -95,7 +96,11 @@ func Execute() error {
 	//log formatter for improved UX
 	// Removing printing command usage on error
 	RootCmd.SilenceUsage = true
+	RootCmd.SilenceErrors = true
 	err := RootCmd.Execute()
+	if err != nil {
+		utils.Log.Errorf("%s", strings.ReplaceAll(err.Error(), " | ", "\n"))
+	}
 	return err
 }
 


### PR DESCRIPTION
**Notes for Reviewers**

This PR addresses the issue where `mesheryctl connection` commands were printing error logs in an unformatted, pipe-separated string (e.g., `Short Description: X | Probable Cause: Y`). 
Instead of modifying the error handling inside every individual command file, this fix updates the top-level `Execute()` function in `mesheryctl/internal/cli/root/root.go`. 
By setting `RootCmd.SilenceErrors = true`, we suppress cobra's default raw string error output. We then manually intercept the error, replace the `" | "` separators with `"\n"`, and print it using `utils.Log.Errorf()`. This provides a universally clean, human-readable format for all commands that return meshkit errors, while keeping the codebase changes minimal and robust.

preview ->
<img width="2195" height="425" alt="{C4DF4F86-5A49-495E-B48C-2D393AF71B65}" src="https://github.com/user-attachments/assets/b24f488c-ed73-4942-9e0d-bf0319c350f1" />


- This PR fixes #20405  and #19375

**[Signed commits](https://github.com/meshery/meshery/blob/master/CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [✅ ] Yes, I signed my commits.

<!--
Thank you for contributing to Meshery! 

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. Sign your commits.
4. Include before and after screenshots/terminal output.

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.
-->
