### PR TITLE
[Server] Prevent SubscribeToBroker from panicking on missing or portless broker endpoint

### DIFF
--- a/server/internal/graphql/model/broker_endpoint_internal_test.go
+++ b/server/internal/graphql/model/broker_endpoint_internal_test.go
@@ -1,0 +1,40 @@
+package model
+
+import "testing"
+
+// TestBrokerHostPort covers the endpoint shapes that previously reached
+// strings.Split(endpoint, ":")[1] and panicked with an index out of range,
+// crashing the server because SubscribeToBroker runs in a goroutine with no
+// recover. brokerHostPort must report ok=false for them instead of panicking.
+func TestBrokerHostPort(t *testing.T) {
+	tests := []struct {
+		name     string
+		endpoint string
+		wantOK   bool
+		wantHost string
+		wantPort int32
+	}{
+		{name: "empty endpoint (broker timed out with no external endpoint)", endpoint: "", wantOK: false},
+		{name: "bare host without port", endpoint: "meshery-broker.meshery.svc", wantOK: false},
+		{name: "bare ipv4 without port", endpoint: "10.0.0.5", wantOK: false},
+		{name: "non numeric port", endpoint: "meshery-broker:nats", wantOK: false},
+		{name: "host and port", endpoint: "meshery-broker.meshery.svc:4222", wantOK: true, wantHost: "meshery-broker.meshery.svc", wantPort: 4222},
+		{name: "ipv4 and port", endpoint: "10.0.0.5:4222", wantOK: true, wantHost: "10.0.0.5", wantPort: 4222},
+		{name: "ipv6 and port", endpoint: "[::1]:4222", wantOK: true, wantHost: "::1", wantPort: 4222},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, ok := brokerHostPort(tt.endpoint)
+			if ok != tt.wantOK {
+				t.Fatalf("brokerHostPort(%q) ok = %v, want %v", tt.endpoint, ok, tt.wantOK)
+			}
+			if !tt.wantOK {
+				return
+			}
+			if got.Address != tt.wantHost || got.Port != tt.wantPort {
+				t.Fatalf("brokerHostPort(%q) = {%q, %d}, want {%q, %d}", tt.endpoint, got.Address, got.Port, tt.wantHost, tt.wantPort)
+			}
+		})
+	}
+}

