### PR TITLE
[Server] Keep MeshSync broker connection reconnecting instead of giving up after ~10s

### DIFF
--- a/server/internal/graphql/model/operator_helper.go
+++ b/server/internal/graphql/model/operator_helper.go
@@ -193,7 +193,11 @@ func SubscribeToBroker(_ models.Provider, mesheryKubeClient *mesherykube.Client,
 		Username:       "",
 		Password:       "",
 		ReconnectWait:  2 * time.Second,
-		MaxReconnect:   5,
+		// Keep retrying to reconnect indefinitely. This subscription is only set up
+		// once per operator subscribe (there is no re-subscribe loop), so a bounded
+		// cap here means a broker restart longer than ReconnectWait*MaxReconnect
+		// permanently severs MeshSync until the user intervenes. See #20465.
+		MaxReconnect: -1,
 	})
 	// Hack for minikube based clusters
 	if err != nil && conn == nil {


### PR DESCRIPTION
**Notes for Reviewers**

MeshSync's NATS connection to the broker was capped at `MaxReconnect: 5` (with `ReconnectWait: 2s`), so after roughly 10 seconds of broker downtime the client stops reconnecting and the connection closes. `SubscribeToBroker` is only called once per operator subscribe and its goroutine returns on success, so there is no re-subscribe loop to recover. A broker pod restart, operator upgrade, or node drain longer than ~10s permanently severs MeshSync until the user intervenes, which is the root cause behind the "Meshery Server lost subscription to Broker -> stale DB -> Flush MeshSync" troubleshooting flow.

This sets `MaxReconnect: -1` so the control-plane connection keeps retrying and self-heals after a transient broker outage. Happy to use a bounded but large value instead if that is preferred.

This is the server-side half of #20465. The other half (re-issuing the `ReSyncDiscoveryEntity` request on reconnect so the DB converges after a gap) needs a reconnect hook in meshkit's `broker/nats` and is tracked in the issue as a follow-up.

- This PR addresses part of #20465

**Signed commits**
- [x] Yes, I signed my commits.
