### PR TITLE
[Server] Validate component spec type before hydrating EnvoyFilter/WasmPlugin

### DIFF
--- a/server/models/pattern/stages/validate.go
+++ b/server/models/pattern/stages/validate.go
@@ -23,7 +23,10 @@ func hydrateComponentWithOriginalType(compType string, spec interface{}) error {
 		return fmt.Errorf("empty spec provided for component: %s", compType)
 	}
 
-	specValue := spec.(map[string]interface{})
+	specValue, ok := spec.(map[string]interface{})
+	if !ok {
+		return fmt.Errorf("invalid spec provided for component %s: expected an object, got %T", compType, spec)
+	}
 
 	switch compType {
 	case "EnvoyFilter":

--- a/server/models/pattern/stages/validate_test.go
+++ b/server/models/pattern/stages/validate_test.go
@@ -1,0 +1,33 @@
+package stages
+
+import "testing"
+
+// TestHydrateComponentWithOriginalType covers the spec shapes that reach
+// hydrateComponentWithOriginalType for EnvoyFilter/WasmPlugin components. A
+// non-object spec (string, number, slice) used to hit an unchecked type
+// assertion spec.(map[string]interface{}) and panic, which surfaced as an
+// HTTP 500 with a stack trace during design deploy instead of a clean
+// validation error. It must now return an error without panicking.
+func TestHydrateComponentWithOriginalType(t *testing.T) {
+	tests := []struct {
+		name     string
+		compType string
+		spec     interface{}
+		wantErr  bool
+	}{
+		{name: "nil spec", compType: "EnvoyFilter", spec: nil, wantErr: true},
+		{name: "string spec", compType: "EnvoyFilter", spec: "not-a-map", wantErr: true},
+		{name: "number spec", compType: "WasmPlugin", spec: 42, wantErr: true},
+		{name: "slice spec", compType: "EnvoyFilter", spec: []interface{}{"a", "b"}, wantErr: true},
+		{name: "valid object spec", compType: "WasmPlugin", spec: map[string]interface{}{}, wantErr: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := hydrateComponentWithOriginalType(tt.compType, tt.spec)
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("hydrateComponentWithOriginalType(%s, %T) err = %v, wantErr = %v", tt.compType, tt.spec, err, tt.wantErr)
+			}
+		})
+	}
+}


### PR DESCRIPTION
**Notes for Reviewers**

- This PR fixes #20437

The `Validator` stage runs `hydrateComponentWithOriginalType` for `EnvoyFilter` and `WasmPlugin` components, passing the component's `spec` from the design. It asserted `spec.(map[string]interface{})` with no comma-ok and guarded only for a nil spec, so a component whose `spec` is a scalar or list (not an object) panicked with `interface conversion: interface {} is string, not map[string]interface {}`.

The stage runs synchronously in the deploy/dry-run request, so the panic became an HTTP 500 with a stack trace in the logs instead of the clean validation error this stage exists to produce. The remaining assertions in the same function already use comma-ok, so this first one was an oversight.

**What changed**

- Use the comma-ok form and return a descriptive error (`invalid spec provided for component %s: expected an object, got %T`) when the spec is not an object.
- Added `TestHydrateComponentWithOriginalType` covering the shapes that used to panic (string, number, slice) plus nil and a valid object.

**Testing**

- `go test ./server/models/pattern/stages/`, `go vet`, and `gofmt` all pass.

**[Signed commits](https://github.com/meshery/meshery/blob/master/CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [x] Yes, I signed my commits.
