### PR TITLE
[Server] Guard control-plane container index to prevent panic on empty pod spec

### DIFF
--- a/server/internal/graphql/model/control_plane_helper.go
+++ b/server/internal/graphql/model/control_plane_helper.go
@@ -55,8 +55,10 @@ func GetControlPlaneState(ctx context.Context, selectors []MeshType, provider mo
 					continue
 				}
 
-				if len(strings.Split(objspec.Containers[0].Image, ":")) > 1 {
-					version = strings.Split(objspec.Containers[0].Image, ":")[1]
+				if len(objspec.Containers) > 0 {
+					if tag := imageTag(objspec.Containers[0].Image); tag != "" {
+						version = tag
+					}
 				}
 
 				members = append(members, &ControlPlaneMember{
@@ -82,4 +84,14 @@ func haveCommonElements(a []string, b map[string]bool) bool {
 		}
 	}
 	return false
+}
+
+// imageTag returns the tag portion of a container image reference
+// (the text after the first ":"), or "" when the reference carries no tag.
+func imageTag(image string) string {
+	parts := strings.Split(image, ":")
+	if len(parts) > 1 {
+		return parts[1]
+	}
+	return ""
 }

--- a/server/internal/graphql/model/control_plane_helper.go
+++ b/server/internal/graphql/model/control_plane_helper.go
@@ -86,12 +86,18 @@ func haveCommonElements(a []string, b map[string]bool) bool {
 	return false
 }
 
-// imageTag returns the tag portion of a container image reference
-// (the text after the first ":"), or "" when the reference carries no tag.
+// imageTag returns the tag portion of a container image reference, or "" when
+// the reference carries no tag. It ignores a registry port (the ":" that comes
+// before the first "/") and any "@digest" suffix, so a reference like
+// "localhost:5000/istio/proxyv2:1.20.0" yields "1.20.0" and
+// "localhost:5000/istio/proxyv2" yields "".
 func imageTag(image string) string {
-	parts := strings.Split(image, ":")
-	if len(parts) > 1 {
-		return parts[1]
+	if at := strings.IndexByte(image, '@'); at != -1 {
+		image = image[:at]
 	}
-	return ""
+	lastColon := strings.LastIndexByte(image, ':')
+	if lastColon == -1 || lastColon < strings.LastIndexByte(image, '/') {
+		return ""
+	}
+	return image[lastColon+1:]
 }

--- a/server/internal/graphql/model/control_plane_helper_internal_test.go
+++ b/server/internal/graphql/model/control_plane_helper_internal_test.go
@@ -1,0 +1,25 @@
+package model
+
+import "testing"
+
+// TestImageTag documents the tag parsing used by GetControlPlaneState. The
+// container index that feeds it is now guarded against an empty Containers
+// slice (a container-less pod spec from meshsync used to panic with index out
+// of range inside the control-plane subscription goroutine, crashing the
+// server).
+func TestImageTag(t *testing.T) {
+	tests := []struct {
+		image string
+		want  string
+	}{
+		{image: "", want: ""},
+		{image: "nginx", want: ""},
+		{image: "istio/proxyv2:1.20.0", want: "1.20.0"},
+		{image: "docker.io/istio/proxyv2:1.20.0", want: "1.20.0"},
+	}
+	for _, tt := range tests {
+		if got := imageTag(tt.image); got != tt.want {
+			t.Errorf("imageTag(%q) = %q, want %q", tt.image, got, tt.want)
+		}
+	}
+}

--- a/server/internal/graphql/model/control_plane_helper_internal_test.go
+++ b/server/internal/graphql/model/control_plane_helper_internal_test.go
@@ -16,6 +16,9 @@ func TestImageTag(t *testing.T) {
 		{image: "nginx", want: ""},
 		{image: "istio/proxyv2:1.20.0", want: "1.20.0"},
 		{image: "docker.io/istio/proxyv2:1.20.0", want: "1.20.0"},
+		{image: "localhost:5000/istio/proxyv2:1.20.0", want: "1.20.0"},
+		{image: "localhost:5000/istio/proxyv2", want: ""},
+		{image: "istio/proxyv2@sha256:abc123", want: ""},
 	}
 	for _, tt := range tests {
 		if got := imageTag(tt.image); got != tt.want {


### PR DESCRIPTION
**Notes for Reviewers**

- This PR fixes #20441

`GetControlPlaneState` indexed `objspec.Containers[0]` without a length check while extracting a control-plane version from a meshsync-delivered pod spec. If that spec unmarshals to a pod with no containers, the index panics with `index out of range [0] with length 0`. It runs in the control-plane subscription goroutine (`listenToControlPlaneState`), which has no `recover()`, so the panic crashed the whole server rather than failing the one subscription.

**What changed**

- Guard `len(objspec.Containers) > 0` before indexing `Containers[0]`.
- Move the tag parsing into a small `imageTag` helper (same behavior as the previous `strings.Split(image, ":")[1]`, kept so registry/version semantics are unchanged) and add a unit test for it.

**Testing**

- `go test ./server/internal/graphql/model/`, `go vet`, and `gofmt` all pass.

**[Signed commits](https://github.com/meshery/meshery/blob/master/CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [x] Yes, I signed my commits.