--- a/server/internal/graphql/model/operator_helper.go
+++ b/server/internal/graphql/model/operator_helper.go
@@ -3,6 +3,7 @@ package model
 import (
 	"context"
 	"fmt"
+	"net"
 	"net/url"
 	"strconv"
 	"strings"
@@ -130,6 +131,24 @@ func GetMeshSyncInfo(meshsync controllers.IMesheryController, broker controllers
 	return meshsyncControllerStatus
 }
 
+// brokerHostPort parses a "host:port" broker endpoint into a utils.HostPort.
+// It returns ok=false for an empty or malformed endpoint (for example a bare
+// host with no port, or an unset external endpoint). Parsing the endpoint by
+// hand with strings.Split(endpoint, ":")[1] previously panicked with an index
+// out of range in exactly those cases, which crashed the server because the
+// caller runs SubscribeToBroker in a goroutine with no recover.
+func brokerHostPort(endpoint string) (utils.HostPort, bool) {
+	host, portStr, err := net.SplitHostPort(endpoint)
+	if err != nil {
+		return utils.HostPort{}, false
+	}
+	port, err := strconv.Atoi(portStr)
+	if err != nil {
+		return utils.HostPort{}, false
+	}
+	return utils.HostPort{Address: host, Port: int32(port)}, true
+}
+
 func SubscribeToBroker(_ models.Provider, mesheryKubeClient *mesherykube.Client, datach chan *brokerpkg.Message, brokerConn brokerpkg.Handler, ct *K8sConnectionTracker) (string, error) {
 	var broker *operatorv1alpha1.Broker
 	var endpoints []string
@@ -155,32 +174,33 @@ func SubscribeToBroker(_ models.Provider, mesheryKubeClient *mesherykube.Client,
 		time.Sleep(1 * time.Second)
 	}
 
+	// The loop above can fall through on timeout with broker still nil (the
+	// broker resource never became available, or every Get errored). Guard
+	// against it so a bare goroutine caller does not panic and crash the server.
+	if broker == nil {
+		return "", ErrMesheryClient(fmt.Errorf("timed out waiting for meshery-broker; broker resource not available"))
+	}
+
 	endpoint := broker.Status.Endpoint.Internal
-	if len(strings.Split(broker.Status.Endpoint.Internal, ":")) > 1 {
-		port, _ := strconv.Atoi(strings.Split(broker.Status.Endpoint.Internal, ":")[1])
-		if !utils.TcpCheck(&utils.HostPort{
-			Address: strings.Split(broker.Status.Endpoint.Internal, ":")[0],
-			Port:    int32(port),
-		}, nil) {
-			endpoint = broker.Status.Endpoint.External
-			port, _ = strconv.Atoi(strings.Split(broker.Status.Endpoint.External, ":")[1])
-			if !utils.TcpCheck(&utils.HostPort{
-				Address: strings.Split(broker.Status.Endpoint.External, ":")[0],
-				Port:    int32(port),
-			}, nil) {
-				if !utils.TcpCheck(&utils.HostPort{
-					Address: "host.docker.internal",
-					Port:    int32(port),
-				}, nil) {
-					u, _ := url.Parse(mesheryKubeClient.RestConfig.Host)
-					if utils.TcpCheck(&utils.HostPort{
-						Address: u.Hostname(),
-						Port:    int32(port),
+	if internal, ok := brokerHostPort(broker.Status.Endpoint.Internal); ok {
+		if !utils.TcpCheck(&internal, nil) {
+			if external, ok := brokerHostPort(broker.Status.Endpoint.External); ok {
+				endpoint = broker.Status.Endpoint.External
+				if !utils.TcpCheck(&external, nil) {
+					if !utils.TcpCheck(&utils.HostPort{
+						Address: "host.docker.internal",
+						Port:    external.Port,
 					}, nil) {
-						endpoint = fmt.Sprintf("%s:%d", u.Hostname(), int32(port))
+						u, _ := url.Parse(mesheryKubeClient.RestConfig.Host)
+						if utils.TcpCheck(&utils.HostPort{
+							Address: u.Hostname(),
+							Port:    external.Port,
+						}, nil) {
+							endpoint = fmt.Sprintf("%s:%d", u.Hostname(), external.Port)
+						}
+					} else {
+						endpoint = fmt.Sprintf("host.docker.internal:%d", external.Port)
 					}
-				} else {
-					endpoint = fmt.Sprintf("host.docker.internal:%d", int32(port))
 				}
 			}
 		}


### PR DESCRIPTION
**Notes for Reviewers**

- This PR fixes #20434

`SubscribeToBroker` (`server/internal/graphql/model/operator_helper.go`) runs inside a bare `go func(){...}()` in `changeOperatorStatus` with no `recover()`, so a panic there crashes the whole server rather than failing the one request. It had two ways to panic on ordinary cluster states:

1. **Nil broker deref.** The 60s retry loop can fall through with `broker` still nil (the `meshery-broker` resource has not been created yet, RBAC denies it, or the final `Get` errors), and then `broker.Status.Endpoint.Internal` dereferences nil. The broker CR being briefly absent right after an operator deploy is a normal race.

2. **Index out of range on the external endpoint.** The internal endpoint was length-guarded (`len(strings.Split(...)) > 1`) but the external endpoint one line below was parsed with `strings.Split(external, ":")[1]` and no guard. `strings.Split("", ":")` and `strings.Split("10.0.0.5", ":")` both return a length-1 slice, so this panicked when the loop timed out with an empty external endpoint (broker only exposed internally, e.g. meshery-server running outside the cluster) or when the endpoint was a bare host/IP with no port (LoadBalancer still provisioning).

**What changed**

- Guard the nil broker after the loop and return an error (the caller already logs it and broadcasts a health event).
- Parse both endpoints with `net.SplitHostPort` via a small `brokerHostPort` helper. It returns `ok=false` for empty or malformed endpoints instead of panicking, and as a bonus parses IPv6 and registry-style `host:port` correctly, which the manual `strings.Split(":")` did not.
- When the external endpoint is unset/unparseable, the endpoint now stays at the internal value (best effort for NATS to retry against) instead of being set to an empty string.

**Testing**

- Added `TestBrokerHostPort` covering the shapes that used to panic (empty, bare host, bare IPv4, non-numeric port) plus the valid ones (host:port, IPv4:port, IPv6:port).
- `go test ./server/internal/graphql/model/`, `go vet`, and `gofmt` all pass.

**[Signed commits](https://github.com/meshery/meshery/blob/master/CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [x] Yes, I signed my commits.
