### PR TITLE
[mesheryctl] Return an error instead of panicking on a non-standard deployment image

### DIFF
--- a/mesheryctl/pkg/utils/platform.go
+++ b/mesheryctl/pkg/utils/platform.go
@@ -249,9 +249,20 @@ func GetDeploymentVersion(filePath string) (string, error) {
 		return "", fmt.Errorf("unable to unmarshal config %s | %s", MesheryDeployment, err)
 	}
 
-	image := compose.Spec.Template.Spec.Containers[0].Image
+	containers := compose.Spec.Template.Spec.Containers
+	if len(containers) == 0 {
+		return "", fmt.Errorf("unable to determine version: no containers found in %s", MesheryDeployment)
+	}
+	image := containers[0].Image
 	spliter := strings.Split(image, ":")
-	version := strings.Split(spliter[1], "-")[1]
+	if len(spliter) < 2 {
+		return "", fmt.Errorf("unable to determine version: image %q in %s has no tag", image, MesheryDeployment)
+	}
+	tag := strings.Split(spliter[1], "-")
+	if len(tag) < 2 {
+		return "", fmt.Errorf("unable to determine version: unexpected image tag %q in %s", spliter[1], MesheryDeployment)
+	}
+	version := tag[1]
 
 	return version, nil
 }

--- a/mesheryctl/pkg/utils/platform.go
+++ b/mesheryctl/pkg/utils/platform.go
@@ -254,17 +254,32 @@ func GetDeploymentVersion(filePath string) (string, error) {
 		return "", fmt.Errorf("unable to determine version: no containers found in %s", MesheryDeployment)
 	}
 	image := containers[0].Image
-	spliter := strings.Split(image, ":")
-	if len(spliter) < 2 {
+	tag := imageTag(image)
+	if tag == "" {
 		return "", fmt.Errorf("unable to determine version: image %q in %s has no tag", image, MesheryDeployment)
 	}
-	tag := strings.Split(spliter[1], "-")
-	if len(tag) < 2 {
-		return "", fmt.Errorf("unable to determine version: unexpected image tag %q in %s", spliter[1], MesheryDeployment)
+	// Meshery deployment tags are "channel-version" (e.g. stable-latest,
+	// stable-v0.7.0); the version is everything after the first dash.
+	_, version, found := strings.Cut(tag, "-")
+	if !found {
+		return "", fmt.Errorf("unable to determine version: unexpected image tag %q in %s", tag, MesheryDeployment)
 	}
-	version := tag[1]
 
 	return version, nil
+}
+
+// imageTag returns the tag portion of a container image reference, or "" when
+// the reference carries no tag. It ignores a registry port (the ":" before the
+// first "/") and any "@digest" suffix.
+func imageTag(image string) string {
+	if at := strings.IndexByte(image, '@'); at != -1 {
+		image = image[:at]
+	}
+	lastColon := strings.LastIndexByte(image, ':')
+	if lastColon == -1 || lastColon < strings.LastIndexByte(image, '/') {
+		return ""
+	}
+	return image[lastColon+1:]
 }
 
 // CanUseCachedOperatorManifests returns an error if it is not possible to use cached operator manifests

--- a/mesheryctl/pkg/utils/platform_version_test.go
+++ b/mesheryctl/pkg/utils/platform_version_test.go
@@ -23,7 +23,10 @@ func TestGetDeploymentVersion(t *testing.T) {
 		wantErr bool
 	}{
 		{name: "standard tag", yaml: deployment("layer5/meshery:stable-latest"), want: "latest", wantErr: false},
+		{name: "registry with port", yaml: deployment("localhost:5000/layer5/meshery:stable-latest"), want: "latest", wantErr: false},
+		{name: "multi dash prerelease tag", yaml: deployment("layer5/meshery:stable-v0.7.0-rc.1"), want: "v0.7.0-rc.1", wantErr: false},
 		{name: "untagged image", yaml: deployment("layer5/meshery"), wantErr: true},
+		{name: "untagged image with registry port", yaml: deployment("localhost:5000/layer5/meshery"), wantErr: true},
 		{name: "tag without dash", yaml: deployment("layer5/meshery:latest"), wantErr: true},
 		{name: "no containers", yaml: noContainers, wantErr: true},
 	}

--- a/mesheryctl/pkg/utils/platform_version_test.go
+++ b/mesheryctl/pkg/utils/platform_version_test.go
@@ -1,0 +1,46 @@
+package utils
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// TestGetDeploymentVersion covers the deployment image shapes that previously
+// reached unchecked slice indexes (Containers[0], the ":" split [1], and the
+// "-" split [1]) and panicked the CLI. A non-standard image must now surface a
+// returned error, consistent with the rest of the function.
+func TestGetDeploymentVersion(t *testing.T) {
+	deployment := func(image string) string {
+		return "apiVersion: apps/v1\nkind: Deployment\nspec:\n  template:\n    spec:\n      containers:\n        - name: meshery\n          image: " + image + "\n"
+	}
+	noContainers := "apiVersion: apps/v1\nkind: Deployment\nspec:\n  template:\n    spec:\n      containers: []\n"
+
+	tests := []struct {
+		name    string
+		yaml    string
+		want    string
+		wantErr bool
+	}{
+		{name: "standard tag", yaml: deployment("layer5/meshery:stable-latest"), want: "latest", wantErr: false},
+		{name: "untagged image", yaml: deployment("layer5/meshery"), wantErr: true},
+		{name: "tag without dash", yaml: deployment("layer5/meshery:latest"), wantErr: true},
+		{name: "no containers", yaml: noContainers, wantErr: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			path := filepath.Join(t.TempDir(), MesheryDeployment)
+			if err := os.WriteFile(path, []byte(tt.yaml), 0o600); err != nil {
+				t.Fatalf("write temp deployment: %v", err)
+			}
+			got, err := GetDeploymentVersion(path)
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("GetDeploymentVersion() err = %v, wantErr = %v", err, tt.wantErr)
+			}
+			if !tt.wantErr && got != tt.want {
+				t.Fatalf("GetDeploymentVersion() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
**Notes for Reviewers**

- This PR fixes #20443

`GetDeploymentVersion` returns `(string, error)` and already surfaces read/unmarshal failures as errors, but parsed the container image with three unchecked slice indexes (`Containers[0]`, the `:` split `[1]`, and the `-` split `[1]`). A deployment with no containers, an untagged image (`layer5/meshery`), or a tag without a dash (`layer5/meshery:latest`) panicked the CLI with `index out of range` instead of returning an error.

**What changed**

- Guard each index and return a descriptive error, matching how the rest of the function already reports failures.
- Added a table test covering the shapes that used to panic (untagged, dashless tag, no containers) plus a valid image.

**Testing**

- `go test ./mesheryctl/pkg/utils/`, `go vet`, and `gofmt` all pass.

**[Signed commits](https://github.com/meshery/meshery/blob/master/CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [x] Yes, I signed my commits.
