### PR TITLE
[mesheryctl] Guard empty design response in apply to avoid index out of range

### DIFF
--- a/mesheryctl/internal/cli/root/design/apply.go
+++ b/mesheryctl/internal/cli/root/design/apply.go
@@ -212,7 +212,7 @@ mesheryctl design apply [design-name]
 					return utils.ErrUnmarshal(err)
 				}
 
-				if len(response) == 0 {
+				if len(response) == 0 || response[0] == nil {
 					return ErrDesignNotFound(file)
 				}
 

--- a/mesheryctl/internal/cli/root/design/apply.go
+++ b/mesheryctl/internal/cli/root/design/apply.go
@@ -212,6 +212,10 @@ mesheryctl design apply [design-name]
 					return utils.ErrUnmarshal(err)
 				}
 
+				if len(response) == 0 {
+					return ErrDesignNotFound(file)
+				}
+
 				// setup pattern file here
 				designFile = response[0].PatternFile
 			}


### PR DESCRIPTION
**Notes for Reviewers**

- This PR fixes #20447

The remote-hosted branch of `mesheryctl design apply` unmarshalled the API response into a slice and then indexed `response[0]` without a length check, so an empty response (design not found) panicked the CLI with `index out of range`. Every sibling design command (`deploy`, `undeploy`, `delete`, `export`, and the other `apply` branch) already guards this with a `len` check that returns `ErrDesignNotFound`; this branch was the one that missed it.

**What changed**

- Add `if len(response) == 0 { return ErrDesignNotFound(file) }` before indexing `response[0]`, matching the existing pattern in the sibling commands.

**Testing**

- `go vet` and `gofmt` pass. The change mirrors the guard already used by the other design subcommands.

**[Signed commits](https://github.com/meshery/meshery/blob/master/CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [x] Yes, I signed my commits.
