### PR TITLE
[Docs] Hide redundant hero logo on mobile home/overview page

### DIFF
--- a/docs/assets/scss/_overview.scss
+++ b/docs/assets/scss/_overview.scss
@@ -95,6 +95,10 @@ a > strong:hover {
     --col-gap: -30rem;
     padding: 0;
   }
+  // Hide the redundant hero logo on mobile; the navbar logo already brands the page.
+  .home-hero-logo {
+    display: none;
+  }
 }
 
 @media (max-width: 320px) {

--- a/docs/content/en/_index.md
+++ b/docs/content/en/_index.md
@@ -7,7 +7,7 @@ linkTitle: Documentation
 ---
 
 <div style="display:grid; justify-items:center">
-  <div class="home-hero-logo" style="align-self:center; margin-bottom:0px; margin-top:0px;padding-top:0px; padding-bottom:0px;width:clamp(170px, 50%, 800px);">
+  <div class="home-hero-logo" style="align-self: center; margin: 0; padding: 0; width: clamp(170px, 50%, 800px);">
     {{< svg/meshery-logo >}}
   </div>
   <h3 style="font-size:1.6rem">As a self-service engineering platform, Meshery enables collaborative design and operation of cloud and cloud native infrastructure.</h3>

--- a/docs/content/en/_index.md
+++ b/docs/content/en/_index.md
@@ -7,7 +7,7 @@ linkTitle: Documentation
 ---
 
 <div style="display:grid; justify-items:center">
-  <div style="align-self:center; margin-bottom:0px; margin-top:0px;padding-top:0px; padding-bottom:0px;width:clamp(170px, 50%, 800px);">
+  <div class="home-hero-logo" style="align-self:center; margin-bottom:0px; margin-top:0px;padding-top:0px; padding-bottom:0px;width:clamp(170px, 50%, 800px);">
     {{< svg/meshery-logo >}}
   </div>
   <h3 style="font-size:1.6rem">As a self-service engineering platform, Meshery enables collaborative design and operation of cloud and cloud native infrastructure.</h3>


### PR DESCRIPTION
**Notes for Reviewers**

The docs.meshery.io home / overview page (`docs/content/en/_index.md`) renders the Meshery hero logo above the intro heading. On small screens this duplicates the logo already shown in the navbar and pushes the actual content further down the fold, which is especially noticeable on mobile.

This change:
- Adds a `home-hero-logo` class to the hero logo wrapper on the home page.
- Hides it via `display: none` inside the **existing** `@media (max-width: 600px)` block in `docs/assets/scss/_overview.scss` — i.e. the same mobile inflection point the docs stylesheet already uses (600px is the dominant mobile breakpoint across `_navbar.scss`, `_layout.scss`, `_overview.scss`, etc.), as requested in the issue.

No new media query is introduced and desktop rendering is unchanged (the navbar logo still brands the page on mobile).

Verified the stylesheet still compiles with dart-sass; the rule resolves inside the `max-width: 600px` block as intended.

- This PR fixes #20459

**[Signed commits](https://github.com/meshery/meshery/blob/master/CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [x] Yes, I signed my commits.
