### PR TITLE
chore(ui): add date-fns dependency for @mui/x-date-pickers' AdapterDateFns

### DIFF
--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -62,6 +62,7 @@
         "cytoscape-fcose": "^2.2.0",
         "cytoscape-layers": "^3.1.0",
         "cytoscape-popper": "^4.0.1",
+        "date-fns": "^4.4.0",
         "dockview": "^7.0.2",
         "emoji-picker-react": "^4.19.1",
         "graphql": "^17.0.1",
@@ -3339,9 +3340,9 @@
       }
     },
     "node_modules/@sistent/sistent": {
-      "version": "0.21.26",
-      "resolved": "https://registry.npmjs.org/@sistent/sistent/-/sistent-0.21.26.tgz",
-      "integrity": "sha512-GRE91gfDSxibd6CoGeLqnCGfzS1bonWazGiiRu3DoIPvmqSgwsNO8CgSL8CUzebPgsahVNNRKtgJwEYI+XVF+Q==",
+      "version": "0.21.29",
+      "resolved": "https://registry.npmjs.org/@sistent/sistent/-/sistent-0.21.29.tgz",
+      "integrity": "sha512-pd90nmtY6soHR/qg6bLwVzU+bTh5nTn+JZX6EIRsjqUx26pxElj4bKO0gSP2UoEMpbDHnKYeKl9xfHZn+71AXQ==",
       "dependencies": {
         "@emotion/react": "^11.14.0",
         "@emotion/styled": "^11.14.1",
@@ -7433,6 +7434,16 @@
       "resolved": "https://registry.npmjs.org/date-arithmetic/-/date-arithmetic-4.1.0.tgz",
       "integrity": "sha512-QWxYLR5P/6GStZcdem+V1xoto6DMadYWpMXU82ES3/RfR3Wdwr3D0+be7mgOJ+Ov0G9D5Dmb9T17sNLQYj9XOg==",
       "license": "MIT"
+    },
+    "node_modules/date-fns": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-4.4.0.tgz",
+      "integrity": "sha512-+1UMbeh68lH1SegH83CGWwpb6OHHbpSgr3+s5Eww5M4CAgswBpoWS0AjTOfEJ33HiYKz1hdj/KTFprzXHmq/6w==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/kossnocorp"
+      }
     },
     "node_modules/dayjs": {
       "version": "1.11.21",

--- a/ui/package.json
+++ b/ui/package.json
@@ -90,6 +90,7 @@
     "cytoscape-fcose": "^2.2.0",
     "cytoscape-layers": "^3.1.0",
     "cytoscape-popper": "^4.0.1",
+    "date-fns": "^4.4.0",
     "dockview": "^7.0.2",
     "emoji-picker-react": "^4.19.1",
     "graphql": "^17.0.1",


### PR DESCRIPTION
## Summary
- Sistent's `UniversalFilter` component now ships an optional date-range picker feature (layer5io/sistent#1683) built on `@mui/x-date-pickers`' `AdapterDateFns`.
- Sistent externalizes its peer dependencies (they stay as plain `require()` calls rather than getting bundled), so any consumer resolving `@sistent/sistent`'s published dist needs `date-fns` installed to satisfy `AdapterDateFns`'s internal imports — even though Meshery UI's own date pickers use `AdapterMoment`, not `date-fns`.
- Without this, `next build` fails with `Module not found: Can't resolve 'date-fns/addDays'` (this is what broke the "Integration Test with Meshery UI" check on the Sistent PR).
- Verified locally: packed the Sistent branch with the date-range feature, installed it here, and confirmed `npm run build` succeeds with this change (and fails without it).

## Test plan
- [x] `npm install` in `ui/` succeeds
- [x] `npm run build` in `ui/` succeeds against a locally-packed Sistent build containing the new `UniversalFilter` date-range feature