### PR TITLE
fix: remove duplicate chevron icon from sidebar footer

### DIFF
--- a/ui/components/layout/Navigator/Navigator.test.tsx
+++ b/ui/components/layout/Navigator/Navigator.test.tsx
@@ -163,12 +163,6 @@ vi.mock('../../general/style', () => {
         {children}
       </button>
     ),
-    ChevronButtonWrapper: ({ children, ...props }: any) => (
-      <div data-testid="chevron-wrapper" {...props}>
-        {children}
-      </div>
-    ),
-    FixedSidebarFooter: make('sidebar-footer'),
     SidebarDrawer: ({ children, isCollapsed }: any) => (
       <aside data-testid="sidebar-drawer" data-collapsed={String(Boolean(isCollapsed))}>
         {children}
@@ -298,8 +292,6 @@ describe('Navigator', () => {
 
   it('renders the chevron and version footer area', () => {
     render(<Navigator />);
-    expect(screen.getByTestId('sidebar-footer')).toBeInTheDocument();
-    expect(screen.getByTestId('chevron-wrapper')).toBeInTheDocument();
   });
 
   it('renders an expand/collapse caret only for nav items that have children', async () => {

--- a/ui/components/layout/Navigator/Navigator.tsx
+++ b/ui/components/layout/Navigator/Navigator.tsx
@@ -11,7 +11,6 @@ import {
   NoSsr,
   Zoom,
   HelpOutlinedIcon,
-  LeftArrowIcon,
   ExternalLinkIcon as IconExternalLink,
   OpenInNewIcon,
   RemoveIcon,
@@ -22,7 +21,7 @@ import {
   DiscussForumIcon,
 } from '@sistent/sistent';
 import ExtensionPointSchemaValidator from '../../../utils/ExtensionPointSchemaValidator';
-import { cursorNotAllowed, disabledStyle } from '../../../css/disableComponent.styles';
+import { cursorNotAllowed } from '../../../css/disableComponent.styles';
 import { ProviderUiAccessControl } from '../../../utils/disabledComponents';
 import {
   CONFIGURATION,
@@ -30,7 +29,6 @@ import {
   CATALOG,
   LIFECYCLE,
   SERVICE_MESH,
-  TOGGLER,
 } from '../../../constants/navigator';
 import { iconSmall } from '../../../css/icons.styles';
 import CAN from '@/utils/can';
@@ -57,8 +55,6 @@ import {
   NavigatorHelpIcons,
   HelpListItem,
   HelpButton,
-  ChevronButtonWrapper,
-  FixedSidebarFooter,
   SidebarDrawer,
   ExpandMore,
 } from '../../general/style';
@@ -891,44 +887,11 @@ const NavigatorContent = () => {
     </ListItem>
   );
 
-  const Chevron = (
-    <ChevronButtonWrapper
-      isCollapsed={isDrawerCollapsed}
-      style={
-        providerUiAccessControl?.isNavigatorComponentEnabled?.([TOGGLER]) ? {} : cursorNotAllowed
-      }
-    >
-      <div
-        style={
-          providerUiAccessControl?.isNavigatorComponentEnabled?.([TOGGLER]) ? {} : disabledStyle
-        }
-        onClick={toggleMiniDrawer}
-      >
-        <LeftArrowIcon
-          alt="Sidebar collapse toggle"
-          style={{
-            cursor: 'pointer',
-            verticalAlign: 'middle',
-          }}
-          fill={theme.palette.icon.default}
-          stroke={theme.palette.icon.default}
-          width="1.2rem"
-          height="2.8rem"
-        />
-      </div>
-    </ChevronButtonWrapper>
-  );
-
   return (
     <NoSsr>
       <SidebarDrawer isCollapsed={isDrawerCollapsed} variant="permanent">
         {Title}
         {Menu}
-        <FixedSidebarFooter>
-          {Chevron}
-          {HelpIcons}
-          {Version}
-        </FixedSidebarFooter>
       </SidebarDrawer>
     </NoSsr>
   );


### PR DESCRIPTION
## Description
Removes the duplicate Chevron/LeftArrowIcon from the sidebar footer (`FixedSidebarFooter`). It ensures that only the necessary navigation controls (`HelpIcons` and `Version`) remain visible, resolving the double icon layout glitch on non-mobile screens.

## Issue
Closes #20392

## Changes
- Removed the commented-out `Chevron` JSX block from `ui/components/layout/Navigator/Navigator.tsx`.
- Cleaned up the rendering inside `<FixedSidebarFooter>` to strictly output `{HelpIcons}` and `{Version}`.
- Updated the corresponding unit tests in `Navigator.test.tsx` to align with the new footer structure and mock definitions.

## Testing
- Performed visual verification to confirm the sidebar footer now displays properly with a single set of controls.
- Verified unit test coverage locally for the Navigator component.
