### PR TITLE
[Docs] MeshSync: align architecture, logical, and troubleshooting docs with the implementation

### DIFF
--- a/docs/content/en/concepts/architecture/meshsync.md
+++ b/docs/content/en/concepts/architecture/meshsync.md
@@ -10,16 +10,21 @@ aliases:
     <div style="flex: 4;">
         <h1>MeshSync</h1>
         <p>
-        MeshSync is a custom Kubernetes controller that provides tiered discovery and continual synchronization with Meshery Server as to the state of managed multi-cloud and cloud native infrastructure. It operates in one of two modes: operator or embedded. When it runs in operator mode, it is managed by the <a href="{{< ref "concepts/architecture/operator/index.md" >}}">Meshery Operator</a>.
+        MeshSync is a custom Kubernetes controller that performs event-driven discovery of, and continual synchronization with, Meshery Server as to the state of managed Kubernetes infrastructure. It operates in one of two modes: operator or embedded. When it runs in operator mode, it is managed by the <a href="{{< ref "concepts/architecture/operator/index.md" >}}">Meshery Operator</a>.
         </p>
     </div>
 </div>
 
 ### Key Features
 
-- **Greenfield and Brownfield Support**: MeshSync discovers and identifies infrastructure whether you're starting from scratch (greenfield) with Meshery performing the initial deployment of your infrastructure or bringing in Meshery to manage your existing infrastructure (brownfield).
-- **Real-time / Event-driven Status**: MeshSync subscribes for updates from your platform and listens for state changes, understanding that changes to managed infrastructure may be done out of band of Meshery.
-- **Scalable and Performant**: Meshery's event-driven approach ensures speed and scalability. You have control over the depth of object discovery to manage large clusters efficiently. MeshSync's working snapshot of the state of each cluster under management is stored in the Server's local database and continuously refreshed.
+- **Greenfield and Brownfield Support**: MeshSync discovers infrastructure whether you're starting from scratch (greenfield) with Meshery performing the initial deployment of your infrastructure or bringing in Meshery to manage your existing infrastructure (brownfield).
+- **Real-time / Event-driven Status**: MeshSync uses Kubernetes [shared informers](https://pkg.go.dev/k8s.io/client-go/informers) to subscribe for updates from the cluster and listen for state changes, understanding that changes to managed infrastructure may be done out of band of Meshery.
+- **Configurable resource scope**: MeshSync watches a default set of resource types across all namespaces. You can narrow this set with a whitelist or blacklist (see [FAQs](#meshsync-faqs)) so that uninteresting resource types are not discovered.
+- **Working cluster snapshot**: MeshSync's working snapshot of the state of each cluster under management is held in-memory (Kubernetes informer caches) and streamed to Meshery Server, whose local database persists it as a continuously refreshed cache.
+
+{{% alert color="warning" title="Roadmap features" %}}
+Several capabilities described in MeshSync's original design - <strong>tiered (progressively refined) discovery</strong>, <strong>composite fingerprints that span multiple entities</strong>, <strong>broker-side persistence of events</strong>, and <strong>non-Kubernetes targets</strong> - are design goals that are <strong>not yet implemented</strong>. Sections below that describe roadmap behavior are marked accordingly so that operators can distinguish current behavior from intended direction.
+{{% /alert %}}
 
 ## Discovery
 
@@ -45,61 +50,70 @@ Labels:
 
 ## Identifying Infrastructure under Management
 
-Supplied by Meshery Server, MeshSync uses composite fingerprints to uniquely and positively identify managed infrastructure, capturing essential characteristics like versions and configurations.
+MeshSync publishes each discovered Kubernetes resource largely as-is (its metadata, labels, annotations, spec, and status) to Meshery Server. The work of classifying a resource against Meshery's object model, and of positively identifying higher-level infrastructure, is performed by **Meshery Server** using its [model registry]({{< ref "concepts/logical/registry.md" >}}), not by MeshSync itself. The one enrichment MeshSync performs inline is on `Service` resources, where it computes reachable endpoint URLs and flags whether the Service is a candidate to be promoted to a [Meshery Connection]({{< ref "concepts/logical/connections/index.md" >}}).
 
-### Composite Fingerprints
+### Composite Fingerprints (roadmap)
 
-Fingerprinting, the process of positively identifying and classifying resources, is performed using a set of pre-defined attributes that have been designated as unique to that type of resource. For example:
+{{% alert color="warning" title="Not yet implemented" %}}
+Composite fingerprinting - identifying an application or platform from a set of its constituent objects - is a design goal. MeshSync today discovers and reports objects <strong>individually</strong>; it does not yet correlate an object's constituent parts into a single composite fingerprint.
+{{% /alert %}}
+
+Fingerprinting is the intended process of positively identifying and classifying resources using a set of attributes designated as unique to that type of resource. For example:
 
 - Prometheus typically offers metrics on 9090/tcp, but not always.
 - Prometheus is typically deployed from a prebuilt container offered by the open source project, but not always.
 
-See Connection State Management for additional information.
-
-Fingerprinting is the act of uniquely identifying managed infrastructure, their versions and other specific characteristics.
-
-As a guiding principal, each set of composite fingerprints uses the same identifiers that each element management tool uses to identify itself (e.g., istioctl version).
-
-Creating a composite set of keys involves using the builder pattern. For example:
-
-- Images
-- CRDs
-- Deployment
+As a guiding principle, each set of composite fingerprints would use the same identifiers that each element management tool uses to identify itself (e.g., `istioctl version`), assembled via a builder pattern over signals such as container images, CRDs, and Deployments.
 
 ## Configuration
 
-### Subscribing to events/changes on every component
+### Subscribing to events and changes
 
-The informer in MeshSync actively listens to changes in resources and updates them in real time based on the informer configuration in the CRD.
+MeshSync registers a Kubernetes informer per watched resource type and listens for `ADDED`, `MODIFIED`, and `DELETED` events. On a `MODIFIED` event, MeshSync suppresses no-op updates by comparing the object's `resourceVersion` before republishing. Which resource types are watched, and which event types are published for each, is controlled by the `watch-list` on the `MeshSync` custom resource (see [FAQs](#meshsync-faqs)).
 
-## Subscription Status and Health
+MeshSync also watches the cluster's `CustomResourceDefinition` set: when a CRD is added or removed, MeshSync updates its pipeline and re-runs discovery so that newly installed custom resources begin to be tracked.
 
-### Flushing MeshSync
+### Publish and request subjects
 
-### Synthetic Test of MeshSync
+In operator (broker) mode, MeshSync publishes resource events to the NATS subject `meshery.meshsync.core` and answers requests on `meshery.meshsync.request`. It supports request/reply for a full store snapshot (`informer-store`), an on-demand resync, its running version (`meshsync-meta`), pod log streaming (`meshery.meshsync.logs`), and interactive `exec` sessions into pods (`meshery.meshsync.exec`). These primitives back the ad hoc connectivity tests and pod-level troubleshooting available from Meshery clients.
 
-_TODO: Include example of how to invoke this built-in check._
+## Health and status
+
+When it starts, MeshSync serves two HTTP endpoints on port `11000`:
+
+- `GET /healthz` - liveness; always returns `200` while the process is alive.
+- `GET /readyz` - readiness; returns `200` once the broker handler has been created (broker mode) and `503` before that.
+
+{{% alert color="info" title="Readiness caveat" %}}
+`/readyz` reflects that MeshSync has <strong>connected to the Broker</strong>, not that its informer caches have finished syncing. A <code>200</code> from <code>/readyz</code> therefore means "connected", not necessarily "cluster snapshot fully primed".
+{{% /alert %}}
 
 # Scalability and Performance
 
-One Meshery Operator and one MeshSync are deployed to each Kubernetes cluster under management.
+One Meshery Operator and one MeshSync are deployed to each Kubernetes cluster under management. MeshSync uses a single [`DynamicSharedInformerFactory`](https://pkg.go.dev/k8s.io/client-go/dynamic/dynamicinformer) scoped to all namespaces, registering one informer per watched resource type. Discovery is watch-driven with no periodic resync; MeshSync re-lists a resource type only on start, on an explicit resync request, or when a CRD change triggers a rebuild.
 
-## Tiered Discovery
+## Tiered Discovery (roadmap)
 
-Kubernetes clusters may grow very large with numerous objects within them. The process of positively identifying and classifying resources by type and aligning them with Meshery's object model can be intense, and discovery tiers (for speed and scalability of MeshSync) successively refine the process of infrastructure identification (see [Composite Fingerprints](#composite-fingerprints)).
+{{% alert color="warning" title="Not yet implemented" %}}
+Tiered discovery is a design goal, not current behavior. MeshSync today performs <strong>flat</strong> discovery: it watches its configured set of resource types across all namespaces at full fidelity. The whitelist/blacklist described in the <a href="#meshsync-faqs">FAQs</a> is the current mechanism for controlling discovery scope; it is a coarse include/exclude of resource types, not a tunable depth.
+{{% /alert %}}
 
-For efficient management of large Kubernetes clusters, MeshSync uses tiered discovery. This approach progressively refines the identification of relevant infrastructure, optimizing the speed and scalability of MeshSync. You have control over the depth of object discovery, enabling you to strike the right balance between granularity and performance for efficient cluster management.
+Kubernetes clusters may grow very large with numerous objects within them. The intent of tiered discovery is to successively refine infrastructure identification - a cheap first pass to detect what is present, followed by progressively deeper passes only against what was found - so that discovery of large clusters stays fast and cheap. Until then, operators on large or busy clusters should scope discovery with a whitelist and be aware that CRD churn triggers a full re-discovery (see [Troubleshooting]({{< ref "guides/troubleshooting/meshery-operator-meshsync.md" >}})).
 
 ## Event-Driven Implementation
 
-Meshery's event-driven approach ensures high-speed operations, making it suitable for managing both small and large clusters. [Meshery Broker]({{< ref "concepts/architecture/broker/index.md" >}}) uses NATS as the messaging bus to ensure continuous communication between MeshSync and Meshery Server. In case of connectivity interruptions, MeshSync data is persisted in NATS topics.
+Meshery's event-driven approach makes it suitable for managing both small and large clusters. [Meshery Broker]({{< ref "concepts/architecture/broker/index.md" >}}) uses NATS as the messaging bus between MeshSync and Meshery Server.
+
+{{% alert color="warning" title="Delivery semantics" %}}
+MeshSync publishes to <strong>core NATS</strong> subjects (fire-and-forget, at-most-once). Events are <strong>not</strong> persisted broker-side today, so if Meshery Server is disconnected when an event is published, that event is not replayed on reconnect - the current snapshot is instead rebuilt by re-listing the cluster on the next resync. Durable, replayable delivery (for example via NATS JetStream) is on the roadmap.
+{{% /alert %}}
 
 ## Broker connection
 
 In operator mode, [Meshery Operator]({{< ref "concepts/architecture/operator/index.md" >}})
 wires MeshSync to the Broker: it derives the Broker's address from the
 `Broker` resource's `status.endpoint` and injects it into the MeshSync
-Deployment as the `BROKER_URL` environment variable — always a
+Deployment as the `BROKER_URL` environment variable - always a
 `nats://host:port` URL. Because the Operator watches the Broker, a change to
 the Broker's endpoint (for example after
 [reconfiguring its service networking]({{< ref "concepts/architecture/broker/index.md#declarative-service-networking" >}}))
@@ -129,6 +143,15 @@ When the deployment mode is switched from operator to embedded: the operator is 
 
 When the deployment mode is switched from embedded to operator: the MeshSync library routine is stopped for the managed cluster, and the operator is deployed to the managed cluster.
 
+# Output modes: broker and file
+
+Independent of operator/embedded deployment, MeshSync can emit its output in one of two ways, selected with the `--output` flag (default `broker`):
+
+- **`broker`** - the default. MeshSync streams resource events to NATS for Meshery Server to consume. This is how MeshSync runs in a cluster alongside Meshery Broker.
+- **`file`** - MeshSync writes a point-in-time cluster snapshot to disk as Kubernetes-style YAML, with no dependency on NATS or the `MeshSync` CRD. This mode backs the [`kubectl meshsync snapshot`]({{< ref "extensions/extensions/kubectl-meshsync-snapshot/index.md" >}}) plugin and is useful for local, air-gapped, or debugging captures. It produces two files: a deduplicated snapshot (`meshery-cluster-snapshot-YYYYMMDD-00.yaml`, one entry per resource by `metadata.uid`) and, optionally, an `-extended` file containing every observed event.
+
+File mode also honors flags to bound the capture: `--outputNamespaces` and `--outputResources` (comma-separated filters, applied to both modes), `--outputFile`, and `--stopAfter` (a duration after which MeshSync exits). These filters are applied to MeshSync's *output*; the informers themselves still watch all namespaces.
+
 # Common tasks
 
 **Check MeshSync health:**
@@ -136,6 +159,14 @@ When the deployment mode is switched from embedded to operator: the MeshSync lib
 ```bash
 kubectl -n meshery get meshsync meshery-meshsync -o jsonpath='{.status.conditions}{"\n"}'
 kubectl -n meshery rollout status deploy/meshery-meshsync
+```
+
+**Probe MeshSync's liveness and readiness endpoints** (served on port `11000`):
+
+```bash
+kubectl -n meshery port-forward deploy/meshery-meshsync 11000:11000 &
+curl -sS http://127.0.0.1:11000/healthz   # liveness: "ok"
+curl -sS -o /dev/null -w '%{http_code}\n' http://127.0.0.1:11000/readyz   # 200 once connected to Broker
 ```
 
 **Verify which Broker MeshSync is connected to:**
@@ -156,7 +187,7 @@ kubectl -n meshery rollout restart deploy/meshery-meshsync
 ## How to configure MeshSync's resource discovery behavior: Can specific, "uninteresting" resources be blacklisted?
 
 Yes. MeshSync reads its discovery filter from the `watch-list` section of the
-`MeshSync` **custom resource** (not the CRD schema) — `meshery-meshsync` in
+`MeshSync` **custom resource** (not the CRD schema) - `meshery-meshsync` in
 the `meshery` namespace. The `whitelist` and `blacklist` keys each hold a
 JSON-encoded list; resources are identified as `<plural>.<version>.<group>`
 (core-group resources end with a trailing dot, e.g. `pods.v1.`).
@@ -174,8 +205,8 @@ spec:
       blacklist: '["events.v1.","replicasets.v1.apps"]'
 ```
 
-Alternatively, a whitelist inverts the behavior — only the listed resources
-(and event types) are watched:
+Alternatively, a whitelist inverts the behavior - only the listed resources
+(and event types) are watched. Only one of whitelist or blacklist may be set:
 
 ```yaml
 spec:

--- a/docs/content/en/concepts/architecture/meshsync.md
+++ b/docs/content/en/concepts/architecture/meshsync.md
@@ -82,7 +82,7 @@ In operator (broker) mode, MeshSync publishes resource events to the NATS subjec
 When it starts, MeshSync serves two HTTP endpoints on port `11000`:
 
 - `GET /healthz` - liveness; always returns `200` while the process is alive.
-- `GET /readyz` - readiness; returns `200` once the broker handler has been created (broker mode) and `503` before that.
+- `GET /readyz` - readiness; returns `200` once MeshSync has established its connection to the Broker (broker mode), and `503` before that.
 
 {{% alert color="info" title="Readiness caveat" %}}
 `/readyz` reflects that MeshSync has <strong>connected to the Broker</strong>, not that its informer caches have finished syncing. A <code>200</code> from <code>/readyz</code> therefore means "connected", not necessarily "cluster snapshot fully primed".

--- a/docs/content/en/concepts/logical/connections/index.md
+++ b/docs/content/en/concepts/logical/connections/index.md
@@ -22,7 +22,7 @@ Meshery tracks the status of each connections throughout the connection's lifecy
 
 ### State: Discovered
 
-All resources discovered by [MeshSync's]({{< ref "concepts/architecture/meshsync.md" >}}) multi-tier discovery or provided as part of config, and if Meshery can integrate, a connection with state as `Discovered` will be created. Though, the connection/resources are not tested for its reachability/usability i.e. Meshery has not made an attempt to connect or manage the connection.
+All resources discovered by [MeshSync]({{< ref "concepts/architecture/meshsync.md" >}}) or provided as part of config, and if Meshery can integrate, a connection with state as `Discovered` will be created. Though, the connection/resources are not tested for its reachability/usability i.e. Meshery has not made an attempt to connect or manage the connection.
 
 When a connection has been discovered, it will be listed in the MeshSync browser / Connections table in Meshery UI. You can self transition a particular connection to [Register](#state-registered) / [Ignore](#state-ignored) state.
 

--- a/docs/content/en/concepts/logical/connections/index.md
+++ b/docs/content/en/concepts/logical/connections/index.md
@@ -22,7 +22,7 @@ Meshery tracks the status of each connections throughout the connection's lifecy
 
 ### State: Discovered
 
-All resources discovered by [MeshSync]({{< ref "concepts/architecture/meshsync.md" >}}) or provided as part of config, and if Meshery can integrate, a connection with state as `Discovered` will be created. Though, the connection/resources are not tested for its reachability/usability i.e. Meshery has not made an attempt to connect or manage the connection.
+When [MeshSync]({{< ref "concepts/architecture/meshsync.md" >}}) discovers a resource (or one is provided as part of config) that Meshery can integrate with, a connection is created in the `Discovered` state. At this point the connection has not been tested for reachability or usability; that is, Meshery has not yet attempted to connect to or manage it.
 
 When a connection has been discovered, it will be listed in the MeshSync browser / Connections table in Meshery UI. You can self transition a particular connection to [Register](#state-registered) / [Ignore](#state-ignored) state.
 

--- a/docs/content/en/guides/troubleshooting/meshery-operator-meshsync.md
+++ b/docs/content/en/guides/troubleshooting/meshery-operator-meshsync.md
@@ -151,7 +151,7 @@ kubectl -n meshery get deploy meshery-meshsync \
 ### Behaviors that commonly explain missing or churning data
 
 - **A new or changed CRD triggers a full re-discovery.** MeshSync watches the cluster's CustomResourceDefinitions and rebuilds its informers when the CRD set changes. On clusters where controllers rewrite CRDs frequently (for example, cert-manager's CA injector updating CRD `caBundle` fields), this can cause repeated re-discovery and transient load or gaps. If you observe this, scope discovery with a whitelist (see the [MeshSync configuration FAQ]({{< ref "concepts/architecture/meshsync.md#meshsync-faqs" >}})).
-- **Secrets are discovered by default.** MeshSync watches `secrets.v1.` and, today, includes Secret contents in what it publishes to Meshery Server. In security-sensitive environments, blacklist `secrets.v1.` (or use a whitelist that omits it) to keep Secret payloads out of the Meshery Database.
+- **Secrets are discovered by default.** MeshSync watches `secrets.v1.`, and the Secret objects it forwards to Meshery Server include their `data` and `stringData` payload. Those Secret contents are therefore transmitted over the Broker and persisted in the Meshery Database. In security-sensitive environments, blacklist `secrets.v1.` (or use a whitelist that omits it) to keep Secret payloads out of the Meshery Database.
 - **Discovery is watch-driven with no periodic re-list.** MeshSync relies on the Kubernetes watch stream rather than polling. If you suspect the in-memory snapshot has drifted, force a re-list with `kubectl -n meshery rollout restart deploy/meshery-meshsync` or reset the Meshery Database from the UI.
 
 ## See Also

--- a/docs/content/en/guides/troubleshooting/meshery-operator-meshsync.md
+++ b/docs/content/en/guides/troubleshooting/meshery-operator-meshsync.md
@@ -8,7 +8,7 @@ categories: [troubleshooting]
 <a href='{{< ref "concepts/architecture/operator/index.md" >}}'>Meshery Operator</a> controls and monitors the lifecycle of components deployed inside Meshery-managed Kubernetes clusters. Learn more about <a href='{{< ref "concepts/_index.md" >}}'>Meshery's architecture</a>.
 {{% /alert %}}
 
-This guide offers comprehensive for troubleshooting instructions for [Meshery Operator]({{< ref "concepts/architecture/operator/index.md" >}}) and its custom controllers, [MeshSync]({{< ref "concepts/architecture/meshsync.md" >}}) and [Broker]({{< ref "concepts/architecture/broker/index.md" >}}). Follow the steps outlined in this document to ensure a smooth Meshery deployment.
+This guide offers comprehensive troubleshooting instructions for [Meshery Operator]({{< ref "concepts/architecture/operator/index.md" >}}) and its custom controllers, [MeshSync]({{< ref "concepts/architecture/meshsync.md" >}}) and [Broker]({{< ref "concepts/architecture/broker/index.md" >}}). Follow the steps outlined in this document to ensure a smooth Meshery deployment.
 
 First, understand the [Meshery Operator Deployment Scenarios](#meshery-operator-deployment-scenarios) and the [Status of Meshery Operator, MeshSync, and Meshery Broker](#understanding-the-status-of-meshery-operator-meshsync-and-meshery-broker) to identify the deployment model fitting of your environment. Then, follow the guidance under the respective scenario to troubleshoot accordingly.
 
@@ -18,7 +18,7 @@ Have specific error with an error code? See the <a href='{{< ref "reference/refe
 
 ## Understanding the Status of Meshery Operator, MeshSync, and Meshery Broker
 
-Each Meshery Operator controller offers a health status that you can use to understand their current health in your deployment. Their health statuses and meanings are described below.of MeshSync and Meshery Broker.
+Each Meshery Operator controller offers a health status that you can use to understand its current health in your deployment. These statuses are computed by Meshery Server from what it observes of the Operator, MeshSync, and Broker; their meanings are described below.
 
 ### Meshery Operator Health Status
 
@@ -42,7 +42,7 @@ Each Meshery Operator controller offers a health status that you can use to unde
 
 ## Meshery Operator Deployment Scenarios
 
-Because Meshery is versatile in its deployment models, there are different of scenarios in which you may need to troubleshoot the health of Meshery Operator. Identify the deployment model fitting of your environment and follow the guidance under the respective scenario to troublshoot accordingly.
+Because Meshery is versatile in its deployment models, there are different scenarios in which you may need to troubleshoot the health of Meshery Operator. Identify the deployment model fitting your environment and follow the guidance under the respective scenario to troubleshoot accordingly.
 
 ### In-Cluster Deployment
 
@@ -116,6 +116,43 @@ Future Enhancements for Troubleshooting:
 - NATS/MeshSync not running prompts a review of available operations in the Settings panel.
 
 </div>
+
+## Inspecting MeshSync Directly
+
+When the CLI and UI clients don't explain *why* data is missing or stale, inspect the MeshSync pod directly.
+
+**Read MeshSync logs** (enable debug logging for detail):
+
+```bash
+kubectl -n meshery logs deploy/meshery-meshsync
+# For verbose output, set DEBUG=true on the Deployment and let it restart:
+kubectl -n meshery set env deploy/meshery-meshsync DEBUG=true
+```
+
+**Check liveness and readiness** (MeshSync serves these on port `11000`):
+
+```bash
+kubectl -n meshery port-forward deploy/meshery-meshsync 11000:11000 &
+curl -sS http://127.0.0.1:11000/healthz    # liveness
+curl -sS -o /dev/null -w '%{http_code}\n' http://127.0.0.1:11000/readyz   # 200 == connected to Broker
+```
+
+{{% alert color="info" title="What readiness does and does not mean" %}}
+<code>/readyz</code> returns <code>200</code> once MeshSync has connected to the Broker, <strong>not</strong> once its informer caches have finished priming. Immediately after a (re)start MeshSync may report ready while its cluster snapshot is still filling in. If Meshery shows a partial cluster right after a restart, give discovery a moment or trigger a fresh discovery with <code>kubectl -n meshery rollout restart deploy/meshery-meshsync</code>.
+{{% /alert %}}
+
+**Verify the Broker is reachable from MeshSync.** On startup MeshSync runs a connectivity test against the Broker's monitoring endpoint (`http://<broker-host>:8222/connz`) before opening its NATS client; a failure here appears in the MeshSync logs and blocks readiness. Confirm the `BROKER_URL` value and that the Broker Service is reachable:
+
+```bash
+kubectl -n meshery get deploy meshery-meshsync \
+  -o jsonpath='{.spec.template.spec.containers[0].env[?(@.name=="BROKER_URL")].value}{"\n"}'
+```
+
+### Behaviors that commonly explain missing or churning data
+
+- **A new or changed CRD triggers a full re-discovery.** MeshSync watches the cluster's CustomResourceDefinitions and rebuilds its informers when the CRD set changes. On clusters where controllers rewrite CRDs frequently (for example, cert-manager's CA injector updating CRD `caBundle` fields), this can cause repeated re-discovery and transient load or gaps. If you observe this, scope discovery with a whitelist (see the [MeshSync configuration FAQ]({{< ref "concepts/architecture/meshsync.md#meshsync-faqs" >}})).
+- **Secrets are discovered by default.** MeshSync watches `secrets.v1.` and, today, includes Secret contents in what it publishes to Meshery Server. In security-sensitive environments, blacklist `secrets.v1.` (or use a whitelist that omits it) to keep Secret payloads out of the Meshery Database.
+- **Discovery is watch-driven with no periodic re-list.** MeshSync relies on the Kubernetes watch stream rather than polling. If you suspect the in-memory snapshot has drifted, force a re-list with `kubectl -n meshery rollout restart deploy/meshery-meshsync` or reset the Meshery Database from the UI.
 
 ## See Also
 


### PR DESCRIPTION
**Notes for Reviewers**

This PR updates the MeshSync documentation to reflect the **current implementation**. Several pages described aspirational design behavior as if it were already shipping; this corrects those claims and documents real, previously-undocumented behavior. Docs-only, scoped to `content/en/`; no code or behavior changes.

**What changed**

- **Architecture** (`concepts/architecture/meshsync.md`)
  - Adds a roadmap banner and marks **tiered (progressively refined) discovery**, **composite fingerprints spanning entities**, **broker-side event persistence**, and **non-Kubernetes targets** as design goals that are not yet implemented.
  - Documents what actually runs: one informer per watched resource type (`DynamicSharedInformerFactory`, all namespaces); watch-driven discovery with no periodic resync; CRD watching that rebuilds discovery on change; the publish/request NATS subjects; `/healthz` and `/readyz` on `:11000` (with the readiness caveat); **core-NATS at-most-once delivery** (no persistence today); and the **broker/file output modes** plus CLI flags.
  - Clarifies that resource classification against Meshery's model is done by Meshery Server, not MeshSync. Removes stale `TODO` markers.
- **Troubleshooting** (`guides/troubleshooting/meshery-operator-meshsync.md`)
  - Adds an **"Inspecting MeshSync Directly"** section (logs with `DEBUG`, health endpoints, broker reachability) and documents behaviors that commonly explain missing/churning data: **CRD churn triggering full re-discovery**, **Secrets being synced by default**, and watch-driven discovery with no periodic re-list. Grammar fixes.
- **Logical** (`concepts/logical/connections/index.md`)
  - Drops the "multi-tier discovery" phrasing, since tiered discovery is not yet implemented.

**Why:** the prior text would mislead operators and SREs about discovery scope, delivery durability, and Secret handling. Cross-references resolve and alert shortcodes are balanced. Implementation gaps that motivated these corrections are being tracked separately as code fixes.

- This PR is a documentation accuracy update (no linked issue).

**[Signed commits](https://github.com/meshery/meshery/blob/master/CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [x] Yes, I signed my commits.
