### PR TITLE
feat(model): add AWS observability & misc relationship definitions

### DIFF
--- a/models/aws-apigatewayv2-controller/v1.3.2/v1.0.0/relationships/edge-binding-network-udxey.json
+++ b/models/aws-apigatewayv2-controller/v1.3.2/v1.0.0/relationships/edge-binding-network-udxey.json
@@ -46,14 +46,14 @@
               "version": ""
             },
             "patch": {
-              "mutatedRef": [
+              "patchStrategy": "replace",
+              "mutatorRef": [
                 [
                   "configuration",
                   "status",
                   "vpcLinkID"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ],
@@ -76,14 +76,14 @@
               "version": ""
             },
             "patch": {
-              "mutatorRef": [
+              "patchStrategy": "replace",
+              "mutatedRef": [
                 [
                   "configuration",
                   "spec",
                   "vpcLinkID"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ]

--- a/models/aws-apigatewayv2-controller/v1.3.2/v1.0.0/relationships/hierarchical-parent-inventory-figxk.json
+++ b/models/aws-apigatewayv2-controller/v1.3.2/v1.0.0/relationships/hierarchical-parent-inventory-figxk.json
@@ -46,12 +46,12 @@
               "version": ""
             },
             "patch": {
-              "mutatedRef": [
+              "patchStrategy": "replace",
+              "mutatorRef": [
                 [
                   "displayName"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ],
@@ -74,14 +74,14 @@
               "version": ""
             },
             "patch": {
-              "mutatorRef": [
+              "patchStrategy": "replace",
+              "mutatedRef": [
                 [
                   "configuration",
                   "spec",
                   "apiID"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ]

--- a/models/aws-apigatewayv2-controller/v1.3.2/v1.0.0/relationships/hierarchical-parent-inventory-khlfj.json
+++ b/models/aws-apigatewayv2-controller/v1.3.2/v1.0.0/relationships/hierarchical-parent-inventory-khlfj.json
@@ -75,12 +75,12 @@
               "version": ""
             },
             "patch": {
-              "mutatedRef": [
+              "patchStrategy": "replace",
+              "mutatorRef": [
                 [
                   "displayName"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ],
@@ -132,14 +132,14 @@
               "version": ""
             },
             "patch": {
-              "mutatorRef": [
+              "patchStrategy": "replace",
+              "mutatedRef": [
                 [
                   "configuration",
                   "spec",
                   "apiID"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ]

--- a/models/aws-apigatewayv2-controller/v1.3.3/v1.0.0/relationships/edge-binding-network-udxey.json
+++ b/models/aws-apigatewayv2-controller/v1.3.3/v1.0.0/relationships/edge-binding-network-udxey.json
@@ -46,14 +46,14 @@
               "version": ""
             },
             "patch": {
-              "mutatedRef": [
+              "patchStrategy": "replace",
+              "mutatorRef": [
                 [
                   "configuration",
                   "status",
                   "vpcLinkID"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ],
@@ -76,14 +76,14 @@
               "version": ""
             },
             "patch": {
-              "mutatorRef": [
+              "patchStrategy": "replace",
+              "mutatedRef": [
                 [
                   "configuration",
                   "spec",
                   "vpcLinkID"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ]

--- a/models/aws-apigatewayv2-controller/v1.3.3/v1.0.0/relationships/hierarchical-parent-inventory-figxk.json
+++ b/models/aws-apigatewayv2-controller/v1.3.3/v1.0.0/relationships/hierarchical-parent-inventory-figxk.json
@@ -46,12 +46,12 @@
               "version": ""
             },
             "patch": {
-              "mutatedRef": [
+              "patchStrategy": "replace",
+              "mutatorRef": [
                 [
                   "displayName"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ],
@@ -74,14 +74,14 @@
               "version": ""
             },
             "patch": {
-              "mutatorRef": [
+              "patchStrategy": "replace",
+              "mutatedRef": [
                 [
                   "configuration",
                   "spec",
                   "apiID"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ]

--- a/models/aws-apigatewayv2-controller/v1.3.3/v1.0.0/relationships/hierarchical-parent-inventory-khlfj.json
+++ b/models/aws-apigatewayv2-controller/v1.3.3/v1.0.0/relationships/hierarchical-parent-inventory-khlfj.json
@@ -75,12 +75,12 @@
               "version": ""
             },
             "patch": {
-              "mutatedRef": [
+              "patchStrategy": "replace",
+              "mutatorRef": [
                 [
                   "displayName"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ],
@@ -132,14 +132,14 @@
               "version": ""
             },
             "patch": {
-              "mutatorRef": [
+              "patchStrategy": "replace",
+              "mutatedRef": [
                 [
                   "configuration",
                   "spec",
                   "apiID"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ]

--- a/models/aws-cloudwatchlogs-controller/v1.0.10/v1.0.0/relationships/edge-binding-reference-dzadz.json
+++ b/models/aws-cloudwatchlogs-controller/v1.0.10/v1.0.0/relationships/edge-binding-reference-dzadz.json
@@ -46,12 +46,12 @@
               "version": ""
             },
             "patch": {
-              "mutatedRef": [
+              "patchStrategy": "replace",
+              "mutatorRef": [
                 [
                   "displayName"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ],
@@ -74,15 +74,15 @@
               "version": ""
             },
             "patch": {
-              "mutatorRef": [
+              "patchStrategy": "replace",
+              "mutatedRef": [
                 [
                   "configuration",
                   "spec",
                   "loggingConfig",
                   "logGroup"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ]

--- a/models/aws-cloudwatchlogs-controller/v1.0.10/v1.0.0/relationships/edge-non-binding-reference-wjvtp.json
+++ b/models/aws-cloudwatchlogs-controller/v1.0.10/v1.0.0/relationships/edge-non-binding-reference-wjvtp.json
@@ -46,12 +46,12 @@
               "version": ""
             },
             "patch": {
-              "mutatedRef": [
+              "patchStrategy": "replace",
+              "mutatorRef": [
                 [
                   "displayName"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ],
@@ -74,14 +74,14 @@
               "version": ""
             },
             "patch": {
-              "mutatorRef": [
+              "patchStrategy": "replace",
+              "mutatedRef": [
                 [
                   "configuration",
                   "spec",
                   "userData"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ]

--- a/models/aws-cloudwatchlogs-controller/v1.0.10/v1.0.0/relationships/hierarchical-parent-inventory-kmjea.json
+++ b/models/aws-cloudwatchlogs-controller/v1.0.10/v1.0.0/relationships/hierarchical-parent-inventory-kmjea.json
@@ -91,7 +91,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatedRef": [
+              "mutatorRef": [
                 [
                   "displayName"
                 ]
@@ -141,7 +141,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "spec",

--- a/models/aws-cloudwatchlogs-controller/v1.0.11/v1.0.0/relationships/edge-binding-reference-dzadz.json
+++ b/models/aws-cloudwatchlogs-controller/v1.0.11/v1.0.0/relationships/edge-binding-reference-dzadz.json
@@ -46,12 +46,12 @@
               "version": ""
             },
             "patch": {
-              "mutatedRef": [
+              "patchStrategy": "replace",
+              "mutatorRef": [
                 [
                   "displayName"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ],
@@ -74,15 +74,15 @@
               "version": ""
             },
             "patch": {
-              "mutatorRef": [
+              "patchStrategy": "replace",
+              "mutatedRef": [
                 [
                   "configuration",
                   "spec",
                   "loggingConfig",
                   "logGroup"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ]

--- a/models/aws-cloudwatchlogs-controller/v1.0.11/v1.0.0/relationships/edge-non-binding-reference-wjvtp.json
+++ b/models/aws-cloudwatchlogs-controller/v1.0.11/v1.0.0/relationships/edge-non-binding-reference-wjvtp.json
@@ -46,12 +46,12 @@
               "version": ""
             },
             "patch": {
-              "mutatedRef": [
+              "patchStrategy": "replace",
+              "mutatorRef": [
                 [
                   "displayName"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ],
@@ -74,14 +74,14 @@
               "version": ""
             },
             "patch": {
-              "mutatorRef": [
+              "patchStrategy": "replace",
+              "mutatedRef": [
                 [
                   "configuration",
                   "spec",
                   "userData"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ]

--- a/models/aws-cloudwatchlogs-controller/v1.0.11/v1.0.0/relationships/hierarchical-parent-inventory-kmjea.json
+++ b/models/aws-cloudwatchlogs-controller/v1.0.11/v1.0.0/relationships/hierarchical-parent-inventory-kmjea.json
@@ -91,7 +91,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatedRef": [
+              "mutatorRef": [
                 [
                   "displayName"
                 ]
@@ -141,7 +141,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "spec",

--- a/models/aws-cloudwatchlogs-controller/v1.0.12/v1.0.0/relationships/edge-binding-reference-dzadz.json
+++ b/models/aws-cloudwatchlogs-controller/v1.0.12/v1.0.0/relationships/edge-binding-reference-dzadz.json
@@ -46,12 +46,12 @@
               "version": ""
             },
             "patch": {
-              "mutatedRef": [
+              "patchStrategy": "replace",
+              "mutatorRef": [
                 [
                   "displayName"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ],
@@ -74,15 +74,15 @@
               "version": ""
             },
             "patch": {
-              "mutatorRef": [
+              "patchStrategy": "replace",
+              "mutatedRef": [
                 [
                   "configuration",
                   "spec",
                   "loggingConfig",
                   "logGroup"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ]

--- a/models/aws-cloudwatchlogs-controller/v1.0.12/v1.0.0/relationships/edge-non-binding-reference-wjvtp.json
+++ b/models/aws-cloudwatchlogs-controller/v1.0.12/v1.0.0/relationships/edge-non-binding-reference-wjvtp.json
@@ -46,12 +46,12 @@
               "version": ""
             },
             "patch": {
-              "mutatedRef": [
+              "patchStrategy": "replace",
+              "mutatorRef": [
                 [
                   "displayName"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ],
@@ -74,14 +74,14 @@
               "version": ""
             },
             "patch": {
-              "mutatorRef": [
+              "patchStrategy": "replace",
+              "mutatedRef": [
                 [
                   "configuration",
                   "spec",
                   "userData"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ]

--- a/models/aws-cloudwatchlogs-controller/v1.0.12/v1.0.0/relationships/hierarchical-parent-inventory-kmjea.json
+++ b/models/aws-cloudwatchlogs-controller/v1.0.12/v1.0.0/relationships/hierarchical-parent-inventory-kmjea.json
@@ -91,7 +91,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatedRef": [
+              "mutatorRef": [
                 [
                   "displayName"
                 ]
@@ -141,7 +141,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "spec",

--- a/models/aws-cloudwatchlogs-controller/v1.0.13/v1.0.0/relationships/edge-binding-reference-dzadz.json
+++ b/models/aws-cloudwatchlogs-controller/v1.0.13/v1.0.0/relationships/edge-binding-reference-dzadz.json
@@ -46,12 +46,12 @@
               "version": ""
             },
             "patch": {
-              "mutatedRef": [
+              "patchStrategy": "replace",
+              "mutatorRef": [
                 [
                   "displayName"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ],
@@ -74,15 +74,15 @@
               "version": ""
             },
             "patch": {
-              "mutatorRef": [
+              "patchStrategy": "replace",
+              "mutatedRef": [
                 [
                   "configuration",
                   "spec",
                   "loggingConfig",
                   "logGroup"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ]

--- a/models/aws-cloudwatchlogs-controller/v1.0.13/v1.0.0/relationships/edge-non-binding-reference-wjvtp.json
+++ b/models/aws-cloudwatchlogs-controller/v1.0.13/v1.0.0/relationships/edge-non-binding-reference-wjvtp.json
@@ -46,12 +46,12 @@
               "version": ""
             },
             "patch": {
-              "mutatedRef": [
+              "patchStrategy": "replace",
+              "mutatorRef": [
                 [
                   "displayName"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ],
@@ -74,14 +74,14 @@
               "version": ""
             },
             "patch": {
-              "mutatorRef": [
+              "patchStrategy": "replace",
+              "mutatedRef": [
                 [
                   "configuration",
                   "spec",
                   "userData"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ]

--- a/models/aws-cloudwatchlogs-controller/v1.0.13/v1.0.0/relationships/hierarchical-parent-inventory-kmjea.json
+++ b/models/aws-cloudwatchlogs-controller/v1.0.13/v1.0.0/relationships/hierarchical-parent-inventory-kmjea.json
@@ -91,7 +91,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatedRef": [
+              "mutatorRef": [
                 [
                   "displayName"
                 ]
@@ -141,7 +141,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "spec",

--- a/models/aws-cloudwatchlogs-controller/v1.0.14/v1.0.0/relationships/edge-binding-reference-dzadz.json
+++ b/models/aws-cloudwatchlogs-controller/v1.0.14/v1.0.0/relationships/edge-binding-reference-dzadz.json
@@ -46,12 +46,12 @@
               "version": ""
             },
             "patch": {
-              "mutatedRef": [
+              "patchStrategy": "replace",
+              "mutatorRef": [
                 [
                   "displayName"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ],
@@ -74,15 +74,15 @@
               "version": ""
             },
             "patch": {
-              "mutatorRef": [
+              "patchStrategy": "replace",
+              "mutatedRef": [
                 [
                   "configuration",
                   "spec",
                   "loggingConfig",
                   "logGroup"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ]

--- a/models/aws-cloudwatchlogs-controller/v1.0.14/v1.0.0/relationships/edge-non-binding-reference-wjvtp.json
+++ b/models/aws-cloudwatchlogs-controller/v1.0.14/v1.0.0/relationships/edge-non-binding-reference-wjvtp.json
@@ -46,12 +46,12 @@
               "version": ""
             },
             "patch": {
-              "mutatedRef": [
+              "patchStrategy": "replace",
+              "mutatorRef": [
                 [
                   "displayName"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ],
@@ -74,14 +74,14 @@
               "version": ""
             },
             "patch": {
-              "mutatorRef": [
+              "patchStrategy": "replace",
+              "mutatedRef": [
                 [
                   "configuration",
                   "spec",
                   "userData"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ]

--- a/models/aws-cloudwatchlogs-controller/v1.0.14/v1.0.0/relationships/hierarchical-parent-inventory-kmjea.json
+++ b/models/aws-cloudwatchlogs-controller/v1.0.14/v1.0.0/relationships/hierarchical-parent-inventory-kmjea.json
@@ -91,7 +91,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatedRef": [
+              "mutatorRef": [
                 [
                   "displayName"
                 ]
@@ -141,7 +141,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "spec",

--- a/models/aws-cloudwatchlogs-controller/v1.0.9/v1.0.0/relationships/edge-binding-reference-dzadz.json
+++ b/models/aws-cloudwatchlogs-controller/v1.0.9/v1.0.0/relationships/edge-binding-reference-dzadz.json
@@ -46,12 +46,12 @@
               "version": ""
             },
             "patch": {
-              "mutatedRef": [
+              "patchStrategy": "replace",
+              "mutatorRef": [
                 [
                   "displayName"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ],
@@ -74,15 +74,15 @@
               "version": ""
             },
             "patch": {
-              "mutatorRef": [
+              "patchStrategy": "replace",
+              "mutatedRef": [
                 [
                   "configuration",
                   "spec",
                   "loggingConfig",
                   "logGroup"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ]

--- a/models/aws-cloudwatchlogs-controller/v1.0.9/v1.0.0/relationships/edge-non-binding-reference-wjvtp.json
+++ b/models/aws-cloudwatchlogs-controller/v1.0.9/v1.0.0/relationships/edge-non-binding-reference-wjvtp.json
@@ -46,12 +46,12 @@
               "version": ""
             },
             "patch": {
-              "mutatedRef": [
+              "patchStrategy": "replace",
+              "mutatorRef": [
                 [
                   "displayName"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ],
@@ -74,14 +74,14 @@
               "version": ""
             },
             "patch": {
-              "mutatorRef": [
+              "patchStrategy": "replace",
+              "mutatedRef": [
                 [
                   "configuration",
                   "spec",
                   "userData"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ]

--- a/models/aws-cloudwatchlogs-controller/v1.0.9/v1.0.0/relationships/hierarchical-parent-inventory-kmjea.json
+++ b/models/aws-cloudwatchlogs-controller/v1.0.9/v1.0.0/relationships/hierarchical-parent-inventory-kmjea.json
@@ -91,7 +91,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatedRef": [
+              "mutatorRef": [
                 [
                   "displayName"
                 ]
@@ -141,7 +141,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "spec",

--- a/models/aws-cloudwatchlogs-controller/v1.1.0/v1.0.0/relationships/edge-binding-reference-dzadz.json
+++ b/models/aws-cloudwatchlogs-controller/v1.1.0/v1.0.0/relationships/edge-binding-reference-dzadz.json
@@ -46,12 +46,12 @@
               "version": ""
             },
             "patch": {
-              "mutatedRef": [
+              "patchStrategy": "replace",
+              "mutatorRef": [
                 [
                   "displayName"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ],
@@ -74,15 +74,15 @@
               "version": ""
             },
             "patch": {
-              "mutatorRef": [
+              "patchStrategy": "replace",
+              "mutatedRef": [
                 [
                   "configuration",
                   "spec",
                   "loggingConfig",
                   "logGroup"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ]

--- a/models/aws-cloudwatchlogs-controller/v1.1.0/v1.0.0/relationships/edge-non-binding-reference-wjvtp.json
+++ b/models/aws-cloudwatchlogs-controller/v1.1.0/v1.0.0/relationships/edge-non-binding-reference-wjvtp.json
@@ -46,12 +46,12 @@
               "version": ""
             },
             "patch": {
-              "mutatedRef": [
+              "patchStrategy": "replace",
+              "mutatorRef": [
                 [
                   "displayName"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ],
@@ -74,14 +74,14 @@
               "version": ""
             },
             "patch": {
-              "mutatorRef": [
+              "patchStrategy": "replace",
+              "mutatedRef": [
                 [
                   "configuration",
                   "spec",
                   "userData"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ]

--- a/models/aws-cloudwatchlogs-controller/v1.1.0/v1.0.0/relationships/hierarchical-parent-inventory-kmjea.json
+++ b/models/aws-cloudwatchlogs-controller/v1.1.0/v1.0.0/relationships/hierarchical-parent-inventory-kmjea.json
@@ -91,7 +91,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatedRef": [
+              "mutatorRef": [
                 [
                   "displayName"
                 ]
@@ -141,7 +141,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "spec",

--- a/models/aws-cloudwatchlogs-controller/v1.1.1/v1.0.0/relationships/edge-binding-reference-dzadz.json
+++ b/models/aws-cloudwatchlogs-controller/v1.1.1/v1.0.0/relationships/edge-binding-reference-dzadz.json
@@ -46,12 +46,12 @@
               "version": ""
             },
             "patch": {
-              "mutatedRef": [
+              "patchStrategy": "replace",
+              "mutatorRef": [
                 [
                   "displayName"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ],
@@ -74,15 +74,15 @@
               "version": ""
             },
             "patch": {
-              "mutatorRef": [
+              "patchStrategy": "replace",
+              "mutatedRef": [
                 [
                   "configuration",
                   "spec",
                   "loggingConfig",
                   "logGroup"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ]

--- a/models/aws-cloudwatchlogs-controller/v1.1.1/v1.0.0/relationships/edge-non-binding-reference-wjvtp.json
+++ b/models/aws-cloudwatchlogs-controller/v1.1.1/v1.0.0/relationships/edge-non-binding-reference-wjvtp.json
@@ -46,12 +46,12 @@
               "version": ""
             },
             "patch": {
-              "mutatedRef": [
+              "patchStrategy": "replace",
+              "mutatorRef": [
                 [
                   "displayName"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ],
@@ -74,14 +74,14 @@
               "version": ""
             },
             "patch": {
-              "mutatorRef": [
+              "patchStrategy": "replace",
+              "mutatedRef": [
                 [
                   "configuration",
                   "spec",
                   "userData"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ]

--- a/models/aws-cloudwatchlogs-controller/v1.1.1/v1.0.0/relationships/hierarchical-parent-inventory-kmjea.json
+++ b/models/aws-cloudwatchlogs-controller/v1.1.1/v1.0.0/relationships/hierarchical-parent-inventory-kmjea.json
@@ -91,7 +91,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatedRef": [
+              "mutatorRef": [
                 [
                   "displayName"
                 ]
@@ -141,7 +141,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "spec",

--- a/models/aws-cloudwatchlogs-controller/v1.1.2/v1.0.0/relationships/edge-binding-reference-dzadz.json
+++ b/models/aws-cloudwatchlogs-controller/v1.1.2/v1.0.0/relationships/edge-binding-reference-dzadz.json
@@ -46,12 +46,12 @@
               "version": ""
             },
             "patch": {
-              "mutatedRef": [
+              "patchStrategy": "replace",
+              "mutatorRef": [
                 [
                   "displayName"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ],
@@ -74,15 +74,15 @@
               "version": ""
             },
             "patch": {
-              "mutatorRef": [
+              "patchStrategy": "replace",
+              "mutatedRef": [
                 [
                   "configuration",
                   "spec",
                   "loggingConfig",
                   "logGroup"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ]

--- a/models/aws-cloudwatchlogs-controller/v1.1.2/v1.0.0/relationships/edge-non-binding-reference-wjvtp.json
+++ b/models/aws-cloudwatchlogs-controller/v1.1.2/v1.0.0/relationships/edge-non-binding-reference-wjvtp.json
@@ -46,12 +46,12 @@
               "version": ""
             },
             "patch": {
-              "mutatedRef": [
+              "patchStrategy": "replace",
+              "mutatorRef": [
                 [
                   "displayName"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ],
@@ -74,14 +74,14 @@
               "version": ""
             },
             "patch": {
-              "mutatorRef": [
+              "patchStrategy": "replace",
+              "mutatedRef": [
                 [
                   "configuration",
                   "spec",
                   "userData"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ]

--- a/models/aws-cloudwatchlogs-controller/v1.2.0/v1.0.0/relationships/edge-binding-reference-dzadz.json
+++ b/models/aws-cloudwatchlogs-controller/v1.2.0/v1.0.0/relationships/edge-binding-reference-dzadz.json
@@ -46,12 +46,12 @@
               "version": ""
             },
             "patch": {
-              "mutatedRef": [
+              "patchStrategy": "replace",
+              "mutatorRef": [
                 [
                   "displayName"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ],
@@ -74,15 +74,15 @@
               "version": ""
             },
             "patch": {
-              "mutatorRef": [
+              "patchStrategy": "replace",
+              "mutatedRef": [
                 [
                   "configuration",
                   "spec",
                   "loggingConfig",
                   "logGroup"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ]

--- a/models/aws-cloudwatchlogs-controller/v1.2.0/v1.0.0/relationships/edge-non-binding-reference-wjvtp.json
+++ b/models/aws-cloudwatchlogs-controller/v1.2.0/v1.0.0/relationships/edge-non-binding-reference-wjvtp.json
@@ -46,12 +46,12 @@
               "version": ""
             },
             "patch": {
-              "mutatedRef": [
+              "patchStrategy": "replace",
+              "mutatorRef": [
                 [
                   "displayName"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ],
@@ -74,14 +74,14 @@
               "version": ""
             },
             "patch": {
-              "mutatorRef": [
+              "patchStrategy": "replace",
+              "mutatedRef": [
                 [
                   "configuration",
                   "spec",
                   "userData"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ]

--- a/models/aws-cloudwatchlogs-controller/v1.2.1/v1.0.0/relationships/edge-binding-reference-dzadz.json
+++ b/models/aws-cloudwatchlogs-controller/v1.2.1/v1.0.0/relationships/edge-binding-reference-dzadz.json
@@ -46,12 +46,12 @@
               "version": ""
             },
             "patch": {
-              "mutatedRef": [
+              "patchStrategy": "replace",
+              "mutatorRef": [
                 [
                   "displayName"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ],
@@ -74,15 +74,15 @@
               "version": ""
             },
             "patch": {
-              "mutatorRef": [
+              "patchStrategy": "replace",
+              "mutatedRef": [
                 [
                   "configuration",
                   "spec",
                   "loggingConfig",
                   "logGroup"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ]

--- a/models/aws-cloudwatchlogs-controller/v1.2.1/v1.0.0/relationships/edge-non-binding-reference-wjvtp.json
+++ b/models/aws-cloudwatchlogs-controller/v1.2.1/v1.0.0/relationships/edge-non-binding-reference-wjvtp.json
@@ -46,12 +46,12 @@
               "version": ""
             },
             "patch": {
-              "mutatedRef": [
+              "patchStrategy": "replace",
+              "mutatorRef": [
                 [
                   "displayName"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ],
@@ -74,14 +74,14 @@
               "version": ""
             },
             "patch": {
-              "mutatorRef": [
+              "patchStrategy": "replace",
+              "mutatedRef": [
                 [
                   "configuration",
                   "spec",
                   "userData"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ]

--- a/models/aws-cloudwatchlogs-controller/v1.2.2/v1.0.0/relationships/edge-binding-reference-dzadz.json
+++ b/models/aws-cloudwatchlogs-controller/v1.2.2/v1.0.0/relationships/edge-binding-reference-dzadz.json
@@ -46,12 +46,12 @@
               "version": ""
             },
             "patch": {
-              "mutatedRef": [
+              "patchStrategy": "replace",
+              "mutatorRef": [
                 [
                   "displayName"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ],
@@ -74,15 +74,15 @@
               "version": ""
             },
             "patch": {
-              "mutatorRef": [
+              "patchStrategy": "replace",
+              "mutatedRef": [
                 [
                   "configuration",
                   "spec",
                   "loggingConfig",
                   "logGroup"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ]

--- a/models/aws-cloudwatchlogs-controller/v1.2.2/v1.0.0/relationships/edge-non-binding-reference-wjvtp.json
+++ b/models/aws-cloudwatchlogs-controller/v1.2.2/v1.0.0/relationships/edge-non-binding-reference-wjvtp.json
@@ -46,12 +46,12 @@
               "version": ""
             },
             "patch": {
-              "mutatedRef": [
+              "patchStrategy": "replace",
+              "mutatorRef": [
                 [
                   "displayName"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ],
@@ -74,14 +74,14 @@
               "version": ""
             },
             "patch": {
-              "mutatorRef": [
+              "patchStrategy": "replace",
+              "mutatedRef": [
                 [
                   "configuration",
                   "spec",
                   "userData"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ]

--- a/models/aws-cloudwatchlogs-controller/v1.2.3/v1.0.0/relationships/edge-binding-reference-dzadz.json
+++ b/models/aws-cloudwatchlogs-controller/v1.2.3/v1.0.0/relationships/edge-binding-reference-dzadz.json
@@ -46,12 +46,12 @@
               "version": ""
             },
             "patch": {
-              "mutatedRef": [
+              "patchStrategy": "replace",
+              "mutatorRef": [
                 [
                   "displayName"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ],
@@ -74,15 +74,15 @@
               "version": ""
             },
             "patch": {
-              "mutatorRef": [
+              "patchStrategy": "replace",
+              "mutatedRef": [
                 [
                   "configuration",
                   "spec",
                   "loggingConfig",
                   "logGroup"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ]

--- a/models/aws-cloudwatchlogs-controller/v1.2.3/v1.0.0/relationships/edge-non-binding-reference-wjvtp.json
+++ b/models/aws-cloudwatchlogs-controller/v1.2.3/v1.0.0/relationships/edge-non-binding-reference-wjvtp.json
@@ -46,12 +46,12 @@
               "version": ""
             },
             "patch": {
-              "mutatedRef": [
+              "patchStrategy": "replace",
+              "mutatorRef": [
                 [
                   "displayName"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ],
@@ -74,14 +74,14 @@
               "version": ""
             },
             "patch": {
-              "mutatorRef": [
+              "patchStrategy": "replace",
+              "mutatedRef": [
                 [
                   "configuration",
                   "spec",
                   "userData"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ]

--- a/models/aws-cloudwatchlogs-controller/v1.2.4/v1.0.0/relationships/edge-binding-reference-dzadz.json
+++ b/models/aws-cloudwatchlogs-controller/v1.2.4/v1.0.0/relationships/edge-binding-reference-dzadz.json
@@ -46,12 +46,12 @@
               "version": ""
             },
             "patch": {
-              "mutatedRef": [
+              "patchStrategy": "replace",
+              "mutatorRef": [
                 [
                   "displayName"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ],
@@ -74,15 +74,15 @@
               "version": ""
             },
             "patch": {
-              "mutatorRef": [
+              "patchStrategy": "replace",
+              "mutatedRef": [
                 [
                   "configuration",
                   "spec",
                   "loggingConfig",
                   "logGroup"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ]

--- a/models/aws-cloudwatchlogs-controller/v1.2.4/v1.0.0/relationships/edge-non-binding-reference-wjvtp.json
+++ b/models/aws-cloudwatchlogs-controller/v1.2.4/v1.0.0/relationships/edge-non-binding-reference-wjvtp.json
@@ -46,12 +46,12 @@
               "version": ""
             },
             "patch": {
-              "mutatedRef": [
+              "patchStrategy": "replace",
+              "mutatorRef": [
                 [
                   "displayName"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ],
@@ -74,14 +74,14 @@
               "version": ""
             },
             "patch": {
-              "mutatorRef": [
+              "patchStrategy": "replace",
+              "mutatedRef": [
                 [
                   "configuration",
                   "spec",
                   "userData"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ]

--- a/models/aws-cloudwatchlogs-controller/v1.3.0/v1.0.0/relationships/edge-binding-reference-dzadz.json
+++ b/models/aws-cloudwatchlogs-controller/v1.3.0/v1.0.0/relationships/edge-binding-reference-dzadz.json
@@ -46,12 +46,12 @@
               "version": ""
             },
             "patch": {
-              "mutatedRef": [
+              "patchStrategy": "replace",
+              "mutatorRef": [
                 [
                   "displayName"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ],
@@ -74,15 +74,15 @@
               "version": ""
             },
             "patch": {
-              "mutatorRef": [
+              "patchStrategy": "replace",
+              "mutatedRef": [
                 [
                   "configuration",
                   "spec",
                   "loggingConfig",
                   "logGroup"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ]

--- a/models/aws-cloudwatchlogs-controller/v1.3.0/v1.0.0/relationships/edge-non-binding-reference-wjvtp.json
+++ b/models/aws-cloudwatchlogs-controller/v1.3.0/v1.0.0/relationships/edge-non-binding-reference-wjvtp.json
@@ -46,12 +46,12 @@
               "version": ""
             },
             "patch": {
-              "mutatedRef": [
+              "patchStrategy": "replace",
+              "mutatorRef": [
                 [
                   "displayName"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ],
@@ -74,14 +74,14 @@
               "version": ""
             },
             "patch": {
-              "mutatorRef": [
+              "patchStrategy": "replace",
+              "mutatedRef": [
                 [
                   "configuration",
                   "spec",
                   "userData"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ]

--- a/models/aws-cloudwatchlogs-controller/v1.3.1/v1.0.0/relationships/edge-binding-reference-dzadz.json
+++ b/models/aws-cloudwatchlogs-controller/v1.3.1/v1.0.0/relationships/edge-binding-reference-dzadz.json
@@ -46,12 +46,12 @@
               "version": ""
             },
             "patch": {
-              "mutatedRef": [
+              "patchStrategy": "replace",
+              "mutatorRef": [
                 [
                   "displayName"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ],
@@ -74,15 +74,15 @@
               "version": ""
             },
             "patch": {
-              "mutatorRef": [
+              "patchStrategy": "replace",
+              "mutatedRef": [
                 [
                   "configuration",
                   "spec",
                   "loggingConfig",
                   "logGroup"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ]

--- a/models/aws-cloudwatchlogs-controller/v1.3.1/v1.0.0/relationships/edge-non-binding-reference-wjvtp.json
+++ b/models/aws-cloudwatchlogs-controller/v1.3.1/v1.0.0/relationships/edge-non-binding-reference-wjvtp.json
@@ -46,12 +46,12 @@
               "version": ""
             },
             "patch": {
-              "mutatedRef": [
+              "patchStrategy": "replace",
+              "mutatorRef": [
                 [
                   "displayName"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ],
@@ -74,14 +74,14 @@
               "version": ""
             },
             "patch": {
-              "mutatorRef": [
+              "patchStrategy": "replace",
+              "mutatedRef": [
                 [
                   "configuration",
                   "spec",
                   "userData"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ]

--- a/models/aws-cloudwatchlogs-controller/v1.3.2/v1.0.0/relationships/edge-binding-permission-loggroup-key.json
+++ b/models/aws-cloudwatchlogs-controller/v1.3.2/v1.0.0/relationships/edge-binding-permission-loggroup-key.json
@@ -1,0 +1,101 @@
+{
+  "id": "00000000-0000-0000-0000-000000000000",
+  "evaluationQuery": "",
+  "kind": "edge",
+  "metadata": {
+    "description": "Binds CLOUDWATCHLOGS LogGroup to Key via spec.kmsKeyID.",
+    "isAnnotation": false,
+    "styles": {
+      "primaryColor": "",
+      "svgColor": "",
+      "svgWhite": ""
+    }
+  },
+  "model": {
+    "displayName": "",
+    "id": "00000000-0000-0000-0000-000000000000",
+    "model": {
+      "version": "v1.3.2"
+    },
+    "name": "aws-cloudwatchlogs-controller",
+    "registrant": {
+      "kind": "github"
+    },
+    "version": "v1.3.2"
+  },
+  "schemaVersion": "relationships.meshery.io/v1beta2",
+  "selectors": [
+    {
+      "allow": {
+        "from": [
+          {
+            "id": null,
+            "kind": "Key",
+            "match": {},
+            "match_strategy_matrix": null,
+            "model": {
+              "displayName": "",
+              "id": "00000000-0000-0000-0000-000000000000",
+              "model": {
+                "version": ""
+              },
+              "name": "aws-kms-controller",
+              "registrant": {
+                "kind": "github"
+              },
+              "version": ""
+            },
+            "patch": {
+              "patchStrategy": "replace",
+              "mutatorRef": [
+                [
+                  "configuration",
+                  "metadata",
+                  "name"
+                ]
+              ]
+            }
+          }
+        ],
+        "to": [
+          {
+            "id": null,
+            "kind": "LogGroup",
+            "match": {},
+            "match_strategy_matrix": null,
+            "model": {
+              "displayName": "",
+              "id": "00000000-0000-0000-0000-000000000000",
+              "model": {
+                "version": ""
+              },
+              "name": "aws-cloudwatchlogs-controller",
+              "registrant": {
+                "kind": "github"
+              },
+              "version": ""
+            },
+            "patch": {
+              "patchStrategy": "replace",
+              "mutatedRef": [
+                [
+                  "configuration",
+                  "spec",
+                  "kmsKeyID"
+                ]
+              ]
+            }
+          }
+        ]
+      },
+      "deny": {
+        "from": [],
+        "to": []
+      }
+    }
+  ],
+  "subType": "permission",
+  "status": "enabled",
+  "type": "non-binding",
+  "version": "v1.0.0"
+}

--- a/models/aws-cloudwatchlogs-controller/v1.3.2/v1.0.0/relationships/edge-binding-reference-dzadz.json
+++ b/models/aws-cloudwatchlogs-controller/v1.3.2/v1.0.0/relationships/edge-binding-reference-dzadz.json
@@ -46,12 +46,12 @@
               "version": ""
             },
             "patch": {
-              "mutatedRef": [
+              "patchStrategy": "replace",
+              "mutatorRef": [
                 [
                   "displayName"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ],
@@ -74,15 +74,15 @@
               "version": ""
             },
             "patch": {
-              "mutatorRef": [
+              "patchStrategy": "replace",
+              "mutatedRef": [
                 [
                   "configuration",
                   "spec",
                   "loggingConfig",
                   "logGroup"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ]

--- a/models/aws-cloudwatchlogs-controller/v1.3.2/v1.0.0/relationships/edge-non-binding-reference-loggroup-key.json
+++ b/models/aws-cloudwatchlogs-controller/v1.3.2/v1.0.0/relationships/edge-non-binding-reference-loggroup-key.json
@@ -47,7 +47,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatedRef": [
+              "mutatorRef": [
                 [
                   "configuration",
                   "spec",
@@ -79,7 +79,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "displayName"
                 ]

--- a/models/aws-cloudwatchlogs-controller/v1.3.2/v1.0.0/relationships/edge-non-binding-reference-loggroup-key.json
+++ b/models/aws-cloudwatchlogs-controller/v1.3.2/v1.0.0/relationships/edge-non-binding-reference-loggroup-key.json
@@ -47,7 +47,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "spec",
@@ -79,7 +79,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatedRef": [
+              "mutatorRef": [
                 [
                   "displayName"
                 ]

--- a/models/aws-cloudwatchlogs-controller/v1.3.2/v1.0.0/relationships/edge-non-binding-reference-loggroup-key.json
+++ b/models/aws-cloudwatchlogs-controller/v1.3.2/v1.0.0/relationships/edge-non-binding-reference-loggroup-key.json
@@ -3,7 +3,7 @@
   "evaluationQuery": "",
   "kind": "edge",
   "metadata": {
-    "description": "Binds CLOUDWATCHLOGS LogGroup to Key via spec.kmsKeyID.",
+    "description": "References a KMS Key from a CloudWatchLogs LogGroup via spec.kmsKeyRef, the key used to encrypt the log group's data.",
     "isAnnotation": false,
     "styles": {
       "primaryColor": "",
@@ -19,45 +19,15 @@
     },
     "name": "aws-cloudwatchlogs-controller",
     "registrant": {
-      "kind": "github"
+      "kind": ""
     },
-    "version": "v1.3.2"
+    "version": ""
   },
   "schemaVersion": "relationships.meshery.io/v1beta2",
   "selectors": [
     {
       "allow": {
         "from": [
-          {
-            "id": null,
-            "kind": "Key",
-            "match": {},
-            "match_strategy_matrix": null,
-            "model": {
-              "displayName": "",
-              "id": "00000000-0000-0000-0000-000000000000",
-              "model": {
-                "version": ""
-              },
-              "name": "aws-kms-controller",
-              "registrant": {
-                "kind": "github"
-              },
-              "version": ""
-            },
-            "patch": {
-              "patchStrategy": "replace",
-              "mutatorRef": [
-                [
-                  "configuration",
-                  "metadata",
-                  "name"
-                ]
-              ]
-            }
-          }
-        ],
-        "to": [
           {
             "id": null,
             "kind": "LogGroup",
@@ -77,11 +47,41 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatedRef": [
+              "mutatorRef": [
                 [
                   "configuration",
                   "spec",
-                  "kmsKeyID"
+                  "kmsKeyRef",
+                  "from",
+                  "name"
+                ]
+              ]
+            }
+          }
+        ],
+        "to": [
+          {
+            "id": null,
+            "kind": "Key",
+            "match": {},
+            "match_strategy_matrix": null,
+            "model": {
+              "displayName": "",
+              "id": "00000000-0000-0000-0000-000000000000",
+              "model": {
+                "version": ""
+              },
+              "name": "aws-kms-controller",
+              "registrant": {
+                "kind": "github"
+              },
+              "version": ""
+            },
+            "patch": {
+              "patchStrategy": "replace",
+              "mutatedRef": [
+                [
+                  "displayName"
                 ]
               ]
             }
@@ -94,7 +94,7 @@
       }
     }
   ],
-  "subType": "permission",
+  "subType": "reference",
   "status": "enabled",
   "type": "non-binding",
   "version": "v1.0.0"

--- a/models/aws-cloudwatchlogs-controller/v1.3.2/v1.0.0/relationships/edge-non-binding-reference-wjvtp.json
+++ b/models/aws-cloudwatchlogs-controller/v1.3.2/v1.0.0/relationships/edge-non-binding-reference-wjvtp.json
@@ -46,12 +46,12 @@
               "version": ""
             },
             "patch": {
-              "mutatedRef": [
+              "patchStrategy": "replace",
+              "mutatorRef": [
                 [
                   "displayName"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ],
@@ -74,14 +74,14 @@
               "version": ""
             },
             "patch": {
-              "mutatorRef": [
+              "patchStrategy": "replace",
+              "mutatedRef": [
                 [
                   "configuration",
                   "spec",
                   "userData"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ]

--- a/models/aws-documentdb-controller/v1.4.1/v1.0.0/relationships/hierarchical-parent-inventory-dwvtf.json
+++ b/models/aws-documentdb-controller/v1.4.1/v1.0.0/relationships/hierarchical-parent-inventory-dwvtf.json
@@ -46,12 +46,12 @@
               "version": ""
             },
             "patch": {
-              "mutatedRef": [
+              "patchStrategy": "replace",
+              "mutatorRef": [
                 [
                   "displayName"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ],
@@ -74,14 +74,14 @@
               "version": ""
             },
             "patch": {
-              "mutatorRef": [
+              "patchStrategy": "replace",
+              "mutatedRef": [
                 [
                   "configuration",
                   "spec",
                   "dbClusterIdentifier"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ]

--- a/models/aws-documentdb-controller/v1.4.2/v1.0.0/relationships/hierarchical-parent-inventory-dwvtf.json
+++ b/models/aws-documentdb-controller/v1.4.2/v1.0.0/relationships/hierarchical-parent-inventory-dwvtf.json
@@ -46,12 +46,12 @@
               "version": ""
             },
             "patch": {
-              "mutatedRef": [
+              "patchStrategy": "replace",
+              "mutatorRef": [
                 [
                   "displayName"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ],
@@ -74,14 +74,14 @@
               "version": ""
             },
             "patch": {
-              "mutatorRef": [
+              "patchStrategy": "replace",
+              "mutatedRef": [
                 [
                   "configuration",
                   "spec",
                   "dbClusterIdentifier"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ]

--- a/models/aws-dynamodb-controller/v1.9.2/v1.0.0/relationships/edge-binding-permission-table-key.json
+++ b/models/aws-dynamodb-controller/v1.9.2/v1.0.0/relationships/edge-binding-permission-table-key.json
@@ -1,0 +1,102 @@
+{
+  "id": "00000000-0000-0000-0000-000000000000",
+  "evaluationQuery": "",
+  "kind": "edge",
+  "metadata": {
+    "description": "Binds DYNAMODB Table to Key via spec.sseSpecification.kmsMasterKeyID.",
+    "isAnnotation": false,
+    "styles": {
+      "primaryColor": "",
+      "svgColor": "",
+      "svgWhite": ""
+    }
+  },
+  "model": {
+    "displayName": "",
+    "id": "00000000-0000-0000-0000-000000000000",
+    "model": {
+      "version": "v1.9.2"
+    },
+    "name": "aws-dynamodb-controller",
+    "registrant": {
+      "kind": "github"
+    },
+    "version": "v1.9.2"
+  },
+  "schemaVersion": "relationships.meshery.io/v1beta2",
+  "selectors": [
+    {
+      "allow": {
+        "from": [
+          {
+            "id": null,
+            "kind": "Key",
+            "match": {},
+            "match_strategy_matrix": null,
+            "model": {
+              "displayName": "",
+              "id": "00000000-0000-0000-0000-000000000000",
+              "model": {
+                "version": ""
+              },
+              "name": "aws-kms-controller",
+              "registrant": {
+                "kind": "github"
+              },
+              "version": ""
+            },
+            "patch": {
+              "patchStrategy": "replace",
+              "mutatorRef": [
+                [
+                  "configuration",
+                  "metadata",
+                  "name"
+                ]
+              ]
+            }
+          }
+        ],
+        "to": [
+          {
+            "id": null,
+            "kind": "Table",
+            "match": {},
+            "match_strategy_matrix": null,
+            "model": {
+              "displayName": "",
+              "id": "00000000-0000-0000-0000-000000000000",
+              "model": {
+                "version": ""
+              },
+              "name": "aws-dynamodb-controller",
+              "registrant": {
+                "kind": "github"
+              },
+              "version": ""
+            },
+            "patch": {
+              "patchStrategy": "replace",
+              "mutatedRef": [
+                [
+                  "configuration",
+                  "spec",
+                  "sseSpecification",
+                  "kmsMasterKeyID"
+                ]
+              ]
+            }
+          }
+        ]
+      },
+      "deny": {
+        "from": [],
+        "to": []
+      }
+    }
+  ],
+  "subType": "permission",
+  "status": "enabled",
+  "type": "non-binding",
+  "version": "v1.0.0"
+}

--- a/models/aws-dynamodb-controller/v1.9.2/v1.0.0/relationships/edge-non-binding-reference-table-key.json
+++ b/models/aws-dynamodb-controller/v1.9.2/v1.0.0/relationships/edge-non-binding-reference-table-key.json
@@ -3,7 +3,7 @@
   "evaluationQuery": "",
   "kind": "edge",
   "metadata": {
-    "description": "Binds PROMETHEUSSERVICE LoggingConfiguration to Workspace via spec.workspaceID.",
+    "description": "References a KMS Key from a DynamoDB Table via spec.sseSpecification.kmsMasterKeyRef, the key used for server-side encryption.",
     "isAnnotation": false,
     "styles": {
       "primaryColor": "",
@@ -15,13 +15,13 @@
     "displayName": "",
     "id": "00000000-0000-0000-0000-000000000000",
     "model": {
-      "version": "v1.5.2"
+      "version": "v1.9.2"
     },
-    "name": "aws-prometheusservice-controller",
+    "name": "aws-dynamodb-controller",
     "registrant": {
-      "kind": "github"
+      "kind": ""
     },
-    "version": "v1.5.2"
+    "version": ""
   },
   "schemaVersion": "relationships.meshery.io/v1beta2",
   "selectors": [
@@ -30,7 +30,7 @@
         "from": [
           {
             "id": null,
-            "kind": "Workspace",
+            "kind": "Table",
             "match": {},
             "match_strategy_matrix": null,
             "model": {
@@ -39,7 +39,7 @@
               "model": {
                 "version": ""
               },
-              "name": "aws-prometheusservice-controller",
+              "name": "aws-dynamodb-controller",
               "registrant": {
                 "kind": "github"
               },
@@ -50,7 +50,10 @@
               "mutatorRef": [
                 [
                   "configuration",
-                  "metadata",
+                  "spec",
+                  "sseSpecification",
+                  "kmsMasterKeyRef",
+                  "from",
                   "name"
                 ]
               ]
@@ -60,7 +63,7 @@
         "to": [
           {
             "id": null,
-            "kind": "LoggingConfiguration",
+            "kind": "Key",
             "match": {},
             "match_strategy_matrix": null,
             "model": {
@@ -69,7 +72,7 @@
               "model": {
                 "version": ""
               },
-              "name": "aws-prometheusservice-controller",
+              "name": "aws-kms-controller",
               "registrant": {
                 "kind": "github"
               },
@@ -79,9 +82,7 @@
               "patchStrategy": "replace",
               "mutatedRef": [
                 [
-                  "configuration",
-                  "spec",
-                  "workspaceID"
+                  "displayName"
                 ]
               ]
             }
@@ -94,7 +95,7 @@
       }
     }
   ],
-  "subType": "network",
+  "subType": "reference",
   "status": "enabled",
   "type": "non-binding",
   "version": "v1.0.0"

--- a/models/aws-dynamodb-controller/v1.9.2/v1.0.0/relationships/edge-non-binding-reference-table-key.json
+++ b/models/aws-dynamodb-controller/v1.9.2/v1.0.0/relationships/edge-non-binding-reference-table-key.json
@@ -47,7 +47,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "spec",
@@ -80,7 +80,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatedRef": [
+              "mutatorRef": [
                 [
                   "displayName"
                 ]

--- a/models/aws-dynamodb-controller/v1.9.2/v1.0.0/relationships/edge-non-binding-reference-table-key.json
+++ b/models/aws-dynamodb-controller/v1.9.2/v1.0.0/relationships/edge-non-binding-reference-table-key.json
@@ -47,7 +47,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatedRef": [
+              "mutatorRef": [
                 [
                   "configuration",
                   "spec",
@@ -80,7 +80,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "displayName"
                 ]

--- a/models/aws-ec2-controller/v1.15.2/v1.0.0/relationships/edge-non-binding-network-zaljh.json
+++ b/models/aws-ec2-controller/v1.15.2/v1.0.0/relationships/edge-non-binding-network-zaljh.json
@@ -46,12 +46,12 @@
               "version": ""
             },
             "patch": {
-              "mutatedRef": [
+              "patchStrategy": "replace",
+              "mutatorRef": [
                 [
                   "displayName"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ],
@@ -74,14 +74,14 @@
               "version": ""
             },
             "patch": {
-              "mutatorRef": [
+              "patchStrategy": "replace",
+              "mutatedRef": [
                 [
                   "configuration",
                   "spec",
                   "vpcID"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ]

--- a/models/aws-ec2-controller/v1.15.2/v1.0.0/relationships/edge-non-binding-reference-istbe.json
+++ b/models/aws-ec2-controller/v1.15.2/v1.0.0/relationships/edge-non-binding-reference-istbe.json
@@ -46,12 +46,12 @@
               "version": ""
             },
             "patch": {
-              "mutatedRef": [
+              "patchStrategy": "replace",
+              "mutatorRef": [
                 [
                   "displayName"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ],
@@ -74,14 +74,14 @@
               "version": ""
             },
             "patch": {
-              "mutatorRef": [
+              "patchStrategy": "replace",
+              "mutatedRef": [
                 [
                   "configuration",
                   "spec",
                   "instanceID"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ]

--- a/models/aws-ec2-controller/v1.15.2/v1.0.0/relationships/hierarchical-parent-inventory-lkvsv.json
+++ b/models/aws-ec2-controller/v1.15.2/v1.0.0/relationships/hierarchical-parent-inventory-lkvsv.json
@@ -46,12 +46,12 @@
               "version": ""
             },
             "patch": {
-              "mutatedRef": [
+              "patchStrategy": "replace",
+              "mutatorRef": [
                 [
                   "displayName"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ],
@@ -74,14 +74,14 @@
               "version": ""
             },
             "patch": {
-              "mutatorRef": [
+              "patchStrategy": "replace",
+              "mutatedRef": [
                 [
                   "configuration",
                   "spec",
                   "vpcID"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ]

--- a/models/aws-ec2-controller/v1.15.2/v1.0.0/relationships/hierarchical-parent-inventory-oascb.json
+++ b/models/aws-ec2-controller/v1.15.2/v1.0.0/relationships/hierarchical-parent-inventory-oascb.json
@@ -46,12 +46,12 @@
               "version": ""
             },
             "patch": {
-              "mutatedRef": [
+              "patchStrategy": "replace",
+              "mutatorRef": [
                 [
                   "displayName"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ],
@@ -74,14 +74,14 @@
               "version": ""
             },
             "patch": {
-              "mutatorRef": [
+              "patchStrategy": "replace",
+              "mutatedRef": [
                 [
                   "configuration",
                   "spec",
                   "vpcID"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ]

--- a/models/aws-ec2-controller/v1.15.2/v1.0.0/relationships/hierarchical-parent-inventory-tauea.json
+++ b/models/aws-ec2-controller/v1.15.2/v1.0.0/relationships/hierarchical-parent-inventory-tauea.json
@@ -46,12 +46,12 @@
               "version": ""
             },
             "patch": {
-              "mutatedRef": [
+              "patchStrategy": "replace",
+              "mutatorRef": [
                 [
                   "displayName"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ],
@@ -74,14 +74,14 @@
               "version": ""
             },
             "patch": {
-              "mutatorRef": [
+              "patchStrategy": "replace",
+              "mutatedRef": [
                 [
                   "configuration",
                   "spec",
                   "vpcID"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ]

--- a/models/aws-ec2-controller/v1.15.2/v1.0.0/relationships/hierarchical-parent-inventory-uzanp.json
+++ b/models/aws-ec2-controller/v1.15.2/v1.0.0/relationships/hierarchical-parent-inventory-uzanp.json
@@ -46,12 +46,12 @@
               "version": ""
             },
             "patch": {
-              "mutatedRef": [
+              "patchStrategy": "replace",
+              "mutatorRef": [
                 [
                   "displayName"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ],
@@ -74,14 +74,14 @@
               "version": ""
             },
             "patch": {
-              "mutatorRef": [
+              "patchStrategy": "replace",
+              "mutatedRef": [
                 [
                   "configuration",
                   "spec",
                   "vpcID"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ]

--- a/models/aws-ec2-controller/v1.16.0/v1.0.0/relationships/edge-non-binding-network-zaljh.json
+++ b/models/aws-ec2-controller/v1.16.0/v1.0.0/relationships/edge-non-binding-network-zaljh.json
@@ -46,12 +46,12 @@
               "version": ""
             },
             "patch": {
-              "mutatedRef": [
+              "patchStrategy": "replace",
+              "mutatorRef": [
                 [
                   "displayName"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ],
@@ -74,14 +74,14 @@
               "version": ""
             },
             "patch": {
-              "mutatorRef": [
+              "patchStrategy": "replace",
+              "mutatedRef": [
                 [
                   "configuration",
                   "spec",
                   "vpcID"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ]

--- a/models/aws-ec2-controller/v1.16.0/v1.0.0/relationships/edge-non-binding-reference-istbe.json
+++ b/models/aws-ec2-controller/v1.16.0/v1.0.0/relationships/edge-non-binding-reference-istbe.json
@@ -46,12 +46,12 @@
               "version": ""
             },
             "patch": {
-              "mutatedRef": [
+              "patchStrategy": "replace",
+              "mutatorRef": [
                 [
                   "displayName"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ],
@@ -74,14 +74,14 @@
               "version": ""
             },
             "patch": {
-              "mutatorRef": [
+              "patchStrategy": "replace",
+              "mutatedRef": [
                 [
                   "configuration",
                   "spec",
                   "instanceID"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ]

--- a/models/aws-ec2-controller/v1.16.0/v1.0.0/relationships/hierarchical-parent-inventory-lkvsv.json
+++ b/models/aws-ec2-controller/v1.16.0/v1.0.0/relationships/hierarchical-parent-inventory-lkvsv.json
@@ -46,12 +46,12 @@
               "version": ""
             },
             "patch": {
-              "mutatedRef": [
+              "patchStrategy": "replace",
+              "mutatorRef": [
                 [
                   "displayName"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ],
@@ -74,14 +74,14 @@
               "version": ""
             },
             "patch": {
-              "mutatorRef": [
+              "patchStrategy": "replace",
+              "mutatedRef": [
                 [
                   "configuration",
                   "spec",
                   "vpcID"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ]

--- a/models/aws-ec2-controller/v1.16.0/v1.0.0/relationships/hierarchical-parent-inventory-oascb.json
+++ b/models/aws-ec2-controller/v1.16.0/v1.0.0/relationships/hierarchical-parent-inventory-oascb.json
@@ -46,12 +46,12 @@
               "version": ""
             },
             "patch": {
-              "mutatedRef": [
+              "patchStrategy": "replace",
+              "mutatorRef": [
                 [
                   "displayName"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ],
@@ -74,14 +74,14 @@
               "version": ""
             },
             "patch": {
-              "mutatorRef": [
+              "patchStrategy": "replace",
+              "mutatedRef": [
                 [
                   "configuration",
                   "spec",
                   "vpcID"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ]

--- a/models/aws-ec2-controller/v1.16.0/v1.0.0/relationships/hierarchical-parent-inventory-tauea.json
+++ b/models/aws-ec2-controller/v1.16.0/v1.0.0/relationships/hierarchical-parent-inventory-tauea.json
@@ -46,12 +46,12 @@
               "version": ""
             },
             "patch": {
-              "mutatedRef": [
+              "patchStrategy": "replace",
+              "mutatorRef": [
                 [
                   "displayName"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ],
@@ -74,14 +74,14 @@
               "version": ""
             },
             "patch": {
-              "mutatorRef": [
+              "patchStrategy": "replace",
+              "mutatedRef": [
                 [
                   "configuration",
                   "spec",
                   "vpcID"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ]

--- a/models/aws-ec2-controller/v1.16.0/v1.0.0/relationships/hierarchical-parent-inventory-uzanp.json
+++ b/models/aws-ec2-controller/v1.16.0/v1.0.0/relationships/hierarchical-parent-inventory-uzanp.json
@@ -46,12 +46,12 @@
               "version": ""
             },
             "patch": {
-              "mutatedRef": [
+              "patchStrategy": "replace",
+              "mutatorRef": [
                 [
                   "displayName"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ],
@@ -74,14 +74,14 @@
               "version": ""
             },
             "patch": {
-              "mutatorRef": [
+              "patchStrategy": "replace",
+              "mutatedRef": [
                 [
                   "configuration",
                   "spec",
                   "vpcID"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ]

--- a/models/aws-ec2-controller/v1.17.0/v1.0.0/relationships/edge-non-binding-network-zaljh.json
+++ b/models/aws-ec2-controller/v1.17.0/v1.0.0/relationships/edge-non-binding-network-zaljh.json
@@ -46,12 +46,12 @@
               "version": ""
             },
             "patch": {
-              "mutatedRef": [
+              "patchStrategy": "replace",
+              "mutatorRef": [
                 [
                   "displayName"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ],
@@ -74,14 +74,14 @@
               "version": ""
             },
             "patch": {
-              "mutatorRef": [
+              "patchStrategy": "replace",
+              "mutatedRef": [
                 [
                   "configuration",
                   "spec",
                   "vpcID"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ]

--- a/models/aws-ec2-controller/v1.17.0/v1.0.0/relationships/edge-non-binding-reference-istbe.json
+++ b/models/aws-ec2-controller/v1.17.0/v1.0.0/relationships/edge-non-binding-reference-istbe.json
@@ -46,12 +46,12 @@
               "version": ""
             },
             "patch": {
-              "mutatedRef": [
+              "patchStrategy": "replace",
+              "mutatorRef": [
                 [
                   "displayName"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ],
@@ -74,14 +74,14 @@
               "version": ""
             },
             "patch": {
-              "mutatorRef": [
+              "patchStrategy": "replace",
+              "mutatedRef": [
                 [
                   "configuration",
                   "spec",
                   "instanceID"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ]

--- a/models/aws-ec2-controller/v1.17.0/v1.0.0/relationships/hierarchical-parent-inventory-lkvsv.json
+++ b/models/aws-ec2-controller/v1.17.0/v1.0.0/relationships/hierarchical-parent-inventory-lkvsv.json
@@ -46,12 +46,12 @@
               "version": ""
             },
             "patch": {
-              "mutatedRef": [
+              "patchStrategy": "replace",
+              "mutatorRef": [
                 [
                   "displayName"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ],
@@ -74,14 +74,14 @@
               "version": ""
             },
             "patch": {
-              "mutatorRef": [
+              "patchStrategy": "replace",
+              "mutatedRef": [
                 [
                   "configuration",
                   "spec",
                   "vpcID"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ]

--- a/models/aws-ec2-controller/v1.17.0/v1.0.0/relationships/hierarchical-parent-inventory-oascb.json
+++ b/models/aws-ec2-controller/v1.17.0/v1.0.0/relationships/hierarchical-parent-inventory-oascb.json
@@ -46,12 +46,12 @@
               "version": ""
             },
             "patch": {
-              "mutatedRef": [
+              "patchStrategy": "replace",
+              "mutatorRef": [
                 [
                   "displayName"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ],
@@ -74,14 +74,14 @@
               "version": ""
             },
             "patch": {
-              "mutatorRef": [
+              "patchStrategy": "replace",
+              "mutatedRef": [
                 [
                   "configuration",
                   "spec",
                   "vpcID"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ]

--- a/models/aws-ec2-controller/v1.17.0/v1.0.0/relationships/hierarchical-parent-inventory-tauea.json
+++ b/models/aws-ec2-controller/v1.17.0/v1.0.0/relationships/hierarchical-parent-inventory-tauea.json
@@ -46,12 +46,12 @@
               "version": ""
             },
             "patch": {
-              "mutatedRef": [
+              "patchStrategy": "replace",
+              "mutatorRef": [
                 [
                   "displayName"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ],
@@ -74,14 +74,14 @@
               "version": ""
             },
             "patch": {
-              "mutatorRef": [
+              "patchStrategy": "replace",
+              "mutatedRef": [
                 [
                   "configuration",
                   "spec",
                   "vpcID"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ]

--- a/models/aws-ec2-controller/v1.17.0/v1.0.0/relationships/hierarchical-parent-inventory-uzanp.json
+++ b/models/aws-ec2-controller/v1.17.0/v1.0.0/relationships/hierarchical-parent-inventory-uzanp.json
@@ -46,12 +46,12 @@
               "version": ""
             },
             "patch": {
-              "mutatedRef": [
+              "patchStrategy": "replace",
+              "mutatorRef": [
                 [
                   "displayName"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ],
@@ -74,14 +74,14 @@
               "version": ""
             },
             "patch": {
-              "mutatorRef": [
+              "patchStrategy": "replace",
+              "mutatedRef": [
                 [
                   "configuration",
                   "spec",
                   "vpcID"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ]

--- a/models/aws-ec2-controller/v1.18.1/v1.0.0/relationships/edge-non-binding-network-zaljh.json
+++ b/models/aws-ec2-controller/v1.18.1/v1.0.0/relationships/edge-non-binding-network-zaljh.json
@@ -46,12 +46,12 @@
               "version": ""
             },
             "patch": {
-              "mutatedRef": [
+              "patchStrategy": "replace",
+              "mutatorRef": [
                 [
                   "displayName"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ],
@@ -74,14 +74,14 @@
               "version": ""
             },
             "patch": {
-              "mutatorRef": [
+              "patchStrategy": "replace",
+              "mutatedRef": [
                 [
                   "configuration",
                   "spec",
                   "vpcID"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ]

--- a/models/aws-ec2-controller/v1.18.1/v1.0.0/relationships/edge-non-binding-reference-istbe.json
+++ b/models/aws-ec2-controller/v1.18.1/v1.0.0/relationships/edge-non-binding-reference-istbe.json
@@ -46,12 +46,12 @@
               "version": ""
             },
             "patch": {
-              "mutatedRef": [
+              "patchStrategy": "replace",
+              "mutatorRef": [
                 [
                   "displayName"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ],
@@ -74,14 +74,14 @@
               "version": ""
             },
             "patch": {
-              "mutatorRef": [
+              "patchStrategy": "replace",
+              "mutatedRef": [
                 [
                   "configuration",
                   "spec",
                   "instanceID"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ]

--- a/models/aws-ec2-controller/v1.18.1/v1.0.0/relationships/hierarchical-parent-inventory-lkvsv.json
+++ b/models/aws-ec2-controller/v1.18.1/v1.0.0/relationships/hierarchical-parent-inventory-lkvsv.json
@@ -46,12 +46,12 @@
               "version": ""
             },
             "patch": {
-              "mutatedRef": [
+              "patchStrategy": "replace",
+              "mutatorRef": [
                 [
                   "displayName"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ],
@@ -74,14 +74,14 @@
               "version": ""
             },
             "patch": {
-              "mutatorRef": [
+              "patchStrategy": "replace",
+              "mutatedRef": [
                 [
                   "configuration",
                   "spec",
                   "vpcID"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ]

--- a/models/aws-ec2-controller/v1.18.1/v1.0.0/relationships/hierarchical-parent-inventory-oascb.json
+++ b/models/aws-ec2-controller/v1.18.1/v1.0.0/relationships/hierarchical-parent-inventory-oascb.json
@@ -46,12 +46,12 @@
               "version": ""
             },
             "patch": {
-              "mutatedRef": [
+              "patchStrategy": "replace",
+              "mutatorRef": [
                 [
                   "displayName"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ],
@@ -74,14 +74,14 @@
               "version": ""
             },
             "patch": {
-              "mutatorRef": [
+              "patchStrategy": "replace",
+              "mutatedRef": [
                 [
                   "configuration",
                   "spec",
                   "vpcID"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ]

--- a/models/aws-ec2-controller/v1.18.1/v1.0.0/relationships/hierarchical-parent-inventory-tauea.json
+++ b/models/aws-ec2-controller/v1.18.1/v1.0.0/relationships/hierarchical-parent-inventory-tauea.json
@@ -46,12 +46,12 @@
               "version": ""
             },
             "patch": {
-              "mutatedRef": [
+              "patchStrategy": "replace",
+              "mutatorRef": [
                 [
                   "displayName"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ],
@@ -74,14 +74,14 @@
               "version": ""
             },
             "patch": {
-              "mutatorRef": [
+              "patchStrategy": "replace",
+              "mutatedRef": [
                 [
                   "configuration",
                   "spec",
                   "vpcID"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ]

--- a/models/aws-ec2-controller/v1.18.1/v1.0.0/relationships/hierarchical-parent-inventory-uzanp.json
+++ b/models/aws-ec2-controller/v1.18.1/v1.0.0/relationships/hierarchical-parent-inventory-uzanp.json
@@ -46,12 +46,12 @@
               "version": ""
             },
             "patch": {
-              "mutatedRef": [
+              "patchStrategy": "replace",
+              "mutatorRef": [
                 [
                   "displayName"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ],
@@ -74,14 +74,14 @@
               "version": ""
             },
             "patch": {
-              "mutatorRef": [
+              "patchStrategy": "replace",
+              "mutatedRef": [
                 [
                   "configuration",
                   "spec",
                   "vpcID"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ]

--- a/models/aws-ec2-controller/v1.18.2/v1.0.0/relationships/edge-non-binding-network-zaljh.json
+++ b/models/aws-ec2-controller/v1.18.2/v1.0.0/relationships/edge-non-binding-network-zaljh.json
@@ -46,12 +46,12 @@
               "version": ""
             },
             "patch": {
-              "mutatedRef": [
+              "patchStrategy": "replace",
+              "mutatorRef": [
                 [
                   "displayName"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ],
@@ -74,14 +74,14 @@
               "version": ""
             },
             "patch": {
-              "mutatorRef": [
+              "patchStrategy": "replace",
+              "mutatedRef": [
                 [
                   "configuration",
                   "spec",
                   "vpcID"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ]

--- a/models/aws-ec2-controller/v1.18.2/v1.0.0/relationships/edge-non-binding-reference-istbe.json
+++ b/models/aws-ec2-controller/v1.18.2/v1.0.0/relationships/edge-non-binding-reference-istbe.json
@@ -46,12 +46,12 @@
               "version": ""
             },
             "patch": {
-              "mutatedRef": [
+              "patchStrategy": "replace",
+              "mutatorRef": [
                 [
                   "displayName"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ],
@@ -74,14 +74,14 @@
               "version": ""
             },
             "patch": {
-              "mutatorRef": [
+              "patchStrategy": "replace",
+              "mutatedRef": [
                 [
                   "configuration",
                   "spec",
                   "instanceID"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ]

--- a/models/aws-ec2-controller/v1.18.2/v1.0.0/relationships/hierarchical-parent-inventory-lkvsv.json
+++ b/models/aws-ec2-controller/v1.18.2/v1.0.0/relationships/hierarchical-parent-inventory-lkvsv.json
@@ -46,12 +46,12 @@
               "version": ""
             },
             "patch": {
-              "mutatedRef": [
+              "patchStrategy": "replace",
+              "mutatorRef": [
                 [
                   "displayName"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ],
@@ -74,14 +74,14 @@
               "version": ""
             },
             "patch": {
-              "mutatorRef": [
+              "patchStrategy": "replace",
+              "mutatedRef": [
                 [
                   "configuration",
                   "spec",
                   "vpcID"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ]

--- a/models/aws-ec2-controller/v1.18.2/v1.0.0/relationships/hierarchical-parent-inventory-oascb.json
+++ b/models/aws-ec2-controller/v1.18.2/v1.0.0/relationships/hierarchical-parent-inventory-oascb.json
@@ -46,12 +46,12 @@
               "version": ""
             },
             "patch": {
-              "mutatedRef": [
+              "patchStrategy": "replace",
+              "mutatorRef": [
                 [
                   "displayName"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ],
@@ -74,14 +74,14 @@
               "version": ""
             },
             "patch": {
-              "mutatorRef": [
+              "patchStrategy": "replace",
+              "mutatedRef": [
                 [
                   "configuration",
                   "spec",
                   "vpcID"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ]

--- a/models/aws-ec2-controller/v1.18.2/v1.0.0/relationships/hierarchical-parent-inventory-tauea.json
+++ b/models/aws-ec2-controller/v1.18.2/v1.0.0/relationships/hierarchical-parent-inventory-tauea.json
@@ -46,12 +46,12 @@
               "version": ""
             },
             "patch": {
-              "mutatedRef": [
+              "patchStrategy": "replace",
+              "mutatorRef": [
                 [
                   "displayName"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ],
@@ -74,14 +74,14 @@
               "version": ""
             },
             "patch": {
-              "mutatorRef": [
+              "patchStrategy": "replace",
+              "mutatedRef": [
                 [
                   "configuration",
                   "spec",
                   "vpcID"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ]

--- a/models/aws-ec2-controller/v1.18.2/v1.0.0/relationships/hierarchical-parent-inventory-uzanp.json
+++ b/models/aws-ec2-controller/v1.18.2/v1.0.0/relationships/hierarchical-parent-inventory-uzanp.json
@@ -46,12 +46,12 @@
               "version": ""
             },
             "patch": {
-              "mutatedRef": [
+              "patchStrategy": "replace",
+              "mutatorRef": [
                 [
                   "displayName"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ],
@@ -74,14 +74,14 @@
               "version": ""
             },
             "patch": {
-              "mutatorRef": [
+              "patchStrategy": "replace",
+              "mutatedRef": [
                 [
                   "configuration",
                   "spec",
                   "vpcID"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ]

--- a/models/aws-elasticsearchservice-controller/v0.0.2/v1.0.0/relationships/hierarchical-parent-inventory-kmjea.json
+++ b/models/aws-elasticsearchservice-controller/v0.0.2/v1.0.0/relationships/hierarchical-parent-inventory-kmjea.json
@@ -91,7 +91,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatedRef": [
+              "mutatorRef": [
                 [
                   "displayName"
                 ]
@@ -141,7 +141,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "spec",

--- a/models/aws-emrcontainers-controller/v1.5.1/v1.0.0/relationships/edge-binding-network-jobrun-virtualcluster.json
+++ b/models/aws-emrcontainers-controller/v1.5.1/v1.0.0/relationships/edge-binding-network-jobrun-virtualcluster.json
@@ -1,0 +1,101 @@
+{
+  "id": "00000000-0000-0000-0000-000000000000",
+  "evaluationQuery": "",
+  "kind": "edge",
+  "metadata": {
+    "description": "Binds EMRCONTAINERS JobRun to VirtualCluster via spec.virtualClusterID.",
+    "isAnnotation": false,
+    "styles": {
+      "primaryColor": "",
+      "svgColor": "",
+      "svgWhite": ""
+    }
+  },
+  "model": {
+    "displayName": "",
+    "id": "00000000-0000-0000-0000-000000000000",
+    "model": {
+      "version": "v1.5.1"
+    },
+    "name": "aws-emrcontainers-controller",
+    "registrant": {
+      "kind": "github"
+    },
+    "version": "v1.5.1"
+  },
+  "schemaVersion": "relationships.meshery.io/v1beta2",
+  "selectors": [
+    {
+      "allow": {
+        "from": [
+          {
+            "id": null,
+            "kind": "VirtualCluster",
+            "match": {},
+            "match_strategy_matrix": null,
+            "model": {
+              "displayName": "",
+              "id": "00000000-0000-0000-0000-000000000000",
+              "model": {
+                "version": ""
+              },
+              "name": "aws-emrcontainers-controller",
+              "registrant": {
+                "kind": "github"
+              },
+              "version": ""
+            },
+            "patch": {
+              "patchStrategy": "replace",
+              "mutatorRef": [
+                [
+                  "configuration",
+                  "metadata",
+                  "name"
+                ]
+              ]
+            }
+          }
+        ],
+        "to": [
+          {
+            "id": null,
+            "kind": "JobRun",
+            "match": {},
+            "match_strategy_matrix": null,
+            "model": {
+              "displayName": "",
+              "id": "00000000-0000-0000-0000-000000000000",
+              "model": {
+                "version": ""
+              },
+              "name": "aws-emrcontainers-controller",
+              "registrant": {
+                "kind": "github"
+              },
+              "version": ""
+            },
+            "patch": {
+              "patchStrategy": "replace",
+              "mutatedRef": [
+                [
+                  "configuration",
+                  "spec",
+                  "virtualClusterID"
+                ]
+              ]
+            }
+          }
+        ]
+      },
+      "deny": {
+        "from": [],
+        "to": []
+      }
+    }
+  ],
+  "subType": "network",
+  "status": "enabled",
+  "type": "non-binding",
+  "version": "v1.0.0"
+}

--- a/models/aws-emrcontainers-controller/v1.5.1/v1.0.0/relationships/edge-non-binding-reference-jobrun-virtualcluster.json
+++ b/models/aws-emrcontainers-controller/v1.5.1/v1.0.0/relationships/edge-non-binding-reference-jobrun-virtualcluster.json
@@ -47,7 +47,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatedRef": [
+              "mutatorRef": [
                 [
                   "configuration",
                   "spec",
@@ -79,7 +79,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "displayName"
                 ]

--- a/models/aws-emrcontainers-controller/v1.5.1/v1.0.0/relationships/edge-non-binding-reference-jobrun-virtualcluster.json
+++ b/models/aws-emrcontainers-controller/v1.5.1/v1.0.0/relationships/edge-non-binding-reference-jobrun-virtualcluster.json
@@ -47,7 +47,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "spec",
@@ -79,7 +79,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatedRef": [
+              "mutatorRef": [
                 [
                   "displayName"
                 ]

--- a/models/aws-emrcontainers-controller/v1.5.1/v1.0.0/relationships/edge-non-binding-reference-jobrun-virtualcluster.json
+++ b/models/aws-emrcontainers-controller/v1.5.1/v1.0.0/relationships/edge-non-binding-reference-jobrun-virtualcluster.json
@@ -3,7 +3,7 @@
   "evaluationQuery": "",
   "kind": "edge",
   "metadata": {
-    "description": "Binds EMRCONTAINERS JobRun to VirtualCluster via spec.virtualClusterID.",
+    "description": "References an EMRContainers VirtualCluster from a JobRun via spec.virtualClusterRef, identifying the virtual cluster the job runs on.",
     "isAnnotation": false,
     "styles": {
       "primaryColor": "",
@@ -19,45 +19,15 @@
     },
     "name": "aws-emrcontainers-controller",
     "registrant": {
-      "kind": "github"
+      "kind": ""
     },
-    "version": "v1.5.1"
+    "version": ""
   },
   "schemaVersion": "relationships.meshery.io/v1beta2",
   "selectors": [
     {
       "allow": {
         "from": [
-          {
-            "id": null,
-            "kind": "VirtualCluster",
-            "match": {},
-            "match_strategy_matrix": null,
-            "model": {
-              "displayName": "",
-              "id": "00000000-0000-0000-0000-000000000000",
-              "model": {
-                "version": ""
-              },
-              "name": "aws-emrcontainers-controller",
-              "registrant": {
-                "kind": "github"
-              },
-              "version": ""
-            },
-            "patch": {
-              "patchStrategy": "replace",
-              "mutatorRef": [
-                [
-                  "configuration",
-                  "metadata",
-                  "name"
-                ]
-              ]
-            }
-          }
-        ],
-        "to": [
           {
             "id": null,
             "kind": "JobRun",
@@ -77,11 +47,41 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatedRef": [
+              "mutatorRef": [
                 [
                   "configuration",
                   "spec",
-                  "virtualClusterID"
+                  "virtualClusterRef",
+                  "from",
+                  "name"
+                ]
+              ]
+            }
+          }
+        ],
+        "to": [
+          {
+            "id": null,
+            "kind": "VirtualCluster",
+            "match": {},
+            "match_strategy_matrix": null,
+            "model": {
+              "displayName": "",
+              "id": "00000000-0000-0000-0000-000000000000",
+              "model": {
+                "version": ""
+              },
+              "name": "aws-emrcontainers-controller",
+              "registrant": {
+                "kind": "github"
+              },
+              "version": ""
+            },
+            "patch": {
+              "patchStrategy": "replace",
+              "mutatedRef": [
+                [
+                  "displayName"
                 ]
               ]
             }
@@ -94,7 +94,7 @@
       }
     }
   ],
-  "subType": "network",
+  "subType": "reference",
   "status": "enabled",
   "type": "non-binding",
   "version": "v1.0.0"

--- a/models/aws-prometheusservice-controller/v1.5.2/v1.0.0/relationships/edge-binding-network-alertmanagerdefinition-workspace.json
+++ b/models/aws-prometheusservice-controller/v1.5.2/v1.0.0/relationships/edge-binding-network-alertmanagerdefinition-workspace.json
@@ -1,0 +1,101 @@
+{
+  "id": "00000000-0000-0000-0000-000000000000",
+  "evaluationQuery": "",
+  "kind": "edge",
+  "metadata": {
+    "description": "Binds PROMETHEUSSERVICE AlertManagerDefinition to Workspace via spec.workspaceID.",
+    "isAnnotation": false,
+    "styles": {
+      "primaryColor": "",
+      "svgColor": "",
+      "svgWhite": ""
+    }
+  },
+  "model": {
+    "displayName": "",
+    "id": "00000000-0000-0000-0000-000000000000",
+    "model": {
+      "version": "v1.5.2"
+    },
+    "name": "aws-prometheusservice-controller",
+    "registrant": {
+      "kind": "github"
+    },
+    "version": "v1.5.2"
+  },
+  "schemaVersion": "relationships.meshery.io/v1beta2",
+  "selectors": [
+    {
+      "allow": {
+        "from": [
+          {
+            "id": null,
+            "kind": "Workspace",
+            "match": {},
+            "match_strategy_matrix": null,
+            "model": {
+              "displayName": "",
+              "id": "00000000-0000-0000-0000-000000000000",
+              "model": {
+                "version": ""
+              },
+              "name": "aws-prometheusservice-controller",
+              "registrant": {
+                "kind": "github"
+              },
+              "version": ""
+            },
+            "patch": {
+              "patchStrategy": "replace",
+              "mutatorRef": [
+                [
+                  "configuration",
+                  "metadata",
+                  "name"
+                ]
+              ]
+            }
+          }
+        ],
+        "to": [
+          {
+            "id": null,
+            "kind": "AlertManagerDefinition",
+            "match": {},
+            "match_strategy_matrix": null,
+            "model": {
+              "displayName": "",
+              "id": "00000000-0000-0000-0000-000000000000",
+              "model": {
+                "version": ""
+              },
+              "name": "aws-prometheusservice-controller",
+              "registrant": {
+                "kind": "github"
+              },
+              "version": ""
+            },
+            "patch": {
+              "patchStrategy": "replace",
+              "mutatedRef": [
+                [
+                  "configuration",
+                  "spec",
+                  "workspaceID"
+                ]
+              ]
+            }
+          }
+        ]
+      },
+      "deny": {
+        "from": [],
+        "to": []
+      }
+    }
+  ],
+  "subType": "network",
+  "status": "enabled",
+  "type": "non-binding",
+  "version": "v1.0.0"
+}

--- a/models/aws-prometheusservice-controller/v1.5.2/v1.0.0/relationships/edge-binding-network-loggingconfiguration-workspace.json
+++ b/models/aws-prometheusservice-controller/v1.5.2/v1.0.0/relationships/edge-binding-network-loggingconfiguration-workspace.json
@@ -1,0 +1,101 @@
+{
+  "id": "00000000-0000-0000-0000-000000000000",
+  "evaluationQuery": "",
+  "kind": "edge",
+  "metadata": {
+    "description": "Binds PROMETHEUSSERVICE LoggingConfiguration to Workspace via spec.workspaceID.",
+    "isAnnotation": false,
+    "styles": {
+      "primaryColor": "",
+      "svgColor": "",
+      "svgWhite": ""
+    }
+  },
+  "model": {
+    "displayName": "",
+    "id": "00000000-0000-0000-0000-000000000000",
+    "model": {
+      "version": "v1.5.2"
+    },
+    "name": "aws-prometheusservice-controller",
+    "registrant": {
+      "kind": "github"
+    },
+    "version": "v1.5.2"
+  },
+  "schemaVersion": "relationships.meshery.io/v1beta2",
+  "selectors": [
+    {
+      "allow": {
+        "from": [
+          {
+            "id": null,
+            "kind": "Workspace",
+            "match": {},
+            "match_strategy_matrix": null,
+            "model": {
+              "displayName": "",
+              "id": "00000000-0000-0000-0000-000000000000",
+              "model": {
+                "version": ""
+              },
+              "name": "aws-prometheusservice-controller",
+              "registrant": {
+                "kind": "github"
+              },
+              "version": ""
+            },
+            "patch": {
+              "patchStrategy": "replace",
+              "mutatorRef": [
+                [
+                  "configuration",
+                  "metadata",
+                  "name"
+                ]
+              ]
+            }
+          }
+        ],
+        "to": [
+          {
+            "id": null,
+            "kind": "LoggingConfiguration",
+            "match": {},
+            "match_strategy_matrix": null,
+            "model": {
+              "displayName": "",
+              "id": "00000000-0000-0000-0000-000000000000",
+              "model": {
+                "version": ""
+              },
+              "name": "aws-prometheusservice-controller",
+              "registrant": {
+                "kind": "github"
+              },
+              "version": ""
+            },
+            "patch": {
+              "patchStrategy": "replace",
+              "mutatedRef": [
+                [
+                  "configuration",
+                  "spec",
+                  "workspaceID"
+                ]
+              ]
+            }
+          }
+        ]
+      },
+      "deny": {
+        "from": [],
+        "to": []
+      }
+    }
+  ],
+  "subType": "network",
+  "status": "enabled",
+  "type": "non-binding",
+  "version": "v1.0.0"
+}

--- a/models/aws-prometheusservice-controller/v1.5.2/v1.0.0/relationships/edge-binding-network-rulegroupsnamespace-workspace.json
+++ b/models/aws-prometheusservice-controller/v1.5.2/v1.0.0/relationships/edge-binding-network-rulegroupsnamespace-workspace.json
@@ -1,0 +1,101 @@
+{
+  "id": "00000000-0000-0000-0000-000000000000",
+  "evaluationQuery": "",
+  "kind": "edge",
+  "metadata": {
+    "description": "Binds PROMETHEUSSERVICE RuleGroupsNamespace to Workspace via spec.workspaceID.",
+    "isAnnotation": false,
+    "styles": {
+      "primaryColor": "",
+      "svgColor": "",
+      "svgWhite": ""
+    }
+  },
+  "model": {
+    "displayName": "",
+    "id": "00000000-0000-0000-0000-000000000000",
+    "model": {
+      "version": "v1.5.2"
+    },
+    "name": "aws-prometheusservice-controller",
+    "registrant": {
+      "kind": "github"
+    },
+    "version": "v1.5.2"
+  },
+  "schemaVersion": "relationships.meshery.io/v1beta2",
+  "selectors": [
+    {
+      "allow": {
+        "from": [
+          {
+            "id": null,
+            "kind": "Workspace",
+            "match": {},
+            "match_strategy_matrix": null,
+            "model": {
+              "displayName": "",
+              "id": "00000000-0000-0000-0000-000000000000",
+              "model": {
+                "version": ""
+              },
+              "name": "aws-prometheusservice-controller",
+              "registrant": {
+                "kind": "github"
+              },
+              "version": ""
+            },
+            "patch": {
+              "patchStrategy": "replace",
+              "mutatorRef": [
+                [
+                  "configuration",
+                  "metadata",
+                  "name"
+                ]
+              ]
+            }
+          }
+        ],
+        "to": [
+          {
+            "id": null,
+            "kind": "RuleGroupsNamespace",
+            "match": {},
+            "match_strategy_matrix": null,
+            "model": {
+              "displayName": "",
+              "id": "00000000-0000-0000-0000-000000000000",
+              "model": {
+                "version": ""
+              },
+              "name": "aws-prometheusservice-controller",
+              "registrant": {
+                "kind": "github"
+              },
+              "version": ""
+            },
+            "patch": {
+              "patchStrategy": "replace",
+              "mutatedRef": [
+                [
+                  "configuration",
+                  "spec",
+                  "workspaceID"
+                ]
+              ]
+            }
+          }
+        ]
+      },
+      "deny": {
+        "from": [],
+        "to": []
+      }
+    }
+  ],
+  "subType": "network",
+  "status": "enabled",
+  "type": "non-binding",
+  "version": "v1.0.0"
+}

--- a/models/aws-prometheusservice-controller/v1.5.2/v1.0.0/relationships/edge-non-binding-reference-alertmanagerdefinition-workspace.json
+++ b/models/aws-prometheusservice-controller/v1.5.2/v1.0.0/relationships/edge-non-binding-reference-alertmanagerdefinition-workspace.json
@@ -47,7 +47,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatedRef": [
+              "mutatorRef": [
                 [
                   "configuration",
                   "spec",
@@ -79,7 +79,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "displayName"
                 ]

--- a/models/aws-prometheusservice-controller/v1.5.2/v1.0.0/relationships/edge-non-binding-reference-alertmanagerdefinition-workspace.json
+++ b/models/aws-prometheusservice-controller/v1.5.2/v1.0.0/relationships/edge-non-binding-reference-alertmanagerdefinition-workspace.json
@@ -47,7 +47,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "spec",
@@ -79,7 +79,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatedRef": [
+              "mutatorRef": [
                 [
                   "displayName"
                 ]

--- a/models/aws-prometheusservice-controller/v1.5.2/v1.0.0/relationships/edge-non-binding-reference-alertmanagerdefinition-workspace.json
+++ b/models/aws-prometheusservice-controller/v1.5.2/v1.0.0/relationships/edge-non-binding-reference-alertmanagerdefinition-workspace.json
@@ -3,7 +3,7 @@
   "evaluationQuery": "",
   "kind": "edge",
   "metadata": {
-    "description": "Binds DYNAMODB Table to Key via spec.sseSpecification.kmsMasterKeyID.",
+    "description": "References a PrometheusService Workspace from a AlertManagerDefinition via spec.workspaceRef, identifying the workspace the AlertManagerDefinition belongs to.",
     "isAnnotation": false,
     "styles": {
       "primaryColor": "",
@@ -15,13 +15,13 @@
     "displayName": "",
     "id": "00000000-0000-0000-0000-000000000000",
     "model": {
-      "version": "v1.9.2"
+      "version": "v1.5.2"
     },
-    "name": "aws-dynamodb-controller",
+    "name": "aws-prometheusservice-controller",
     "registrant": {
-      "kind": "github"
+      "kind": ""
     },
-    "version": "v1.9.2"
+    "version": ""
   },
   "schemaVersion": "relationships.meshery.io/v1beta2",
   "selectors": [
@@ -30,7 +30,7 @@
         "from": [
           {
             "id": null,
-            "kind": "Key",
+            "kind": "AlertManagerDefinition",
             "match": {},
             "match_strategy_matrix": null,
             "model": {
@@ -39,7 +39,7 @@
               "model": {
                 "version": ""
               },
-              "name": "aws-kms-controller",
+              "name": "aws-prometheusservice-controller",
               "registrant": {
                 "kind": "github"
               },
@@ -50,7 +50,9 @@
               "mutatorRef": [
                 [
                   "configuration",
-                  "metadata",
+                  "spec",
+                  "workspaceRef",
+                  "from",
                   "name"
                 ]
               ]
@@ -60,7 +62,7 @@
         "to": [
           {
             "id": null,
-            "kind": "Table",
+            "kind": "Workspace",
             "match": {},
             "match_strategy_matrix": null,
             "model": {
@@ -69,7 +71,7 @@
               "model": {
                 "version": ""
               },
-              "name": "aws-dynamodb-controller",
+              "name": "aws-prometheusservice-controller",
               "registrant": {
                 "kind": "github"
               },
@@ -79,10 +81,7 @@
               "patchStrategy": "replace",
               "mutatedRef": [
                 [
-                  "configuration",
-                  "spec",
-                  "sseSpecification",
-                  "kmsMasterKeyID"
+                  "displayName"
                 ]
               ]
             }
@@ -95,7 +94,7 @@
       }
     }
   ],
-  "subType": "permission",
+  "subType": "reference",
   "status": "enabled",
   "type": "non-binding",
   "version": "v1.0.0"

--- a/models/aws-prometheusservice-controller/v1.5.2/v1.0.0/relationships/edge-non-binding-reference-loggingconfiguration-workspace.json
+++ b/models/aws-prometheusservice-controller/v1.5.2/v1.0.0/relationships/edge-non-binding-reference-loggingconfiguration-workspace.json
@@ -3,7 +3,7 @@
   "evaluationQuery": "",
   "kind": "edge",
   "metadata": {
-    "description": "Binds PROMETHEUSSERVICE RuleGroupsNamespace to Workspace via spec.workspaceID.",
+    "description": "References a PrometheusService Workspace from a LoggingConfiguration via spec.workspaceRef, identifying the workspace the LoggingConfiguration belongs to.",
     "isAnnotation": false,
     "styles": {
       "primaryColor": "",
@@ -19,9 +19,9 @@
     },
     "name": "aws-prometheusservice-controller",
     "registrant": {
-      "kind": "github"
+      "kind": ""
     },
-    "version": "v1.5.2"
+    "version": ""
   },
   "schemaVersion": "relationships.meshery.io/v1beta2",
   "selectors": [
@@ -30,7 +30,7 @@
         "from": [
           {
             "id": null,
-            "kind": "Workspace",
+            "kind": "LoggingConfiguration",
             "match": {},
             "match_strategy_matrix": null,
             "model": {
@@ -50,7 +50,9 @@
               "mutatorRef": [
                 [
                   "configuration",
-                  "metadata",
+                  "spec",
+                  "workspaceRef",
+                  "from",
                   "name"
                 ]
               ]
@@ -60,7 +62,7 @@
         "to": [
           {
             "id": null,
-            "kind": "RuleGroupsNamespace",
+            "kind": "Workspace",
             "match": {},
             "match_strategy_matrix": null,
             "model": {
@@ -79,9 +81,7 @@
               "patchStrategy": "replace",
               "mutatedRef": [
                 [
-                  "configuration",
-                  "spec",
-                  "workspaceID"
+                  "displayName"
                 ]
               ]
             }
@@ -94,7 +94,7 @@
       }
     }
   ],
-  "subType": "network",
+  "subType": "reference",
   "status": "enabled",
   "type": "non-binding",
   "version": "v1.0.0"

--- a/models/aws-prometheusservice-controller/v1.5.2/v1.0.0/relationships/edge-non-binding-reference-loggingconfiguration-workspace.json
+++ b/models/aws-prometheusservice-controller/v1.5.2/v1.0.0/relationships/edge-non-binding-reference-loggingconfiguration-workspace.json
@@ -47,7 +47,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatedRef": [
+              "mutatorRef": [
                 [
                   "configuration",
                   "spec",
@@ -79,7 +79,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "displayName"
                 ]

--- a/models/aws-prometheusservice-controller/v1.5.2/v1.0.0/relationships/edge-non-binding-reference-loggingconfiguration-workspace.json
+++ b/models/aws-prometheusservice-controller/v1.5.2/v1.0.0/relationships/edge-non-binding-reference-loggingconfiguration-workspace.json
@@ -47,7 +47,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "spec",
@@ -79,7 +79,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatedRef": [
+              "mutatorRef": [
                 [
                   "displayName"
                 ]

--- a/models/aws-prometheusservice-controller/v1.5.2/v1.0.0/relationships/edge-non-binding-reference-rulegroupsnamespace-workspace.json
+++ b/models/aws-prometheusservice-controller/v1.5.2/v1.0.0/relationships/edge-non-binding-reference-rulegroupsnamespace-workspace.json
@@ -47,7 +47,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatedRef": [
+              "mutatorRef": [
                 [
                   "configuration",
                   "spec",
@@ -79,7 +79,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "displayName"
                 ]

--- a/models/aws-prometheusservice-controller/v1.5.2/v1.0.0/relationships/edge-non-binding-reference-rulegroupsnamespace-workspace.json
+++ b/models/aws-prometheusservice-controller/v1.5.2/v1.0.0/relationships/edge-non-binding-reference-rulegroupsnamespace-workspace.json
@@ -47,7 +47,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "spec",
@@ -79,7 +79,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatedRef": [
+              "mutatorRef": [
                 [
                   "displayName"
                 ]

--- a/models/aws-prometheusservice-controller/v1.5.2/v1.0.0/relationships/edge-non-binding-reference-rulegroupsnamespace-workspace.json
+++ b/models/aws-prometheusservice-controller/v1.5.2/v1.0.0/relationships/edge-non-binding-reference-rulegroupsnamespace-workspace.json
@@ -3,7 +3,7 @@
   "evaluationQuery": "",
   "kind": "edge",
   "metadata": {
-    "description": "Binds PROMETHEUSSERVICE AlertManagerDefinition to Workspace via spec.workspaceID.",
+    "description": "References a PrometheusService Workspace from a RuleGroupsNamespace via spec.workspaceRef, identifying the workspace the RuleGroupsNamespace belongs to.",
     "isAnnotation": false,
     "styles": {
       "primaryColor": "",
@@ -19,9 +19,9 @@
     },
     "name": "aws-prometheusservice-controller",
     "registrant": {
-      "kind": "github"
+      "kind": ""
     },
-    "version": "v1.5.2"
+    "version": ""
   },
   "schemaVersion": "relationships.meshery.io/v1beta2",
   "selectors": [
@@ -30,7 +30,7 @@
         "from": [
           {
             "id": null,
-            "kind": "Workspace",
+            "kind": "RuleGroupsNamespace",
             "match": {},
             "match_strategy_matrix": null,
             "model": {
@@ -50,7 +50,9 @@
               "mutatorRef": [
                 [
                   "configuration",
-                  "metadata",
+                  "spec",
+                  "workspaceRef",
+                  "from",
                   "name"
                 ]
               ]
@@ -60,7 +62,7 @@
         "to": [
           {
             "id": null,
-            "kind": "AlertManagerDefinition",
+            "kind": "Workspace",
             "match": {},
             "match_strategy_matrix": null,
             "model": {
@@ -79,9 +81,7 @@
               "patchStrategy": "replace",
               "mutatedRef": [
                 [
-                  "configuration",
-                  "spec",
-                  "workspaceID"
+                  "displayName"
                 ]
               ]
             }
@@ -94,7 +94,7 @@
       }
     }
   ],
-  "subType": "network",
+  "subType": "reference",
   "status": "enabled",
   "type": "non-binding",
   "version": "v1.0.0"

--- a/models/aws-rds-controller/v1.10.0/v1.0.0/relationships/edge-non-binding-reference-pixjj.json
+++ b/models/aws-rds-controller/v1.10.0/v1.0.0/relationships/edge-non-binding-reference-pixjj.json
@@ -46,14 +46,14 @@
               "version": ""
             },
             "patch": {
-              "mutatedRef": [
+              "patchStrategy": "replace",
+              "mutatorRef": [
                 [
                   "configuration",
                   "spec",
                   "dbSubnetGroupName"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ],
@@ -76,12 +76,12 @@
               "version": ""
             },
             "patch": {
-              "mutatorRef": [
+              "patchStrategy": "replace",
+              "mutatedRef": [
                 [
                   "name"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ]

--- a/models/aws-rds-controller/v1.10.1/v1.0.0/relationships/edge-non-binding-reference-pixjj.json
+++ b/models/aws-rds-controller/v1.10.1/v1.0.0/relationships/edge-non-binding-reference-pixjj.json
@@ -46,14 +46,14 @@
               "version": ""
             },
             "patch": {
-              "mutatedRef": [
+              "patchStrategy": "replace",
+              "mutatorRef": [
                 [
                   "configuration",
                   "spec",
                   "dbSubnetGroupName"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ],
@@ -76,12 +76,12 @@
               "version": ""
             },
             "patch": {
-              "mutatorRef": [
+              "patchStrategy": "replace",
+              "mutatedRef": [
                 [
                   "name"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ]

--- a/models/aws-rds-controller/v1.9.4/v1.0.0/relationships/edge-non-binding-reference-pixjj.json
+++ b/models/aws-rds-controller/v1.9.4/v1.0.0/relationships/edge-non-binding-reference-pixjj.json
@@ -46,14 +46,14 @@
               "version": ""
             },
             "patch": {
-              "mutatedRef": [
+              "patchStrategy": "replace",
+              "mutatorRef": [
                 [
                   "configuration",
                   "spec",
                   "dbSubnetGroupName"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ],
@@ -76,12 +76,12 @@
               "version": ""
             },
             "patch": {
-              "mutatorRef": [
+              "patchStrategy": "replace",
+              "mutatedRef": [
                 [
                   "name"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ]

--- a/models/aws-route53-controller/v1.4.3/v1.0.0/relationships/hierarchical-parent-inventory-xsxsz.json
+++ b/models/aws-route53-controller/v1.4.3/v1.0.0/relationships/hierarchical-parent-inventory-xsxsz.json
@@ -46,12 +46,12 @@
               "version": ""
             },
             "patch": {
-              "mutatedRef": [
+              "patchStrategy": "replace",
+              "mutatorRef": [
                 [
                   "displayName"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ],
@@ -74,14 +74,14 @@
               "version": ""
             },
             "patch": {
-              "mutatorRef": [
+              "patchStrategy": "replace",
+              "mutatedRef": [
                 [
                   "configuration",
                   "spec",
                   "hostedZoneID"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ]

--- a/models/aws-route53-controller/v1.4.4/v1.0.0/relationships/hierarchical-parent-inventory-xsxsz.json
+++ b/models/aws-route53-controller/v1.4.4/v1.0.0/relationships/hierarchical-parent-inventory-xsxsz.json
@@ -46,12 +46,12 @@
               "version": ""
             },
             "patch": {
-              "mutatedRef": [
+              "patchStrategy": "replace",
+              "mutatorRef": [
                 [
                   "displayName"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ],
@@ -74,14 +74,14 @@
               "version": ""
             },
             "patch": {
-              "mutatorRef": [
+              "patchStrategy": "replace",
+              "mutatedRef": [
                 [
                   "configuration",
                   "spec",
                   "hostedZoneID"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ]

--- a/models/aws-sagemaker-controller/v1.8.0/v1.0.0/relationships/hierarchical-parent-inventory-asuic.json
+++ b/models/aws-sagemaker-controller/v1.8.0/v1.0.0/relationships/hierarchical-parent-inventory-asuic.json
@@ -46,12 +46,12 @@
               "version": ""
             },
             "patch": {
-              "mutatedRef": [
+              "patchStrategy": "replace",
+              "mutatorRef": [
                 [
                   "displayName"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ],
@@ -74,14 +74,14 @@
               "version": ""
             },
             "patch": {
-              "mutatorRef": [
+              "patchStrategy": "replace",
+              "mutatedRef": [
                 [
                   "configuration",
                   "spec",
                   "userProfileName"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ]

--- a/models/aws-sagemaker-controller/v1.8.0/v1.0.0/relationships/hierarchical-parent-inventory-cadaz.json
+++ b/models/aws-sagemaker-controller/v1.8.0/v1.0.0/relationships/hierarchical-parent-inventory-cadaz.json
@@ -46,12 +46,12 @@
               "version": ""
             },
             "patch": {
-              "mutatedRef": [
+              "patchStrategy": "replace",
+              "mutatorRef": [
                 [
                   "displayName"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ],
@@ -74,14 +74,14 @@
               "version": ""
             },
             "patch": {
-              "mutatorRef": [
+              "patchStrategy": "replace",
+              "mutatedRef": [
                 [
                   "configuration",
                   "spec",
                   "pipelineName"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ]

--- a/models/aws-sagemaker-controller/v1.8.0/v1.0.0/relationships/hierarchical-parent-inventory-upbgv.json
+++ b/models/aws-sagemaker-controller/v1.8.0/v1.0.0/relationships/hierarchical-parent-inventory-upbgv.json
@@ -46,12 +46,12 @@
               "version": ""
             },
             "patch": {
-              "mutatedRef": [
+              "patchStrategy": "replace",
+              "mutatorRef": [
                 [
                   "displayName"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ],
@@ -74,14 +74,14 @@
               "version": ""
             },
             "patch": {
-              "mutatorRef": [
+              "patchStrategy": "replace",
+              "mutatedRef": [
                 [
                   "configuration",
                   "spec",
                   "modelPackageGroupName"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ]

--- a/models/aws-sagemaker-controller/v1.8.0/v1.0.0/relationships/hierarchical-parent-inventory-yamdj.json
+++ b/models/aws-sagemaker-controller/v1.8.0/v1.0.0/relationships/hierarchical-parent-inventory-yamdj.json
@@ -75,12 +75,12 @@
               "version": ""
             },
             "patch": {
-              "mutatedRef": [
+              "patchStrategy": "replace",
+              "mutatorRef": [
                 [
                   "displayName"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ],
@@ -132,14 +132,14 @@
               "version": ""
             },
             "patch": {
-              "mutatorRef": [
+              "patchStrategy": "replace",
+              "mutatedRef": [
                 [
                   "configuration",
                   "spec",
                   "domainID"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ]

--- a/models/aws-sagemaker-controller/v1.8.1/v1.0.0/relationships/hierarchical-parent-inventory-asuic.json
+++ b/models/aws-sagemaker-controller/v1.8.1/v1.0.0/relationships/hierarchical-parent-inventory-asuic.json
@@ -46,12 +46,12 @@
               "version": ""
             },
             "patch": {
-              "mutatedRef": [
+              "patchStrategy": "replace",
+              "mutatorRef": [
                 [
                   "displayName"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ],
@@ -74,14 +74,14 @@
               "version": ""
             },
             "patch": {
-              "mutatorRef": [
+              "patchStrategy": "replace",
+              "mutatedRef": [
                 [
                   "configuration",
                   "spec",
                   "userProfileName"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ]

--- a/models/aws-sagemaker-controller/v1.8.1/v1.0.0/relationships/hierarchical-parent-inventory-cadaz.json
+++ b/models/aws-sagemaker-controller/v1.8.1/v1.0.0/relationships/hierarchical-parent-inventory-cadaz.json
@@ -46,12 +46,12 @@
               "version": ""
             },
             "patch": {
-              "mutatedRef": [
+              "patchStrategy": "replace",
+              "mutatorRef": [
                 [
                   "displayName"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ],
@@ -74,14 +74,14 @@
               "version": ""
             },
             "patch": {
-              "mutatorRef": [
+              "patchStrategy": "replace",
+              "mutatedRef": [
                 [
                   "configuration",
                   "spec",
                   "pipelineName"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ]

--- a/models/aws-sagemaker-controller/v1.8.1/v1.0.0/relationships/hierarchical-parent-inventory-upbgv.json
+++ b/models/aws-sagemaker-controller/v1.8.1/v1.0.0/relationships/hierarchical-parent-inventory-upbgv.json
@@ -46,12 +46,12 @@
               "version": ""
             },
             "patch": {
-              "mutatedRef": [
+              "patchStrategy": "replace",
+              "mutatorRef": [
                 [
                   "displayName"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ],
@@ -74,14 +74,14 @@
               "version": ""
             },
             "patch": {
-              "mutatorRef": [
+              "patchStrategy": "replace",
+              "mutatedRef": [
                 [
                   "configuration",
                   "spec",
                   "modelPackageGroupName"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ]

--- a/models/aws-sagemaker-controller/v1.8.1/v1.0.0/relationships/hierarchical-parent-inventory-yamdj.json
+++ b/models/aws-sagemaker-controller/v1.8.1/v1.0.0/relationships/hierarchical-parent-inventory-yamdj.json
@@ -75,12 +75,12 @@
               "version": ""
             },
             "patch": {
-              "mutatedRef": [
+              "patchStrategy": "replace",
+              "mutatorRef": [
                 [
                   "displayName"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ],
@@ -132,14 +132,14 @@
               "version": ""
             },
             "patch": {
-              "mutatorRef": [
+              "patchStrategy": "replace",
+              "mutatedRef": [
                 [
                   "configuration",
                   "spec",
                   "domainID"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ]

--- a/models/aws-sagemaker-controller/v1.8.3/v1.0.0/relationships/hierarchical-parent-inventory-asuic.json
+++ b/models/aws-sagemaker-controller/v1.8.3/v1.0.0/relationships/hierarchical-parent-inventory-asuic.json
@@ -46,12 +46,12 @@
               "version": ""
             },
             "patch": {
-              "mutatedRef": [
+              "patchStrategy": "replace",
+              "mutatorRef": [
                 [
                   "displayName"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ],
@@ -74,14 +74,14 @@
               "version": ""
             },
             "patch": {
-              "mutatorRef": [
+              "patchStrategy": "replace",
+              "mutatedRef": [
                 [
                   "configuration",
                   "spec",
                   "userProfileName"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ]

--- a/models/aws-sagemaker-controller/v1.8.3/v1.0.0/relationships/hierarchical-parent-inventory-cadaz.json
+++ b/models/aws-sagemaker-controller/v1.8.3/v1.0.0/relationships/hierarchical-parent-inventory-cadaz.json
@@ -46,12 +46,12 @@
               "version": ""
             },
             "patch": {
-              "mutatedRef": [
+              "patchStrategy": "replace",
+              "mutatorRef": [
                 [
                   "displayName"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ],
@@ -74,14 +74,14 @@
               "version": ""
             },
             "patch": {
-              "mutatorRef": [
+              "patchStrategy": "replace",
+              "mutatedRef": [
                 [
                   "configuration",
                   "spec",
                   "pipelineName"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ]

--- a/models/aws-sagemaker-controller/v1.8.3/v1.0.0/relationships/hierarchical-parent-inventory-upbgv.json
+++ b/models/aws-sagemaker-controller/v1.8.3/v1.0.0/relationships/hierarchical-parent-inventory-upbgv.json
@@ -46,12 +46,12 @@
               "version": ""
             },
             "patch": {
-              "mutatedRef": [
+              "patchStrategy": "replace",
+              "mutatorRef": [
                 [
                   "displayName"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ],
@@ -74,14 +74,14 @@
               "version": ""
             },
             "patch": {
-              "mutatorRef": [
+              "patchStrategy": "replace",
+              "mutatedRef": [
                 [
                   "configuration",
                   "spec",
                   "modelPackageGroupName"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ]

--- a/models/aws-sagemaker-controller/v1.8.3/v1.0.0/relationships/hierarchical-parent-inventory-yamdj.json
+++ b/models/aws-sagemaker-controller/v1.8.3/v1.0.0/relationships/hierarchical-parent-inventory-yamdj.json
@@ -75,12 +75,12 @@
               "version": ""
             },
             "patch": {
-              "mutatedRef": [
+              "patchStrategy": "replace",
+              "mutatorRef": [
                 [
                   "displayName"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ],
@@ -132,14 +132,14 @@
               "version": ""
             },
             "patch": {
-              "mutatorRef": [
+              "patchStrategy": "replace",
+              "mutatedRef": [
                 [
                   "configuration",
                   "spec",
                   "domainID"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ]

--- a/models/aws-sns-controller/v1.5.3/v1.0.0/relationships/edge-binding-network-bqddq.json
+++ b/models/aws-sns-controller/v1.5.3/v1.0.0/relationships/edge-binding-network-bqddq.json
@@ -46,12 +46,12 @@
               "version": ""
             },
             "patch": {
-              "mutatedRef": [
+              "patchStrategy": "replace",
+              "mutatorRef": [
                 [
                   "displayName"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ],
@@ -74,14 +74,14 @@
               "version": ""
             },
             "patch": {
-              "mutatorRef": [
+              "patchStrategy": "replace",
+              "mutatedRef": [
                 [
                   "configuration",
                   "spec",
                   "topicARN"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ]

--- a/models/aws-sns-controller/v1.5.3/v1.0.0/relationships/edge-non-binding-network-qwafj.json
+++ b/models/aws-sns-controller/v1.5.3/v1.0.0/relationships/edge-non-binding-network-qwafj.json
@@ -46,15 +46,15 @@
               "version": ""
             },
             "patch": {
-              "mutatedRef": [
+              "patchStrategy": "replace",
+              "mutatorRef": [
                 [
                   "configuration",
                   "status",
                   "ackResourceMetadata",
                   "arn"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ],
@@ -77,14 +77,14 @@
               "version": ""
             },
             "patch": {
-              "mutatorRef": [
+              "patchStrategy": "replace",
+              "mutatedRef": [
                 [
                   "configuration",
                   "spec",
                   "endpoint"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ]

--- a/models/aws-sns-controller/v1.6.0/v1.0.0/relationships/edge-binding-network-bqddq.json
+++ b/models/aws-sns-controller/v1.6.0/v1.0.0/relationships/edge-binding-network-bqddq.json
@@ -46,12 +46,12 @@
               "version": ""
             },
             "patch": {
-              "mutatedRef": [
+              "patchStrategy": "replace",
+              "mutatorRef": [
                 [
                   "displayName"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ],
@@ -74,14 +74,14 @@
               "version": ""
             },
             "patch": {
-              "mutatorRef": [
+              "patchStrategy": "replace",
+              "mutatedRef": [
                 [
                   "configuration",
                   "spec",
                   "topicARN"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ]

--- a/models/aws-sns-controller/v1.6.0/v1.0.0/relationships/edge-non-binding-network-qwafj.json
+++ b/models/aws-sns-controller/v1.6.0/v1.0.0/relationships/edge-non-binding-network-qwafj.json
@@ -46,15 +46,15 @@
               "version": ""
             },
             "patch": {
-              "mutatedRef": [
+              "patchStrategy": "replace",
+              "mutatorRef": [
                 [
                   "configuration",
                   "status",
                   "ackResourceMetadata",
                   "arn"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ],
@@ -77,14 +77,14 @@
               "version": ""
             },
             "patch": {
-              "mutatorRef": [
+              "patchStrategy": "replace",
+              "mutatedRef": [
                 [
                   "configuration",
                   "spec",
                   "endpoint"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ]

--- a/models/aws-sns-controller/v1.7.0/v1.0.0/relationships/edge-binding-network-bqddq.json
+++ b/models/aws-sns-controller/v1.7.0/v1.0.0/relationships/edge-binding-network-bqddq.json
@@ -46,12 +46,12 @@
               "version": ""
             },
             "patch": {
-              "mutatedRef": [
+              "patchStrategy": "replace",
+              "mutatorRef": [
                 [
                   "displayName"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ],
@@ -74,14 +74,14 @@
               "version": ""
             },
             "patch": {
-              "mutatorRef": [
+              "patchStrategy": "replace",
+              "mutatedRef": [
                 [
                   "configuration",
                   "spec",
                   "topicARN"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ]

--- a/models/aws-sns-controller/v1.7.0/v1.0.0/relationships/edge-non-binding-network-qwafj.json
+++ b/models/aws-sns-controller/v1.7.0/v1.0.0/relationships/edge-non-binding-network-qwafj.json
@@ -46,15 +46,15 @@
               "version": ""
             },
             "patch": {
-              "mutatedRef": [
+              "patchStrategy": "replace",
+              "mutatorRef": [
                 [
                   "configuration",
                   "status",
                   "ackResourceMetadata",
                   "arn"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ],
@@ -77,14 +77,14 @@
               "version": ""
             },
             "patch": {
-              "mutatorRef": [
+              "patchStrategy": "replace",
+              "mutatedRef": [
                 [
                   "configuration",
                   "spec",
                   "endpoint"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ]

--- a/models/aws-sns-controller/v1.7.1/v1.0.0/relationships/edge-binding-network-bqddq.json
+++ b/models/aws-sns-controller/v1.7.1/v1.0.0/relationships/edge-binding-network-bqddq.json
@@ -46,12 +46,12 @@
               "version": ""
             },
             "patch": {
-              "mutatedRef": [
+              "patchStrategy": "replace",
+              "mutatorRef": [
                 [
                   "displayName"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ],
@@ -74,14 +74,14 @@
               "version": ""
             },
             "patch": {
-              "mutatorRef": [
+              "patchStrategy": "replace",
+              "mutatedRef": [
                 [
                   "configuration",
                   "spec",
                   "topicARN"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ]

--- a/models/aws-sns-controller/v1.7.1/v1.0.0/relationships/edge-non-binding-network-qwafj.json
+++ b/models/aws-sns-controller/v1.7.1/v1.0.0/relationships/edge-non-binding-network-qwafj.json
@@ -46,15 +46,15 @@
               "version": ""
             },
             "patch": {
-              "mutatedRef": [
+              "patchStrategy": "replace",
+              "mutatorRef": [
                 [
                   "configuration",
                   "status",
                   "ackResourceMetadata",
                   "arn"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ],
@@ -77,14 +77,14 @@
               "version": ""
             },
             "patch": {
-              "mutatorRef": [
+              "patchStrategy": "replace",
+              "mutatedRef": [
                 [
                   "configuration",
                   "spec",
                   "endpoint"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ]

--- a/models/azure-alerts-management/azureserviceoperator_customresourcedefinitions_v2.13.0.yaml/v1.0.0/relationships/edge-non-binding-alias-fpnda.json
+++ b/models/azure-alerts-management/azureserviceoperator_customresourcedefinitions_v2.13.0.yaml/v1.0.0/relationships/edge-non-binding-alias-fpnda.json
@@ -45,7 +45,8 @@
               "version": ""
             },
             "patch": {
-              "mutatedRef": [
+              "patchStrategy": "replace",
+              "mutatorRef": [
                 [
                   "configuration",
                   "spec",
@@ -64,8 +65,7 @@
                   "scopesReferences",
                   "name"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ],
@@ -87,7 +87,8 @@
               "version": ""
             },
             "patch": {
-              "mutatorRef": [
+              "patchStrategy": "replace",
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -101,8 +102,7 @@
                   "metadata",
                   "name"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ]

--- a/models/azure-alerts-management/azureserviceoperator_customresourcedefinitions_v2.13.0.yaml/v1.0.0/relationships/edge-non-binding-alias-nhjbm.json
+++ b/models/azure-alerts-management/azureserviceoperator_customresourcedefinitions_v2.13.0.yaml/v1.0.0/relationships/edge-non-binding-alias-nhjbm.json
@@ -45,7 +45,8 @@
               "version": ""
             },
             "patch": {
-              "mutatedRef": [
+              "patchStrategy": "replace",
+              "mutatorRef": [
                 [
                   "configuration",
                   "spec",
@@ -64,8 +65,7 @@
                   "scopesReferences",
                   "name"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ],
@@ -87,7 +87,8 @@
               "version": ""
             },
             "patch": {
-              "mutatorRef": [
+              "patchStrategy": "replace",
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -101,8 +102,7 @@
                   "metadata",
                   "name"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ]

--- a/models/azure-alerts-management/azureserviceoperator_customresourcedefinitions_v2.13.0.yaml/v1.0.0/relationships/edge-non-binding-alias-qgcfo.json
+++ b/models/azure-alerts-management/azureserviceoperator_customresourcedefinitions_v2.13.0.yaml/v1.0.0/relationships/edge-non-binding-alias-qgcfo.json
@@ -45,7 +45,8 @@
               "version": ""
             },
             "patch": {
-              "mutatedRef": [
+              "patchStrategy": "replace",
+              "mutatorRef": [
                 [
                   "configuration",
                   "spec",
@@ -67,8 +68,7 @@
                   "groupReferences",
                   "name"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ],
@@ -90,7 +90,8 @@
               "version": ""
             },
             "patch": {
-              "mutatorRef": [
+              "patchStrategy": "replace",
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -104,8 +105,7 @@
                   "metadata",
                   "name"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ]

--- a/models/azure-alerts-management/azureserviceoperator_customresourcedefinitions_v2.13.0.yaml/v1.0.0/relationships/hierarchical-parent-inventory-kmjea.json
+++ b/models/azure-alerts-management/azureserviceoperator_customresourcedefinitions_v2.13.0.yaml/v1.0.0/relationships/hierarchical-parent-inventory-kmjea.json
@@ -91,7 +91,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatedRef": [
+              "mutatorRef": [
                 [
                   "configuration",
                   "spec",
@@ -159,7 +159,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"

--- a/models/azure-alerts-management/azureserviceoperator_customresourcedefinitions_v2.14.0.yaml/v1.0.0/relationships/edge-non-binding-alias-fpnda.json
+++ b/models/azure-alerts-management/azureserviceoperator_customresourcedefinitions_v2.14.0.yaml/v1.0.0/relationships/edge-non-binding-alias-fpnda.json
@@ -45,7 +45,8 @@
               "version": ""
             },
             "patch": {
-              "mutatedRef": [
+              "patchStrategy": "replace",
+              "mutatorRef": [
                 [
                   "configuration",
                   "spec",
@@ -64,8 +65,7 @@
                   "scopesReferences",
                   "name"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ],
@@ -87,7 +87,8 @@
               "version": ""
             },
             "patch": {
-              "mutatorRef": [
+              "patchStrategy": "replace",
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -101,8 +102,7 @@
                   "metadata",
                   "name"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ]

--- a/models/azure-alerts-management/azureserviceoperator_customresourcedefinitions_v2.14.0.yaml/v1.0.0/relationships/edge-non-binding-alias-nhjbm.json
+++ b/models/azure-alerts-management/azureserviceoperator_customresourcedefinitions_v2.14.0.yaml/v1.0.0/relationships/edge-non-binding-alias-nhjbm.json
@@ -45,7 +45,8 @@
               "version": ""
             },
             "patch": {
-              "mutatedRef": [
+              "patchStrategy": "replace",
+              "mutatorRef": [
                 [
                   "configuration",
                   "spec",
@@ -64,8 +65,7 @@
                   "scopesReferences",
                   "name"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ],
@@ -87,7 +87,8 @@
               "version": ""
             },
             "patch": {
-              "mutatorRef": [
+              "patchStrategy": "replace",
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -101,8 +102,7 @@
                   "metadata",
                   "name"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ]

--- a/models/azure-alerts-management/azureserviceoperator_customresourcedefinitions_v2.14.0.yaml/v1.0.0/relationships/edge-non-binding-alias-qgcfo.json
+++ b/models/azure-alerts-management/azureserviceoperator_customresourcedefinitions_v2.14.0.yaml/v1.0.0/relationships/edge-non-binding-alias-qgcfo.json
@@ -45,7 +45,8 @@
               "version": ""
             },
             "patch": {
-              "mutatedRef": [
+              "patchStrategy": "replace",
+              "mutatorRef": [
                 [
                   "configuration",
                   "spec",
@@ -67,8 +68,7 @@
                   "groupReferences",
                   "name"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ],
@@ -90,7 +90,8 @@
               "version": ""
             },
             "patch": {
-              "mutatorRef": [
+              "patchStrategy": "replace",
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -104,8 +105,7 @@
                   "metadata",
                   "name"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ]

--- a/models/azure-alerts-management/azureserviceoperator_customresourcedefinitions_v2.14.0.yaml/v1.0.0/relationships/hierarchical-parent-inventory-kmjea.json
+++ b/models/azure-alerts-management/azureserviceoperator_customresourcedefinitions_v2.14.0.yaml/v1.0.0/relationships/hierarchical-parent-inventory-kmjea.json
@@ -91,7 +91,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatedRef": [
+              "mutatorRef": [
                 [
                   "configuration",
                   "spec",
@@ -159,7 +159,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"

--- a/models/azure-api-management/azureserviceoperator_customresourcedefinitions_v2.13.0.yaml/v1.0.0/relationships/hierarchical-parent-inventory-bemsl.json
+++ b/models/azure-api-management/azureserviceoperator_customresourcedefinitions_v2.13.0.yaml/v1.0.0/relationships/hierarchical-parent-inventory-bemsl.json
@@ -45,15 +45,15 @@
               "version": ""
             },
             "patch": {
-              "mutatedRef": [
+              "patchStrategy": "replace",
+              "mutatorRef": [
                 [
                   "configuration",
                   "spec",
                   "owner",
                   "name"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ],
@@ -75,12 +75,12 @@
               "version": ""
             },
             "patch": {
-              "mutatorRef": [
+              "patchStrategy": "replace",
+              "mutatedRef": [
                 [
                   "displayName"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ]

--- a/models/azure-api-management/azureserviceoperator_customresourcedefinitions_v2.13.0.yaml/v1.0.0/relationships/hierarchical-parent-inventory-hgkgw.json
+++ b/models/azure-api-management/azureserviceoperator_customresourcedefinitions_v2.13.0.yaml/v1.0.0/relationships/hierarchical-parent-inventory-hgkgw.json
@@ -45,15 +45,15 @@
               "version": ""
             },
             "patch": {
-              "mutatedRef": [
+              "patchStrategy": "replace",
+              "mutatorRef": [
                 [
                   "configuration",
                   "spec",
                   "owner",
                   "name"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ],
@@ -75,12 +75,12 @@
               "version": ""
             },
             "patch": {
-              "mutatorRef": [
+              "patchStrategy": "replace",
+              "mutatedRef": [
                 [
                   "displayName"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ]

--- a/models/azure-api-management/azureserviceoperator_customresourcedefinitions_v2.13.0.yaml/v1.0.0/relationships/hierarchical-parent-inventory-joyul.json
+++ b/models/azure-api-management/azureserviceoperator_customresourcedefinitions_v2.13.0.yaml/v1.0.0/relationships/hierarchical-parent-inventory-joyul.json
@@ -45,15 +45,15 @@
               "version": ""
             },
             "patch": {
-              "mutatedRef": [
+              "patchStrategy": "replace",
+              "mutatorRef": [
                 [
                   "configuration",
                   "spec",
                   "owner",
                   "name"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ],
@@ -75,12 +75,12 @@
               "version": ""
             },
             "patch": {
-              "mutatorRef": [
+              "patchStrategy": "replace",
+              "mutatedRef": [
                 [
                   "displayName"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ]

--- a/models/azure-api-management/azureserviceoperator_customresourcedefinitions_v2.13.0.yaml/v1.0.0/relationships/hierarchical-parent-inventory-kmjea.json
+++ b/models/azure-api-management/azureserviceoperator_customresourcedefinitions_v2.13.0.yaml/v1.0.0/relationships/hierarchical-parent-inventory-kmjea.json
@@ -91,7 +91,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatedRef": [
+              "mutatorRef": [
                 [
                   "configuration",
                   "spec",
@@ -144,7 +144,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "displayName"
                 ]

--- a/models/azure-api-management/azureserviceoperator_customresourcedefinitions_v2.13.0.yaml/v1.0.0/relationships/hierarchical-parent-inventory-makng.json
+++ b/models/azure-api-management/azureserviceoperator_customresourcedefinitions_v2.13.0.yaml/v1.0.0/relationships/hierarchical-parent-inventory-makng.json
@@ -45,15 +45,15 @@
               "version": ""
             },
             "patch": {
-              "mutatedRef": [
+              "patchStrategy": "replace",
+              "mutatorRef": [
                 [
                   "configuration",
                   "spec",
                   "owner",
                   "name"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ],
@@ -75,12 +75,12 @@
               "version": ""
             },
             "patch": {
-              "mutatorRef": [
+              "patchStrategy": "replace",
+              "mutatedRef": [
                 [
                   "displayName"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ]

--- a/models/azure-api-management/azureserviceoperator_customresourcedefinitions_v2.13.0.yaml/v1.0.0/relationships/hierarchical-parent-inventory-mxhyl.json
+++ b/models/azure-api-management/azureserviceoperator_customresourcedefinitions_v2.13.0.yaml/v1.0.0/relationships/hierarchical-parent-inventory-mxhyl.json
@@ -45,15 +45,15 @@
               "version": ""
             },
             "patch": {
-              "mutatedRef": [
+              "patchStrategy": "replace",
+              "mutatorRef": [
                 [
                   "configuration",
                   "spec",
                   "owner",
                   "name"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ],
@@ -75,12 +75,12 @@
               "version": ""
             },
             "patch": {
-              "mutatorRef": [
+              "patchStrategy": "replace",
+              "mutatedRef": [
                 [
                   "displayName"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ]

--- a/models/azure-api-management/azureserviceoperator_customresourcedefinitions_v2.13.0.yaml/v1.0.0/relationships/hierarchical-parent-inventory-rnuqu.json
+++ b/models/azure-api-management/azureserviceoperator_customresourcedefinitions_v2.13.0.yaml/v1.0.0/relationships/hierarchical-parent-inventory-rnuqu.json
@@ -45,15 +45,15 @@
               "version": ""
             },
             "patch": {
-              "mutatedRef": [
+              "patchStrategy": "replace",
+              "mutatorRef": [
                 [
                   "configuration",
                   "spec",
                   "owner",
                   "name"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ],
@@ -75,12 +75,12 @@
               "version": ""
             },
             "patch": {
-              "mutatorRef": [
+              "patchStrategy": "replace",
+              "mutatedRef": [
                 [
                   "displayName"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ]

--- a/models/azure-api-management/azureserviceoperator_customresourcedefinitions_v2.13.0.yaml/v1.0.0/relationships/hierarchical-parent-inventory-tnewm.json
+++ b/models/azure-api-management/azureserviceoperator_customresourcedefinitions_v2.13.0.yaml/v1.0.0/relationships/hierarchical-parent-inventory-tnewm.json
@@ -45,15 +45,15 @@
               "version": ""
             },
             "patch": {
-              "mutatedRef": [
+              "patchStrategy": "replace",
+              "mutatorRef": [
                 [
                   "configuration",
                   "spec",
                   "owner",
                   "name"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ],
@@ -75,12 +75,12 @@
               "version": ""
             },
             "patch": {
-              "mutatorRef": [
+              "patchStrategy": "replace",
+              "mutatedRef": [
                 [
                   "displayName"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ]

--- a/models/azure-api-management/azureserviceoperator_customresourcedefinitions_v2.13.0.yaml/v1.0.0/relationships/hierarchical-parent-inventory-wines.json
+++ b/models/azure-api-management/azureserviceoperator_customresourcedefinitions_v2.13.0.yaml/v1.0.0/relationships/hierarchical-parent-inventory-wines.json
@@ -45,15 +45,15 @@
               "version": ""
             },
             "patch": {
-              "mutatedRef": [
+              "patchStrategy": "replace",
+              "mutatorRef": [
                 [
                   "configuration",
                   "spec",
                   "owner",
                   "name"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ],
@@ -75,12 +75,12 @@
               "version": ""
             },
             "patch": {
-              "mutatorRef": [
+              "patchStrategy": "replace",
+              "mutatedRef": [
                 [
                   "displayName"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ]

--- a/models/azure-api-management/azureserviceoperator_customresourcedefinitions_v2.13.0.yaml/v1.0.0/relationships/hierarchical-parent-inventory-xcdfn.json
+++ b/models/azure-api-management/azureserviceoperator_customresourcedefinitions_v2.13.0.yaml/v1.0.0/relationships/hierarchical-parent-inventory-xcdfn.json
@@ -45,15 +45,15 @@
               "version": ""
             },
             "patch": {
-              "mutatedRef": [
+              "patchStrategy": "replace",
+              "mutatorRef": [
                 [
                   "configuration",
                   "spec",
                   "owner",
                   "name"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ],
@@ -75,12 +75,12 @@
               "version": ""
             },
             "patch": {
-              "mutatorRef": [
+              "patchStrategy": "replace",
+              "mutatedRef": [
                 [
                   "displayName"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ]

--- a/models/azure-api-management/azureserviceoperator_customresourcedefinitions_v2.14.0.yaml/v1.0.0/relationships/hierarchical-parent-inventory-bemsl.json
+++ b/models/azure-api-management/azureserviceoperator_customresourcedefinitions_v2.14.0.yaml/v1.0.0/relationships/hierarchical-parent-inventory-bemsl.json
@@ -45,15 +45,15 @@
               "version": ""
             },
             "patch": {
-              "mutatedRef": [
+              "patchStrategy": "replace",
+              "mutatorRef": [
                 [
                   "configuration",
                   "spec",
                   "owner",
                   "name"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ],
@@ -75,12 +75,12 @@
               "version": ""
             },
             "patch": {
-              "mutatorRef": [
+              "patchStrategy": "replace",
+              "mutatedRef": [
                 [
                   "displayName"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ]

--- a/models/azure-api-management/azureserviceoperator_customresourcedefinitions_v2.14.0.yaml/v1.0.0/relationships/hierarchical-parent-inventory-hgkgw.json
+++ b/models/azure-api-management/azureserviceoperator_customresourcedefinitions_v2.14.0.yaml/v1.0.0/relationships/hierarchical-parent-inventory-hgkgw.json
@@ -45,15 +45,15 @@
               "version": ""
             },
             "patch": {
-              "mutatedRef": [
+              "patchStrategy": "replace",
+              "mutatorRef": [
                 [
                   "configuration",
                   "spec",
                   "owner",
                   "name"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ],
@@ -75,12 +75,12 @@
               "version": ""
             },
             "patch": {
-              "mutatorRef": [
+              "patchStrategy": "replace",
+              "mutatedRef": [
                 [
                   "displayName"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ]

--- a/models/azure-api-management/azureserviceoperator_customresourcedefinitions_v2.14.0.yaml/v1.0.0/relationships/hierarchical-parent-inventory-joyul.json
+++ b/models/azure-api-management/azureserviceoperator_customresourcedefinitions_v2.14.0.yaml/v1.0.0/relationships/hierarchical-parent-inventory-joyul.json
@@ -45,15 +45,15 @@
               "version": ""
             },
             "patch": {
-              "mutatedRef": [
+              "patchStrategy": "replace",
+              "mutatorRef": [
                 [
                   "configuration",
                   "spec",
                   "owner",
                   "name"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ],
@@ -75,12 +75,12 @@
               "version": ""
             },
             "patch": {
-              "mutatorRef": [
+              "patchStrategy": "replace",
+              "mutatedRef": [
                 [
                   "displayName"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ]

--- a/models/azure-api-management/azureserviceoperator_customresourcedefinitions_v2.14.0.yaml/v1.0.0/relationships/hierarchical-parent-inventory-kmjea.json
+++ b/models/azure-api-management/azureserviceoperator_customresourcedefinitions_v2.14.0.yaml/v1.0.0/relationships/hierarchical-parent-inventory-kmjea.json
@@ -91,7 +91,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatedRef": [
+              "mutatorRef": [
                 [
                   "configuration",
                   "spec",
@@ -144,7 +144,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "displayName"
                 ]

--- a/models/azure-api-management/azureserviceoperator_customresourcedefinitions_v2.14.0.yaml/v1.0.0/relationships/hierarchical-parent-inventory-makng.json
+++ b/models/azure-api-management/azureserviceoperator_customresourcedefinitions_v2.14.0.yaml/v1.0.0/relationships/hierarchical-parent-inventory-makng.json
@@ -45,15 +45,15 @@
               "version": ""
             },
             "patch": {
-              "mutatedRef": [
+              "patchStrategy": "replace",
+              "mutatorRef": [
                 [
                   "configuration",
                   "spec",
                   "owner",
                   "name"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ],
@@ -75,12 +75,12 @@
               "version": ""
             },
             "patch": {
-              "mutatorRef": [
+              "patchStrategy": "replace",
+              "mutatedRef": [
                 [
                   "displayName"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ]

--- a/models/azure-api-management/azureserviceoperator_customresourcedefinitions_v2.14.0.yaml/v1.0.0/relationships/hierarchical-parent-inventory-mxhyl.json
+++ b/models/azure-api-management/azureserviceoperator_customresourcedefinitions_v2.14.0.yaml/v1.0.0/relationships/hierarchical-parent-inventory-mxhyl.json
@@ -45,15 +45,15 @@
               "version": ""
             },
             "patch": {
-              "mutatedRef": [
+              "patchStrategy": "replace",
+              "mutatorRef": [
                 [
                   "configuration",
                   "spec",
                   "owner",
                   "name"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ],
@@ -75,12 +75,12 @@
               "version": ""
             },
             "patch": {
-              "mutatorRef": [
+              "patchStrategy": "replace",
+              "mutatedRef": [
                 [
                   "displayName"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ]

--- a/models/azure-api-management/azureserviceoperator_customresourcedefinitions_v2.14.0.yaml/v1.0.0/relationships/hierarchical-parent-inventory-rnuqu.json
+++ b/models/azure-api-management/azureserviceoperator_customresourcedefinitions_v2.14.0.yaml/v1.0.0/relationships/hierarchical-parent-inventory-rnuqu.json
@@ -45,15 +45,15 @@
               "version": ""
             },
             "patch": {
-              "mutatedRef": [
+              "patchStrategy": "replace",
+              "mutatorRef": [
                 [
                   "configuration",
                   "spec",
                   "owner",
                   "name"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ],
@@ -75,12 +75,12 @@
               "version": ""
             },
             "patch": {
-              "mutatorRef": [
+              "patchStrategy": "replace",
+              "mutatedRef": [
                 [
                   "displayName"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ]

--- a/models/azure-api-management/azureserviceoperator_customresourcedefinitions_v2.14.0.yaml/v1.0.0/relationships/hierarchical-parent-inventory-tnewm.json
+++ b/models/azure-api-management/azureserviceoperator_customresourcedefinitions_v2.14.0.yaml/v1.0.0/relationships/hierarchical-parent-inventory-tnewm.json
@@ -45,15 +45,15 @@
               "version": ""
             },
             "patch": {
-              "mutatedRef": [
+              "patchStrategy": "replace",
+              "mutatorRef": [
                 [
                   "configuration",
                   "spec",
                   "owner",
                   "name"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ],
@@ -75,12 +75,12 @@
               "version": ""
             },
             "patch": {
-              "mutatorRef": [
+              "patchStrategy": "replace",
+              "mutatedRef": [
                 [
                   "displayName"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ]

--- a/models/azure-api-management/azureserviceoperator_customresourcedefinitions_v2.14.0.yaml/v1.0.0/relationships/hierarchical-parent-inventory-wines.json
+++ b/models/azure-api-management/azureserviceoperator_customresourcedefinitions_v2.14.0.yaml/v1.0.0/relationships/hierarchical-parent-inventory-wines.json
@@ -45,15 +45,15 @@
               "version": ""
             },
             "patch": {
-              "mutatedRef": [
+              "patchStrategy": "replace",
+              "mutatorRef": [
                 [
                   "configuration",
                   "spec",
                   "owner",
                   "name"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ],
@@ -75,12 +75,12 @@
               "version": ""
             },
             "patch": {
-              "mutatorRef": [
+              "patchStrategy": "replace",
+              "mutatedRef": [
                 [
                   "displayName"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ]

--- a/models/azure-api-management/azureserviceoperator_customresourcedefinitions_v2.14.0.yaml/v1.0.0/relationships/hierarchical-parent-inventory-xcdfn.json
+++ b/models/azure-api-management/azureserviceoperator_customresourcedefinitions_v2.14.0.yaml/v1.0.0/relationships/hierarchical-parent-inventory-xcdfn.json
@@ -45,15 +45,15 @@
               "version": ""
             },
             "patch": {
-              "mutatedRef": [
+              "patchStrategy": "replace",
+              "mutatorRef": [
                 [
                   "configuration",
                   "spec",
                   "owner",
                   "name"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ],
@@ -75,12 +75,12 @@
               "version": ""
             },
             "patch": {
-              "mutatorRef": [
+              "patchStrategy": "replace",
+              "mutatedRef": [
                 [
                   "displayName"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ]

--- a/models/azure-app-service/azureserviceoperator_customresourcedefinitions_v2.13.0.yaml/v1.0.0/relationships/edge-non-binding-alias-tdvhq.json
+++ b/models/azure-app-service/azureserviceoperator_customresourcedefinitions_v2.13.0.yaml/v1.0.0/relationships/edge-non-binding-alias-tdvhq.json
@@ -45,7 +45,8 @@
               "version": ""
             },
             "patch": {
-              "mutatedRef": [
+              "patchStrategy": "replace",
+              "mutatorRef": [
                 [
                   "configuration",
                   "spec",
@@ -64,8 +65,7 @@
                   "environmentReference",
                   "name"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ],
@@ -87,7 +87,8 @@
               "version": ""
             },
             "patch": {
-              "mutatorRef": [
+              "patchStrategy": "replace",
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -101,8 +102,7 @@
                   "metadata",
                   "name"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ]

--- a/models/azure-app-service/azureserviceoperator_customresourcedefinitions_v2.13.0.yaml/v1.0.0/relationships/hierarchical-parent-inventory-kmjea.json
+++ b/models/azure-app-service/azureserviceoperator_customresourcedefinitions_v2.13.0.yaml/v1.0.0/relationships/hierarchical-parent-inventory-kmjea.json
@@ -91,7 +91,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatedRef": [
+              "mutatorRef": [
                 [
                   "configuration",
                   "spec",
@@ -156,7 +156,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"

--- a/models/azure-app-service/azureserviceoperator_customresourcedefinitions_v2.14.0.yaml/v1.0.0/relationships/edge-non-binding-alias-tdvhq.json
+++ b/models/azure-app-service/azureserviceoperator_customresourcedefinitions_v2.14.0.yaml/v1.0.0/relationships/edge-non-binding-alias-tdvhq.json
@@ -45,7 +45,8 @@
               "version": ""
             },
             "patch": {
-              "mutatedRef": [
+              "patchStrategy": "replace",
+              "mutatorRef": [
                 [
                   "configuration",
                   "spec",
@@ -64,8 +65,7 @@
                   "environmentReference",
                   "name"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ],
@@ -87,7 +87,8 @@
               "version": ""
             },
             "patch": {
-              "mutatorRef": [
+              "patchStrategy": "replace",
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -101,8 +102,7 @@
                   "metadata",
                   "name"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ]

--- a/models/azure-app-service/azureserviceoperator_customresourcedefinitions_v2.14.0.yaml/v1.0.0/relationships/hierarchical-parent-inventory-kmjea.json
+++ b/models/azure-app-service/azureserviceoperator_customresourcedefinitions_v2.14.0.yaml/v1.0.0/relationships/hierarchical-parent-inventory-kmjea.json
@@ -91,7 +91,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatedRef": [
+              "mutatorRef": [
                 [
                   "configuration",
                   "spec",
@@ -156,7 +156,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"

--- a/models/azure-authorization/azureserviceoperator_customresourcedefinitions_v2.13.0.yaml/v1.0.0/relationships/hierarchical-parent-inventory-dnuyh.json
+++ b/models/azure-authorization/azureserviceoperator_customresourcedefinitions_v2.13.0.yaml/v1.0.0/relationships/hierarchical-parent-inventory-dnuyh.json
@@ -47,7 +47,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatedRef": [
+              "mutatorRef": [
                 [
                   "configuration",
                   "spec",
@@ -90,7 +90,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -126,7 +126,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -162,7 +162,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -198,7 +198,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -234,7 +234,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -270,7 +270,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -306,7 +306,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -342,7 +342,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -378,7 +378,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -414,7 +414,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -450,7 +450,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -486,7 +486,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -522,7 +522,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -558,7 +558,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -594,7 +594,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -630,7 +630,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -666,7 +666,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -702,7 +702,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -738,7 +738,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -774,7 +774,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -810,7 +810,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -846,7 +846,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -882,7 +882,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -918,7 +918,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -954,7 +954,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -990,7 +990,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -1026,7 +1026,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -1062,7 +1062,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -1098,7 +1098,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -1134,7 +1134,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -1170,7 +1170,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -1206,7 +1206,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -1242,7 +1242,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -1278,7 +1278,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -1314,7 +1314,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -1350,7 +1350,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -1386,7 +1386,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -1422,7 +1422,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -1458,7 +1458,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -1494,7 +1494,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -1530,7 +1530,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -1566,7 +1566,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -1602,7 +1602,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -1638,7 +1638,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -1674,7 +1674,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -1710,7 +1710,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -1746,7 +1746,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -1782,7 +1782,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -1818,7 +1818,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -1854,7 +1854,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -1890,7 +1890,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -1926,7 +1926,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -1962,7 +1962,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -1998,7 +1998,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -2034,7 +2034,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -2070,7 +2070,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -2106,7 +2106,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -2142,7 +2142,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -2178,7 +2178,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -2214,7 +2214,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -2250,7 +2250,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -2286,7 +2286,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -2322,7 +2322,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -2358,7 +2358,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -2394,7 +2394,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -2430,7 +2430,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -2466,7 +2466,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -2502,7 +2502,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -2538,7 +2538,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -2574,7 +2574,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -2610,7 +2610,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -2646,7 +2646,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -2682,7 +2682,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -2718,7 +2718,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -2754,7 +2754,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -2790,7 +2790,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -2826,7 +2826,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -2862,7 +2862,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -2898,7 +2898,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -2934,7 +2934,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -2970,7 +2970,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -3006,7 +3006,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -3042,7 +3042,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -3078,7 +3078,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -3114,7 +3114,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -3150,7 +3150,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -3186,7 +3186,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -3222,7 +3222,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -3258,7 +3258,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -3294,7 +3294,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -3330,7 +3330,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -3366,7 +3366,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -3402,7 +3402,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -3438,7 +3438,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -3474,7 +3474,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -3510,7 +3510,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -3546,7 +3546,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -3582,7 +3582,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -3618,7 +3618,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -3654,7 +3654,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -3690,7 +3690,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -3726,7 +3726,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -3762,7 +3762,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -3798,7 +3798,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -3834,7 +3834,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -3870,7 +3870,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -3906,7 +3906,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -3942,7 +3942,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -3978,7 +3978,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -4014,7 +4014,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -4050,7 +4050,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -4086,7 +4086,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -4122,7 +4122,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -4158,7 +4158,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -4194,7 +4194,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -4230,7 +4230,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -4266,7 +4266,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -4302,7 +4302,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -4338,7 +4338,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -4374,7 +4374,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -4410,7 +4410,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -4446,7 +4446,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -4482,7 +4482,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -4518,7 +4518,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -4554,7 +4554,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -4590,7 +4590,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -4626,7 +4626,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -4662,7 +4662,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -4698,7 +4698,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -4734,7 +4734,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -4770,7 +4770,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -4806,7 +4806,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -4842,7 +4842,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -4878,7 +4878,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -4914,7 +4914,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -4950,7 +4950,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -4986,7 +4986,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -5022,7 +5022,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -5058,7 +5058,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -5094,7 +5094,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -5130,7 +5130,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -5166,7 +5166,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -5202,7 +5202,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -5238,7 +5238,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -5274,7 +5274,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -5310,7 +5310,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -5346,7 +5346,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"

--- a/models/azure-authorization/azureserviceoperator_customresourcedefinitions_v2.13.0.yaml/v1.0.0/relationships/hierarchical-parent-inventory-epkez.json
+++ b/models/azure-authorization/azureserviceoperator_customresourcedefinitions_v2.13.0.yaml/v1.0.0/relationships/hierarchical-parent-inventory-epkez.json
@@ -47,7 +47,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatedRef": [
+              "mutatorRef": [
                 [
                   "configuration",
                   "spec",
@@ -90,7 +90,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -126,7 +126,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -162,7 +162,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -198,7 +198,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -234,7 +234,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -270,7 +270,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -306,7 +306,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -342,7 +342,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -378,7 +378,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -414,7 +414,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -450,7 +450,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -486,7 +486,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -522,7 +522,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -558,7 +558,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -594,7 +594,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -630,7 +630,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -666,7 +666,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -702,7 +702,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -738,7 +738,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -774,7 +774,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -810,7 +810,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -846,7 +846,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -882,7 +882,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -918,7 +918,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -954,7 +954,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -990,7 +990,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -1026,7 +1026,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -1062,7 +1062,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -1098,7 +1098,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -1134,7 +1134,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -1170,7 +1170,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -1206,7 +1206,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -1242,7 +1242,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -1278,7 +1278,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -1314,7 +1314,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -1350,7 +1350,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -1386,7 +1386,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -1422,7 +1422,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -1458,7 +1458,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -1494,7 +1494,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -1530,7 +1530,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -1566,7 +1566,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -1602,7 +1602,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -1638,7 +1638,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -1674,7 +1674,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -1710,7 +1710,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -1746,7 +1746,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -1782,7 +1782,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -1818,7 +1818,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -1854,7 +1854,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -1890,7 +1890,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -1926,7 +1926,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -1962,7 +1962,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -1998,7 +1998,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -2034,7 +2034,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -2070,7 +2070,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -2106,7 +2106,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -2142,7 +2142,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -2178,7 +2178,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -2214,7 +2214,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -2250,7 +2250,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -2286,7 +2286,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -2322,7 +2322,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -2358,7 +2358,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -2394,7 +2394,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -2430,7 +2430,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -2466,7 +2466,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -2502,7 +2502,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -2538,7 +2538,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -2574,7 +2574,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -2610,7 +2610,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -2646,7 +2646,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -2682,7 +2682,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -2718,7 +2718,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -2754,7 +2754,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -2790,7 +2790,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -2826,7 +2826,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -2862,7 +2862,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -2898,7 +2898,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -2934,7 +2934,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -2970,7 +2970,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -3006,7 +3006,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -3042,7 +3042,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -3078,7 +3078,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -3114,7 +3114,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -3150,7 +3150,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -3186,7 +3186,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -3222,7 +3222,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -3258,7 +3258,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -3294,7 +3294,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -3330,7 +3330,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -3366,7 +3366,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -3402,7 +3402,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -3438,7 +3438,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -3474,7 +3474,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -3510,7 +3510,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -3546,7 +3546,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -3582,7 +3582,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -3618,7 +3618,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -3654,7 +3654,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -3690,7 +3690,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -3726,7 +3726,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -3762,7 +3762,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -3798,7 +3798,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -3834,7 +3834,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -3870,7 +3870,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -3906,7 +3906,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -3942,7 +3942,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -3978,7 +3978,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -4014,7 +4014,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -4050,7 +4050,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -4086,7 +4086,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -4122,7 +4122,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -4158,7 +4158,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -4194,7 +4194,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -4230,7 +4230,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -4266,7 +4266,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -4302,7 +4302,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -4338,7 +4338,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -4374,7 +4374,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -4410,7 +4410,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -4446,7 +4446,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -4482,7 +4482,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -4518,7 +4518,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -4554,7 +4554,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -4590,7 +4590,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -4626,7 +4626,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -4662,7 +4662,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -4698,7 +4698,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -4734,7 +4734,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -4770,7 +4770,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -4806,7 +4806,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -4842,7 +4842,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -4878,7 +4878,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -4914,7 +4914,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -4950,7 +4950,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -4986,7 +4986,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -5022,7 +5022,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -5058,7 +5058,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -5094,7 +5094,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -5130,7 +5130,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -5166,7 +5166,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -5202,7 +5202,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -5238,7 +5238,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -5274,7 +5274,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -5310,7 +5310,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -5346,7 +5346,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"

--- a/models/azure-authorization/azureserviceoperator_customresourcedefinitions_v2.13.0.yaml/v1.0.0/relationships/hierarchical-parent-inventory-kmjea.json
+++ b/models/azure-authorization/azureserviceoperator_customresourcedefinitions_v2.13.0.yaml/v1.0.0/relationships/hierarchical-parent-inventory-kmjea.json
@@ -91,7 +91,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatedRef": [
+              "mutatorRef": [
                 [
                   "configuration",
                   "spec",
@@ -156,7 +156,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -214,7 +214,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -272,7 +272,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -330,7 +330,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -388,7 +388,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -446,7 +446,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -504,7 +504,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -562,7 +562,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -620,7 +620,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -678,7 +678,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -736,7 +736,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -794,7 +794,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -852,7 +852,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -910,7 +910,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -968,7 +968,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -1026,7 +1026,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -1084,7 +1084,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -1142,7 +1142,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -1200,7 +1200,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -1258,7 +1258,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -1316,7 +1316,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -1374,7 +1374,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -1432,7 +1432,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -1490,7 +1490,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -1548,7 +1548,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -1606,7 +1606,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -1664,7 +1664,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -1722,7 +1722,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -1780,7 +1780,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -1838,7 +1838,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -1896,7 +1896,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -1954,7 +1954,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -2012,7 +2012,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -2070,7 +2070,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -2128,7 +2128,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -2186,7 +2186,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -2244,7 +2244,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -2302,7 +2302,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -2360,7 +2360,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -2418,7 +2418,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -2476,7 +2476,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -2534,7 +2534,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -2592,7 +2592,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -2650,7 +2650,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -2708,7 +2708,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -2766,7 +2766,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -2824,7 +2824,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -2882,7 +2882,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -2940,7 +2940,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -2998,7 +2998,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -3056,7 +3056,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -3114,7 +3114,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -3172,7 +3172,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -3230,7 +3230,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -3288,7 +3288,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -3346,7 +3346,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -3404,7 +3404,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -3462,7 +3462,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -3520,7 +3520,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -3578,7 +3578,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -3636,7 +3636,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -3694,7 +3694,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -3752,7 +3752,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -3810,7 +3810,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -3868,7 +3868,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -3926,7 +3926,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -3984,7 +3984,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -4042,7 +4042,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -4100,7 +4100,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -4158,7 +4158,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -4216,7 +4216,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -4274,7 +4274,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -4332,7 +4332,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -4390,7 +4390,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -4448,7 +4448,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -4506,7 +4506,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -4564,7 +4564,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -4622,7 +4622,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -4680,7 +4680,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -4738,7 +4738,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -4796,7 +4796,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -4854,7 +4854,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -4912,7 +4912,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -4970,7 +4970,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -5028,7 +5028,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -5086,7 +5086,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -5144,7 +5144,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -5202,7 +5202,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -5260,7 +5260,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -5318,7 +5318,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -5376,7 +5376,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -5434,7 +5434,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -5492,7 +5492,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -5550,7 +5550,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -5608,7 +5608,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -5666,7 +5666,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -5724,7 +5724,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -5782,7 +5782,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -5840,7 +5840,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -5898,7 +5898,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -5956,7 +5956,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -6014,7 +6014,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -6072,7 +6072,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -6130,7 +6130,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -6188,7 +6188,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -6246,7 +6246,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -6304,7 +6304,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -6362,7 +6362,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -6420,7 +6420,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -6478,7 +6478,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -6536,7 +6536,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -6594,7 +6594,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -6652,7 +6652,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -6710,7 +6710,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -6768,7 +6768,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -6826,7 +6826,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -6884,7 +6884,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -6942,7 +6942,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -7000,7 +7000,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -7058,7 +7058,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -7116,7 +7116,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -7174,7 +7174,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -7232,7 +7232,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -7290,7 +7290,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -7348,7 +7348,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -7406,7 +7406,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -7464,7 +7464,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -7522,7 +7522,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -7580,7 +7580,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -7638,7 +7638,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -7696,7 +7696,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -7754,7 +7754,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -7812,7 +7812,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -7870,7 +7870,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -7928,7 +7928,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -7986,7 +7986,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -8044,7 +8044,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -8102,7 +8102,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -8160,7 +8160,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -8218,7 +8218,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -8276,7 +8276,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -8334,7 +8334,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -8392,7 +8392,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -8450,7 +8450,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -8508,7 +8508,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -8566,7 +8566,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -8624,7 +8624,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"

--- a/models/azure-authorization/azureserviceoperator_customresourcedefinitions_v2.14.0.yaml/v1.0.0/relationships/hierarchical-parent-inventory-dnuyh.json
+++ b/models/azure-authorization/azureserviceoperator_customresourcedefinitions_v2.14.0.yaml/v1.0.0/relationships/hierarchical-parent-inventory-dnuyh.json
@@ -47,7 +47,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatedRef": [
+              "mutatorRef": [
                 [
                   "configuration",
                   "spec",
@@ -90,7 +90,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -126,7 +126,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -162,7 +162,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -198,7 +198,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -234,7 +234,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -270,7 +270,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -306,7 +306,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -342,7 +342,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -378,7 +378,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -414,7 +414,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -450,7 +450,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -486,7 +486,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -522,7 +522,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -558,7 +558,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -594,7 +594,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -630,7 +630,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -666,7 +666,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -702,7 +702,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -738,7 +738,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -774,7 +774,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -810,7 +810,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -846,7 +846,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -882,7 +882,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -918,7 +918,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -954,7 +954,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -990,7 +990,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -1026,7 +1026,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -1062,7 +1062,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -1098,7 +1098,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -1134,7 +1134,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -1170,7 +1170,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -1206,7 +1206,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -1242,7 +1242,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -1278,7 +1278,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -1314,7 +1314,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -1350,7 +1350,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -1386,7 +1386,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -1422,7 +1422,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -1458,7 +1458,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -1494,7 +1494,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -1530,7 +1530,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -1566,7 +1566,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -1602,7 +1602,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -1638,7 +1638,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -1674,7 +1674,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -1710,7 +1710,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -1746,7 +1746,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -1782,7 +1782,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -1818,7 +1818,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -1854,7 +1854,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -1890,7 +1890,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -1926,7 +1926,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -1962,7 +1962,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -1998,7 +1998,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -2034,7 +2034,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -2070,7 +2070,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -2106,7 +2106,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -2142,7 +2142,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -2178,7 +2178,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -2214,7 +2214,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -2250,7 +2250,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -2286,7 +2286,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -2322,7 +2322,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -2358,7 +2358,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -2394,7 +2394,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -2430,7 +2430,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -2466,7 +2466,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -2502,7 +2502,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -2538,7 +2538,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -2574,7 +2574,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -2610,7 +2610,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -2646,7 +2646,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -2682,7 +2682,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -2718,7 +2718,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -2754,7 +2754,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -2790,7 +2790,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -2826,7 +2826,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -2862,7 +2862,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -2898,7 +2898,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -2934,7 +2934,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -2970,7 +2970,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -3006,7 +3006,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -3042,7 +3042,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -3078,7 +3078,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -3114,7 +3114,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -3150,7 +3150,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -3186,7 +3186,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -3222,7 +3222,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -3258,7 +3258,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -3294,7 +3294,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -3330,7 +3330,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -3366,7 +3366,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -3402,7 +3402,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -3438,7 +3438,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -3474,7 +3474,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -3510,7 +3510,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -3546,7 +3546,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -3582,7 +3582,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -3618,7 +3618,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -3654,7 +3654,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -3690,7 +3690,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -3726,7 +3726,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -3762,7 +3762,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -3798,7 +3798,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -3834,7 +3834,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -3870,7 +3870,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -3906,7 +3906,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -3942,7 +3942,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -3978,7 +3978,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -4014,7 +4014,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -4050,7 +4050,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -4086,7 +4086,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -4122,7 +4122,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -4158,7 +4158,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -4194,7 +4194,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -4230,7 +4230,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -4266,7 +4266,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -4302,7 +4302,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -4338,7 +4338,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -4374,7 +4374,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -4410,7 +4410,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -4446,7 +4446,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -4482,7 +4482,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -4518,7 +4518,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -4554,7 +4554,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -4590,7 +4590,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -4626,7 +4626,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -4662,7 +4662,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -4698,7 +4698,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -4734,7 +4734,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -4770,7 +4770,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -4806,7 +4806,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -4842,7 +4842,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -4878,7 +4878,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -4914,7 +4914,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -4950,7 +4950,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -4986,7 +4986,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -5022,7 +5022,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -5058,7 +5058,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -5094,7 +5094,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -5130,7 +5130,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -5166,7 +5166,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -5202,7 +5202,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -5238,7 +5238,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -5274,7 +5274,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -5310,7 +5310,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -5346,7 +5346,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"

--- a/models/azure-authorization/azureserviceoperator_customresourcedefinitions_v2.14.0.yaml/v1.0.0/relationships/hierarchical-parent-inventory-epkez.json
+++ b/models/azure-authorization/azureserviceoperator_customresourcedefinitions_v2.14.0.yaml/v1.0.0/relationships/hierarchical-parent-inventory-epkez.json
@@ -47,7 +47,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatedRef": [
+              "mutatorRef": [
                 [
                   "configuration",
                   "spec",
@@ -90,7 +90,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -126,7 +126,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -162,7 +162,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -198,7 +198,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -234,7 +234,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -270,7 +270,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -306,7 +306,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -342,7 +342,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -378,7 +378,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -414,7 +414,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -450,7 +450,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -486,7 +486,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -522,7 +522,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -558,7 +558,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -594,7 +594,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -630,7 +630,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -666,7 +666,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -702,7 +702,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -738,7 +738,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -774,7 +774,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -810,7 +810,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -846,7 +846,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -882,7 +882,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -918,7 +918,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -954,7 +954,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -990,7 +990,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -1026,7 +1026,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -1062,7 +1062,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -1098,7 +1098,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -1134,7 +1134,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -1170,7 +1170,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -1206,7 +1206,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -1242,7 +1242,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -1278,7 +1278,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -1314,7 +1314,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -1350,7 +1350,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -1386,7 +1386,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -1422,7 +1422,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -1458,7 +1458,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -1494,7 +1494,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -1530,7 +1530,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -1566,7 +1566,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -1602,7 +1602,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -1638,7 +1638,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -1674,7 +1674,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -1710,7 +1710,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -1746,7 +1746,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -1782,7 +1782,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -1818,7 +1818,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -1854,7 +1854,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -1890,7 +1890,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -1926,7 +1926,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -1962,7 +1962,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -1998,7 +1998,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -2034,7 +2034,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -2070,7 +2070,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -2106,7 +2106,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -2142,7 +2142,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -2178,7 +2178,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -2214,7 +2214,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -2250,7 +2250,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -2286,7 +2286,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -2322,7 +2322,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -2358,7 +2358,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -2394,7 +2394,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -2430,7 +2430,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -2466,7 +2466,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -2502,7 +2502,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -2538,7 +2538,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -2574,7 +2574,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -2610,7 +2610,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -2646,7 +2646,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -2682,7 +2682,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -2718,7 +2718,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -2754,7 +2754,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -2790,7 +2790,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -2826,7 +2826,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -2862,7 +2862,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -2898,7 +2898,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -2934,7 +2934,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -2970,7 +2970,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -3006,7 +3006,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -3042,7 +3042,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -3078,7 +3078,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -3114,7 +3114,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -3150,7 +3150,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -3186,7 +3186,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -3222,7 +3222,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -3258,7 +3258,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -3294,7 +3294,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -3330,7 +3330,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -3366,7 +3366,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -3402,7 +3402,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -3438,7 +3438,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -3474,7 +3474,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -3510,7 +3510,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -3546,7 +3546,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -3582,7 +3582,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -3618,7 +3618,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -3654,7 +3654,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -3690,7 +3690,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -3726,7 +3726,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -3762,7 +3762,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -3798,7 +3798,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -3834,7 +3834,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -3870,7 +3870,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -3906,7 +3906,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -3942,7 +3942,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -3978,7 +3978,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -4014,7 +4014,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -4050,7 +4050,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -4086,7 +4086,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -4122,7 +4122,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -4158,7 +4158,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -4194,7 +4194,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -4230,7 +4230,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -4266,7 +4266,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -4302,7 +4302,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -4338,7 +4338,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -4374,7 +4374,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -4410,7 +4410,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -4446,7 +4446,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -4482,7 +4482,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -4518,7 +4518,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -4554,7 +4554,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -4590,7 +4590,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -4626,7 +4626,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -4662,7 +4662,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -4698,7 +4698,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -4734,7 +4734,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -4770,7 +4770,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -4806,7 +4806,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -4842,7 +4842,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -4878,7 +4878,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -4914,7 +4914,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -4950,7 +4950,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -4986,7 +4986,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -5022,7 +5022,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -5058,7 +5058,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -5094,7 +5094,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -5130,7 +5130,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -5166,7 +5166,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -5202,7 +5202,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -5238,7 +5238,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -5274,7 +5274,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -5310,7 +5310,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -5346,7 +5346,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"

--- a/models/azure-authorization/azureserviceoperator_customresourcedefinitions_v2.14.0.yaml/v1.0.0/relationships/hierarchical-parent-inventory-kmjea.json
+++ b/models/azure-authorization/azureserviceoperator_customresourcedefinitions_v2.14.0.yaml/v1.0.0/relationships/hierarchical-parent-inventory-kmjea.json
@@ -91,7 +91,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatedRef": [
+              "mutatorRef": [
                 [
                   "configuration",
                   "spec",
@@ -156,7 +156,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -214,7 +214,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -272,7 +272,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -330,7 +330,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -388,7 +388,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -446,7 +446,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -504,7 +504,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -562,7 +562,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -620,7 +620,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -678,7 +678,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -736,7 +736,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -794,7 +794,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -852,7 +852,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -910,7 +910,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -968,7 +968,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -1026,7 +1026,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -1084,7 +1084,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -1142,7 +1142,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -1200,7 +1200,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -1258,7 +1258,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -1316,7 +1316,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -1374,7 +1374,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -1432,7 +1432,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -1490,7 +1490,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -1548,7 +1548,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -1606,7 +1606,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -1664,7 +1664,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -1722,7 +1722,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -1780,7 +1780,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -1838,7 +1838,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -1896,7 +1896,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -1954,7 +1954,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -2012,7 +2012,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -2070,7 +2070,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -2128,7 +2128,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -2186,7 +2186,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -2244,7 +2244,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -2302,7 +2302,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -2360,7 +2360,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -2418,7 +2418,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -2476,7 +2476,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -2534,7 +2534,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -2592,7 +2592,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -2650,7 +2650,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -2708,7 +2708,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -2766,7 +2766,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -2824,7 +2824,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -2882,7 +2882,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -2940,7 +2940,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -2998,7 +2998,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -3056,7 +3056,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -3114,7 +3114,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -3172,7 +3172,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -3230,7 +3230,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -3288,7 +3288,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -3346,7 +3346,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -3404,7 +3404,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -3462,7 +3462,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -3520,7 +3520,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -3578,7 +3578,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -3636,7 +3636,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -3694,7 +3694,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -3752,7 +3752,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -3810,7 +3810,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -3868,7 +3868,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -3926,7 +3926,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -3984,7 +3984,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -4042,7 +4042,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -4100,7 +4100,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -4158,7 +4158,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -4216,7 +4216,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -4274,7 +4274,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -4332,7 +4332,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -4390,7 +4390,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -4448,7 +4448,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -4506,7 +4506,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -4564,7 +4564,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -4622,7 +4622,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -4680,7 +4680,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -4738,7 +4738,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -4796,7 +4796,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -4854,7 +4854,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -4912,7 +4912,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -4970,7 +4970,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -5028,7 +5028,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -5086,7 +5086,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -5144,7 +5144,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -5202,7 +5202,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -5260,7 +5260,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -5318,7 +5318,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -5376,7 +5376,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -5434,7 +5434,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -5492,7 +5492,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -5550,7 +5550,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -5608,7 +5608,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -5666,7 +5666,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -5724,7 +5724,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -5782,7 +5782,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -5840,7 +5840,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -5898,7 +5898,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -5956,7 +5956,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -6014,7 +6014,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -6072,7 +6072,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -6130,7 +6130,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -6188,7 +6188,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -6246,7 +6246,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -6304,7 +6304,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -6362,7 +6362,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -6420,7 +6420,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -6478,7 +6478,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -6536,7 +6536,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -6594,7 +6594,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -6652,7 +6652,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -6710,7 +6710,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -6768,7 +6768,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -6826,7 +6826,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -6884,7 +6884,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -6942,7 +6942,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -7000,7 +7000,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -7058,7 +7058,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -7116,7 +7116,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -7174,7 +7174,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -7232,7 +7232,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -7290,7 +7290,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -7348,7 +7348,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -7406,7 +7406,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -7464,7 +7464,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -7522,7 +7522,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -7580,7 +7580,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -7638,7 +7638,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -7696,7 +7696,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -7754,7 +7754,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -7812,7 +7812,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -7870,7 +7870,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -7928,7 +7928,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -7986,7 +7986,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -8044,7 +8044,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -8102,7 +8102,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -8160,7 +8160,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -8218,7 +8218,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -8276,7 +8276,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -8334,7 +8334,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -8392,7 +8392,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -8450,7 +8450,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -8508,7 +8508,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -8566,7 +8566,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -8624,7 +8624,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"

--- a/models/azure-cache/azureserviceoperator_customresourcedefinitions_v2.13.0.yaml/v1.0.0/relationships/hierarchical-parent-inventory-bdwnz.json
+++ b/models/azure-cache/azureserviceoperator_customresourcedefinitions_v2.13.0.yaml/v1.0.0/relationships/hierarchical-parent-inventory-bdwnz.json
@@ -45,15 +45,15 @@
               "version": ""
             },
             "patch": {
-              "mutatedRef": [
+              "patchStrategy": "replace",
+              "mutatorRef": [
                 [
                   "configuration",
                   "spec",
                   "owner",
                   "name"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ],
@@ -75,12 +75,12 @@
               "version": ""
             },
             "patch": {
-              "mutatorRef": [
+              "patchStrategy": "replace",
+              "mutatedRef": [
                 [
                   "displayName"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ]

--- a/models/azure-cache/azureserviceoperator_customresourcedefinitions_v2.13.0.yaml/v1.0.0/relationships/hierarchical-parent-inventory-bnqlc.json
+++ b/models/azure-cache/azureserviceoperator_customresourcedefinitions_v2.13.0.yaml/v1.0.0/relationships/hierarchical-parent-inventory-bnqlc.json
@@ -45,15 +45,15 @@
               "version": ""
             },
             "patch": {
-              "mutatedRef": [
+              "patchStrategy": "replace",
+              "mutatorRef": [
                 [
                   "configuration",
                   "spec",
                   "owner",
                   "name"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ],
@@ -75,12 +75,12 @@
               "version": ""
             },
             "patch": {
-              "mutatorRef": [
+              "patchStrategy": "replace",
+              "mutatedRef": [
                 [
                   "displayName"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ]

--- a/models/azure-cache/azureserviceoperator_customresourcedefinitions_v2.13.0.yaml/v1.0.0/relationships/hierarchical-parent-inventory-gxguj.json
+++ b/models/azure-cache/azureserviceoperator_customresourcedefinitions_v2.13.0.yaml/v1.0.0/relationships/hierarchical-parent-inventory-gxguj.json
@@ -45,15 +45,15 @@
               "version": ""
             },
             "patch": {
-              "mutatedRef": [
+              "patchStrategy": "replace",
+              "mutatorRef": [
                 [
                   "configuration",
                   "spec",
                   "owner",
                   "name"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ],
@@ -75,12 +75,12 @@
               "version": ""
             },
             "patch": {
-              "mutatorRef": [
+              "patchStrategy": "replace",
+              "mutatedRef": [
                 [
                   "displayName"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ]

--- a/models/azure-cache/azureserviceoperator_customresourcedefinitions_v2.13.0.yaml/v1.0.0/relationships/hierarchical-parent-inventory-kmjea.json
+++ b/models/azure-cache/azureserviceoperator_customresourcedefinitions_v2.13.0.yaml/v1.0.0/relationships/hierarchical-parent-inventory-kmjea.json
@@ -91,7 +91,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatedRef": [
+              "mutatorRef": [
                 [
                   "configuration",
                   "spec",
@@ -144,7 +144,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "displayName"
                 ]

--- a/models/azure-cache/azureserviceoperator_customresourcedefinitions_v2.13.0.yaml/v1.0.0/relationships/hierarchical-parent-inventory-pdtwb.json
+++ b/models/azure-cache/azureserviceoperator_customresourcedefinitions_v2.13.0.yaml/v1.0.0/relationships/hierarchical-parent-inventory-pdtwb.json
@@ -45,15 +45,15 @@
               "version": ""
             },
             "patch": {
-              "mutatedRef": [
+              "patchStrategy": "replace",
+              "mutatorRef": [
                 [
                   "configuration",
                   "spec",
                   "owner",
                   "name"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ],
@@ -75,12 +75,12 @@
               "version": ""
             },
             "patch": {
-              "mutatorRef": [
+              "patchStrategy": "replace",
+              "mutatedRef": [
                 [
                   "displayName"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ]

--- a/models/azure-cache/azureserviceoperator_customresourcedefinitions_v2.14.0.yaml/v1.0.0/relationships/hierarchical-parent-inventory-bdwnz.json
+++ b/models/azure-cache/azureserviceoperator_customresourcedefinitions_v2.14.0.yaml/v1.0.0/relationships/hierarchical-parent-inventory-bdwnz.json
@@ -45,15 +45,15 @@
               "version": ""
             },
             "patch": {
-              "mutatedRef": [
+              "patchStrategy": "replace",
+              "mutatorRef": [
                 [
                   "configuration",
                   "spec",
                   "owner",
                   "name"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ],
@@ -75,12 +75,12 @@
               "version": ""
             },
             "patch": {
-              "mutatorRef": [
+              "patchStrategy": "replace",
+              "mutatedRef": [
                 [
                   "displayName"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ]

--- a/models/azure-cache/azureserviceoperator_customresourcedefinitions_v2.14.0.yaml/v1.0.0/relationships/hierarchical-parent-inventory-bnqlc.json
+++ b/models/azure-cache/azureserviceoperator_customresourcedefinitions_v2.14.0.yaml/v1.0.0/relationships/hierarchical-parent-inventory-bnqlc.json
@@ -45,15 +45,15 @@
               "version": ""
             },
             "patch": {
-              "mutatedRef": [
+              "patchStrategy": "replace",
+              "mutatorRef": [
                 [
                   "configuration",
                   "spec",
                   "owner",
                   "name"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ],
@@ -75,12 +75,12 @@
               "version": ""
             },
             "patch": {
-              "mutatorRef": [
+              "patchStrategy": "replace",
+              "mutatedRef": [
                 [
                   "displayName"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ]

--- a/models/azure-cache/azureserviceoperator_customresourcedefinitions_v2.14.0.yaml/v1.0.0/relationships/hierarchical-parent-inventory-gxguj.json
+++ b/models/azure-cache/azureserviceoperator_customresourcedefinitions_v2.14.0.yaml/v1.0.0/relationships/hierarchical-parent-inventory-gxguj.json
@@ -45,15 +45,15 @@
               "version": ""
             },
             "patch": {
-              "mutatedRef": [
+              "patchStrategy": "replace",
+              "mutatorRef": [
                 [
                   "configuration",
                   "spec",
                   "owner",
                   "name"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ],
@@ -75,12 +75,12 @@
               "version": ""
             },
             "patch": {
-              "mutatorRef": [
+              "patchStrategy": "replace",
+              "mutatedRef": [
                 [
                   "displayName"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ]

--- a/models/azure-cache/azureserviceoperator_customresourcedefinitions_v2.14.0.yaml/v1.0.0/relationships/hierarchical-parent-inventory-kmjea.json
+++ b/models/azure-cache/azureserviceoperator_customresourcedefinitions_v2.14.0.yaml/v1.0.0/relationships/hierarchical-parent-inventory-kmjea.json
@@ -91,7 +91,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatedRef": [
+              "mutatorRef": [
                 [
                   "configuration",
                   "spec",
@@ -144,7 +144,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "displayName"
                 ]

--- a/models/azure-cache/azureserviceoperator_customresourcedefinitions_v2.14.0.yaml/v1.0.0/relationships/hierarchical-parent-inventory-pdtwb.json
+++ b/models/azure-cache/azureserviceoperator_customresourcedefinitions_v2.14.0.yaml/v1.0.0/relationships/hierarchical-parent-inventory-pdtwb.json
@@ -45,15 +45,15 @@
               "version": ""
             },
             "patch": {
-              "mutatedRef": [
+              "patchStrategy": "replace",
+              "mutatorRef": [
                 [
                   "configuration",
                   "spec",
                   "owner",
                   "name"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ],
@@ -75,12 +75,12 @@
               "version": ""
             },
             "patch": {
-              "mutatorRef": [
+              "patchStrategy": "replace",
+              "mutatedRef": [
                 [
                   "displayName"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ]

--- a/models/azure-cdn/azureserviceoperator_customresourcedefinitions_v2.13.0.yaml/v1.0.0/relationships/edge-non-binding-alias-aupod.json
+++ b/models/azure-cdn/azureserviceoperator_customresourcedefinitions_v2.13.0.yaml/v1.0.0/relationships/edge-non-binding-alias-aupod.json
@@ -45,7 +45,8 @@
               "version": ""
             },
             "patch": {
-              "mutatedRef": [
+              "patchStrategy": "replace",
+              "mutatorRef": [
                 [
                   "configuration",
                   "spec",
@@ -64,8 +65,7 @@
                   "reference",
                   "name"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ],
@@ -87,7 +87,8 @@
               "version": ""
             },
             "patch": {
-              "mutatorRef": [
+              "patchStrategy": "replace",
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -101,8 +102,7 @@
                   "metadata",
                   "name"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ]

--- a/models/azure-cdn/azureserviceoperator_customresourcedefinitions_v2.13.0.yaml/v1.0.0/relationships/edge-non-binding-alias-bbiyr.json
+++ b/models/azure-cdn/azureserviceoperator_customresourcedefinitions_v2.13.0.yaml/v1.0.0/relationships/edge-non-binding-alias-bbiyr.json
@@ -45,7 +45,8 @@
               "version": ""
             },
             "patch": {
-              "mutatedRef": [
+              "patchStrategy": "replace",
+              "mutatorRef": [
                 [
                   "configuration",
                   "spec",
@@ -64,8 +65,7 @@
                   "reference",
                   "name"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ],
@@ -87,7 +87,8 @@
               "version": ""
             },
             "patch": {
-              "mutatorRef": [
+              "patchStrategy": "replace",
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -101,8 +102,7 @@
                   "metadata",
                   "name"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ]

--- a/models/azure-cdn/azureserviceoperator_customresourcedefinitions_v2.13.0.yaml/v1.0.0/relationships/edge-non-binding-alias-biigg.json
+++ b/models/azure-cdn/azureserviceoperator_customresourcedefinitions_v2.13.0.yaml/v1.0.0/relationships/edge-non-binding-alias-biigg.json
@@ -45,7 +45,8 @@
               "version": ""
             },
             "patch": {
-              "mutatedRef": [
+              "patchStrategy": "replace",
+              "mutatorRef": [
                 [
                   "configuration",
                   "spec",
@@ -88,8 +89,7 @@
                   "reference",
                   "name"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ],
@@ -111,7 +111,8 @@
               "version": ""
             },
             "patch": {
-              "mutatorRef": [
+              "patchStrategy": "replace",
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -125,8 +126,7 @@
                   "metadata",
                   "name"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ]

--- a/models/azure-cdn/azureserviceoperator_customresourcedefinitions_v2.13.0.yaml/v1.0.0/relationships/edge-non-binding-alias-iyjki.json
+++ b/models/azure-cdn/azureserviceoperator_customresourcedefinitions_v2.13.0.yaml/v1.0.0/relationships/edge-non-binding-alias-iyjki.json
@@ -45,7 +45,8 @@
               "version": ""
             },
             "patch": {
-              "mutatedRef": [
+              "patchStrategy": "replace",
+              "mutatorRef": [
                 [
                   "configuration",
                   "spec",
@@ -88,8 +89,7 @@
                   "reference",
                   "name"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ],
@@ -111,7 +111,8 @@
               "version": ""
             },
             "patch": {
-              "mutatorRef": [
+              "patchStrategy": "replace",
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -125,8 +126,7 @@
                   "metadata",
                   "name"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ]

--- a/models/azure-cdn/azureserviceoperator_customresourcedefinitions_v2.13.0.yaml/v1.0.0/relationships/hierarchical-parent-inventory-baiib.json
+++ b/models/azure-cdn/azureserviceoperator_customresourcedefinitions_v2.13.0.yaml/v1.0.0/relationships/hierarchical-parent-inventory-baiib.json
@@ -45,15 +45,15 @@
               "version": ""
             },
             "patch": {
-              "mutatedRef": [
+              "patchStrategy": "replace",
+              "mutatorRef": [
                 [
                   "configuration",
                   "spec",
                   "owner",
                   "name"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ],
@@ -75,12 +75,12 @@
               "version": ""
             },
             "patch": {
-              "mutatorRef": [
+              "patchStrategy": "replace",
+              "mutatedRef": [
                 [
                   "displayName"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ]

--- a/models/azure-cdn/azureserviceoperator_customresourcedefinitions_v2.13.0.yaml/v1.0.0/relationships/hierarchical-parent-inventory-bkujm.json
+++ b/models/azure-cdn/azureserviceoperator_customresourcedefinitions_v2.13.0.yaml/v1.0.0/relationships/hierarchical-parent-inventory-bkujm.json
@@ -45,15 +45,15 @@
               "version": ""
             },
             "patch": {
-              "mutatedRef": [
+              "patchStrategy": "replace",
+              "mutatorRef": [
                 [
                   "configuration",
                   "spec",
                   "owner",
                   "name"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ],
@@ -75,12 +75,12 @@
               "version": ""
             },
             "patch": {
-              "mutatorRef": [
+              "patchStrategy": "replace",
+              "mutatedRef": [
                 [
                   "displayName"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ]

--- a/models/azure-cdn/azureserviceoperator_customresourcedefinitions_v2.13.0.yaml/v1.0.0/relationships/hierarchical-parent-inventory-cekjk.json
+++ b/models/azure-cdn/azureserviceoperator_customresourcedefinitions_v2.13.0.yaml/v1.0.0/relationships/hierarchical-parent-inventory-cekjk.json
@@ -45,15 +45,15 @@
               "version": ""
             },
             "patch": {
-              "mutatedRef": [
+              "patchStrategy": "replace",
+              "mutatorRef": [
                 [
                   "configuration",
                   "spec",
                   "owner",
                   "name"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ],
@@ -75,12 +75,12 @@
               "version": ""
             },
             "patch": {
-              "mutatorRef": [
+              "patchStrategy": "replace",
+              "mutatedRef": [
                 [
                   "displayName"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ]

--- a/models/azure-cdn/azureserviceoperator_customresourcedefinitions_v2.13.0.yaml/v1.0.0/relationships/hierarchical-parent-inventory-hdeyv.json
+++ b/models/azure-cdn/azureserviceoperator_customresourcedefinitions_v2.13.0.yaml/v1.0.0/relationships/hierarchical-parent-inventory-hdeyv.json
@@ -45,15 +45,15 @@
               "version": ""
             },
             "patch": {
-              "mutatedRef": [
+              "patchStrategy": "replace",
+              "mutatorRef": [
                 [
                   "configuration",
                   "spec",
                   "owner",
                   "name"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ],
@@ -75,12 +75,12 @@
               "version": ""
             },
             "patch": {
-              "mutatorRef": [
+              "patchStrategy": "replace",
+              "mutatedRef": [
                 [
                   "displayName"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ]

--- a/models/azure-cdn/azureserviceoperator_customresourcedefinitions_v2.13.0.yaml/v1.0.0/relationships/hierarchical-parent-inventory-kmjea.json
+++ b/models/azure-cdn/azureserviceoperator_customresourcedefinitions_v2.13.0.yaml/v1.0.0/relationships/hierarchical-parent-inventory-kmjea.json
@@ -91,7 +91,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatedRef": [
+              "mutatorRef": [
                 [
                   "configuration",
                   "spec",
@@ -156,7 +156,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"

--- a/models/azure-cdn/azureserviceoperator_customresourcedefinitions_v2.13.0.yaml/v1.0.0/relationships/hierarchical-parent-inventory-nhuvj.json
+++ b/models/azure-cdn/azureserviceoperator_customresourcedefinitions_v2.13.0.yaml/v1.0.0/relationships/hierarchical-parent-inventory-nhuvj.json
@@ -45,15 +45,15 @@
               "version": ""
             },
             "patch": {
-              "mutatedRef": [
+              "patchStrategy": "replace",
+              "mutatorRef": [
                 [
                   "configuration",
                   "spec",
                   "owner",
                   "name"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ],
@@ -75,12 +75,12 @@
               "version": ""
             },
             "patch": {
-              "mutatorRef": [
+              "patchStrategy": "replace",
+              "mutatedRef": [
                 [
                   "displayName"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ]

--- a/models/azure-cdn/azureserviceoperator_customresourcedefinitions_v2.13.0.yaml/v1.0.0/relationships/hierarchical-parent-inventory-osxyr.json
+++ b/models/azure-cdn/azureserviceoperator_customresourcedefinitions_v2.13.0.yaml/v1.0.0/relationships/hierarchical-parent-inventory-osxyr.json
@@ -45,15 +45,15 @@
               "version": ""
             },
             "patch": {
-              "mutatedRef": [
+              "patchStrategy": "replace",
+              "mutatorRef": [
                 [
                   "configuration",
                   "spec",
                   "owner",
                   "name"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ],
@@ -75,12 +75,12 @@
               "version": ""
             },
             "patch": {
-              "mutatorRef": [
+              "patchStrategy": "replace",
+              "mutatedRef": [
                 [
                   "displayName"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ]

--- a/models/azure-cdn/azureserviceoperator_customresourcedefinitions_v2.13.0.yaml/v1.0.0/relationships/hierarchical-parent-inventory-rixpw.json
+++ b/models/azure-cdn/azureserviceoperator_customresourcedefinitions_v2.13.0.yaml/v1.0.0/relationships/hierarchical-parent-inventory-rixpw.json
@@ -45,15 +45,15 @@
               "version": ""
             },
             "patch": {
-              "mutatedRef": [
+              "patchStrategy": "replace",
+              "mutatorRef": [
                 [
                   "configuration",
                   "spec",
                   "owner",
                   "name"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ],
@@ -75,12 +75,12 @@
               "version": ""
             },
             "patch": {
-              "mutatorRef": [
+              "patchStrategy": "replace",
+              "mutatedRef": [
                 [
                   "displayName"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ]

--- a/models/azure-cdn/azureserviceoperator_customresourcedefinitions_v2.13.0.yaml/v1.0.0/relationships/hierarchical-parent-inventory-rjgfy.json
+++ b/models/azure-cdn/azureserviceoperator_customresourcedefinitions_v2.13.0.yaml/v1.0.0/relationships/hierarchical-parent-inventory-rjgfy.json
@@ -45,15 +45,15 @@
               "version": ""
             },
             "patch": {
-              "mutatedRef": [
+              "patchStrategy": "replace",
+              "mutatorRef": [
                 [
                   "configuration",
                   "spec",
                   "owner",
                   "name"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ],
@@ -75,12 +75,12 @@
               "version": ""
             },
             "patch": {
-              "mutatorRef": [
+              "patchStrategy": "replace",
+              "mutatedRef": [
                 [
                   "displayName"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ]

--- a/models/azure-cdn/azureserviceoperator_customresourcedefinitions_v2.13.0.yaml/v1.0.0/relationships/hierarchical-parent-inventory-yowkb.json
+++ b/models/azure-cdn/azureserviceoperator_customresourcedefinitions_v2.13.0.yaml/v1.0.0/relationships/hierarchical-parent-inventory-yowkb.json
@@ -45,15 +45,15 @@
               "version": ""
             },
             "patch": {
-              "mutatedRef": [
+              "patchStrategy": "replace",
+              "mutatorRef": [
                 [
                   "configuration",
                   "spec",
                   "owner",
                   "name"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ],
@@ -75,12 +75,12 @@
               "version": ""
             },
             "patch": {
-              "mutatorRef": [
+              "patchStrategy": "replace",
+              "mutatedRef": [
                 [
                   "displayName"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ]

--- a/models/azure-cdn/azureserviceoperator_customresourcedefinitions_v2.13.0.yaml/v1.0.0/relationships/hierarchical-parent-inventory-ytttn.json
+++ b/models/azure-cdn/azureserviceoperator_customresourcedefinitions_v2.13.0.yaml/v1.0.0/relationships/hierarchical-parent-inventory-ytttn.json
@@ -45,15 +45,15 @@
               "version": ""
             },
             "patch": {
-              "mutatedRef": [
+              "patchStrategy": "replace",
+              "mutatorRef": [
                 [
                   "configuration",
                   "spec",
                   "owner",
                   "name"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ],
@@ -75,12 +75,12 @@
               "version": ""
             },
             "patch": {
-              "mutatorRef": [
+              "patchStrategy": "replace",
+              "mutatedRef": [
                 [
                   "displayName"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ]

--- a/models/azure-cdn/azureserviceoperator_customresourcedefinitions_v2.14.0.yaml/v1.0.0/relationships/edge-non-binding-alias-aupod.json
+++ b/models/azure-cdn/azureserviceoperator_customresourcedefinitions_v2.14.0.yaml/v1.0.0/relationships/edge-non-binding-alias-aupod.json
@@ -45,7 +45,8 @@
               "version": ""
             },
             "patch": {
-              "mutatedRef": [
+              "patchStrategy": "replace",
+              "mutatorRef": [
                 [
                   "configuration",
                   "spec",
@@ -64,8 +65,7 @@
                   "reference",
                   "name"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ],
@@ -87,7 +87,8 @@
               "version": ""
             },
             "patch": {
-              "mutatorRef": [
+              "patchStrategy": "replace",
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -101,8 +102,7 @@
                   "metadata",
                   "name"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ]

--- a/models/azure-cdn/azureserviceoperator_customresourcedefinitions_v2.14.0.yaml/v1.0.0/relationships/edge-non-binding-alias-bbiyr.json
+++ b/models/azure-cdn/azureserviceoperator_customresourcedefinitions_v2.14.0.yaml/v1.0.0/relationships/edge-non-binding-alias-bbiyr.json
@@ -45,7 +45,8 @@
               "version": ""
             },
             "patch": {
-              "mutatedRef": [
+              "patchStrategy": "replace",
+              "mutatorRef": [
                 [
                   "configuration",
                   "spec",
@@ -64,8 +65,7 @@
                   "reference",
                   "name"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ],
@@ -87,7 +87,8 @@
               "version": ""
             },
             "patch": {
-              "mutatorRef": [
+              "patchStrategy": "replace",
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -101,8 +102,7 @@
                   "metadata",
                   "name"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ]

--- a/models/azure-cdn/azureserviceoperator_customresourcedefinitions_v2.14.0.yaml/v1.0.0/relationships/edge-non-binding-alias-biigg.json
+++ b/models/azure-cdn/azureserviceoperator_customresourcedefinitions_v2.14.0.yaml/v1.0.0/relationships/edge-non-binding-alias-biigg.json
@@ -45,7 +45,8 @@
               "version": ""
             },
             "patch": {
-              "mutatedRef": [
+              "patchStrategy": "replace",
+              "mutatorRef": [
                 [
                   "configuration",
                   "spec",
@@ -88,8 +89,7 @@
                   "reference",
                   "name"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ],
@@ -111,7 +111,8 @@
               "version": ""
             },
             "patch": {
-              "mutatorRef": [
+              "patchStrategy": "replace",
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -125,8 +126,7 @@
                   "metadata",
                   "name"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ]

--- a/models/azure-cdn/azureserviceoperator_customresourcedefinitions_v2.14.0.yaml/v1.0.0/relationships/edge-non-binding-alias-iyjki.json
+++ b/models/azure-cdn/azureserviceoperator_customresourcedefinitions_v2.14.0.yaml/v1.0.0/relationships/edge-non-binding-alias-iyjki.json
@@ -45,7 +45,8 @@
               "version": ""
             },
             "patch": {
-              "mutatedRef": [
+              "patchStrategy": "replace",
+              "mutatorRef": [
                 [
                   "configuration",
                   "spec",
@@ -88,8 +89,7 @@
                   "reference",
                   "name"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ],
@@ -111,7 +111,8 @@
               "version": ""
             },
             "patch": {
-              "mutatorRef": [
+              "patchStrategy": "replace",
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -125,8 +126,7 @@
                   "metadata",
                   "name"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ]

--- a/models/azure-cdn/azureserviceoperator_customresourcedefinitions_v2.14.0.yaml/v1.0.0/relationships/hierarchical-parent-inventory-baiib.json
+++ b/models/azure-cdn/azureserviceoperator_customresourcedefinitions_v2.14.0.yaml/v1.0.0/relationships/hierarchical-parent-inventory-baiib.json
@@ -45,15 +45,15 @@
               "version": ""
             },
             "patch": {
-              "mutatedRef": [
+              "patchStrategy": "replace",
+              "mutatorRef": [
                 [
                   "configuration",
                   "spec",
                   "owner",
                   "name"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ],
@@ -75,12 +75,12 @@
               "version": ""
             },
             "patch": {
-              "mutatorRef": [
+              "patchStrategy": "replace",
+              "mutatedRef": [
                 [
                   "displayName"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ]

--- a/models/azure-cdn/azureserviceoperator_customresourcedefinitions_v2.14.0.yaml/v1.0.0/relationships/hierarchical-parent-inventory-bkujm.json
+++ b/models/azure-cdn/azureserviceoperator_customresourcedefinitions_v2.14.0.yaml/v1.0.0/relationships/hierarchical-parent-inventory-bkujm.json
@@ -45,15 +45,15 @@
               "version": ""
             },
             "patch": {
-              "mutatedRef": [
+              "patchStrategy": "replace",
+              "mutatorRef": [
                 [
                   "configuration",
                   "spec",
                   "owner",
                   "name"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ],
@@ -75,12 +75,12 @@
               "version": ""
             },
             "patch": {
-              "mutatorRef": [
+              "patchStrategy": "replace",
+              "mutatedRef": [
                 [
                   "displayName"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ]

--- a/models/azure-cdn/azureserviceoperator_customresourcedefinitions_v2.14.0.yaml/v1.0.0/relationships/hierarchical-parent-inventory-cekjk.json
+++ b/models/azure-cdn/azureserviceoperator_customresourcedefinitions_v2.14.0.yaml/v1.0.0/relationships/hierarchical-parent-inventory-cekjk.json
@@ -45,15 +45,15 @@
               "version": ""
             },
             "patch": {
-              "mutatedRef": [
+              "patchStrategy": "replace",
+              "mutatorRef": [
                 [
                   "configuration",
                   "spec",
                   "owner",
                   "name"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ],
@@ -75,12 +75,12 @@
               "version": ""
             },
             "patch": {
-              "mutatorRef": [
+              "patchStrategy": "replace",
+              "mutatedRef": [
                 [
                   "displayName"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ]

--- a/models/azure-cdn/azureserviceoperator_customresourcedefinitions_v2.14.0.yaml/v1.0.0/relationships/hierarchical-parent-inventory-hdeyv.json
+++ b/models/azure-cdn/azureserviceoperator_customresourcedefinitions_v2.14.0.yaml/v1.0.0/relationships/hierarchical-parent-inventory-hdeyv.json
@@ -45,15 +45,15 @@
               "version": ""
             },
             "patch": {
-              "mutatedRef": [
+              "patchStrategy": "replace",
+              "mutatorRef": [
                 [
                   "configuration",
                   "spec",
                   "owner",
                   "name"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ],
@@ -75,12 +75,12 @@
               "version": ""
             },
             "patch": {
-              "mutatorRef": [
+              "patchStrategy": "replace",
+              "mutatedRef": [
                 [
                   "displayName"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ]

--- a/models/azure-cdn/azureserviceoperator_customresourcedefinitions_v2.14.0.yaml/v1.0.0/relationships/hierarchical-parent-inventory-kmjea.json
+++ b/models/azure-cdn/azureserviceoperator_customresourcedefinitions_v2.14.0.yaml/v1.0.0/relationships/hierarchical-parent-inventory-kmjea.json
@@ -91,7 +91,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatedRef": [
+              "mutatorRef": [
                 [
                   "configuration",
                   "spec",
@@ -156,7 +156,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"

--- a/models/azure-cdn/azureserviceoperator_customresourcedefinitions_v2.14.0.yaml/v1.0.0/relationships/hierarchical-parent-inventory-nhuvj.json
+++ b/models/azure-cdn/azureserviceoperator_customresourcedefinitions_v2.14.0.yaml/v1.0.0/relationships/hierarchical-parent-inventory-nhuvj.json
@@ -45,15 +45,15 @@
               "version": ""
             },
             "patch": {
-              "mutatedRef": [
+              "patchStrategy": "replace",
+              "mutatorRef": [
                 [
                   "configuration",
                   "spec",
                   "owner",
                   "name"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ],
@@ -75,12 +75,12 @@
               "version": ""
             },
             "patch": {
-              "mutatorRef": [
+              "patchStrategy": "replace",
+              "mutatedRef": [
                 [
                   "displayName"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ]

--- a/models/azure-cdn/azureserviceoperator_customresourcedefinitions_v2.14.0.yaml/v1.0.0/relationships/hierarchical-parent-inventory-osxyr.json
+++ b/models/azure-cdn/azureserviceoperator_customresourcedefinitions_v2.14.0.yaml/v1.0.0/relationships/hierarchical-parent-inventory-osxyr.json
@@ -45,15 +45,15 @@
               "version": ""
             },
             "patch": {
-              "mutatedRef": [
+              "patchStrategy": "replace",
+              "mutatorRef": [
                 [
                   "configuration",
                   "spec",
                   "owner",
                   "name"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ],
@@ -75,12 +75,12 @@
               "version": ""
             },
             "patch": {
-              "mutatorRef": [
+              "patchStrategy": "replace",
+              "mutatedRef": [
                 [
                   "displayName"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ]

--- a/models/azure-cdn/azureserviceoperator_customresourcedefinitions_v2.14.0.yaml/v1.0.0/relationships/hierarchical-parent-inventory-rixpw.json
+++ b/models/azure-cdn/azureserviceoperator_customresourcedefinitions_v2.14.0.yaml/v1.0.0/relationships/hierarchical-parent-inventory-rixpw.json
@@ -45,15 +45,15 @@
               "version": ""
             },
             "patch": {
-              "mutatedRef": [
+              "patchStrategy": "replace",
+              "mutatorRef": [
                 [
                   "configuration",
                   "spec",
                   "owner",
                   "name"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ],
@@ -75,12 +75,12 @@
               "version": ""
             },
             "patch": {
-              "mutatorRef": [
+              "patchStrategy": "replace",
+              "mutatedRef": [
                 [
                   "displayName"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ]

--- a/models/azure-cdn/azureserviceoperator_customresourcedefinitions_v2.14.0.yaml/v1.0.0/relationships/hierarchical-parent-inventory-rjgfy.json
+++ b/models/azure-cdn/azureserviceoperator_customresourcedefinitions_v2.14.0.yaml/v1.0.0/relationships/hierarchical-parent-inventory-rjgfy.json
@@ -45,15 +45,15 @@
               "version": ""
             },
             "patch": {
-              "mutatedRef": [
+              "patchStrategy": "replace",
+              "mutatorRef": [
                 [
                   "configuration",
                   "spec",
                   "owner",
                   "name"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ],
@@ -75,12 +75,12 @@
               "version": ""
             },
             "patch": {
-              "mutatorRef": [
+              "patchStrategy": "replace",
+              "mutatedRef": [
                 [
                   "displayName"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ]

--- a/models/azure-cdn/azureserviceoperator_customresourcedefinitions_v2.14.0.yaml/v1.0.0/relationships/hierarchical-parent-inventory-yowkb.json
+++ b/models/azure-cdn/azureserviceoperator_customresourcedefinitions_v2.14.0.yaml/v1.0.0/relationships/hierarchical-parent-inventory-yowkb.json
@@ -45,15 +45,15 @@
               "version": ""
             },
             "patch": {
-              "mutatedRef": [
+              "patchStrategy": "replace",
+              "mutatorRef": [
                 [
                   "configuration",
                   "spec",
                   "owner",
                   "name"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ],
@@ -75,12 +75,12 @@
               "version": ""
             },
             "patch": {
-              "mutatorRef": [
+              "patchStrategy": "replace",
+              "mutatedRef": [
                 [
                   "displayName"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ]

--- a/models/azure-cdn/azureserviceoperator_customresourcedefinitions_v2.14.0.yaml/v1.0.0/relationships/hierarchical-parent-inventory-ytttn.json
+++ b/models/azure-cdn/azureserviceoperator_customresourcedefinitions_v2.14.0.yaml/v1.0.0/relationships/hierarchical-parent-inventory-ytttn.json
@@ -45,15 +45,15 @@
               "version": ""
             },
             "patch": {
-              "mutatedRef": [
+              "patchStrategy": "replace",
+              "mutatorRef": [
                 [
                   "configuration",
                   "spec",
                   "owner",
                   "name"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ],
@@ -75,12 +75,12 @@
               "version": ""
             },
             "patch": {
-              "mutatorRef": [
+              "patchStrategy": "replace",
+              "mutatedRef": [
                 [
                   "displayName"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ]

--- a/models/azure-compute/azureserviceoperator_customresourcedefinitions_v2.13.0.yaml/v1.0.0/relationships/edge-non-binding-alias-lysls.json
+++ b/models/azure-compute/azureserviceoperator_customresourcedefinitions_v2.13.0.yaml/v1.0.0/relationships/edge-non-binding-alias-lysls.json
@@ -45,7 +45,8 @@
               "version": ""
             },
             "patch": {
-              "mutatedRef": [
+              "patchStrategy": "replace",
+              "mutatorRef": [
                 [
                   "configuration",
                   "spec",
@@ -64,8 +65,7 @@
                   "reference",
                   "name"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ],
@@ -87,7 +87,8 @@
               "version": ""
             },
             "patch": {
-              "mutatorRef": [
+              "patchStrategy": "replace",
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -101,8 +102,7 @@
                   "metadata",
                   "name"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ]

--- a/models/azure-compute/azureserviceoperator_customresourcedefinitions_v2.13.0.yaml/v1.0.0/relationships/edge-non-binding-alias-pzdie.json
+++ b/models/azure-compute/azureserviceoperator_customresourcedefinitions_v2.13.0.yaml/v1.0.0/relationships/edge-non-binding-alias-pzdie.json
@@ -45,7 +45,8 @@
               "version": ""
             },
             "patch": {
-              "mutatedRef": [
+              "patchStrategy": "replace",
+              "mutatorRef": [
                 [
                   "configuration",
                   "spec",
@@ -64,8 +65,7 @@
                   "reference",
                   "name"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ],
@@ -87,7 +87,8 @@
               "version": ""
             },
             "patch": {
-              "mutatorRef": [
+              "patchStrategy": "replace",
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -101,8 +102,7 @@
                   "metadata",
                   "name"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ]

--- a/models/azure-compute/azureserviceoperator_customresourcedefinitions_v2.13.0.yaml/v1.0.0/relationships/hierarchical-parent-inventory-fpmol.json
+++ b/models/azure-compute/azureserviceoperator_customresourcedefinitions_v2.13.0.yaml/v1.0.0/relationships/hierarchical-parent-inventory-fpmol.json
@@ -45,15 +45,15 @@
               "version": ""
             },
             "patch": {
-              "mutatedRef": [
+              "patchStrategy": "replace",
+              "mutatorRef": [
                 [
                   "configuration",
                   "spec",
                   "owner",
                   "name"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ],
@@ -75,12 +75,12 @@
               "version": ""
             },
             "patch": {
-              "mutatorRef": [
+              "patchStrategy": "replace",
+              "mutatedRef": [
                 [
                   "displayName"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ]

--- a/models/azure-compute/azureserviceoperator_customresourcedefinitions_v2.13.0.yaml/v1.0.0/relationships/hierarchical-parent-inventory-kmjea.json
+++ b/models/azure-compute/azureserviceoperator_customresourcedefinitions_v2.13.0.yaml/v1.0.0/relationships/hierarchical-parent-inventory-kmjea.json
@@ -91,7 +91,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatedRef": [
+              "mutatorRef": [
                 [
                   "configuration",
                   "spec",
@@ -156,7 +156,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"

--- a/models/azure-compute/azureserviceoperator_customresourcedefinitions_v2.13.0.yaml/v1.0.0/relationships/hierarchical-parent-inventory-smmri.json
+++ b/models/azure-compute/azureserviceoperator_customresourcedefinitions_v2.13.0.yaml/v1.0.0/relationships/hierarchical-parent-inventory-smmri.json
@@ -45,15 +45,15 @@
               "version": ""
             },
             "patch": {
-              "mutatedRef": [
+              "patchStrategy": "replace",
+              "mutatorRef": [
                 [
                   "configuration",
                   "spec",
                   "owner",
                   "name"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ],
@@ -75,12 +75,12 @@
               "version": ""
             },
             "patch": {
-              "mutatorRef": [
+              "patchStrategy": "replace",
+              "mutatedRef": [
                 [
                   "displayName"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ]

--- a/models/azure-compute/azureserviceoperator_customresourcedefinitions_v2.14.0.yaml/v1.0.0/relationships/edge-non-binding-alias-lysls.json
+++ b/models/azure-compute/azureserviceoperator_customresourcedefinitions_v2.14.0.yaml/v1.0.0/relationships/edge-non-binding-alias-lysls.json
@@ -45,7 +45,8 @@
               "version": ""
             },
             "patch": {
-              "mutatedRef": [
+              "patchStrategy": "replace",
+              "mutatorRef": [
                 [
                   "configuration",
                   "spec",
@@ -64,8 +65,7 @@
                   "reference",
                   "name"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ],
@@ -87,7 +87,8 @@
               "version": ""
             },
             "patch": {
-              "mutatorRef": [
+              "patchStrategy": "replace",
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -101,8 +102,7 @@
                   "metadata",
                   "name"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ]

--- a/models/azure-compute/azureserviceoperator_customresourcedefinitions_v2.14.0.yaml/v1.0.0/relationships/edge-non-binding-alias-pzdie.json
+++ b/models/azure-compute/azureserviceoperator_customresourcedefinitions_v2.14.0.yaml/v1.0.0/relationships/edge-non-binding-alias-pzdie.json
@@ -45,7 +45,8 @@
               "version": ""
             },
             "patch": {
-              "mutatedRef": [
+              "patchStrategy": "replace",
+              "mutatorRef": [
                 [
                   "configuration",
                   "spec",
@@ -64,8 +65,7 @@
                   "reference",
                   "name"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ],
@@ -87,7 +87,8 @@
               "version": ""
             },
             "patch": {
-              "mutatorRef": [
+              "patchStrategy": "replace",
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -101,8 +102,7 @@
                   "metadata",
                   "name"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ]

--- a/models/azure-compute/azureserviceoperator_customresourcedefinitions_v2.14.0.yaml/v1.0.0/relationships/hierarchical-parent-inventory-fpmol.json
+++ b/models/azure-compute/azureserviceoperator_customresourcedefinitions_v2.14.0.yaml/v1.0.0/relationships/hierarchical-parent-inventory-fpmol.json
@@ -45,15 +45,15 @@
               "version": ""
             },
             "patch": {
-              "mutatedRef": [
+              "patchStrategy": "replace",
+              "mutatorRef": [
                 [
                   "configuration",
                   "spec",
                   "owner",
                   "name"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ],
@@ -75,12 +75,12 @@
               "version": ""
             },
             "patch": {
-              "mutatorRef": [
+              "patchStrategy": "replace",
+              "mutatedRef": [
                 [
                   "displayName"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ]

--- a/models/azure-compute/azureserviceoperator_customresourcedefinitions_v2.14.0.yaml/v1.0.0/relationships/hierarchical-parent-inventory-kmjea.json
+++ b/models/azure-compute/azureserviceoperator_customresourcedefinitions_v2.14.0.yaml/v1.0.0/relationships/hierarchical-parent-inventory-kmjea.json
@@ -91,7 +91,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatedRef": [
+              "mutatorRef": [
                 [
                   "configuration",
                   "spec",
@@ -156,7 +156,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"

--- a/models/azure-compute/azureserviceoperator_customresourcedefinitions_v2.14.0.yaml/v1.0.0/relationships/hierarchical-parent-inventory-smmri.json
+++ b/models/azure-compute/azureserviceoperator_customresourcedefinitions_v2.14.0.yaml/v1.0.0/relationships/hierarchical-parent-inventory-smmri.json
@@ -45,15 +45,15 @@
               "version": ""
             },
             "patch": {
-              "mutatedRef": [
+              "patchStrategy": "replace",
+              "mutatorRef": [
                 [
                   "configuration",
                   "spec",
                   "owner",
                   "name"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ],
@@ -75,12 +75,12 @@
               "version": ""
             },
             "patch": {
-              "mutatorRef": [
+              "patchStrategy": "replace",
+              "mutatedRef": [
                 [
                   "displayName"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ]

--- a/models/azure-container-registry/azureserviceoperator_customresourcedefinitions_v2.13.0.yaml/v1.0.0/relationships/hierarchical-parent-inventory-ivxzd.json
+++ b/models/azure-container-registry/azureserviceoperator_customresourcedefinitions_v2.13.0.yaml/v1.0.0/relationships/hierarchical-parent-inventory-ivxzd.json
@@ -45,15 +45,15 @@
               "version": ""
             },
             "patch": {
-              "mutatedRef": [
+              "patchStrategy": "replace",
+              "mutatorRef": [
                 [
                   "configuration",
                   "spec",
                   "owner",
                   "name"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ],
@@ -75,12 +75,12 @@
               "version": ""
             },
             "patch": {
-              "mutatorRef": [
+              "patchStrategy": "replace",
+              "mutatedRef": [
                 [
                   "displayName"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ]

--- a/models/azure-container-registry/azureserviceoperator_customresourcedefinitions_v2.13.0.yaml/v1.0.0/relationships/hierarchical-parent-inventory-kmjea.json
+++ b/models/azure-container-registry/azureserviceoperator_customresourcedefinitions_v2.13.0.yaml/v1.0.0/relationships/hierarchical-parent-inventory-kmjea.json
@@ -91,7 +91,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatedRef": [
+              "mutatorRef": [
                 [
                   "configuration",
                   "spec",
@@ -144,7 +144,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "displayName"
                 ]

--- a/models/azure-container-registry/azureserviceoperator_customresourcedefinitions_v2.14.0.yaml/v1.0.0/relationships/hierarchical-parent-inventory-ivxzd.json
+++ b/models/azure-container-registry/azureserviceoperator_customresourcedefinitions_v2.14.0.yaml/v1.0.0/relationships/hierarchical-parent-inventory-ivxzd.json
@@ -45,15 +45,15 @@
               "version": ""
             },
             "patch": {
-              "mutatedRef": [
+              "patchStrategy": "replace",
+              "mutatorRef": [
                 [
                   "configuration",
                   "spec",
                   "owner",
                   "name"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ],
@@ -75,12 +75,12 @@
               "version": ""
             },
             "patch": {
-              "mutatorRef": [
+              "patchStrategy": "replace",
+              "mutatedRef": [
                 [
                   "displayName"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ]

--- a/models/azure-container-registry/azureserviceoperator_customresourcedefinitions_v2.14.0.yaml/v1.0.0/relationships/hierarchical-parent-inventory-kmjea.json
+++ b/models/azure-container-registry/azureserviceoperator_customresourcedefinitions_v2.14.0.yaml/v1.0.0/relationships/hierarchical-parent-inventory-kmjea.json
@@ -91,7 +91,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatedRef": [
+              "mutatorRef": [
                 [
                   "configuration",
                   "spec",
@@ -144,7 +144,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "displayName"
                 ]

--- a/models/azure-container-service/azureserviceoperator_customresourcedefinitions_v2.13.0.yaml/v1.0.0/relationships/edge-non-binding-alias-givah.json
+++ b/models/azure-container-service/azureserviceoperator_customresourcedefinitions_v2.13.0.yaml/v1.0.0/relationships/edge-non-binding-alias-givah.json
@@ -45,7 +45,8 @@
               "version": ""
             },
             "patch": {
-              "mutatedRef": [
+              "patchStrategy": "replace",
+              "mutatorRef": [
                 [
                   "configuration",
                   "spec",
@@ -64,8 +65,7 @@
                   "clusterResourceReference",
                   "name"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ],
@@ -87,7 +87,8 @@
               "version": ""
             },
             "patch": {
-              "mutatorRef": [
+              "patchStrategy": "replace",
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -101,8 +102,7 @@
                   "metadata",
                   "name"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ]

--- a/models/azure-container-service/azureserviceoperator_customresourcedefinitions_v2.13.0.yaml/v1.0.0/relationships/edge-non-binding-alias-oabre.json
+++ b/models/azure-container-service/azureserviceoperator_customresourcedefinitions_v2.13.0.yaml/v1.0.0/relationships/edge-non-binding-alias-oabre.json
@@ -45,7 +45,8 @@
               "version": ""
             },
             "patch": {
-              "mutatedRef": [
+              "patchStrategy": "replace",
+              "mutatorRef": [
                 [
                   "configuration",
                   "spec",
@@ -64,8 +65,7 @@
                   "sourceResourceReference",
                   "name"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ],
@@ -87,7 +87,8 @@
               "version": ""
             },
             "patch": {
-              "mutatorRef": [
+              "patchStrategy": "replace",
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -101,8 +102,7 @@
                   "metadata",
                   "name"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ]

--- a/models/azure-container-service/azureserviceoperator_customresourcedefinitions_v2.13.0.yaml/v1.0.0/relationships/hierarchical-parent-inventory-bhzce.json
+++ b/models/azure-container-service/azureserviceoperator_customresourcedefinitions_v2.13.0.yaml/v1.0.0/relationships/hierarchical-parent-inventory-bhzce.json
@@ -45,15 +45,15 @@
               "version": ""
             },
             "patch": {
-              "mutatedRef": [
+              "patchStrategy": "replace",
+              "mutatorRef": [
                 [
                   "configuration",
                   "spec",
                   "owner",
                   "name"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ],
@@ -75,12 +75,12 @@
               "version": ""
             },
             "patch": {
-              "mutatorRef": [
+              "patchStrategy": "replace",
+              "mutatedRef": [
                 [
                   "displayName"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ]

--- a/models/azure-container-service/azureserviceoperator_customresourcedefinitions_v2.13.0.yaml/v1.0.0/relationships/hierarchical-parent-inventory-cezfs.json
+++ b/models/azure-container-service/azureserviceoperator_customresourcedefinitions_v2.13.0.yaml/v1.0.0/relationships/hierarchical-parent-inventory-cezfs.json
@@ -45,15 +45,15 @@
               "version": ""
             },
             "patch": {
-              "mutatedRef": [
+              "patchStrategy": "replace",
+              "mutatorRef": [
                 [
                   "configuration",
                   "spec",
                   "owner",
                   "name"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ],
@@ -75,12 +75,12 @@
               "version": ""
             },
             "patch": {
-              "mutatorRef": [
+              "patchStrategy": "replace",
+              "mutatedRef": [
                 [
                   "displayName"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ]

--- a/models/azure-container-service/azureserviceoperator_customresourcedefinitions_v2.13.0.yaml/v1.0.0/relationships/hierarchical-parent-inventory-dyvxu.json
+++ b/models/azure-container-service/azureserviceoperator_customresourcedefinitions_v2.13.0.yaml/v1.0.0/relationships/hierarchical-parent-inventory-dyvxu.json
@@ -45,15 +45,15 @@
               "version": ""
             },
             "patch": {
-              "mutatedRef": [
+              "patchStrategy": "replace",
+              "mutatorRef": [
                 [
                   "configuration",
                   "spec",
                   "owner",
                   "name"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ],
@@ -75,12 +75,12 @@
               "version": ""
             },
             "patch": {
-              "mutatorRef": [
+              "patchStrategy": "replace",
+              "mutatedRef": [
                 [
                   "displayName"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ]

--- a/models/azure-container-service/azureserviceoperator_customresourcedefinitions_v2.13.0.yaml/v1.0.0/relationships/hierarchical-parent-inventory-hqjkq.json
+++ b/models/azure-container-service/azureserviceoperator_customresourcedefinitions_v2.13.0.yaml/v1.0.0/relationships/hierarchical-parent-inventory-hqjkq.json
@@ -45,15 +45,15 @@
               "version": ""
             },
             "patch": {
-              "mutatedRef": [
+              "patchStrategy": "replace",
+              "mutatorRef": [
                 [
                   "configuration",
                   "spec",
                   "owner",
                   "name"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ],
@@ -75,12 +75,12 @@
               "version": ""
             },
             "patch": {
-              "mutatorRef": [
+              "patchStrategy": "replace",
+              "mutatedRef": [
                 [
                   "displayName"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ]

--- a/models/azure-container-service/azureserviceoperator_customresourcedefinitions_v2.13.0.yaml/v1.0.0/relationships/hierarchical-parent-inventory-kmjea.json
+++ b/models/azure-container-service/azureserviceoperator_customresourcedefinitions_v2.13.0.yaml/v1.0.0/relationships/hierarchical-parent-inventory-kmjea.json
@@ -91,7 +91,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatedRef": [
+              "mutatorRef": [
                 [
                   "configuration",
                   "spec",
@@ -156,7 +156,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"

--- a/models/azure-container-service/azureserviceoperator_customresourcedefinitions_v2.13.0.yaml/v1.0.0/relationships/hierarchical-parent-inventory-petjw.json
+++ b/models/azure-container-service/azureserviceoperator_customresourcedefinitions_v2.13.0.yaml/v1.0.0/relationships/hierarchical-parent-inventory-petjw.json
@@ -45,15 +45,15 @@
               "version": ""
             },
             "patch": {
-              "mutatedRef": [
+              "patchStrategy": "replace",
+              "mutatorRef": [
                 [
                   "configuration",
                   "spec",
                   "owner",
                   "name"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ],
@@ -75,12 +75,12 @@
               "version": ""
             },
             "patch": {
-              "mutatorRef": [
+              "patchStrategy": "replace",
+              "mutatedRef": [
                 [
                   "displayName"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ]

--- a/models/azure-container-service/azureserviceoperator_customresourcedefinitions_v2.14.0.yaml/v1.0.0/relationships/edge-non-binding-alias-givah.json
+++ b/models/azure-container-service/azureserviceoperator_customresourcedefinitions_v2.14.0.yaml/v1.0.0/relationships/edge-non-binding-alias-givah.json
@@ -45,7 +45,8 @@
               "version": ""
             },
             "patch": {
-              "mutatedRef": [
+              "patchStrategy": "replace",
+              "mutatorRef": [
                 [
                   "configuration",
                   "spec",
@@ -64,8 +65,7 @@
                   "clusterResourceReference",
                   "name"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ],
@@ -87,7 +87,8 @@
               "version": ""
             },
             "patch": {
-              "mutatorRef": [
+              "patchStrategy": "replace",
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -101,8 +102,7 @@
                   "metadata",
                   "name"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ]

--- a/models/azure-container-service/azureserviceoperator_customresourcedefinitions_v2.14.0.yaml/v1.0.0/relationships/edge-non-binding-alias-oabre.json
+++ b/models/azure-container-service/azureserviceoperator_customresourcedefinitions_v2.14.0.yaml/v1.0.0/relationships/edge-non-binding-alias-oabre.json
@@ -45,7 +45,8 @@
               "version": ""
             },
             "patch": {
-              "mutatedRef": [
+              "patchStrategy": "replace",
+              "mutatorRef": [
                 [
                   "configuration",
                   "spec",
@@ -64,8 +65,7 @@
                   "sourceResourceReference",
                   "name"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ],
@@ -87,7 +87,8 @@
               "version": ""
             },
             "patch": {
-              "mutatorRef": [
+              "patchStrategy": "replace",
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -101,8 +102,7 @@
                   "metadata",
                   "name"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ]

--- a/models/azure-container-service/azureserviceoperator_customresourcedefinitions_v2.14.0.yaml/v1.0.0/relationships/hierarchical-parent-inventory-bhzce.json
+++ b/models/azure-container-service/azureserviceoperator_customresourcedefinitions_v2.14.0.yaml/v1.0.0/relationships/hierarchical-parent-inventory-bhzce.json
@@ -45,15 +45,15 @@
               "version": ""
             },
             "patch": {
-              "mutatedRef": [
+              "patchStrategy": "replace",
+              "mutatorRef": [
                 [
                   "configuration",
                   "spec",
                   "owner",
                   "name"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ],
@@ -75,12 +75,12 @@
               "version": ""
             },
             "patch": {
-              "mutatorRef": [
+              "patchStrategy": "replace",
+              "mutatedRef": [
                 [
                   "displayName"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ]

--- a/models/azure-container-service/azureserviceoperator_customresourcedefinitions_v2.14.0.yaml/v1.0.0/relationships/hierarchical-parent-inventory-cezfs.json
+++ b/models/azure-container-service/azureserviceoperator_customresourcedefinitions_v2.14.0.yaml/v1.0.0/relationships/hierarchical-parent-inventory-cezfs.json
@@ -45,15 +45,15 @@
               "version": ""
             },
             "patch": {
-              "mutatedRef": [
+              "patchStrategy": "replace",
+              "mutatorRef": [
                 [
                   "configuration",
                   "spec",
                   "owner",
                   "name"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ],
@@ -75,12 +75,12 @@
               "version": ""
             },
             "patch": {
-              "mutatorRef": [
+              "patchStrategy": "replace",
+              "mutatedRef": [
                 [
                   "displayName"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ]

--- a/models/azure-container-service/azureserviceoperator_customresourcedefinitions_v2.14.0.yaml/v1.0.0/relationships/hierarchical-parent-inventory-dyvxu.json
+++ b/models/azure-container-service/azureserviceoperator_customresourcedefinitions_v2.14.0.yaml/v1.0.0/relationships/hierarchical-parent-inventory-dyvxu.json
@@ -45,15 +45,15 @@
               "version": ""
             },
             "patch": {
-              "mutatedRef": [
+              "patchStrategy": "replace",
+              "mutatorRef": [
                 [
                   "configuration",
                   "spec",
                   "owner",
                   "name"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ],
@@ -75,12 +75,12 @@
               "version": ""
             },
             "patch": {
-              "mutatorRef": [
+              "patchStrategy": "replace",
+              "mutatedRef": [
                 [
                   "displayName"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ]

--- a/models/azure-container-service/azureserviceoperator_customresourcedefinitions_v2.14.0.yaml/v1.0.0/relationships/hierarchical-parent-inventory-hqjkq.json
+++ b/models/azure-container-service/azureserviceoperator_customresourcedefinitions_v2.14.0.yaml/v1.0.0/relationships/hierarchical-parent-inventory-hqjkq.json
@@ -45,15 +45,15 @@
               "version": ""
             },
             "patch": {
-              "mutatedRef": [
+              "patchStrategy": "replace",
+              "mutatorRef": [
                 [
                   "configuration",
                   "spec",
                   "owner",
                   "name"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ],
@@ -75,12 +75,12 @@
               "version": ""
             },
             "patch": {
-              "mutatorRef": [
+              "patchStrategy": "replace",
+              "mutatedRef": [
                 [
                   "displayName"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ]

--- a/models/azure-container-service/azureserviceoperator_customresourcedefinitions_v2.14.0.yaml/v1.0.0/relationships/hierarchical-parent-inventory-kmjea.json
+++ b/models/azure-container-service/azureserviceoperator_customresourcedefinitions_v2.14.0.yaml/v1.0.0/relationships/hierarchical-parent-inventory-kmjea.json
@@ -91,7 +91,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatedRef": [
+              "mutatorRef": [
                 [
                   "configuration",
                   "spec",
@@ -156,7 +156,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"

--- a/models/azure-container-service/azureserviceoperator_customresourcedefinitions_v2.14.0.yaml/v1.0.0/relationships/hierarchical-parent-inventory-petjw.json
+++ b/models/azure-container-service/azureserviceoperator_customresourcedefinitions_v2.14.0.yaml/v1.0.0/relationships/hierarchical-parent-inventory-petjw.json
@@ -45,15 +45,15 @@
               "version": ""
             },
             "patch": {
-              "mutatedRef": [
+              "patchStrategy": "replace",
+              "mutatorRef": [
                 [
                   "configuration",
                   "spec",
                   "owner",
                   "name"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ],
@@ -75,12 +75,12 @@
               "version": ""
             },
             "patch": {
-              "mutatorRef": [
+              "patchStrategy": "replace",
+              "mutatedRef": [
                 [
                   "displayName"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ]

--- a/models/azure-data-protection/azureserviceoperator_customresourcedefinitions_v2.13.0.yaml/v1.0.0/relationships/edge-non-binding-alias-dshtt.json
+++ b/models/azure-data-protection/azureserviceoperator_customresourcedefinitions_v2.13.0.yaml/v1.0.0/relationships/edge-non-binding-alias-dshtt.json
@@ -45,7 +45,8 @@
               "version": ""
             },
             "patch": {
-              "mutatedRef": [
+              "patchStrategy": "replace",
+              "mutatorRef": [
                 [
                   "configuration",
                   "spec",
@@ -64,8 +65,7 @@
                   "resourceReference",
                   "name"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ],
@@ -87,7 +87,8 @@
               "version": ""
             },
             "patch": {
-              "mutatorRef": [
+              "patchStrategy": "replace",
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -101,8 +102,7 @@
                   "metadata",
                   "name"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ]

--- a/models/azure-data-protection/azureserviceoperator_customresourcedefinitions_v2.13.0.yaml/v1.0.0/relationships/edge-non-binding-alias-rjerv.json
+++ b/models/azure-data-protection/azureserviceoperator_customresourcedefinitions_v2.13.0.yaml/v1.0.0/relationships/edge-non-binding-alias-rjerv.json
@@ -45,7 +45,8 @@
               "version": ""
             },
             "patch": {
-              "mutatedRef": [
+              "patchStrategy": "replace",
+              "mutatorRef": [
                 [
                   "configuration",
                   "spec",
@@ -64,8 +65,7 @@
                   "policyReference",
                   "name"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ],
@@ -87,7 +87,8 @@
               "version": ""
             },
             "patch": {
-              "mutatorRef": [
+              "patchStrategy": "replace",
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -101,8 +102,7 @@
                   "metadata",
                   "name"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ]

--- a/models/azure-data-protection/azureserviceoperator_customresourcedefinitions_v2.13.0.yaml/v1.0.0/relationships/hierarchical-parent-inventory-kmjea.json
+++ b/models/azure-data-protection/azureserviceoperator_customresourcedefinitions_v2.13.0.yaml/v1.0.0/relationships/hierarchical-parent-inventory-kmjea.json
@@ -91,7 +91,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatedRef": [
+              "mutatorRef": [
                 [
                   "configuration",
                   "spec",
@@ -156,7 +156,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"

--- a/models/azure-data-protection/azureserviceoperator_customresourcedefinitions_v2.13.0.yaml/v1.0.0/relationships/hierarchical-parent-inventory-tjjew.json
+++ b/models/azure-data-protection/azureserviceoperator_customresourcedefinitions_v2.13.0.yaml/v1.0.0/relationships/hierarchical-parent-inventory-tjjew.json
@@ -45,15 +45,15 @@
               "version": ""
             },
             "patch": {
-              "mutatedRef": [
+              "patchStrategy": "replace",
+              "mutatorRef": [
                 [
                   "configuration",
                   "spec",
                   "owner",
                   "name"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ],
@@ -75,12 +75,12 @@
               "version": ""
             },
             "patch": {
-              "mutatorRef": [
+              "patchStrategy": "replace",
+              "mutatedRef": [
                 [
                   "displayName"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ]

--- a/models/azure-data-protection/azureserviceoperator_customresourcedefinitions_v2.13.0.yaml/v1.0.0/relationships/hierarchical-parent-inventory-zvkwf.json
+++ b/models/azure-data-protection/azureserviceoperator_customresourcedefinitions_v2.13.0.yaml/v1.0.0/relationships/hierarchical-parent-inventory-zvkwf.json
@@ -45,15 +45,15 @@
               "version": ""
             },
             "patch": {
-              "mutatedRef": [
+              "patchStrategy": "replace",
+              "mutatorRef": [
                 [
                   "configuration",
                   "spec",
                   "owner",
                   "name"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ],
@@ -75,12 +75,12 @@
               "version": ""
             },
             "patch": {
-              "mutatorRef": [
+              "patchStrategy": "replace",
+              "mutatedRef": [
                 [
                   "displayName"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ]

--- a/models/azure-data-protection/azureserviceoperator_customresourcedefinitions_v2.14.0.yaml/v1.0.0/relationships/edge-non-binding-alias-dshtt.json
+++ b/models/azure-data-protection/azureserviceoperator_customresourcedefinitions_v2.14.0.yaml/v1.0.0/relationships/edge-non-binding-alias-dshtt.json
@@ -45,7 +45,8 @@
               "version": ""
             },
             "patch": {
-              "mutatedRef": [
+              "patchStrategy": "replace",
+              "mutatorRef": [
                 [
                   "configuration",
                   "spec",
@@ -64,8 +65,7 @@
                   "resourceReference",
                   "name"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ],
@@ -87,7 +87,8 @@
               "version": ""
             },
             "patch": {
-              "mutatorRef": [
+              "patchStrategy": "replace",
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -101,8 +102,7 @@
                   "metadata",
                   "name"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ]

--- a/models/azure-data-protection/azureserviceoperator_customresourcedefinitions_v2.14.0.yaml/v1.0.0/relationships/edge-non-binding-alias-rjerv.json
+++ b/models/azure-data-protection/azureserviceoperator_customresourcedefinitions_v2.14.0.yaml/v1.0.0/relationships/edge-non-binding-alias-rjerv.json
@@ -45,7 +45,8 @@
               "version": ""
             },
             "patch": {
-              "mutatedRef": [
+              "patchStrategy": "replace",
+              "mutatorRef": [
                 [
                   "configuration",
                   "spec",
@@ -64,8 +65,7 @@
                   "policyReference",
                   "name"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ],
@@ -87,7 +87,8 @@
               "version": ""
             },
             "patch": {
-              "mutatorRef": [
+              "patchStrategy": "replace",
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -101,8 +102,7 @@
                   "metadata",
                   "name"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ]

--- a/models/azure-data-protection/azureserviceoperator_customresourcedefinitions_v2.14.0.yaml/v1.0.0/relationships/hierarchical-parent-inventory-kmjea.json
+++ b/models/azure-data-protection/azureserviceoperator_customresourcedefinitions_v2.14.0.yaml/v1.0.0/relationships/hierarchical-parent-inventory-kmjea.json
@@ -91,7 +91,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatedRef": [
+              "mutatorRef": [
                 [
                   "configuration",
                   "spec",
@@ -156,7 +156,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"

--- a/models/azure-data-protection/azureserviceoperator_customresourcedefinitions_v2.14.0.yaml/v1.0.0/relationships/hierarchical-parent-inventory-tjjew.json
+++ b/models/azure-data-protection/azureserviceoperator_customresourcedefinitions_v2.14.0.yaml/v1.0.0/relationships/hierarchical-parent-inventory-tjjew.json
@@ -45,15 +45,15 @@
               "version": ""
             },
             "patch": {
-              "mutatedRef": [
+              "patchStrategy": "replace",
+              "mutatorRef": [
                 [
                   "configuration",
                   "spec",
                   "owner",
                   "name"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ],
@@ -75,12 +75,12 @@
               "version": ""
             },
             "patch": {
-              "mutatorRef": [
+              "patchStrategy": "replace",
+              "mutatedRef": [
                 [
                   "displayName"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ]

--- a/models/azure-data-protection/azureserviceoperator_customresourcedefinitions_v2.14.0.yaml/v1.0.0/relationships/hierarchical-parent-inventory-zvkwf.json
+++ b/models/azure-data-protection/azureserviceoperator_customresourcedefinitions_v2.14.0.yaml/v1.0.0/relationships/hierarchical-parent-inventory-zvkwf.json
@@ -45,15 +45,15 @@
               "version": ""
             },
             "patch": {
-              "mutatedRef": [
+              "patchStrategy": "replace",
+              "mutatorRef": [
                 [
                   "configuration",
                   "spec",
                   "owner",
                   "name"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ],
@@ -75,12 +75,12 @@
               "version": ""
             },
             "patch": {
-              "mutatorRef": [
+              "patchStrategy": "replace",
+              "mutatedRef": [
                 [
                   "displayName"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ]

--- a/models/azure-db-for-mariadb/azureserviceoperator_customresourcedefinitions_v2.13.0.yaml/v1.0.0/relationships/hierarchical-parent-inventory-kmjea.json
+++ b/models/azure-db-for-mariadb/azureserviceoperator_customresourcedefinitions_v2.13.0.yaml/v1.0.0/relationships/hierarchical-parent-inventory-kmjea.json
@@ -91,7 +91,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatedRef": [
+              "mutatorRef": [
                 [
                   "configuration",
                   "spec",
@@ -144,7 +144,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "displayName"
                 ]

--- a/models/azure-db-for-mariadb/azureserviceoperator_customresourcedefinitions_v2.13.0.yaml/v1.0.0/relationships/hierarchical-parent-inventory-rwyva.json
+++ b/models/azure-db-for-mariadb/azureserviceoperator_customresourcedefinitions_v2.13.0.yaml/v1.0.0/relationships/hierarchical-parent-inventory-rwyva.json
@@ -45,15 +45,15 @@
               "version": ""
             },
             "patch": {
-              "mutatedRef": [
+              "patchStrategy": "replace",
+              "mutatorRef": [
                 [
                   "configuration",
                   "spec",
                   "owner",
                   "name"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ],
@@ -75,12 +75,12 @@
               "version": ""
             },
             "patch": {
-              "mutatorRef": [
+              "patchStrategy": "replace",
+              "mutatedRef": [
                 [
                   "displayName"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ]

--- a/models/azure-db-for-mariadb/azureserviceoperator_customresourcedefinitions_v2.13.0.yaml/v1.0.0/relationships/hierarchical-parent-inventory-sctnh.json
+++ b/models/azure-db-for-mariadb/azureserviceoperator_customresourcedefinitions_v2.13.0.yaml/v1.0.0/relationships/hierarchical-parent-inventory-sctnh.json
@@ -45,15 +45,15 @@
               "version": ""
             },
             "patch": {
-              "mutatedRef": [
+              "patchStrategy": "replace",
+              "mutatorRef": [
                 [
                   "configuration",
                   "spec",
                   "owner",
                   "name"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ],
@@ -75,12 +75,12 @@
               "version": ""
             },
             "patch": {
-              "mutatorRef": [
+              "patchStrategy": "replace",
+              "mutatedRef": [
                 [
                   "displayName"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ]

--- a/models/azure-db-for-mariadb/azureserviceoperator_customresourcedefinitions_v2.14.0.yaml/v1.0.0/relationships/hierarchical-parent-inventory-kmjea.json
+++ b/models/azure-db-for-mariadb/azureserviceoperator_customresourcedefinitions_v2.14.0.yaml/v1.0.0/relationships/hierarchical-parent-inventory-kmjea.json
@@ -91,7 +91,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatedRef": [
+              "mutatorRef": [
                 [
                   "configuration",
                   "spec",
@@ -144,7 +144,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "displayName"
                 ]

--- a/models/azure-db-for-mariadb/azureserviceoperator_customresourcedefinitions_v2.14.0.yaml/v1.0.0/relationships/hierarchical-parent-inventory-rwyva.json
+++ b/models/azure-db-for-mariadb/azureserviceoperator_customresourcedefinitions_v2.14.0.yaml/v1.0.0/relationships/hierarchical-parent-inventory-rwyva.json
@@ -45,15 +45,15 @@
               "version": ""
             },
             "patch": {
-              "mutatedRef": [
+              "patchStrategy": "replace",
+              "mutatorRef": [
                 [
                   "configuration",
                   "spec",
                   "owner",
                   "name"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ],
@@ -75,12 +75,12 @@
               "version": ""
             },
             "patch": {
-              "mutatorRef": [
+              "patchStrategy": "replace",
+              "mutatedRef": [
                 [
                   "displayName"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ]

--- a/models/azure-db-for-mariadb/azureserviceoperator_customresourcedefinitions_v2.14.0.yaml/v1.0.0/relationships/hierarchical-parent-inventory-sctnh.json
+++ b/models/azure-db-for-mariadb/azureserviceoperator_customresourcedefinitions_v2.14.0.yaml/v1.0.0/relationships/hierarchical-parent-inventory-sctnh.json
@@ -45,15 +45,15 @@
               "version": ""
             },
             "patch": {
-              "mutatedRef": [
+              "patchStrategy": "replace",
+              "mutatorRef": [
                 [
                   "configuration",
                   "spec",
                   "owner",
                   "name"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ],
@@ -75,12 +75,12 @@
               "version": ""
             },
             "patch": {
-              "mutatorRef": [
+              "patchStrategy": "replace",
+              "mutatedRef": [
                 [
                   "displayName"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ]

--- a/models/azure-db-for-mysql/azureserviceoperator_customresourcedefinitions_v2.13.0.yaml/v1.0.0/relationships/hierarchical-parent-inventory-denaj.json
+++ b/models/azure-db-for-mysql/azureserviceoperator_customresourcedefinitions_v2.13.0.yaml/v1.0.0/relationships/hierarchical-parent-inventory-denaj.json
@@ -45,15 +45,15 @@
               "version": ""
             },
             "patch": {
-              "mutatedRef": [
+              "patchStrategy": "replace",
+              "mutatorRef": [
                 [
                   "configuration",
                   "spec",
                   "owner",
                   "name"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ],
@@ -75,12 +75,12 @@
               "version": ""
             },
             "patch": {
-              "mutatorRef": [
+              "patchStrategy": "replace",
+              "mutatedRef": [
                 [
                   "displayName"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ]

--- a/models/azure-db-for-mysql/azureserviceoperator_customresourcedefinitions_v2.13.0.yaml/v1.0.0/relationships/hierarchical-parent-inventory-kmjea.json
+++ b/models/azure-db-for-mysql/azureserviceoperator_customresourcedefinitions_v2.13.0.yaml/v1.0.0/relationships/hierarchical-parent-inventory-kmjea.json
@@ -91,7 +91,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatedRef": [
+              "mutatorRef": [
                 [
                   "configuration",
                   "spec",
@@ -144,7 +144,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "displayName"
                 ]

--- a/models/azure-db-for-mysql/azureserviceoperator_customresourcedefinitions_v2.13.0.yaml/v1.0.0/relationships/hierarchical-parent-inventory-negtd.json
+++ b/models/azure-db-for-mysql/azureserviceoperator_customresourcedefinitions_v2.13.0.yaml/v1.0.0/relationships/hierarchical-parent-inventory-negtd.json
@@ -45,15 +45,15 @@
               "version": ""
             },
             "patch": {
-              "mutatedRef": [
+              "patchStrategy": "replace",
+              "mutatorRef": [
                 [
                   "configuration",
                   "spec",
                   "owner",
                   "name"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ],
@@ -75,12 +75,12 @@
               "version": ""
             },
             "patch": {
-              "mutatorRef": [
+              "patchStrategy": "replace",
+              "mutatedRef": [
                 [
                   "displayName"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ]

--- a/models/azure-db-for-mysql/azureserviceoperator_customresourcedefinitions_v2.13.0.yaml/v1.0.0/relationships/hierarchical-parent-inventory-nryyb.json
+++ b/models/azure-db-for-mysql/azureserviceoperator_customresourcedefinitions_v2.13.0.yaml/v1.0.0/relationships/hierarchical-parent-inventory-nryyb.json
@@ -45,15 +45,15 @@
               "version": ""
             },
             "patch": {
-              "mutatedRef": [
+              "patchStrategy": "replace",
+              "mutatorRef": [
                 [
                   "configuration",
                   "spec",
                   "owner",
                   "name"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ],
@@ -75,12 +75,12 @@
               "version": ""
             },
             "patch": {
-              "mutatorRef": [
+              "patchStrategy": "replace",
+              "mutatedRef": [
                 [
                   "displayName"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ]

--- a/models/azure-db-for-mysql/azureserviceoperator_customresourcedefinitions_v2.13.0.yaml/v1.0.0/relationships/hierarchical-parent-inventory-nsubp.json
+++ b/models/azure-db-for-mysql/azureserviceoperator_customresourcedefinitions_v2.13.0.yaml/v1.0.0/relationships/hierarchical-parent-inventory-nsubp.json
@@ -45,15 +45,15 @@
               "version": ""
             },
             "patch": {
-              "mutatedRef": [
+              "patchStrategy": "replace",
+              "mutatorRef": [
                 [
                   "configuration",
                   "spec",
                   "owner",
                   "name"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ],
@@ -75,12 +75,12 @@
               "version": ""
             },
             "patch": {
-              "mutatorRef": [
+              "patchStrategy": "replace",
+              "mutatedRef": [
                 [
                   "displayName"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ]

--- a/models/azure-db-for-mysql/azureserviceoperator_customresourcedefinitions_v2.13.0.yaml/v1.0.0/relationships/hierarchical-parent-inventory-skvbc.json
+++ b/models/azure-db-for-mysql/azureserviceoperator_customresourcedefinitions_v2.13.0.yaml/v1.0.0/relationships/hierarchical-parent-inventory-skvbc.json
@@ -45,15 +45,15 @@
               "version": ""
             },
             "patch": {
-              "mutatedRef": [
+              "patchStrategy": "replace",
+              "mutatorRef": [
                 [
                   "configuration",
                   "spec",
                   "owner",
                   "name"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ],
@@ -75,12 +75,12 @@
               "version": ""
             },
             "patch": {
-              "mutatorRef": [
+              "patchStrategy": "replace",
+              "mutatedRef": [
                 [
                   "displayName"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ]

--- a/models/azure-db-for-mysql/azureserviceoperator_customresourcedefinitions_v2.14.0.yaml/v1.0.0/relationships/hierarchical-parent-inventory-denaj.json
+++ b/models/azure-db-for-mysql/azureserviceoperator_customresourcedefinitions_v2.14.0.yaml/v1.0.0/relationships/hierarchical-parent-inventory-denaj.json
@@ -45,15 +45,15 @@
               "version": ""
             },
             "patch": {
-              "mutatedRef": [
+              "patchStrategy": "replace",
+              "mutatorRef": [
                 [
                   "configuration",
                   "spec",
                   "owner",
                   "name"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ],
@@ -75,12 +75,12 @@
               "version": ""
             },
             "patch": {
-              "mutatorRef": [
+              "patchStrategy": "replace",
+              "mutatedRef": [
                 [
                   "displayName"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ]

--- a/models/azure-db-for-mysql/azureserviceoperator_customresourcedefinitions_v2.14.0.yaml/v1.0.0/relationships/hierarchical-parent-inventory-kmjea.json
+++ b/models/azure-db-for-mysql/azureserviceoperator_customresourcedefinitions_v2.14.0.yaml/v1.0.0/relationships/hierarchical-parent-inventory-kmjea.json
@@ -91,7 +91,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatedRef": [
+              "mutatorRef": [
                 [
                   "configuration",
                   "spec",
@@ -144,7 +144,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "displayName"
                 ]

--- a/models/azure-db-for-mysql/azureserviceoperator_customresourcedefinitions_v2.14.0.yaml/v1.0.0/relationships/hierarchical-parent-inventory-negtd.json
+++ b/models/azure-db-for-mysql/azureserviceoperator_customresourcedefinitions_v2.14.0.yaml/v1.0.0/relationships/hierarchical-parent-inventory-negtd.json
@@ -45,15 +45,15 @@
               "version": ""
             },
             "patch": {
-              "mutatedRef": [
+              "patchStrategy": "replace",
+              "mutatorRef": [
                 [
                   "configuration",
                   "spec",
                   "owner",
                   "name"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ],
@@ -75,12 +75,12 @@
               "version": ""
             },
             "patch": {
-              "mutatorRef": [
+              "patchStrategy": "replace",
+              "mutatedRef": [
                 [
                   "displayName"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ]

--- a/models/azure-db-for-mysql/azureserviceoperator_customresourcedefinitions_v2.14.0.yaml/v1.0.0/relationships/hierarchical-parent-inventory-nryyb.json
+++ b/models/azure-db-for-mysql/azureserviceoperator_customresourcedefinitions_v2.14.0.yaml/v1.0.0/relationships/hierarchical-parent-inventory-nryyb.json
@@ -45,15 +45,15 @@
               "version": ""
             },
             "patch": {
-              "mutatedRef": [
+              "patchStrategy": "replace",
+              "mutatorRef": [
                 [
                   "configuration",
                   "spec",
                   "owner",
                   "name"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ],
@@ -75,12 +75,12 @@
               "version": ""
             },
             "patch": {
-              "mutatorRef": [
+              "patchStrategy": "replace",
+              "mutatedRef": [
                 [
                   "displayName"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ]

--- a/models/azure-db-for-mysql/azureserviceoperator_customresourcedefinitions_v2.14.0.yaml/v1.0.0/relationships/hierarchical-parent-inventory-nsubp.json
+++ b/models/azure-db-for-mysql/azureserviceoperator_customresourcedefinitions_v2.14.0.yaml/v1.0.0/relationships/hierarchical-parent-inventory-nsubp.json
@@ -45,15 +45,15 @@
               "version": ""
             },
             "patch": {
-              "mutatedRef": [
+              "patchStrategy": "replace",
+              "mutatorRef": [
                 [
                   "configuration",
                   "spec",
                   "owner",
                   "name"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ],
@@ -75,12 +75,12 @@
               "version": ""
             },
             "patch": {
-              "mutatorRef": [
+              "patchStrategy": "replace",
+              "mutatedRef": [
                 [
                   "displayName"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ]

--- a/models/azure-db-for-mysql/azureserviceoperator_customresourcedefinitions_v2.14.0.yaml/v1.0.0/relationships/hierarchical-parent-inventory-skvbc.json
+++ b/models/azure-db-for-mysql/azureserviceoperator_customresourcedefinitions_v2.14.0.yaml/v1.0.0/relationships/hierarchical-parent-inventory-skvbc.json
@@ -45,15 +45,15 @@
               "version": ""
             },
             "patch": {
-              "mutatedRef": [
+              "patchStrategy": "replace",
+              "mutatorRef": [
                 [
                   "configuration",
                   "spec",
                   "owner",
                   "name"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ],
@@ -75,12 +75,12 @@
               "version": ""
             },
             "patch": {
-              "mutatorRef": [
+              "patchStrategy": "replace",
+              "mutatedRef": [
                 [
                   "displayName"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ]

--- a/models/azure-db-for-postgresql/azureserviceoperator_customresourcedefinitions_v2.13.0.yaml/v1.0.0/relationships/hierarchical-parent-inventory-epkhm.json
+++ b/models/azure-db-for-postgresql/azureserviceoperator_customresourcedefinitions_v2.13.0.yaml/v1.0.0/relationships/hierarchical-parent-inventory-epkhm.json
@@ -45,15 +45,15 @@
               "version": ""
             },
             "patch": {
-              "mutatedRef": [
+              "patchStrategy": "replace",
+              "mutatorRef": [
                 [
                   "configuration",
                   "spec",
                   "owner",
                   "name"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ],
@@ -75,12 +75,12 @@
               "version": ""
             },
             "patch": {
-              "mutatorRef": [
+              "patchStrategy": "replace",
+              "mutatedRef": [
                 [
                   "displayName"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ]

--- a/models/azure-db-for-postgresql/azureserviceoperator_customresourcedefinitions_v2.13.0.yaml/v1.0.0/relationships/hierarchical-parent-inventory-exotu.json
+++ b/models/azure-db-for-postgresql/azureserviceoperator_customresourcedefinitions_v2.13.0.yaml/v1.0.0/relationships/hierarchical-parent-inventory-exotu.json
@@ -45,15 +45,15 @@
               "version": ""
             },
             "patch": {
-              "mutatedRef": [
+              "patchStrategy": "replace",
+              "mutatorRef": [
                 [
                   "configuration",
                   "spec",
                   "owner",
                   "name"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ],
@@ -75,12 +75,12 @@
               "version": ""
             },
             "patch": {
-              "mutatorRef": [
+              "patchStrategy": "replace",
+              "mutatedRef": [
                 [
                   "displayName"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ]

--- a/models/azure-db-for-postgresql/azureserviceoperator_customresourcedefinitions_v2.13.0.yaml/v1.0.0/relationships/hierarchical-parent-inventory-ienqc.json
+++ b/models/azure-db-for-postgresql/azureserviceoperator_customresourcedefinitions_v2.13.0.yaml/v1.0.0/relationships/hierarchical-parent-inventory-ienqc.json
@@ -45,15 +45,15 @@
               "version": ""
             },
             "patch": {
-              "mutatedRef": [
+              "patchStrategy": "replace",
+              "mutatorRef": [
                 [
                   "configuration",
                   "spec",
                   "owner",
                   "name"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ],
@@ -75,12 +75,12 @@
               "version": ""
             },
             "patch": {
-              "mutatorRef": [
+              "patchStrategy": "replace",
+              "mutatedRef": [
                 [
                   "displayName"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ]

--- a/models/azure-db-for-postgresql/azureserviceoperator_customresourcedefinitions_v2.13.0.yaml/v1.0.0/relationships/hierarchical-parent-inventory-isfcx.json
+++ b/models/azure-db-for-postgresql/azureserviceoperator_customresourcedefinitions_v2.13.0.yaml/v1.0.0/relationships/hierarchical-parent-inventory-isfcx.json
@@ -45,15 +45,15 @@
               "version": ""
             },
             "patch": {
-              "mutatedRef": [
+              "patchStrategy": "replace",
+              "mutatorRef": [
                 [
                   "configuration",
                   "spec",
                   "owner",
                   "name"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ],
@@ -75,12 +75,12 @@
               "version": ""
             },
             "patch": {
-              "mutatorRef": [
+              "patchStrategy": "replace",
+              "mutatedRef": [
                 [
                   "displayName"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ]

--- a/models/azure-db-for-postgresql/azureserviceoperator_customresourcedefinitions_v2.13.0.yaml/v1.0.0/relationships/hierarchical-parent-inventory-ivfiy.json
+++ b/models/azure-db-for-postgresql/azureserviceoperator_customresourcedefinitions_v2.13.0.yaml/v1.0.0/relationships/hierarchical-parent-inventory-ivfiy.json
@@ -45,15 +45,15 @@
               "version": ""
             },
             "patch": {
-              "mutatedRef": [
+              "patchStrategy": "replace",
+              "mutatorRef": [
                 [
                   "configuration",
                   "spec",
                   "owner",
                   "name"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ],
@@ -75,12 +75,12 @@
               "version": ""
             },
             "patch": {
-              "mutatorRef": [
+              "patchStrategy": "replace",
+              "mutatedRef": [
                 [
                   "displayName"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ]

--- a/models/azure-db-for-postgresql/azureserviceoperator_customresourcedefinitions_v2.13.0.yaml/v1.0.0/relationships/hierarchical-parent-inventory-kccqt.json
+++ b/models/azure-db-for-postgresql/azureserviceoperator_customresourcedefinitions_v2.13.0.yaml/v1.0.0/relationships/hierarchical-parent-inventory-kccqt.json
@@ -45,15 +45,15 @@
               "version": ""
             },
             "patch": {
-              "mutatedRef": [
+              "patchStrategy": "replace",
+              "mutatorRef": [
                 [
                   "configuration",
                   "spec",
                   "owner",
                   "name"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ],
@@ -75,12 +75,12 @@
               "version": ""
             },
             "patch": {
-              "mutatorRef": [
+              "patchStrategy": "replace",
+              "mutatedRef": [
                 [
                   "displayName"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ]

--- a/models/azure-db-for-postgresql/azureserviceoperator_customresourcedefinitions_v2.13.0.yaml/v1.0.0/relationships/hierarchical-parent-inventory-kmjea.json
+++ b/models/azure-db-for-postgresql/azureserviceoperator_customresourcedefinitions_v2.13.0.yaml/v1.0.0/relationships/hierarchical-parent-inventory-kmjea.json
@@ -91,7 +91,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatedRef": [
+              "mutatorRef": [
                 [
                   "configuration",
                   "spec",
@@ -144,7 +144,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "displayName"
                 ]

--- a/models/azure-db-for-postgresql/azureserviceoperator_customresourcedefinitions_v2.14.0.yaml/v1.0.0/relationships/hierarchical-parent-inventory-epkhm.json
+++ b/models/azure-db-for-postgresql/azureserviceoperator_customresourcedefinitions_v2.14.0.yaml/v1.0.0/relationships/hierarchical-parent-inventory-epkhm.json
@@ -45,15 +45,15 @@
               "version": ""
             },
             "patch": {
-              "mutatedRef": [
+              "patchStrategy": "replace",
+              "mutatorRef": [
                 [
                   "configuration",
                   "spec",
                   "owner",
                   "name"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ],
@@ -75,12 +75,12 @@
               "version": ""
             },
             "patch": {
-              "mutatorRef": [
+              "patchStrategy": "replace",
+              "mutatedRef": [
                 [
                   "displayName"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ]

--- a/models/azure-db-for-postgresql/azureserviceoperator_customresourcedefinitions_v2.14.0.yaml/v1.0.0/relationships/hierarchical-parent-inventory-exotu.json
+++ b/models/azure-db-for-postgresql/azureserviceoperator_customresourcedefinitions_v2.14.0.yaml/v1.0.0/relationships/hierarchical-parent-inventory-exotu.json
@@ -45,15 +45,15 @@
               "version": ""
             },
             "patch": {
-              "mutatedRef": [
+              "patchStrategy": "replace",
+              "mutatorRef": [
                 [
                   "configuration",
                   "spec",
                   "owner",
                   "name"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ],
@@ -75,12 +75,12 @@
               "version": ""
             },
             "patch": {
-              "mutatorRef": [
+              "patchStrategy": "replace",
+              "mutatedRef": [
                 [
                   "displayName"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ]

--- a/models/azure-db-for-postgresql/azureserviceoperator_customresourcedefinitions_v2.14.0.yaml/v1.0.0/relationships/hierarchical-parent-inventory-ienqc.json
+++ b/models/azure-db-for-postgresql/azureserviceoperator_customresourcedefinitions_v2.14.0.yaml/v1.0.0/relationships/hierarchical-parent-inventory-ienqc.json
@@ -45,15 +45,15 @@
               "version": ""
             },
             "patch": {
-              "mutatedRef": [
+              "patchStrategy": "replace",
+              "mutatorRef": [
                 [
                   "configuration",
                   "spec",
                   "owner",
                   "name"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ],
@@ -75,12 +75,12 @@
               "version": ""
             },
             "patch": {
-              "mutatorRef": [
+              "patchStrategy": "replace",
+              "mutatedRef": [
                 [
                   "displayName"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ]

--- a/models/azure-db-for-postgresql/azureserviceoperator_customresourcedefinitions_v2.14.0.yaml/v1.0.0/relationships/hierarchical-parent-inventory-isfcx.json
+++ b/models/azure-db-for-postgresql/azureserviceoperator_customresourcedefinitions_v2.14.0.yaml/v1.0.0/relationships/hierarchical-parent-inventory-isfcx.json
@@ -45,15 +45,15 @@
               "version": ""
             },
             "patch": {
-              "mutatedRef": [
+              "patchStrategy": "replace",
+              "mutatorRef": [
                 [
                   "configuration",
                   "spec",
                   "owner",
                   "name"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ],
@@ -75,12 +75,12 @@
               "version": ""
             },
             "patch": {
-              "mutatorRef": [
+              "patchStrategy": "replace",
+              "mutatedRef": [
                 [
                   "displayName"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ]

--- a/models/azure-db-for-postgresql/azureserviceoperator_customresourcedefinitions_v2.14.0.yaml/v1.0.0/relationships/hierarchical-parent-inventory-ivfiy.json
+++ b/models/azure-db-for-postgresql/azureserviceoperator_customresourcedefinitions_v2.14.0.yaml/v1.0.0/relationships/hierarchical-parent-inventory-ivfiy.json
@@ -45,15 +45,15 @@
               "version": ""
             },
             "patch": {
-              "mutatedRef": [
+              "patchStrategy": "replace",
+              "mutatorRef": [
                 [
                   "configuration",
                   "spec",
                   "owner",
                   "name"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ],
@@ -75,12 +75,12 @@
               "version": ""
             },
             "patch": {
-              "mutatorRef": [
+              "patchStrategy": "replace",
+              "mutatedRef": [
                 [
                   "displayName"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ]

--- a/models/azure-db-for-postgresql/azureserviceoperator_customresourcedefinitions_v2.14.0.yaml/v1.0.0/relationships/hierarchical-parent-inventory-kccqt.json
+++ b/models/azure-db-for-postgresql/azureserviceoperator_customresourcedefinitions_v2.14.0.yaml/v1.0.0/relationships/hierarchical-parent-inventory-kccqt.json
@@ -45,15 +45,15 @@
               "version": ""
             },
             "patch": {
-              "mutatedRef": [
+              "patchStrategy": "replace",
+              "mutatorRef": [
                 [
                   "configuration",
                   "spec",
                   "owner",
                   "name"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ],
@@ -75,12 +75,12 @@
               "version": ""
             },
             "patch": {
-              "mutatorRef": [
+              "patchStrategy": "replace",
+              "mutatedRef": [
                 [
                   "displayName"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ]

--- a/models/azure-db-for-postgresql/azureserviceoperator_customresourcedefinitions_v2.14.0.yaml/v1.0.0/relationships/hierarchical-parent-inventory-kmjea.json
+++ b/models/azure-db-for-postgresql/azureserviceoperator_customresourcedefinitions_v2.14.0.yaml/v1.0.0/relationships/hierarchical-parent-inventory-kmjea.json
@@ -91,7 +91,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatedRef": [
+              "mutatorRef": [
                 [
                   "configuration",
                   "spec",
@@ -144,7 +144,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "displayName"
                 ]

--- a/models/azure-documentdb/azureserviceoperator_customresourcedefinitions_v2.13.0.yaml/v1.0.0/relationships/hierarchical-parent-inventory-aucwu.json
+++ b/models/azure-documentdb/azureserviceoperator_customresourcedefinitions_v2.13.0.yaml/v1.0.0/relationships/hierarchical-parent-inventory-aucwu.json
@@ -45,15 +45,15 @@
               "version": ""
             },
             "patch": {
-              "mutatedRef": [
+              "patchStrategy": "replace",
+              "mutatorRef": [
                 [
                   "configuration",
                   "spec",
                   "owner",
                   "name"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ],
@@ -75,12 +75,12 @@
               "version": ""
             },
             "patch": {
-              "mutatorRef": [
+              "patchStrategy": "replace",
+              "mutatedRef": [
                 [
                   "displayName"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ]

--- a/models/azure-documentdb/azureserviceoperator_customresourcedefinitions_v2.13.0.yaml/v1.0.0/relationships/hierarchical-parent-inventory-ddomz.json
+++ b/models/azure-documentdb/azureserviceoperator_customresourcedefinitions_v2.13.0.yaml/v1.0.0/relationships/hierarchical-parent-inventory-ddomz.json
@@ -45,15 +45,15 @@
               "version": ""
             },
             "patch": {
-              "mutatedRef": [
+              "patchStrategy": "replace",
+              "mutatorRef": [
                 [
                   "configuration",
                   "spec",
                   "owner",
                   "name"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ],
@@ -75,12 +75,12 @@
               "version": ""
             },
             "patch": {
-              "mutatorRef": [
+              "patchStrategy": "replace",
+              "mutatedRef": [
                 [
                   "displayName"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ]

--- a/models/azure-documentdb/azureserviceoperator_customresourcedefinitions_v2.13.0.yaml/v1.0.0/relationships/hierarchical-parent-inventory-dhdby.json
+++ b/models/azure-documentdb/azureserviceoperator_customresourcedefinitions_v2.13.0.yaml/v1.0.0/relationships/hierarchical-parent-inventory-dhdby.json
@@ -45,15 +45,15 @@
               "version": ""
             },
             "patch": {
-              "mutatedRef": [
+              "patchStrategy": "replace",
+              "mutatorRef": [
                 [
                   "configuration",
                   "spec",
                   "owner",
                   "name"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ],
@@ -75,12 +75,12 @@
               "version": ""
             },
             "patch": {
-              "mutatorRef": [
+              "patchStrategy": "replace",
+              "mutatedRef": [
                 [
                   "displayName"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ]

--- a/models/azure-documentdb/azureserviceoperator_customresourcedefinitions_v2.13.0.yaml/v1.0.0/relationships/hierarchical-parent-inventory-eqjvl.json
+++ b/models/azure-documentdb/azureserviceoperator_customresourcedefinitions_v2.13.0.yaml/v1.0.0/relationships/hierarchical-parent-inventory-eqjvl.json
@@ -45,15 +45,15 @@
               "version": ""
             },
             "patch": {
-              "mutatedRef": [
+              "patchStrategy": "replace",
+              "mutatorRef": [
                 [
                   "configuration",
                   "spec",
                   "owner",
                   "name"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ],
@@ -75,12 +75,12 @@
               "version": ""
             },
             "patch": {
-              "mutatorRef": [
+              "patchStrategy": "replace",
+              "mutatedRef": [
                 [
                   "displayName"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ]

--- a/models/azure-documentdb/azureserviceoperator_customresourcedefinitions_v2.13.0.yaml/v1.0.0/relationships/hierarchical-parent-inventory-gmgjt.json
+++ b/models/azure-documentdb/azureserviceoperator_customresourcedefinitions_v2.13.0.yaml/v1.0.0/relationships/hierarchical-parent-inventory-gmgjt.json
@@ -45,15 +45,15 @@
               "version": ""
             },
             "patch": {
-              "mutatedRef": [
+              "patchStrategy": "replace",
+              "mutatorRef": [
                 [
                   "configuration",
                   "spec",
                   "owner",
                   "name"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ],
@@ -75,12 +75,12 @@
               "version": ""
             },
             "patch": {
-              "mutatorRef": [
+              "patchStrategy": "replace",
+              "mutatedRef": [
                 [
                   "displayName"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ]

--- a/models/azure-documentdb/azureserviceoperator_customresourcedefinitions_v2.13.0.yaml/v1.0.0/relationships/hierarchical-parent-inventory-hgkhu.json
+++ b/models/azure-documentdb/azureserviceoperator_customresourcedefinitions_v2.13.0.yaml/v1.0.0/relationships/hierarchical-parent-inventory-hgkhu.json
@@ -45,15 +45,15 @@
               "version": ""
             },
             "patch": {
-              "mutatedRef": [
+              "patchStrategy": "replace",
+              "mutatorRef": [
                 [
                   "configuration",
                   "spec",
                   "owner",
                   "name"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ],
@@ -75,12 +75,12 @@
               "version": ""
             },
             "patch": {
-              "mutatorRef": [
+              "patchStrategy": "replace",
+              "mutatedRef": [
                 [
                   "displayName"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ]

--- a/models/azure-documentdb/azureserviceoperator_customresourcedefinitions_v2.13.0.yaml/v1.0.0/relationships/hierarchical-parent-inventory-kmjea.json
+++ b/models/azure-documentdb/azureserviceoperator_customresourcedefinitions_v2.13.0.yaml/v1.0.0/relationships/hierarchical-parent-inventory-kmjea.json
@@ -91,7 +91,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatedRef": [
+              "mutatorRef": [
                 [
                   "configuration",
                   "spec",
@@ -144,7 +144,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "displayName"
                 ]

--- a/models/azure-documentdb/azureserviceoperator_customresourcedefinitions_v2.13.0.yaml/v1.0.0/relationships/hierarchical-parent-inventory-lpwtv.json
+++ b/models/azure-documentdb/azureserviceoperator_customresourcedefinitions_v2.13.0.yaml/v1.0.0/relationships/hierarchical-parent-inventory-lpwtv.json
@@ -45,15 +45,15 @@
               "version": ""
             },
             "patch": {
-              "mutatedRef": [
+              "patchStrategy": "replace",
+              "mutatorRef": [
                 [
                   "configuration",
                   "spec",
                   "owner",
                   "name"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ],
@@ -75,12 +75,12 @@
               "version": ""
             },
             "patch": {
-              "mutatorRef": [
+              "patchStrategy": "replace",
+              "mutatedRef": [
                 [
                   "displayName"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ]

--- a/models/azure-documentdb/azureserviceoperator_customresourcedefinitions_v2.13.0.yaml/v1.0.0/relationships/hierarchical-parent-inventory-lpyab.json
+++ b/models/azure-documentdb/azureserviceoperator_customresourcedefinitions_v2.13.0.yaml/v1.0.0/relationships/hierarchical-parent-inventory-lpyab.json
@@ -45,15 +45,15 @@
               "version": ""
             },
             "patch": {
-              "mutatedRef": [
+              "patchStrategy": "replace",
+              "mutatorRef": [
                 [
                   "configuration",
                   "spec",
                   "owner",
                   "name"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ],
@@ -75,12 +75,12 @@
               "version": ""
             },
             "patch": {
-              "mutatorRef": [
+              "patchStrategy": "replace",
+              "mutatedRef": [
                 [
                   "displayName"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ]

--- a/models/azure-documentdb/azureserviceoperator_customresourcedefinitions_v2.13.0.yaml/v1.0.0/relationships/hierarchical-parent-inventory-nimkq.json
+++ b/models/azure-documentdb/azureserviceoperator_customresourcedefinitions_v2.13.0.yaml/v1.0.0/relationships/hierarchical-parent-inventory-nimkq.json
@@ -45,15 +45,15 @@
               "version": ""
             },
             "patch": {
-              "mutatedRef": [
+              "patchStrategy": "replace",
+              "mutatorRef": [
                 [
                   "configuration",
                   "spec",
                   "owner",
                   "name"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ],
@@ -75,12 +75,12 @@
               "version": ""
             },
             "patch": {
-              "mutatorRef": [
+              "patchStrategy": "replace",
+              "mutatedRef": [
                 [
                   "displayName"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ]

--- a/models/azure-documentdb/azureserviceoperator_customresourcedefinitions_v2.13.0.yaml/v1.0.0/relationships/hierarchical-parent-inventory-nowzt.json
+++ b/models/azure-documentdb/azureserviceoperator_customresourcedefinitions_v2.13.0.yaml/v1.0.0/relationships/hierarchical-parent-inventory-nowzt.json
@@ -45,15 +45,15 @@
               "version": ""
             },
             "patch": {
-              "mutatedRef": [
+              "patchStrategy": "replace",
+              "mutatorRef": [
                 [
                   "configuration",
                   "spec",
                   "owner",
                   "name"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ],
@@ -75,12 +75,12 @@
               "version": ""
             },
             "patch": {
-              "mutatorRef": [
+              "patchStrategy": "replace",
+              "mutatedRef": [
                 [
                   "displayName"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ]

--- a/models/azure-documentdb/azureserviceoperator_customresourcedefinitions_v2.13.0.yaml/v1.0.0/relationships/hierarchical-parent-inventory-rnbir.json
+++ b/models/azure-documentdb/azureserviceoperator_customresourcedefinitions_v2.13.0.yaml/v1.0.0/relationships/hierarchical-parent-inventory-rnbir.json
@@ -45,15 +45,15 @@
               "version": ""
             },
             "patch": {
-              "mutatedRef": [
+              "patchStrategy": "replace",
+              "mutatorRef": [
                 [
                   "configuration",
                   "spec",
                   "owner",
                   "name"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ],
@@ -75,12 +75,12 @@
               "version": ""
             },
             "patch": {
-              "mutatorRef": [
+              "patchStrategy": "replace",
+              "mutatedRef": [
                 [
                   "displayName"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ]

--- a/models/azure-documentdb/azureserviceoperator_customresourcedefinitions_v2.13.0.yaml/v1.0.0/relationships/hierarchical-parent-inventory-sadxz.json
+++ b/models/azure-documentdb/azureserviceoperator_customresourcedefinitions_v2.13.0.yaml/v1.0.0/relationships/hierarchical-parent-inventory-sadxz.json
@@ -45,15 +45,15 @@
               "version": ""
             },
             "patch": {
-              "mutatedRef": [
+              "patchStrategy": "replace",
+              "mutatorRef": [
                 [
                   "configuration",
                   "spec",
                   "owner",
                   "name"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ],
@@ -75,12 +75,12 @@
               "version": ""
             },
             "patch": {
-              "mutatorRef": [
+              "patchStrategy": "replace",
+              "mutatedRef": [
                 [
                   "displayName"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ]

--- a/models/azure-documentdb/azureserviceoperator_customresourcedefinitions_v2.13.0.yaml/v1.0.0/relationships/hierarchical-parent-inventory-widor.json
+++ b/models/azure-documentdb/azureserviceoperator_customresourcedefinitions_v2.13.0.yaml/v1.0.0/relationships/hierarchical-parent-inventory-widor.json
@@ -45,15 +45,15 @@
               "version": ""
             },
             "patch": {
-              "mutatedRef": [
+              "patchStrategy": "replace",
+              "mutatorRef": [
                 [
                   "configuration",
                   "spec",
                   "owner",
                   "name"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ],
@@ -75,12 +75,12 @@
               "version": ""
             },
             "patch": {
-              "mutatorRef": [
+              "patchStrategy": "replace",
+              "mutatedRef": [
                 [
                   "displayName"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ]

--- a/models/azure-documentdb/azureserviceoperator_customresourcedefinitions_v2.14.0.yaml/v1.0.0/relationships/hierarchical-parent-inventory-aucwu.json
+++ b/models/azure-documentdb/azureserviceoperator_customresourcedefinitions_v2.14.0.yaml/v1.0.0/relationships/hierarchical-parent-inventory-aucwu.json
@@ -45,15 +45,15 @@
               "version": ""
             },
             "patch": {
-              "mutatedRef": [
+              "patchStrategy": "replace",
+              "mutatorRef": [
                 [
                   "configuration",
                   "spec",
                   "owner",
                   "name"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ],
@@ -75,12 +75,12 @@
               "version": ""
             },
             "patch": {
-              "mutatorRef": [
+              "patchStrategy": "replace",
+              "mutatedRef": [
                 [
                   "displayName"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ]

--- a/models/azure-documentdb/azureserviceoperator_customresourcedefinitions_v2.14.0.yaml/v1.0.0/relationships/hierarchical-parent-inventory-ddomz.json
+++ b/models/azure-documentdb/azureserviceoperator_customresourcedefinitions_v2.14.0.yaml/v1.0.0/relationships/hierarchical-parent-inventory-ddomz.json
@@ -45,15 +45,15 @@
               "version": ""
             },
             "patch": {
-              "mutatedRef": [
+              "patchStrategy": "replace",
+              "mutatorRef": [
                 [
                   "configuration",
                   "spec",
                   "owner",
                   "name"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ],
@@ -75,12 +75,12 @@
               "version": ""
             },
             "patch": {
-              "mutatorRef": [
+              "patchStrategy": "replace",
+              "mutatedRef": [
                 [
                   "displayName"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ]

--- a/models/azure-documentdb/azureserviceoperator_customresourcedefinitions_v2.14.0.yaml/v1.0.0/relationships/hierarchical-parent-inventory-dhdby.json
+++ b/models/azure-documentdb/azureserviceoperator_customresourcedefinitions_v2.14.0.yaml/v1.0.0/relationships/hierarchical-parent-inventory-dhdby.json
@@ -45,15 +45,15 @@
               "version": ""
             },
             "patch": {
-              "mutatedRef": [
+              "patchStrategy": "replace",
+              "mutatorRef": [
                 [
                   "configuration",
                   "spec",
                   "owner",
                   "name"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ],
@@ -75,12 +75,12 @@
               "version": ""
             },
             "patch": {
-              "mutatorRef": [
+              "patchStrategy": "replace",
+              "mutatedRef": [
                 [
                   "displayName"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ]

--- a/models/azure-documentdb/azureserviceoperator_customresourcedefinitions_v2.14.0.yaml/v1.0.0/relationships/hierarchical-parent-inventory-eqjvl.json
+++ b/models/azure-documentdb/azureserviceoperator_customresourcedefinitions_v2.14.0.yaml/v1.0.0/relationships/hierarchical-parent-inventory-eqjvl.json
@@ -45,15 +45,15 @@
               "version": ""
             },
             "patch": {
-              "mutatedRef": [
+              "patchStrategy": "replace",
+              "mutatorRef": [
                 [
                   "configuration",
                   "spec",
                   "owner",
                   "name"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ],
@@ -75,12 +75,12 @@
               "version": ""
             },
             "patch": {
-              "mutatorRef": [
+              "patchStrategy": "replace",
+              "mutatedRef": [
                 [
                   "displayName"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ]

--- a/models/azure-documentdb/azureserviceoperator_customresourcedefinitions_v2.14.0.yaml/v1.0.0/relationships/hierarchical-parent-inventory-gmgjt.json
+++ b/models/azure-documentdb/azureserviceoperator_customresourcedefinitions_v2.14.0.yaml/v1.0.0/relationships/hierarchical-parent-inventory-gmgjt.json
@@ -45,15 +45,15 @@
               "version": ""
             },
             "patch": {
-              "mutatedRef": [
+              "patchStrategy": "replace",
+              "mutatorRef": [
                 [
                   "configuration",
                   "spec",
                   "owner",
                   "name"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ],
@@ -75,12 +75,12 @@
               "version": ""
             },
             "patch": {
-              "mutatorRef": [
+              "patchStrategy": "replace",
+              "mutatedRef": [
                 [
                   "displayName"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ]

--- a/models/azure-documentdb/azureserviceoperator_customresourcedefinitions_v2.14.0.yaml/v1.0.0/relationships/hierarchical-parent-inventory-hgkhu.json
+++ b/models/azure-documentdb/azureserviceoperator_customresourcedefinitions_v2.14.0.yaml/v1.0.0/relationships/hierarchical-parent-inventory-hgkhu.json
@@ -45,15 +45,15 @@
               "version": ""
             },
             "patch": {
-              "mutatedRef": [
+              "patchStrategy": "replace",
+              "mutatorRef": [
                 [
                   "configuration",
                   "spec",
                   "owner",
                   "name"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ],
@@ -75,12 +75,12 @@
               "version": ""
             },
             "patch": {
-              "mutatorRef": [
+              "patchStrategy": "replace",
+              "mutatedRef": [
                 [
                   "displayName"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ]

--- a/models/azure-documentdb/azureserviceoperator_customresourcedefinitions_v2.14.0.yaml/v1.0.0/relationships/hierarchical-parent-inventory-kmjea.json
+++ b/models/azure-documentdb/azureserviceoperator_customresourcedefinitions_v2.14.0.yaml/v1.0.0/relationships/hierarchical-parent-inventory-kmjea.json
@@ -91,7 +91,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatedRef": [
+              "mutatorRef": [
                 [
                   "configuration",
                   "spec",
@@ -144,7 +144,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "displayName"
                 ]

--- a/models/azure-documentdb/azureserviceoperator_customresourcedefinitions_v2.14.0.yaml/v1.0.0/relationships/hierarchical-parent-inventory-lpwtv.json
+++ b/models/azure-documentdb/azureserviceoperator_customresourcedefinitions_v2.14.0.yaml/v1.0.0/relationships/hierarchical-parent-inventory-lpwtv.json
@@ -45,15 +45,15 @@
               "version": ""
             },
             "patch": {
-              "mutatedRef": [
+              "patchStrategy": "replace",
+              "mutatorRef": [
                 [
                   "configuration",
                   "spec",
                   "owner",
                   "name"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ],
@@ -75,12 +75,12 @@
               "version": ""
             },
             "patch": {
-              "mutatorRef": [
+              "patchStrategy": "replace",
+              "mutatedRef": [
                 [
                   "displayName"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ]

--- a/models/azure-documentdb/azureserviceoperator_customresourcedefinitions_v2.14.0.yaml/v1.0.0/relationships/hierarchical-parent-inventory-lpyab.json
+++ b/models/azure-documentdb/azureserviceoperator_customresourcedefinitions_v2.14.0.yaml/v1.0.0/relationships/hierarchical-parent-inventory-lpyab.json
@@ -45,15 +45,15 @@
               "version": ""
             },
             "patch": {
-              "mutatedRef": [
+              "patchStrategy": "replace",
+              "mutatorRef": [
                 [
                   "configuration",
                   "spec",
                   "owner",
                   "name"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ],
@@ -75,12 +75,12 @@
               "version": ""
             },
             "patch": {
-              "mutatorRef": [
+              "patchStrategy": "replace",
+              "mutatedRef": [
                 [
                   "displayName"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ]

--- a/models/azure-documentdb/azureserviceoperator_customresourcedefinitions_v2.14.0.yaml/v1.0.0/relationships/hierarchical-parent-inventory-nimkq.json
+++ b/models/azure-documentdb/azureserviceoperator_customresourcedefinitions_v2.14.0.yaml/v1.0.0/relationships/hierarchical-parent-inventory-nimkq.json
@@ -45,15 +45,15 @@
               "version": ""
             },
             "patch": {
-              "mutatedRef": [
+              "patchStrategy": "replace",
+              "mutatorRef": [
                 [
                   "configuration",
                   "spec",
                   "owner",
                   "name"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ],
@@ -75,12 +75,12 @@
               "version": ""
             },
             "patch": {
-              "mutatorRef": [
+              "patchStrategy": "replace",
+              "mutatedRef": [
                 [
                   "displayName"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ]

--- a/models/azure-documentdb/azureserviceoperator_customresourcedefinitions_v2.14.0.yaml/v1.0.0/relationships/hierarchical-parent-inventory-nowzt.json
+++ b/models/azure-documentdb/azureserviceoperator_customresourcedefinitions_v2.14.0.yaml/v1.0.0/relationships/hierarchical-parent-inventory-nowzt.json
@@ -45,15 +45,15 @@
               "version": ""
             },
             "patch": {
-              "mutatedRef": [
+              "patchStrategy": "replace",
+              "mutatorRef": [
                 [
                   "configuration",
                   "spec",
                   "owner",
                   "name"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ],
@@ -75,12 +75,12 @@
               "version": ""
             },
             "patch": {
-              "mutatorRef": [
+              "patchStrategy": "replace",
+              "mutatedRef": [
                 [
                   "displayName"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ]

--- a/models/azure-documentdb/azureserviceoperator_customresourcedefinitions_v2.14.0.yaml/v1.0.0/relationships/hierarchical-parent-inventory-rnbir.json
+++ b/models/azure-documentdb/azureserviceoperator_customresourcedefinitions_v2.14.0.yaml/v1.0.0/relationships/hierarchical-parent-inventory-rnbir.json
@@ -45,15 +45,15 @@
               "version": ""
             },
             "patch": {
-              "mutatedRef": [
+              "patchStrategy": "replace",
+              "mutatorRef": [
                 [
                   "configuration",
                   "spec",
                   "owner",
                   "name"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ],
@@ -75,12 +75,12 @@
               "version": ""
             },
             "patch": {
-              "mutatorRef": [
+              "patchStrategy": "replace",
+              "mutatedRef": [
                 [
                   "displayName"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ]

--- a/models/azure-documentdb/azureserviceoperator_customresourcedefinitions_v2.14.0.yaml/v1.0.0/relationships/hierarchical-parent-inventory-sadxz.json
+++ b/models/azure-documentdb/azureserviceoperator_customresourcedefinitions_v2.14.0.yaml/v1.0.0/relationships/hierarchical-parent-inventory-sadxz.json
@@ -45,15 +45,15 @@
               "version": ""
             },
             "patch": {
-              "mutatedRef": [
+              "patchStrategy": "replace",
+              "mutatorRef": [
                 [
                   "configuration",
                   "spec",
                   "owner",
                   "name"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ],
@@ -75,12 +75,12 @@
               "version": ""
             },
             "patch": {
-              "mutatorRef": [
+              "patchStrategy": "replace",
+              "mutatedRef": [
                 [
                   "displayName"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ]

--- a/models/azure-documentdb/azureserviceoperator_customresourcedefinitions_v2.14.0.yaml/v1.0.0/relationships/hierarchical-parent-inventory-widor.json
+++ b/models/azure-documentdb/azureserviceoperator_customresourcedefinitions_v2.14.0.yaml/v1.0.0/relationships/hierarchical-parent-inventory-widor.json
@@ -45,15 +45,15 @@
               "version": ""
             },
             "patch": {
-              "mutatedRef": [
+              "patchStrategy": "replace",
+              "mutatorRef": [
                 [
                   "configuration",
                   "spec",
                   "owner",
                   "name"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ],
@@ -75,12 +75,12 @@
               "version": ""
             },
             "patch": {
-              "mutatorRef": [
+              "patchStrategy": "replace",
+              "mutatedRef": [
                 [
                   "displayName"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ]

--- a/models/azure-event-grid/azureserviceoperator_customresourcedefinitions_v2.13.0.yaml/v1.0.0/relationships/edge-non-binding-alias-byxsc.json
+++ b/models/azure-event-grid/azureserviceoperator_customresourcedefinitions_v2.13.0.yaml/v1.0.0/relationships/edge-non-binding-alias-byxsc.json
@@ -45,7 +45,8 @@
               "version": ""
             },
             "patch": {
-              "mutatedRef": [
+              "patchStrategy": "replace",
+              "mutatorRef": [
                 [
                   "configuration",
                   "spec",
@@ -64,8 +65,7 @@
                   "resourceReference",
                   "name"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ],
@@ -87,7 +87,8 @@
               "version": ""
             },
             "patch": {
-              "mutatorRef": [
+              "patchStrategy": "replace",
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -101,8 +102,7 @@
                   "metadata",
                   "name"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ]

--- a/models/azure-event-grid/azureserviceoperator_customresourcedefinitions_v2.13.0.yaml/v1.0.0/relationships/hierarchical-parent-inventory-cljum.json
+++ b/models/azure-event-grid/azureserviceoperator_customresourcedefinitions_v2.13.0.yaml/v1.0.0/relationships/hierarchical-parent-inventory-cljum.json
@@ -45,15 +45,15 @@
               "version": ""
             },
             "patch": {
-              "mutatedRef": [
+              "patchStrategy": "replace",
+              "mutatorRef": [
                 [
                   "configuration",
                   "spec",
                   "owner",
                   "name"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ],
@@ -75,12 +75,12 @@
               "version": ""
             },
             "patch": {
-              "mutatorRef": [
+              "patchStrategy": "replace",
+              "mutatedRef": [
                 [
                   "displayName"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ]

--- a/models/azure-event-grid/azureserviceoperator_customresourcedefinitions_v2.13.0.yaml/v1.0.0/relationships/hierarchical-parent-inventory-kmjea.json
+++ b/models/azure-event-grid/azureserviceoperator_customresourcedefinitions_v2.13.0.yaml/v1.0.0/relationships/hierarchical-parent-inventory-kmjea.json
@@ -91,7 +91,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatedRef": [
+              "mutatorRef": [
                 [
                   "configuration",
                   "spec",
@@ -156,7 +156,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"

--- a/models/azure-event-grid/azureserviceoperator_customresourcedefinitions_v2.13.0.yaml/v1.0.0/relationships/hierarchical-parent-inventory-xdaqz.json
+++ b/models/azure-event-grid/azureserviceoperator_customresourcedefinitions_v2.13.0.yaml/v1.0.0/relationships/hierarchical-parent-inventory-xdaqz.json
@@ -45,15 +45,15 @@
               "version": ""
             },
             "patch": {
-              "mutatedRef": [
+              "patchStrategy": "replace",
+              "mutatorRef": [
                 [
                   "configuration",
                   "spec",
                   "owner",
                   "name"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ],
@@ -75,12 +75,12 @@
               "version": ""
             },
             "patch": {
-              "mutatorRef": [
+              "patchStrategy": "replace",
+              "mutatedRef": [
                 [
                   "displayName"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ]

--- a/models/azure-event-grid/azureserviceoperator_customresourcedefinitions_v2.14.0.yaml/v1.0.0/relationships/edge-non-binding-alias-byxsc.json
+++ b/models/azure-event-grid/azureserviceoperator_customresourcedefinitions_v2.14.0.yaml/v1.0.0/relationships/edge-non-binding-alias-byxsc.json
@@ -45,7 +45,8 @@
               "version": ""
             },
             "patch": {
-              "mutatedRef": [
+              "patchStrategy": "replace",
+              "mutatorRef": [
                 [
                   "configuration",
                   "spec",
@@ -64,8 +65,7 @@
                   "resourceReference",
                   "name"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ],
@@ -87,7 +87,8 @@
               "version": ""
             },
             "patch": {
-              "mutatorRef": [
+              "patchStrategy": "replace",
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -101,8 +102,7 @@
                   "metadata",
                   "name"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ]

--- a/models/azure-event-grid/azureserviceoperator_customresourcedefinitions_v2.14.0.yaml/v1.0.0/relationships/hierarchical-parent-inventory-cljum.json
+++ b/models/azure-event-grid/azureserviceoperator_customresourcedefinitions_v2.14.0.yaml/v1.0.0/relationships/hierarchical-parent-inventory-cljum.json
@@ -45,15 +45,15 @@
               "version": ""
             },
             "patch": {
-              "mutatedRef": [
+              "patchStrategy": "replace",
+              "mutatorRef": [
                 [
                   "configuration",
                   "spec",
                   "owner",
                   "name"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ],
@@ -75,12 +75,12 @@
               "version": ""
             },
             "patch": {
-              "mutatorRef": [
+              "patchStrategy": "replace",
+              "mutatedRef": [
                 [
                   "displayName"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ]

--- a/models/azure-event-grid/azureserviceoperator_customresourcedefinitions_v2.14.0.yaml/v1.0.0/relationships/hierarchical-parent-inventory-kmjea.json
+++ b/models/azure-event-grid/azureserviceoperator_customresourcedefinitions_v2.14.0.yaml/v1.0.0/relationships/hierarchical-parent-inventory-kmjea.json
@@ -91,7 +91,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatedRef": [
+              "mutatorRef": [
                 [
                   "configuration",
                   "spec",
@@ -156,7 +156,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"

--- a/models/azure-event-grid/azureserviceoperator_customresourcedefinitions_v2.14.0.yaml/v1.0.0/relationships/hierarchical-parent-inventory-xdaqz.json
+++ b/models/azure-event-grid/azureserviceoperator_customresourcedefinitions_v2.14.0.yaml/v1.0.0/relationships/hierarchical-parent-inventory-xdaqz.json
@@ -45,15 +45,15 @@
               "version": ""
             },
             "patch": {
-              "mutatedRef": [
+              "patchStrategy": "replace",
+              "mutatorRef": [
                 [
                   "configuration",
                   "spec",
                   "owner",
                   "name"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ],
@@ -75,12 +75,12 @@
               "version": ""
             },
             "patch": {
-              "mutatorRef": [
+              "patchStrategy": "replace",
+              "mutatedRef": [
                 [
                   "displayName"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ]

--- a/models/azure-event-hub/azureserviceoperator_customresourcedefinitions_v2.13.0.yaml/v1.0.0/relationships/hierarchical-parent-inventory-kmjea.json
+++ b/models/azure-event-hub/azureserviceoperator_customresourcedefinitions_v2.13.0.yaml/v1.0.0/relationships/hierarchical-parent-inventory-kmjea.json
@@ -91,7 +91,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatedRef": [
+              "mutatorRef": [
                 [
                   "configuration",
                   "spec",
@@ -144,7 +144,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "displayName"
                 ]

--- a/models/azure-event-hub/azureserviceoperator_customresourcedefinitions_v2.13.0.yaml/v1.0.0/relationships/hierarchical-parent-inventory-latgq.json
+++ b/models/azure-event-hub/azureserviceoperator_customresourcedefinitions_v2.13.0.yaml/v1.0.0/relationships/hierarchical-parent-inventory-latgq.json
@@ -45,15 +45,15 @@
               "version": ""
             },
             "patch": {
-              "mutatedRef": [
+              "patchStrategy": "replace",
+              "mutatorRef": [
                 [
                   "configuration",
                   "spec",
                   "owner",
                   "name"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ],
@@ -75,12 +75,12 @@
               "version": ""
             },
             "patch": {
-              "mutatorRef": [
+              "patchStrategy": "replace",
+              "mutatedRef": [
                 [
                   "displayName"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ]

--- a/models/azure-event-hub/azureserviceoperator_customresourcedefinitions_v2.13.0.yaml/v1.0.0/relationships/hierarchical-parent-inventory-qudlh.json
+++ b/models/azure-event-hub/azureserviceoperator_customresourcedefinitions_v2.13.0.yaml/v1.0.0/relationships/hierarchical-parent-inventory-qudlh.json
@@ -45,15 +45,15 @@
               "version": ""
             },
             "patch": {
-              "mutatedRef": [
+              "patchStrategy": "replace",
+              "mutatorRef": [
                 [
                   "configuration",
                   "spec",
                   "owner",
                   "name"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ],
@@ -75,12 +75,12 @@
               "version": ""
             },
             "patch": {
-              "mutatorRef": [
+              "patchStrategy": "replace",
+              "mutatedRef": [
                 [
                   "displayName"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ]

--- a/models/azure-event-hub/azureserviceoperator_customresourcedefinitions_v2.13.0.yaml/v1.0.0/relationships/hierarchical-parent-inventory-tqgld.json
+++ b/models/azure-event-hub/azureserviceoperator_customresourcedefinitions_v2.13.0.yaml/v1.0.0/relationships/hierarchical-parent-inventory-tqgld.json
@@ -45,15 +45,15 @@
               "version": ""
             },
             "patch": {
-              "mutatedRef": [
+              "patchStrategy": "replace",
+              "mutatorRef": [
                 [
                   "configuration",
                   "spec",
                   "owner",
                   "name"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ],
@@ -75,12 +75,12 @@
               "version": ""
             },
             "patch": {
-              "mutatorRef": [
+              "patchStrategy": "replace",
+              "mutatedRef": [
                 [
                   "displayName"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ]

--- a/models/azure-event-hub/azureserviceoperator_customresourcedefinitions_v2.13.0.yaml/v1.0.0/relationships/hierarchical-parent-inventory-upcep.json
+++ b/models/azure-event-hub/azureserviceoperator_customresourcedefinitions_v2.13.0.yaml/v1.0.0/relationships/hierarchical-parent-inventory-upcep.json
@@ -45,15 +45,15 @@
               "version": ""
             },
             "patch": {
-              "mutatedRef": [
+              "patchStrategy": "replace",
+              "mutatorRef": [
                 [
                   "configuration",
                   "spec",
                   "owner",
                   "name"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ],
@@ -75,12 +75,12 @@
               "version": ""
             },
             "patch": {
-              "mutatorRef": [
+              "patchStrategy": "replace",
+              "mutatedRef": [
                 [
                   "displayName"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ]

--- a/models/azure-event-hub/azureserviceoperator_customresourcedefinitions_v2.14.0.yaml/v1.0.0/relationships/hierarchical-parent-inventory-kmjea.json
+++ b/models/azure-event-hub/azureserviceoperator_customresourcedefinitions_v2.14.0.yaml/v1.0.0/relationships/hierarchical-parent-inventory-kmjea.json
@@ -91,7 +91,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatedRef": [
+              "mutatorRef": [
                 [
                   "configuration",
                   "spec",
@@ -144,7 +144,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "displayName"
                 ]

--- a/models/azure-event-hub/azureserviceoperator_customresourcedefinitions_v2.14.0.yaml/v1.0.0/relationships/hierarchical-parent-inventory-latgq.json
+++ b/models/azure-event-hub/azureserviceoperator_customresourcedefinitions_v2.14.0.yaml/v1.0.0/relationships/hierarchical-parent-inventory-latgq.json
@@ -45,15 +45,15 @@
               "version": ""
             },
             "patch": {
-              "mutatedRef": [
+              "patchStrategy": "replace",
+              "mutatorRef": [
                 [
                   "configuration",
                   "spec",
                   "owner",
                   "name"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ],
@@ -75,12 +75,12 @@
               "version": ""
             },
             "patch": {
-              "mutatorRef": [
+              "patchStrategy": "replace",
+              "mutatedRef": [
                 [
                   "displayName"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ]

--- a/models/azure-event-hub/azureserviceoperator_customresourcedefinitions_v2.14.0.yaml/v1.0.0/relationships/hierarchical-parent-inventory-qudlh.json
+++ b/models/azure-event-hub/azureserviceoperator_customresourcedefinitions_v2.14.0.yaml/v1.0.0/relationships/hierarchical-parent-inventory-qudlh.json
@@ -45,15 +45,15 @@
               "version": ""
             },
             "patch": {
-              "mutatedRef": [
+              "patchStrategy": "replace",
+              "mutatorRef": [
                 [
                   "configuration",
                   "spec",
                   "owner",
                   "name"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ],
@@ -75,12 +75,12 @@
               "version": ""
             },
             "patch": {
-              "mutatorRef": [
+              "patchStrategy": "replace",
+              "mutatedRef": [
                 [
                   "displayName"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ]

--- a/models/azure-event-hub/azureserviceoperator_customresourcedefinitions_v2.14.0.yaml/v1.0.0/relationships/hierarchical-parent-inventory-tqgld.json
+++ b/models/azure-event-hub/azureserviceoperator_customresourcedefinitions_v2.14.0.yaml/v1.0.0/relationships/hierarchical-parent-inventory-tqgld.json
@@ -45,15 +45,15 @@
               "version": ""
             },
             "patch": {
-              "mutatedRef": [
+              "patchStrategy": "replace",
+              "mutatorRef": [
                 [
                   "configuration",
                   "spec",
                   "owner",
                   "name"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ],
@@ -75,12 +75,12 @@
               "version": ""
             },
             "patch": {
-              "mutatorRef": [
+              "patchStrategy": "replace",
+              "mutatedRef": [
                 [
                   "displayName"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ]

--- a/models/azure-event-hub/azureserviceoperator_customresourcedefinitions_v2.14.0.yaml/v1.0.0/relationships/hierarchical-parent-inventory-upcep.json
+++ b/models/azure-event-hub/azureserviceoperator_customresourcedefinitions_v2.14.0.yaml/v1.0.0/relationships/hierarchical-parent-inventory-upcep.json
@@ -45,15 +45,15 @@
               "version": ""
             },
             "patch": {
-              "mutatedRef": [
+              "patchStrategy": "replace",
+              "mutatorRef": [
                 [
                   "configuration",
                   "spec",
                   "owner",
                   "name"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ],
@@ -75,12 +75,12 @@
               "version": ""
             },
             "patch": {
-              "mutatorRef": [
+              "patchStrategy": "replace",
+              "mutatedRef": [
                 [
                   "displayName"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ]

--- a/models/azure-insights/azureserviceoperator_customresourcedefinitions_v2.13.0.yaml/v1.0.0/relationships/edge-non-binding-reference-cpmsp.json
+++ b/models/azure-insights/azureserviceoperator_customresourcedefinitions_v2.13.0.yaml/v1.0.0/relationships/edge-non-binding-reference-cpmsp.json
@@ -45,7 +45,8 @@
               "version": ""
             },
             "patch": {
-              "mutatedRef": [
+              "patchStrategy": "replace",
+              "mutatorRef": [
                 [
                   "configuration",
                   "spec",
@@ -64,8 +65,7 @@
                   "metricResourceUriReference",
                   "name"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ],
@@ -87,7 +87,8 @@
               "version": ""
             },
             "patch": {
-              "mutatorRef": [
+              "patchStrategy": "replace",
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -101,8 +102,7 @@
                   "spec",
                   "name"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ]

--- a/models/azure-insights/azureserviceoperator_customresourcedefinitions_v2.13.0.yaml/v1.0.0/relationships/edge-non-binding-reference-ixver.json
+++ b/models/azure-insights/azureserviceoperator_customresourcedefinitions_v2.13.0.yaml/v1.0.0/relationships/edge-non-binding-reference-ixver.json
@@ -45,7 +45,8 @@
               "version": ""
             },
             "patch": {
-              "mutatedRef": [
+              "patchStrategy": "replace",
+              "mutatorRef": [
                 [
                   "configuration",
                   "spec",
@@ -67,8 +68,7 @@
                   "0",
                   "name"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ],
@@ -90,7 +90,8 @@
               "version": ""
             },
             "patch": {
-              "mutatorRef": [
+              "patchStrategy": "replace",
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -104,8 +105,7 @@
                   "spec",
                   "name"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ]

--- a/models/azure-insights/azureserviceoperator_customresourcedefinitions_v2.13.0.yaml/v1.0.0/relationships/edge-non-binding-reference-qpovb.json
+++ b/models/azure-insights/azureserviceoperator_customresourcedefinitions_v2.13.0.yaml/v1.0.0/relationships/edge-non-binding-reference-qpovb.json
@@ -45,7 +45,8 @@
               "version": ""
             },
             "patch": {
-              "mutatedRef": [
+              "patchStrategy": "replace",
+              "mutatorRef": [
                 [
                   "configuration",
                   "spec",
@@ -64,8 +65,7 @@
                   "workspaceResourceReference",
                   "name"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ],
@@ -87,7 +87,8 @@
               "version": ""
             },
             "patch": {
-              "mutatorRef": [
+              "patchStrategy": "replace",
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -101,8 +102,7 @@
                   "spec",
                   "name"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ]

--- a/models/azure-insights/azureserviceoperator_customresourcedefinitions_v2.13.0.yaml/v1.0.0/relationships/edge-non-binding-reference-rzvzz.json
+++ b/models/azure-insights/azureserviceoperator_customresourcedefinitions_v2.13.0.yaml/v1.0.0/relationships/edge-non-binding-reference-rzvzz.json
@@ -45,7 +45,8 @@
               "version": ""
             },
             "patch": {
-              "mutatedRef": [
+              "patchStrategy": "replace",
+              "mutatorRef": [
                 [
                   "configuration",
                   "spec",
@@ -64,8 +65,7 @@
                   "targetResourceUriReference",
                   "name"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ],
@@ -87,7 +87,8 @@
               "version": ""
             },
             "patch": {
-              "mutatorRef": [
+              "patchStrategy": "replace",
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -101,8 +102,7 @@
                   "spec",
                   "name"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ]

--- a/models/azure-insights/azureserviceoperator_customresourcedefinitions_v2.13.0.yaml/v1.0.0/relationships/edge-non-binding-reference-xxrai.json
+++ b/models/azure-insights/azureserviceoperator_customresourcedefinitions_v2.13.0.yaml/v1.0.0/relationships/edge-non-binding-reference-xxrai.json
@@ -45,7 +45,8 @@
               "version": ""
             },
             "patch": {
-              "mutatedRef": [
+              "patchStrategy": "replace",
+              "mutatorRef": [
                 [
                   "configuration",
                   "spec",
@@ -64,8 +65,7 @@
                   "storageAccountReference",
                   "name"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ],
@@ -87,7 +87,8 @@
               "version": ""
             },
             "patch": {
-              "mutatorRef": [
+              "patchStrategy": "replace",
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -101,8 +102,7 @@
                   "spec",
                   "name"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ]

--- a/models/azure-insights/azureserviceoperator_customresourcedefinitions_v2.13.0.yaml/v1.0.0/relationships/edge-non-binding-reference-znmqv.json
+++ b/models/azure-insights/azureserviceoperator_customresourcedefinitions_v2.13.0.yaml/v1.0.0/relationships/edge-non-binding-reference-znmqv.json
@@ -45,7 +45,8 @@
               "version": ""
             },
             "patch": {
-              "mutatedRef": [
+              "patchStrategy": "replace",
+              "mutatorRef": [
                 [
                   "configuration",
                   "spec",
@@ -67,8 +68,7 @@
                   "0",
                   "name"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ],
@@ -90,7 +90,8 @@
               "version": ""
             },
             "patch": {
-              "mutatorRef": [
+              "patchStrategy": "replace",
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -104,8 +105,7 @@
                   "spec",
                   "name"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ]

--- a/models/azure-insights/azureserviceoperator_customresourcedefinitions_v2.13.0.yaml/v1.0.0/relationships/hierarchical-parent-inventory-kmjea.json
+++ b/models/azure-insights/azureserviceoperator_customresourcedefinitions_v2.13.0.yaml/v1.0.0/relationships/hierarchical-parent-inventory-kmjea.json
@@ -91,7 +91,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatedRef": [
+              "mutatorRef": [
                 [
                   "configuration",
                   "spec",
@@ -159,7 +159,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"

--- a/models/azure-insights/azureserviceoperator_customresourcedefinitions_v2.13.0.yaml/v1.0.0/relationships/hierarchical-parent-inventory-qtfrs.json
+++ b/models/azure-insights/azureserviceoperator_customresourcedefinitions_v2.13.0.yaml/v1.0.0/relationships/hierarchical-parent-inventory-qtfrs.json
@@ -45,7 +45,8 @@
               "version": ""
             },
             "patch": {
-              "mutatedRef": [
+              "patchStrategy": "replace",
+              "mutatorRef": [
                 [
                   "configuration",
                   "spec",
@@ -64,8 +65,7 @@
                   "owner",
                   "name"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ],
@@ -87,7 +87,8 @@
               "version": ""
             },
             "patch": {
-              "mutatorRef": [
+              "patchStrategy": "replace",
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -101,8 +102,7 @@
                   "metadata",
                   "name"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ]

--- a/models/azure-insights/azureserviceoperator_customresourcedefinitions_v2.14.0.yaml/v1.0.0/relationships/edge-non-binding-reference-cpmsp.json
+++ b/models/azure-insights/azureserviceoperator_customresourcedefinitions_v2.14.0.yaml/v1.0.0/relationships/edge-non-binding-reference-cpmsp.json
@@ -45,7 +45,8 @@
               "version": ""
             },
             "patch": {
-              "mutatedRef": [
+              "patchStrategy": "replace",
+              "mutatorRef": [
                 [
                   "configuration",
                   "spec",
@@ -64,8 +65,7 @@
                   "metricResourceUriReference",
                   "name"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ],
@@ -87,7 +87,8 @@
               "version": ""
             },
             "patch": {
-              "mutatorRef": [
+              "patchStrategy": "replace",
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -101,8 +102,7 @@
                   "spec",
                   "name"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ]

--- a/models/azure-insights/azureserviceoperator_customresourcedefinitions_v2.14.0.yaml/v1.0.0/relationships/edge-non-binding-reference-ixver.json
+++ b/models/azure-insights/azureserviceoperator_customresourcedefinitions_v2.14.0.yaml/v1.0.0/relationships/edge-non-binding-reference-ixver.json
@@ -45,7 +45,8 @@
               "version": ""
             },
             "patch": {
-              "mutatedRef": [
+              "patchStrategy": "replace",
+              "mutatorRef": [
                 [
                   "configuration",
                   "spec",
@@ -67,8 +68,7 @@
                   "0",
                   "name"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ],
@@ -90,7 +90,8 @@
               "version": ""
             },
             "patch": {
-              "mutatorRef": [
+              "patchStrategy": "replace",
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -104,8 +105,7 @@
                   "spec",
                   "name"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ]

--- a/models/azure-insights/azureserviceoperator_customresourcedefinitions_v2.14.0.yaml/v1.0.0/relationships/edge-non-binding-reference-qpovb.json
+++ b/models/azure-insights/azureserviceoperator_customresourcedefinitions_v2.14.0.yaml/v1.0.0/relationships/edge-non-binding-reference-qpovb.json
@@ -45,7 +45,8 @@
               "version": ""
             },
             "patch": {
-              "mutatedRef": [
+              "patchStrategy": "replace",
+              "mutatorRef": [
                 [
                   "configuration",
                   "spec",
@@ -64,8 +65,7 @@
                   "workspaceResourceReference",
                   "name"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ],
@@ -87,7 +87,8 @@
               "version": ""
             },
             "patch": {
-              "mutatorRef": [
+              "patchStrategy": "replace",
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -101,8 +102,7 @@
                   "spec",
                   "name"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ]

--- a/models/azure-insights/azureserviceoperator_customresourcedefinitions_v2.14.0.yaml/v1.0.0/relationships/edge-non-binding-reference-rzvzz.json
+++ b/models/azure-insights/azureserviceoperator_customresourcedefinitions_v2.14.0.yaml/v1.0.0/relationships/edge-non-binding-reference-rzvzz.json
@@ -45,7 +45,8 @@
               "version": ""
             },
             "patch": {
-              "mutatedRef": [
+              "patchStrategy": "replace",
+              "mutatorRef": [
                 [
                   "configuration",
                   "spec",
@@ -64,8 +65,7 @@
                   "targetResourceUriReference",
                   "name"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ],
@@ -87,7 +87,8 @@
               "version": ""
             },
             "patch": {
-              "mutatorRef": [
+              "patchStrategy": "replace",
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -101,8 +102,7 @@
                   "spec",
                   "name"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ]

--- a/models/azure-insights/azureserviceoperator_customresourcedefinitions_v2.14.0.yaml/v1.0.0/relationships/edge-non-binding-reference-xxrai.json
+++ b/models/azure-insights/azureserviceoperator_customresourcedefinitions_v2.14.0.yaml/v1.0.0/relationships/edge-non-binding-reference-xxrai.json
@@ -45,7 +45,8 @@
               "version": ""
             },
             "patch": {
-              "mutatedRef": [
+              "patchStrategy": "replace",
+              "mutatorRef": [
                 [
                   "configuration",
                   "spec",
@@ -64,8 +65,7 @@
                   "storageAccountReference",
                   "name"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ],
@@ -87,7 +87,8 @@
               "version": ""
             },
             "patch": {
-              "mutatorRef": [
+              "patchStrategy": "replace",
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -101,8 +102,7 @@
                   "spec",
                   "name"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ]

--- a/models/azure-insights/azureserviceoperator_customresourcedefinitions_v2.14.0.yaml/v1.0.0/relationships/edge-non-binding-reference-znmqv.json
+++ b/models/azure-insights/azureserviceoperator_customresourcedefinitions_v2.14.0.yaml/v1.0.0/relationships/edge-non-binding-reference-znmqv.json
@@ -45,7 +45,8 @@
               "version": ""
             },
             "patch": {
-              "mutatedRef": [
+              "patchStrategy": "replace",
+              "mutatorRef": [
                 [
                   "configuration",
                   "spec",
@@ -67,8 +68,7 @@
                   "0",
                   "name"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ],
@@ -90,7 +90,8 @@
               "version": ""
             },
             "patch": {
-              "mutatorRef": [
+              "patchStrategy": "replace",
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -104,8 +105,7 @@
                   "spec",
                   "name"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ]

--- a/models/azure-insights/azureserviceoperator_customresourcedefinitions_v2.14.0.yaml/v1.0.0/relationships/hierarchical-parent-inventory-kmjea.json
+++ b/models/azure-insights/azureserviceoperator_customresourcedefinitions_v2.14.0.yaml/v1.0.0/relationships/hierarchical-parent-inventory-kmjea.json
@@ -91,7 +91,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatedRef": [
+              "mutatorRef": [
                 [
                   "configuration",
                   "spec",
@@ -159,7 +159,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"

--- a/models/azure-insights/azureserviceoperator_customresourcedefinitions_v2.14.0.yaml/v1.0.0/relationships/hierarchical-parent-inventory-qtfrs.json
+++ b/models/azure-insights/azureserviceoperator_customresourcedefinitions_v2.14.0.yaml/v1.0.0/relationships/hierarchical-parent-inventory-qtfrs.json
@@ -45,7 +45,8 @@
               "version": ""
             },
             "patch": {
-              "mutatedRef": [
+              "patchStrategy": "replace",
+              "mutatorRef": [
                 [
                   "configuration",
                   "spec",
@@ -64,8 +65,7 @@
                   "owner",
                   "name"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ],
@@ -87,7 +87,8 @@
               "version": ""
             },
             "patch": {
-              "mutatorRef": [
+              "patchStrategy": "replace",
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -101,8 +102,7 @@
                   "metadata",
                   "name"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ]

--- a/models/azure-kubernetes-configuration/azureserviceoperator_customresourcedefinitions_v2.13.0.yaml/v1.0.0/relationships/hierarchical-parent-inventory-kmjea.json
+++ b/models/azure-kubernetes-configuration/azureserviceoperator_customresourcedefinitions_v2.13.0.yaml/v1.0.0/relationships/hierarchical-parent-inventory-kmjea.json
@@ -91,7 +91,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatedRef": [
+              "mutatorRef": [
                 [
                   "configuration",
                   "spec",
@@ -156,7 +156,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"

--- a/models/azure-kubernetes-configuration/azureserviceoperator_customresourcedefinitions_v2.13.0.yaml/v1.0.0/relationships/hierarchical-parent-inventory-lpqmx.json
+++ b/models/azure-kubernetes-configuration/azureserviceoperator_customresourcedefinitions_v2.13.0.yaml/v1.0.0/relationships/hierarchical-parent-inventory-lpqmx.json
@@ -45,7 +45,8 @@
               "version": ""
             },
             "patch": {
-              "mutatedRef": [
+              "patchStrategy": "replace",
+              "mutatorRef": [
                 [
                   "configuration",
                   "spec",
@@ -64,8 +65,7 @@
                   "owner",
                   "name"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ],
@@ -87,7 +87,8 @@
               "version": ""
             },
             "patch": {
-              "mutatorRef": [
+              "patchStrategy": "replace",
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -101,8 +102,7 @@
                   "metadata",
                   "name"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ]

--- a/models/azure-kubernetes-configuration/azureserviceoperator_customresourcedefinitions_v2.13.0.yaml/v1.0.0/relationships/hierarchical-parent-inventory-tydjn.json
+++ b/models/azure-kubernetes-configuration/azureserviceoperator_customresourcedefinitions_v2.13.0.yaml/v1.0.0/relationships/hierarchical-parent-inventory-tydjn.json
@@ -45,7 +45,8 @@
               "version": ""
             },
             "patch": {
-              "mutatedRef": [
+              "patchStrategy": "replace",
+              "mutatorRef": [
                 [
                   "configuration",
                   "spec",
@@ -64,8 +65,7 @@
                   "owner",
                   "name"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ],
@@ -87,7 +87,8 @@
               "version": ""
             },
             "patch": {
-              "mutatorRef": [
+              "patchStrategy": "replace",
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -101,8 +102,7 @@
                   "metadata",
                   "name"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ]

--- a/models/azure-kubernetes-configuration/azureserviceoperator_customresourcedefinitions_v2.14.0.yaml/v1.0.0/relationships/hierarchical-parent-inventory-kmjea.json
+++ b/models/azure-kubernetes-configuration/azureserviceoperator_customresourcedefinitions_v2.14.0.yaml/v1.0.0/relationships/hierarchical-parent-inventory-kmjea.json
@@ -91,7 +91,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatedRef": [
+              "mutatorRef": [
                 [
                   "configuration",
                   "spec",
@@ -156,7 +156,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"

--- a/models/azure-kubernetes-configuration/azureserviceoperator_customresourcedefinitions_v2.14.0.yaml/v1.0.0/relationships/hierarchical-parent-inventory-lpqmx.json
+++ b/models/azure-kubernetes-configuration/azureserviceoperator_customresourcedefinitions_v2.14.0.yaml/v1.0.0/relationships/hierarchical-parent-inventory-lpqmx.json
@@ -45,7 +45,8 @@
               "version": ""
             },
             "patch": {
-              "mutatedRef": [
+              "patchStrategy": "replace",
+              "mutatorRef": [
                 [
                   "configuration",
                   "spec",
@@ -64,8 +65,7 @@
                   "owner",
                   "name"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ],
@@ -87,7 +87,8 @@
               "version": ""
             },
             "patch": {
-              "mutatorRef": [
+              "patchStrategy": "replace",
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -101,8 +102,7 @@
                   "metadata",
                   "name"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ]

--- a/models/azure-kubernetes-configuration/azureserviceoperator_customresourcedefinitions_v2.14.0.yaml/v1.0.0/relationships/hierarchical-parent-inventory-tydjn.json
+++ b/models/azure-kubernetes-configuration/azureserviceoperator_customresourcedefinitions_v2.14.0.yaml/v1.0.0/relationships/hierarchical-parent-inventory-tydjn.json
@@ -45,7 +45,8 @@
               "version": ""
             },
             "patch": {
-              "mutatedRef": [
+              "patchStrategy": "replace",
+              "mutatorRef": [
                 [
                   "configuration",
                   "spec",
@@ -64,8 +65,7 @@
                   "owner",
                   "name"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ],
@@ -87,7 +87,8 @@
               "version": ""
             },
             "patch": {
-              "mutatorRef": [
+              "patchStrategy": "replace",
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -101,8 +102,7 @@
                   "metadata",
                   "name"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ]

--- a/models/azure-kusto/azureserviceoperator_customresourcedefinitions_v2.13.0.yaml/v1.0.0/relationships/edge-non-binding-reference-cqcpg.json
+++ b/models/azure-kusto/azureserviceoperator_customresourcedefinitions_v2.13.0.yaml/v1.0.0/relationships/edge-non-binding-reference-cqcpg.json
@@ -45,7 +45,8 @@
               "version": ""
             },
             "patch": {
-              "mutatedRef": [
+              "patchStrategy": "replace",
+              "mutatorRef": [
                 [
                   "configuration",
                   "spec",
@@ -64,8 +65,7 @@
                   "eventHubResourceReference",
                   "name"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ],
@@ -87,7 +87,8 @@
               "version": ""
             },
             "patch": {
-              "mutatorRef": [
+              "patchStrategy": "replace",
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -101,8 +102,7 @@
                   "spec",
                   "name"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ]

--- a/models/azure-kusto/azureserviceoperator_customresourcedefinitions_v2.13.0.yaml/v1.0.0/relationships/hierarchical-parent-inventory-caujw.json
+++ b/models/azure-kusto/azureserviceoperator_customresourcedefinitions_v2.13.0.yaml/v1.0.0/relationships/hierarchical-parent-inventory-caujw.json
@@ -45,15 +45,15 @@
               "version": ""
             },
             "patch": {
-              "mutatedRef": [
+              "patchStrategy": "replace",
+              "mutatorRef": [
                 [
                   "configuration",
                   "spec",
                   "owner",
                   "name"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ],
@@ -75,12 +75,12 @@
               "version": ""
             },
             "patch": {
-              "mutatorRef": [
+              "patchStrategy": "replace",
+              "mutatedRef": [
                 [
                   "displayName"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ]

--- a/models/azure-kusto/azureserviceoperator_customresourcedefinitions_v2.13.0.yaml/v1.0.0/relationships/hierarchical-parent-inventory-fzaff.json
+++ b/models/azure-kusto/azureserviceoperator_customresourcedefinitions_v2.13.0.yaml/v1.0.0/relationships/hierarchical-parent-inventory-fzaff.json
@@ -45,15 +45,15 @@
               "version": ""
             },
             "patch": {
-              "mutatedRef": [
+              "patchStrategy": "replace",
+              "mutatorRef": [
                 [
                   "configuration",
                   "spec",
                   "owner",
                   "name"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ],
@@ -75,12 +75,12 @@
               "version": ""
             },
             "patch": {
-              "mutatorRef": [
+              "patchStrategy": "replace",
+              "mutatedRef": [
                 [
                   "displayName"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ]

--- a/models/azure-kusto/azureserviceoperator_customresourcedefinitions_v2.13.0.yaml/v1.0.0/relationships/hierarchical-parent-inventory-kmjea.json
+++ b/models/azure-kusto/azureserviceoperator_customresourcedefinitions_v2.13.0.yaml/v1.0.0/relationships/hierarchical-parent-inventory-kmjea.json
@@ -91,7 +91,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatedRef": [
+              "mutatorRef": [
                 [
                   "configuration",
                   "spec",
@@ -156,7 +156,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"

--- a/models/azure-kusto/azureserviceoperator_customresourcedefinitions_v2.14.0.yaml/v1.0.0/relationships/edge-non-binding-reference-cqcpg.json
+++ b/models/azure-kusto/azureserviceoperator_customresourcedefinitions_v2.14.0.yaml/v1.0.0/relationships/edge-non-binding-reference-cqcpg.json
@@ -45,7 +45,8 @@
               "version": ""
             },
             "patch": {
-              "mutatedRef": [
+              "patchStrategy": "replace",
+              "mutatorRef": [
                 [
                   "configuration",
                   "spec",
@@ -64,8 +65,7 @@
                   "eventHubResourceReference",
                   "name"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ],
@@ -87,7 +87,8 @@
               "version": ""
             },
             "patch": {
-              "mutatorRef": [
+              "patchStrategy": "replace",
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -101,8 +102,7 @@
                   "spec",
                   "name"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ]

--- a/models/azure-kusto/azureserviceoperator_customresourcedefinitions_v2.14.0.yaml/v1.0.0/relationships/hierarchical-parent-inventory-caujw.json
+++ b/models/azure-kusto/azureserviceoperator_customresourcedefinitions_v2.14.0.yaml/v1.0.0/relationships/hierarchical-parent-inventory-caujw.json
@@ -45,15 +45,15 @@
               "version": ""
             },
             "patch": {
-              "mutatedRef": [
+              "patchStrategy": "replace",
+              "mutatorRef": [
                 [
                   "configuration",
                   "spec",
                   "owner",
                   "name"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ],
@@ -75,12 +75,12 @@
               "version": ""
             },
             "patch": {
-              "mutatorRef": [
+              "patchStrategy": "replace",
+              "mutatedRef": [
                 [
                   "displayName"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ]

--- a/models/azure-kusto/azureserviceoperator_customresourcedefinitions_v2.14.0.yaml/v1.0.0/relationships/hierarchical-parent-inventory-fzaff.json
+++ b/models/azure-kusto/azureserviceoperator_customresourcedefinitions_v2.14.0.yaml/v1.0.0/relationships/hierarchical-parent-inventory-fzaff.json
@@ -45,15 +45,15 @@
               "version": ""
             },
             "patch": {
-              "mutatedRef": [
+              "patchStrategy": "replace",
+              "mutatorRef": [
                 [
                   "configuration",
                   "spec",
                   "owner",
                   "name"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ],
@@ -75,12 +75,12 @@
               "version": ""
             },
             "patch": {
-              "mutatorRef": [
+              "patchStrategy": "replace",
+              "mutatedRef": [
                 [
                   "displayName"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ]

--- a/models/azure-kusto/azureserviceoperator_customresourcedefinitions_v2.14.0.yaml/v1.0.0/relationships/hierarchical-parent-inventory-kmjea.json
+++ b/models/azure-kusto/azureserviceoperator_customresourcedefinitions_v2.14.0.yaml/v1.0.0/relationships/hierarchical-parent-inventory-kmjea.json
@@ -91,7 +91,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatedRef": [
+              "mutatorRef": [
                 [
                   "configuration",
                   "spec",
@@ -156,7 +156,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"

--- a/models/azure-machine-learning-services/azureserviceoperator_customresourcedefinitions_v2.13.0.yaml/v1.0.0/relationships/edge-non-binding-reference-mxqpo.json
+++ b/models/azure-machine-learning-services/azureserviceoperator_customresourcedefinitions_v2.13.0.yaml/v1.0.0/relationships/edge-non-binding-reference-mxqpo.json
@@ -45,7 +45,8 @@
               "version": ""
             },
             "patch": {
-              "mutatedRef": [
+              "patchStrategy": "replace",
+              "mutatorRef": [
                 [
                   "configuration",
                   "spec",
@@ -64,8 +65,7 @@
                   "resourceReference",
                   "name"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ],
@@ -87,7 +87,8 @@
               "version": ""
             },
             "patch": {
-              "mutatorRef": [
+              "patchStrategy": "replace",
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -101,8 +102,7 @@
                   "spec",
                   "name"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ]

--- a/models/azure-machine-learning-services/azureserviceoperator_customresourcedefinitions_v2.13.0.yaml/v1.0.0/relationships/edge-non-binding-reference-psaqe.json
+++ b/models/azure-machine-learning-services/azureserviceoperator_customresourcedefinitions_v2.13.0.yaml/v1.0.0/relationships/edge-non-binding-reference-psaqe.json
@@ -45,7 +45,8 @@
               "version": ""
             },
             "patch": {
-              "mutatedRef": [
+              "patchStrategy": "replace",
+              "mutatorRef": [
                 [
                   "configuration",
                   "spec",
@@ -64,8 +65,7 @@
                   "storageAccountReference",
                   "name"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ],
@@ -87,7 +87,8 @@
               "version": ""
             },
             "patch": {
-              "mutatorRef": [
+              "patchStrategy": "replace",
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -101,8 +102,7 @@
                   "spec",
                   "name"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ]

--- a/models/azure-machine-learning-services/azureserviceoperator_customresourcedefinitions_v2.13.0.yaml/v1.0.0/relationships/edge-non-binding-reference-xnudd.json
+++ b/models/azure-machine-learning-services/azureserviceoperator_customresourcedefinitions_v2.13.0.yaml/v1.0.0/relationships/edge-non-binding-reference-xnudd.json
@@ -45,7 +45,8 @@
               "version": ""
             },
             "patch": {
-              "mutatedRef": [
+              "patchStrategy": "replace",
+              "mutatorRef": [
                 [
                   "configuration",
                   "spec",
@@ -64,8 +65,7 @@
                   "keyVaultReference",
                   "name"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ],
@@ -87,7 +87,8 @@
               "version": ""
             },
             "patch": {
-              "mutatorRef": [
+              "patchStrategy": "replace",
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -101,8 +102,7 @@
                   "spec",
                   "name"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ]

--- a/models/azure-machine-learning-services/azureserviceoperator_customresourcedefinitions_v2.13.0.yaml/v1.0.0/relationships/hierarchical-parent-inventory-kmjea.json
+++ b/models/azure-machine-learning-services/azureserviceoperator_customresourcedefinitions_v2.13.0.yaml/v1.0.0/relationships/hierarchical-parent-inventory-kmjea.json
@@ -91,7 +91,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatedRef": [
+              "mutatorRef": [
                 [
                   "configuration",
                   "spec",
@@ -156,7 +156,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"

--- a/models/azure-machine-learning-services/azureserviceoperator_customresourcedefinitions_v2.13.0.yaml/v1.0.0/relationships/hierarchical-parent-inventory-mlcxy.json
+++ b/models/azure-machine-learning-services/azureserviceoperator_customresourcedefinitions_v2.13.0.yaml/v1.0.0/relationships/hierarchical-parent-inventory-mlcxy.json
@@ -45,15 +45,15 @@
               "version": ""
             },
             "patch": {
-              "mutatedRef": [
+              "patchStrategy": "replace",
+              "mutatorRef": [
                 [
                   "configuration",
                   "spec",
                   "owner",
                   "name"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ],
@@ -75,12 +75,12 @@
               "version": ""
             },
             "patch": {
-              "mutatorRef": [
+              "patchStrategy": "replace",
+              "mutatedRef": [
                 [
                   "displayName"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ]

--- a/models/azure-machine-learning-services/azureserviceoperator_customresourcedefinitions_v2.13.0.yaml/v1.0.0/relationships/hierarchical-parent-inventory-qdwzo.json
+++ b/models/azure-machine-learning-services/azureserviceoperator_customresourcedefinitions_v2.13.0.yaml/v1.0.0/relationships/hierarchical-parent-inventory-qdwzo.json
@@ -45,15 +45,15 @@
               "version": ""
             },
             "patch": {
-              "mutatedRef": [
+              "patchStrategy": "replace",
+              "mutatorRef": [
                 [
                   "configuration",
                   "spec",
                   "owner",
                   "name"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ],
@@ -75,12 +75,12 @@
               "version": ""
             },
             "patch": {
-              "mutatorRef": [
+              "patchStrategy": "replace",
+              "mutatedRef": [
                 [
                   "displayName"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ]

--- a/models/azure-machine-learning-services/azureserviceoperator_customresourcedefinitions_v2.14.0.yaml/v1.0.0/relationships/edge-non-binding-reference-mxqpo.json
+++ b/models/azure-machine-learning-services/azureserviceoperator_customresourcedefinitions_v2.14.0.yaml/v1.0.0/relationships/edge-non-binding-reference-mxqpo.json
@@ -45,7 +45,8 @@
               "version": ""
             },
             "patch": {
-              "mutatedRef": [
+              "patchStrategy": "replace",
+              "mutatorRef": [
                 [
                   "configuration",
                   "spec",
@@ -64,8 +65,7 @@
                   "resourceReference",
                   "name"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ],
@@ -87,7 +87,8 @@
               "version": ""
             },
             "patch": {
-              "mutatorRef": [
+              "patchStrategy": "replace",
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -101,8 +102,7 @@
                   "spec",
                   "name"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ]

--- a/models/azure-machine-learning-services/azureserviceoperator_customresourcedefinitions_v2.14.0.yaml/v1.0.0/relationships/edge-non-binding-reference-psaqe.json
+++ b/models/azure-machine-learning-services/azureserviceoperator_customresourcedefinitions_v2.14.0.yaml/v1.0.0/relationships/edge-non-binding-reference-psaqe.json
@@ -45,7 +45,8 @@
               "version": ""
             },
             "patch": {
-              "mutatedRef": [
+              "patchStrategy": "replace",
+              "mutatorRef": [
                 [
                   "configuration",
                   "spec",
@@ -64,8 +65,7 @@
                   "storageAccountReference",
                   "name"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ],
@@ -87,7 +87,8 @@
               "version": ""
             },
             "patch": {
-              "mutatorRef": [
+              "patchStrategy": "replace",
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -101,8 +102,7 @@
                   "spec",
                   "name"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ]

--- a/models/azure-machine-learning-services/azureserviceoperator_customresourcedefinitions_v2.14.0.yaml/v1.0.0/relationships/edge-non-binding-reference-xnudd.json
+++ b/models/azure-machine-learning-services/azureserviceoperator_customresourcedefinitions_v2.14.0.yaml/v1.0.0/relationships/edge-non-binding-reference-xnudd.json
@@ -45,7 +45,8 @@
               "version": ""
             },
             "patch": {
-              "mutatedRef": [
+              "patchStrategy": "replace",
+              "mutatorRef": [
                 [
                   "configuration",
                   "spec",
@@ -64,8 +65,7 @@
                   "keyVaultReference",
                   "name"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ],
@@ -87,7 +87,8 @@
               "version": ""
             },
             "patch": {
-              "mutatorRef": [
+              "patchStrategy": "replace",
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -101,8 +102,7 @@
                   "spec",
                   "name"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ]

--- a/models/azure-machine-learning-services/azureserviceoperator_customresourcedefinitions_v2.14.0.yaml/v1.0.0/relationships/hierarchical-parent-inventory-kmjea.json
+++ b/models/azure-machine-learning-services/azureserviceoperator_customresourcedefinitions_v2.14.0.yaml/v1.0.0/relationships/hierarchical-parent-inventory-kmjea.json
@@ -91,7 +91,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatedRef": [
+              "mutatorRef": [
                 [
                   "configuration",
                   "spec",
@@ -156,7 +156,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"

--- a/models/azure-machine-learning-services/azureserviceoperator_customresourcedefinitions_v2.14.0.yaml/v1.0.0/relationships/hierarchical-parent-inventory-mlcxy.json
+++ b/models/azure-machine-learning-services/azureserviceoperator_customresourcedefinitions_v2.14.0.yaml/v1.0.0/relationships/hierarchical-parent-inventory-mlcxy.json
@@ -45,15 +45,15 @@
               "version": ""
             },
             "patch": {
-              "mutatedRef": [
+              "patchStrategy": "replace",
+              "mutatorRef": [
                 [
                   "configuration",
                   "spec",
                   "owner",
                   "name"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ],
@@ -75,12 +75,12 @@
               "version": ""
             },
             "patch": {
-              "mutatorRef": [
+              "patchStrategy": "replace",
+              "mutatedRef": [
                 [
                   "displayName"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ]

--- a/models/azure-machine-learning-services/azureserviceoperator_customresourcedefinitions_v2.14.0.yaml/v1.0.0/relationships/hierarchical-parent-inventory-qdwzo.json
+++ b/models/azure-machine-learning-services/azureserviceoperator_customresourcedefinitions_v2.14.0.yaml/v1.0.0/relationships/hierarchical-parent-inventory-qdwzo.json
@@ -45,15 +45,15 @@
               "version": ""
             },
             "patch": {
-              "mutatedRef": [
+              "patchStrategy": "replace",
+              "mutatorRef": [
                 [
                   "configuration",
                   "spec",
                   "owner",
                   "name"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ],
@@ -75,12 +75,12 @@
               "version": ""
             },
             "patch": {
-              "mutatorRef": [
+              "patchStrategy": "replace",
+              "mutatedRef": [
                 [
                   "displayName"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ]

--- a/models/azure-managed-identity/azureserviceoperator_customresourcedefinitions_v2.13.0.yaml/v1.0.0/relationships/hierarchical-parent-inventory-kmjea.json
+++ b/models/azure-managed-identity/azureserviceoperator_customresourcedefinitions_v2.13.0.yaml/v1.0.0/relationships/hierarchical-parent-inventory-kmjea.json
@@ -91,7 +91,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatedRef": [
+              "mutatorRef": [
                 [
                   "configuration",
                   "spec",
@@ -144,7 +144,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "displayName"
                 ]

--- a/models/azure-managed-identity/azureserviceoperator_customresourcedefinitions_v2.13.0.yaml/v1.0.0/relationships/hierarchical-parent-inventory-nyfjr.json
+++ b/models/azure-managed-identity/azureserviceoperator_customresourcedefinitions_v2.13.0.yaml/v1.0.0/relationships/hierarchical-parent-inventory-nyfjr.json
@@ -45,15 +45,15 @@
               "version": ""
             },
             "patch": {
-              "mutatedRef": [
+              "patchStrategy": "replace",
+              "mutatorRef": [
                 [
                   "configuration",
                   "spec",
                   "owner",
                   "name"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ],
@@ -75,12 +75,12 @@
               "version": ""
             },
             "patch": {
-              "mutatorRef": [
+              "patchStrategy": "replace",
+              "mutatedRef": [
                 [
                   "displayName"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ]

--- a/models/azure-managed-identity/azureserviceoperator_customresourcedefinitions_v2.14.0.yaml/v1.0.0/relationships/hierarchical-parent-inventory-kmjea.json
+++ b/models/azure-managed-identity/azureserviceoperator_customresourcedefinitions_v2.14.0.yaml/v1.0.0/relationships/hierarchical-parent-inventory-kmjea.json
@@ -91,7 +91,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatedRef": [
+              "mutatorRef": [
                 [
                   "configuration",
                   "spec",
@@ -144,7 +144,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "displayName"
                 ]

--- a/models/azure-managed-identity/azureserviceoperator_customresourcedefinitions_v2.14.0.yaml/v1.0.0/relationships/hierarchical-parent-inventory-nyfjr.json
+++ b/models/azure-managed-identity/azureserviceoperator_customresourcedefinitions_v2.14.0.yaml/v1.0.0/relationships/hierarchical-parent-inventory-nyfjr.json
@@ -45,15 +45,15 @@
               "version": ""
             },
             "patch": {
-              "mutatedRef": [
+              "patchStrategy": "replace",
+              "mutatorRef": [
                 [
                   "configuration",
                   "spec",
                   "owner",
                   "name"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ],
@@ -75,12 +75,12 @@
               "version": ""
             },
             "patch": {
-              "mutatorRef": [
+              "patchStrategy": "replace",
+              "mutatedRef": [
                 [
                   "displayName"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ]

--- a/models/azure-network/azureserviceoperator_customresourcedefinitions_v2.13.0.yaml/v1.0.0/relationships/edge-non-binding-reference-anqgu.json
+++ b/models/azure-network/azureserviceoperator_customresourcedefinitions_v2.13.0.yaml/v1.0.0/relationships/edge-non-binding-reference-anqgu.json
@@ -45,7 +45,8 @@
               "version": ""
             },
             "patch": {
-              "mutatedRef": [
+              "patchStrategy": "replace",
+              "mutatorRef": [
                 [
                   "configuration",
                   "spec",
@@ -64,8 +65,7 @@
                   "reference",
                   "name"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ],
@@ -87,7 +87,8 @@
               "version": ""
             },
             "patch": {
-              "mutatorRef": [
+              "patchStrategy": "replace",
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -101,8 +102,7 @@
                   "spec",
                   "name"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ]

--- a/models/azure-network/azureserviceoperator_customresourcedefinitions_v2.13.0.yaml/v1.0.0/relationships/edge-non-binding-reference-crtzt.json
+++ b/models/azure-network/azureserviceoperator_customresourcedefinitions_v2.13.0.yaml/v1.0.0/relationships/edge-non-binding-reference-crtzt.json
@@ -45,7 +45,8 @@
               "version": ""
             },
             "patch": {
-              "mutatedRef": [
+              "patchStrategy": "replace",
+              "mutatorRef": [
                 [
                   "configuration",
                   "spec",
@@ -64,8 +65,7 @@
                   "reference1",
                   "name"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ],
@@ -87,7 +87,8 @@
               "version": ""
             },
             "patch": {
-              "mutatorRef": [
+              "patchStrategy": "replace",
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -101,8 +102,7 @@
                   "spec",
                   "name"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ]

--- a/models/azure-network/azureserviceoperator_customresourcedefinitions_v2.13.0.yaml/v1.0.0/relationships/edge-non-binding-reference-ctxsr.json
+++ b/models/azure-network/azureserviceoperator_customresourcedefinitions_v2.13.0.yaml/v1.0.0/relationships/edge-non-binding-reference-ctxsr.json
@@ -45,7 +45,8 @@
               "version": ""
             },
             "patch": {
-              "mutatedRef": [
+              "patchStrategy": "replace",
+              "mutatorRef": [
                 [
                   "configuration",
                   "spec",
@@ -64,8 +65,7 @@
                   "reference1",
                   "name"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ],
@@ -87,7 +87,8 @@
               "version": ""
             },
             "patch": {
-              "mutatorRef": [
+              "patchStrategy": "replace",
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -101,8 +102,7 @@
                   "spec",
                   "name"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ]

--- a/models/azure-network/azureserviceoperator_customresourcedefinitions_v2.13.0.yaml/v1.0.0/relationships/edge-non-binding-reference-dqsei.json
+++ b/models/azure-network/azureserviceoperator_customresourcedefinitions_v2.13.0.yaml/v1.0.0/relationships/edge-non-binding-reference-dqsei.json
@@ -45,7 +45,8 @@
               "version": ""
             },
             "patch": {
-              "mutatedRef": [
+              "patchStrategy": "replace",
+              "mutatorRef": [
                 [
                   "configuration",
                   "spec",
@@ -64,8 +65,7 @@
                   "firewallPolicy",
                   "name"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ],
@@ -87,7 +87,8 @@
               "version": ""
             },
             "patch": {
-              "mutatorRef": [
+              "patchStrategy": "replace",
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -101,8 +102,7 @@
                   "spec",
                   "name"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ]

--- a/models/azure-network/azureserviceoperator_customresourcedefinitions_v2.13.0.yaml/v1.0.0/relationships/edge-non-binding-reference-eblaq.json
+++ b/models/azure-network/azureserviceoperator_customresourcedefinitions_v2.13.0.yaml/v1.0.0/relationships/edge-non-binding-reference-eblaq.json
@@ -45,7 +45,8 @@
               "version": ""
             },
             "patch": {
-              "mutatedRef": [
+              "patchStrategy": "replace",
+              "mutatorRef": [
                 [
                   "configuration",
                   "spec",
@@ -64,8 +65,7 @@
                   "reference2",
                   "name"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ],
@@ -87,7 +87,8 @@
               "version": ""
             },
             "patch": {
-              "mutatorRef": [
+              "patchStrategy": "replace",
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -101,8 +102,7 @@
                   "spec",
                   "name"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ]

--- a/models/azure-network/azureserviceoperator_customresourcedefinitions_v2.13.0.yaml/v1.0.0/relationships/edge-non-binding-reference-ewtcj.json
+++ b/models/azure-network/azureserviceoperator_customresourcedefinitions_v2.13.0.yaml/v1.0.0/relationships/edge-non-binding-reference-ewtcj.json
@@ -45,7 +45,8 @@
               "version": ""
             },
             "patch": {
-              "mutatedRef": [
+              "patchStrategy": "replace",
+              "mutatorRef": [
                 [
                   "configuration",
                   "spec",
@@ -64,8 +65,7 @@
                   "reference",
                   "name"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ],
@@ -87,7 +87,8 @@
               "version": ""
             },
             "patch": {
-              "mutatorRef": [
+              "patchStrategy": "replace",
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -101,8 +102,7 @@
                   "spec",
                   "name"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ]

--- a/models/azure-network/azureserviceoperator_customresourcedefinitions_v2.13.0.yaml/v1.0.0/relationships/edge-non-binding-reference-gyaoi.json
+++ b/models/azure-network/azureserviceoperator_customresourcedefinitions_v2.13.0.yaml/v1.0.0/relationships/edge-non-binding-reference-gyaoi.json
@@ -45,7 +45,8 @@
               "version": ""
             },
             "patch": {
-              "mutatedRef": [
+              "patchStrategy": "replace",
+              "mutatorRef": [
                 [
                   "configuration",
                   "spec",
@@ -64,8 +65,7 @@
                   "reference",
                   "name"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ],
@@ -87,7 +87,8 @@
               "version": ""
             },
             "patch": {
-              "mutatorRef": [
+              "patchStrategy": "replace",
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -101,8 +102,7 @@
                   "spec",
                   "name"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ]

--- a/models/azure-network/azureserviceoperator_customresourcedefinitions_v2.13.0.yaml/v1.0.0/relationships/edge-non-binding-reference-jkdks.json
+++ b/models/azure-network/azureserviceoperator_customresourcedefinitions_v2.13.0.yaml/v1.0.0/relationships/edge-non-binding-reference-jkdks.json
@@ -45,7 +45,8 @@
               "version": ""
             },
             "patch": {
-              "mutatedRef": [
+              "patchStrategy": "replace",
+              "mutatorRef": [
                 [
                   "configuration",
                   "spec",
@@ -64,8 +65,7 @@
                   "reference",
                   "name"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ],
@@ -87,7 +87,8 @@
               "version": ""
             },
             "patch": {
-              "mutatorRef": [
+              "patchStrategy": "replace",
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -101,8 +102,7 @@
                   "spec",
                   "name"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ]

--- a/models/azure-network/azureserviceoperator_customresourcedefinitions_v2.13.0.yaml/v1.0.0/relationships/edge-non-binding-reference-kutmc.json
+++ b/models/azure-network/azureserviceoperator_customresourcedefinitions_v2.13.0.yaml/v1.0.0/relationships/edge-non-binding-reference-kutmc.json
@@ -45,7 +45,8 @@
               "version": ""
             },
             "patch": {
-              "mutatedRef": [
+              "patchStrategy": "replace",
+              "mutatorRef": [
                 [
                   "configuration",
                   "spec",
@@ -64,8 +65,7 @@
                   "reference",
                   "name"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ],
@@ -87,7 +87,8 @@
               "version": ""
             },
             "patch": {
-              "mutatorRef": [
+              "patchStrategy": "replace",
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -101,8 +102,7 @@
                   "spec",
                   "name"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ]

--- a/models/azure-network/azureserviceoperator_customresourcedefinitions_v2.13.0.yaml/v1.0.0/relationships/edge-non-binding-reference-mbged.json
+++ b/models/azure-network/azureserviceoperator_customresourcedefinitions_v2.13.0.yaml/v1.0.0/relationships/edge-non-binding-reference-mbged.json
@@ -45,7 +45,8 @@
               "version": ""
             },
             "patch": {
-              "mutatedRef": [
+              "patchStrategy": "replace",
+              "mutatorRef": [
                 [
                   "configuration",
                   "spec",
@@ -64,8 +65,7 @@
                   "reference1",
                   "name"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ],
@@ -87,7 +87,8 @@
               "version": ""
             },
             "patch": {
-              "mutatorRef": [
+              "patchStrategy": "replace",
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -101,8 +102,7 @@
                   "spec",
                   "name"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ]

--- a/models/azure-network/azureserviceoperator_customresourcedefinitions_v2.13.0.yaml/v1.0.0/relationships/edge-non-binding-reference-mfgny.json
+++ b/models/azure-network/azureserviceoperator_customresourcedefinitions_v2.13.0.yaml/v1.0.0/relationships/edge-non-binding-reference-mfgny.json
@@ -45,7 +45,8 @@
               "version": ""
             },
             "patch": {
-              "mutatedRef": [
+              "patchStrategy": "replace",
+              "mutatorRef": [
                 [
                   "configuration",
                   "spec",
@@ -64,8 +65,7 @@
                   "reference1",
                   "name"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ],
@@ -87,7 +87,8 @@
               "version": ""
             },
             "patch": {
-              "mutatorRef": [
+              "patchStrategy": "replace",
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -101,8 +102,7 @@
                   "spec",
                   "name"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ]

--- a/models/azure-network/azureserviceoperator_customresourcedefinitions_v2.13.0.yaml/v1.0.0/relationships/edge-non-binding-reference-mnkbz.json
+++ b/models/azure-network/azureserviceoperator_customresourcedefinitions_v2.13.0.yaml/v1.0.0/relationships/edge-non-binding-reference-mnkbz.json
@@ -45,7 +45,8 @@
               "version": ""
             },
             "patch": {
-              "mutatedRef": [
+              "patchStrategy": "replace",
+              "mutatorRef": [
                 [
                   "configuration",
                   "spec",
@@ -64,8 +65,7 @@
                   "subnetReference",
                   "name"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ],
@@ -87,7 +87,8 @@
               "version": ""
             },
             "patch": {
-              "mutatorRef": [
+              "patchStrategy": "replace",
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -101,8 +102,7 @@
                   "spec",
                   "name"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ]

--- a/models/azure-network/azureserviceoperator_customresourcedefinitions_v2.13.0.yaml/v1.0.0/relationships/edge-non-binding-reference-omqpd.json
+++ b/models/azure-network/azureserviceoperator_customresourcedefinitions_v2.13.0.yaml/v1.0.0/relationships/edge-non-binding-reference-omqpd.json
@@ -45,7 +45,8 @@
               "version": ""
             },
             "patch": {
-              "mutatedRef": [
+              "patchStrategy": "replace",
+              "mutatorRef": [
                 [
                   "configuration",
                   "spec",
@@ -64,8 +65,7 @@
                   "privateLinkServiceReference",
                   "name"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ],
@@ -87,7 +87,8 @@
               "version": ""
             },
             "patch": {
-              "mutatorRef": [
+              "patchStrategy": "replace",
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -101,8 +102,7 @@
                   "spec",
                   "name"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ]

--- a/models/azure-network/azureserviceoperator_customresourcedefinitions_v2.13.0.yaml/v1.0.0/relationships/edge-non-binding-reference-pajdm.json
+++ b/models/azure-network/azureserviceoperator_customresourcedefinitions_v2.13.0.yaml/v1.0.0/relationships/edge-non-binding-reference-pajdm.json
@@ -45,7 +45,8 @@
               "version": ""
             },
             "patch": {
-              "mutatedRef": [
+              "patchStrategy": "replace",
+              "mutatorRef": [
                 [
                   "configuration",
                   "spec",
@@ -64,8 +65,7 @@
                   "reference",
                   "name"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ],
@@ -87,7 +87,8 @@
               "version": ""
             },
             "patch": {
-              "mutatorRef": [
+              "patchStrategy": "replace",
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -101,8 +102,7 @@
                   "spec",
                   "name"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ]

--- a/models/azure-network/azureserviceoperator_customresourcedefinitions_v2.13.0.yaml/v1.0.0/relationships/edge-non-binding-reference-qyrwr.json
+++ b/models/azure-network/azureserviceoperator_customresourcedefinitions_v2.13.0.yaml/v1.0.0/relationships/edge-non-binding-reference-qyrwr.json
@@ -45,7 +45,8 @@
               "version": ""
             },
             "patch": {
-              "mutatedRef": [
+              "patchStrategy": "replace",
+              "mutatorRef": [
                 [
                   "configuration",
                   "spec",
@@ -64,8 +65,7 @@
                   "reference",
                   "name"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ],
@@ -87,7 +87,8 @@
               "version": ""
             },
             "patch": {
-              "mutatorRef": [
+              "patchStrategy": "replace",
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -101,8 +102,7 @@
                   "spec",
                   "name"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ]

--- a/models/azure-network/azureserviceoperator_customresourcedefinitions_v2.13.0.yaml/v1.0.0/relationships/edge-non-binding-reference-sxtjb.json
+++ b/models/azure-network/azureserviceoperator_customresourcedefinitions_v2.13.0.yaml/v1.0.0/relationships/edge-non-binding-reference-sxtjb.json
@@ -45,7 +45,8 @@
               "version": ""
             },
             "patch": {
-              "mutatedRef": [
+              "patchStrategy": "replace",
+              "mutatorRef": [
                 [
                   "configuration",
                   "spec",
@@ -64,8 +65,7 @@
                   "reference",
                   "name"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ],
@@ -87,7 +87,8 @@
               "version": ""
             },
             "patch": {
-              "mutatorRef": [
+              "patchStrategy": "replace",
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -101,8 +102,7 @@
                   "spec",
                   "name"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ]

--- a/models/azure-network/azureserviceoperator_customresourcedefinitions_v2.13.0.yaml/v1.0.0/relationships/edge-non-binding-reference-szsmt.json
+++ b/models/azure-network/azureserviceoperator_customresourcedefinitions_v2.13.0.yaml/v1.0.0/relationships/edge-non-binding-reference-szsmt.json
@@ -45,7 +45,8 @@
               "version": ""
             },
             "patch": {
-              "mutatedRef": [
+              "patchStrategy": "replace",
+              "mutatorRef": [
                 [
                   "configuration",
                   "spec",
@@ -64,8 +65,7 @@
                   "targetResourceReference",
                   "name"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ],
@@ -87,7 +87,8 @@
               "version": ""
             },
             "patch": {
-              "mutatorRef": [
+              "patchStrategy": "replace",
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -101,8 +102,7 @@
                   "spec",
                   "name"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ]

--- a/models/azure-network/azureserviceoperator_customresourcedefinitions_v2.13.0.yaml/v1.0.0/relationships/edge-non-binding-reference-tncec.json
+++ b/models/azure-network/azureserviceoperator_customresourcedefinitions_v2.13.0.yaml/v1.0.0/relationships/edge-non-binding-reference-tncec.json
@@ -45,7 +45,8 @@
               "version": ""
             },
             "patch": {
-              "mutatedRef": [
+              "patchStrategy": "replace",
+              "mutatorRef": [
                 [
                   "configuration",
                   "spec",
@@ -64,8 +65,7 @@
                   "reference",
                   "name"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ],
@@ -87,7 +87,8 @@
               "version": ""
             },
             "patch": {
-              "mutatorRef": [
+              "patchStrategy": "replace",
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -101,8 +102,7 @@
                   "spec",
                   "name"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ]

--- a/models/azure-network/azureserviceoperator_customresourcedefinitions_v2.13.0.yaml/v1.0.0/relationships/edge-non-binding-reference-vymxt.json
+++ b/models/azure-network/azureserviceoperator_customresourcedefinitions_v2.13.0.yaml/v1.0.0/relationships/edge-non-binding-reference-vymxt.json
@@ -45,7 +45,8 @@
               "version": ""
             },
             "patch": {
-              "mutatedRef": [
+              "patchStrategy": "replace",
+              "mutatorRef": [
                 [
                   "configuration",
                   "spec",
@@ -64,8 +65,7 @@
                   "publicIPReference",
                   "name"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ],
@@ -87,7 +87,8 @@
               "version": ""
             },
             "patch": {
-              "mutatorRef": [
+              "patchStrategy": "replace",
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -101,8 +102,7 @@
                   "spec",
                   "name"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ]

--- a/models/azure-network/azureserviceoperator_customresourcedefinitions_v2.13.0.yaml/v1.0.0/relationships/edge-non-binding-reference-ycsfs.json
+++ b/models/azure-network/azureserviceoperator_customresourcedefinitions_v2.13.0.yaml/v1.0.0/relationships/edge-non-binding-reference-ycsfs.json
@@ -45,7 +45,8 @@
               "version": ""
             },
             "patch": {
-              "mutatedRef": [
+              "patchStrategy": "replace",
+              "mutatorRef": [
                 [
                   "configuration",
                   "spec",
@@ -64,8 +65,7 @@
                   "reference",
                   "name"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ],
@@ -87,7 +87,8 @@
               "version": ""
             },
             "patch": {
-              "mutatorRef": [
+              "patchStrategy": "replace",
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -101,8 +102,7 @@
                   "spec",
                   "name"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ]

--- a/models/azure-network/azureserviceoperator_customresourcedefinitions_v2.13.0.yaml/v1.0.0/relationships/edge-non-binding-reference-yhpdu.json
+++ b/models/azure-network/azureserviceoperator_customresourcedefinitions_v2.13.0.yaml/v1.0.0/relationships/edge-non-binding-reference-yhpdu.json
@@ -45,7 +45,8 @@
               "version": ""
             },
             "patch": {
-              "mutatedRef": [
+              "patchStrategy": "replace",
+              "mutatorRef": [
                 [
                   "configuration",
                   "spec",
@@ -64,8 +65,7 @@
                   "privateDnsZoneReference",
                   "name"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ],
@@ -87,7 +87,8 @@
               "version": ""
             },
             "patch": {
-              "mutatorRef": [
+              "patchStrategy": "replace",
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -101,8 +102,7 @@
                   "spec",
                   "name"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ]

--- a/models/azure-network/azureserviceoperator_customresourcedefinitions_v2.13.0.yaml/v1.0.0/relationships/edge-non-binding-reference-ypqua.json
+++ b/models/azure-network/azureserviceoperator_customresourcedefinitions_v2.13.0.yaml/v1.0.0/relationships/edge-non-binding-reference-ypqua.json
@@ -45,7 +45,8 @@
               "version": ""
             },
             "patch": {
-              "mutatedRef": [
+              "patchStrategy": "replace",
+              "mutatorRef": [
                 [
                   "configuration",
                   "spec",
@@ -64,8 +65,7 @@
                   "reference",
                   "name"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ],
@@ -87,7 +87,8 @@
               "version": ""
             },
             "patch": {
-              "mutatorRef": [
+              "patchStrategy": "replace",
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -101,8 +102,7 @@
                   "spec",
                   "name"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ]

--- a/models/azure-network/azureserviceoperator_customresourcedefinitions_v2.13.0.yaml/v1.0.0/relationships/hierarchical-parent-inventory-auepj.json
+++ b/models/azure-network/azureserviceoperator_customresourcedefinitions_v2.13.0.yaml/v1.0.0/relationships/hierarchical-parent-inventory-auepj.json
@@ -45,15 +45,15 @@
               "version": ""
             },
             "patch": {
-              "mutatedRef": [
+              "patchStrategy": "replace",
+              "mutatorRef": [
                 [
                   "configuration",
                   "spec",
                   "owner",
                   "name"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ],
@@ -75,12 +75,12 @@
               "version": ""
             },
             "patch": {
-              "mutatorRef": [
+              "patchStrategy": "replace",
+              "mutatedRef": [
                 [
                   "displayName"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ]

--- a/models/azure-network/azureserviceoperator_customresourcedefinitions_v2.13.0.yaml/v1.0.0/relationships/hierarchical-parent-inventory-bdauh.json
+++ b/models/azure-network/azureserviceoperator_customresourcedefinitions_v2.13.0.yaml/v1.0.0/relationships/hierarchical-parent-inventory-bdauh.json
@@ -45,15 +45,15 @@
               "version": ""
             },
             "patch": {
-              "mutatedRef": [
+              "patchStrategy": "replace",
+              "mutatorRef": [
                 [
                   "configuration",
                   "spec",
                   "owner",
                   "name"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ],
@@ -75,12 +75,12 @@
               "version": ""
             },
             "patch": {
-              "mutatorRef": [
+              "patchStrategy": "replace",
+              "mutatedRef": [
                 [
                   "displayName"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ]

--- a/models/azure-network/azureserviceoperator_customresourcedefinitions_v2.13.0.yaml/v1.0.0/relationships/hierarchical-parent-inventory-bsxdq.json
+++ b/models/azure-network/azureserviceoperator_customresourcedefinitions_v2.13.0.yaml/v1.0.0/relationships/hierarchical-parent-inventory-bsxdq.json
@@ -45,15 +45,15 @@
               "version": ""
             },
             "patch": {
-              "mutatedRef": [
+              "patchStrategy": "replace",
+              "mutatorRef": [
                 [
                   "configuration",
                   "spec",
                   "owner",
                   "name"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ],
@@ -75,12 +75,12 @@
               "version": ""
             },
             "patch": {
-              "mutatorRef": [
+              "patchStrategy": "replace",
+              "mutatedRef": [
                 [
                   "displayName"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ]

--- a/models/azure-network/azureserviceoperator_customresourcedefinitions_v2.13.0.yaml/v1.0.0/relationships/hierarchical-parent-inventory-crveh.json
+++ b/models/azure-network/azureserviceoperator_customresourcedefinitions_v2.13.0.yaml/v1.0.0/relationships/hierarchical-parent-inventory-crveh.json
@@ -45,15 +45,15 @@
               "version": ""
             },
             "patch": {
-              "mutatedRef": [
+              "patchStrategy": "replace",
+              "mutatorRef": [
                 [
                   "configuration",
                   "spec",
                   "owner",
                   "name"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ],
@@ -75,12 +75,12 @@
               "version": ""
             },
             "patch": {
-              "mutatorRef": [
+              "patchStrategy": "replace",
+              "mutatedRef": [
                 [
                   "displayName"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ]

--- a/models/azure-network/azureserviceoperator_customresourcedefinitions_v2.13.0.yaml/v1.0.0/relationships/hierarchical-parent-inventory-ddtix.json
+++ b/models/azure-network/azureserviceoperator_customresourcedefinitions_v2.13.0.yaml/v1.0.0/relationships/hierarchical-parent-inventory-ddtix.json
@@ -45,15 +45,15 @@
               "version": ""
             },
             "patch": {
-              "mutatedRef": [
+              "patchStrategy": "replace",
+              "mutatorRef": [
                 [
                   "configuration",
                   "spec",
                   "owner",
                   "name"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ],
@@ -75,12 +75,12 @@
               "version": ""
             },
             "patch": {
-              "mutatorRef": [
+              "patchStrategy": "replace",
+              "mutatedRef": [
                 [
                   "displayName"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ]

--- a/models/azure-network/azureserviceoperator_customresourcedefinitions_v2.13.0.yaml/v1.0.0/relationships/hierarchical-parent-inventory-dlzlx.json
+++ b/models/azure-network/azureserviceoperator_customresourcedefinitions_v2.13.0.yaml/v1.0.0/relationships/hierarchical-parent-inventory-dlzlx.json
@@ -45,15 +45,15 @@
               "version": ""
             },
             "patch": {
-              "mutatedRef": [
+              "patchStrategy": "replace",
+              "mutatorRef": [
                 [
                   "configuration",
                   "spec",
                   "owner",
                   "name"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ],
@@ -75,12 +75,12 @@
               "version": ""
             },
             "patch": {
-              "mutatorRef": [
+              "patchStrategy": "replace",
+              "mutatedRef": [
                 [
                   "displayName"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ]

--- a/models/azure-network/azureserviceoperator_customresourcedefinitions_v2.13.0.yaml/v1.0.0/relationships/hierarchical-parent-inventory-doulx.json
+++ b/models/azure-network/azureserviceoperator_customresourcedefinitions_v2.13.0.yaml/v1.0.0/relationships/hierarchical-parent-inventory-doulx.json
@@ -45,15 +45,15 @@
               "version": ""
             },
             "patch": {
-              "mutatedRef": [
+              "patchStrategy": "replace",
+              "mutatorRef": [
                 [
                   "configuration",
                   "spec",
                   "owner",
                   "name"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ],
@@ -75,12 +75,12 @@
               "version": ""
             },
             "patch": {
-              "mutatorRef": [
+              "patchStrategy": "replace",
+              "mutatedRef": [
                 [
                   "displayName"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ]

--- a/models/azure-network/azureserviceoperator_customresourcedefinitions_v2.13.0.yaml/v1.0.0/relationships/hierarchical-parent-inventory-ebdjd.json
+++ b/models/azure-network/azureserviceoperator_customresourcedefinitions_v2.13.0.yaml/v1.0.0/relationships/hierarchical-parent-inventory-ebdjd.json
@@ -45,15 +45,15 @@
               "version": ""
             },
             "patch": {
-              "mutatedRef": [
+              "patchStrategy": "replace",
+              "mutatorRef": [
                 [
                   "configuration",
                   "spec",
                   "owner",
                   "name"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ],
@@ -75,12 +75,12 @@
               "version": ""
             },
             "patch": {
-              "mutatorRef": [
+              "patchStrategy": "replace",
+              "mutatedRef": [
                 [
                   "displayName"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ]

--- a/models/azure-network/azureserviceoperator_customresourcedefinitions_v2.13.0.yaml/v1.0.0/relationships/hierarchical-parent-inventory-gahtg.json
+++ b/models/azure-network/azureserviceoperator_customresourcedefinitions_v2.13.0.yaml/v1.0.0/relationships/hierarchical-parent-inventory-gahtg.json
@@ -45,15 +45,15 @@
               "version": ""
             },
             "patch": {
-              "mutatedRef": [
+              "patchStrategy": "replace",
+              "mutatorRef": [
                 [
                   "configuration",
                   "spec",
                   "owner",
                   "name"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ],
@@ -75,12 +75,12 @@
               "version": ""
             },
             "patch": {
-              "mutatorRef": [
+              "patchStrategy": "replace",
+              "mutatedRef": [
                 [
                   "displayName"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ]

--- a/models/azure-network/azureserviceoperator_customresourcedefinitions_v2.13.0.yaml/v1.0.0/relationships/hierarchical-parent-inventory-gnpow.json
+++ b/models/azure-network/azureserviceoperator_customresourcedefinitions_v2.13.0.yaml/v1.0.0/relationships/hierarchical-parent-inventory-gnpow.json
@@ -45,15 +45,15 @@
               "version": ""
             },
             "patch": {
-              "mutatedRef": [
+              "patchStrategy": "replace",
+              "mutatorRef": [
                 [
                   "configuration",
                   "spec",
                   "owner",
                   "name"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ],
@@ -75,12 +75,12 @@
               "version": ""
             },
             "patch": {
-              "mutatorRef": [
+              "patchStrategy": "replace",
+              "mutatedRef": [
                 [
                   "displayName"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ]

--- a/models/azure-network/azureserviceoperator_customresourcedefinitions_v2.13.0.yaml/v1.0.0/relationships/hierarchical-parent-inventory-gxrgg.json
+++ b/models/azure-network/azureserviceoperator_customresourcedefinitions_v2.13.0.yaml/v1.0.0/relationships/hierarchical-parent-inventory-gxrgg.json
@@ -45,15 +45,15 @@
               "version": ""
             },
             "patch": {
-              "mutatedRef": [
+              "patchStrategy": "replace",
+              "mutatorRef": [
                 [
                   "configuration",
                   "spec",
                   "owner",
                   "name"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ],
@@ -75,12 +75,12 @@
               "version": ""
             },
             "patch": {
-              "mutatorRef": [
+              "patchStrategy": "replace",
+              "mutatedRef": [
                 [
                   "displayName"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ]

--- a/models/azure-network/azureserviceoperator_customresourcedefinitions_v2.13.0.yaml/v1.0.0/relationships/hierarchical-parent-inventory-hhlaj.json
+++ b/models/azure-network/azureserviceoperator_customresourcedefinitions_v2.13.0.yaml/v1.0.0/relationships/hierarchical-parent-inventory-hhlaj.json
@@ -45,15 +45,15 @@
               "version": ""
             },
             "patch": {
-              "mutatedRef": [
+              "patchStrategy": "replace",
+              "mutatorRef": [
                 [
                   "configuration",
                   "spec",
                   "owner",
                   "name"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ],
@@ -75,12 +75,12 @@
               "version": ""
             },
             "patch": {
-              "mutatorRef": [
+              "patchStrategy": "replace",
+              "mutatedRef": [
                 [
                   "displayName"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ]

--- a/models/azure-network/azureserviceoperator_customresourcedefinitions_v2.13.0.yaml/v1.0.0/relationships/hierarchical-parent-inventory-jsdxn.json
+++ b/models/azure-network/azureserviceoperator_customresourcedefinitions_v2.13.0.yaml/v1.0.0/relationships/hierarchical-parent-inventory-jsdxn.json
@@ -45,15 +45,15 @@
               "version": ""
             },
             "patch": {
-              "mutatedRef": [
+              "patchStrategy": "replace",
+              "mutatorRef": [
                 [
                   "configuration",
                   "spec",
                   "owner",
                   "name"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ],
@@ -75,12 +75,12 @@
               "version": ""
             },
             "patch": {
-              "mutatorRef": [
+              "patchStrategy": "replace",
+              "mutatedRef": [
                 [
                   "displayName"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ]

--- a/models/azure-network/azureserviceoperator_customresourcedefinitions_v2.13.0.yaml/v1.0.0/relationships/hierarchical-parent-inventory-kjdyg.json
+++ b/models/azure-network/azureserviceoperator_customresourcedefinitions_v2.13.0.yaml/v1.0.0/relationships/hierarchical-parent-inventory-kjdyg.json
@@ -45,15 +45,15 @@
               "version": ""
             },
             "patch": {
-              "mutatedRef": [
+              "patchStrategy": "replace",
+              "mutatorRef": [
                 [
                   "configuration",
                   "spec",
                   "owner",
                   "name"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ],
@@ -75,12 +75,12 @@
               "version": ""
             },
             "patch": {
-              "mutatorRef": [
+              "patchStrategy": "replace",
+              "mutatedRef": [
                 [
                   "displayName"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ]

--- a/models/azure-network/azureserviceoperator_customresourcedefinitions_v2.13.0.yaml/v1.0.0/relationships/hierarchical-parent-inventory-kmjea.json
+++ b/models/azure-network/azureserviceoperator_customresourcedefinitions_v2.13.0.yaml/v1.0.0/relationships/hierarchical-parent-inventory-kmjea.json
@@ -91,7 +91,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatedRef": [
+              "mutatorRef": [
                 [
                   "configuration",
                   "spec",
@@ -156,7 +156,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"

--- a/models/azure-network/azureserviceoperator_customresourcedefinitions_v2.13.0.yaml/v1.0.0/relationships/hierarchical-parent-inventory-kxyok.json
+++ b/models/azure-network/azureserviceoperator_customresourcedefinitions_v2.13.0.yaml/v1.0.0/relationships/hierarchical-parent-inventory-kxyok.json
@@ -45,15 +45,15 @@
               "version": ""
             },
             "patch": {
-              "mutatedRef": [
+              "patchStrategy": "replace",
+              "mutatorRef": [
                 [
                   "configuration",
                   "spec",
                   "owner",
                   "name"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ],
@@ -75,12 +75,12 @@
               "version": ""
             },
             "patch": {
-              "mutatorRef": [
+              "patchStrategy": "replace",
+              "mutatedRef": [
                 [
                   "displayName"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ]

--- a/models/azure-network/azureserviceoperator_customresourcedefinitions_v2.13.0.yaml/v1.0.0/relationships/hierarchical-parent-inventory-mbmny.json
+++ b/models/azure-network/azureserviceoperator_customresourcedefinitions_v2.13.0.yaml/v1.0.0/relationships/hierarchical-parent-inventory-mbmny.json
@@ -45,15 +45,15 @@
               "version": ""
             },
             "patch": {
-              "mutatedRef": [
+              "patchStrategy": "replace",
+              "mutatorRef": [
                 [
                   "configuration",
                   "spec",
                   "owner",
                   "name"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ],
@@ -75,12 +75,12 @@
               "version": ""
             },
             "patch": {
-              "mutatorRef": [
+              "patchStrategy": "replace",
+              "mutatedRef": [
                 [
                   "displayName"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ]

--- a/models/azure-network/azureserviceoperator_customresourcedefinitions_v2.13.0.yaml/v1.0.0/relationships/hierarchical-parent-inventory-oimpd.json
+++ b/models/azure-network/azureserviceoperator_customresourcedefinitions_v2.13.0.yaml/v1.0.0/relationships/hierarchical-parent-inventory-oimpd.json
@@ -45,15 +45,15 @@
               "version": ""
             },
             "patch": {
-              "mutatedRef": [
+              "patchStrategy": "replace",
+              "mutatorRef": [
                 [
                   "configuration",
                   "spec",
                   "owner",
                   "name"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ],
@@ -75,12 +75,12 @@
               "version": ""
             },
             "patch": {
-              "mutatorRef": [
+              "patchStrategy": "replace",
+              "mutatedRef": [
                 [
                   "displayName"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ]

--- a/models/azure-network/azureserviceoperator_customresourcedefinitions_v2.13.0.yaml/v1.0.0/relationships/hierarchical-parent-inventory-prswt.json
+++ b/models/azure-network/azureserviceoperator_customresourcedefinitions_v2.13.0.yaml/v1.0.0/relationships/hierarchical-parent-inventory-prswt.json
@@ -45,15 +45,15 @@
               "version": ""
             },
             "patch": {
-              "mutatedRef": [
+              "patchStrategy": "replace",
+              "mutatorRef": [
                 [
                   "configuration",
                   "spec",
                   "owner",
                   "name"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ],
@@ -75,12 +75,12 @@
               "version": ""
             },
             "patch": {
-              "mutatorRef": [
+              "patchStrategy": "replace",
+              "mutatedRef": [
                 [
                   "displayName"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ]

--- a/models/azure-network/azureserviceoperator_customresourcedefinitions_v2.13.0.yaml/v1.0.0/relationships/hierarchical-parent-inventory-pvcbv.json
+++ b/models/azure-network/azureserviceoperator_customresourcedefinitions_v2.13.0.yaml/v1.0.0/relationships/hierarchical-parent-inventory-pvcbv.json
@@ -45,15 +45,15 @@
               "version": ""
             },
             "patch": {
-              "mutatedRef": [
+              "patchStrategy": "replace",
+              "mutatorRef": [
                 [
                   "configuration",
                   "spec",
                   "owner",
                   "name"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ],
@@ -75,12 +75,12 @@
               "version": ""
             },
             "patch": {
-              "mutatorRef": [
+              "patchStrategy": "replace",
+              "mutatedRef": [
                 [
                   "displayName"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ]

--- a/models/azure-network/azureserviceoperator_customresourcedefinitions_v2.13.0.yaml/v1.0.0/relationships/hierarchical-parent-inventory-sbpxf.json
+++ b/models/azure-network/azureserviceoperator_customresourcedefinitions_v2.13.0.yaml/v1.0.0/relationships/hierarchical-parent-inventory-sbpxf.json
@@ -45,15 +45,15 @@
               "version": ""
             },
             "patch": {
-              "mutatedRef": [
+              "patchStrategy": "replace",
+              "mutatorRef": [
                 [
                   "configuration",
                   "spec",
                   "owner",
                   "name"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ],
@@ -75,12 +75,12 @@
               "version": ""
             },
             "patch": {
-              "mutatorRef": [
+              "patchStrategy": "replace",
+              "mutatedRef": [
                 [
                   "displayName"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ]

--- a/models/azure-network/azureserviceoperator_customresourcedefinitions_v2.13.0.yaml/v1.0.0/relationships/hierarchical-parent-inventory-tbcpq.json
+++ b/models/azure-network/azureserviceoperator_customresourcedefinitions_v2.13.0.yaml/v1.0.0/relationships/hierarchical-parent-inventory-tbcpq.json
@@ -45,15 +45,15 @@
               "version": ""
             },
             "patch": {
-              "mutatedRef": [
+              "patchStrategy": "replace",
+              "mutatorRef": [
                 [
                   "configuration",
                   "spec",
                   "owner",
                   "name"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ],
@@ -75,12 +75,12 @@
               "version": ""
             },
             "patch": {
-              "mutatorRef": [
+              "patchStrategy": "replace",
+              "mutatedRef": [
                 [
                   "displayName"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ]

--- a/models/azure-network/azureserviceoperator_customresourcedefinitions_v2.13.0.yaml/v1.0.0/relationships/hierarchical-parent-inventory-wcqpe.json
+++ b/models/azure-network/azureserviceoperator_customresourcedefinitions_v2.13.0.yaml/v1.0.0/relationships/hierarchical-parent-inventory-wcqpe.json
@@ -45,15 +45,15 @@
               "version": ""
             },
             "patch": {
-              "mutatedRef": [
+              "patchStrategy": "replace",
+              "mutatorRef": [
                 [
                   "configuration",
                   "spec",
                   "owner",
                   "name"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ],
@@ -75,12 +75,12 @@
               "version": ""
             },
             "patch": {
-              "mutatorRef": [
+              "patchStrategy": "replace",
+              "mutatedRef": [
                 [
                   "displayName"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ]

--- a/models/azure-network/azureserviceoperator_customresourcedefinitions_v2.13.0.yaml/v1.0.0/relationships/hierarchical-parent-inventory-wjzbn.json
+++ b/models/azure-network/azureserviceoperator_customresourcedefinitions_v2.13.0.yaml/v1.0.0/relationships/hierarchical-parent-inventory-wjzbn.json
@@ -45,15 +45,15 @@
               "version": ""
             },
             "patch": {
-              "mutatedRef": [
+              "patchStrategy": "replace",
+              "mutatorRef": [
                 [
                   "configuration",
                   "spec",
                   "owner",
                   "name"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ],
@@ -75,12 +75,12 @@
               "version": ""
             },
             "patch": {
-              "mutatorRef": [
+              "patchStrategy": "replace",
+              "mutatedRef": [
                 [
                   "displayName"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ]

--- a/models/azure-network/azureserviceoperator_customresourcedefinitions_v2.13.0.yaml/v1.0.0/relationships/hierarchical-parent-inventory-ycetf.json
+++ b/models/azure-network/azureserviceoperator_customresourcedefinitions_v2.13.0.yaml/v1.0.0/relationships/hierarchical-parent-inventory-ycetf.json
@@ -45,15 +45,15 @@
               "version": ""
             },
             "patch": {
-              "mutatedRef": [
+              "patchStrategy": "replace",
+              "mutatorRef": [
                 [
                   "configuration",
                   "spec",
                   "owner",
                   "name"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ],
@@ -75,12 +75,12 @@
               "version": ""
             },
             "patch": {
-              "mutatorRef": [
+              "patchStrategy": "replace",
+              "mutatedRef": [
                 [
                   "displayName"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ]

--- a/models/azure-network/azureserviceoperator_customresourcedefinitions_v2.13.0.yaml/v1.0.0/relationships/hierarchical-parent-inventory-ydjtj.json
+++ b/models/azure-network/azureserviceoperator_customresourcedefinitions_v2.13.0.yaml/v1.0.0/relationships/hierarchical-parent-inventory-ydjtj.json
@@ -45,15 +45,15 @@
               "version": ""
             },
             "patch": {
-              "mutatedRef": [
+              "patchStrategy": "replace",
+              "mutatorRef": [
                 [
                   "configuration",
                   "spec",
                   "owner",
                   "name"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ],
@@ -75,12 +75,12 @@
               "version": ""
             },
             "patch": {
-              "mutatorRef": [
+              "patchStrategy": "replace",
+              "mutatedRef": [
                 [
                   "displayName"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ]

--- a/models/azure-network/azureserviceoperator_customresourcedefinitions_v2.13.0.yaml/v1.0.0/relationships/hierarchical-parent-inventory-yikoi.json
+++ b/models/azure-network/azureserviceoperator_customresourcedefinitions_v2.13.0.yaml/v1.0.0/relationships/hierarchical-parent-inventory-yikoi.json
@@ -45,15 +45,15 @@
               "version": ""
             },
             "patch": {
-              "mutatedRef": [
+              "patchStrategy": "replace",
+              "mutatorRef": [
                 [
                   "configuration",
                   "spec",
                   "owner",
                   "name"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ],
@@ -75,12 +75,12 @@
               "version": ""
             },
             "patch": {
-              "mutatorRef": [
+              "patchStrategy": "replace",
+              "mutatedRef": [
                 [
                   "displayName"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ]

--- a/models/azure-network/azureserviceoperator_customresourcedefinitions_v2.13.0.yaml/v1.0.0/relationships/hierarchical-parent-inventory-zfrsp.json
+++ b/models/azure-network/azureserviceoperator_customresourcedefinitions_v2.13.0.yaml/v1.0.0/relationships/hierarchical-parent-inventory-zfrsp.json
@@ -45,15 +45,15 @@
               "version": ""
             },
             "patch": {
-              "mutatedRef": [
+              "patchStrategy": "replace",
+              "mutatorRef": [
                 [
                   "configuration",
                   "spec",
                   "owner",
                   "name"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ],
@@ -75,12 +75,12 @@
               "version": ""
             },
             "patch": {
-              "mutatorRef": [
+              "patchStrategy": "replace",
+              "mutatedRef": [
                 [
                   "displayName"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ]

--- a/models/azure-network/azureserviceoperator_customresourcedefinitions_v2.13.0.yaml/v1.0.0/relationships/hierarchical-parent-inventory-zhlpp.json
+++ b/models/azure-network/azureserviceoperator_customresourcedefinitions_v2.13.0.yaml/v1.0.0/relationships/hierarchical-parent-inventory-zhlpp.json
@@ -45,15 +45,15 @@
               "version": ""
             },
             "patch": {
-              "mutatedRef": [
+              "patchStrategy": "replace",
+              "mutatorRef": [
                 [
                   "configuration",
                   "spec",
                   "owner",
                   "name"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ],
@@ -75,12 +75,12 @@
               "version": ""
             },
             "patch": {
-              "mutatorRef": [
+              "patchStrategy": "replace",
+              "mutatedRef": [
                 [
                   "displayName"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ]

--- a/models/azure-network/azureserviceoperator_customresourcedefinitions_v2.13.0.yaml/v1.0.0/relationships/hierarchical-parent-inventory-zkyqp.json
+++ b/models/azure-network/azureserviceoperator_customresourcedefinitions_v2.13.0.yaml/v1.0.0/relationships/hierarchical-parent-inventory-zkyqp.json
@@ -45,15 +45,15 @@
               "version": ""
             },
             "patch": {
-              "mutatedRef": [
+              "patchStrategy": "replace",
+              "mutatorRef": [
                 [
                   "configuration",
                   "spec",
                   "owner",
                   "name"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ],
@@ -75,12 +75,12 @@
               "version": ""
             },
             "patch": {
-              "mutatorRef": [
+              "patchStrategy": "replace",
+              "mutatedRef": [
                 [
                   "displayName"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ]

--- a/models/azure-network/azureserviceoperator_customresourcedefinitions_v2.13.0.yaml/v1.0.0/relationships/hierarchical-parent-inventory-zofbt.json
+++ b/models/azure-network/azureserviceoperator_customresourcedefinitions_v2.13.0.yaml/v1.0.0/relationships/hierarchical-parent-inventory-zofbt.json
@@ -45,15 +45,15 @@
               "version": ""
             },
             "patch": {
-              "mutatedRef": [
+              "patchStrategy": "replace",
+              "mutatorRef": [
                 [
                   "configuration",
                   "spec",
                   "owner",
                   "name"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ],
@@ -75,12 +75,12 @@
               "version": ""
             },
             "patch": {
-              "mutatorRef": [
+              "patchStrategy": "replace",
+              "mutatedRef": [
                 [
                   "displayName"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ]

--- a/models/azure-network/azureserviceoperator_customresourcedefinitions_v2.14.0.yaml/v1.0.0/relationships/edge-non-binding-reference-anqgu.json
+++ b/models/azure-network/azureserviceoperator_customresourcedefinitions_v2.14.0.yaml/v1.0.0/relationships/edge-non-binding-reference-anqgu.json
@@ -45,7 +45,8 @@
               "version": ""
             },
             "patch": {
-              "mutatedRef": [
+              "patchStrategy": "replace",
+              "mutatorRef": [
                 [
                   "configuration",
                   "spec",
@@ -64,8 +65,7 @@
                   "reference",
                   "name"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ],
@@ -87,7 +87,8 @@
               "version": ""
             },
             "patch": {
-              "mutatorRef": [
+              "patchStrategy": "replace",
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -101,8 +102,7 @@
                   "spec",
                   "name"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ]

--- a/models/azure-network/azureserviceoperator_customresourcedefinitions_v2.14.0.yaml/v1.0.0/relationships/edge-non-binding-reference-crtzt.json
+++ b/models/azure-network/azureserviceoperator_customresourcedefinitions_v2.14.0.yaml/v1.0.0/relationships/edge-non-binding-reference-crtzt.json
@@ -45,7 +45,8 @@
               "version": ""
             },
             "patch": {
-              "mutatedRef": [
+              "patchStrategy": "replace",
+              "mutatorRef": [
                 [
                   "configuration",
                   "spec",
@@ -64,8 +65,7 @@
                   "reference1",
                   "name"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ],
@@ -87,7 +87,8 @@
               "version": ""
             },
             "patch": {
-              "mutatorRef": [
+              "patchStrategy": "replace",
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -101,8 +102,7 @@
                   "spec",
                   "name"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ]

--- a/models/azure-network/azureserviceoperator_customresourcedefinitions_v2.14.0.yaml/v1.0.0/relationships/edge-non-binding-reference-ctxsr.json
+++ b/models/azure-network/azureserviceoperator_customresourcedefinitions_v2.14.0.yaml/v1.0.0/relationships/edge-non-binding-reference-ctxsr.json
@@ -45,7 +45,8 @@
               "version": ""
             },
             "patch": {
-              "mutatedRef": [
+              "patchStrategy": "replace",
+              "mutatorRef": [
                 [
                   "configuration",
                   "spec",
@@ -64,8 +65,7 @@
                   "reference1",
                   "name"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ],
@@ -87,7 +87,8 @@
               "version": ""
             },
             "patch": {
-              "mutatorRef": [
+              "patchStrategy": "replace",
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -101,8 +102,7 @@
                   "spec",
                   "name"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ]

--- a/models/azure-network/azureserviceoperator_customresourcedefinitions_v2.14.0.yaml/v1.0.0/relationships/edge-non-binding-reference-dqsei.json
+++ b/models/azure-network/azureserviceoperator_customresourcedefinitions_v2.14.0.yaml/v1.0.0/relationships/edge-non-binding-reference-dqsei.json
@@ -45,7 +45,8 @@
               "version": ""
             },
             "patch": {
-              "mutatedRef": [
+              "patchStrategy": "replace",
+              "mutatorRef": [
                 [
                   "configuration",
                   "spec",
@@ -64,8 +65,7 @@
                   "firewallPolicy",
                   "name"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ],
@@ -87,7 +87,8 @@
               "version": ""
             },
             "patch": {
-              "mutatorRef": [
+              "patchStrategy": "replace",
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -101,8 +102,7 @@
                   "spec",
                   "name"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ]

--- a/models/azure-network/azureserviceoperator_customresourcedefinitions_v2.14.0.yaml/v1.0.0/relationships/edge-non-binding-reference-eblaq.json
+++ b/models/azure-network/azureserviceoperator_customresourcedefinitions_v2.14.0.yaml/v1.0.0/relationships/edge-non-binding-reference-eblaq.json
@@ -45,7 +45,8 @@
               "version": ""
             },
             "patch": {
-              "mutatedRef": [
+              "patchStrategy": "replace",
+              "mutatorRef": [
                 [
                   "configuration",
                   "spec",
@@ -64,8 +65,7 @@
                   "reference2",
                   "name"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ],
@@ -87,7 +87,8 @@
               "version": ""
             },
             "patch": {
-              "mutatorRef": [
+              "patchStrategy": "replace",
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -101,8 +102,7 @@
                   "spec",
                   "name"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ]

--- a/models/azure-network/azureserviceoperator_customresourcedefinitions_v2.14.0.yaml/v1.0.0/relationships/edge-non-binding-reference-ewtcj.json
+++ b/models/azure-network/azureserviceoperator_customresourcedefinitions_v2.14.0.yaml/v1.0.0/relationships/edge-non-binding-reference-ewtcj.json
@@ -45,7 +45,8 @@
               "version": ""
             },
             "patch": {
-              "mutatedRef": [
+              "patchStrategy": "replace",
+              "mutatorRef": [
                 [
                   "configuration",
                   "spec",
@@ -64,8 +65,7 @@
                   "reference",
                   "name"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ],
@@ -87,7 +87,8 @@
               "version": ""
             },
             "patch": {
-              "mutatorRef": [
+              "patchStrategy": "replace",
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -101,8 +102,7 @@
                   "spec",
                   "name"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ]

--- a/models/azure-network/azureserviceoperator_customresourcedefinitions_v2.14.0.yaml/v1.0.0/relationships/edge-non-binding-reference-gyaoi.json
+++ b/models/azure-network/azureserviceoperator_customresourcedefinitions_v2.14.0.yaml/v1.0.0/relationships/edge-non-binding-reference-gyaoi.json
@@ -45,7 +45,8 @@
               "version": ""
             },
             "patch": {
-              "mutatedRef": [
+              "patchStrategy": "replace",
+              "mutatorRef": [
                 [
                   "configuration",
                   "spec",
@@ -64,8 +65,7 @@
                   "reference",
                   "name"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ],
@@ -87,7 +87,8 @@
               "version": ""
             },
             "patch": {
-              "mutatorRef": [
+              "patchStrategy": "replace",
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -101,8 +102,7 @@
                   "spec",
                   "name"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ]

--- a/models/azure-network/azureserviceoperator_customresourcedefinitions_v2.14.0.yaml/v1.0.0/relationships/edge-non-binding-reference-jkdks.json
+++ b/models/azure-network/azureserviceoperator_customresourcedefinitions_v2.14.0.yaml/v1.0.0/relationships/edge-non-binding-reference-jkdks.json
@@ -45,7 +45,8 @@
               "version": ""
             },
             "patch": {
-              "mutatedRef": [
+              "patchStrategy": "replace",
+              "mutatorRef": [
                 [
                   "configuration",
                   "spec",
@@ -64,8 +65,7 @@
                   "reference",
                   "name"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ],
@@ -87,7 +87,8 @@
               "version": ""
             },
             "patch": {
-              "mutatorRef": [
+              "patchStrategy": "replace",
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -101,8 +102,7 @@
                   "spec",
                   "name"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ]

--- a/models/azure-network/azureserviceoperator_customresourcedefinitions_v2.14.0.yaml/v1.0.0/relationships/edge-non-binding-reference-kutmc.json
+++ b/models/azure-network/azureserviceoperator_customresourcedefinitions_v2.14.0.yaml/v1.0.0/relationships/edge-non-binding-reference-kutmc.json
@@ -45,7 +45,8 @@
               "version": ""
             },
             "patch": {
-              "mutatedRef": [
+              "patchStrategy": "replace",
+              "mutatorRef": [
                 [
                   "configuration",
                   "spec",
@@ -64,8 +65,7 @@
                   "reference",
                   "name"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ],
@@ -87,7 +87,8 @@
               "version": ""
             },
             "patch": {
-              "mutatorRef": [
+              "patchStrategy": "replace",
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -101,8 +102,7 @@
                   "spec",
                   "name"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ]

--- a/models/azure-network/azureserviceoperator_customresourcedefinitions_v2.14.0.yaml/v1.0.0/relationships/edge-non-binding-reference-mbged.json
+++ b/models/azure-network/azureserviceoperator_customresourcedefinitions_v2.14.0.yaml/v1.0.0/relationships/edge-non-binding-reference-mbged.json
@@ -45,7 +45,8 @@
               "version": ""
             },
             "patch": {
-              "mutatedRef": [
+              "patchStrategy": "replace",
+              "mutatorRef": [
                 [
                   "configuration",
                   "spec",
@@ -64,8 +65,7 @@
                   "reference1",
                   "name"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ],
@@ -87,7 +87,8 @@
               "version": ""
             },
             "patch": {
-              "mutatorRef": [
+              "patchStrategy": "replace",
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -101,8 +102,7 @@
                   "spec",
                   "name"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ]

--- a/models/azure-network/azureserviceoperator_customresourcedefinitions_v2.14.0.yaml/v1.0.0/relationships/edge-non-binding-reference-mfgny.json
+++ b/models/azure-network/azureserviceoperator_customresourcedefinitions_v2.14.0.yaml/v1.0.0/relationships/edge-non-binding-reference-mfgny.json
@@ -45,7 +45,8 @@
               "version": ""
             },
             "patch": {
-              "mutatedRef": [
+              "patchStrategy": "replace",
+              "mutatorRef": [
                 [
                   "configuration",
                   "spec",
@@ -64,8 +65,7 @@
                   "reference1",
                   "name"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ],
@@ -87,7 +87,8 @@
               "version": ""
             },
             "patch": {
-              "mutatorRef": [
+              "patchStrategy": "replace",
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -101,8 +102,7 @@
                   "spec",
                   "name"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ]

--- a/models/azure-network/azureserviceoperator_customresourcedefinitions_v2.14.0.yaml/v1.0.0/relationships/edge-non-binding-reference-mnkbz.json
+++ b/models/azure-network/azureserviceoperator_customresourcedefinitions_v2.14.0.yaml/v1.0.0/relationships/edge-non-binding-reference-mnkbz.json
@@ -45,7 +45,8 @@
               "version": ""
             },
             "patch": {
-              "mutatedRef": [
+              "patchStrategy": "replace",
+              "mutatorRef": [
                 [
                   "configuration",
                   "spec",
@@ -64,8 +65,7 @@
                   "subnetReference",
                   "name"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ],
@@ -87,7 +87,8 @@
               "version": ""
             },
             "patch": {
-              "mutatorRef": [
+              "patchStrategy": "replace",
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -101,8 +102,7 @@
                   "spec",
                   "name"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ]

--- a/models/azure-network/azureserviceoperator_customresourcedefinitions_v2.14.0.yaml/v1.0.0/relationships/edge-non-binding-reference-omqpd.json
+++ b/models/azure-network/azureserviceoperator_customresourcedefinitions_v2.14.0.yaml/v1.0.0/relationships/edge-non-binding-reference-omqpd.json
@@ -45,7 +45,8 @@
               "version": ""
             },
             "patch": {
-              "mutatedRef": [
+              "patchStrategy": "replace",
+              "mutatorRef": [
                 [
                   "configuration",
                   "spec",
@@ -64,8 +65,7 @@
                   "privateLinkServiceReference",
                   "name"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ],
@@ -87,7 +87,8 @@
               "version": ""
             },
             "patch": {
-              "mutatorRef": [
+              "patchStrategy": "replace",
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -101,8 +102,7 @@
                   "spec",
                   "name"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ]

--- a/models/azure-network/azureserviceoperator_customresourcedefinitions_v2.14.0.yaml/v1.0.0/relationships/edge-non-binding-reference-pajdm.json
+++ b/models/azure-network/azureserviceoperator_customresourcedefinitions_v2.14.0.yaml/v1.0.0/relationships/edge-non-binding-reference-pajdm.json
@@ -45,7 +45,8 @@
               "version": ""
             },
             "patch": {
-              "mutatedRef": [
+              "patchStrategy": "replace",
+              "mutatorRef": [
                 [
                   "configuration",
                   "spec",
@@ -64,8 +65,7 @@
                   "reference",
                   "name"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ],
@@ -87,7 +87,8 @@
               "version": ""
             },
             "patch": {
-              "mutatorRef": [
+              "patchStrategy": "replace",
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -101,8 +102,7 @@
                   "spec",
                   "name"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ]

--- a/models/azure-network/azureserviceoperator_customresourcedefinitions_v2.14.0.yaml/v1.0.0/relationships/edge-non-binding-reference-qyrwr.json
+++ b/models/azure-network/azureserviceoperator_customresourcedefinitions_v2.14.0.yaml/v1.0.0/relationships/edge-non-binding-reference-qyrwr.json
@@ -45,7 +45,8 @@
               "version": ""
             },
             "patch": {
-              "mutatedRef": [
+              "patchStrategy": "replace",
+              "mutatorRef": [
                 [
                   "configuration",
                   "spec",
@@ -64,8 +65,7 @@
                   "reference",
                   "name"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ],
@@ -87,7 +87,8 @@
               "version": ""
             },
             "patch": {
-              "mutatorRef": [
+              "patchStrategy": "replace",
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -101,8 +102,7 @@
                   "spec",
                   "name"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ]

--- a/models/azure-network/azureserviceoperator_customresourcedefinitions_v2.14.0.yaml/v1.0.0/relationships/edge-non-binding-reference-sxtjb.json
+++ b/models/azure-network/azureserviceoperator_customresourcedefinitions_v2.14.0.yaml/v1.0.0/relationships/edge-non-binding-reference-sxtjb.json
@@ -45,7 +45,8 @@
               "version": ""
             },
             "patch": {
-              "mutatedRef": [
+              "patchStrategy": "replace",
+              "mutatorRef": [
                 [
                   "configuration",
                   "spec",
@@ -64,8 +65,7 @@
                   "reference",
                   "name"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ],
@@ -87,7 +87,8 @@
               "version": ""
             },
             "patch": {
-              "mutatorRef": [
+              "patchStrategy": "replace",
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -101,8 +102,7 @@
                   "spec",
                   "name"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ]

--- a/models/azure-network/azureserviceoperator_customresourcedefinitions_v2.14.0.yaml/v1.0.0/relationships/edge-non-binding-reference-szsmt.json
+++ b/models/azure-network/azureserviceoperator_customresourcedefinitions_v2.14.0.yaml/v1.0.0/relationships/edge-non-binding-reference-szsmt.json
@@ -45,7 +45,8 @@
               "version": ""
             },
             "patch": {
-              "mutatedRef": [
+              "patchStrategy": "replace",
+              "mutatorRef": [
                 [
                   "configuration",
                   "spec",
@@ -64,8 +65,7 @@
                   "targetResourceReference",
                   "name"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ],
@@ -87,7 +87,8 @@
               "version": ""
             },
             "patch": {
-              "mutatorRef": [
+              "patchStrategy": "replace",
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -101,8 +102,7 @@
                   "spec",
                   "name"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ]

--- a/models/azure-network/azureserviceoperator_customresourcedefinitions_v2.14.0.yaml/v1.0.0/relationships/edge-non-binding-reference-tncec.json
+++ b/models/azure-network/azureserviceoperator_customresourcedefinitions_v2.14.0.yaml/v1.0.0/relationships/edge-non-binding-reference-tncec.json
@@ -45,7 +45,8 @@
               "version": ""
             },
             "patch": {
-              "mutatedRef": [
+              "patchStrategy": "replace",
+              "mutatorRef": [
                 [
                   "configuration",
                   "spec",
@@ -64,8 +65,7 @@
                   "reference",
                   "name"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ],
@@ -87,7 +87,8 @@
               "version": ""
             },
             "patch": {
-              "mutatorRef": [
+              "patchStrategy": "replace",
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -101,8 +102,7 @@
                   "spec",
                   "name"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ]

--- a/models/azure-network/azureserviceoperator_customresourcedefinitions_v2.14.0.yaml/v1.0.0/relationships/edge-non-binding-reference-vymxt.json
+++ b/models/azure-network/azureserviceoperator_customresourcedefinitions_v2.14.0.yaml/v1.0.0/relationships/edge-non-binding-reference-vymxt.json
@@ -45,7 +45,8 @@
               "version": ""
             },
             "patch": {
-              "mutatedRef": [
+              "patchStrategy": "replace",
+              "mutatorRef": [
                 [
                   "configuration",
                   "spec",
@@ -64,8 +65,7 @@
                   "publicIPReference",
                   "name"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ],
@@ -87,7 +87,8 @@
               "version": ""
             },
             "patch": {
-              "mutatorRef": [
+              "patchStrategy": "replace",
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -101,8 +102,7 @@
                   "spec",
                   "name"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ]

--- a/models/azure-network/azureserviceoperator_customresourcedefinitions_v2.14.0.yaml/v1.0.0/relationships/edge-non-binding-reference-ycsfs.json
+++ b/models/azure-network/azureserviceoperator_customresourcedefinitions_v2.14.0.yaml/v1.0.0/relationships/edge-non-binding-reference-ycsfs.json
@@ -45,7 +45,8 @@
               "version": ""
             },
             "patch": {
-              "mutatedRef": [
+              "patchStrategy": "replace",
+              "mutatorRef": [
                 [
                   "configuration",
                   "spec",
@@ -64,8 +65,7 @@
                   "reference",
                   "name"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ],
@@ -87,7 +87,8 @@
               "version": ""
             },
             "patch": {
-              "mutatorRef": [
+              "patchStrategy": "replace",
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -101,8 +102,7 @@
                   "spec",
                   "name"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ]

--- a/models/azure-network/azureserviceoperator_customresourcedefinitions_v2.14.0.yaml/v1.0.0/relationships/edge-non-binding-reference-yhpdu.json
+++ b/models/azure-network/azureserviceoperator_customresourcedefinitions_v2.14.0.yaml/v1.0.0/relationships/edge-non-binding-reference-yhpdu.json
@@ -45,7 +45,8 @@
               "version": ""
             },
             "patch": {
-              "mutatedRef": [
+              "patchStrategy": "replace",
+              "mutatorRef": [
                 [
                   "configuration",
                   "spec",
@@ -64,8 +65,7 @@
                   "privateDnsZoneReference",
                   "name"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ],
@@ -87,7 +87,8 @@
               "version": ""
             },
             "patch": {
-              "mutatorRef": [
+              "patchStrategy": "replace",
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -101,8 +102,7 @@
                   "spec",
                   "name"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ]

--- a/models/azure-network/azureserviceoperator_customresourcedefinitions_v2.14.0.yaml/v1.0.0/relationships/edge-non-binding-reference-ypqua.json
+++ b/models/azure-network/azureserviceoperator_customresourcedefinitions_v2.14.0.yaml/v1.0.0/relationships/edge-non-binding-reference-ypqua.json
@@ -45,7 +45,8 @@
               "version": ""
             },
             "patch": {
-              "mutatedRef": [
+              "patchStrategy": "replace",
+              "mutatorRef": [
                 [
                   "configuration",
                   "spec",
@@ -64,8 +65,7 @@
                   "reference",
                   "name"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ],
@@ -87,7 +87,8 @@
               "version": ""
             },
             "patch": {
-              "mutatorRef": [
+              "patchStrategy": "replace",
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -101,8 +102,7 @@
                   "spec",
                   "name"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ]

--- a/models/azure-network/azureserviceoperator_customresourcedefinitions_v2.14.0.yaml/v1.0.0/relationships/hierarchical-parent-inventory-auepj.json
+++ b/models/azure-network/azureserviceoperator_customresourcedefinitions_v2.14.0.yaml/v1.0.0/relationships/hierarchical-parent-inventory-auepj.json
@@ -45,15 +45,15 @@
               "version": ""
             },
             "patch": {
-              "mutatedRef": [
+              "patchStrategy": "replace",
+              "mutatorRef": [
                 [
                   "configuration",
                   "spec",
                   "owner",
                   "name"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ],
@@ -75,12 +75,12 @@
               "version": ""
             },
             "patch": {
-              "mutatorRef": [
+              "patchStrategy": "replace",
+              "mutatedRef": [
                 [
                   "displayName"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ]

--- a/models/azure-network/azureserviceoperator_customresourcedefinitions_v2.14.0.yaml/v1.0.0/relationships/hierarchical-parent-inventory-bdauh.json
+++ b/models/azure-network/azureserviceoperator_customresourcedefinitions_v2.14.0.yaml/v1.0.0/relationships/hierarchical-parent-inventory-bdauh.json
@@ -45,15 +45,15 @@
               "version": ""
             },
             "patch": {
-              "mutatedRef": [
+              "patchStrategy": "replace",
+              "mutatorRef": [
                 [
                   "configuration",
                   "spec",
                   "owner",
                   "name"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ],
@@ -75,12 +75,12 @@
               "version": ""
             },
             "patch": {
-              "mutatorRef": [
+              "patchStrategy": "replace",
+              "mutatedRef": [
                 [
                   "displayName"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ]

--- a/models/azure-network/azureserviceoperator_customresourcedefinitions_v2.14.0.yaml/v1.0.0/relationships/hierarchical-parent-inventory-bsxdq.json
+++ b/models/azure-network/azureserviceoperator_customresourcedefinitions_v2.14.0.yaml/v1.0.0/relationships/hierarchical-parent-inventory-bsxdq.json
@@ -45,15 +45,15 @@
               "version": ""
             },
             "patch": {
-              "mutatedRef": [
+              "patchStrategy": "replace",
+              "mutatorRef": [
                 [
                   "configuration",
                   "spec",
                   "owner",
                   "name"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ],
@@ -75,12 +75,12 @@
               "version": ""
             },
             "patch": {
-              "mutatorRef": [
+              "patchStrategy": "replace",
+              "mutatedRef": [
                 [
                   "displayName"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ]

--- a/models/azure-network/azureserviceoperator_customresourcedefinitions_v2.14.0.yaml/v1.0.0/relationships/hierarchical-parent-inventory-crveh.json
+++ b/models/azure-network/azureserviceoperator_customresourcedefinitions_v2.14.0.yaml/v1.0.0/relationships/hierarchical-parent-inventory-crveh.json
@@ -45,15 +45,15 @@
               "version": ""
             },
             "patch": {
-              "mutatedRef": [
+              "patchStrategy": "replace",
+              "mutatorRef": [
                 [
                   "configuration",
                   "spec",
                   "owner",
                   "name"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ],
@@ -75,12 +75,12 @@
               "version": ""
             },
             "patch": {
-              "mutatorRef": [
+              "patchStrategy": "replace",
+              "mutatedRef": [
                 [
                   "displayName"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ]

--- a/models/azure-network/azureserviceoperator_customresourcedefinitions_v2.14.0.yaml/v1.0.0/relationships/hierarchical-parent-inventory-ddtix.json
+++ b/models/azure-network/azureserviceoperator_customresourcedefinitions_v2.14.0.yaml/v1.0.0/relationships/hierarchical-parent-inventory-ddtix.json
@@ -45,15 +45,15 @@
               "version": ""
             },
             "patch": {
-              "mutatedRef": [
+              "patchStrategy": "replace",
+              "mutatorRef": [
                 [
                   "configuration",
                   "spec",
                   "owner",
                   "name"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ],
@@ -75,12 +75,12 @@
               "version": ""
             },
             "patch": {
-              "mutatorRef": [
+              "patchStrategy": "replace",
+              "mutatedRef": [
                 [
                   "displayName"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ]

--- a/models/azure-network/azureserviceoperator_customresourcedefinitions_v2.14.0.yaml/v1.0.0/relationships/hierarchical-parent-inventory-dlzlx.json
+++ b/models/azure-network/azureserviceoperator_customresourcedefinitions_v2.14.0.yaml/v1.0.0/relationships/hierarchical-parent-inventory-dlzlx.json
@@ -45,15 +45,15 @@
               "version": ""
             },
             "patch": {
-              "mutatedRef": [
+              "patchStrategy": "replace",
+              "mutatorRef": [
                 [
                   "configuration",
                   "spec",
                   "owner",
                   "name"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ],
@@ -75,12 +75,12 @@
               "version": ""
             },
             "patch": {
-              "mutatorRef": [
+              "patchStrategy": "replace",
+              "mutatedRef": [
                 [
                   "displayName"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ]

--- a/models/azure-network/azureserviceoperator_customresourcedefinitions_v2.14.0.yaml/v1.0.0/relationships/hierarchical-parent-inventory-doulx.json
+++ b/models/azure-network/azureserviceoperator_customresourcedefinitions_v2.14.0.yaml/v1.0.0/relationships/hierarchical-parent-inventory-doulx.json
@@ -45,15 +45,15 @@
               "version": ""
             },
             "patch": {
-              "mutatedRef": [
+              "patchStrategy": "replace",
+              "mutatorRef": [
                 [
                   "configuration",
                   "spec",
                   "owner",
                   "name"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ],
@@ -75,12 +75,12 @@
               "version": ""
             },
             "patch": {
-              "mutatorRef": [
+              "patchStrategy": "replace",
+              "mutatedRef": [
                 [
                   "displayName"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ]

--- a/models/azure-network/azureserviceoperator_customresourcedefinitions_v2.14.0.yaml/v1.0.0/relationships/hierarchical-parent-inventory-ebdjd.json
+++ b/models/azure-network/azureserviceoperator_customresourcedefinitions_v2.14.0.yaml/v1.0.0/relationships/hierarchical-parent-inventory-ebdjd.json
@@ -45,15 +45,15 @@
               "version": ""
             },
             "patch": {
-              "mutatedRef": [
+              "patchStrategy": "replace",
+              "mutatorRef": [
                 [
                   "configuration",
                   "spec",
                   "owner",
                   "name"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ],
@@ -75,12 +75,12 @@
               "version": ""
             },
             "patch": {
-              "mutatorRef": [
+              "patchStrategy": "replace",
+              "mutatedRef": [
                 [
                   "displayName"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ]

--- a/models/azure-network/azureserviceoperator_customresourcedefinitions_v2.14.0.yaml/v1.0.0/relationships/hierarchical-parent-inventory-gahtg.json
+++ b/models/azure-network/azureserviceoperator_customresourcedefinitions_v2.14.0.yaml/v1.0.0/relationships/hierarchical-parent-inventory-gahtg.json
@@ -45,15 +45,15 @@
               "version": ""
             },
             "patch": {
-              "mutatedRef": [
+              "patchStrategy": "replace",
+              "mutatorRef": [
                 [
                   "configuration",
                   "spec",
                   "owner",
                   "name"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ],
@@ -75,12 +75,12 @@
               "version": ""
             },
             "patch": {
-              "mutatorRef": [
+              "patchStrategy": "replace",
+              "mutatedRef": [
                 [
                   "displayName"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ]

--- a/models/azure-network/azureserviceoperator_customresourcedefinitions_v2.14.0.yaml/v1.0.0/relationships/hierarchical-parent-inventory-gnpow.json
+++ b/models/azure-network/azureserviceoperator_customresourcedefinitions_v2.14.0.yaml/v1.0.0/relationships/hierarchical-parent-inventory-gnpow.json
@@ -45,15 +45,15 @@
               "version": ""
             },
             "patch": {
-              "mutatedRef": [
+              "patchStrategy": "replace",
+              "mutatorRef": [
                 [
                   "configuration",
                   "spec",
                   "owner",
                   "name"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ],
@@ -75,12 +75,12 @@
               "version": ""
             },
             "patch": {
-              "mutatorRef": [
+              "patchStrategy": "replace",
+              "mutatedRef": [
                 [
                   "displayName"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ]

--- a/models/azure-network/azureserviceoperator_customresourcedefinitions_v2.14.0.yaml/v1.0.0/relationships/hierarchical-parent-inventory-gxrgg.json
+++ b/models/azure-network/azureserviceoperator_customresourcedefinitions_v2.14.0.yaml/v1.0.0/relationships/hierarchical-parent-inventory-gxrgg.json
@@ -45,15 +45,15 @@
               "version": ""
             },
             "patch": {
-              "mutatedRef": [
+              "patchStrategy": "replace",
+              "mutatorRef": [
                 [
                   "configuration",
                   "spec",
                   "owner",
                   "name"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ],
@@ -75,12 +75,12 @@
               "version": ""
             },
             "patch": {
-              "mutatorRef": [
+              "patchStrategy": "replace",
+              "mutatedRef": [
                 [
                   "displayName"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ]

--- a/models/azure-network/azureserviceoperator_customresourcedefinitions_v2.14.0.yaml/v1.0.0/relationships/hierarchical-parent-inventory-hhlaj.json
+++ b/models/azure-network/azureserviceoperator_customresourcedefinitions_v2.14.0.yaml/v1.0.0/relationships/hierarchical-parent-inventory-hhlaj.json
@@ -45,15 +45,15 @@
               "version": ""
             },
             "patch": {
-              "mutatedRef": [
+              "patchStrategy": "replace",
+              "mutatorRef": [
                 [
                   "configuration",
                   "spec",
                   "owner",
                   "name"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ],
@@ -75,12 +75,12 @@
               "version": ""
             },
             "patch": {
-              "mutatorRef": [
+              "patchStrategy": "replace",
+              "mutatedRef": [
                 [
                   "displayName"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ]

--- a/models/azure-network/azureserviceoperator_customresourcedefinitions_v2.14.0.yaml/v1.0.0/relationships/hierarchical-parent-inventory-jsdxn.json
+++ b/models/azure-network/azureserviceoperator_customresourcedefinitions_v2.14.0.yaml/v1.0.0/relationships/hierarchical-parent-inventory-jsdxn.json
@@ -45,15 +45,15 @@
               "version": ""
             },
             "patch": {
-              "mutatedRef": [
+              "patchStrategy": "replace",
+              "mutatorRef": [
                 [
                   "configuration",
                   "spec",
                   "owner",
                   "name"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ],
@@ -75,12 +75,12 @@
               "version": ""
             },
             "patch": {
-              "mutatorRef": [
+              "patchStrategy": "replace",
+              "mutatedRef": [
                 [
                   "displayName"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ]

--- a/models/azure-network/azureserviceoperator_customresourcedefinitions_v2.14.0.yaml/v1.0.0/relationships/hierarchical-parent-inventory-kjdyg.json
+++ b/models/azure-network/azureserviceoperator_customresourcedefinitions_v2.14.0.yaml/v1.0.0/relationships/hierarchical-parent-inventory-kjdyg.json
@@ -45,15 +45,15 @@
               "version": ""
             },
             "patch": {
-              "mutatedRef": [
+              "patchStrategy": "replace",
+              "mutatorRef": [
                 [
                   "configuration",
                   "spec",
                   "owner",
                   "name"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ],
@@ -75,12 +75,12 @@
               "version": ""
             },
             "patch": {
-              "mutatorRef": [
+              "patchStrategy": "replace",
+              "mutatedRef": [
                 [
                   "displayName"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ]

--- a/models/azure-network/azureserviceoperator_customresourcedefinitions_v2.14.0.yaml/v1.0.0/relationships/hierarchical-parent-inventory-kmjea.json
+++ b/models/azure-network/azureserviceoperator_customresourcedefinitions_v2.14.0.yaml/v1.0.0/relationships/hierarchical-parent-inventory-kmjea.json
@@ -91,7 +91,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatedRef": [
+              "mutatorRef": [
                 [
                   "configuration",
                   "spec",
@@ -156,7 +156,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"

--- a/models/azure-network/azureserviceoperator_customresourcedefinitions_v2.14.0.yaml/v1.0.0/relationships/hierarchical-parent-inventory-kxyok.json
+++ b/models/azure-network/azureserviceoperator_customresourcedefinitions_v2.14.0.yaml/v1.0.0/relationships/hierarchical-parent-inventory-kxyok.json
@@ -45,15 +45,15 @@
               "version": ""
             },
             "patch": {
-              "mutatedRef": [
+              "patchStrategy": "replace",
+              "mutatorRef": [
                 [
                   "configuration",
                   "spec",
                   "owner",
                   "name"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ],
@@ -75,12 +75,12 @@
               "version": ""
             },
             "patch": {
-              "mutatorRef": [
+              "patchStrategy": "replace",
+              "mutatedRef": [
                 [
                   "displayName"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ]

--- a/models/azure-network/azureserviceoperator_customresourcedefinitions_v2.14.0.yaml/v1.0.0/relationships/hierarchical-parent-inventory-mbmny.json
+++ b/models/azure-network/azureserviceoperator_customresourcedefinitions_v2.14.0.yaml/v1.0.0/relationships/hierarchical-parent-inventory-mbmny.json
@@ -45,15 +45,15 @@
               "version": ""
             },
             "patch": {
-              "mutatedRef": [
+              "patchStrategy": "replace",
+              "mutatorRef": [
                 [
                   "configuration",
                   "spec",
                   "owner",
                   "name"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ],
@@ -75,12 +75,12 @@
               "version": ""
             },
             "patch": {
-              "mutatorRef": [
+              "patchStrategy": "replace",
+              "mutatedRef": [
                 [
                   "displayName"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ]

--- a/models/azure-network/azureserviceoperator_customresourcedefinitions_v2.14.0.yaml/v1.0.0/relationships/hierarchical-parent-inventory-oimpd.json
+++ b/models/azure-network/azureserviceoperator_customresourcedefinitions_v2.14.0.yaml/v1.0.0/relationships/hierarchical-parent-inventory-oimpd.json
@@ -45,15 +45,15 @@
               "version": ""
             },
             "patch": {
-              "mutatedRef": [
+              "patchStrategy": "replace",
+              "mutatorRef": [
                 [
                   "configuration",
                   "spec",
                   "owner",
                   "name"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ],
@@ -75,12 +75,12 @@
               "version": ""
             },
             "patch": {
-              "mutatorRef": [
+              "patchStrategy": "replace",
+              "mutatedRef": [
                 [
                   "displayName"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ]

--- a/models/azure-network/azureserviceoperator_customresourcedefinitions_v2.14.0.yaml/v1.0.0/relationships/hierarchical-parent-inventory-prswt.json
+++ b/models/azure-network/azureserviceoperator_customresourcedefinitions_v2.14.0.yaml/v1.0.0/relationships/hierarchical-parent-inventory-prswt.json
@@ -45,15 +45,15 @@
               "version": ""
             },
             "patch": {
-              "mutatedRef": [
+              "patchStrategy": "replace",
+              "mutatorRef": [
                 [
                   "configuration",
                   "spec",
                   "owner",
                   "name"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ],
@@ -75,12 +75,12 @@
               "version": ""
             },
             "patch": {
-              "mutatorRef": [
+              "patchStrategy": "replace",
+              "mutatedRef": [
                 [
                   "displayName"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ]

--- a/models/azure-network/azureserviceoperator_customresourcedefinitions_v2.14.0.yaml/v1.0.0/relationships/hierarchical-parent-inventory-pvcbv.json
+++ b/models/azure-network/azureserviceoperator_customresourcedefinitions_v2.14.0.yaml/v1.0.0/relationships/hierarchical-parent-inventory-pvcbv.json
@@ -45,15 +45,15 @@
               "version": ""
             },
             "patch": {
-              "mutatedRef": [
+              "patchStrategy": "replace",
+              "mutatorRef": [
                 [
                   "configuration",
                   "spec",
                   "owner",
                   "name"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ],
@@ -75,12 +75,12 @@
               "version": ""
             },
             "patch": {
-              "mutatorRef": [
+              "patchStrategy": "replace",
+              "mutatedRef": [
                 [
                   "displayName"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ]

--- a/models/azure-network/azureserviceoperator_customresourcedefinitions_v2.14.0.yaml/v1.0.0/relationships/hierarchical-parent-inventory-sbpxf.json
+++ b/models/azure-network/azureserviceoperator_customresourcedefinitions_v2.14.0.yaml/v1.0.0/relationships/hierarchical-parent-inventory-sbpxf.json
@@ -45,15 +45,15 @@
               "version": ""
             },
             "patch": {
-              "mutatedRef": [
+              "patchStrategy": "replace",
+              "mutatorRef": [
                 [
                   "configuration",
                   "spec",
                   "owner",
                   "name"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ],
@@ -75,12 +75,12 @@
               "version": ""
             },
             "patch": {
-              "mutatorRef": [
+              "patchStrategy": "replace",
+              "mutatedRef": [
                 [
                   "displayName"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ]

--- a/models/azure-network/azureserviceoperator_customresourcedefinitions_v2.14.0.yaml/v1.0.0/relationships/hierarchical-parent-inventory-tbcpq.json
+++ b/models/azure-network/azureserviceoperator_customresourcedefinitions_v2.14.0.yaml/v1.0.0/relationships/hierarchical-parent-inventory-tbcpq.json
@@ -45,15 +45,15 @@
               "version": ""
             },
             "patch": {
-              "mutatedRef": [
+              "patchStrategy": "replace",
+              "mutatorRef": [
                 [
                   "configuration",
                   "spec",
                   "owner",
                   "name"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ],
@@ -75,12 +75,12 @@
               "version": ""
             },
             "patch": {
-              "mutatorRef": [
+              "patchStrategy": "replace",
+              "mutatedRef": [
                 [
                   "displayName"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ]

--- a/models/azure-network/azureserviceoperator_customresourcedefinitions_v2.14.0.yaml/v1.0.0/relationships/hierarchical-parent-inventory-wcqpe.json
+++ b/models/azure-network/azureserviceoperator_customresourcedefinitions_v2.14.0.yaml/v1.0.0/relationships/hierarchical-parent-inventory-wcqpe.json
@@ -45,15 +45,15 @@
               "version": ""
             },
             "patch": {
-              "mutatedRef": [
+              "patchStrategy": "replace",
+              "mutatorRef": [
                 [
                   "configuration",
                   "spec",
                   "owner",
                   "name"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ],
@@ -75,12 +75,12 @@
               "version": ""
             },
             "patch": {
-              "mutatorRef": [
+              "patchStrategy": "replace",
+              "mutatedRef": [
                 [
                   "displayName"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ]

--- a/models/azure-network/azureserviceoperator_customresourcedefinitions_v2.14.0.yaml/v1.0.0/relationships/hierarchical-parent-inventory-wjzbn.json
+++ b/models/azure-network/azureserviceoperator_customresourcedefinitions_v2.14.0.yaml/v1.0.0/relationships/hierarchical-parent-inventory-wjzbn.json
@@ -45,15 +45,15 @@
               "version": ""
             },
             "patch": {
-              "mutatedRef": [
+              "patchStrategy": "replace",
+              "mutatorRef": [
                 [
                   "configuration",
                   "spec",
                   "owner",
                   "name"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ],
@@ -75,12 +75,12 @@
               "version": ""
             },
             "patch": {
-              "mutatorRef": [
+              "patchStrategy": "replace",
+              "mutatedRef": [
                 [
                   "displayName"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ]

--- a/models/azure-network/azureserviceoperator_customresourcedefinitions_v2.14.0.yaml/v1.0.0/relationships/hierarchical-parent-inventory-ycetf.json
+++ b/models/azure-network/azureserviceoperator_customresourcedefinitions_v2.14.0.yaml/v1.0.0/relationships/hierarchical-parent-inventory-ycetf.json
@@ -45,15 +45,15 @@
               "version": ""
             },
             "patch": {
-              "mutatedRef": [
+              "patchStrategy": "replace",
+              "mutatorRef": [
                 [
                   "configuration",
                   "spec",
                   "owner",
                   "name"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ],
@@ -75,12 +75,12 @@
               "version": ""
             },
             "patch": {
-              "mutatorRef": [
+              "patchStrategy": "replace",
+              "mutatedRef": [
                 [
                   "displayName"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ]

--- a/models/azure-network/azureserviceoperator_customresourcedefinitions_v2.14.0.yaml/v1.0.0/relationships/hierarchical-parent-inventory-ydjtj.json
+++ b/models/azure-network/azureserviceoperator_customresourcedefinitions_v2.14.0.yaml/v1.0.0/relationships/hierarchical-parent-inventory-ydjtj.json
@@ -45,15 +45,15 @@
               "version": ""
             },
             "patch": {
-              "mutatedRef": [
+              "patchStrategy": "replace",
+              "mutatorRef": [
                 [
                   "configuration",
                   "spec",
                   "owner",
                   "name"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ],
@@ -75,12 +75,12 @@
               "version": ""
             },
             "patch": {
-              "mutatorRef": [
+              "patchStrategy": "replace",
+              "mutatedRef": [
                 [
                   "displayName"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ]

--- a/models/azure-network/azureserviceoperator_customresourcedefinitions_v2.14.0.yaml/v1.0.0/relationships/hierarchical-parent-inventory-yikoi.json
+++ b/models/azure-network/azureserviceoperator_customresourcedefinitions_v2.14.0.yaml/v1.0.0/relationships/hierarchical-parent-inventory-yikoi.json
@@ -45,15 +45,15 @@
               "version": ""
             },
             "patch": {
-              "mutatedRef": [
+              "patchStrategy": "replace",
+              "mutatorRef": [
                 [
                   "configuration",
                   "spec",
                   "owner",
                   "name"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ],
@@ -75,12 +75,12 @@
               "version": ""
             },
             "patch": {
-              "mutatorRef": [
+              "patchStrategy": "replace",
+              "mutatedRef": [
                 [
                   "displayName"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ]

--- a/models/azure-network/azureserviceoperator_customresourcedefinitions_v2.14.0.yaml/v1.0.0/relationships/hierarchical-parent-inventory-zfrsp.json
+++ b/models/azure-network/azureserviceoperator_customresourcedefinitions_v2.14.0.yaml/v1.0.0/relationships/hierarchical-parent-inventory-zfrsp.json
@@ -45,15 +45,15 @@
               "version": ""
             },
             "patch": {
-              "mutatedRef": [
+              "patchStrategy": "replace",
+              "mutatorRef": [
                 [
                   "configuration",
                   "spec",
                   "owner",
                   "name"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ],
@@ -75,12 +75,12 @@
               "version": ""
             },
             "patch": {
-              "mutatorRef": [
+              "patchStrategy": "replace",
+              "mutatedRef": [
                 [
                   "displayName"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ]

--- a/models/azure-network/azureserviceoperator_customresourcedefinitions_v2.14.0.yaml/v1.0.0/relationships/hierarchical-parent-inventory-zhlpp.json
+++ b/models/azure-network/azureserviceoperator_customresourcedefinitions_v2.14.0.yaml/v1.0.0/relationships/hierarchical-parent-inventory-zhlpp.json
@@ -45,15 +45,15 @@
               "version": ""
             },
             "patch": {
-              "mutatedRef": [
+              "patchStrategy": "replace",
+              "mutatorRef": [
                 [
                   "configuration",
                   "spec",
                   "owner",
                   "name"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ],
@@ -75,12 +75,12 @@
               "version": ""
             },
             "patch": {
-              "mutatorRef": [
+              "patchStrategy": "replace",
+              "mutatedRef": [
                 [
                   "displayName"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ]

--- a/models/azure-network/azureserviceoperator_customresourcedefinitions_v2.14.0.yaml/v1.0.0/relationships/hierarchical-parent-inventory-zkyqp.json
+++ b/models/azure-network/azureserviceoperator_customresourcedefinitions_v2.14.0.yaml/v1.0.0/relationships/hierarchical-parent-inventory-zkyqp.json
@@ -45,15 +45,15 @@
               "version": ""
             },
             "patch": {
-              "mutatedRef": [
+              "patchStrategy": "replace",
+              "mutatorRef": [
                 [
                   "configuration",
                   "spec",
                   "owner",
                   "name"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ],
@@ -75,12 +75,12 @@
               "version": ""
             },
             "patch": {
-              "mutatorRef": [
+              "patchStrategy": "replace",
+              "mutatedRef": [
                 [
                   "displayName"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ]

--- a/models/azure-network/azureserviceoperator_customresourcedefinitions_v2.14.0.yaml/v1.0.0/relationships/hierarchical-parent-inventory-zofbt.json
+++ b/models/azure-network/azureserviceoperator_customresourcedefinitions_v2.14.0.yaml/v1.0.0/relationships/hierarchical-parent-inventory-zofbt.json
@@ -45,15 +45,15 @@
               "version": ""
             },
             "patch": {
-              "mutatedRef": [
+              "patchStrategy": "replace",
+              "mutatorRef": [
                 [
                   "configuration",
                   "spec",
                   "owner",
                   "name"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ],
@@ -75,12 +75,12 @@
               "version": ""
             },
             "patch": {
-              "mutatorRef": [
+              "patchStrategy": "replace",
+              "mutatedRef": [
                 [
                   "displayName"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ]

--- a/models/azure-notification-hubs/azureserviceoperator_customresourcedefinitions_v2.13.0.yaml/v1.0.0/relationships/hierarchical-parent-inventory-jabom.json
+++ b/models/azure-notification-hubs/azureserviceoperator_customresourcedefinitions_v2.13.0.yaml/v1.0.0/relationships/hierarchical-parent-inventory-jabom.json
@@ -45,15 +45,15 @@
               "version": ""
             },
             "patch": {
-              "mutatedRef": [
+              "patchStrategy": "replace",
+              "mutatorRef": [
                 [
                   "configuration",
                   "spec",
                   "owner",
                   "name"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ],
@@ -75,12 +75,12 @@
               "version": ""
             },
             "patch": {
-              "mutatorRef": [
+              "patchStrategy": "replace",
+              "mutatedRef": [
                 [
                   "displayName"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ]

--- a/models/azure-notification-hubs/azureserviceoperator_customresourcedefinitions_v2.13.0.yaml/v1.0.0/relationships/hierarchical-parent-inventory-kmjea.json
+++ b/models/azure-notification-hubs/azureserviceoperator_customresourcedefinitions_v2.13.0.yaml/v1.0.0/relationships/hierarchical-parent-inventory-kmjea.json
@@ -91,7 +91,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatedRef": [
+              "mutatorRef": [
                 [
                   "configuration",
                   "spec",
@@ -144,7 +144,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "displayName"
                 ]

--- a/models/azure-notification-hubs/azureserviceoperator_customresourcedefinitions_v2.13.0.yaml/v1.0.0/relationships/hierarchical-parent-inventory-qzvsl.json
+++ b/models/azure-notification-hubs/azureserviceoperator_customresourcedefinitions_v2.13.0.yaml/v1.0.0/relationships/hierarchical-parent-inventory-qzvsl.json
@@ -45,15 +45,15 @@
               "version": ""
             },
             "patch": {
-              "mutatedRef": [
+              "patchStrategy": "replace",
+              "mutatorRef": [
                 [
                   "configuration",
                   "spec",
                   "owner",
                   "name"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ],
@@ -75,12 +75,12 @@
               "version": ""
             },
             "patch": {
-              "mutatorRef": [
+              "patchStrategy": "replace",
+              "mutatedRef": [
                 [
                   "displayName"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ]

--- a/models/azure-notification-hubs/azureserviceoperator_customresourcedefinitions_v2.14.0.yaml/v1.0.0/relationships/hierarchical-parent-inventory-jabom.json
+++ b/models/azure-notification-hubs/azureserviceoperator_customresourcedefinitions_v2.14.0.yaml/v1.0.0/relationships/hierarchical-parent-inventory-jabom.json
@@ -45,15 +45,15 @@
               "version": ""
             },
             "patch": {
-              "mutatedRef": [
+              "patchStrategy": "replace",
+              "mutatorRef": [
                 [
                   "configuration",
                   "spec",
                   "owner",
                   "name"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ],
@@ -75,12 +75,12 @@
               "version": ""
             },
             "patch": {
-              "mutatorRef": [
+              "patchStrategy": "replace",
+              "mutatedRef": [
                 [
                   "displayName"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ]

--- a/models/azure-notification-hubs/azureserviceoperator_customresourcedefinitions_v2.14.0.yaml/v1.0.0/relationships/hierarchical-parent-inventory-kmjea.json
+++ b/models/azure-notification-hubs/azureserviceoperator_customresourcedefinitions_v2.14.0.yaml/v1.0.0/relationships/hierarchical-parent-inventory-kmjea.json
@@ -91,7 +91,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatedRef": [
+              "mutatorRef": [
                 [
                   "configuration",
                   "spec",
@@ -144,7 +144,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "displayName"
                 ]

--- a/models/azure-notification-hubs/azureserviceoperator_customresourcedefinitions_v2.14.0.yaml/v1.0.0/relationships/hierarchical-parent-inventory-qzvsl.json
+++ b/models/azure-notification-hubs/azureserviceoperator_customresourcedefinitions_v2.14.0.yaml/v1.0.0/relationships/hierarchical-parent-inventory-qzvsl.json
@@ -45,15 +45,15 @@
               "version": ""
             },
             "patch": {
-              "mutatedRef": [
+              "patchStrategy": "replace",
+              "mutatorRef": [
                 [
                   "configuration",
                   "spec",
                   "owner",
                   "name"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ],
@@ -75,12 +75,12 @@
               "version": ""
             },
             "patch": {
-              "mutatorRef": [
+              "patchStrategy": "replace",
+              "mutatedRef": [
                 [
                   "displayName"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ]

--- a/models/azure-red-hat-openshift/azureserviceoperator_customresourcedefinitions_v2.13.0.yaml/v1.0.0/relationships/edge-non-binding-reference-mcjrj.json
+++ b/models/azure-red-hat-openshift/azureserviceoperator_customresourcedefinitions_v2.13.0.yaml/v1.0.0/relationships/edge-non-binding-reference-mcjrj.json
@@ -45,7 +45,8 @@
               "version": ""
             },
             "patch": {
-              "mutatedRef": [
+              "patchStrategy": "replace",
+              "mutatorRef": [
                 [
                   "configuration",
                   "spec",
@@ -64,8 +65,7 @@
                   "subnetReference",
                   "name"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ],
@@ -87,7 +87,8 @@
               "version": ""
             },
             "patch": {
-              "mutatorRef": [
+              "patchStrategy": "replace",
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -101,8 +102,7 @@
                   "spec",
                   "name"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ]

--- a/models/azure-red-hat-openshift/azureserviceoperator_customresourcedefinitions_v2.13.0.yaml/v1.0.0/relationships/hierarchical-parent-inventory-kmjea.json
+++ b/models/azure-red-hat-openshift/azureserviceoperator_customresourcedefinitions_v2.13.0.yaml/v1.0.0/relationships/hierarchical-parent-inventory-kmjea.json
@@ -91,7 +91,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatedRef": [
+              "mutatorRef": [
                 [
                   "configuration",
                   "spec",
@@ -156,7 +156,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"

--- a/models/azure-red-hat-openshift/azureserviceoperator_customresourcedefinitions_v2.14.0.yaml/v1.0.0/relationships/edge-non-binding-reference-mcjrj.json
+++ b/models/azure-red-hat-openshift/azureserviceoperator_customresourcedefinitions_v2.14.0.yaml/v1.0.0/relationships/edge-non-binding-reference-mcjrj.json
@@ -45,7 +45,8 @@
               "version": ""
             },
             "patch": {
-              "mutatedRef": [
+              "patchStrategy": "replace",
+              "mutatorRef": [
                 [
                   "configuration",
                   "spec",
@@ -64,8 +65,7 @@
                   "subnetReference",
                   "name"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ],
@@ -87,7 +87,8 @@
               "version": ""
             },
             "patch": {
-              "mutatorRef": [
+              "patchStrategy": "replace",
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -101,8 +102,7 @@
                   "spec",
                   "name"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ]

--- a/models/azure-red-hat-openshift/azureserviceoperator_customresourcedefinitions_v2.14.0.yaml/v1.0.0/relationships/hierarchical-parent-inventory-kmjea.json
+++ b/models/azure-red-hat-openshift/azureserviceoperator_customresourcedefinitions_v2.14.0.yaml/v1.0.0/relationships/hierarchical-parent-inventory-kmjea.json
@@ -91,7 +91,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatedRef": [
+              "mutatorRef": [
                 [
                   "configuration",
                   "spec",
@@ -156,7 +156,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"

--- a/models/azure-service-bus/azureserviceoperator_customresourcedefinitions_v2.13.0.yaml/v1.0.0/relationships/hierarchical-parent-inventory-ensma.json
+++ b/models/azure-service-bus/azureserviceoperator_customresourcedefinitions_v2.13.0.yaml/v1.0.0/relationships/hierarchical-parent-inventory-ensma.json
@@ -45,15 +45,15 @@
               "version": ""
             },
             "patch": {
-              "mutatedRef": [
+              "patchStrategy": "replace",
+              "mutatorRef": [
                 [
                   "configuration",
                   "spec",
                   "owner",
                   "name"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ],
@@ -75,12 +75,12 @@
               "version": ""
             },
             "patch": {
-              "mutatorRef": [
+              "patchStrategy": "replace",
+              "mutatedRef": [
                 [
                   "displayName"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ]

--- a/models/azure-service-bus/azureserviceoperator_customresourcedefinitions_v2.13.0.yaml/v1.0.0/relationships/hierarchical-parent-inventory-gsame.json
+++ b/models/azure-service-bus/azureserviceoperator_customresourcedefinitions_v2.13.0.yaml/v1.0.0/relationships/hierarchical-parent-inventory-gsame.json
@@ -45,15 +45,15 @@
               "version": ""
             },
             "patch": {
-              "mutatedRef": [
+              "patchStrategy": "replace",
+              "mutatorRef": [
                 [
                   "configuration",
                   "spec",
                   "owner",
                   "name"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ],
@@ -75,12 +75,12 @@
               "version": ""
             },
             "patch": {
-              "mutatorRef": [
+              "patchStrategy": "replace",
+              "mutatedRef": [
                 [
                   "displayName"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ]

--- a/models/azure-service-bus/azureserviceoperator_customresourcedefinitions_v2.13.0.yaml/v1.0.0/relationships/hierarchical-parent-inventory-iqmqv.json
+++ b/models/azure-service-bus/azureserviceoperator_customresourcedefinitions_v2.13.0.yaml/v1.0.0/relationships/hierarchical-parent-inventory-iqmqv.json
@@ -45,15 +45,15 @@
               "version": ""
             },
             "patch": {
-              "mutatedRef": [
+              "patchStrategy": "replace",
+              "mutatorRef": [
                 [
                   "configuration",
                   "spec",
                   "owner",
                   "name"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ],
@@ -75,12 +75,12 @@
               "version": ""
             },
             "patch": {
-              "mutatorRef": [
+              "patchStrategy": "replace",
+              "mutatedRef": [
                 [
                   "displayName"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ]

--- a/models/azure-service-bus/azureserviceoperator_customresourcedefinitions_v2.13.0.yaml/v1.0.0/relationships/hierarchical-parent-inventory-kmjea.json
+++ b/models/azure-service-bus/azureserviceoperator_customresourcedefinitions_v2.13.0.yaml/v1.0.0/relationships/hierarchical-parent-inventory-kmjea.json
@@ -91,7 +91,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatedRef": [
+              "mutatorRef": [
                 [
                   "configuration",
                   "spec",
@@ -144,7 +144,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "displayName"
                 ]

--- a/models/azure-service-bus/azureserviceoperator_customresourcedefinitions_v2.13.0.yaml/v1.0.0/relationships/hierarchical-parent-inventory-luhmv.json
+++ b/models/azure-service-bus/azureserviceoperator_customresourcedefinitions_v2.13.0.yaml/v1.0.0/relationships/hierarchical-parent-inventory-luhmv.json
@@ -45,15 +45,15 @@
               "version": ""
             },
             "patch": {
-              "mutatedRef": [
+              "patchStrategy": "replace",
+              "mutatorRef": [
                 [
                   "configuration",
                   "spec",
                   "owner",
                   "name"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ],
@@ -75,12 +75,12 @@
               "version": ""
             },
             "patch": {
-              "mutatorRef": [
+              "patchStrategy": "replace",
+              "mutatedRef": [
                 [
                   "displayName"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ]

--- a/models/azure-service-bus/azureserviceoperator_customresourcedefinitions_v2.13.0.yaml/v1.0.0/relationships/hierarchical-parent-inventory-nwfau.json
+++ b/models/azure-service-bus/azureserviceoperator_customresourcedefinitions_v2.13.0.yaml/v1.0.0/relationships/hierarchical-parent-inventory-nwfau.json
@@ -45,15 +45,15 @@
               "version": ""
             },
             "patch": {
-              "mutatedRef": [
+              "patchStrategy": "replace",
+              "mutatorRef": [
                 [
                   "configuration",
                   "spec",
                   "owner",
                   "name"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ],
@@ -75,12 +75,12 @@
               "version": ""
             },
             "patch": {
-              "mutatorRef": [
+              "patchStrategy": "replace",
+              "mutatedRef": [
                 [
                   "displayName"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ]

--- a/models/azure-service-bus/azureserviceoperator_customresourcedefinitions_v2.13.0.yaml/v1.0.0/relationships/hierarchical-parent-inventory-pssgl.json
+++ b/models/azure-service-bus/azureserviceoperator_customresourcedefinitions_v2.13.0.yaml/v1.0.0/relationships/hierarchical-parent-inventory-pssgl.json
@@ -45,15 +45,15 @@
               "version": ""
             },
             "patch": {
-              "mutatedRef": [
+              "patchStrategy": "replace",
+              "mutatorRef": [
                 [
                   "configuration",
                   "spec",
                   "owner",
                   "name"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ],
@@ -75,12 +75,12 @@
               "version": ""
             },
             "patch": {
-              "mutatorRef": [
+              "patchStrategy": "replace",
+              "mutatedRef": [
                 [
                   "displayName"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ]

--- a/models/azure-service-bus/azureserviceoperator_customresourcedefinitions_v2.14.0.yaml/v1.0.0/relationships/hierarchical-parent-inventory-ensma.json
+++ b/models/azure-service-bus/azureserviceoperator_customresourcedefinitions_v2.14.0.yaml/v1.0.0/relationships/hierarchical-parent-inventory-ensma.json
@@ -45,15 +45,15 @@
               "version": ""
             },
             "patch": {
-              "mutatedRef": [
+              "patchStrategy": "replace",
+              "mutatorRef": [
                 [
                   "configuration",
                   "spec",
                   "owner",
                   "name"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ],
@@ -75,12 +75,12 @@
               "version": ""
             },
             "patch": {
-              "mutatorRef": [
+              "patchStrategy": "replace",
+              "mutatedRef": [
                 [
                   "displayName"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ]

--- a/models/azure-service-bus/azureserviceoperator_customresourcedefinitions_v2.14.0.yaml/v1.0.0/relationships/hierarchical-parent-inventory-gsame.json
+++ b/models/azure-service-bus/azureserviceoperator_customresourcedefinitions_v2.14.0.yaml/v1.0.0/relationships/hierarchical-parent-inventory-gsame.json
@@ -45,15 +45,15 @@
               "version": ""
             },
             "patch": {
-              "mutatedRef": [
+              "patchStrategy": "replace",
+              "mutatorRef": [
                 [
                   "configuration",
                   "spec",
                   "owner",
                   "name"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ],
@@ -75,12 +75,12 @@
               "version": ""
             },
             "patch": {
-              "mutatorRef": [
+              "patchStrategy": "replace",
+              "mutatedRef": [
                 [
                   "displayName"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ]

--- a/models/azure-service-bus/azureserviceoperator_customresourcedefinitions_v2.14.0.yaml/v1.0.0/relationships/hierarchical-parent-inventory-iqmqv.json
+++ b/models/azure-service-bus/azureserviceoperator_customresourcedefinitions_v2.14.0.yaml/v1.0.0/relationships/hierarchical-parent-inventory-iqmqv.json
@@ -45,15 +45,15 @@
               "version": ""
             },
             "patch": {
-              "mutatedRef": [
+              "patchStrategy": "replace",
+              "mutatorRef": [
                 [
                   "configuration",
                   "spec",
                   "owner",
                   "name"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ],
@@ -75,12 +75,12 @@
               "version": ""
             },
             "patch": {
-              "mutatorRef": [
+              "patchStrategy": "replace",
+              "mutatedRef": [
                 [
                   "displayName"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ]

--- a/models/azure-service-bus/azureserviceoperator_customresourcedefinitions_v2.14.0.yaml/v1.0.0/relationships/hierarchical-parent-inventory-kmjea.json
+++ b/models/azure-service-bus/azureserviceoperator_customresourcedefinitions_v2.14.0.yaml/v1.0.0/relationships/hierarchical-parent-inventory-kmjea.json
@@ -91,7 +91,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatedRef": [
+              "mutatorRef": [
                 [
                   "configuration",
                   "spec",
@@ -144,7 +144,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "displayName"
                 ]

--- a/models/azure-service-bus/azureserviceoperator_customresourcedefinitions_v2.14.0.yaml/v1.0.0/relationships/hierarchical-parent-inventory-luhmv.json
+++ b/models/azure-service-bus/azureserviceoperator_customresourcedefinitions_v2.14.0.yaml/v1.0.0/relationships/hierarchical-parent-inventory-luhmv.json
@@ -45,15 +45,15 @@
               "version": ""
             },
             "patch": {
-              "mutatedRef": [
+              "patchStrategy": "replace",
+              "mutatorRef": [
                 [
                   "configuration",
                   "spec",
                   "owner",
                   "name"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ],
@@ -75,12 +75,12 @@
               "version": ""
             },
             "patch": {
-              "mutatorRef": [
+              "patchStrategy": "replace",
+              "mutatedRef": [
                 [
                   "displayName"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ]

--- a/models/azure-service-bus/azureserviceoperator_customresourcedefinitions_v2.14.0.yaml/v1.0.0/relationships/hierarchical-parent-inventory-nwfau.json
+++ b/models/azure-service-bus/azureserviceoperator_customresourcedefinitions_v2.14.0.yaml/v1.0.0/relationships/hierarchical-parent-inventory-nwfau.json
@@ -45,15 +45,15 @@
               "version": ""
             },
             "patch": {
-              "mutatedRef": [
+              "patchStrategy": "replace",
+              "mutatorRef": [
                 [
                   "configuration",
                   "spec",
                   "owner",
                   "name"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ],
@@ -75,12 +75,12 @@
               "version": ""
             },
             "patch": {
-              "mutatorRef": [
+              "patchStrategy": "replace",
+              "mutatedRef": [
                 [
                   "displayName"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ]

--- a/models/azure-service-bus/azureserviceoperator_customresourcedefinitions_v2.14.0.yaml/v1.0.0/relationships/hierarchical-parent-inventory-pssgl.json
+++ b/models/azure-service-bus/azureserviceoperator_customresourcedefinitions_v2.14.0.yaml/v1.0.0/relationships/hierarchical-parent-inventory-pssgl.json
@@ -45,15 +45,15 @@
               "version": ""
             },
             "patch": {
-              "mutatedRef": [
+              "patchStrategy": "replace",
+              "mutatorRef": [
                 [
                   "configuration",
                   "spec",
                   "owner",
                   "name"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ],
@@ -75,12 +75,12 @@
               "version": ""
             },
             "patch": {
-              "mutatorRef": [
+              "patchStrategy": "replace",
+              "mutatedRef": [
                 [
                   "displayName"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ]

--- a/models/azure-signalr-service/azureserviceoperator_customresourcedefinitions_v2.13.0.yaml/v1.0.0/relationships/edge-non-binding-reference-bieam.json
+++ b/models/azure-signalr-service/azureserviceoperator_customresourcedefinitions_v2.13.0.yaml/v1.0.0/relationships/edge-non-binding-reference-bieam.json
@@ -45,7 +45,8 @@
               "version": ""
             },
             "patch": {
-              "mutatedRef": [
+              "patchStrategy": "replace",
+              "mutatorRef": [
                 [
                   "configuration",
                   "spec",
@@ -64,8 +65,7 @@
                   "customCertificate",
                   "name"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ],
@@ -87,7 +87,8 @@
               "version": ""
             },
             "patch": {
-              "mutatorRef": [
+              "patchStrategy": "replace",
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -101,8 +102,7 @@
                   "spec",
                   "name"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ]

--- a/models/azure-signalr-service/azureserviceoperator_customresourcedefinitions_v2.13.0.yaml/v1.0.0/relationships/hierarchical-parent-inventory-jsnal.json
+++ b/models/azure-signalr-service/azureserviceoperator_customresourcedefinitions_v2.13.0.yaml/v1.0.0/relationships/hierarchical-parent-inventory-jsnal.json
@@ -45,15 +45,15 @@
               "version": ""
             },
             "patch": {
-              "mutatedRef": [
+              "patchStrategy": "replace",
+              "mutatorRef": [
                 [
                   "configuration",
                   "spec",
                   "owner",
                   "name"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ],
@@ -75,12 +75,12 @@
               "version": ""
             },
             "patch": {
-              "mutatorRef": [
+              "patchStrategy": "replace",
+              "mutatedRef": [
                 [
                   "displayName"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ]

--- a/models/azure-signalr-service/azureserviceoperator_customresourcedefinitions_v2.13.0.yaml/v1.0.0/relationships/hierarchical-parent-inventory-kmjea.json
+++ b/models/azure-signalr-service/azureserviceoperator_customresourcedefinitions_v2.13.0.yaml/v1.0.0/relationships/hierarchical-parent-inventory-kmjea.json
@@ -91,7 +91,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatedRef": [
+              "mutatorRef": [
                 [
                   "configuration",
                   "spec",
@@ -156,7 +156,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"

--- a/models/azure-signalr-service/azureserviceoperator_customresourcedefinitions_v2.13.0.yaml/v1.0.0/relationships/hierarchical-parent-inventory-ogrfh.json
+++ b/models/azure-signalr-service/azureserviceoperator_customresourcedefinitions_v2.13.0.yaml/v1.0.0/relationships/hierarchical-parent-inventory-ogrfh.json
@@ -45,15 +45,15 @@
               "version": ""
             },
             "patch": {
-              "mutatedRef": [
+              "patchStrategy": "replace",
+              "mutatorRef": [
                 [
                   "configuration",
                   "spec",
                   "owner",
                   "name"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ],
@@ -75,12 +75,12 @@
               "version": ""
             },
             "patch": {
-              "mutatorRef": [
+              "patchStrategy": "replace",
+              "mutatedRef": [
                 [
                   "displayName"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ]

--- a/models/azure-signalr-service/azureserviceoperator_customresourcedefinitions_v2.13.0.yaml/v1.0.0/relationships/hierarchical-parent-inventory-yjfgm.json
+++ b/models/azure-signalr-service/azureserviceoperator_customresourcedefinitions_v2.13.0.yaml/v1.0.0/relationships/hierarchical-parent-inventory-yjfgm.json
@@ -45,15 +45,15 @@
               "version": ""
             },
             "patch": {
-              "mutatedRef": [
+              "patchStrategy": "replace",
+              "mutatorRef": [
                 [
                   "configuration",
                   "spec",
                   "owner",
                   "name"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ],
@@ -75,12 +75,12 @@
               "version": ""
             },
             "patch": {
-              "mutatorRef": [
+              "patchStrategy": "replace",
+              "mutatedRef": [
                 [
                   "displayName"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ]

--- a/models/azure-signalr-service/azureserviceoperator_customresourcedefinitions_v2.14.0.yaml/v1.0.0/relationships/edge-non-binding-reference-bieam.json
+++ b/models/azure-signalr-service/azureserviceoperator_customresourcedefinitions_v2.14.0.yaml/v1.0.0/relationships/edge-non-binding-reference-bieam.json
@@ -45,7 +45,8 @@
               "version": ""
             },
             "patch": {
-              "mutatedRef": [
+              "patchStrategy": "replace",
+              "mutatorRef": [
                 [
                   "configuration",
                   "spec",
@@ -64,8 +65,7 @@
                   "customCertificate",
                   "name"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ],
@@ -87,7 +87,8 @@
               "version": ""
             },
             "patch": {
-              "mutatorRef": [
+              "patchStrategy": "replace",
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -101,8 +102,7 @@
                   "spec",
                   "name"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ]

--- a/models/azure-signalr-service/azureserviceoperator_customresourcedefinitions_v2.14.0.yaml/v1.0.0/relationships/hierarchical-parent-inventory-jsnal.json
+++ b/models/azure-signalr-service/azureserviceoperator_customresourcedefinitions_v2.14.0.yaml/v1.0.0/relationships/hierarchical-parent-inventory-jsnal.json
@@ -45,15 +45,15 @@
               "version": ""
             },
             "patch": {
-              "mutatedRef": [
+              "patchStrategy": "replace",
+              "mutatorRef": [
                 [
                   "configuration",
                   "spec",
                   "owner",
                   "name"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ],
@@ -75,12 +75,12 @@
               "version": ""
             },
             "patch": {
-              "mutatorRef": [
+              "patchStrategy": "replace",
+              "mutatedRef": [
                 [
                   "displayName"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ]

--- a/models/azure-signalr-service/azureserviceoperator_customresourcedefinitions_v2.14.0.yaml/v1.0.0/relationships/hierarchical-parent-inventory-kmjea.json
+++ b/models/azure-signalr-service/azureserviceoperator_customresourcedefinitions_v2.14.0.yaml/v1.0.0/relationships/hierarchical-parent-inventory-kmjea.json
@@ -91,7 +91,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatedRef": [
+              "mutatorRef": [
                 [
                   "configuration",
                   "spec",
@@ -156,7 +156,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"

--- a/models/azure-signalr-service/azureserviceoperator_customresourcedefinitions_v2.14.0.yaml/v1.0.0/relationships/hierarchical-parent-inventory-ogrfh.json
+++ b/models/azure-signalr-service/azureserviceoperator_customresourcedefinitions_v2.14.0.yaml/v1.0.0/relationships/hierarchical-parent-inventory-ogrfh.json
@@ -45,15 +45,15 @@
               "version": ""
             },
             "patch": {
-              "mutatedRef": [
+              "patchStrategy": "replace",
+              "mutatorRef": [
                 [
                   "configuration",
                   "spec",
                   "owner",
                   "name"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ],
@@ -75,12 +75,12 @@
               "version": ""
             },
             "patch": {
-              "mutatorRef": [
+              "patchStrategy": "replace",
+              "mutatedRef": [
                 [
                   "displayName"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ]

--- a/models/azure-signalr-service/azureserviceoperator_customresourcedefinitions_v2.14.0.yaml/v1.0.0/relationships/hierarchical-parent-inventory-yjfgm.json
+++ b/models/azure-signalr-service/azureserviceoperator_customresourcedefinitions_v2.14.0.yaml/v1.0.0/relationships/hierarchical-parent-inventory-yjfgm.json
@@ -45,15 +45,15 @@
               "version": ""
             },
             "patch": {
-              "mutatedRef": [
+              "patchStrategy": "replace",
+              "mutatorRef": [
                 [
                   "configuration",
                   "spec",
                   "owner",
                   "name"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ],
@@ -75,12 +75,12 @@
               "version": ""
             },
             "patch": {
-              "mutatorRef": [
+              "patchStrategy": "replace",
+              "mutatedRef": [
                 [
                   "displayName"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ]

--- a/models/azure-sql/azureserviceoperator_customresourcedefinitions_v2.13.0.yaml/v1.0.0/relationships/edge-non-binding-reference-dsfss.json
+++ b/models/azure-sql/azureserviceoperator_customresourcedefinitions_v2.13.0.yaml/v1.0.0/relationships/edge-non-binding-reference-dsfss.json
@@ -45,7 +45,8 @@
               "version": ""
             },
             "patch": {
-              "mutatedRef": [
+              "patchStrategy": "replace",
+              "mutatorRef": [
                 [
                   "configuration",
                   "spec",
@@ -64,8 +65,7 @@
                   "reference",
                   "name"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ],
@@ -87,7 +87,8 @@
               "version": ""
             },
             "patch": {
-              "mutatorRef": [
+              "patchStrategy": "replace",
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -101,8 +102,7 @@
                   "spec",
                   "name"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ]

--- a/models/azure-sql/azureserviceoperator_customresourcedefinitions_v2.13.0.yaml/v1.0.0/relationships/edge-non-binding-reference-ijhrr.json
+++ b/models/azure-sql/azureserviceoperator_customresourcedefinitions_v2.13.0.yaml/v1.0.0/relationships/edge-non-binding-reference-ijhrr.json
@@ -91,7 +91,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatedRef": [
+              "mutatorRef": [
                 [
                   "configuration",
                   "spec",
@@ -156,7 +156,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"

--- a/models/azure-sql/azureserviceoperator_customresourcedefinitions_v2.13.0.yaml/v1.0.0/relationships/edge-non-binding-reference-tgvyv.json
+++ b/models/azure-sql/azureserviceoperator_customresourcedefinitions_v2.13.0.yaml/v1.0.0/relationships/edge-non-binding-reference-tgvyv.json
@@ -45,7 +45,8 @@
               "version": ""
             },
             "patch": {
-              "mutatedRef": [
+              "patchStrategy": "replace",
+              "mutatorRef": [
                 [
                   "configuration",
                   "spec",
@@ -64,8 +65,7 @@
                   "virtualNetworkSubnetReference",
                   "name"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ],
@@ -87,7 +87,8 @@
               "version": ""
             },
             "patch": {
-              "mutatorRef": [
+              "patchStrategy": "replace",
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -101,8 +102,7 @@
                   "spec",
                   "name"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ]

--- a/models/azure-sql/azureserviceoperator_customresourcedefinitions_v2.13.0.yaml/v1.0.0/relationships/hierarchical-parent-inventory-czhhd.json
+++ b/models/azure-sql/azureserviceoperator_customresourcedefinitions_v2.13.0.yaml/v1.0.0/relationships/hierarchical-parent-inventory-czhhd.json
@@ -45,15 +45,15 @@
               "version": ""
             },
             "patch": {
-              "mutatedRef": [
+              "patchStrategy": "replace",
+              "mutatorRef": [
                 [
                   "configuration",
                   "spec",
                   "owner",
                   "name"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ],
@@ -75,12 +75,12 @@
               "version": ""
             },
             "patch": {
-              "mutatorRef": [
+              "patchStrategy": "replace",
+              "mutatedRef": [
                 [
                   "displayName"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ]

--- a/models/azure-sql/azureserviceoperator_customresourcedefinitions_v2.13.0.yaml/v1.0.0/relationships/hierarchical-parent-inventory-hrusz.json
+++ b/models/azure-sql/azureserviceoperator_customresourcedefinitions_v2.13.0.yaml/v1.0.0/relationships/hierarchical-parent-inventory-hrusz.json
@@ -45,15 +45,15 @@
               "version": ""
             },
             "patch": {
-              "mutatedRef": [
+              "patchStrategy": "replace",
+              "mutatorRef": [
                 [
                   "configuration",
                   "spec",
                   "owner",
                   "name"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ],
@@ -75,12 +75,12 @@
               "version": ""
             },
             "patch": {
-              "mutatorRef": [
+              "patchStrategy": "replace",
+              "mutatedRef": [
                 [
                   "displayName"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ]

--- a/models/azure-sql/azureserviceoperator_customresourcedefinitions_v2.13.0.yaml/v1.0.0/relationships/hierarchical-parent-inventory-hvdin.json
+++ b/models/azure-sql/azureserviceoperator_customresourcedefinitions_v2.13.0.yaml/v1.0.0/relationships/hierarchical-parent-inventory-hvdin.json
@@ -45,15 +45,15 @@
               "version": ""
             },
             "patch": {
-              "mutatedRef": [
+              "patchStrategy": "replace",
+              "mutatorRef": [
                 [
                   "configuration",
                   "spec",
                   "owner",
                   "name"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ],
@@ -75,12 +75,12 @@
               "version": ""
             },
             "patch": {
-              "mutatorRef": [
+              "patchStrategy": "replace",
+              "mutatedRef": [
                 [
                   "displayName"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ]

--- a/models/azure-sql/azureserviceoperator_customresourcedefinitions_v2.13.0.yaml/v1.0.0/relationships/hierarchical-parent-inventory-idiuh.json
+++ b/models/azure-sql/azureserviceoperator_customresourcedefinitions_v2.13.0.yaml/v1.0.0/relationships/hierarchical-parent-inventory-idiuh.json
@@ -45,15 +45,15 @@
               "version": ""
             },
             "patch": {
-              "mutatedRef": [
+              "patchStrategy": "replace",
+              "mutatorRef": [
                 [
                   "configuration",
                   "spec",
                   "owner",
                   "name"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ],
@@ -75,12 +75,12 @@
               "version": ""
             },
             "patch": {
-              "mutatorRef": [
+              "patchStrategy": "replace",
+              "mutatedRef": [
                 [
                   "displayName"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ]

--- a/models/azure-sql/azureserviceoperator_customresourcedefinitions_v2.13.0.yaml/v1.0.0/relationships/hierarchical-parent-inventory-jlwit.json
+++ b/models/azure-sql/azureserviceoperator_customresourcedefinitions_v2.13.0.yaml/v1.0.0/relationships/hierarchical-parent-inventory-jlwit.json
@@ -45,15 +45,15 @@
               "version": ""
             },
             "patch": {
-              "mutatedRef": [
+              "patchStrategy": "replace",
+              "mutatorRef": [
                 [
                   "configuration",
                   "spec",
                   "owner",
                   "name"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ],
@@ -75,12 +75,12 @@
               "version": ""
             },
             "patch": {
-              "mutatorRef": [
+              "patchStrategy": "replace",
+              "mutatedRef": [
                 [
                   "displayName"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ]

--- a/models/azure-sql/azureserviceoperator_customresourcedefinitions_v2.13.0.yaml/v1.0.0/relationships/hierarchical-parent-inventory-kmjea.json
+++ b/models/azure-sql/azureserviceoperator_customresourcedefinitions_v2.13.0.yaml/v1.0.0/relationships/hierarchical-parent-inventory-kmjea.json
@@ -91,7 +91,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatedRef": [
+              "mutatorRef": [
                 [
                   "configuration",
                   "spec",
@@ -156,7 +156,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"

--- a/models/azure-sql/azureserviceoperator_customresourcedefinitions_v2.13.0.yaml/v1.0.0/relationships/hierarchical-parent-inventory-mkubo.json
+++ b/models/azure-sql/azureserviceoperator_customresourcedefinitions_v2.13.0.yaml/v1.0.0/relationships/hierarchical-parent-inventory-mkubo.json
@@ -45,15 +45,15 @@
               "version": ""
             },
             "patch": {
-              "mutatedRef": [
+              "patchStrategy": "replace",
+              "mutatorRef": [
                 [
                   "configuration",
                   "spec",
                   "owner",
                   "name"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ],
@@ -75,12 +75,12 @@
               "version": ""
             },
             "patch": {
-              "mutatorRef": [
+              "patchStrategy": "replace",
+              "mutatedRef": [
                 [
                   "displayName"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ]

--- a/models/azure-sql/azureserviceoperator_customresourcedefinitions_v2.13.0.yaml/v1.0.0/relationships/hierarchical-parent-inventory-nhyiu.json
+++ b/models/azure-sql/azureserviceoperator_customresourcedefinitions_v2.13.0.yaml/v1.0.0/relationships/hierarchical-parent-inventory-nhyiu.json
@@ -45,15 +45,15 @@
               "version": ""
             },
             "patch": {
-              "mutatedRef": [
+              "patchStrategy": "replace",
+              "mutatorRef": [
                 [
                   "configuration",
                   "spec",
                   "owner",
                   "name"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ],
@@ -75,12 +75,12 @@
               "version": ""
             },
             "patch": {
-              "mutatorRef": [
+              "patchStrategy": "replace",
+              "mutatedRef": [
                 [
                   "displayName"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ]

--- a/models/azure-sql/azureserviceoperator_customresourcedefinitions_v2.13.0.yaml/v1.0.0/relationships/hierarchical-parent-inventory-nqddp.json
+++ b/models/azure-sql/azureserviceoperator_customresourcedefinitions_v2.13.0.yaml/v1.0.0/relationships/hierarchical-parent-inventory-nqddp.json
@@ -45,15 +45,15 @@
               "version": ""
             },
             "patch": {
-              "mutatedRef": [
+              "patchStrategy": "replace",
+              "mutatorRef": [
                 [
                   "configuration",
                   "spec",
                   "owner",
                   "name"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ],
@@ -75,12 +75,12 @@
               "version": ""
             },
             "patch": {
-              "mutatorRef": [
+              "patchStrategy": "replace",
+              "mutatedRef": [
                 [
                   "displayName"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ]

--- a/models/azure-sql/azureserviceoperator_customresourcedefinitions_v2.13.0.yaml/v1.0.0/relationships/hierarchical-parent-inventory-osawm.json
+++ b/models/azure-sql/azureserviceoperator_customresourcedefinitions_v2.13.0.yaml/v1.0.0/relationships/hierarchical-parent-inventory-osawm.json
@@ -45,15 +45,15 @@
               "version": ""
             },
             "patch": {
-              "mutatedRef": [
+              "patchStrategy": "replace",
+              "mutatorRef": [
                 [
                   "configuration",
                   "spec",
                   "owner",
                   "name"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ],
@@ -75,12 +75,12 @@
               "version": ""
             },
             "patch": {
-              "mutatorRef": [
+              "patchStrategy": "replace",
+              "mutatedRef": [
                 [
                   "displayName"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ]

--- a/models/azure-sql/azureserviceoperator_customresourcedefinitions_v2.13.0.yaml/v1.0.0/relationships/hierarchical-parent-inventory-oukgx.json
+++ b/models/azure-sql/azureserviceoperator_customresourcedefinitions_v2.13.0.yaml/v1.0.0/relationships/hierarchical-parent-inventory-oukgx.json
@@ -45,15 +45,15 @@
               "version": ""
             },
             "patch": {
-              "mutatedRef": [
+              "patchStrategy": "replace",
+              "mutatorRef": [
                 [
                   "configuration",
                   "spec",
                   "owner",
                   "name"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ],
@@ -75,12 +75,12 @@
               "version": ""
             },
             "patch": {
-              "mutatorRef": [
+              "patchStrategy": "replace",
+              "mutatedRef": [
                 [
                   "displayName"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ]

--- a/models/azure-sql/azureserviceoperator_customresourcedefinitions_v2.13.0.yaml/v1.0.0/relationships/hierarchical-parent-inventory-pqttn.json
+++ b/models/azure-sql/azureserviceoperator_customresourcedefinitions_v2.13.0.yaml/v1.0.0/relationships/hierarchical-parent-inventory-pqttn.json
@@ -45,15 +45,15 @@
               "version": ""
             },
             "patch": {
-              "mutatedRef": [
+              "patchStrategy": "replace",
+              "mutatorRef": [
                 [
                   "configuration",
                   "spec",
                   "owner",
                   "name"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ],
@@ -75,12 +75,12 @@
               "version": ""
             },
             "patch": {
-              "mutatorRef": [
+              "patchStrategy": "replace",
+              "mutatedRef": [
                 [
                   "displayName"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ]

--- a/models/azure-sql/azureserviceoperator_customresourcedefinitions_v2.13.0.yaml/v1.0.0/relationships/hierarchical-parent-inventory-pvkhn.json
+++ b/models/azure-sql/azureserviceoperator_customresourcedefinitions_v2.13.0.yaml/v1.0.0/relationships/hierarchical-parent-inventory-pvkhn.json
@@ -45,15 +45,15 @@
               "version": ""
             },
             "patch": {
-              "mutatedRef": [
+              "patchStrategy": "replace",
+              "mutatorRef": [
                 [
                   "configuration",
                   "spec",
                   "owner",
                   "name"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ],
@@ -75,12 +75,12 @@
               "version": ""
             },
             "patch": {
-              "mutatorRef": [
+              "patchStrategy": "replace",
+              "mutatedRef": [
                 [
                   "displayName"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ]

--- a/models/azure-sql/azureserviceoperator_customresourcedefinitions_v2.13.0.yaml/v1.0.0/relationships/hierarchical-parent-inventory-qjteb.json
+++ b/models/azure-sql/azureserviceoperator_customresourcedefinitions_v2.13.0.yaml/v1.0.0/relationships/hierarchical-parent-inventory-qjteb.json
@@ -45,15 +45,15 @@
               "version": ""
             },
             "patch": {
-              "mutatedRef": [
+              "patchStrategy": "replace",
+              "mutatorRef": [
                 [
                   "configuration",
                   "spec",
                   "owner",
                   "name"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ],
@@ -75,12 +75,12 @@
               "version": ""
             },
             "patch": {
-              "mutatorRef": [
+              "patchStrategy": "replace",
+              "mutatedRef": [
                 [
                   "displayName"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ]

--- a/models/azure-sql/azureserviceoperator_customresourcedefinitions_v2.13.0.yaml/v1.0.0/relationships/hierarchical-parent-inventory-qkade.json
+++ b/models/azure-sql/azureserviceoperator_customresourcedefinitions_v2.13.0.yaml/v1.0.0/relationships/hierarchical-parent-inventory-qkade.json
@@ -45,15 +45,15 @@
               "version": ""
             },
             "patch": {
-              "mutatedRef": [
+              "patchStrategy": "replace",
+              "mutatorRef": [
                 [
                   "configuration",
                   "spec",
                   "owner",
                   "name"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ],
@@ -75,12 +75,12 @@
               "version": ""
             },
             "patch": {
-              "mutatorRef": [
+              "patchStrategy": "replace",
+              "mutatedRef": [
                 [
                   "displayName"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ]

--- a/models/azure-sql/azureserviceoperator_customresourcedefinitions_v2.13.0.yaml/v1.0.0/relationships/hierarchical-parent-inventory-qoovn.json
+++ b/models/azure-sql/azureserviceoperator_customresourcedefinitions_v2.13.0.yaml/v1.0.0/relationships/hierarchical-parent-inventory-qoovn.json
@@ -45,15 +45,15 @@
               "version": ""
             },
             "patch": {
-              "mutatedRef": [
+              "patchStrategy": "replace",
+              "mutatorRef": [
                 [
                   "configuration",
                   "spec",
                   "owner",
                   "name"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ],
@@ -75,12 +75,12 @@
               "version": ""
             },
             "patch": {
-              "mutatorRef": [
+              "patchStrategy": "replace",
+              "mutatedRef": [
                 [
                   "displayName"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ]

--- a/models/azure-sql/azureserviceoperator_customresourcedefinitions_v2.13.0.yaml/v1.0.0/relationships/hierarchical-parent-inventory-tdldl.json
+++ b/models/azure-sql/azureserviceoperator_customresourcedefinitions_v2.13.0.yaml/v1.0.0/relationships/hierarchical-parent-inventory-tdldl.json
@@ -45,15 +45,15 @@
               "version": ""
             },
             "patch": {
-              "mutatedRef": [
+              "patchStrategy": "replace",
+              "mutatorRef": [
                 [
                   "configuration",
                   "spec",
                   "owner",
                   "name"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ],
@@ -75,12 +75,12 @@
               "version": ""
             },
             "patch": {
-              "mutatorRef": [
+              "patchStrategy": "replace",
+              "mutatedRef": [
                 [
                   "displayName"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ]

--- a/models/azure-sql/azureserviceoperator_customresourcedefinitions_v2.13.0.yaml/v1.0.0/relationships/hierarchical-parent-inventory-vvnkq.json
+++ b/models/azure-sql/azureserviceoperator_customresourcedefinitions_v2.13.0.yaml/v1.0.0/relationships/hierarchical-parent-inventory-vvnkq.json
@@ -45,15 +45,15 @@
               "version": ""
             },
             "patch": {
-              "mutatedRef": [
+              "patchStrategy": "replace",
+              "mutatorRef": [
                 [
                   "configuration",
                   "spec",
                   "owner",
                   "name"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ],
@@ -75,12 +75,12 @@
               "version": ""
             },
             "patch": {
-              "mutatorRef": [
+              "patchStrategy": "replace",
+              "mutatedRef": [
                 [
                   "displayName"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ]

--- a/models/azure-sql/azureserviceoperator_customresourcedefinitions_v2.13.0.yaml/v1.0.0/relationships/hierarchical-parent-inventory-wyoir.json
+++ b/models/azure-sql/azureserviceoperator_customresourcedefinitions_v2.13.0.yaml/v1.0.0/relationships/hierarchical-parent-inventory-wyoir.json
@@ -45,15 +45,15 @@
               "version": ""
             },
             "patch": {
-              "mutatedRef": [
+              "patchStrategy": "replace",
+              "mutatorRef": [
                 [
                   "configuration",
                   "spec",
                   "owner",
                   "name"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ],
@@ -75,12 +75,12 @@
               "version": ""
             },
             "patch": {
-              "mutatorRef": [
+              "patchStrategy": "replace",
+              "mutatedRef": [
                 [
                   "displayName"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ]

--- a/models/azure-sql/azureserviceoperator_customresourcedefinitions_v2.13.0.yaml/v1.0.0/relationships/hierarchical-parent-inventory-xfxar.json
+++ b/models/azure-sql/azureserviceoperator_customresourcedefinitions_v2.13.0.yaml/v1.0.0/relationships/hierarchical-parent-inventory-xfxar.json
@@ -45,15 +45,15 @@
               "version": ""
             },
             "patch": {
-              "mutatedRef": [
+              "patchStrategy": "replace",
+              "mutatorRef": [
                 [
                   "configuration",
                   "spec",
                   "owner",
                   "name"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ],
@@ -75,12 +75,12 @@
               "version": ""
             },
             "patch": {
-              "mutatorRef": [
+              "patchStrategy": "replace",
+              "mutatedRef": [
                 [
                   "displayName"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ]

--- a/models/azure-sql/azureserviceoperator_customresourcedefinitions_v2.13.0.yaml/v1.0.0/relationships/hierarchical-parent-inventory-xmtry.json
+++ b/models/azure-sql/azureserviceoperator_customresourcedefinitions_v2.13.0.yaml/v1.0.0/relationships/hierarchical-parent-inventory-xmtry.json
@@ -45,15 +45,15 @@
               "version": ""
             },
             "patch": {
-              "mutatedRef": [
+              "patchStrategy": "replace",
+              "mutatorRef": [
                 [
                   "configuration",
                   "spec",
                   "owner",
                   "name"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ],
@@ -75,12 +75,12 @@
               "version": ""
             },
             "patch": {
-              "mutatorRef": [
+              "patchStrategy": "replace",
+              "mutatedRef": [
                 [
                   "displayName"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ]

--- a/models/azure-sql/azureserviceoperator_customresourcedefinitions_v2.13.0.yaml/v1.0.0/relationships/hierarchical-parent-inventory-yficd.json
+++ b/models/azure-sql/azureserviceoperator_customresourcedefinitions_v2.13.0.yaml/v1.0.0/relationships/hierarchical-parent-inventory-yficd.json
@@ -45,15 +45,15 @@
               "version": ""
             },
             "patch": {
-              "mutatedRef": [
+              "patchStrategy": "replace",
+              "mutatorRef": [
                 [
                   "configuration",
                   "spec",
                   "owner",
                   "name"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ],
@@ -75,12 +75,12 @@
               "version": ""
             },
             "patch": {
-              "mutatorRef": [
+              "patchStrategy": "replace",
+              "mutatedRef": [
                 [
                   "displayName"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ]

--- a/models/azure-sql/azureserviceoperator_customresourcedefinitions_v2.13.0.yaml/v1.0.0/relationships/hierarchical-parent-inventory-zgpbp.json
+++ b/models/azure-sql/azureserviceoperator_customresourcedefinitions_v2.13.0.yaml/v1.0.0/relationships/hierarchical-parent-inventory-zgpbp.json
@@ -45,15 +45,15 @@
               "version": ""
             },
             "patch": {
-              "mutatedRef": [
+              "patchStrategy": "replace",
+              "mutatorRef": [
                 [
                   "configuration",
                   "spec",
                   "owner",
                   "name"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ],
@@ -75,12 +75,12 @@
               "version": ""
             },
             "patch": {
-              "mutatorRef": [
+              "patchStrategy": "replace",
+              "mutatedRef": [
                 [
                   "displayName"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ]

--- a/models/azure-sql/azureserviceoperator_customresourcedefinitions_v2.14.0.yaml/v1.0.0/relationships/edge-non-binding-reference-dsfss.json
+++ b/models/azure-sql/azureserviceoperator_customresourcedefinitions_v2.14.0.yaml/v1.0.0/relationships/edge-non-binding-reference-dsfss.json
@@ -45,7 +45,8 @@
               "version": ""
             },
             "patch": {
-              "mutatedRef": [
+              "patchStrategy": "replace",
+              "mutatorRef": [
                 [
                   "configuration",
                   "spec",
@@ -64,8 +65,7 @@
                   "reference",
                   "name"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ],
@@ -87,7 +87,8 @@
               "version": ""
             },
             "patch": {
-              "mutatorRef": [
+              "patchStrategy": "replace",
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -101,8 +102,7 @@
                   "spec",
                   "name"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ]

--- a/models/azure-sql/azureserviceoperator_customresourcedefinitions_v2.14.0.yaml/v1.0.0/relationships/edge-non-binding-reference-ijhrr.json
+++ b/models/azure-sql/azureserviceoperator_customresourcedefinitions_v2.14.0.yaml/v1.0.0/relationships/edge-non-binding-reference-ijhrr.json
@@ -91,7 +91,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatedRef": [
+              "mutatorRef": [
                 [
                   "configuration",
                   "spec",
@@ -156,7 +156,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"

--- a/models/azure-sql/azureserviceoperator_customresourcedefinitions_v2.14.0.yaml/v1.0.0/relationships/edge-non-binding-reference-tgvyv.json
+++ b/models/azure-sql/azureserviceoperator_customresourcedefinitions_v2.14.0.yaml/v1.0.0/relationships/edge-non-binding-reference-tgvyv.json
@@ -45,7 +45,8 @@
               "version": ""
             },
             "patch": {
-              "mutatedRef": [
+              "patchStrategy": "replace",
+              "mutatorRef": [
                 [
                   "configuration",
                   "spec",
@@ -64,8 +65,7 @@
                   "virtualNetworkSubnetReference",
                   "name"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ],
@@ -87,7 +87,8 @@
               "version": ""
             },
             "patch": {
-              "mutatorRef": [
+              "patchStrategy": "replace",
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"
@@ -101,8 +102,7 @@
                   "spec",
                   "name"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ]

--- a/models/azure-sql/azureserviceoperator_customresourcedefinitions_v2.14.0.yaml/v1.0.0/relationships/hierarchical-parent-inventory-czhhd.json
+++ b/models/azure-sql/azureserviceoperator_customresourcedefinitions_v2.14.0.yaml/v1.0.0/relationships/hierarchical-parent-inventory-czhhd.json
@@ -45,15 +45,15 @@
               "version": ""
             },
             "patch": {
-              "mutatedRef": [
+              "patchStrategy": "replace",
+              "mutatorRef": [
                 [
                   "configuration",
                   "spec",
                   "owner",
                   "name"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ],
@@ -75,12 +75,12 @@
               "version": ""
             },
             "patch": {
-              "mutatorRef": [
+              "patchStrategy": "replace",
+              "mutatedRef": [
                 [
                   "displayName"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ]

--- a/models/azure-sql/azureserviceoperator_customresourcedefinitions_v2.14.0.yaml/v1.0.0/relationships/hierarchical-parent-inventory-hrusz.json
+++ b/models/azure-sql/azureserviceoperator_customresourcedefinitions_v2.14.0.yaml/v1.0.0/relationships/hierarchical-parent-inventory-hrusz.json
@@ -45,15 +45,15 @@
               "version": ""
             },
             "patch": {
-              "mutatedRef": [
+              "patchStrategy": "replace",
+              "mutatorRef": [
                 [
                   "configuration",
                   "spec",
                   "owner",
                   "name"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ],
@@ -75,12 +75,12 @@
               "version": ""
             },
             "patch": {
-              "mutatorRef": [
+              "patchStrategy": "replace",
+              "mutatedRef": [
                 [
                   "displayName"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ]

--- a/models/azure-sql/azureserviceoperator_customresourcedefinitions_v2.14.0.yaml/v1.0.0/relationships/hierarchical-parent-inventory-hvdin.json
+++ b/models/azure-sql/azureserviceoperator_customresourcedefinitions_v2.14.0.yaml/v1.0.0/relationships/hierarchical-parent-inventory-hvdin.json
@@ -45,15 +45,15 @@
               "version": ""
             },
             "patch": {
-              "mutatedRef": [
+              "patchStrategy": "replace",
+              "mutatorRef": [
                 [
                   "configuration",
                   "spec",
                   "owner",
                   "name"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ],
@@ -75,12 +75,12 @@
               "version": ""
             },
             "patch": {
-              "mutatorRef": [
+              "patchStrategy": "replace",
+              "mutatedRef": [
                 [
                   "displayName"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ]

--- a/models/azure-sql/azureserviceoperator_customresourcedefinitions_v2.14.0.yaml/v1.0.0/relationships/hierarchical-parent-inventory-idiuh.json
+++ b/models/azure-sql/azureserviceoperator_customresourcedefinitions_v2.14.0.yaml/v1.0.0/relationships/hierarchical-parent-inventory-idiuh.json
@@ -45,15 +45,15 @@
               "version": ""
             },
             "patch": {
-              "mutatedRef": [
+              "patchStrategy": "replace",
+              "mutatorRef": [
                 [
                   "configuration",
                   "spec",
                   "owner",
                   "name"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ],
@@ -75,12 +75,12 @@
               "version": ""
             },
             "patch": {
-              "mutatorRef": [
+              "patchStrategy": "replace",
+              "mutatedRef": [
                 [
                   "displayName"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ]

--- a/models/azure-sql/azureserviceoperator_customresourcedefinitions_v2.14.0.yaml/v1.0.0/relationships/hierarchical-parent-inventory-jlwit.json
+++ b/models/azure-sql/azureserviceoperator_customresourcedefinitions_v2.14.0.yaml/v1.0.0/relationships/hierarchical-parent-inventory-jlwit.json
@@ -45,15 +45,15 @@
               "version": ""
             },
             "patch": {
-              "mutatedRef": [
+              "patchStrategy": "replace",
+              "mutatorRef": [
                 [
                   "configuration",
                   "spec",
                   "owner",
                   "name"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ],
@@ -75,12 +75,12 @@
               "version": ""
             },
             "patch": {
-              "mutatorRef": [
+              "patchStrategy": "replace",
+              "mutatedRef": [
                 [
                   "displayName"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ]

--- a/models/azure-sql/azureserviceoperator_customresourcedefinitions_v2.14.0.yaml/v1.0.0/relationships/hierarchical-parent-inventory-kmjea.json
+++ b/models/azure-sql/azureserviceoperator_customresourcedefinitions_v2.14.0.yaml/v1.0.0/relationships/hierarchical-parent-inventory-kmjea.json
@@ -91,7 +91,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatedRef": [
+              "mutatorRef": [
                 [
                   "configuration",
                   "spec",
@@ -156,7 +156,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "configuration",
                   "group"

--- a/models/azure-sql/azureserviceoperator_customresourcedefinitions_v2.14.0.yaml/v1.0.0/relationships/hierarchical-parent-inventory-mkubo.json
+++ b/models/azure-sql/azureserviceoperator_customresourcedefinitions_v2.14.0.yaml/v1.0.0/relationships/hierarchical-parent-inventory-mkubo.json
@@ -45,15 +45,15 @@
               "version": ""
             },
             "patch": {
-              "mutatedRef": [
+              "patchStrategy": "replace",
+              "mutatorRef": [
                 [
                   "configuration",
                   "spec",
                   "owner",
                   "name"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ],
@@ -75,12 +75,12 @@
               "version": ""
             },
             "patch": {
-              "mutatorRef": [
+              "patchStrategy": "replace",
+              "mutatedRef": [
                 [
                   "displayName"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ]

--- a/models/azure-sql/azureserviceoperator_customresourcedefinitions_v2.14.0.yaml/v1.0.0/relationships/hierarchical-parent-inventory-nhyiu.json
+++ b/models/azure-sql/azureserviceoperator_customresourcedefinitions_v2.14.0.yaml/v1.0.0/relationships/hierarchical-parent-inventory-nhyiu.json
@@ -45,15 +45,15 @@
               "version": ""
             },
             "patch": {
-              "mutatedRef": [
+              "patchStrategy": "replace",
+              "mutatorRef": [
                 [
                   "configuration",
                   "spec",
                   "owner",
                   "name"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ],
@@ -75,12 +75,12 @@
               "version": ""
             },
             "patch": {
-              "mutatorRef": [
+              "patchStrategy": "replace",
+              "mutatedRef": [
                 [
                   "displayName"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ]

--- a/models/azure-sql/azureserviceoperator_customresourcedefinitions_v2.14.0.yaml/v1.0.0/relationships/hierarchical-parent-inventory-nqddp.json
+++ b/models/azure-sql/azureserviceoperator_customresourcedefinitions_v2.14.0.yaml/v1.0.0/relationships/hierarchical-parent-inventory-nqddp.json
@@ -45,15 +45,15 @@
               "version": ""
             },
             "patch": {
-              "mutatedRef": [
+              "patchStrategy": "replace",
+              "mutatorRef": [
                 [
                   "configuration",
                   "spec",
                   "owner",
                   "name"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ],
@@ -75,12 +75,12 @@
               "version": ""
             },
             "patch": {
-              "mutatorRef": [
+              "patchStrategy": "replace",
+              "mutatedRef": [
                 [
                   "displayName"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ]

--- a/models/azure-sql/azureserviceoperator_customresourcedefinitions_v2.14.0.yaml/v1.0.0/relationships/hierarchical-parent-inventory-osawm.json
+++ b/models/azure-sql/azureserviceoperator_customresourcedefinitions_v2.14.0.yaml/v1.0.0/relationships/hierarchical-parent-inventory-osawm.json
@@ -45,15 +45,15 @@
               "version": ""
             },
             "patch": {
-              "mutatedRef": [
+              "patchStrategy": "replace",
+              "mutatorRef": [
                 [
                   "configuration",
                   "spec",
                   "owner",
                   "name"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ],
@@ -75,12 +75,12 @@
               "version": ""
             },
             "patch": {
-              "mutatorRef": [
+              "patchStrategy": "replace",
+              "mutatedRef": [
                 [
                   "displayName"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ]

--- a/models/azure-sql/azureserviceoperator_customresourcedefinitions_v2.14.0.yaml/v1.0.0/relationships/hierarchical-parent-inventory-oukgx.json
+++ b/models/azure-sql/azureserviceoperator_customresourcedefinitions_v2.14.0.yaml/v1.0.0/relationships/hierarchical-parent-inventory-oukgx.json
@@ -45,15 +45,15 @@
               "version": ""
             },
             "patch": {
-              "mutatedRef": [
+              "patchStrategy": "replace",
+              "mutatorRef": [
                 [
                   "configuration",
                   "spec",
                   "owner",
                   "name"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ],
@@ -75,12 +75,12 @@
               "version": ""
             },
             "patch": {
-              "mutatorRef": [
+              "patchStrategy": "replace",
+              "mutatedRef": [
                 [
                   "displayName"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ]

--- a/models/azure-sql/azureserviceoperator_customresourcedefinitions_v2.14.0.yaml/v1.0.0/relationships/hierarchical-parent-inventory-pqttn.json
+++ b/models/azure-sql/azureserviceoperator_customresourcedefinitions_v2.14.0.yaml/v1.0.0/relationships/hierarchical-parent-inventory-pqttn.json
@@ -45,15 +45,15 @@
               "version": ""
             },
             "patch": {
-              "mutatedRef": [
+              "patchStrategy": "replace",
+              "mutatorRef": [
                 [
                   "configuration",
                   "spec",
                   "owner",
                   "name"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ],
@@ -75,12 +75,12 @@
               "version": ""
             },
             "patch": {
-              "mutatorRef": [
+              "patchStrategy": "replace",
+              "mutatedRef": [
                 [
                   "displayName"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ]

--- a/models/azure-sql/azureserviceoperator_customresourcedefinitions_v2.14.0.yaml/v1.0.0/relationships/hierarchical-parent-inventory-pvkhn.json
+++ b/models/azure-sql/azureserviceoperator_customresourcedefinitions_v2.14.0.yaml/v1.0.0/relationships/hierarchical-parent-inventory-pvkhn.json
@@ -45,15 +45,15 @@
               "version": ""
             },
             "patch": {
-              "mutatedRef": [
+              "patchStrategy": "replace",
+              "mutatorRef": [
                 [
                   "configuration",
                   "spec",
                   "owner",
                   "name"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ],
@@ -75,12 +75,12 @@
               "version": ""
             },
             "patch": {
-              "mutatorRef": [
+              "patchStrategy": "replace",
+              "mutatedRef": [
                 [
                   "displayName"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ]

--- a/models/azure-sql/azureserviceoperator_customresourcedefinitions_v2.14.0.yaml/v1.0.0/relationships/hierarchical-parent-inventory-qjteb.json
+++ b/models/azure-sql/azureserviceoperator_customresourcedefinitions_v2.14.0.yaml/v1.0.0/relationships/hierarchical-parent-inventory-qjteb.json
@@ -45,15 +45,15 @@
               "version": ""
             },
             "patch": {
-              "mutatedRef": [
+              "patchStrategy": "replace",
+              "mutatorRef": [
                 [
                   "configuration",
                   "spec",
                   "owner",
                   "name"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ],
@@ -75,12 +75,12 @@
               "version": ""
             },
             "patch": {
-              "mutatorRef": [
+              "patchStrategy": "replace",
+              "mutatedRef": [
                 [
                   "displayName"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ]

--- a/models/azure-sql/azureserviceoperator_customresourcedefinitions_v2.14.0.yaml/v1.0.0/relationships/hierarchical-parent-inventory-qkade.json
+++ b/models/azure-sql/azureserviceoperator_customresourcedefinitions_v2.14.0.yaml/v1.0.0/relationships/hierarchical-parent-inventory-qkade.json
@@ -45,15 +45,15 @@
               "version": ""
             },
             "patch": {
-              "mutatedRef": [
+              "patchStrategy": "replace",
+              "mutatorRef": [
                 [
                   "configuration",
                   "spec",
                   "owner",
                   "name"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ],
@@ -75,12 +75,12 @@
               "version": ""
             },
             "patch": {
-              "mutatorRef": [
+              "patchStrategy": "replace",
+              "mutatedRef": [
                 [
                   "displayName"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ]

--- a/models/azure-sql/azureserviceoperator_customresourcedefinitions_v2.14.0.yaml/v1.0.0/relationships/hierarchical-parent-inventory-qoovn.json
+++ b/models/azure-sql/azureserviceoperator_customresourcedefinitions_v2.14.0.yaml/v1.0.0/relationships/hierarchical-parent-inventory-qoovn.json
@@ -45,15 +45,15 @@
               "version": ""
             },
             "patch": {
-              "mutatedRef": [
+              "patchStrategy": "replace",
+              "mutatorRef": [
                 [
                   "configuration",
                   "spec",
                   "owner",
                   "name"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ],
@@ -75,12 +75,12 @@
               "version": ""
             },
             "patch": {
-              "mutatorRef": [
+              "patchStrategy": "replace",
+              "mutatedRef": [
                 [
                   "displayName"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ]

--- a/models/azure-sql/azureserviceoperator_customresourcedefinitions_v2.14.0.yaml/v1.0.0/relationships/hierarchical-parent-inventory-tdldl.json
+++ b/models/azure-sql/azureserviceoperator_customresourcedefinitions_v2.14.0.yaml/v1.0.0/relationships/hierarchical-parent-inventory-tdldl.json
@@ -45,15 +45,15 @@
               "version": ""
             },
             "patch": {
-              "mutatedRef": [
+              "patchStrategy": "replace",
+              "mutatorRef": [
                 [
                   "configuration",
                   "spec",
                   "owner",
                   "name"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ],
@@ -75,12 +75,12 @@
               "version": ""
             },
             "patch": {
-              "mutatorRef": [
+              "patchStrategy": "replace",
+              "mutatedRef": [
                 [
                   "displayName"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ]

--- a/models/azure-sql/azureserviceoperator_customresourcedefinitions_v2.14.0.yaml/v1.0.0/relationships/hierarchical-parent-inventory-vvnkq.json
+++ b/models/azure-sql/azureserviceoperator_customresourcedefinitions_v2.14.0.yaml/v1.0.0/relationships/hierarchical-parent-inventory-vvnkq.json
@@ -45,15 +45,15 @@
               "version": ""
             },
             "patch": {
-              "mutatedRef": [
+              "patchStrategy": "replace",
+              "mutatorRef": [
                 [
                   "configuration",
                   "spec",
                   "owner",
                   "name"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ],
@@ -75,12 +75,12 @@
               "version": ""
             },
             "patch": {
-              "mutatorRef": [
+              "patchStrategy": "replace",
+              "mutatedRef": [
                 [
                   "displayName"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ]

--- a/models/azure-sql/azureserviceoperator_customresourcedefinitions_v2.14.0.yaml/v1.0.0/relationships/hierarchical-parent-inventory-wyoir.json
+++ b/models/azure-sql/azureserviceoperator_customresourcedefinitions_v2.14.0.yaml/v1.0.0/relationships/hierarchical-parent-inventory-wyoir.json
@@ -45,15 +45,15 @@
               "version": ""
             },
             "patch": {
-              "mutatedRef": [
+              "patchStrategy": "replace",
+              "mutatorRef": [
                 [
                   "configuration",
                   "spec",
                   "owner",
                   "name"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ],
@@ -75,12 +75,12 @@
               "version": ""
             },
             "patch": {
-              "mutatorRef": [
+              "patchStrategy": "replace",
+              "mutatedRef": [
                 [
                   "displayName"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ]

--- a/models/azure-sql/azureserviceoperator_customresourcedefinitions_v2.14.0.yaml/v1.0.0/relationships/hierarchical-parent-inventory-xfxar.json
+++ b/models/azure-sql/azureserviceoperator_customresourcedefinitions_v2.14.0.yaml/v1.0.0/relationships/hierarchical-parent-inventory-xfxar.json
@@ -45,15 +45,15 @@
               "version": ""
             },
             "patch": {
-              "mutatedRef": [
+              "patchStrategy": "replace",
+              "mutatorRef": [
                 [
                   "configuration",
                   "spec",
                   "owner",
                   "name"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ],
@@ -75,12 +75,12 @@
               "version": ""
             },
             "patch": {
-              "mutatorRef": [
+              "patchStrategy": "replace",
+              "mutatedRef": [
                 [
                   "displayName"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ]

--- a/models/azure-sql/azureserviceoperator_customresourcedefinitions_v2.14.0.yaml/v1.0.0/relationships/hierarchical-parent-inventory-xmtry.json
+++ b/models/azure-sql/azureserviceoperator_customresourcedefinitions_v2.14.0.yaml/v1.0.0/relationships/hierarchical-parent-inventory-xmtry.json
@@ -45,15 +45,15 @@
               "version": ""
             },
             "patch": {
-              "mutatedRef": [
+              "patchStrategy": "replace",
+              "mutatorRef": [
                 [
                   "configuration",
                   "spec",
                   "owner",
                   "name"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ],
@@ -75,12 +75,12 @@
               "version": ""
             },
             "patch": {
-              "mutatorRef": [
+              "patchStrategy": "replace",
+              "mutatedRef": [
                 [
                   "displayName"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ]

--- a/models/azure-sql/azureserviceoperator_customresourcedefinitions_v2.14.0.yaml/v1.0.0/relationships/hierarchical-parent-inventory-yficd.json
+++ b/models/azure-sql/azureserviceoperator_customresourcedefinitions_v2.14.0.yaml/v1.0.0/relationships/hierarchical-parent-inventory-yficd.json
@@ -45,15 +45,15 @@
               "version": ""
             },
             "patch": {
-              "mutatedRef": [
+              "patchStrategy": "replace",
+              "mutatorRef": [
                 [
                   "configuration",
                   "spec",
                   "owner",
                   "name"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ],
@@ -75,12 +75,12 @@
               "version": ""
             },
             "patch": {
-              "mutatorRef": [
+              "patchStrategy": "replace",
+              "mutatedRef": [
                 [
                   "displayName"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ]

--- a/models/azure-sql/azureserviceoperator_customresourcedefinitions_v2.14.0.yaml/v1.0.0/relationships/hierarchical-parent-inventory-zgpbp.json
+++ b/models/azure-sql/azureserviceoperator_customresourcedefinitions_v2.14.0.yaml/v1.0.0/relationships/hierarchical-parent-inventory-zgpbp.json
@@ -45,15 +45,15 @@
               "version": ""
             },
             "patch": {
-              "mutatedRef": [
+              "patchStrategy": "replace",
+              "mutatorRef": [
                 [
                   "configuration",
                   "spec",
                   "owner",
                   "name"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ],
@@ -75,12 +75,12 @@
               "version": ""
             },
             "patch": {
-              "mutatorRef": [
+              "patchStrategy": "replace",
+              "mutatedRef": [
                 [
                   "displayName"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ]

--- a/models/azure-storage/azureserviceoperator_customresourcedefinitions_v2.13.0.yaml/v1.0.0/relationships/hierarchical-parent-inventory-fcmqh.json
+++ b/models/azure-storage/azureserviceoperator_customresourcedefinitions_v2.13.0.yaml/v1.0.0/relationships/hierarchical-parent-inventory-fcmqh.json
@@ -45,15 +45,15 @@
               "version": ""
             },
             "patch": {
-              "mutatedRef": [
+              "patchStrategy": "replace",
+              "mutatorRef": [
                 [
                   "configuration",
                   "spec",
                   "owner",
                   "name"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ],
@@ -75,12 +75,12 @@
               "version": ""
             },
             "patch": {
-              "mutatorRef": [
+              "patchStrategy": "replace",
+              "mutatedRef": [
                 [
                   "displayName"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ]

--- a/models/azure-storage/azureserviceoperator_customresourcedefinitions_v2.13.0.yaml/v1.0.0/relationships/hierarchical-parent-inventory-fkomk.json
+++ b/models/azure-storage/azureserviceoperator_customresourcedefinitions_v2.13.0.yaml/v1.0.0/relationships/hierarchical-parent-inventory-fkomk.json
@@ -45,15 +45,15 @@
               "version": ""
             },
             "patch": {
-              "mutatedRef": [
+              "patchStrategy": "replace",
+              "mutatorRef": [
                 [
                   "configuration",
                   "spec",
                   "owner",
                   "name"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ],
@@ -75,12 +75,12 @@
               "version": ""
             },
             "patch": {
-              "mutatorRef": [
+              "patchStrategy": "replace",
+              "mutatedRef": [
                 [
                   "displayName"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ]

--- a/models/azure-storage/azureserviceoperator_customresourcedefinitions_v2.13.0.yaml/v1.0.0/relationships/hierarchical-parent-inventory-goayj.json
+++ b/models/azure-storage/azureserviceoperator_customresourcedefinitions_v2.13.0.yaml/v1.0.0/relationships/hierarchical-parent-inventory-goayj.json
@@ -45,15 +45,15 @@
               "version": ""
             },
             "patch": {
-              "mutatedRef": [
+              "patchStrategy": "replace",
+              "mutatorRef": [
                 [
                   "configuration",
                   "spec",
                   "owner",
                   "name"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ],
@@ -75,12 +75,12 @@
               "version": ""
             },
             "patch": {
-              "mutatorRef": [
+              "patchStrategy": "replace",
+              "mutatedRef": [
                 [
                   "displayName"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ]

--- a/models/azure-storage/azureserviceoperator_customresourcedefinitions_v2.13.0.yaml/v1.0.0/relationships/hierarchical-parent-inventory-ihqhs.json
+++ b/models/azure-storage/azureserviceoperator_customresourcedefinitions_v2.13.0.yaml/v1.0.0/relationships/hierarchical-parent-inventory-ihqhs.json
@@ -45,15 +45,15 @@
               "version": ""
             },
             "patch": {
-              "mutatedRef": [
+              "patchStrategy": "replace",
+              "mutatorRef": [
                 [
                   "configuration",
                   "spec",
                   "owner",
                   "name"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ],
@@ -75,12 +75,12 @@
               "version": ""
             },
             "patch": {
-              "mutatorRef": [
+              "patchStrategy": "replace",
+              "mutatedRef": [
                 [
                   "displayName"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ]

--- a/models/azure-storage/azureserviceoperator_customresourcedefinitions_v2.13.0.yaml/v1.0.0/relationships/hierarchical-parent-inventory-jitmd.json
+++ b/models/azure-storage/azureserviceoperator_customresourcedefinitions_v2.13.0.yaml/v1.0.0/relationships/hierarchical-parent-inventory-jitmd.json
@@ -45,15 +45,15 @@
               "version": ""
             },
             "patch": {
-              "mutatedRef": [
+              "patchStrategy": "replace",
+              "mutatorRef": [
                 [
                   "configuration",
                   "spec",
                   "owner",
                   "name"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ],
@@ -75,12 +75,12 @@
               "version": ""
             },
             "patch": {
-              "mutatorRef": [
+              "patchStrategy": "replace",
+              "mutatedRef": [
                 [
                   "displayName"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ]

--- a/models/azure-storage/azureserviceoperator_customresourcedefinitions_v2.13.0.yaml/v1.0.0/relationships/hierarchical-parent-inventory-kmjea.json
+++ b/models/azure-storage/azureserviceoperator_customresourcedefinitions_v2.13.0.yaml/v1.0.0/relationships/hierarchical-parent-inventory-kmjea.json
@@ -91,7 +91,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatedRef": [
+              "mutatorRef": [
                 [
                   "configuration",
                   "spec",
@@ -144,7 +144,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "displayName"
                 ]

--- a/models/azure-storage/azureserviceoperator_customresourcedefinitions_v2.13.0.yaml/v1.0.0/relationships/hierarchical-parent-inventory-krkgx.json
+++ b/models/azure-storage/azureserviceoperator_customresourcedefinitions_v2.13.0.yaml/v1.0.0/relationships/hierarchical-parent-inventory-krkgx.json
@@ -45,15 +45,15 @@
               "version": ""
             },
             "patch": {
-              "mutatedRef": [
+              "patchStrategy": "replace",
+              "mutatorRef": [
                 [
                   "configuration",
                   "spec",
                   "owner",
                   "name"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ],
@@ -75,12 +75,12 @@
               "version": ""
             },
             "patch": {
-              "mutatorRef": [
+              "patchStrategy": "replace",
+              "mutatedRef": [
                 [
                   "displayName"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ]

--- a/models/azure-storage/azureserviceoperator_customresourcedefinitions_v2.13.0.yaml/v1.0.0/relationships/hierarchical-parent-inventory-oldzd.json
+++ b/models/azure-storage/azureserviceoperator_customresourcedefinitions_v2.13.0.yaml/v1.0.0/relationships/hierarchical-parent-inventory-oldzd.json
@@ -45,15 +45,15 @@
               "version": ""
             },
             "patch": {
-              "mutatedRef": [
+              "patchStrategy": "replace",
+              "mutatorRef": [
                 [
                   "configuration",
                   "spec",
                   "owner",
                   "name"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ],
@@ -75,12 +75,12 @@
               "version": ""
             },
             "patch": {
-              "mutatorRef": [
+              "patchStrategy": "replace",
+              "mutatedRef": [
                 [
                   "displayName"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ]

--- a/models/azure-storage/azureserviceoperator_customresourcedefinitions_v2.13.0.yaml/v1.0.0/relationships/hierarchical-parent-inventory-qrrkd.json
+++ b/models/azure-storage/azureserviceoperator_customresourcedefinitions_v2.13.0.yaml/v1.0.0/relationships/hierarchical-parent-inventory-qrrkd.json
@@ -45,15 +45,15 @@
               "version": ""
             },
             "patch": {
-              "mutatedRef": [
+              "patchStrategy": "replace",
+              "mutatorRef": [
                 [
                   "configuration",
                   "spec",
                   "owner",
                   "name"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ],
@@ -75,12 +75,12 @@
               "version": ""
             },
             "patch": {
-              "mutatorRef": [
+              "patchStrategy": "replace",
+              "mutatedRef": [
                 [
                   "displayName"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ]

--- a/models/azure-storage/azureserviceoperator_customresourcedefinitions_v2.13.0.yaml/v1.0.0/relationships/hierarchical-parent-inventory-ybwdz.json
+++ b/models/azure-storage/azureserviceoperator_customresourcedefinitions_v2.13.0.yaml/v1.0.0/relationships/hierarchical-parent-inventory-ybwdz.json
@@ -45,15 +45,15 @@
               "version": ""
             },
             "patch": {
-              "mutatedRef": [
+              "patchStrategy": "replace",
+              "mutatorRef": [
                 [
                   "configuration",
                   "spec",
                   "owner",
                   "name"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ],
@@ -75,12 +75,12 @@
               "version": ""
             },
             "patch": {
-              "mutatorRef": [
+              "patchStrategy": "replace",
+              "mutatedRef": [
                 [
                   "displayName"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ]

--- a/models/azure-storage/azureserviceoperator_customresourcedefinitions_v2.14.0.yaml/v1.0.0/relationships/hierarchical-parent-inventory-fcmqh.json
+++ b/models/azure-storage/azureserviceoperator_customresourcedefinitions_v2.14.0.yaml/v1.0.0/relationships/hierarchical-parent-inventory-fcmqh.json
@@ -45,15 +45,15 @@
               "version": ""
             },
             "patch": {
-              "mutatedRef": [
+              "patchStrategy": "replace",
+              "mutatorRef": [
                 [
                   "configuration",
                   "spec",
                   "owner",
                   "name"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ],
@@ -75,12 +75,12 @@
               "version": ""
             },
             "patch": {
-              "mutatorRef": [
+              "patchStrategy": "replace",
+              "mutatedRef": [
                 [
                   "displayName"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ]

--- a/models/azure-storage/azureserviceoperator_customresourcedefinitions_v2.14.0.yaml/v1.0.0/relationships/hierarchical-parent-inventory-fkomk.json
+++ b/models/azure-storage/azureserviceoperator_customresourcedefinitions_v2.14.0.yaml/v1.0.0/relationships/hierarchical-parent-inventory-fkomk.json
@@ -45,15 +45,15 @@
               "version": ""
             },
             "patch": {
-              "mutatedRef": [
+              "patchStrategy": "replace",
+              "mutatorRef": [
                 [
                   "configuration",
                   "spec",
                   "owner",
                   "name"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ],
@@ -75,12 +75,12 @@
               "version": ""
             },
             "patch": {
-              "mutatorRef": [
+              "patchStrategy": "replace",
+              "mutatedRef": [
                 [
                   "displayName"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ]

--- a/models/azure-storage/azureserviceoperator_customresourcedefinitions_v2.14.0.yaml/v1.0.0/relationships/hierarchical-parent-inventory-goayj.json
+++ b/models/azure-storage/azureserviceoperator_customresourcedefinitions_v2.14.0.yaml/v1.0.0/relationships/hierarchical-parent-inventory-goayj.json
@@ -45,15 +45,15 @@
               "version": ""
             },
             "patch": {
-              "mutatedRef": [
+              "patchStrategy": "replace",
+              "mutatorRef": [
                 [
                   "configuration",
                   "spec",
                   "owner",
                   "name"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ],
@@ -75,12 +75,12 @@
               "version": ""
             },
             "patch": {
-              "mutatorRef": [
+              "patchStrategy": "replace",
+              "mutatedRef": [
                 [
                   "displayName"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ]

--- a/models/azure-storage/azureserviceoperator_customresourcedefinitions_v2.14.0.yaml/v1.0.0/relationships/hierarchical-parent-inventory-ihqhs.json
+++ b/models/azure-storage/azureserviceoperator_customresourcedefinitions_v2.14.0.yaml/v1.0.0/relationships/hierarchical-parent-inventory-ihqhs.json
@@ -45,15 +45,15 @@
               "version": ""
             },
             "patch": {
-              "mutatedRef": [
+              "patchStrategy": "replace",
+              "mutatorRef": [
                 [
                   "configuration",
                   "spec",
                   "owner",
                   "name"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ],
@@ -75,12 +75,12 @@
               "version": ""
             },
             "patch": {
-              "mutatorRef": [
+              "patchStrategy": "replace",
+              "mutatedRef": [
                 [
                   "displayName"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ]

--- a/models/azure-storage/azureserviceoperator_customresourcedefinitions_v2.14.0.yaml/v1.0.0/relationships/hierarchical-parent-inventory-jitmd.json
+++ b/models/azure-storage/azureserviceoperator_customresourcedefinitions_v2.14.0.yaml/v1.0.0/relationships/hierarchical-parent-inventory-jitmd.json
@@ -45,15 +45,15 @@
               "version": ""
             },
             "patch": {
-              "mutatedRef": [
+              "patchStrategy": "replace",
+              "mutatorRef": [
                 [
                   "configuration",
                   "spec",
                   "owner",
                   "name"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ],
@@ -75,12 +75,12 @@
               "version": ""
             },
             "patch": {
-              "mutatorRef": [
+              "patchStrategy": "replace",
+              "mutatedRef": [
                 [
                   "displayName"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ]

--- a/models/azure-storage/azureserviceoperator_customresourcedefinitions_v2.14.0.yaml/v1.0.0/relationships/hierarchical-parent-inventory-kmjea.json
+++ b/models/azure-storage/azureserviceoperator_customresourcedefinitions_v2.14.0.yaml/v1.0.0/relationships/hierarchical-parent-inventory-kmjea.json
@@ -91,7 +91,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatedRef": [
+              "mutatorRef": [
                 [
                   "configuration",
                   "spec",
@@ -144,7 +144,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "displayName"
                 ]

--- a/models/azure-storage/azureserviceoperator_customresourcedefinitions_v2.14.0.yaml/v1.0.0/relationships/hierarchical-parent-inventory-krkgx.json
+++ b/models/azure-storage/azureserviceoperator_customresourcedefinitions_v2.14.0.yaml/v1.0.0/relationships/hierarchical-parent-inventory-krkgx.json
@@ -45,15 +45,15 @@
               "version": ""
             },
             "patch": {
-              "mutatedRef": [
+              "patchStrategy": "replace",
+              "mutatorRef": [
                 [
                   "configuration",
                   "spec",
                   "owner",
                   "name"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ],
@@ -75,12 +75,12 @@
               "version": ""
             },
             "patch": {
-              "mutatorRef": [
+              "patchStrategy": "replace",
+              "mutatedRef": [
                 [
                   "displayName"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ]

--- a/models/azure-storage/azureserviceoperator_customresourcedefinitions_v2.14.0.yaml/v1.0.0/relationships/hierarchical-parent-inventory-oldzd.json
+++ b/models/azure-storage/azureserviceoperator_customresourcedefinitions_v2.14.0.yaml/v1.0.0/relationships/hierarchical-parent-inventory-oldzd.json
@@ -45,15 +45,15 @@
               "version": ""
             },
             "patch": {
-              "mutatedRef": [
+              "patchStrategy": "replace",
+              "mutatorRef": [
                 [
                   "configuration",
                   "spec",
                   "owner",
                   "name"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ],
@@ -75,12 +75,12 @@
               "version": ""
             },
             "patch": {
-              "mutatorRef": [
+              "patchStrategy": "replace",
+              "mutatedRef": [
                 [
                   "displayName"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ]

--- a/models/azure-storage/azureserviceoperator_customresourcedefinitions_v2.14.0.yaml/v1.0.0/relationships/hierarchical-parent-inventory-qrrkd.json
+++ b/models/azure-storage/azureserviceoperator_customresourcedefinitions_v2.14.0.yaml/v1.0.0/relationships/hierarchical-parent-inventory-qrrkd.json
@@ -45,15 +45,15 @@
               "version": ""
             },
             "patch": {
-              "mutatedRef": [
+              "patchStrategy": "replace",
+              "mutatorRef": [
                 [
                   "configuration",
                   "spec",
                   "owner",
                   "name"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ],
@@ -75,12 +75,12 @@
               "version": ""
             },
             "patch": {
-              "mutatorRef": [
+              "patchStrategy": "replace",
+              "mutatedRef": [
                 [
                   "displayName"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ]

--- a/models/azure-storage/azureserviceoperator_customresourcedefinitions_v2.14.0.yaml/v1.0.0/relationships/hierarchical-parent-inventory-ybwdz.json
+++ b/models/azure-storage/azureserviceoperator_customresourcedefinitions_v2.14.0.yaml/v1.0.0/relationships/hierarchical-parent-inventory-ybwdz.json
@@ -45,15 +45,15 @@
               "version": ""
             },
             "patch": {
-              "mutatedRef": [
+              "patchStrategy": "replace",
+              "mutatorRef": [
                 [
                   "configuration",
                   "spec",
                   "owner",
                   "name"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ],
@@ -75,12 +75,12 @@
               "version": ""
             },
             "patch": {
-              "mutatorRef": [
+              "patchStrategy": "replace",
+              "mutatedRef": [
                 [
                   "displayName"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ]

--- a/models/azure-synapse/azureserviceoperator_customresourcedefinitions_v2.13.0.yaml/v1.0.0/relationships/hierarchical-parent-inventory-kmjea.json
+++ b/models/azure-synapse/azureserviceoperator_customresourcedefinitions_v2.13.0.yaml/v1.0.0/relationships/hierarchical-parent-inventory-kmjea.json
@@ -91,7 +91,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatedRef": [
+              "mutatorRef": [
                 [
                   "configuration",
                   "spec",
@@ -144,7 +144,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "displayName"
                 ]

--- a/models/azure-synapse/azureserviceoperator_customresourcedefinitions_v2.13.0.yaml/v1.0.0/relationships/hierarchical-parent-inventory-wqpmi.json
+++ b/models/azure-synapse/azureserviceoperator_customresourcedefinitions_v2.13.0.yaml/v1.0.0/relationships/hierarchical-parent-inventory-wqpmi.json
@@ -45,15 +45,15 @@
               "version": ""
             },
             "patch": {
-              "mutatedRef": [
+              "patchStrategy": "replace",
+              "mutatorRef": [
                 [
                   "configuration",
                   "spec",
                   "owner",
                   "name"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ],
@@ -75,12 +75,12 @@
               "version": ""
             },
             "patch": {
-              "mutatorRef": [
+              "patchStrategy": "replace",
+              "mutatedRef": [
                 [
                   "displayName"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ]

--- a/models/azure-synapse/azureserviceoperator_customresourcedefinitions_v2.14.0.yaml/v1.0.0/relationships/hierarchical-parent-inventory-kmjea.json
+++ b/models/azure-synapse/azureserviceoperator_customresourcedefinitions_v2.14.0.yaml/v1.0.0/relationships/hierarchical-parent-inventory-kmjea.json
@@ -91,7 +91,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatedRef": [
+              "mutatorRef": [
                 [
                   "configuration",
                   "spec",
@@ -144,7 +144,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "displayName"
                 ]

--- a/models/azure-synapse/azureserviceoperator_customresourcedefinitions_v2.14.0.yaml/v1.0.0/relationships/hierarchical-parent-inventory-wqpmi.json
+++ b/models/azure-synapse/azureserviceoperator_customresourcedefinitions_v2.14.0.yaml/v1.0.0/relationships/hierarchical-parent-inventory-wqpmi.json
@@ -45,15 +45,15 @@
               "version": ""
             },
             "patch": {
-              "mutatedRef": [
+              "patchStrategy": "replace",
+              "mutatorRef": [
                 [
                   "configuration",
                   "spec",
                   "owner",
                   "name"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ],
@@ -75,12 +75,12 @@
               "version": ""
             },
             "patch": {
-              "mutatorRef": [
+              "patchStrategy": "replace",
+              "mutatedRef": [
                 [
                   "displayName"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ]

--- a/models/azure-web/azureserviceoperator_customresourcedefinitions_v2.13.0.yaml/v1.0.0/relationships/hierarchical-parent-inventory-kmjea.json
+++ b/models/azure-web/azureserviceoperator_customresourcedefinitions_v2.13.0.yaml/v1.0.0/relationships/hierarchical-parent-inventory-kmjea.json
@@ -91,7 +91,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatedRef": [
+              "mutatorRef": [
                 [
                   "configuration",
                   "spec",
@@ -144,7 +144,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "displayName"
                 ]

--- a/models/azure-web/azureserviceoperator_customresourcedefinitions_v2.13.0.yaml/v1.0.0/relationships/hierarchical-parent-inventory-zsqqs.json
+++ b/models/azure-web/azureserviceoperator_customresourcedefinitions_v2.13.0.yaml/v1.0.0/relationships/hierarchical-parent-inventory-zsqqs.json
@@ -45,15 +45,15 @@
               "version": ""
             },
             "patch": {
-              "mutatedRef": [
+              "patchStrategy": "replace",
+              "mutatorRef": [
                 [
                   "configuration",
                   "spec",
                   "owner",
                   "name"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ],
@@ -75,12 +75,12 @@
               "version": ""
             },
             "patch": {
-              "mutatorRef": [
+              "patchStrategy": "replace",
+              "mutatedRef": [
                 [
                   "displayName"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ]

--- a/models/azure-web/azureserviceoperator_customresourcedefinitions_v2.14.0.yaml/v1.0.0/relationships/hierarchical-parent-inventory-kmjea.json
+++ b/models/azure-web/azureserviceoperator_customresourcedefinitions_v2.14.0.yaml/v1.0.0/relationships/hierarchical-parent-inventory-kmjea.json
@@ -91,7 +91,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatedRef": [
+              "mutatorRef": [
                 [
                   "configuration",
                   "spec",
@@ -144,7 +144,7 @@
             },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
+              "mutatedRef": [
                 [
                   "displayName"
                 ]

--- a/models/azure-web/azureserviceoperator_customresourcedefinitions_v2.14.0.yaml/v1.0.0/relationships/hierarchical-parent-inventory-zsqqs.json
+++ b/models/azure-web/azureserviceoperator_customresourcedefinitions_v2.14.0.yaml/v1.0.0/relationships/hierarchical-parent-inventory-zsqqs.json
@@ -45,15 +45,15 @@
               "version": ""
             },
             "patch": {
-              "mutatedRef": [
+              "patchStrategy": "replace",
+              "mutatorRef": [
                 [
                   "configuration",
                   "spec",
                   "owner",
                   "name"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ],
@@ -75,12 +75,12 @@
               "version": ""
             },
             "patch": {
-              "mutatorRef": [
+              "patchStrategy": "replace",
+              "mutatedRef": [
                 [
                   "displayName"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ]

--- a/models/kubernetes/v1.35.0-alpha.1/v1.0.0/relationships/edge-non-binding-network-jccsr.json
+++ b/models/kubernetes/v1.35.0-alpha.1/v1.0.0/relationships/edge-non-binding-network-jccsr.json
@@ -45,7 +45,8 @@
               "version": ""
             },
             "patch": {
-              "mutatedRef": [
+              "patchStrategy": "replace",
+              "mutatorRef": [
                 [
                   "configuration",
                   "spec",
@@ -68,8 +69,7 @@
                   "backend",
                   "servicePort"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ],
@@ -91,7 +91,8 @@
               "version": ""
             },
             "patch": {
-              "mutatorRef": [
+              "patchStrategy": "replace",
+              "mutatedRef": [
                 [
                   "displayName"
                 ],
@@ -102,8 +103,7 @@
                   "0",
                   "port"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ]

--- a/models/kubernetes/v1.35.0-alpha.1/v1.0.0/relationships/edge-non-binding-reference-jqrat.json
+++ b/models/kubernetes/v1.35.0-alpha.1/v1.0.0/relationships/edge-non-binding-reference-jqrat.json
@@ -45,14 +45,14 @@
               "version": ""
             },
             "patch": {
-              "mutatedRef": [
+              "patchStrategy": "replace",
+              "mutatorRef": [
                 [
                   "configuration",
                   "auth",
                   "clusterUserName"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ],

--- a/models/kubernetes/v1.35.0-alpha.1/v1.0.0/relationships/edge-sibling-matchlabels-bsxnr.json
+++ b/models/kubernetes/v1.35.0-alpha.1/v1.0.0/relationships/edge-sibling-matchlabels-bsxnr.json
@@ -45,14 +45,14 @@
               "version": ""
             },
             "patch": {
-              "mutatedRef": [
+              "patchStrategy": "replace",
+              "mutatorRef": [
                 [
                   "configuration",
                   "metadata",
                   "labels"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ],

--- a/models/kubernetes/v1.35.0-alpha.1/v1.0.0/relationships/hierarchical-parent-inventory-dyowc.json
+++ b/models/kubernetes/v1.35.0-alpha.1/v1.0.0/relationships/hierarchical-parent-inventory-dyowc.json
@@ -45,14 +45,14 @@
               "version": ""
             },
             "patch": {
-              "mutatedRef": [
+              "patchStrategy": "replace",
+              "mutatorRef": [
                 [
                   "configuration",
                   "spec",
                   "nodeName"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ],
@@ -74,12 +74,12 @@
               "version": ""
             },
             "patch": {
-              "mutatorRef": [
+              "patchStrategy": "replace",
+              "mutatedRef": [
                 [
                   "displayName"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ]

--- a/models/kubernetes/v1.35.0-alpha.1/v1.0.0/relationships/hierarchical-parent-inventory-kmjea.json
+++ b/models/kubernetes/v1.35.0-alpha.1/v1.0.0/relationships/hierarchical-parent-inventory-kmjea.json
@@ -45,14 +45,14 @@
               "version": ""
             },
             "patch": {
-              "mutatedRef": [
+              "patchStrategy": "replace",
+              "mutatorRef": [
                 [
                   "configuration",
                   "metadata",
                   "namespace"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ],
@@ -74,12 +74,12 @@
               "version": ""
             },
             "patch": {
-              "mutatorRef": [
+              "patchStrategy": "replace",
+              "mutatedRef": [
                 [
                   "displayName"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ]

--- a/models/kubernetes/v1.35.0-alpha.2/v1.0.0/relationships/edge-non-binding-network-jccsr.json
+++ b/models/kubernetes/v1.35.0-alpha.2/v1.0.0/relationships/edge-non-binding-network-jccsr.json
@@ -45,7 +45,8 @@
               "version": ""
             },
             "patch": {
-              "mutatedRef": [
+              "patchStrategy": "replace",
+              "mutatorRef": [
                 [
                   "configuration",
                   "spec",
@@ -68,8 +69,7 @@
                   "backend",
                   "servicePort"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ],
@@ -91,7 +91,8 @@
               "version": ""
             },
             "patch": {
-              "mutatorRef": [
+              "patchStrategy": "replace",
+              "mutatedRef": [
                 [
                   "displayName"
                 ],
@@ -102,8 +103,7 @@
                   "0",
                   "port"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ]

--- a/models/kubernetes/v1.35.0-alpha.2/v1.0.0/relationships/edge-non-binding-reference-jqrat.json
+++ b/models/kubernetes/v1.35.0-alpha.2/v1.0.0/relationships/edge-non-binding-reference-jqrat.json
@@ -45,14 +45,14 @@
               "version": ""
             },
             "patch": {
-              "mutatedRef": [
+              "patchStrategy": "replace",
+              "mutatorRef": [
                 [
                   "configuration",
                   "auth",
                   "clusterUserName"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ],

--- a/models/kubernetes/v1.35.0-alpha.2/v1.0.0/relationships/edge-sibling-matchlabels-bsxnr.json
+++ b/models/kubernetes/v1.35.0-alpha.2/v1.0.0/relationships/edge-sibling-matchlabels-bsxnr.json
@@ -45,14 +45,14 @@
               "version": ""
             },
             "patch": {
-              "mutatedRef": [
+              "patchStrategy": "replace",
+              "mutatorRef": [
                 [
                   "configuration",
                   "metadata",
                   "labels"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ],

--- a/models/kubernetes/v1.35.0-alpha.2/v1.0.0/relationships/hierarchical-parent-inventory-dyowc.json
+++ b/models/kubernetes/v1.35.0-alpha.2/v1.0.0/relationships/hierarchical-parent-inventory-dyowc.json
@@ -45,14 +45,14 @@
               "version": ""
             },
             "patch": {
-              "mutatedRef": [
+              "patchStrategy": "replace",
+              "mutatorRef": [
                 [
                   "configuration",
                   "spec",
                   "nodeName"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ],
@@ -74,12 +74,12 @@
               "version": ""
             },
             "patch": {
-              "mutatorRef": [
+              "patchStrategy": "replace",
+              "mutatedRef": [
                 [
                   "displayName"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ]

--- a/models/kubernetes/v1.35.0-alpha.2/v1.0.0/relationships/hierarchical-parent-inventory-kmjea.json
+++ b/models/kubernetes/v1.35.0-alpha.2/v1.0.0/relationships/hierarchical-parent-inventory-kmjea.json
@@ -45,14 +45,14 @@
               "version": ""
             },
             "patch": {
-              "mutatedRef": [
+              "patchStrategy": "replace",
+              "mutatorRef": [
                 [
                   "configuration",
                   "metadata",
                   "namespace"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ],
@@ -74,12 +74,12 @@
               "version": ""
             },
             "patch": {
-              "mutatorRef": [
+              "patchStrategy": "replace",
+              "mutatedRef": [
                 [
                   "displayName"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ]

--- a/models/kubernetes/v1.35.0-alpha.3/v1.0.0/relationships/edge-non-binding-network-jccsr.json
+++ b/models/kubernetes/v1.35.0-alpha.3/v1.0.0/relationships/edge-non-binding-network-jccsr.json
@@ -45,7 +45,8 @@
               "version": ""
             },
             "patch": {
-              "mutatedRef": [
+              "patchStrategy": "replace",
+              "mutatorRef": [
                 [
                   "configuration",
                   "spec",
@@ -68,8 +69,7 @@
                   "backend",
                   "servicePort"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ],
@@ -91,7 +91,8 @@
               "version": ""
             },
             "patch": {
-              "mutatorRef": [
+              "patchStrategy": "replace",
+              "mutatedRef": [
                 [
                   "displayName"
                 ],
@@ -102,8 +103,7 @@
                   "0",
                   "port"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ]

--- a/models/kubernetes/v1.35.0-alpha.3/v1.0.0/relationships/edge-non-binding-reference-jqrat.json
+++ b/models/kubernetes/v1.35.0-alpha.3/v1.0.0/relationships/edge-non-binding-reference-jqrat.json
@@ -45,14 +45,14 @@
               "version": ""
             },
             "patch": {
-              "mutatedRef": [
+              "patchStrategy": "replace",
+              "mutatorRef": [
                 [
                   "configuration",
                   "auth",
                   "clusterUserName"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ],

--- a/models/kubernetes/v1.35.0-alpha.3/v1.0.0/relationships/edge-sibling-matchlabels-bsxnr.json
+++ b/models/kubernetes/v1.35.0-alpha.3/v1.0.0/relationships/edge-sibling-matchlabels-bsxnr.json
@@ -45,14 +45,14 @@
               "version": ""
             },
             "patch": {
-              "mutatedRef": [
+              "patchStrategy": "replace",
+              "mutatorRef": [
                 [
                   "configuration",
                   "metadata",
                   "labels"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ],

--- a/models/kubernetes/v1.35.0-alpha.3/v1.0.0/relationships/hierarchical-parent-inventory-dyowc.json
+++ b/models/kubernetes/v1.35.0-alpha.3/v1.0.0/relationships/hierarchical-parent-inventory-dyowc.json
@@ -45,14 +45,14 @@
               "version": ""
             },
             "patch": {
-              "mutatedRef": [
+              "patchStrategy": "replace",
+              "mutatorRef": [
                 [
                   "configuration",
                   "spec",
                   "nodeName"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ],
@@ -74,12 +74,12 @@
               "version": ""
             },
             "patch": {
-              "mutatorRef": [
+              "patchStrategy": "replace",
+              "mutatedRef": [
                 [
                   "displayName"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ]

--- a/models/kubernetes/v1.35.0-alpha.3/v1.0.0/relationships/hierarchical-parent-inventory-kmjea.json
+++ b/models/kubernetes/v1.35.0-alpha.3/v1.0.0/relationships/hierarchical-parent-inventory-kmjea.json
@@ -45,14 +45,14 @@
               "version": ""
             },
             "patch": {
-              "mutatedRef": [
+              "patchStrategy": "replace",
+              "mutatorRef": [
                 [
                   "configuration",
                   "metadata",
                   "namespace"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ],
@@ -74,12 +74,12 @@
               "version": ""
             },
             "patch": {
-              "mutatorRef": [
+              "patchStrategy": "replace",
+              "mutatedRef": [
                 [
                   "displayName"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ]

--- a/models/kubernetes/v1.35.0-beta.0/v1.0.0/relationships/edge-non-binding-network-jccsr.json
+++ b/models/kubernetes/v1.35.0-beta.0/v1.0.0/relationships/edge-non-binding-network-jccsr.json
@@ -45,7 +45,8 @@
               "version": ""
             },
             "patch": {
-              "mutatedRef": [
+              "patchStrategy": "replace",
+              "mutatorRef": [
                 [
                   "configuration",
                   "spec",
@@ -68,8 +69,7 @@
                   "backend",
                   "servicePort"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ],
@@ -91,7 +91,8 @@
               "version": ""
             },
             "patch": {
-              "mutatorRef": [
+              "patchStrategy": "replace",
+              "mutatedRef": [
                 [
                   "displayName"
                 ],
@@ -102,8 +103,7 @@
                   "0",
                   "port"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ]

--- a/models/kubernetes/v1.35.0-beta.0/v1.0.0/relationships/edge-non-binding-reference-jqrat.json
+++ b/models/kubernetes/v1.35.0-beta.0/v1.0.0/relationships/edge-non-binding-reference-jqrat.json
@@ -45,14 +45,14 @@
               "version": ""
             },
             "patch": {
-              "mutatedRef": [
+              "patchStrategy": "replace",
+              "mutatorRef": [
                 [
                   "configuration",
                   "auth",
                   "clusterUserName"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ],

--- a/models/kubernetes/v1.35.0-beta.0/v1.0.0/relationships/edge-sibling-matchlabels-bsxnr.json
+++ b/models/kubernetes/v1.35.0-beta.0/v1.0.0/relationships/edge-sibling-matchlabels-bsxnr.json
@@ -45,14 +45,14 @@
               "version": ""
             },
             "patch": {
-              "mutatedRef": [
+              "patchStrategy": "replace",
+              "mutatorRef": [
                 [
                   "configuration",
                   "metadata",
                   "labels"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ],

--- a/models/kubernetes/v1.35.0-beta.0/v1.0.0/relationships/hierarchical-parent-inventory-dyowc.json
+++ b/models/kubernetes/v1.35.0-beta.0/v1.0.0/relationships/hierarchical-parent-inventory-dyowc.json
@@ -45,14 +45,14 @@
               "version": ""
             },
             "patch": {
-              "mutatedRef": [
+              "patchStrategy": "replace",
+              "mutatorRef": [
                 [
                   "configuration",
                   "spec",
                   "nodeName"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ],
@@ -74,12 +74,12 @@
               "version": ""
             },
             "patch": {
-              "mutatorRef": [
+              "patchStrategy": "replace",
+              "mutatedRef": [
                 [
                   "displayName"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ]

--- a/models/kubernetes/v1.35.0-beta.0/v1.0.0/relationships/hierarchical-parent-inventory-kmjea.json
+++ b/models/kubernetes/v1.35.0-beta.0/v1.0.0/relationships/hierarchical-parent-inventory-kmjea.json
@@ -45,14 +45,14 @@
               "version": ""
             },
             "patch": {
-              "mutatedRef": [
+              "patchStrategy": "replace",
+              "mutatorRef": [
                 [
                   "configuration",
                   "metadata",
                   "namespace"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ],
@@ -74,12 +74,12 @@
               "version": ""
             },
             "patch": {
-              "mutatorRef": [
+              "patchStrategy": "replace",
+              "mutatedRef": [
                 [
                   "displayName"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ]

--- a/models/kubernetes/v1.35.0-rc.0/v1.0.0/relationships/edge-non-binding-network-jccsr.json
+++ b/models/kubernetes/v1.35.0-rc.0/v1.0.0/relationships/edge-non-binding-network-jccsr.json
@@ -45,7 +45,8 @@
               "version": ""
             },
             "patch": {
-              "mutatedRef": [
+              "patchStrategy": "replace",
+              "mutatorRef": [
                 [
                   "configuration",
                   "spec",
@@ -68,8 +69,7 @@
                   "backend",
                   "servicePort"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ],
@@ -91,7 +91,8 @@
               "version": ""
             },
             "patch": {
-              "mutatorRef": [
+              "patchStrategy": "replace",
+              "mutatedRef": [
                 [
                   "displayName"
                 ],
@@ -102,8 +103,7 @@
                   "0",
                   "port"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ]

--- a/models/kubernetes/v1.35.0-rc.0/v1.0.0/relationships/edge-non-binding-reference-jqrat.json
+++ b/models/kubernetes/v1.35.0-rc.0/v1.0.0/relationships/edge-non-binding-reference-jqrat.json
@@ -45,14 +45,14 @@
               "version": ""
             },
             "patch": {
-              "mutatedRef": [
+              "patchStrategy": "replace",
+              "mutatorRef": [
                 [
                   "configuration",
                   "auth",
                   "clusterUserName"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ],

--- a/models/kubernetes/v1.35.0-rc.0/v1.0.0/relationships/edge-sibling-matchlabels-bsxnr.json
+++ b/models/kubernetes/v1.35.0-rc.0/v1.0.0/relationships/edge-sibling-matchlabels-bsxnr.json
@@ -45,14 +45,14 @@
               "version": ""
             },
             "patch": {
-              "mutatedRef": [
+              "patchStrategy": "replace",
+              "mutatorRef": [
                 [
                   "configuration",
                   "metadata",
                   "labels"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ],

--- a/models/kubernetes/v1.35.0-rc.0/v1.0.0/relationships/hierarchical-parent-inventory-dyowc.json
+++ b/models/kubernetes/v1.35.0-rc.0/v1.0.0/relationships/hierarchical-parent-inventory-dyowc.json
@@ -45,14 +45,14 @@
               "version": ""
             },
             "patch": {
-              "mutatedRef": [
+              "patchStrategy": "replace",
+              "mutatorRef": [
                 [
                   "configuration",
                   "spec",
                   "nodeName"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ],
@@ -74,12 +74,12 @@
               "version": ""
             },
             "patch": {
-              "mutatorRef": [
+              "patchStrategy": "replace",
+              "mutatedRef": [
                 [
                   "displayName"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ]

--- a/models/kubernetes/v1.35.0-rc.0/v1.0.0/relationships/hierarchical-parent-inventory-kmjea.json
+++ b/models/kubernetes/v1.35.0-rc.0/v1.0.0/relationships/hierarchical-parent-inventory-kmjea.json
@@ -45,14 +45,14 @@
               "version": ""
             },
             "patch": {
-              "mutatedRef": [
+              "patchStrategy": "replace",
+              "mutatorRef": [
                 [
                   "configuration",
                   "metadata",
                   "namespace"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ],
@@ -74,12 +74,12 @@
               "version": ""
             },
             "patch": {
-              "mutatorRef": [
+              "patchStrategy": "replace",
+              "mutatedRef": [
                 [
                   "displayName"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ]

--- a/models/kubernetes/v1.35.0-rc.1/v1.0.0/relationships/edge-non-binding-network-jccsr.json
+++ b/models/kubernetes/v1.35.0-rc.1/v1.0.0/relationships/edge-non-binding-network-jccsr.json
@@ -45,7 +45,8 @@
               "version": ""
             },
             "patch": {
-              "mutatedRef": [
+              "patchStrategy": "replace",
+              "mutatorRef": [
                 [
                   "configuration",
                   "spec",
@@ -68,8 +69,7 @@
                   "backend",
                   "servicePort"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ],
@@ -91,7 +91,8 @@
               "version": ""
             },
             "patch": {
-              "mutatorRef": [
+              "patchStrategy": "replace",
+              "mutatedRef": [
                 [
                   "displayName"
                 ],
@@ -102,8 +103,7 @@
                   "0",
                   "port"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ]

--- a/models/kubernetes/v1.35.0-rc.1/v1.0.0/relationships/edge-non-binding-reference-jqrat.json
+++ b/models/kubernetes/v1.35.0-rc.1/v1.0.0/relationships/edge-non-binding-reference-jqrat.json
@@ -45,14 +45,14 @@
               "version": ""
             },
             "patch": {
-              "mutatedRef": [
+              "patchStrategy": "replace",
+              "mutatorRef": [
                 [
                   "configuration",
                   "auth",
                   "clusterUserName"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ],

--- a/models/kubernetes/v1.35.0-rc.1/v1.0.0/relationships/edge-sibling-matchlabels-bsxnr.json
+++ b/models/kubernetes/v1.35.0-rc.1/v1.0.0/relationships/edge-sibling-matchlabels-bsxnr.json
@@ -45,14 +45,14 @@
               "version": ""
             },
             "patch": {
-              "mutatedRef": [
+              "patchStrategy": "replace",
+              "mutatorRef": [
                 [
                   "configuration",
                   "metadata",
                   "labels"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ],

--- a/models/kubernetes/v1.35.0-rc.1/v1.0.0/relationships/hierarchical-parent-inventory-dyowc.json
+++ b/models/kubernetes/v1.35.0-rc.1/v1.0.0/relationships/hierarchical-parent-inventory-dyowc.json
@@ -45,14 +45,14 @@
               "version": ""
             },
             "patch": {
-              "mutatedRef": [
+              "patchStrategy": "replace",
+              "mutatorRef": [
                 [
                   "configuration",
                   "spec",
                   "nodeName"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ],
@@ -74,12 +74,12 @@
               "version": ""
             },
             "patch": {
-              "mutatorRef": [
+              "patchStrategy": "replace",
+              "mutatedRef": [
                 [
                   "displayName"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ]

--- a/models/kubernetes/v1.35.0-rc.1/v1.0.0/relationships/hierarchical-parent-inventory-kmjea.json
+++ b/models/kubernetes/v1.35.0-rc.1/v1.0.0/relationships/hierarchical-parent-inventory-kmjea.json
@@ -45,14 +45,14 @@
               "version": ""
             },
             "patch": {
-              "mutatedRef": [
+              "patchStrategy": "replace",
+              "mutatorRef": [
                 [
                   "configuration",
                   "metadata",
                   "namespace"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ],
@@ -74,12 +74,12 @@
               "version": ""
             },
             "patch": {
-              "mutatorRef": [
+              "patchStrategy": "replace",
+              "mutatedRef": [
                 [
                   "displayName"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ]

--- a/models/kubernetes/v1.35.0/v1.0.0/relationships/edge-non-binding-network-jccsr.json
+++ b/models/kubernetes/v1.35.0/v1.0.0/relationships/edge-non-binding-network-jccsr.json
@@ -45,7 +45,8 @@
               "version": ""
             },
             "patch": {
-              "mutatedRef": [
+              "patchStrategy": "replace",
+              "mutatorRef": [
                 [
                   "configuration",
                   "spec",
@@ -68,8 +69,7 @@
                   "backend",
                   "servicePort"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ],
@@ -91,7 +91,8 @@
               "version": ""
             },
             "patch": {
-              "mutatorRef": [
+              "patchStrategy": "replace",
+              "mutatedRef": [
                 [
                   "displayName"
                 ],
@@ -102,8 +103,7 @@
                   "0",
                   "port"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ]

--- a/models/kubernetes/v1.35.0/v1.0.0/relationships/edge-non-binding-reference-jqrat.json
+++ b/models/kubernetes/v1.35.0/v1.0.0/relationships/edge-non-binding-reference-jqrat.json
@@ -45,14 +45,14 @@
               "version": ""
             },
             "patch": {
-              "mutatedRef": [
+              "patchStrategy": "replace",
+              "mutatorRef": [
                 [
                   "configuration",
                   "auth",
                   "clusterUserName"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ],

--- a/models/kubernetes/v1.35.0/v1.0.0/relationships/edge-sibling-matchlabels-bsxnr.json
+++ b/models/kubernetes/v1.35.0/v1.0.0/relationships/edge-sibling-matchlabels-bsxnr.json
@@ -45,14 +45,14 @@
               "version": ""
             },
             "patch": {
-              "mutatedRef": [
+              "patchStrategy": "replace",
+              "mutatorRef": [
                 [
                   "configuration",
                   "metadata",
                   "labels"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ],

--- a/models/kubernetes/v1.35.0/v1.0.0/relationships/hierarchical-parent-inventory-dyowc.json
+++ b/models/kubernetes/v1.35.0/v1.0.0/relationships/hierarchical-parent-inventory-dyowc.json
@@ -45,14 +45,14 @@
               "version": ""
             },
             "patch": {
-              "mutatedRef": [
+              "patchStrategy": "replace",
+              "mutatorRef": [
                 [
                   "configuration",
                   "spec",
                   "nodeName"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ],
@@ -74,12 +74,12 @@
               "version": ""
             },
             "patch": {
-              "mutatorRef": [
+              "patchStrategy": "replace",
+              "mutatedRef": [
                 [
                   "displayName"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ]

--- a/models/kubernetes/v1.35.0/v1.0.0/relationships/hierarchical-parent-inventory-kmjea.json
+++ b/models/kubernetes/v1.35.0/v1.0.0/relationships/hierarchical-parent-inventory-kmjea.json
@@ -45,14 +45,14 @@
               "version": ""
             },
             "patch": {
-              "mutatedRef": [
+              "patchStrategy": "replace",
+              "mutatorRef": [
                 [
                   "configuration",
                   "metadata",
                   "namespace"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ],
@@ -74,12 +74,12 @@
               "version": ""
             },
             "patch": {
-              "mutatorRef": [
+              "patchStrategy": "replace",
+              "mutatedRef": [
                 [
                   "displayName"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ]

--- a/models/kubernetes/v1.36.0-alpha.2/v1.0.0/relationships/edge-non-binding-network-jccsr.json
+++ b/models/kubernetes/v1.36.0-alpha.2/v1.0.0/relationships/edge-non-binding-network-jccsr.json
@@ -45,7 +45,8 @@
               "version": ""
             },
             "patch": {
-              "mutatedRef": [
+              "patchStrategy": "replace",
+              "mutatorRef": [
                 [
                   "configuration",
                   "spec",
@@ -68,8 +69,7 @@
                   "backend",
                   "servicePort"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ],
@@ -91,7 +91,8 @@
               "version": ""
             },
             "patch": {
-              "mutatorRef": [
+              "patchStrategy": "replace",
+              "mutatedRef": [
                 [
                   "displayName"
                 ],
@@ -102,8 +103,7 @@
                   "0",
                   "port"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ]

--- a/models/kubernetes/v1.36.0-alpha.2/v1.0.0/relationships/edge-non-binding-reference-jqrat.json
+++ b/models/kubernetes/v1.36.0-alpha.2/v1.0.0/relationships/edge-non-binding-reference-jqrat.json
@@ -45,14 +45,14 @@
               "version": ""
             },
             "patch": {
-              "mutatedRef": [
+              "patchStrategy": "replace",
+              "mutatorRef": [
                 [
                   "configuration",
                   "auth",
                   "clusterUserName"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ],

--- a/models/kubernetes/v1.36.0-alpha.2/v1.0.0/relationships/edge-sibling-matchlabels-bsxnr.json
+++ b/models/kubernetes/v1.36.0-alpha.2/v1.0.0/relationships/edge-sibling-matchlabels-bsxnr.json
@@ -45,14 +45,14 @@
               "version": ""
             },
             "patch": {
-              "mutatedRef": [
+              "patchStrategy": "replace",
+              "mutatorRef": [
                 [
                   "configuration",
                   "metadata",
                   "labels"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ],

--- a/models/kubernetes/v1.36.0-alpha.2/v1.0.0/relationships/hierarchical-parent-inventory-dyowc.json
+++ b/models/kubernetes/v1.36.0-alpha.2/v1.0.0/relationships/hierarchical-parent-inventory-dyowc.json
@@ -45,14 +45,14 @@
               "version": ""
             },
             "patch": {
-              "mutatedRef": [
+              "patchStrategy": "replace",
+              "mutatorRef": [
                 [
                   "configuration",
                   "spec",
                   "nodeName"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ],
@@ -74,12 +74,12 @@
               "version": ""
             },
             "patch": {
-              "mutatorRef": [
+              "patchStrategy": "replace",
+              "mutatedRef": [
                 [
                   "displayName"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ]

--- a/models/kubernetes/v1.36.0-alpha.2/v1.0.0/relationships/hierarchical-parent-inventory-kmjea.json
+++ b/models/kubernetes/v1.36.0-alpha.2/v1.0.0/relationships/hierarchical-parent-inventory-kmjea.json
@@ -45,14 +45,14 @@
               "version": ""
             },
             "patch": {
-              "mutatedRef": [
+              "patchStrategy": "replace",
+              "mutatorRef": [
                 [
                   "configuration",
                   "metadata",
                   "namespace"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ],
@@ -74,12 +74,12 @@
               "version": ""
             },
             "patch": {
-              "mutatorRef": [
+              "patchStrategy": "replace",
+              "mutatedRef": [
                 [
                   "displayName"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ]

--- a/models/kubernetes/v1.36.0-beta.0/v1.0.0/relationships/edge-non-binding-network-jccsr.json
+++ b/models/kubernetes/v1.36.0-beta.0/v1.0.0/relationships/edge-non-binding-network-jccsr.json
@@ -45,7 +45,8 @@
               "version": ""
             },
             "patch": {
-              "mutatedRef": [
+              "patchStrategy": "replace",
+              "mutatorRef": [
                 [
                   "configuration",
                   "spec",
@@ -68,8 +69,7 @@
                   "backend",
                   "servicePort"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ],
@@ -91,7 +91,8 @@
               "version": ""
             },
             "patch": {
-              "mutatorRef": [
+              "patchStrategy": "replace",
+              "mutatedRef": [
                 [
                   "displayName"
                 ],
@@ -102,8 +103,7 @@
                   "0",
                   "port"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ]

--- a/models/kubernetes/v1.36.0-beta.0/v1.0.0/relationships/edge-non-binding-reference-jqrat.json
+++ b/models/kubernetes/v1.36.0-beta.0/v1.0.0/relationships/edge-non-binding-reference-jqrat.json
@@ -45,14 +45,14 @@
               "version": ""
             },
             "patch": {
-              "mutatedRef": [
+              "patchStrategy": "replace",
+              "mutatorRef": [
                 [
                   "configuration",
                   "auth",
                   "clusterUserName"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ],

--- a/models/kubernetes/v1.36.0-beta.0/v1.0.0/relationships/edge-sibling-matchlabels-bsxnr.json
+++ b/models/kubernetes/v1.36.0-beta.0/v1.0.0/relationships/edge-sibling-matchlabels-bsxnr.json
@@ -45,14 +45,14 @@
               "version": ""
             },
             "patch": {
-              "mutatedRef": [
+              "patchStrategy": "replace",
+              "mutatorRef": [
                 [
                   "configuration",
                   "metadata",
                   "labels"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ],

--- a/models/kubernetes/v1.36.0-beta.0/v1.0.0/relationships/hierarchical-parent-inventory-dyowc.json
+++ b/models/kubernetes/v1.36.0-beta.0/v1.0.0/relationships/hierarchical-parent-inventory-dyowc.json
@@ -45,14 +45,14 @@
               "version": ""
             },
             "patch": {
-              "mutatedRef": [
+              "patchStrategy": "replace",
+              "mutatorRef": [
                 [
                   "configuration",
                   "spec",
                   "nodeName"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ],
@@ -74,12 +74,12 @@
               "version": ""
             },
             "patch": {
-              "mutatorRef": [
+              "patchStrategy": "replace",
+              "mutatedRef": [
                 [
                   "displayName"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ]

--- a/models/kubernetes/v1.36.0-beta.0/v1.0.0/relationships/hierarchical-parent-inventory-kmjea.json
+++ b/models/kubernetes/v1.36.0-beta.0/v1.0.0/relationships/hierarchical-parent-inventory-kmjea.json
@@ -45,14 +45,14 @@
               "version": ""
             },
             "patch": {
-              "mutatedRef": [
+              "patchStrategy": "replace",
+              "mutatorRef": [
                 [
                   "configuration",
                   "metadata",
                   "namespace"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ],
@@ -74,12 +74,12 @@
               "version": ""
             },
             "patch": {
-              "mutatorRef": [
+              "patchStrategy": "replace",
+              "mutatedRef": [
                 [
                   "displayName"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ]

--- a/models/kubernetes/v1.36.0-rc.0/v1.0.0/relationships/edge-non-binding-network-jccsr.json
+++ b/models/kubernetes/v1.36.0-rc.0/v1.0.0/relationships/edge-non-binding-network-jccsr.json
@@ -45,7 +45,8 @@
               "version": ""
             },
             "patch": {
-              "mutatedRef": [
+              "patchStrategy": "replace",
+              "mutatorRef": [
                 [
                   "configuration",
                   "spec",
@@ -68,8 +69,7 @@
                   "backend",
                   "servicePort"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ],
@@ -91,7 +91,8 @@
               "version": ""
             },
             "patch": {
-              "mutatorRef": [
+              "patchStrategy": "replace",
+              "mutatedRef": [
                 [
                   "displayName"
                 ],
@@ -102,8 +103,7 @@
                   "0",
                   "port"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ]

--- a/models/kubernetes/v1.36.0-rc.0/v1.0.0/relationships/edge-non-binding-reference-jqrat.json
+++ b/models/kubernetes/v1.36.0-rc.0/v1.0.0/relationships/edge-non-binding-reference-jqrat.json
@@ -45,14 +45,14 @@
               "version": ""
             },
             "patch": {
-              "mutatedRef": [
+              "patchStrategy": "replace",
+              "mutatorRef": [
                 [
                   "configuration",
                   "auth",
                   "clusterUserName"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ],

--- a/models/kubernetes/v1.36.0-rc.0/v1.0.0/relationships/edge-sibling-matchlabels-bsxnr.json
+++ b/models/kubernetes/v1.36.0-rc.0/v1.0.0/relationships/edge-sibling-matchlabels-bsxnr.json
@@ -45,14 +45,14 @@
               "version": ""
             },
             "patch": {
-              "mutatedRef": [
+              "patchStrategy": "replace",
+              "mutatorRef": [
                 [
                   "configuration",
                   "metadata",
                   "labels"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ],

--- a/models/kubernetes/v1.36.0-rc.0/v1.0.0/relationships/hierarchical-parent-inventory-dyowc.json
+++ b/models/kubernetes/v1.36.0-rc.0/v1.0.0/relationships/hierarchical-parent-inventory-dyowc.json
@@ -45,14 +45,14 @@
               "version": ""
             },
             "patch": {
-              "mutatedRef": [
+              "patchStrategy": "replace",
+              "mutatorRef": [
                 [
                   "configuration",
                   "spec",
                   "nodeName"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ],
@@ -74,12 +74,12 @@
               "version": ""
             },
             "patch": {
-              "mutatorRef": [
+              "patchStrategy": "replace",
+              "mutatedRef": [
                 [
                   "displayName"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ]

--- a/models/kubernetes/v1.36.0-rc.0/v1.0.0/relationships/hierarchical-parent-inventory-kmjea.json
+++ b/models/kubernetes/v1.36.0-rc.0/v1.0.0/relationships/hierarchical-parent-inventory-kmjea.json
@@ -45,14 +45,14 @@
               "version": ""
             },
             "patch": {
-              "mutatedRef": [
+              "patchStrategy": "replace",
+              "mutatorRef": [
                 [
                   "configuration",
                   "metadata",
                   "namespace"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ],
@@ -74,12 +74,12 @@
               "version": ""
             },
             "patch": {
-              "mutatorRef": [
+              "patchStrategy": "replace",
+              "mutatedRef": [
                 [
                   "displayName"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ]

--- a/models/kubernetes/v1.36.0-rc.1/v1.0.0/relationships/edge-non-binding-network-jccsr.json
+++ b/models/kubernetes/v1.36.0-rc.1/v1.0.0/relationships/edge-non-binding-network-jccsr.json
@@ -45,7 +45,8 @@
               "version": ""
             },
             "patch": {
-              "mutatedRef": [
+              "patchStrategy": "replace",
+              "mutatorRef": [
                 [
                   "configuration",
                   "spec",
@@ -68,8 +69,7 @@
                   "backend",
                   "servicePort"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ],
@@ -91,7 +91,8 @@
               "version": ""
             },
             "patch": {
-              "mutatorRef": [
+              "patchStrategy": "replace",
+              "mutatedRef": [
                 [
                   "displayName"
                 ],
@@ -102,8 +103,7 @@
                   "0",
                   "port"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ]

--- a/models/kubernetes/v1.36.0-rc.1/v1.0.0/relationships/edge-non-binding-reference-jqrat.json
+++ b/models/kubernetes/v1.36.0-rc.1/v1.0.0/relationships/edge-non-binding-reference-jqrat.json
@@ -45,14 +45,14 @@
               "version": ""
             },
             "patch": {
-              "mutatedRef": [
+              "patchStrategy": "replace",
+              "mutatorRef": [
                 [
                   "configuration",
                   "auth",
                   "clusterUserName"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ],

--- a/models/kubernetes/v1.36.0-rc.1/v1.0.0/relationships/edge-sibling-matchlabels-bsxnr.json
+++ b/models/kubernetes/v1.36.0-rc.1/v1.0.0/relationships/edge-sibling-matchlabels-bsxnr.json
@@ -45,14 +45,14 @@
               "version": ""
             },
             "patch": {
-              "mutatedRef": [
+              "patchStrategy": "replace",
+              "mutatorRef": [
                 [
                   "configuration",
                   "metadata",
                   "labels"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ],

--- a/models/kubernetes/v1.36.0-rc.1/v1.0.0/relationships/hierarchical-parent-inventory-dyowc.json
+++ b/models/kubernetes/v1.36.0-rc.1/v1.0.0/relationships/hierarchical-parent-inventory-dyowc.json
@@ -45,14 +45,14 @@
               "version": ""
             },
             "patch": {
-              "mutatedRef": [
+              "patchStrategy": "replace",
+              "mutatorRef": [
                 [
                   "configuration",
                   "spec",
                   "nodeName"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ],
@@ -74,12 +74,12 @@
               "version": ""
             },
             "patch": {
-              "mutatorRef": [
+              "patchStrategy": "replace",
+              "mutatedRef": [
                 [
                   "displayName"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ]

--- a/models/kubernetes/v1.36.0-rc.1/v1.0.0/relationships/hierarchical-parent-inventory-kmjea.json
+++ b/models/kubernetes/v1.36.0-rc.1/v1.0.0/relationships/hierarchical-parent-inventory-kmjea.json
@@ -45,14 +45,14 @@
               "version": ""
             },
             "patch": {
-              "mutatedRef": [
+              "patchStrategy": "replace",
+              "mutatorRef": [
                 [
                   "configuration",
                   "metadata",
                   "namespace"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ],
@@ -74,12 +74,12 @@
               "version": ""
             },
             "patch": {
-              "mutatorRef": [
+              "patchStrategy": "replace",
+              "mutatedRef": [
                 [
                   "displayName"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ]

--- a/models/kubernetes/v1.36.0/v1.0.0/relationships/edge-non-binding-network-jccsr.json
+++ b/models/kubernetes/v1.36.0/v1.0.0/relationships/edge-non-binding-network-jccsr.json
@@ -45,7 +45,8 @@
               "version": ""
             },
             "patch": {
-              "mutatedRef": [
+              "patchStrategy": "replace",
+              "mutatorRef": [
                 [
                   "configuration",
                   "spec",
@@ -68,8 +69,7 @@
                   "backend",
                   "servicePort"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ],
@@ -91,7 +91,8 @@
               "version": ""
             },
             "patch": {
-              "mutatorRef": [
+              "patchStrategy": "replace",
+              "mutatedRef": [
                 [
                   "displayName"
                 ],
@@ -102,8 +103,7 @@
                   "0",
                   "port"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ]

--- a/models/kubernetes/v1.36.0/v1.0.0/relationships/edge-non-binding-reference-jqrat.json
+++ b/models/kubernetes/v1.36.0/v1.0.0/relationships/edge-non-binding-reference-jqrat.json
@@ -45,14 +45,14 @@
               "version": ""
             },
             "patch": {
-              "mutatedRef": [
+              "patchStrategy": "replace",
+              "mutatorRef": [
                 [
                   "configuration",
                   "auth",
                   "clusterUserName"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ],

--- a/models/kubernetes/v1.36.0/v1.0.0/relationships/edge-sibling-matchlabels-bsxnr.json
+++ b/models/kubernetes/v1.36.0/v1.0.0/relationships/edge-sibling-matchlabels-bsxnr.json
@@ -45,14 +45,14 @@
               "version": ""
             },
             "patch": {
-              "mutatedRef": [
+              "patchStrategy": "replace",
+              "mutatorRef": [
                 [
                   "configuration",
                   "metadata",
                   "labels"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ],

--- a/models/kubernetes/v1.36.0/v1.0.0/relationships/hierarchical-parent-inventory-dyowc.json
+++ b/models/kubernetes/v1.36.0/v1.0.0/relationships/hierarchical-parent-inventory-dyowc.json
@@ -45,14 +45,14 @@
               "version": ""
             },
             "patch": {
-              "mutatedRef": [
+              "patchStrategy": "replace",
+              "mutatorRef": [
                 [
                   "configuration",
                   "spec",
                   "nodeName"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ],
@@ -74,12 +74,12 @@
               "version": ""
             },
             "patch": {
-              "mutatorRef": [
+              "patchStrategy": "replace",
+              "mutatedRef": [
                 [
                   "displayName"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ]

--- a/models/kubernetes/v1.36.0/v1.0.0/relationships/hierarchical-parent-inventory-kmjea.json
+++ b/models/kubernetes/v1.36.0/v1.0.0/relationships/hierarchical-parent-inventory-kmjea.json
@@ -45,14 +45,14 @@
               "version": ""
             },
             "patch": {
-              "mutatedRef": [
+              "patchStrategy": "replace",
+              "mutatorRef": [
                 [
                   "configuration",
                   "metadata",
                   "namespace"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ],
@@ -74,12 +74,12 @@
               "version": ""
             },
             "patch": {
-              "mutatorRef": [
+              "patchStrategy": "replace",
+              "mutatedRef": [
                 [
                   "displayName"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ]

--- a/models/kubernetes/v1.36.1/v1.0.0/relationships/edge-non-binding-network-jccsr.json
+++ b/models/kubernetes/v1.36.1/v1.0.0/relationships/edge-non-binding-network-jccsr.json
@@ -45,7 +45,8 @@
               "version": ""
             },
             "patch": {
-              "mutatedRef": [
+              "patchStrategy": "replace",
+              "mutatorRef": [
                 [
                   "configuration",
                   "spec",
@@ -68,8 +69,7 @@
                   "backend",
                   "servicePort"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ],
@@ -91,7 +91,8 @@
               "version": ""
             },
             "patch": {
-              "mutatorRef": [
+              "patchStrategy": "replace",
+              "mutatedRef": [
                 [
                   "displayName"
                 ],
@@ -102,8 +103,7 @@
                   "0",
                   "port"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ]

--- a/models/kubernetes/v1.36.1/v1.0.0/relationships/edge-non-binding-reference-jqrat.json
+++ b/models/kubernetes/v1.36.1/v1.0.0/relationships/edge-non-binding-reference-jqrat.json
@@ -45,14 +45,14 @@
               "version": ""
             },
             "patch": {
-              "mutatedRef": [
+              "patchStrategy": "replace",
+              "mutatorRef": [
                 [
                   "configuration",
                   "auth",
                   "clusterUserName"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ],

--- a/models/kubernetes/v1.36.1/v1.0.0/relationships/edge-sibling-matchlabels-bsxnr.json
+++ b/models/kubernetes/v1.36.1/v1.0.0/relationships/edge-sibling-matchlabels-bsxnr.json
@@ -45,14 +45,14 @@
               "version": ""
             },
             "patch": {
-              "mutatedRef": [
+              "patchStrategy": "replace",
+              "mutatorRef": [
                 [
                   "configuration",
                   "metadata",
                   "labels"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ],

--- a/models/kubernetes/v1.36.1/v1.0.0/relationships/hierarchical-parent-inventory-dyowc.json
+++ b/models/kubernetes/v1.36.1/v1.0.0/relationships/hierarchical-parent-inventory-dyowc.json
@@ -45,14 +45,14 @@
               "version": ""
             },
             "patch": {
-              "mutatedRef": [
+              "patchStrategy": "replace",
+              "mutatorRef": [
                 [
                   "configuration",
                   "spec",
                   "nodeName"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ],
@@ -74,12 +74,12 @@
               "version": ""
             },
             "patch": {
-              "mutatorRef": [
+              "patchStrategy": "replace",
+              "mutatedRef": [
                 [
                   "displayName"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ]

--- a/models/kubernetes/v1.36.1/v1.0.0/relationships/hierarchical-parent-inventory-kmjea.json
+++ b/models/kubernetes/v1.36.1/v1.0.0/relationships/hierarchical-parent-inventory-kmjea.json
@@ -45,14 +45,14 @@
               "version": ""
             },
             "patch": {
-              "mutatedRef": [
+              "patchStrategy": "replace",
+              "mutatorRef": [
                 [
                   "configuration",
                   "metadata",
                   "namespace"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ],
@@ -74,12 +74,12 @@
               "version": ""
             },
             "patch": {
-              "mutatorRef": [
+              "patchStrategy": "replace",
+              "mutatedRef": [
                 [
                   "displayName"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ]

--- a/models/kubernetes/v1.37.0-alpha.1/v1.0.0/relationships/edge-non-binding-network-jccsr.json
+++ b/models/kubernetes/v1.37.0-alpha.1/v1.0.0/relationships/edge-non-binding-network-jccsr.json
@@ -45,7 +45,8 @@
               "version": ""
             },
             "patch": {
-              "mutatedRef": [
+              "patchStrategy": "replace",
+              "mutatorRef": [
                 [
                   "configuration",
                   "spec",
@@ -68,8 +69,7 @@
                   "backend",
                   "servicePort"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ],
@@ -91,7 +91,8 @@
               "version": ""
             },
             "patch": {
-              "mutatorRef": [
+              "patchStrategy": "replace",
+              "mutatedRef": [
                 [
                   "displayName"
                 ],
@@ -102,8 +103,7 @@
                   "0",
                   "port"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ]

--- a/models/kubernetes/v1.37.0-alpha.1/v1.0.0/relationships/edge-non-binding-reference-jqrat.json
+++ b/models/kubernetes/v1.37.0-alpha.1/v1.0.0/relationships/edge-non-binding-reference-jqrat.json
@@ -45,14 +45,14 @@
               "version": ""
             },
             "patch": {
-              "mutatedRef": [
+              "patchStrategy": "replace",
+              "mutatorRef": [
                 [
                   "configuration",
                   "auth",
                   "clusterUserName"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ],

--- a/models/kubernetes/v1.37.0-alpha.1/v1.0.0/relationships/edge-sibling-matchlabels-bsxnr.json
+++ b/models/kubernetes/v1.37.0-alpha.1/v1.0.0/relationships/edge-sibling-matchlabels-bsxnr.json
@@ -45,14 +45,14 @@
               "version": ""
             },
             "patch": {
-              "mutatedRef": [
+              "patchStrategy": "replace",
+              "mutatorRef": [
                 [
                   "configuration",
                   "metadata",
                   "labels"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ],

--- a/models/kubernetes/v1.37.0-alpha.1/v1.0.0/relationships/hierarchical-parent-inventory-dyowc.json
+++ b/models/kubernetes/v1.37.0-alpha.1/v1.0.0/relationships/hierarchical-parent-inventory-dyowc.json
@@ -45,14 +45,14 @@
               "version": ""
             },
             "patch": {
-              "mutatedRef": [
+              "patchStrategy": "replace",
+              "mutatorRef": [
                 [
                   "configuration",
                   "spec",
                   "nodeName"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ],
@@ -74,12 +74,12 @@
               "version": ""
             },
             "patch": {
-              "mutatorRef": [
+              "patchStrategy": "replace",
+              "mutatedRef": [
                 [
                   "displayName"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ]

--- a/models/kubernetes/v1.37.0-alpha.1/v1.0.0/relationships/hierarchical-parent-inventory-kmjea.json
+++ b/models/kubernetes/v1.37.0-alpha.1/v1.0.0/relationships/hierarchical-parent-inventory-kmjea.json
@@ -45,14 +45,14 @@
               "version": ""
             },
             "patch": {
-              "mutatedRef": [
+              "patchStrategy": "replace",
+              "mutatorRef": [
                 [
                   "configuration",
                   "metadata",
                   "namespace"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ],
@@ -74,12 +74,12 @@
               "version": ""
             },
             "patch": {
-              "mutatorRef": [
+              "patchStrategy": "replace",
+              "mutatedRef": [
                 [
                   "displayName"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ]

--- a/models/kubernetes/v1.37.0-alpha.2/v1.0.0/relationships/edge-non-binding-network-jccsr.json
+++ b/models/kubernetes/v1.37.0-alpha.2/v1.0.0/relationships/edge-non-binding-network-jccsr.json
@@ -45,7 +45,8 @@
               "version": ""
             },
             "patch": {
-              "mutatedRef": [
+              "patchStrategy": "replace",
+              "mutatorRef": [
                 [
                   "configuration",
                   "spec",
@@ -68,8 +69,7 @@
                   "backend",
                   "servicePort"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ],
@@ -91,7 +91,8 @@
               "version": ""
             },
             "patch": {
-              "mutatorRef": [
+              "patchStrategy": "replace",
+              "mutatedRef": [
                 [
                   "displayName"
                 ],
@@ -102,8 +103,7 @@
                   "0",
                   "port"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ]

--- a/models/kubernetes/v1.37.0-alpha.2/v1.0.0/relationships/edge-non-binding-reference-jqrat.json
+++ b/models/kubernetes/v1.37.0-alpha.2/v1.0.0/relationships/edge-non-binding-reference-jqrat.json
@@ -45,14 +45,14 @@
               "version": ""
             },
             "patch": {
-              "mutatedRef": [
+              "patchStrategy": "replace",
+              "mutatorRef": [
                 [
                   "configuration",
                   "auth",
                   "clusterUserName"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ],

--- a/models/kubernetes/v1.37.0-alpha.2/v1.0.0/relationships/edge-sibling-matchlabels-bsxnr.json
+++ b/models/kubernetes/v1.37.0-alpha.2/v1.0.0/relationships/edge-sibling-matchlabels-bsxnr.json
@@ -45,14 +45,14 @@
               "version": ""
             },
             "patch": {
-              "mutatedRef": [
+              "patchStrategy": "replace",
+              "mutatorRef": [
                 [
                   "configuration",
                   "metadata",
                   "labels"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ],

--- a/models/kubernetes/v1.37.0-alpha.2/v1.0.0/relationships/hierarchical-parent-inventory-dyowc.json
+++ b/models/kubernetes/v1.37.0-alpha.2/v1.0.0/relationships/hierarchical-parent-inventory-dyowc.json
@@ -45,14 +45,14 @@
               "version": ""
             },
             "patch": {
-              "mutatedRef": [
+              "patchStrategy": "replace",
+              "mutatorRef": [
                 [
                   "configuration",
                   "spec",
                   "nodeName"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ],
@@ -74,12 +74,12 @@
               "version": ""
             },
             "patch": {
-              "mutatorRef": [
+              "patchStrategy": "replace",
+              "mutatedRef": [
                 [
                   "displayName"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ]

--- a/models/kubernetes/v1.37.0-alpha.2/v1.0.0/relationships/hierarchical-parent-inventory-kmjea.json
+++ b/models/kubernetes/v1.37.0-alpha.2/v1.0.0/relationships/hierarchical-parent-inventory-kmjea.json
@@ -45,14 +45,14 @@
               "version": ""
             },
             "patch": {
-              "mutatedRef": [
+              "patchStrategy": "replace",
+              "mutatorRef": [
                 [
                   "configuration",
                   "metadata",
                   "namespace"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ],
@@ -74,12 +74,12 @@
               "version": ""
             },
             "patch": {
-              "mutatorRef": [
+              "patchStrategy": "replace",
+              "mutatedRef": [
                 [
                   "displayName"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ]

--- a/models/kubernetes/v1.37.0-alpha.3/v1.0.0/relationships/edge-non-binding-network-jccsr.json
+++ b/models/kubernetes/v1.37.0-alpha.3/v1.0.0/relationships/edge-non-binding-network-jccsr.json
@@ -45,7 +45,8 @@
               "version": ""
             },
             "patch": {
-              "mutatedRef": [
+              "patchStrategy": "replace",
+              "mutatorRef": [
                 [
                   "configuration",
                   "spec",
@@ -68,8 +69,7 @@
                   "backend",
                   "servicePort"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ],
@@ -91,7 +91,8 @@
               "version": ""
             },
             "patch": {
-              "mutatorRef": [
+              "patchStrategy": "replace",
+              "mutatedRef": [
                 [
                   "displayName"
                 ],
@@ -102,8 +103,7 @@
                   "0",
                   "port"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ]

--- a/models/kubernetes/v1.37.0-alpha.3/v1.0.0/relationships/edge-non-binding-reference-jqrat.json
+++ b/models/kubernetes/v1.37.0-alpha.3/v1.0.0/relationships/edge-non-binding-reference-jqrat.json
@@ -45,14 +45,14 @@
               "version": ""
             },
             "patch": {
-              "mutatedRef": [
+              "patchStrategy": "replace",
+              "mutatorRef": [
                 [
                   "configuration",
                   "auth",
                   "clusterUserName"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ],

--- a/models/kubernetes/v1.37.0-alpha.3/v1.0.0/relationships/edge-sibling-matchlabels-bsxnr.json
+++ b/models/kubernetes/v1.37.0-alpha.3/v1.0.0/relationships/edge-sibling-matchlabels-bsxnr.json
@@ -45,14 +45,14 @@
               "version": ""
             },
             "patch": {
-              "mutatedRef": [
+              "patchStrategy": "replace",
+              "mutatorRef": [
                 [
                   "configuration",
                   "metadata",
                   "labels"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ],

--- a/models/kubernetes/v1.37.0-alpha.3/v1.0.0/relationships/hierarchical-parent-inventory-dyowc.json
+++ b/models/kubernetes/v1.37.0-alpha.3/v1.0.0/relationships/hierarchical-parent-inventory-dyowc.json
@@ -45,14 +45,14 @@
               "version": ""
             },
             "patch": {
-              "mutatedRef": [
+              "patchStrategy": "replace",
+              "mutatorRef": [
                 [
                   "configuration",
                   "spec",
                   "nodeName"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ],
@@ -74,12 +74,12 @@
               "version": ""
             },
             "patch": {
-              "mutatorRef": [
+              "patchStrategy": "replace",
+              "mutatedRef": [
                 [
                   "displayName"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ]

--- a/models/kubernetes/v1.37.0-alpha.3/v1.0.0/relationships/hierarchical-parent-inventory-kmjea.json
+++ b/models/kubernetes/v1.37.0-alpha.3/v1.0.0/relationships/hierarchical-parent-inventory-kmjea.json
@@ -45,14 +45,14 @@
               "version": ""
             },
             "patch": {
-              "mutatedRef": [
+              "patchStrategy": "replace",
+              "mutatorRef": [
                 [
                   "configuration",
                   "metadata",
                   "namespace"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ],
@@ -74,12 +74,12 @@
               "version": ""
             },
             "patch": {
-              "mutatorRef": [
+              "patchStrategy": "replace",
+              "mutatedRef": [
                 [
                   "displayName"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ]


### PR DESCRIPTION
### Description
This PR introduces **6 new relationship definitions** across AWS CloudWatchLogs, DynamoDB, PrometheusService, and EMRContainers, contributing to  AWS relationship (#17096).

### Added Component Relationships
- **CloudWatchLogs**: `LogGroup` → KMS `Key`
- **DynamoDB**: `Table` → KMS `Key`
- **PrometheusService**: `AlertManagerDefinition`, `LoggingConfiguration`, and `RuleGroupsNamespace` → `Workspace`
- **EMRContainers**: `JobRun` → `VirtualCluster`



