### PR TITLE
[UI] Fix invalid MUI variant, hardcoded colors, and deprecated prop in GrafanaDateRangePicker

### DIFF
--- a/ui/components/telemetry/grafana/GrafanaDateRangePicker.tsx
+++ b/ui/components/telemetry/grafana/GrafanaDateRangePicker.tsx
@@ -27,18 +27,18 @@ const StyledDialog = styled(Dialog)(({ theme }) => ({
   },
 }));
 
-const DialogTitleBar = styled('div')(() => ({
+const DialogTitleBar = styled('div')(({ theme }) => ({
   display: 'flex',
   justifyContent: 'space-between',
-  backgroundColor: 'rgb(57, 102, 121)',
-  color: 'white',
+  backgroundColor: theme.palette.primary.main,
+  color: theme.palette.primary.contrastText,
 }));
 
-const CloseIconButton = styled(IconButton)(() => ({
+const CloseIconButton = styled(IconButton)(({ theme }) => ({
   height: '2.3rem',
   marginTop: '0.8rem',
   marginRight: '10px',
-  color: 'white',
+  color: theme.palette.primary.contrastText,
 }));
 
 const CloseIcon = styled(Close)({
@@ -577,7 +577,7 @@ const GrafanaDateRangePicker = (props) => {
 
   return (
     <NoSsr>
-      <RangeButton variant="filled" onClick={handleClick}>
+      <RangeButton variant="outlined" onClick={handleClick}>
         <AccessTimeIcon sx={{ marginRight: '0.25rem', fontSize: '1.15rem' }} />
         <Moment format="LLLL">{startDate}</Moment>
         <Space>-</Space>
@@ -650,7 +650,7 @@ const GrafanaDateRangePicker = (props) => {
                 Quick Ranges
                 <Grid2 container spacing={0} size="grow">
                   {quickRanges.map((qr, index) => (
-                    <TimeList item key={`qr-${index}`} size={{ xs: 12, sm: 3 }}>
+                    <TimeList key={`qr-${index}`} size={{ xs: 12, sm: 3 }}>
                       {qr.map((q) => (
                         <Button key={q} variant="text" onClick={setRange(q)}>
                           {q}


### PR DESCRIPTION
## Description

This PR addresses the following UI issue in `GrafanaDateRangePicker`:

- Replacing the invalid MUI Button variant `filled` with the supported `outlined` variant.
- Replacing hardcoded colors in `DialogTitleBar` and `CloseIconButton` with theme-aware palette values.
- Removing the deprecated `item` prop from the `Grid2` (`TimeList`) component.

Related to #14572


**Notes for Reviewers**

This PR addresses only the `GrafanaDateRangePicker` changes related to #14572. The other issues mentioned in the report (table color, chart visibility, delete connection chip) are not covered here, as they require a working Grafana connection to reproduce and will need separate investigation.

## Changes made

- Updated `RangeButton` to use a valid MUI Button variant.
- Made the dialog header and close button use theme-aware colors.
- Removed deprecated `Grid2` API usage.


## Testing

- Production build completed successfully using:

```
cd ui
npm run build
```

**[Signed commits](https://github.com/meshery/meshery/blob/master/CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [x] Yes, I signed my commits.

<!--
Thank you for contributing to Meshery! 

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. Sign your commits.
4. Include before and after screenshots/terminal output.

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.
-->
