### PR TITLE
docs: Upgrading Meshery guide; Server-managed operator lifecycle; Operator/MeshSync/Broker concept uplift

### DIFF
--- a/docs/content/en/concepts/architecture/broker/index.md
+++ b/docs/content/en/concepts/architecture/broker/index.md
@@ -5,27 +5,134 @@ aliases:
 - /architecture/broker/
 ---
 
-Broker is a custom Kubernetes controller that provides data streaming across independent components of Meshery whether those components are running inside or outside of the Kubernetes cluster.
+Meshery Broker provides data streaming across independent components of
+Meshery, whether those components are running inside or outside of the
+Kubernetes cluster. It is a [NATS](https://nats.io) message broker, deployed
+and managed by [Meshery Operator]({{< ref "concepts/architecture/operator/index.md" >}})
+from a `Broker` custom resource: the Operator reconciles the resource into a
+NATS `StatefulSet`, a client `Service` (plus a headless `Service` for peer
+discovery), and its configuration, following the official NATS Helm chart's
+topology. Client access is authenticated with a token that the Operator
+generates into a Secret — no static credentials ship with the deployment.
 
 [![Meshery Log Viewer](./images/meshery-log-viewer.svg
 )](./images/meshery-log-viewer.svg)
 
+## Declarative service networking
+
+How the Broker is exposed on the network is part of the `Broker` resource's
+spec, and every field is **reconfigurable on a live Broker**: the Operator
+updates the Service in place (no pod deletion), re-derives
+`status.endpoint`, and re-reconciles MeshSync so it reconnects to the new
+address.
+
+```yaml
+apiVersion: meshery.io/v1alpha2
+kind: Broker
+metadata:
+  name: meshery-broker
+  namespace: meshery
+spec:
+  size: 1
+  service:
+    type: NodePort                  # ClusterIP (default) | NodePort | LoadBalancer
+    annotations:                    # cloud LB hints, MetalLB pools, internal-LB switches
+      service.beta.kubernetes.io/aws-load-balancer-internal: "true"
+    loadBalancerClass: metallb      # LoadBalancer type only
+    loadBalancerSourceRanges:       # LoadBalancer type only
+      - 10.0.0.0/8
+    externalEndpointOverride: nats.example.com:4222   # pin the advertised endpoint
+```
+
+- **`type`** — `ClusterIP` keeps the Broker cluster-internal (the default;
+  suitable for in-cluster Meshery Server, kind, minikube, and bare metal).
+  `NodePort` or `LoadBalancer` expose it to an out-of-cluster Meshery Server.
+- **`externalEndpointOverride`** — advertises a fixed `host:port` instead of
+  the derived one, for Brokers behind an ingress/gateway, NAT, or in
+  air-gapped topologies.
+- Invalid combinations (for example `loadBalancerClass` without
+  `type: LoadBalancer`) are rejected at admission by validation rules on the
+  CRD.
+
+The Operator publishes the resulting addresses on the resource's status:
+
+```yaml
+status:
+  endpoint:
+    external: 1e2cd156-0123456789.us-south-3.elb.cloud-provider.com:4222
+    internal: 10.96.49.130:4222
+```
+
+See [How does the operator expose information about broker endpoints?]({{< ref "concepts/architecture/operator/index.md#how-does-the-operator-expose-information-about-broker-endpoints" >}})
+for the endpoint selection order.
+
+## Common tasks
+
+**Change how the Broker is exposed — on a live Broker:**
+
+```bash
+kubectl -n meshery patch broker meshery-broker --type merge \
+  -p '{"spec":{"service":{"type":"NodePort"}}}'
+kubectl -n meshery get broker meshery-broker -o jsonpath='{.status.endpoint}{"\n"}'
+```
+
+**Pin the advertised endpoint** (ingress/NAT in front of the Broker):
+
+```bash
+kubectl -n meshery patch broker meshery-broker --type merge \
+  -p '{"spec":{"service":{"externalEndpointOverride":"nats.example.com:4222"}}}'
+```
+
+**Check Broker health:**
+
+```bash
+kubectl -n meshery get broker meshery-broker -o jsonpath='{.status.conditions}{"\n"}'
+kubectl -n meshery get statefulset meshery-nats
+```
+
+**Scale the Broker:**
+
+```bash
+kubectl -n meshery patch broker meshery-broker --type merge -p '{"spec":{"size":3}}'
+```
+
 ### Broker FAQs
 
 #### How many Brokers can run?
-It is recommended to run one broker instance for each kubernetes cluster, However the instance itself can be scaled up based on the incoming data volume in each of the cluster. The scaling is independent of the number of instances running.
+It is recommended to run one Broker instance (one `Broker` resource) per
+Kubernetes cluster. The instance itself can be scaled through `spec.size`
+(1–10 replicas) based on the data volume in the cluster.
 
 #### What does an HA configuration look like?
-We leverage on the kubernetes functionality in terms of the High-Availability behaviour. Meaning, the broker instance gets instantiated/restarted on its own when an issue occurs. In part, Meshery-Operator is also responsible for keeping the broker functional.
+We leverage Kubernetes functionality for high availability: the Broker runs as
+a StatefulSet whose pods are restarted automatically on failure, with the
+headless Service providing stable peer identities, and Meshery Operator
+continuously reconciles the Broker back to its declared state. The Operator
+reports readiness through the `Broker` resource's status conditions.
 
 #### What stateful characteristics does the Broker have?
-All the messages that are published to the broker is persisted in-memory within the broker instance until it get consumed. Persistent-volume/Disk-space is not currently being used by the Broker.
+All messages published to the Broker are persisted in-memory within the
+Broker instance until consumed. Persistent volumes/disk are not used by
+default (NATS JetStream is available in the underlying deployment but
+disabled by default).
+
+#### How is access to the Broker secured?
+Client connections authenticate with a token that Meshery Operator generates
+and stores in a Kubernetes Secret in the Broker's namespace. MeshSync and
+Meshery Server obtain the token from the same source; no credentials are
+committed to images or manifests. Use `spec.service.loadBalancerSourceRanges`
+to restrict network access when exposing the Broker through a load balancer.
 
 #### How do I know if the Broker is working? How do I troubleshoot the Broker?
 To check if your Broker instance is running smoothly (it's deployed as a Kubernetes StatefulSet), follow these quick checks:
 
-- Confirm that the Broker pods are running.
-- Verify your cluster supports `LoadBalancer` or `NodePort` service types.
-- Make sure the Meshery Server can reach the Broker service.
+- Confirm that the Broker pods are running and `status.conditions` on the
+  `Broker` resource report ready.
+- Confirm `status.endpoint` is populated, and that the external endpoint is
+  reachable from wherever Meshery Server runs (only `ClusterIP` requires no
+  external exposure — use `NodePort`/`LoadBalancer`, or an
+  `externalEndpointOverride`, for out-of-cluster Servers).
+- Make sure MeshSync's `BROKER_URL` points at the Broker's current endpoint
+  (the Operator maintains this automatically).
 
 Still seeing issues? The **[Meshery Troubleshooting Guide]({{< ref "guides/troubleshooting/meshery-operator-meshsync.md" >}})** covers common problems with the Broker, MeshSync, and Operator — and offers clear steps to resolve them.

--- a/docs/content/en/concepts/architecture/meshsync.md
+++ b/docs/content/en/concepts/architecture/meshsync.md
@@ -181,7 +181,7 @@ Alternatively, a whitelist inverts the behavior — only the listed resources
 spec:
   watch-list:
     data:
-      whitelist: '[{"Resource":"namespaces.v1.","Events":["ADDED","DELETE"]},{"Resource":"pods.v1.","Events":["MODIFIED"]}]'
+      whitelist: '[{"Resource":"namespaces.v1.","Events":["ADDED","MODIFIED","DELETED"]},{"Resource":"pods.v1.","Events":["MODIFIED"]}]'
 ```
 
 Restart MeshSync (`kubectl -n meshery rollout restart deploy/meshery-meshsync`)

--- a/docs/content/en/concepts/architecture/meshsync.md
+++ b/docs/content/en/concepts/architecture/meshsync.md
@@ -94,6 +94,19 @@ For efficient management of large Kubernetes clusters, MeshSync uses tiered disc
 
 Meshery's event-driven approach ensures high-speed operations, making it suitable for managing both small and large clusters. [Meshery Broker]({{< ref "concepts/architecture/broker/index.md" >}}) uses NATS as the messaging bus to ensure continuous communication between MeshSync and Meshery Server. In case of connectivity interruptions, MeshSync data is persisted in NATS topics.
 
+## Broker connection
+
+In operator mode, [Meshery Operator]({{< ref "concepts/architecture/operator/index.md" >}})
+wires MeshSync to the Broker: it derives the Broker's address from the
+`Broker` resource's `status.endpoint` and injects it into the MeshSync
+Deployment as the `BROKER_URL` environment variable — always a
+`nats://host:port` URL. Because the Operator watches the Broker, a change to
+the Broker's endpoint (for example after
+[reconfiguring its service networking]({{< ref "concepts/architecture/broker/index.md#declarative-service-networking" >}}))
+re-reconciles MeshSync so it reconnects to the new address automatically. To
+point MeshSync at an externally managed NATS instead, set
+`spec.broker.custom.url` on the `MeshSync` resource.
+
 # MeshSync deployment mode
 
 MeshSync operates in one of two modes: operator or embedded.
@@ -116,15 +129,63 @@ When the deployment mode is switched from operator to embedded: the operator is 
 
 When the deployment mode is switched from embedded to operator: the MeshSync library routine is stopped for the managed cluster, and the operator is deployed to the managed cluster.
 
+# Common tasks
+
+**Check MeshSync health:**
+
+```bash
+kubectl -n meshery get meshsync meshery-meshsync -o jsonpath='{.status.conditions}{"\n"}'
+kubectl -n meshery rollout status deploy/meshery-meshsync
+```
+
+**Verify which Broker MeshSync is connected to:**
+
+```bash
+kubectl -n meshery get deploy meshery-meshsync \
+  -o jsonpath='{.spec.template.spec.containers[0].env[?(@.name=="BROKER_URL")].value}{"\n"}'
+```
+
+**Trigger a fresh discovery** (MeshSync re-discovers on start):
+
+```bash
+kubectl -n meshery rollout restart deploy/meshery-meshsync
+```
+
 # MeshSync FAQs
 
 ## How to configure MeshSync's resource discovery behavior: Can specific, "uninteresting" resources be blacklisted?
 
-MeshSync is managed by [Meshery Operator]({{< ref "concepts/architecture/operator/index.md" >}}), which watches for changes on the meshsync CRD for changes and updates the deployed MeshSync instance accordingly. You can blacklist specific Kubernetes resources from being discovered and watched by MeshSync. In order to identify the list of one or more resources for MeshSync to ignore, update the meshsync CRD using kubectl:
+Yes. MeshSync reads its discovery filter from the `watch-list` section of the
+`MeshSync` **custom resource** (not the CRD schema) — `meshery-meshsync` in
+the `meshery` namespace. The `whitelist` and `blacklist` keys each hold a
+JSON-encoded list; resources are identified as `<plural>.<version>.<group>`
+(core-group resources end with a trailing dot, e.g. `pods.v1.`).
 
-- Download the CRD with kubectl get crd meshsyncs.meshery.io -o yaml > meshsync.yaml
-- Open the downloaded file and edit the field informer_config to blacklist all the types of resources that you don't want updates from.
-- Apply the new definition with kubectl apply -f meshsync.yaml
+To ignore specific resource types, edit the custom resource:
+
+```bash
+kubectl -n meshery edit meshsync meshery-meshsync
+```
+
+```yaml
+spec:
+  watch-list:
+    data:
+      blacklist: '["events.v1.","replicasets.v1.apps"]'
+```
+
+Alternatively, a whitelist inverts the behavior — only the listed resources
+(and event types) are watched:
+
+```yaml
+spec:
+  watch-list:
+    data:
+      whitelist: '[{"Resource":"namespaces.v1.","Events":["ADDED","DELETE"]},{"Resource":"pods.v1.","Events":["MODIFIED"]}]'
+```
+
+Restart MeshSync (`kubectl -n meshery rollout restart deploy/meshery-meshsync`)
+for the new filter to take effect.
 
 
 {{% alert color="info" title="Still seeing issues?" %}}

--- a/docs/content/en/concepts/architecture/operator/index.md
+++ b/docs/content/en/concepts/architecture/operator/index.md
@@ -8,7 +8,13 @@ aliases:
 
 # Meshery Operator <img src="./images/B203EFA85E89491B.png" width="30" height="35" style="display:inline"/>
 
-Meshery Operator is a Kubernetes Operator that deploys and manages the lifecycle of two Meshery components critical to Meshery's operations of Kubernetes clusters. Deploy one Meshery Operator per Kubernetes cluster under management - whether Meshery Server is deploy inside or outside of the clusters under management. 
+Meshery Operator is a Kubernetes operator (built on the
+[Kubebuilder](https://book.kubebuilder.io) `go/v4` framework) that deploys and
+manages the lifecycle of two Meshery components critical to Meshery's
+operation of Kubernetes clusters: [Meshery Broker]({{< ref "concepts/architecture/broker/index.md" >}})
+and [MeshSync]({{< ref "concepts/architecture/meshsync.md" >}}). Deploy one
+Meshery Operator per Kubernetes cluster under management — whether Meshery
+Server is deployed inside or outside of the clusters under management.
 
 ## Deployments
 
@@ -22,23 +28,77 @@ It is recommended to deploy one Meshery Operator per cluster.
 [![Meshery Operator and MeshSync](./images/meshery-operator-deployment-sequence.svg
 )](./images/meshery-operator-deployment-sequence.svg)
 
+### How Meshery Server installs and upgrades the Operator
+
+Meshery Server installs the `meshery-operator` Helm chart from
+[meshery.io/charts](https://meshery.io/charts) into the `meshery` namespace of
+each managed cluster, requesting the chart version that **matches the Meshery
+Server release**. Upgrading Meshery Server is therefore what upgrades the
+Operator: the Server re-applies the newer chart, the chart's CRD update Job
+refreshes the CRD schemas, and the Operator Deployment rolls to the operator
+version pinned in that chart. Manual operator upgrades on Server-managed
+clusters are reverted by the Server's reconciliation — see
+[How Meshery Server manages Meshery Operator]({{< ref "installation/upgrades/index.md#how-meshery-server-manages-meshery-operator" >}}).
+
+## Custom resources
+
+The Operator owns two CRDs, each reconciled into concrete workloads:
+
+| CRD | Custom resource | Reconciles into |
+|---|---|---|
+| `brokers.meshery.io` | `meshery-broker` | NATS `StatefulSet`, client + headless `Service`s, configuration |
+| `meshsyncs.meshery.io` | `meshery-meshsync` | MeshSync `Deployment` (with the Broker endpoint injected) |
+
+Both CRDs serve two API versions — `v1alpha1` (compatibility) and `v1alpha2`
+(storage) — with identical schemas, so either version can be read and written
+interchangeably. Reconciliation uses Kubernetes Server-Side Apply with a
+stable field manager: the Operator converges owned objects to their desired
+state without fighting other controllers, watches the objects it owns
+(including the Broker's Services), and reports health through standard status
+`conditions` on each custom resource.
+
 ## Controllers managed by Meshery Operator
 
 ### Broker Controller
 
-Meshery broker is one of the core components of the meshery architecture. This controller manages the lifecycle of broker that meshery uses for data streaming across the cluster and the outside world.
+Meshery Broker is one of the core components of the Meshery architecture. This controller manages the lifecycle of the NATS-backed broker that Meshery uses for data streaming across the cluster and the outside world, including declarative, in-place reconfiguration of the Broker's service networking.
 
 See [Meshery Broker]({{< ref "concepts/architecture/broker/index.md" >}}) for more information.
 
 ### MeshSync Controller
 
-MeshSync Controller manages the lifecycle of MeshSync that is deployed for resource synchronization for the cluster.
+MeshSync Controller manages the lifecycle of MeshSync that is deployed for resource synchronization for the cluster. It derives the Broker's address from the `Broker` resource's status and injects it into MeshSync as `BROKER_URL` (a `nats://host:port` URL); when the Broker's endpoint changes, the controller re-reconciles MeshSync so it reconnects.
 
 See [MeshSync]({{< ref "concepts/architecture/meshsync.md" >}}) for more information.
 
+## Common tasks
+
+**Check Operator health:**
+
+```bash
+kubectl -n meshery rollout status deploy/meshery-operator
+kubectl -n meshery get brokers,meshsyncs
+kubectl -n meshery get broker meshery-broker -o jsonpath='{.status.conditions}'
+```
+
+**Find the running Operator version:**
+
+```bash
+kubectl -n meshery get deploy meshery-operator \
+  -o jsonpath='{.spec.template.spec.containers[0].image}{"\n"}'
+```
+
+**Scrape Operator metrics:** the Operator serves Prometheus metrics over TLS
+on port `8443` with authentication and authorization. Bind your scraper's
+ServiceAccount to the `meshery-metrics-reader` ClusterRole and scrape the
+`meshery-operator` Service.
+
+**Upgrade the Operator:** upgrade Meshery Server — see the
+[Upgrading Meshery guide]({{< ref "guides/upgrading-meshery/index.md" >}}).
+
 ## Operator FAQs
 
-### When is Meshery Operator deployed and when is it deleted?  
+### When is Meshery Operator deployed and when is it deleted?
 As a Kubernetes custom controller, Meshery Operator is provisioned and deprovisioned when Meshery Server is connected to or disconnected from Kubernetes cluster. Meshery Server connections to Kubernetes clusters are controlled using Meshery Server clients: `mesheryctl` or Meshery UI.  This behavior described below is consistent whether your Meshery deployment is using Docker or Kubernetes as the platform to host the Meshery deployment.
 
 **Meshery CLI**
@@ -49,12 +109,24 @@ As a Kubernetes custom controller, Meshery Operator is provisioned and deprovisi
 
 Meshery UI offers more granular control over the deployment of Meshery Operator in that you can remove Meshery Operator from a Kubernetes cluster without disconnecting Meshery Server from the Kubernetes cluster. You can control the deployment of Meshery Operator using the on/off switch found in the Meshery Operator section of  Settings.
 
-### Does the Meshery Operator use an SDK or framework? 
-Yes, Meshery Operator used the Operator SDK.
+### Does the Meshery Operator use an SDK or framework?
+Yes. Meshery Operator is built on [Kubebuilder](https://book.kubebuilder.io)
+(`go/v4` layout) with controller-runtime; the Operator SDK is used to produce
+its OLM bundle for Operator Lifecycle Manager installations.
+
+### What happens to the CRDs when the Operator is removed?
+The `brokers.meshery.io` and `meshsyncs.meshery.io` CRDs — and any `Broker`
+and `MeshSync` objects — deliberately survive operator removal, so
+reinstalling the Operator picks up where it left off with no data loss.
+Deleting the CRDs (which deletes every custom resource of those types) is an
+explicit manual step: `kubectl delete crd brokers.meshery.io meshsyncs.meshery.io`.
 
 ### How does the operator expose information about broker endpoints?
 
-During the broker reconciliation step (a concept from the Operator SDK), the operator reads the deployed broker Service and populates the `status` field of the `brokers/meshery-broker` Custom Resource (CR) with endpoint information:
+During Broker reconciliation, the operator derives endpoints **purely from
+the Broker's client Service** (its spec and status — no network probing) and
+populates the `status` field of the `brokers/meshery-broker` Custom Resource
+(CR):
 
 For example, for an in-cluster Meshery deployment:
 
@@ -74,17 +146,21 @@ status:
     internal: 10.96.49.130:4222
 ```
 
-The internal endpoint is always set up to the Service's `ClusterIP` + `clusterPort`.
+The internal endpoint is always the Service's `ClusterIP` + client port.
 
-The external endpoint is selected as one of the following based on Service configuration and network accessibility: 
+The external endpoint is selected in order of precedence:
 
-- LoadBalancer hostname (if available and not an IP) + `clusterPort`
-- LoadBalancer IP (if valid and not the ClusterIP) + `clusterPort`
-- `kubeconfig` host + `nodePort`
-- `ClusterIP` + `clusterPort`
-- `WorkerNodeIP` + `nodePort`
+- `spec.service.externalEndpointOverride` on the `Broker` resource, verbatim
+  (for brokers fronted by an ingress/gateway, NAT, or air-gapped topologies)
+- LoadBalancer ingress hostname (if present) + client port
+- LoadBalancer ingress IP + client port
+- Kubernetes API server host + the Service's `nodePort` (NodePort services)
+- `ClusterIP` + client port (cluster-internal only)
 
-Refer to [meshkit/utils/kubernetes::GetEndpoint](https://github.com/meshery/meshkit/blob/master/utils/kubernetes/service.go) function for more precise logic.
+Because derivation is driven by watches on the Service, changing the Broker's
+service networking (for example `ClusterIP` → `NodePort`) recomputes
+`status.endpoint` automatically, and MeshSync is re-reconciled to connect to
+the new address.
 
 ### Troubleshooting Meshery Operator and Related Components
 

--- a/docs/content/en/guides/upgrading-meshery/index.md
+++ b/docs/content/en/guides/upgrading-meshery/index.md
@@ -1,0 +1,135 @@
+---
+title: Upgrading Meshery
+description: >-
+  Step-by-step procedure for upgrading Meshery and all of its components —
+  CLI, Server, Operator, MeshSync, and Broker — on Docker and Kubernetes
+  deployments.
+categories: [installation]
+weight: 10
+aliases:
+- /guides/upgrade
+- /guides/upgrading-meshery
+---
+
+This guide walks through upgrading a running Meshery deployment. Meshery is a
+composition of components that upgrade in a specific order: the CLI first, the
+Server second, and the components on managed clusters — Meshery Operator,
+MeshSync, and Broker — **automatically, driven by the Server**. You do not
+upgrade the Operator by hand.
+
+For background on which components version together, see the
+[Upgrade Guide]({{< ref "installation/upgrades/index.md" >}}). For production
+practices (pinned versions, upgrade-friendly probes, rollback rehearsal), see
+the [Operational Readiness Checklist]({{< ref "installation/production/operational-readiness-checklist.md" >}}).
+
+## Before you begin
+
+- Note your release channel (`stable` for production; `edge` for testing).
+- Record current versions so you can verify the upgrade:
+
+```bash
+mesheryctl version
+kubectl -n meshery get deploy meshery-operator \
+  -o jsonpath='{.spec.template.spec.containers[0].image}{"\n"}'
+```
+
+## Step 1: Upgrade `mesheryctl`
+
+Use the package manager you installed with:
+
+```bash
+brew upgrade mesheryctl        # Homebrew
+scoop update mesheryctl        # Scoop
+curl -L https://meshery.io/install | DEPLOY_MESHERY=false bash -   # Bash
+```
+
+## Step 2: Upgrade Meshery Server
+
+### Docker deployments
+
+```bash
+mesheryctl system update    # pull latest images per your release channel
+mesheryctl system restart   # apply them to the running deployment
+```
+
+### Kubernetes deployments (Helm)
+
+Pin an explicit chart version rather than tracking latest, and use the
+upgrade-friendly probe values so Server pods are not killed while reloading
+capabilities:
+
+```bash
+helm repo update meshery
+helm upgrade meshery meshery/meshery --namespace meshery \
+  --version <target-version> \
+  -f values-upgrade.yaml \
+  --wait --timeout 10m
+```
+
+Keep your copy of
+[`values-upgrade.yaml`](https://github.com/meshery/meshery/blob/master/install/kubernetes/helm/meshery/values-upgrade.yaml)
+version-controlled alongside your own values.
+
+## Step 3: Managed-cluster components upgrade themselves
+
+When the upgraded Meshery Server (re)connects to a managed cluster, it
+re-applies the `meshery-operator` Helm chart **at the chart version matching
+the Server release**. That single `helm upgrade`, performed by the Server:
+
+1. runs the chart's CRD update Job, which server-side-applies the current
+   `Broker` and `MeshSync` CRD schemas (Helm alone never updates CRDs on
+   upgrade — the Job is what delivers schema changes to live clusters);
+2. rolls the Operator Deployment to the operator image version pinned in that
+   chart;
+3. the Operator then reconciles MeshSync and Broker to their expected
+   versions and configuration.
+
+No action is required on managed clusters. See
+[How Meshery Server manages Meshery Operator]({{< ref "installation/upgrades/index.md#how-meshery-server-manages-meshery-operator" >}})
+for the mechanics and caveats.
+
+{{% alert title="Do not hand-upgrade the Operator on Server-managed clusters" color="warning" %}}
+A manual `helm upgrade` of `meshery-operator` (or a hand-edited image tag) on
+a cluster that Meshery Server manages is a stopgap at best: the Server's
+reconciliation re-applies its own pinned chart version and will revert your
+change. The durable way to get a newer Operator is to upgrade Meshery Server.
+{{% /alert %}}
+
+## Step 4: Verify
+
+```bash
+# Server and components
+mesheryctl system status
+
+# Operator image now matches the release bundled with your Server version
+kubectl -n meshery get deploy meshery-operator \
+  -o jsonpath='{.spec.template.spec.containers[0].image}{"\n"}'
+
+# CRDs are current (v1alpha2 storage) and healthy
+kubectl get crds brokers.meshery.io meshsyncs.meshery.io
+
+# Broker and MeshSync are reconciled and ready
+kubectl -n meshery get brokers,meshsyncs
+kubectl -n meshery get statefulset meshery-broker deploy meshery-meshsync
+```
+
+In Meshery UI, confirm the cluster connection shows the Operator, MeshSync,
+and Broker as connected under **Settings → Environment**.
+
+## Rolling back
+
+```bash
+helm rollback meshery --namespace meshery    # Kubernetes deployments
+```
+
+Rolling back the Server is low-risk for data: durable state lives with your
+Remote Provider, and the local database is a rebuildable cache. Two notes:
+
+- The Operator follows the Server: after a rollback, the Server re-applies the
+  older operator chart on managed clusters.
+- CRD schemas are not rolled back automatically (the older chart's CRD update
+  Job re-applies the older schema on its next run; stored objects remain
+  readable because served versions stay identical across current schema
+  revisions).
+
+{{< related-discussions tag="meshery" >}}

--- a/docs/content/en/guides/upgrading-meshery/index.md
+++ b/docs/content/en/guides/upgrading-meshery/index.md
@@ -8,7 +8,6 @@ categories: [installation]
 weight: 10
 aliases:
 - /guides/upgrade
-- /guides/upgrading-meshery
 ---
 
 This guide walks through upgrading a running Meshery deployment. Meshery is a
@@ -110,7 +109,7 @@ kubectl get crds brokers.meshery.io meshsyncs.meshery.io
 
 # Broker and MeshSync are reconciled and ready
 kubectl -n meshery get brokers,meshsyncs
-kubectl -n meshery get statefulset meshery-broker deploy meshery-meshsync
+kubectl -n meshery get statefulset/meshery-nats deployment/meshery-meshsync
 ```
 
 In Meshery UI, confirm the cluster connection shows the Operator, MeshSync,
@@ -127,9 +126,10 @@ Remote Provider, and the local database is a rebuildable cache. Two notes:
 
 - The Operator follows the Server: after a rollback, the Server re-applies the
   older operator chart on managed clusters.
-- CRD schemas are not rolled back automatically (the older chart's CRD update
-  Job re-applies the older schema on its next run; stored objects remain
-  readable because served versions stay identical across current schema
-  revisions).
+- CRD schemas are not rolled back by `helm rollback` directly. When the
+  rolled-back Server reconnects to managed clusters, it re-applies the older
+  operator chart as a Helm upgrade, and that chart's CRD update Job re-applies
+  the older schemas. Stored objects remain readable throughout, because served
+  versions stay identical across current schema revisions.
 
 {{< related-discussions tag="meshery" >}}

--- a/docs/content/en/installation/production/operational-readiness-checklist.md
+++ b/docs/content/en/installation/production/operational-readiness-checklist.md
@@ -47,11 +47,27 @@ independently. For Kubernetes production deployments:
   only for testing. The channel is reflected by `RELEASE_CHANNEL`.
 - **Mind component groupings.** See the
   [Upgrade Guide]({{< ref "installation/upgrades/index.md" >}}) for which components move together
-  (e.g., Server/UI/Load Generators/Database) versus independently (Operator and
-  its controllers, Adapters, `mesheryctl`).
+  (e.g., Server/UI/Load Generators/Database) versus independently (Adapters,
+  `mesheryctl`). The Operator and its controllers effectively move **with the
+  Server**: each Server release pins the operator chart (and operator image)
+  it deploys to managed clusters.
+- **Let the Server own the Operator.** On Server-managed clusters, do not
+  hand-upgrade or hand-configure the `meshery-operator` Helm release — the
+  Server's reconciliation re-applies its own pinned chart version and reverts
+  manual changes. Upgrading the Server is the supported way to upgrade the
+  Operator; the chart's CRD update Job refreshes the `Broker`/`MeshSync` CRD
+  schemas on each upgrade (Helm alone never updates CRDs). See
+  [How Meshery Server manages Meshery Operator]({{< ref "installation/upgrades/index.md#how-meshery-server-manages-meshery-operator" >}}).
+- **Expect CRDs to persist.** The `brokers.meshery.io` and
+  `meshsyncs.meshery.io` CRDs (and their objects) deliberately survive
+  operator uninstalls and Helm release deletion; include the explicit
+  `kubectl delete crd ...` step in decommissioning runbooks only when
+  permanent removal is intended.
 - **Rehearse and roll back.** Because durable state lives with the Remote
   Provider and the local database is a cache, rolling back the deployment is
-  low-risk for data—validate the rollback path anyway.
+  low-risk for data—validate the rollback path anyway. On rollback, managed
+  clusters converge back to the older Server's pinned operator chart
+  automatically.
 - **Edge caches need no purge.** If a CDN or caching reverse proxy fronts
   Meshery, its UI cache busts itself on upgrade—hashed asset URLs change and the
   HTML `ETag` follows the build/release version—so a manual cache purge is not

--- a/docs/content/en/installation/upgrades/index.md
+++ b/docs/content/en/installation/upgrades/index.md
@@ -8,6 +8,12 @@ weight: 30
 
 # Upgrade Guide
 
+{{% alert title="Looking for the step-by-step procedure?" color="info" %}}
+This page explains how Meshery's components version and upgrade in relation to
+one another. For the hands-on procedure, follow the
+[Upgrading Meshery guide]({{< ref "guides/upgrading-meshery/index.md" >}}).
+{{% /alert %}}
+
 ## Upgrading Meshery Server, Adapters, and UI
 
 Various components of Meshery will need to be upgraded as new releases become available. Meshery is comprised of a number of components including a server, adapters, UI, and CLI. As an application, Meshery is a composition of different functional components.
@@ -81,6 +87,54 @@ Docker Deployment: Watchtower updates this component in accordance with the user
 
 Sub-components deploy as a unit; however, they do not share the same version number.
 
+## How Meshery Server manages Meshery Operator
+
+Meshery Server owns the lifecycle of Meshery Operator on every managed
+cluster. Understanding this relationship explains what upgrades automatically
+and what you should — and should not — touch by hand.
+
+**Installation.** When Meshery Server connects to a Kubernetes cluster (in
+operator deployment mode), it installs the `meshery-operator` Helm chart from
+[meshery.io/charts](https://meshery.io/charts) into the `meshery` namespace.
+The chart version it requests **matches the Meshery Server release version** —
+each Server release snapshots the operator chart (and the operator version
+pinned inside it) as of that release.
+
+**Upgrades.** Upgrading Meshery Server is what upgrades the Operator: on
+(re)connection, the Server re-applies the operator chart at its own (new)
+version. That `helm upgrade` triggers the chart's CRD update Job — a
+pre-upgrade hook that server-side-applies the current `Broker` and `MeshSync`
+CRD schemas (Helm alone never updates CRDs on upgrade) — and rolls the
+Operator Deployment to the operator image pinned in the chart. The Operator
+then reconciles MeshSync and the Broker.
+
+**Reconciliation.** The Server periodically re-applies the operator chart if
+the Operator is missing or unhealthy (`UpgradeIfInstalled`). Two practical
+consequences:
+
+- **Manual operator changes are temporary.** A hand-run
+  `helm upgrade meshery-operator --version <x>` or an edited image tag on a
+  Server-managed cluster will be reverted to the Server's pinned chart version
+  by the next reconciliation. Standalone/manual operator installs are only
+  durable on clusters that Meshery Server does not manage.
+- **Operator versions are pinned, not floating.** The operator image is a
+  fixed version per chart release (no `stable-latest` drift): an Operator pod
+  restart never silently changes the operator version. Upgrades happen only
+  when the chart content changes — that is, when you upgrade Meshery Server.
+
+**CRDs persist.** The `brokers.meshery.io` and `meshsyncs.meshery.io` CRDs
+(and your `Broker`/`MeshSync` objects) deliberately survive operator
+uninstalls and Helm release deletion. Removing them — and with them every
+custom resource of those types — is an explicit, manual step:
+`kubectl delete crd brokers.meshery.io meshsyncs.meshery.io`.
+
+You can toggle operator deployment per cluster in Meshery UI under
+**Settings**, or avoid deploying the operator entirely by choosing MeshSync's
+[embedded mode]({{< ref "concepts/architecture/meshsync.md#meshsync-deployment-mode" >}})
+for the connection. See
+[Meshery Operator]({{< ref "concepts/architecture/operator/index.md" >}}) for
+the architecture.
+
 ### Meshery Docker Deployments
 
 In order to pull the latest images for Meshery Server, Adapters, and UI, execute the following command:
@@ -97,7 +151,17 @@ If you wish to update a running Meshery deployment with the images you just pull
 
 ### Meshery Kubernetes Deployments
 
-Use `kubectl apply` or `helm` to upgrade the Meshery application manifests in your Kubernetes cluster.
+Upgrade with Helm, pinning an explicit chart version and using the
+upgrade-friendly probe values:
+
+ <pre class="codeblock-pre"><div class="codeblock">
+ <div class="clipboardjs">helm upgrade meshery meshery/meshery --namespace meshery --version &lt;target-version&gt; -f values-upgrade.yaml --wait</div></div>
+ </pre>
+
+The [Upgrading Meshery guide]({{< ref "guides/upgrading-meshery/index.md" >}})
+covers the full procedure, verification steps, and rollback; the
+[Operational Readiness Checklist]({{< ref "installation/production/operational-readiness-checklist.md" >}})
+covers production upgrade strategy.
 
 ## Upgrading Meshery CLI
 

--- a/docs/content/en/installation/upgrades/index.md
+++ b/docs/content/en/installation/upgrades/index.md
@@ -109,8 +109,7 @@ Operator Deployment to the operator image pinned in the chart. The Operator
 then reconciles MeshSync and the Broker.
 
 **Reconciliation.** The Server periodically re-applies the operator chart if
-the Operator is missing or unhealthy (`UpgradeIfInstalled`). Two practical
-consequences:
+the Operator is missing or unhealthy. Two practical consequences:
 
 - **Manual operator changes are temporary.** A hand-run
   `helm upgrade meshery-operator --version <x>` or an edited image tag on a


### PR DESCRIPTION
## What

User-facing documentation for how Meshery Operator installations and upgrades actually work, plus the missing common-task guide for upgrading Meshery.

| Page | Change |
|---|---|
| **`guides/upgrading-meshery`** (new) | Step-by-step upgrade guide: CLI → Server (Docker + Helm paths, pinned versions, `values-upgrade.yaml`) → managed-cluster components (automatic), verification commands, rollback notes. |
| `installation/upgrades` | New **"How Meshery Server manages Meshery Operator"** section: chart version follows the Server release; upgrades flow through the Server; the chart's CRD update Job refreshes CRD schemas on upgrade (Helm alone never does); manual operator changes on Server-managed clusters are reverted by reconciliation; operator images are pinned per release (no `stable-latest` drift); CRDs deliberately survive uninstall. Kubernetes upgrade one-liner replaced with pinned-version Helm guidance. |
| `installation/production/operational-readiness-checklist` | Upgrade-strategy best practices: *Let the Server own the Operator*, *Expect CRDs to persist*, corrected component-grouping note (Operator moves **with** the Server), rollback convergence note. |
| `concepts/architecture/operator` | Corrected framework claim (Kubebuilder `go/v4`; operator-sdk only for the OLM bundle), added CRD/API-version + reconciliation model (SSA, watches, conditions), Server-managed install/upgrade section, **current** endpoint-derivation order (`externalEndpointOverride` → LB hostname → LB IP → NodePort → ClusterIP; derived purely from the Service, no network probing — replaces the stale meshkit `GetEndpoint` reference), CRD-persistence FAQ, Common tasks. |
| `concepts/architecture/broker` | NATS-backed topology (official chart structure, headless + client Services), token-secured access, **declarative + live-reconfigurable service networking** with `Broker` spec examples and `kubectl patch` tasks, endpoint status, refreshed FAQs (scaling via `spec.size`, JetStream note, no more "requires LoadBalancer/NodePort" claim — ClusterIP is the default). |
| `concepts/architecture/meshsync` | New **Broker connection** section (`BROKER_URL` injection from Broker status, `nats://` scheme, auto-reconnect on endpoint change, `spec.broker.custom.url` for external NATS), **corrected watch-list FAQ** — the old text said to edit `informer_config` on the CRD; the real mechanism is the `MeshSync` custom resource's `spec.watch-list` `whitelist`/`blacklist` JSON strings (verified against meshsync's `internal/config/crd_config.go`), Common tasks. |

## Accuracy notes

Behavior descriptions were verified against the current meshery-operator `master` (v1.0.0) and meshsync source — not written from memory. The Server-managed lifecycle sections describe the behavior that lands with meshery#20410 (CRD update Job, pinned operator image); **merge that PR before or with this one**.

## Verification

Hugo build passes cleanly (`hugo` exit 0; all refs resolve). Rendered output spot-checked: the new guide page renders, and each updated page contains its new sections. (Local build note: requires dart-sass; a stray ruby-sass shim on PATH produces the same `TOCSS-DART ... unexpected EOF` error the Docsy theme is known for.)
