### PR TITLE
fix: make expand/collapse icon always visible in Navigator (#20392)

### DIFF
--- a/ui/components/general/style.tsx
+++ b/ui/components/general/style.tsx
@@ -114,8 +114,8 @@ export const MainLogoText = styled('img')(({ theme }) => ({
 export const ExpandMoreIcon = styled('svg', {
   shouldForwardProp: (prop) => prop !== 'isExpanded' && prop !== 'hasChildren',
 })(({ isExpanded, hasChildren, theme }) => ({
-  opacity: 0, // Initially hidden
-  visibility: 'hidden',
+  opacity: 1,
+  visibility: 'visible',
   cursor: 'pointer',
   display: hasChildren ? 'inline-block' : 'none',
   transform: isExpanded ? 'rotate(180deg) translateX(-0.8px)' : 'translateX(3px)',

--- a/ui/components/general/style.tsx
+++ b/ui/components/general/style.tsx
@@ -137,8 +137,8 @@ export const ExpandMore = ({ isExpanded, hasChildren, theme, isCollapsed, ...pro
       ...(isCollapsed && {
         position: 'absolute',
         right: '2px',
-        bottom: '2px',
-        transform: 'scale(0.8)',
+        top: '50%',
+        transform: 'translateY(-50%) scale(0.8)',
       }),
     }}
     {...props}

--- a/ui/components/general/style.tsx
+++ b/ui/components/general/style.tsx
@@ -115,9 +115,9 @@ export const ExpandMoreIcon = styled('svg', {
   shouldForwardProp: (prop) => prop !== 'isExpanded' && prop !== 'hasChildren',
 })(({ isExpanded, hasChildren, theme }) => ({
   opacity: 1,
-  visibility: hasChildren ? 'visible' : 'hidden',
+  visibility: 'visible',
   cursor: 'pointer',
-  display: 'inline-block',
+  display: hasChildren ? 'inline-block' : 'none',
   transform: isExpanded ? 'rotate(180deg) translateX(-0.8px)' : 'translateX(3px)',
   transition:
     'transform 200ms ease-in-out, opacity 200ms ease-in-out, visibility 200ms ease-in-out',
@@ -127,14 +127,19 @@ export const ExpandMoreIcon = styled('svg', {
   },
 }));
 
-export const ExpandMore = ({ isExpanded, hasChildren, theme, ...props }) => (
+export const ExpandMore = ({ isExpanded, hasChildren, theme, isCollapsed, ...props }) => (
   <IconButton
     aria-expanded={!!isExpanded}
     aria-label={isExpanded ? 'Collapse' : 'Expand'}
     style={{
       padding: 0,
-      display: 'inline-block',
-      visibility: hasChildren ? 'visible' : 'hidden',
+      display: hasChildren ? 'inline-block' : 'none',
+      ...(isCollapsed && {
+        position: 'absolute',
+        right: '2px',
+        bottom: '2px',
+        transform: 'scale(0.8)',
+      }),
     }}
     {...props}
   >

--- a/ui/components/general/style.tsx
+++ b/ui/components/general/style.tsx
@@ -115,9 +115,9 @@ export const ExpandMoreIcon = styled('svg', {
   shouldForwardProp: (prop) => prop !== 'isExpanded' && prop !== 'hasChildren',
 })(({ isExpanded, hasChildren, theme }) => ({
   opacity: 1,
-  visibility: 'visible',
+  visibility: hasChildren ? 'visible' : 'hidden',
   cursor: 'pointer',
-  display: hasChildren ? 'inline-block' : 'none',
+  display: 'inline-block',
   transform: isExpanded ? 'rotate(180deg) translateX(-0.8px)' : 'translateX(3px)',
   transition:
     'transform 200ms ease-in-out, opacity 200ms ease-in-out, visibility 200ms ease-in-out',
@@ -133,7 +133,8 @@ export const ExpandMore = ({ isExpanded, hasChildren, theme, ...props }) => (
     aria-label={isExpanded ? 'Collapse' : 'Expand'}
     style={{
       padding: 0,
-      display: hasChildren ? 'inline-block' : 'none',
+      display: 'inline-block',
+      visibility: hasChildren ? 'visible' : 'hidden',
     }}
     {...props}
   >

--- a/ui/components/general/style.tsx
+++ b/ui/components/general/style.tsx
@@ -122,12 +122,6 @@ export const ExpandMoreIcon = styled('svg', {
   transition:
     'transform 200ms ease-in-out, opacity 200ms ease-in-out, visibility 200ms ease-in-out',
 
-  // Show icon when the parent element is hovered
-  '&:hover, *:hover > &': {
-    opacity: 1,
-    visibility: 'visible',
-  },
-
   '&:hover': {
     fill: theme?.palette?.background?.brand?.default || 'black',
   },

--- a/ui/components/layout/Navigator/Navigator.tsx
+++ b/ui/components/layout/Navigator/Navigator.tsx
@@ -727,18 +727,16 @@ const NavigatorContent = () => {
                       <SideBarText drawerCollapsed={isDrawerCollapsed}>{title}</SideBarText>
                     </NavigatorLink>
                   </SideBarListItem>
-                  {hasChildren && (
-                    <ExpandMore
-                      onClick={(e) => {
-                        e.preventDefault();
-                        e.stopPropagation();
-                        toggleItemCollapse(childId);
-                      }}
-                      isExpanded={openItems.includes(childId)}
-                      theme={theme}
-                      hasChildren={hasChildren}
-                    />
-                  )}
+                  <ExpandMore
+                    onClick={(e) => {
+                      e.preventDefault();
+                      e.stopPropagation();
+                      toggleItemCollapse(childId);
+                    }}
+                    isExpanded={openItems.includes(childId)}
+                    theme={theme}
+                    hasChildren={hasChildren}
+                  />
                 </div>
                 <Collapse
                   in={openItems.includes(childId)}

--- a/ui/components/layout/Navigator/Navigator.tsx
+++ b/ui/components/layout/Navigator/Navigator.tsx
@@ -739,22 +739,9 @@ const NavigatorContent = () => {
                         disableTouchListener={!isDrawerCollapsed}
                         TransitionComponent={Zoom}
                       >
-                        {isDrawerCollapsed &&
-                        (hoveredId === childId || (openItems.includes(childId) && submenu)) ? (
-                          <div>
-                            <CustomTooltip
-                              title={title}
-                              placement="right"
-                              TransitionComponent={Zoom}
-                            >
-                              <ListItemIcon style={{ marginLeft: '20%', marginBottom: '0.4rem' }}>
-                                {hovericon}
-                              </ListItemIcon>
-                            </CustomTooltip>
-                          </div>
-                        ) : (
+
                           <MainListIcon>{icon}</MainListIcon>
-                        )}
+                        
                       </CustomTooltip>
                       <SideBarText drawerCollapsed={isDrawerCollapsed}>{title}</SideBarText>
                     </NavigatorLink>

--- a/ui/components/layout/Navigator/Navigator.tsx
+++ b/ui/components/layout/Navigator/Navigator.tsx
@@ -715,7 +715,7 @@ const NavigatorContent = () => {
                   >
                     <NavigatorLink data-testid={childId}>
                       <CustomTooltip
-                        title={childId.charAt(0).toUpperCase() + childId.slice(1)}
+                        title={title ?? childId}
                         placement="right"
                         disableFocusListener={!isDrawerCollapsed}
                         disableHoverListener={!isDrawerCollapsed}

--- a/ui/components/layout/Navigator/Navigator.tsx
+++ b/ui/components/layout/Navigator/Navigator.tsx
@@ -693,7 +693,7 @@ const NavigatorContent = () => {
               <RootDiv key={childId}>
                 {/* Row wraps the navigable anchor and the expand/collapse caret as
                     siblings so the caret button is never nested inside the anchor. */}
-                <div style={{ display: 'flex', alignItems: 'center' }}>
+                <div style={{ display: 'flex', alignItems: 'center', position: 'relative' }}>
                   <SideBarListItem
                     dense
                     key={childId}
@@ -727,16 +727,19 @@ const NavigatorContent = () => {
                       <SideBarText drawerCollapsed={isDrawerCollapsed}>{title}</SideBarText>
                     </NavigatorLink>
                   </SideBarListItem>
-                  <ExpandMore
-                    onClick={(e) => {
-                      e.preventDefault();
-                      e.stopPropagation();
-                      toggleItemCollapse(childId);
-                    }}
-                    isExpanded={openItems.includes(childId)}
-                    theme={theme}
-                    hasChildren={hasChildren}
-                  />
+                  {hasChildren && (
+                    <ExpandMore
+                      onClick={(e) => {
+                        e.preventDefault();
+                        e.stopPropagation();
+                        toggleItemCollapse(childId);
+                      }}
+                      isExpanded={openItems.includes(childId)}
+                      theme={theme}
+                      hasChildren={hasChildren}
+                      isCollapsed={isDrawerCollapsed}
+                    />
+                  )}
                 </div>
                 <Collapse
                   in={openItems.includes(childId)}

--- a/ui/components/layout/Navigator/Navigator.tsx
+++ b/ui/components/layout/Navigator/Navigator.tsx
@@ -718,7 +718,7 @@ const NavigatorContent = () => {
                         title={childId}
                         placement="right"
                         disableFocusListener={!isDrawerCollapsed}
-                        disableHoverListener={true}
+                        disableHoverListener={!isDrawerCollapsed}
                         disableTouchListener={!isDrawerCollapsed}
                         TransitionComponent={Zoom}
                       >

--- a/ui/components/layout/Navigator/Navigator.tsx
+++ b/ui/components/layout/Navigator/Navigator.tsx
@@ -715,7 +715,7 @@ const NavigatorContent = () => {
                   >
                     <NavigatorLink data-testid={childId}>
                       <CustomTooltip
-                        title={childId}
+                        title={childId.charAt(0).toUpperCase() + childId.slice(1)}
                         placement="right"
                         disableFocusListener={!isDrawerCollapsed}
                         disableHoverListener={!isDrawerCollapsed}

--- a/ui/components/layout/Navigator/Navigator.tsx
+++ b/ui/components/layout/Navigator/Navigator.tsx
@@ -2,7 +2,6 @@ import React, { useEffect, useMemo, useState } from 'react';
 import Link from 'next/link';
 import {
   CustomTooltip,
-  ListItemIcon,
   Grow,
   ListItem,
   List,
@@ -229,7 +228,6 @@ const NavigatorContent = () => {
   );
   const [showHelperButton, setShowHelperButton] = useState(false);
   const [openItems, setOpenItems] = useState<string[]>([]);
-  const [hoveredId, setHoveredId] = useState<string | null>(null);
   const [providerUiAccessControl, setProviderUiAccessControl] =
     useState<ProviderUiAccessControl | null>(null);
   const [versionDetail, setVersionDetail] = useState(defaultVersionDetail);
@@ -689,18 +687,7 @@ const NavigatorContent = () => {
     <>
       <HideScrollbar disablePadding>
         {navigatorComponents.map(
-          ({
-            id: childId,
-            title,
-            icon,
-            href,
-            show,
-            link,
-            children,
-            hovericon,
-            submenu,
-            permission,
-          }) => {
+          ({ id: childId, title, icon, href, show, link, children, permission }) => {
             const hasChildren = Array.isArray(children) && children.length > 0;
             return (
               <RootDiv key={childId}>
@@ -722,10 +709,6 @@ const NavigatorContent = () => {
                       if (link && openItems.includes(childId)) return;
                       toggleItemCollapse(childId);
                     }}
-                    onMouseOver={() => (isDrawerCollapsed ? setHoveredId(childId) : null)}
-                    onMouseLeave={() =>
-                      !submenu || !openItems.includes(childId) ? setHoveredId(null) : null
-                    }
                     disabled={permission ? !CAN(permission.action, permission.subject) : false}
                     style={{ flex: 1, minWidth: 0 }}
                     {...(link && href ? { component: Link, href } : {})}
@@ -739,9 +722,7 @@ const NavigatorContent = () => {
                         disableTouchListener={!isDrawerCollapsed}
                         TransitionComponent={Zoom}
                       >
-
-                          <MainListIcon>{icon}</MainListIcon>
-                        
+                        <MainListIcon>{icon}</MainListIcon>
                       </CustomTooltip>
                       <SideBarText drawerCollapsed={isDrawerCollapsed}>{title}</SideBarText>
                     </NavigatorLink>


### PR DESCRIPTION
## What this fixes
Fixes #20392 — The expand/collapse icon in the Navigator sidebar 
was hidden by default (opacity: 0, visibility: hidden) and only 
appeared on hover, causing confusion with duplicate icons.

## What I changed
Made the ExpandMore icon permanently visible for nav items that 
have children by setting opacity: 1 and visibility: visible in 
the ExpandMoreIcon styled component.
Also , i solved duplicate icon problem by removing hover icon with caused it.

## Screenshots
<img width="168" height="594" alt="image" src="https://github.com/user-attachments/assets/7e9d9bb3-2e9b-43a5-ae53-978e118f6166" />


## Signed commits
- [x] Yes, I signed my commits.