### PR TITLE
[Server] feat: Add OCI push/pull endpoints for Meshery Models

### DIFF
--- a/server/handlers/component_handler.go
+++ b/server/handlers/component_handler.go
@@ -1331,7 +1331,11 @@ func (h *Handler) ExportModel(rw http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	model := e[0].(*_model.ModelDefinition)
+	model, ok := e[0].(*_model.ModelDefinition)
+	if !ok {
+		writeJSONError(rw, "invalid model definition type", http.StatusInternalServerError)
+		return
+	}
 	//This path is used to so that the function can be aware of where the svg file is
 	//This is for relative path as we are inside meshery/server/cmd/main.go
 	//File is stored in Ui folder so we need to move 2 directories back
@@ -1533,7 +1537,11 @@ func (h *Handler) PushModel(rw http.ResponseWriter, r *http.Request, _ *models.P
 		return
 	}
 
-	model := e[0].(*_model.ModelDefinition)
+	model, ok := e[0].(*_model.ModelDefinition)
+	if !ok {
+		writeJSONError(rw, "invalid model definition type", http.StatusInternalServerError)
+		return
+	}
 
 	modelDir, err := os.MkdirTemp("", "model-push-")
 	if err != nil {
@@ -1766,13 +1774,13 @@ func extractFromOCIStore(pullDir, tag, destDir string) error {
 	if err != nil {
 		return fmt.Errorf("cannot open layer blob %s: %w", layerDigest, err)
 	}
-	defer f.Close()
+	defer func() { _ = f.Close() }()
 
 	gzr, err := gzip.NewReader(f)
 	if err != nil {
 		return fmt.Errorf("cannot decompress layer: %w", err)
 	}
-	defer gzr.Close()
+	defer func() { _ = gzr.Close() }()
 
 	var totalExtracted int64
 	var fileCount int
@@ -1820,14 +1828,16 @@ func extractFromOCIStore(pullDir, tag, destDir string) error {
 				return fmt.Errorf("cannot create parent dir for %s: %w", target, err)
 			}
 			// Restrict created file permissions; ignore header mode bits
-			// that grant group/world write.
-			mode := os.FileMode(header.Mode) & 0666
+			// that grant execute, setuid, setgid, or group/world write.
+			mode := os.FileMode(header.Mode) & 0644
 			fw, err := os.OpenFile(target, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, mode)
 			if err != nil {
 				return fmt.Errorf("cannot create file %s: %w", target, err)
 			}
 			written, err := io.Copy(fw, io.LimitReader(tr, header.Size))
-			fw.Close()
+			if cerr := fw.Close(); cerr != nil && err == nil {
+				err = fmt.Errorf("cannot close file %s: %w", target, cerr)
+			}
 			if err != nil {
 				return fmt.Errorf("cannot write file %s: %w", target, err)
 			}
@@ -1867,9 +1877,9 @@ func resolveCredentials(r *http.Request, credentialID *string, inlineUsername, i
 		if !ok {
 			return "", "", fmt.Errorf("failed to retrieve auth token from context")
 		}
-		cid := uuid.FromStringOrNil(*credentialID)
-		if cid.IsNil() {
-			return "", "", fmt.Errorf("invalid credentialId: %s", *credentialID)
+		cid, parseErr := uuid.FromString(*credentialID)
+		if parseErr != nil {
+			return "", "", fmt.Errorf("invalid credentialId: %w", parseErr)
 		}
 		cred, _, cerr := provider.GetCredentialByID(token, cid)
 		if cerr != nil {
@@ -1923,8 +1933,8 @@ func validateOCIRegistryDestination(registry, repository string) error {
 		return fmt.Errorf("registry host is empty")
 	}
 
-	// Reject path separators in registry (must be pure host:port)
-	if strings.ContainsAny(registry, "/\\") {
+	// Reject path separators in host (must be pure host:port)
+	if strings.ContainsAny(raw, "/\\") {
 		return fmt.Errorf("registry must be a host:port, not a path")
 	}
 

--- a/server/handlers/component_handler.go
+++ b/server/handlers/component_handler.go
@@ -1798,8 +1798,9 @@ func extractFromOCIStore(pullDir, tag, destDir string) error {
 			return fmt.Errorf("rejected symlink/hardlink entry: %s", header.Name)
 		}
 
-		target := filepath.Join(destDir, filepath.Clean(header.Name))
-		if !strings.HasPrefix(target, filepath.Clean(destDir)+string(os.PathSeparator)) {
+		cleanDest := filepath.Clean(destDir)
+		target := filepath.Join(cleanDest, filepath.Clean(header.Name))
+		if target != cleanDest && !strings.HasPrefix(target, cleanDest+string(os.PathSeparator)) {
 			return fmt.Errorf("path traversal rejected: %s", header.Name)
 		}
 

--- a/server/handlers/component_handler.go
+++ b/server/handlers/component_handler.go
@@ -1587,11 +1587,13 @@ func (h *Handler) PushModel(rw http.ResponseWriter, r *http.Request, _ *models.P
 		}
 	}
 
-	_ = model.ReplaceSVGData("../../")
-	model.Relationships = nil
-	model.Components = nil
+	// Work on a copy to avoid mutating shared registry state.
+	mc := *model
+	_ = mc.ReplaceSVGData("../../")
+	mc.Relationships = nil
+	mc.Components = nil
 
-	if err := model.WriteModelDefinition(filepath.Join(versionDir, "model.json"), "json"); err != nil {
+	if err := mc.WriteModelDefinition(filepath.Join(versionDir, "model.json"), "json"); err != nil {
 		h.log.Error(err)
 		writeMeshkitError(rw, ErrPushModel(err, "model definition write"), http.StatusInternalServerError)
 		return
@@ -1862,7 +1864,7 @@ func validateOCIDigest(digest string) error {
 		return fmt.Errorf("invalid digest length: %s", digest)
 	}
 	for _, c := range hexPart {
-		if !((c >= '0' && c <= '9') || (c >= 'a' && c <= 'f') || (c >= 'A' && c <= 'F')) {
+		if (c < '0' || c > '9') && (c < 'a' || c > 'f') && (c < 'A' || c > 'F') {
 			return fmt.Errorf("invalid hex character in digest: %s", digest)
 		}
 	}
@@ -1920,6 +1922,9 @@ func validateOCIRegistryDestination(registry, repository string) error {
 		}
 		if u.Scheme != "" && u.Scheme != "https" && u.Scheme != "http" {
 			return fmt.Errorf("unsupported registry scheme: %s", u.Scheme)
+		}
+		if u.Path != "" || u.RawQuery != "" || u.Fragment != "" {
+			return fmt.Errorf("registry URL must not contain path, query, or fragment")
 		}
 		raw = u.Host
 	}

--- a/server/handlers/component_handler.go
+++ b/server/handlers/component_handler.go
@@ -1,12 +1,16 @@
 package handlers
 
 import (
+	"archive/tar"
 	"bytes"
+	"compress/gzip"
 	"encoding/base64"
 	"encoding/json"
 	"fmt"
 	"io"
+	"net"
 	"net/http"
+	"net/url"
 	"os"
 	"path/filepath"
 	"strconv"
@@ -32,9 +36,9 @@ import (
 	_models "github.com/meshery/meshkit/models/meshmodel/core/v1beta1"
 	"github.com/meshery/schemas/models/v1alpha3/relationship"
 	schemav1beta1 "github.com/meshery/schemas/models/v1beta1"
-	"github.com/meshery/schemas/models/v1beta3/component"
 	"github.com/meshery/schemas/models/v1beta1/connection"
 	_model "github.com/meshery/schemas/models/v1beta1/model"
+	"github.com/meshery/schemas/models/v1beta3/component"
 
 	"github.com/meshery/meshkit/models/meshmodel/entity"
 	"github.com/meshery/meshkit/models/meshmodel/registry"
@@ -84,10 +88,10 @@ func (h *Handler) GetMeshmodelModelsByCategories(rw http.ResponseWriter, r *http
 	}
 
 	res := models.MeshmodelsDuplicateAPIResponse{
-		Page:     page,
-		PageSize: int(pgSize),
-		TotalCount:    count,
-		Models:   models.FindDuplicateModels(modelDefs),
+		Page:       page,
+		PageSize:   int(pgSize),
+		TotalCount: count,
+		Models:     models.FindDuplicateModels(modelDefs),
 	}
 
 	if err := enc.Encode(res); err != nil {
@@ -140,10 +144,10 @@ func (h *Handler) GetMeshmodelModelsByCategoriesByModel(rw http.ResponseWriter, 
 	}
 
 	res := models.MeshmodelsDuplicateAPIResponse{
-		Page:     page,
-		PageSize: int(pgSize),
-		TotalCount:    count,
-		Models:   models.FindDuplicateModels(modelDefs),
+		Page:       page,
+		PageSize:   int(pgSize),
+		TotalCount: count,
+		Models:     models.FindDuplicateModels(modelDefs),
 	}
 
 	if err := enc.Encode(res); err != nil {
@@ -200,10 +204,10 @@ func (h *Handler) GetMeshmodelModels(rw http.ResponseWriter, r *http.Request) {
 	}
 
 	res := models.MeshmodelsDuplicateAPIResponse{
-		Page:     page,
-		PageSize: int(pgSize),
-		TotalCount:    count,
-		Models:   models.FindDuplicateModels(modelDefs),
+		Page:       page,
+		PageSize:   int(pgSize),
+		TotalCount: count,
+		Models:     models.FindDuplicateModels(modelDefs),
 	}
 
 	if err := enc.Encode(res); err != nil {
@@ -257,10 +261,10 @@ func (h *Handler) GetMeshmodelModelsByName(rw http.ResponseWriter, r *http.Reque
 	}
 
 	res := models.MeshmodelsDuplicateAPIResponse{
-		Page:     page,
-		PageSize: int(pgSize),
-		TotalCount:    count,
-		Models:   models.FindDuplicateModels(modelDefs),
+		Page:       page,
+		PageSize:   int(pgSize),
+		TotalCount: count,
+		Models:     models.FindDuplicateModels(modelDefs),
 	}
 
 	if err := enc.Encode(res); err != nil {
@@ -300,7 +304,7 @@ func (h *Handler) GetMeshmodelCategories(rw http.ResponseWriter, r *http.Request
 	res := models.MeshmodelCategoriesAPIResponse{
 		Page:       page,
 		PageSize:   int(pgSize),
-		TotalCount:      count,
+		TotalCount: count,
 		Categories: categories,
 	}
 
@@ -342,7 +346,7 @@ func (h *Handler) GetMeshmodelCategoriesByName(rw http.ResponseWriter, r *http.R
 	res := models.MeshmodelCategoriesAPIResponse{
 		Page:       page,
 		PageSize:   int(pgSize),
-		TotalCount:      count,
+		TotalCount: count,
 		Categories: categories,
 	}
 
@@ -396,7 +400,7 @@ func (h *Handler) GetMeshmodelComponentsByNameByModelByCategory(rw http.Response
 	response := models.MeshmodelComponentsDuplicateAPIResponse{
 		Page:       page,
 		PageSize:   int(pgSize),
-		TotalCount:      count,
+		TotalCount: count,
 		Components: models.FindDuplicateComponents(comps),
 	}
 
@@ -448,7 +452,7 @@ func (h *Handler) GetMeshmodelComponentsByNameByCategory(rw http.ResponseWriter,
 	response := models.MeshmodelComponentsDuplicateAPIResponse{
 		Page:       page,
 		PageSize:   int(pgSize),
-		TotalCount:      count,
+		TotalCount: count,
 		Components: models.FindDuplicateComponents(comps),
 	}
 
@@ -501,7 +505,7 @@ func (h *Handler) GetMeshmodelComponentsByNameByModel(rw http.ResponseWriter, r 
 	response := models.MeshmodelComponentsDuplicateAPIResponse{
 		Page:       page,
 		PageSize:   int(pgSize),
-		TotalCount:      count,
+		TotalCount: count,
 		Components: models.FindDuplicateComponents(comps),
 	}
 
@@ -552,7 +556,7 @@ func (h *Handler) GetAllMeshmodelComponentsByName(rw http.ResponseWriter, r *htt
 	response := models.MeshmodelComponentsDuplicateAPIResponse{
 		Page:       page,
 		PageSize:   int(pgSize),
-		TotalCount:      count,
+		TotalCount: count,
 		Components: models.FindDuplicateComponents(comps),
 	}
 
@@ -603,7 +607,7 @@ func (h *Handler) GetMeshmodelComponentByModel(rw http.ResponseWriter, r *http.R
 	response := models.MeshmodelComponentsDuplicateAPIResponse{
 		Page:       page,
 		PageSize:   int(pgSize),
-		TotalCount:      count,
+		TotalCount: count,
 		Components: models.FindDuplicateComponents(comps),
 	}
 
@@ -654,7 +658,7 @@ func (h *Handler) GetMeshmodelComponentByModelByCategory(rw http.ResponseWriter,
 	response := models.MeshmodelComponentsDuplicateAPIResponse{
 		Page:       page,
 		PageSize:   int(pgSize),
-		TotalCount:      count,
+		TotalCount: count,
 		Components: models.FindDuplicateComponents(comps),
 	}
 
@@ -703,7 +707,7 @@ func (h *Handler) GetMeshmodelComponentByCategory(rw http.ResponseWriter, r *htt
 	response := models.MeshmodelComponentsDuplicateAPIResponse{
 		Page:       page,
 		PageSize:   int(pgSize),
-		TotalCount:      count,
+		TotalCount: count,
 		Components: models.FindDuplicateComponents(comps),
 	}
 
@@ -752,7 +756,7 @@ func (h *Handler) GetAllMeshmodelComponents(rw http.ResponseWriter, r *http.Requ
 	res := models.MeshmodelComponentsDuplicateAPIResponse{
 		Page:       page,
 		PageSize:   int(pgSize),
-		TotalCount:      count,
+		TotalCount: count,
 		Components: models.FindDuplicateComponents(comps),
 	}
 
@@ -838,7 +842,7 @@ func (h *Handler) GetMeshmodelRegistrants(rw http.ResponseWriter, r *http.Reques
 	res := models.MeshmodelRegistrantsAPIResponse{
 		Page:        page,
 		PageSize:    int(pgSize),
-		TotalCount:       count,
+		TotalCount:  count,
 		Registrants: hosts,
 	}
 
@@ -1468,6 +1472,508 @@ func (h *Handler) ExportModel(rw http.ResponseWriter, r *http.Request) {
 			h.log.Error(ErrEncodeResponse(err))
 		}
 	}
+}
+
+func (h *Handler) PushModel(rw http.ResponseWriter, r *http.Request, _ *models.Preference, _ *models.User, provider models.Provider) {
+	var req struct {
+		ModelID      string `json:"modelId"`
+		ModelName    string `json:"modelName"`
+		Version      string `json:"version"`
+		Registry     string `json:"registry"`
+		Repository   string `json:"repository"`
+		Tag          string `json:"tag"`
+		CredentialID string `json:"credentialId"`
+		Username     string `json:"username"`
+		Password     string `json:"password"`
+	}
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		writeJSONError(rw, "Invalid request body", http.StatusBadRequest)
+		return
+	}
+	if req.ModelID == "" && req.ModelName == "" {
+		writeJSONError(rw, "modelId or modelName is required", http.StatusBadRequest)
+		return
+	}
+
+	username, password, err := resolveCredentials(r, &req.CredentialID, req.Username, req.Password, provider)
+	// Clear inline credentials from the request struct to minimise
+	// accidental exposure lifetime. This is not secure memory erasure;
+	// strings in Go are immutable and may linger in memory until GC.
+	req.Username = ""
+	req.Password = ""
+	if err != nil {
+		writeMeshkitError(rw, ErrPushModel(err, "credential resolution"), http.StatusBadRequest)
+		return
+	}
+
+	if err := validateOCIRegistryDestination(req.Registry, req.Repository); err != nil {
+		writeJSONError(rw, err.Error(), http.StatusBadRequest)
+		return
+	}
+	if req.Tag == "" {
+		req.Tag = "latest"
+	}
+
+	modelFilter := &regv1beta1.ModelFilter{
+		Id:            req.ModelID,
+		Name:          req.ModelName,
+		Components:    true,
+		Relationships: true,
+		Greedy:        true,
+		Version:       req.Version,
+	}
+	e, _, _, err := h.registryManager.GetEntities(modelFilter)
+	if err != nil {
+		h.log.Error(ErrGetMeshModels(err))
+		writeMeshkitError(rw, ErrGetMeshModels(err), http.StatusInternalServerError)
+		return
+	}
+	if len(e) == 0 {
+		writeJSONError(rw, "model not found", http.StatusNotFound)
+		return
+	}
+
+	model := e[0].(*_model.ModelDefinition)
+
+	modelDir, err := os.MkdirTemp("", "model-push-")
+	if err != nil {
+		h.log.Error(err)
+		writeMeshkitError(rw, ErrPushModel(err, "temp directory creation"), http.StatusInternalServerError)
+		return
+	}
+	defer func() {
+		if err := os.RemoveAll(modelDir); err != nil {
+			h.log.Error(err)
+		}
+	}()
+
+	versionDir := filepath.Join(modelDir, model.Model.Version, model.Version)
+	for _, dir := range []string{versionDir, filepath.Join(versionDir, "components"), filepath.Join(versionDir, "relationships")} {
+		if err := os.MkdirAll(dir, 0700); err != nil {
+			h.log.Error(err)
+			writeMeshkitError(rw, ErrPushModel(err, "temp directory creation"), http.StatusInternalServerError)
+			return
+		}
+	}
+
+	var components []component.ComponentDefinition
+	if model.Components != nil {
+		var ok bool
+		components, ok = model.Components.([]component.ComponentDefinition)
+		if !ok {
+			err := fmt.Errorf("unexpected type for Components: %T", model.Components)
+			h.log.Error(err)
+			writeMeshkitError(rw, ErrPushModel(err, "type assertion"), http.StatusInternalServerError)
+			return
+		}
+	}
+	var relationships []relationship.RelationshipDefinition
+	if model.Relationships != nil {
+		var ok bool
+		relationships, ok = model.Relationships.([]relationship.RelationshipDefinition)
+		if !ok {
+			err := fmt.Errorf("unexpected type for Relationships: %T", model.Relationships)
+			h.log.Error(err)
+			writeMeshkitError(rw, ErrPushModel(err, "type assertion"), http.StatusInternalServerError)
+			return
+		}
+	}
+
+	_ = model.ReplaceSVGData("../../")
+	model.Relationships = nil
+	model.Components = nil
+
+	if err := model.WriteModelDefinition(filepath.Join(versionDir, "model.json"), "json"); err != nil {
+		h.log.Error(err)
+		writeMeshkitError(rw, ErrPushModel(err, "model definition write"), http.StatusInternalServerError)
+		return
+	}
+	for _, comp := range components {
+		_ = comp.ReplaceSVGData("../../")
+		comp.Model = model
+		if _, err := comp.WriteComponentDefinition(filepath.Join(versionDir, "components"), "json"); err != nil {
+			h.log.Error(err)
+			writeMeshkitError(rw, ErrPushModel(err, "component definition write"), http.StatusInternalServerError)
+			return
+		}
+	}
+	for _, rel := range relationships {
+		rel.Model = model.ToReference()
+		if err := rel.WriteRelationshipDefinition(filepath.Join(versionDir, "relationships"), "json"); err != nil {
+			h.log.Error(err)
+			writeMeshkitError(rw, ErrPushModel(err, "relationship definition write"), http.StatusInternalServerError)
+			return
+		}
+	}
+
+	if err := meshkitOci.PushToOCIRegistry(modelDir, req.Registry, req.Repository, req.Tag, username, password); err != nil {
+		h.log.Error(err)
+		writeMeshkitError(rw, ErrPushModel(err, "OCI push"), http.StatusInternalServerError)
+		return
+	}
+
+	writeJSONMessage(rw, map[string]string{"message": "Model pushed successfully"}, http.StatusOK)
+}
+
+func (h *Handler) PullModel(rw http.ResponseWriter, r *http.Request, _ *models.Preference, _ *models.User, provider models.Provider) {
+	var req struct {
+		Registry     string `json:"registry"`
+		Repository   string `json:"repository"`
+		Tag          string `json:"tag"`
+		CredentialID string `json:"credentialId"`
+		Username     string `json:"username"`
+		Password     string `json:"password"`
+	}
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		writeJSONError(rw, "Invalid request body", http.StatusBadRequest)
+		return
+	}
+
+	username, password, err := resolveCredentials(r, &req.CredentialID, req.Username, req.Password, provider)
+	req.Username = ""
+	req.Password = ""
+	if err != nil {
+		writeMeshkitError(rw, ErrPullModel(err, "credential resolution"), http.StatusBadRequest)
+		return
+	}
+
+	if err := validateOCIRegistryDestination(req.Registry, req.Repository); err != nil {
+		writeJSONError(rw, err.Error(), http.StatusBadRequest)
+		return
+	}
+	if req.Tag == "" {
+		req.Tag = "latest"
+	}
+
+	pullDir, err := os.MkdirTemp("", "model-pull-")
+	if err != nil {
+		h.log.Error(err)
+		writeMeshkitError(rw, ErrPullModel(err, "pull directory creation"), http.StatusInternalServerError)
+		return
+	}
+	defer func() {
+		if err := os.RemoveAll(pullDir); err != nil {
+			h.log.Error(err)
+		}
+	}()
+
+	if err := meshkitOci.PullFromOCIRegistry(pullDir, req.Registry, req.Repository, req.Tag, username, password); err != nil {
+		h.log.Error(err)
+		writeMeshkitError(rw, ErrPullModel(err, "OCI pull"), http.StatusInternalServerError)
+		return
+	}
+
+	extractDir, err := os.MkdirTemp("", "model-extract-")
+	if err != nil {
+		h.log.Error(err)
+		writeMeshkitError(rw, ErrPullModel(err, "extract directory creation"), http.StatusInternalServerError)
+		return
+	}
+	defer func() {
+		if err := os.RemoveAll(extractDir); err != nil {
+			h.log.Error(err)
+		}
+	}()
+
+	if err := extractFromOCIStore(pullDir, req.Tag, extractDir); err != nil {
+		h.log.Error(err)
+		writeMeshkitError(rw, ErrPullModel(err, "artifact extraction"), http.StatusInternalServerError)
+		return
+	}
+
+	regErrorStore := models.NewRegistrationFailureLogHandler()
+	registrationHelper := registration.NewRegistrationHelper(utils.UI, h.registryManager, regErrorStore)
+	dir := registration.NewDir(extractDir)
+	registrationHelper.Register(dir)
+
+	if len(registrationHelper.PkgUnits) == 0 {
+		h.log.Error(ErrPullModel(fmt.Errorf("registration produced no valid package units"), "registration"))
+		writeMeshkitError(rw, ErrPullModel(fmt.Errorf("registration produced no valid package units"), "registration"), http.StatusInternalServerError)
+		return
+	}
+
+	writeJSONMessage(rw, map[string]string{"message": "Model pulled and registered successfully"}, http.StatusOK)
+}
+
+// extractFromOCIStore reads an ORAS file store (created by PullFromOCIRegistry),
+// finds its first layer blob, decompresses and untars it into destDir.
+// It validates digests before reading files, streams layer content instead of
+// reading the entire blob into memory, rejects symlinks/hardlinks, enforces
+// resource limits, and prevents path traversal.
+func extractFromOCIStore(pullDir, tag, destDir string) error {
+	const (
+		maxTotalBytes = 500 << 20 // 500 MiB total decompressed
+		maxFileSize   = 100 << 20 // 100 MiB per file
+		maxFileCount  = 10000
+	)
+
+	indexFile := filepath.Join(pullDir, "index.json")
+	data, err := os.ReadFile(indexFile)
+	if err != nil {
+		return fmt.Errorf("cannot read index.json: %w", err)
+	}
+
+	var index struct {
+		Manifests []struct {
+			Digest      string            `json:"digest"`
+			Annotations map[string]string `json:"annotations,omitempty"`
+		} `json:"manifests"`
+	}
+	if err := json.Unmarshal(data, &index); err != nil {
+		return fmt.Errorf("cannot parse index.json: %w", err)
+	}
+	if len(index.Manifests) == 0 {
+		return fmt.Errorf("no manifests found in pulled artifact")
+	}
+
+	manifestDigest := index.Manifests[0].Digest
+	for _, m := range index.Manifests {
+		if ref, ok := m.Annotations["org.opencontainers.image.ref.name"]; ok && ref == tag {
+			manifestDigest = m.Digest
+			break
+		}
+	}
+
+	if err := validateOCIDigest(manifestDigest); err != nil {
+		return fmt.Errorf("invalid manifest digest: %w", err)
+	}
+
+	manifestFile := filepath.Join(pullDir, "blobs", "sha256", strings.TrimPrefix(manifestDigest, "sha256:"))
+	manifestData, err := os.ReadFile(manifestFile)
+	if err != nil {
+		return fmt.Errorf("cannot read manifest blob %s: %w", manifestDigest, err)
+	}
+
+	var manifest struct {
+		Layers []struct {
+			Digest string `json:"digest"`
+		} `json:"layers"`
+	}
+	if err := json.Unmarshal(manifestData, &manifest); err != nil {
+		return fmt.Errorf("cannot parse manifest: %w", err)
+	}
+	if len(manifest.Layers) == 0 {
+		return fmt.Errorf("no layers found in pulled artifact")
+	}
+
+	layerDigest := manifest.Layers[0].Digest
+	if err := validateOCIDigest(layerDigest); err != nil {
+		return fmt.Errorf("invalid layer digest: %w", err)
+	}
+
+	layerFile := filepath.Join(pullDir, "blobs", "sha256", strings.TrimPrefix(layerDigest, "sha256:"))
+	f, err := os.Open(layerFile)
+	if err != nil {
+		return fmt.Errorf("cannot open layer blob %s: %w", layerDigest, err)
+	}
+	defer f.Close()
+
+	gzr, err := gzip.NewReader(f)
+	if err != nil {
+		return fmt.Errorf("cannot decompress layer: %w", err)
+	}
+	defer gzr.Close()
+
+	var totalExtracted int64
+	var fileCount int
+	tr := tar.NewReader(gzr)
+	for {
+		header, err := tr.Next()
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			return fmt.Errorf("error reading tar stream: %w", err)
+		}
+
+		if header.Typeflag == tar.TypeSymlink || header.Typeflag == tar.TypeLink {
+			return fmt.Errorf("rejected symlink/hardlink entry: %s", header.Name)
+		}
+
+		target := filepath.Join(destDir, filepath.Clean(header.Name))
+		if !strings.HasPrefix(target, filepath.Clean(destDir)+string(os.PathSeparator)) {
+			return fmt.Errorf("path traversal rejected: %s", header.Name)
+		}
+
+		switch header.Typeflag {
+		case tar.TypeDir:
+			mode := os.FileMode(header.Mode) & os.ModePerm
+			if mode > 0777 {
+				mode = 0755
+			}
+			if err := os.MkdirAll(target, mode); err != nil {
+				return fmt.Errorf("cannot create dir %s: %w", target, err)
+			}
+		case tar.TypeReg:
+			if header.Size > maxFileSize {
+				return fmt.Errorf("file %s exceeds max size %d", header.Name, maxFileSize)
+			}
+			if totalExtracted+header.Size > maxTotalBytes {
+				return fmt.Errorf("total extracted size would exceed limit %d", maxTotalBytes)
+			}
+			if fileCount >= maxFileCount {
+				return fmt.Errorf("extracted file count exceeds limit %d", maxFileCount)
+			}
+			fileCount++
+
+			if err := os.MkdirAll(filepath.Dir(target), 0755); err != nil {
+				return fmt.Errorf("cannot create parent dir for %s: %w", target, err)
+			}
+			// Restrict created file permissions; ignore header mode bits
+			// that grant group/world write.
+			mode := os.FileMode(header.Mode) & 0666
+			fw, err := os.OpenFile(target, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, mode)
+			if err != nil {
+				return fmt.Errorf("cannot create file %s: %w", target, err)
+			}
+			written, err := io.Copy(fw, io.LimitReader(tr, header.Size))
+			fw.Close()
+			if err != nil {
+				return fmt.Errorf("cannot write file %s: %w", target, err)
+			}
+			if written != header.Size {
+				return fmt.Errorf("short write for %s: wrote %d, expected %d", target, written, header.Size)
+			}
+			totalExtracted += written
+		}
+	}
+
+	return nil
+}
+
+// validateOCIDigest checks that a digest string has the form "sha256:<hex>".
+func validateOCIDigest(digest string) error {
+	if !strings.HasPrefix(digest, "sha256:") {
+		return fmt.Errorf("unsupported digest algorithm: %s", digest)
+	}
+	hexPart := strings.TrimPrefix(digest, "sha256:")
+	if len(hexPart) != 64 {
+		return fmt.Errorf("invalid digest length: %s", digest)
+	}
+	for _, c := range hexPart {
+		if !((c >= '0' && c <= '9') || (c >= 'a' && c <= 'f') || (c >= 'A' && c <= 'F')) {
+			return fmt.Errorf("invalid hex character in digest: %s", digest)
+		}
+	}
+	return nil
+}
+
+// resolveCredentials retrieves OCI registry credentials either from a stored
+// Credential (by ID) or from inline username/password. If credentialId is set
+// it takes precedence over inline values.
+func resolveCredentials(r *http.Request, credentialID *string, inlineUsername, inlinePassword string, provider models.Provider) (username, password string, err error) {
+	if credentialID != nil && *credentialID != "" {
+		token, ok := r.Context().Value(models.TokenCtxKey).(string)
+		if !ok {
+			return "", "", fmt.Errorf("failed to retrieve auth token from context")
+		}
+		cid := uuid.FromStringOrNil(*credentialID)
+		if cid.IsNil() {
+			return "", "", fmt.Errorf("invalid credentialId: %s", *credentialID)
+		}
+		cred, _, cerr := provider.GetCredentialByID(token, cid)
+		if cerr != nil {
+			return "", "", fmt.Errorf("failed to retrieve credential: %w", cerr)
+		}
+		if cred == nil {
+			return "", "", fmt.Errorf("credential not found")
+		}
+		u, _ := cred.Secret["username"].(string)
+		p, _ := cred.Secret["password"].(string)
+		if u == "" {
+			return "", "", fmt.Errorf("credential %q has no username", *credentialID)
+		}
+		return u, p, nil
+	}
+	return inlineUsername, inlinePassword, nil
+}
+
+// validateOCIRegistryDestination validates the registry address and repository
+// for OCI operations. It rejects private/loopback/link-local destinations to
+// prevent SSRF attacks.
+func validateOCIRegistryDestination(registry, repository string) error {
+	if registry == "" {
+		return fmt.Errorf("registry is required")
+	}
+	if repository == "" {
+		return fmt.Errorf("repository is required")
+	}
+
+	// Strip optional scheme for parsing; only https/http are potentially
+	// acceptable, but we strip them to focus on the host.
+	raw := registry
+	if strings.Contains(raw, "://") {
+		u, perr := url.Parse(raw)
+		if perr != nil {
+			return fmt.Errorf("invalid registry URL: %w", perr)
+		}
+		if u.Scheme != "" && u.Scheme != "https" && u.Scheme != "http" {
+			return fmt.Errorf("unsupported registry scheme: %s", u.Scheme)
+		}
+		raw = u.Host
+	}
+
+	// Extract host (and optional port)
+	host := raw
+	if h, _, err := net.SplitHostPort(raw); err == nil {
+		host = h
+	}
+
+	if host == "" {
+		return fmt.Errorf("registry host is empty")
+	}
+
+	// Reject path separators in registry (must be pure host:port)
+	if strings.ContainsAny(registry, "/\\") {
+		return fmt.Errorf("registry must be a host:port, not a path")
+	}
+
+	// Reject repository path traversal
+	if strings.Contains(repository, "..") {
+		return fmt.Errorf("repository must not contain path traversal")
+	}
+
+	// Reject known-bad host patterns including unspecified addresses.
+	lower := strings.ToLower(host)
+	if lower == "localhost" || lower == "127.0.0.1" || lower == "::1" {
+		return fmt.Errorf("registry must not be a loopback address")
+	}
+	if lower == "0.0.0.0" || lower == "::" {
+		return fmt.Errorf("registry must not be an unspecified address")
+	}
+
+	// Resolve hostname and check IP ranges.
+	// NOTE: DNS-rebinding TOCTOU — the resolution below happens at
+	// SSRF-check time, not at connection time. The meshkit OCI transport
+	// (PushToOCIRegistry / PullFromOCIRegistry) does not expose a dial
+	// control function, so the resolved addresses cannot be re-checked
+	// on the actual TCP connection. This is an upstream limitation of
+	// github.com/meshery/meshkit v1.0.19. The correct fix would require
+	// meshkit to accept a net.Dialer or dial-context function.
+	ips, err := net.LookupHost(host)
+	if err != nil {
+		return fmt.Errorf("registry host %q could not be resolved: %w", host, err)
+	}
+	for _, ipStr := range ips {
+		ip := net.ParseIP(ipStr)
+		if ip == nil {
+			continue
+		}
+		if ip.IsLoopback() {
+			return fmt.Errorf("registry resolved to loopback address: %s", ipStr)
+		}
+		if ip.IsUnspecified() {
+			return fmt.Errorf("registry resolved to unspecified address: %s", ipStr)
+		}
+		if ip.IsPrivate() {
+			return fmt.Errorf("registry resolved to private address: %s", ipStr)
+		}
+		if ip.IsLinkLocalUnicast() || ip.IsLinkLocalMulticast() {
+			return fmt.Errorf("registry resolved to link-local address: %s", ipStr)
+		}
+	}
+
+	return nil
 }
 
 func RegisterEntity(content []byte, entityType entity.EntityType, h *Handler) error {

--- a/server/handlers/component_handler_test.go
+++ b/server/handlers/component_handler_test.go
@@ -1,0 +1,600 @@
+package handlers
+
+import (
+	"archive/tar"
+	"bytes"
+	"compress/gzip"
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/gofrs/uuid"
+	"github.com/meshery/meshery/server/models"
+	"github.com/meshery/schemas/models/core"
+)
+
+// ---- spy provider for credential resolution tests ----
+
+type ociCredentialSpyProvider struct {
+	*models.DefaultLocalProvider
+	getCredentialFn func(token string, credentialID core.Uuid) (*models.Credential, int, error)
+}
+
+func (m *ociCredentialSpyProvider) GetCredentialByID(token string, credentialID core.Uuid) (*models.Credential, int, error) {
+	if m.getCredentialFn != nil {
+		return m.getCredentialFn(token, credentialID)
+	}
+	return m.DefaultLocalProvider.GetCredentialByID(token, credentialID)
+}
+
+// ---- helpers ----
+
+func withTokenCtx(t *testing.T) context.Context {
+	t.Helper()
+	return context.WithValue(context.Background(), models.TokenCtxKey, "test-token")
+}
+
+func jsonBody(t *testing.T, v interface{}) *bytes.Buffer {
+	t.Helper()
+	var b bytes.Buffer
+	if err := json.NewEncoder(&b).Encode(v); err != nil {
+		t.Fatal(err)
+	}
+	return &b
+}
+
+// writeOCIStore creates a minimal OCI layout at dir containing the given
+// layer files, tagged with tag.
+func writeOCIStore(t *testing.T, dir, tag string, layerFiles map[string]string) {
+	t.Helper()
+
+	var buf bytes.Buffer
+	gz := gzip.NewWriter(&buf)
+	tw := tar.NewWriter(gz)
+	for name, content := range layerFiles {
+		if err := tw.WriteHeader(&tar.Header{Name: name, Size: int64(len(content)), Mode: 0644, Typeflag: tar.TypeReg}); err != nil {
+			t.Fatal(err)
+		}
+		if _, err := io.WriteString(tw, content); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if err := tw.Close(); err != nil {
+		t.Fatal(err)
+	}
+	if err := gz.Close(); err != nil {
+		t.Fatal(err)
+	}
+	layerData := buf.Bytes()
+	h := sha256.Sum256(layerData)
+	layerDigest := fmt.Sprintf("sha256:%s", hex.EncodeToString(h[:]))
+
+	// manifest
+	m := struct {
+		Layers []struct {
+			Digest string `json:"digest"`
+		} `json:"layers"`
+	}{Layers: []struct {
+		Digest string `json:"digest"`
+	}{{Digest: layerDigest}}}
+	md, err := json.Marshal(m)
+	if err != nil {
+		t.Fatal(err)
+	}
+	hm := sha256.Sum256(md)
+	manifestDigest := fmt.Sprintf("sha256:%s", hex.EncodeToString(hm[:]))
+
+	// write blobs
+	blobDir := filepath.Join(dir, "blobs", "sha256")
+	if err := os.MkdirAll(blobDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(blobDir, strings.TrimPrefix(layerDigest, "sha256:")), layerData, 0644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(blobDir, strings.TrimPrefix(manifestDigest, "sha256:")), md, 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	// index.json
+	idx := struct {
+		Manifests []struct {
+			Digest      string            `json:"digest"`
+			Annotations map[string]string `json:"annotations,omitempty"`
+		} `json:"manifests"`
+	}{
+		Manifests: []struct {
+			Digest      string            `json:"digest"`
+			Annotations map[string]string `json:"annotations,omitempty"`
+		}{{Digest: manifestDigest, Annotations: map[string]string{"org.opencontainers.image.ref.name": tag}}},
+	}
+	idxData, _ := json.Marshal(idx)
+	if err := os.WriteFile(filepath.Join(dir, "index.json"), idxData, 0644); err != nil {
+		t.Fatal(err)
+	}
+}
+
+// ---- validateOCIDigest ----
+
+func TestValidateOCIDigest(t *testing.T) {
+	cases := []struct {
+		name, digest, want string
+	}{
+		{"empty", "", "unsupported digest algorithm"},
+		{"no prefix", "abc", "unsupported digest algorithm"},
+		{"wrong prefix", "sha1:abc", "unsupported digest algorithm"},
+		{"wrong length", "sha256:abc", "invalid digest length"},
+		{"non-hex", fmt.Sprintf("sha256:%s", strings.Repeat("z", 64)), "invalid hex character"},
+		{"valid", fmt.Sprintf("sha256:%s", strings.Repeat("a", 64)), ""},
+		{"valid mixed", fmt.Sprintf("sha256:%s", "a"+strings.Repeat("b", 63)), ""},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			err := validateOCIDigest(c.digest)
+			if c.want == "" {
+				if err != nil {
+					t.Fatalf("unexpected error: %v", err)
+				}
+				return
+			}
+			if err == nil {
+				t.Fatal("expected error")
+			}
+			if !strings.Contains(err.Error(), c.want) {
+				t.Errorf("expected %q in %v", c.want, err)
+			}
+		})
+	}
+}
+
+// ---- validateOCIRegistryDestination ----
+
+func TestValidateOCIRegistryDestination_RejectsEmpty(t *testing.T) {
+	if err := validateOCIRegistryDestination("", "repo"); err == nil || !strings.Contains(err.Error(), "registry is required") {
+		t.Fatal("expected registry required error")
+	}
+	if err := validateOCIRegistryDestination("reg.example.com", ""); err == nil || !strings.Contains(err.Error(), "repository is required") {
+		t.Fatal("expected repository required error")
+	}
+}
+
+func TestValidateOCIRegistryDestination_RejectsLocal(t *testing.T) {
+	for _, h := range []string{"localhost", "127.0.0.1", "::1"} {
+		t.Run(h, func(t *testing.T) {
+			err := validateOCIRegistryDestination(h, "repo")
+			if err == nil || !strings.Contains(err.Error(), "loopback") {
+				t.Fatalf("expected loopback error, got %v", err)
+			}
+		})
+	}
+}
+
+func TestValidateOCIRegistryDestination_RejectsPath(t *testing.T) {
+	err := validateOCIRegistryDestination("reg.example.com/path", "repo")
+	if err == nil || !strings.Contains(err.Error(), "path") {
+		t.Fatal("expected path error, got:", err)
+	}
+}
+
+func TestValidateOCIRegistryDestination_RejectsTraversal(t *testing.T) {
+	err := validateOCIRegistryDestination("reg.example.com", "../evil")
+	if err == nil || !strings.Contains(err.Error(), "path traversal") {
+		t.Fatal("expected path traversal error, got:", err)
+	}
+}
+
+func TestValidateOCIRegistryDestination_RejectsBadScheme(t *testing.T) {
+	err := validateOCIRegistryDestination("ftp://reg.example.com", "repo")
+	if err == nil || !strings.Contains(err.Error(), "unsupported registry scheme") {
+		t.Fatal("expected scheme error, got:", err)
+	}
+}
+
+func TestValidateOCIRegistryDestination_RejectsUnspecified(t *testing.T) {
+	for _, h := range []string{"0.0.0.0", "::"} {
+		t.Run(h, func(t *testing.T) {
+			err := validateOCIRegistryDestination(h, "repo")
+			if err == nil || !strings.Contains(err.Error(), "unspecified") {
+				t.Fatalf("expected unspecified address error, got %v", err)
+			}
+		})
+	}
+}
+
+func TestValidateOCIRegistryDestination_RejectsUnspecifiedWithPort(t *testing.T) {
+	err := validateOCIRegistryDestination("0.0.0.0:5000", "repo")
+	if err == nil || !strings.Contains(err.Error(), "unspecified") {
+		t.Fatal("expected unspecified address error, got:", err)
+	}
+}
+
+// ---- resolveCredentials ----
+
+func TestResolveCredentials_Inline(t *testing.T) {
+	p := &ociCredentialSpyProvider{DefaultLocalProvider: &models.DefaultLocalProvider{}}
+	p.Initialize()
+
+	u, pw, err := resolveCredentials(
+		httptest.NewRequest(http.MethodPost, "/", nil).WithContext(withTokenCtx(t)),
+		nil, "alice", "secret", p,
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if u != "alice" {
+		t.Errorf("got username %q, want alice", u)
+	}
+	if pw != "secret" {
+		t.Errorf("got password %q, want secret", pw)
+	}
+}
+
+func TestResolveCredentials_EmptyIDFallsBack(t *testing.T) {
+	p := &ociCredentialSpyProvider{DefaultLocalProvider: &models.DefaultLocalProvider{}}
+	p.Initialize()
+
+	cid := ""
+	u, pw, err := resolveCredentials(
+		httptest.NewRequest(http.MethodPost, "/", nil).WithContext(withTokenCtx(t)),
+		&cid, "bob", "pass", p,
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if u != "bob" || pw != "pass" {
+		t.Fatalf("got %q/%q, want bob/pass", u, pw)
+	}
+}
+
+func TestResolveCredentials_InvalidUUID(t *testing.T) {
+	p := &ociCredentialSpyProvider{DefaultLocalProvider: &models.DefaultLocalProvider{}}
+	p.Initialize()
+
+	cid := "not-a-uuid"
+	_, _, err := resolveCredentials(
+		httptest.NewRequest(http.MethodPost, "/", nil).WithContext(withTokenCtx(t)),
+		&cid, "", "", p,
+	)
+	if err == nil || !strings.Contains(err.Error(), "invalid credentialId") {
+		t.Fatalf("expected invalid credentialId error, got %v", err)
+	}
+}
+
+func TestResolveCredentials_LookupByID(t *testing.T) {
+	p := &ociCredentialSpyProvider{
+		DefaultLocalProvider: &models.DefaultLocalProvider{},
+		getCredentialFn: func(_ string, _ core.Uuid) (*models.Credential, int, error) {
+			return &models.Credential{
+				Secret: map[string]interface{}{"username": "su", "password": "sp"},
+			}, 200, nil
+		},
+	}
+	p.Initialize()
+
+	cid := uuid.Must(uuid.NewV4()).String()
+	u, pw, err := resolveCredentials(
+		httptest.NewRequest(http.MethodPost, "/", nil).WithContext(withTokenCtx(t)),
+		&cid, "", "", p,
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if u != "su" {
+		t.Errorf("got username %q, want su", u)
+	}
+	if pw != "sp" {
+		t.Errorf("got password %q, want sp", pw)
+	}
+}
+
+func TestResolveCredentials_ProviderError(t *testing.T) {
+	p := &ociCredentialSpyProvider{
+		DefaultLocalProvider: &models.DefaultLocalProvider{},
+		getCredentialFn: func(_ string, _ core.Uuid) (*models.Credential, int, error) {
+			return nil, 500, fmt.Errorf("provider err")
+		},
+	}
+	p.Initialize()
+
+	cid := uuid.Must(uuid.NewV4()).String()
+	_, _, err := resolveCredentials(
+		httptest.NewRequest(http.MethodPost, "/", nil).WithContext(withTokenCtx(t)),
+		&cid, "", "", p,
+	)
+	if err == nil || !strings.Contains(err.Error(), "failed to retrieve credential") {
+		t.Fatalf("expected credential retrieval error, got %v", err)
+	}
+}
+
+func TestResolveCredentials_NilCredential(t *testing.T) {
+	p := &ociCredentialSpyProvider{
+		DefaultLocalProvider: &models.DefaultLocalProvider{},
+		getCredentialFn: func(_ string, _ core.Uuid) (*models.Credential, int, error) {
+			return nil, 200, nil
+		},
+	}
+	p.Initialize()
+
+	cid := uuid.Must(uuid.NewV4()).String()
+	_, _, err := resolveCredentials(
+		httptest.NewRequest(http.MethodPost, "/", nil).WithContext(withTokenCtx(t)),
+		&cid, "", "", p,
+	)
+	if err == nil || !strings.Contains(err.Error(), "credential not found") {
+		t.Fatalf("expected credential not found error, got %v", err)
+	}
+}
+
+func TestResolveCredentials_MissingUsernameInStore(t *testing.T) {
+	p := &ociCredentialSpyProvider{
+		DefaultLocalProvider: &models.DefaultLocalProvider{},
+		getCredentialFn: func(_ string, _ core.Uuid) (*models.Credential, int, error) {
+			return &models.Credential{
+				Secret: map[string]interface{}{"password": "sp"},
+			}, 200, nil
+		},
+	}
+	p.Initialize()
+
+	cid := uuid.Must(uuid.NewV4()).String()
+	_, _, err := resolveCredentials(
+		httptest.NewRequest(http.MethodPost, "/", nil).WithContext(withTokenCtx(t)),
+		&cid, "", "", p,
+	)
+	if err == nil || !strings.Contains(err.Error(), "no username") {
+		t.Fatalf("expected missing username error, got %v", err)
+	}
+}
+
+func TestResolveCredentials_MissingToken(t *testing.T) {
+	p := &ociCredentialSpyProvider{DefaultLocalProvider: &models.DefaultLocalProvider{}}
+	p.Initialize()
+
+	cid := uuid.Must(uuid.NewV4()).String()
+	_, _, err := resolveCredentials(
+		httptest.NewRequest(http.MethodPost, "/", nil),
+		&cid, "", "", p,
+	)
+	if err == nil || !strings.Contains(err.Error(), "auth token") {
+		t.Fatalf("expected auth token error, got %v", err)
+	}
+}
+
+// ---- extractFromOCIStore ----
+
+func TestExtractFromOCIStore_ValidArtifact(t *testing.T) {
+	src := t.TempDir()
+	dst := t.TempDir()
+	writeOCIStore(t, src, "latest", map[string]string{
+		"model.json":  `{"name":"test"}`,
+		"comp/c.json": `{}`,
+		"rel/r.json":  `{}`,
+	})
+
+	if err := extractFromOCIStore(src, "latest", dst); err != nil {
+		t.Fatal(err)
+	}
+	for _, path := range []string{"model.json", "comp/c.json", "rel/r.json"} {
+		if _, err := os.Stat(filepath.Join(dst, path)); err != nil {
+			t.Errorf("%s not extracted: %v", path, err)
+		}
+	}
+	data, _ := os.ReadFile(filepath.Join(dst, "model.json"))
+	if !bytes.Contains(data, []byte("test")) {
+		t.Error("model.json has wrong content")
+	}
+}
+
+func TestExtractFromOCIStore_PathTraversal(t *testing.T) {
+	src := t.TempDir()
+	dst := t.TempDir()
+	writeOCIStore(t, src, "latest", map[string]string{"../../../etc/passwd": "x"})
+
+	err := extractFromOCIStore(src, "latest", dst)
+	if err == nil || !strings.Contains(err.Error(), "path traversal") {
+		t.Fatal("expected path traversal error, got:", err)
+	}
+}
+
+func TestExtractFromOCIStore_Symlink(t *testing.T) {
+	src := t.TempDir()
+	dst := t.TempDir()
+
+	var buf bytes.Buffer
+	gz := gzip.NewWriter(&buf)
+	tw := tar.NewWriter(gz)
+	if err := tw.WriteHeader(&tar.Header{Name: "link", Typeflag: tar.TypeSymlink, Linkname: "/etc/passwd"}); err != nil {
+		t.Fatal(err)
+	}
+	tw.Close()
+	gz.Close()
+
+	h := sha256.Sum256(buf.Bytes())
+	ld := fmt.Sprintf("sha256:%s", hex.EncodeToString(h[:]))
+	layerData := buf.Bytes()
+	md, mDigest := func() ([]byte, string) {
+		m := struct {
+			Layers []struct {
+				Digest string `json:"digest"`
+			} `json:"layers"`
+		}{Layers: []struct {
+			Digest string `json:"digest"`
+		}{{Digest: ld}}}
+		d, _ := json.Marshal(m)
+		hm := sha256.Sum256(d)
+		return d, fmt.Sprintf("sha256:%s", hex.EncodeToString(hm[:]))
+	}()
+
+	os.MkdirAll(filepath.Join(src, "blobs", "sha256"), 0755)
+	os.WriteFile(filepath.Join(src, "blobs", "sha256", strings.TrimPrefix(ld, "sha256:")), layerData, 0644)
+	os.WriteFile(filepath.Join(src, "blobs", "sha256", strings.TrimPrefix(mDigest, "sha256:")), md, 0644)
+	idx, _ := json.Marshal(struct {
+		Manifests []struct {
+			Digest      string            `json:"digest"`
+			Annotations map[string]string `json:"annotations,omitempty"`
+		} `json:"manifests"`
+	}{
+		Manifests: []struct {
+			Digest      string            `json:"digest"`
+			Annotations map[string]string `json:"annotations,omitempty"`
+		}{{Digest: mDigest, Annotations: map[string]string{"org.opencontainers.image.ref.name": "latest"}}},
+	})
+	os.WriteFile(filepath.Join(src, "index.json"), idx, 0644)
+
+	err := extractFromOCIStore(src, "latest", dst)
+	if err == nil || !strings.Contains(err.Error(), "symlink") {
+		t.Fatal("expected symlink error, got:", err)
+	}
+}
+
+func TestExtractFromOCIStore_InvalidLayerDigest(t *testing.T) {
+	src := t.TempDir()
+	dst := t.TempDir()
+
+	md, mDigest := func() ([]byte, string) {
+		m := struct {
+			Layers []struct {
+				Digest string `json:"digest"`
+			} `json:"layers"`
+		}{Layers: []struct {
+			Digest string `json:"digest"`
+		}{{Digest: "sha256:bad"}}}
+		d, _ := json.Marshal(m)
+		hm := sha256.Sum256(d)
+		return d, fmt.Sprintf("sha256:%s", hex.EncodeToString(hm[:]))
+	}()
+
+	os.MkdirAll(filepath.Join(src, "blobs", "sha256"), 0755)
+	os.WriteFile(filepath.Join(src, "blobs", "sha256", strings.TrimPrefix(mDigest, "sha256:")), md, 0644)
+	idx, _ := json.Marshal(struct {
+		Manifests []struct {
+			Digest string `json:"digest"`
+		} `json:"manifests"`
+	}{Manifests: []struct {
+		Digest string `json:"digest"`
+	}{{Digest: mDigest}}})
+	os.WriteFile(filepath.Join(src, "index.json"), idx, 0644)
+
+	err := extractFromOCIStore(src, "latest", dst)
+	if err == nil || !strings.Contains(err.Error(), "invalid layer digest") {
+		t.Fatal("expected invalid layer digest error, got:", err)
+	}
+}
+
+func TestExtractFromOCIStore_NoManifests(t *testing.T) {
+	src := t.TempDir()
+	dst := t.TempDir()
+	os.WriteFile(filepath.Join(src, "index.json"), []byte(`{"manifests":[]}`), 0644)
+
+	err := extractFromOCIStore(src, "latest", dst)
+	if err == nil || !strings.Contains(err.Error(), "no manifests") {
+		t.Fatal("expected no manifests error, got:", err)
+	}
+}
+
+func TestExtractFromOCIStore_MissingIndex(t *testing.T) {
+	src := t.TempDir()
+	dst := t.TempDir()
+
+	err := extractFromOCIStore(src, "latest", dst)
+	if err == nil || !strings.Contains(err.Error(), "index.json") {
+		t.Fatal("expected index.json error, got:", err)
+	}
+}
+
+// ---- PushModel handler-level tests ----
+//
+// These tests exercise early-exit validation paths that do not require
+// registryManager or live OCI network calls.
+
+func TestPushModel_InvalidJSON(t *testing.T) {
+	h := newTestHandler(t, nil, "")
+	prov := &ociCredentialSpyProvider{DefaultLocalProvider: &models.DefaultLocalProvider{}}
+	prov.Initialize()
+
+	req := httptest.NewRequest(http.MethodPost, "/", strings.NewReader("not json")).WithContext(withTokenCtx(t))
+	rec := httptest.NewRecorder()
+
+	h.PushModel(rec, req, nil, nil, prov)
+
+	resp := rec.Result()
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusBadRequest {
+		t.Errorf("expected 400, got %d", resp.StatusCode)
+	}
+}
+
+func TestPushModel_MissingModelId(t *testing.T) {
+	h := newTestHandler(t, nil, "")
+	prov := &ociCredentialSpyProvider{DefaultLocalProvider: &models.DefaultLocalProvider{}}
+	prov.Initialize()
+
+	body := jsonBody(t, map[string]string{
+		"registry":   "reg.example.com",
+		"repository": "my-org/my-model",
+	})
+	req := httptest.NewRequest(http.MethodPost, "/", body).WithContext(withTokenCtx(t))
+	rec := httptest.NewRecorder()
+
+	h.PushModel(rec, req, nil, nil, prov)
+
+	resp := rec.Result()
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusBadRequest {
+		t.Errorf("expected 400, got %d", resp.StatusCode)
+	}
+}
+
+func TestPullModel_InvalidJSON(t *testing.T) {
+	h := newTestHandler(t, nil, "")
+	prov := &ociCredentialSpyProvider{DefaultLocalProvider: &models.DefaultLocalProvider{}}
+	prov.Initialize()
+
+	req := httptest.NewRequest(http.MethodPost, "/", strings.NewReader("not json")).WithContext(withTokenCtx(t))
+	rec := httptest.NewRecorder()
+
+	h.PullModel(rec, req, nil, nil, prov)
+
+	resp := rec.Result()
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusBadRequest {
+		t.Errorf("expected 400, got %d", resp.StatusCode)
+	}
+}
+
+// ---- extractFromOCIStore ----
+
+func TestExtractFromOCIStore_NoLayers(t *testing.T) {
+	src := t.TempDir()
+	dst := t.TempDir()
+
+	// Manifest with an empty layers array — exercises len(manifest.Layers) == 0.
+	md := []byte(`{"layers":[]}`)
+	hm := sha256.Sum256(md)
+	mDigest := fmt.Sprintf("sha256:%s", hex.EncodeToString(hm[:]))
+
+	os.MkdirAll(filepath.Join(src, "blobs", "sha256"), 0755)
+	os.WriteFile(filepath.Join(src, "blobs", "sha256", strings.TrimPrefix(mDigest, "sha256:")), md, 0644)
+	idx, _ := json.Marshal(struct {
+		Manifests []struct {
+			Digest string `json:"digest"`
+		} `json:"manifests"`
+	}{Manifests: []struct {
+		Digest string `json:"digest"`
+	}{{Digest: mDigest}}})
+	os.WriteFile(filepath.Join(src, "index.json"), idx, 0644)
+
+	err := extractFromOCIStore(src, "latest", dst)
+	if err == nil || !strings.Contains(err.Error(), "no layers") {
+		t.Fatal("expected no layers error, got:", err)
+	}
+}

--- a/server/handlers/component_handler_test.go
+++ b/server/handlers/component_handler_test.go
@@ -415,8 +415,12 @@ func TestExtractFromOCIStore_Symlink(t *testing.T) {
 	if err := tw.WriteHeader(&tar.Header{Name: "link", Typeflag: tar.TypeSymlink, Linkname: "/etc/passwd"}); err != nil {
 		t.Fatal(err)
 	}
-	tw.Close()
-	gz.Close()
+	if err := tw.Close(); err != nil {
+		t.Fatal(err)
+	}
+	if err := gz.Close(); err != nil {
+		t.Fatal(err)
+	}
 
 	h := sha256.Sum256(buf.Bytes())
 	ld := fmt.Sprintf("sha256:%s", hex.EncodeToString(h[:]))
@@ -434,10 +438,16 @@ func TestExtractFromOCIStore_Symlink(t *testing.T) {
 		return d, fmt.Sprintf("sha256:%s", hex.EncodeToString(hm[:]))
 	}()
 
-	os.MkdirAll(filepath.Join(src, "blobs", "sha256"), 0755)
-	os.WriteFile(filepath.Join(src, "blobs", "sha256", strings.TrimPrefix(ld, "sha256:")), layerData, 0644)
-	os.WriteFile(filepath.Join(src, "blobs", "sha256", strings.TrimPrefix(mDigest, "sha256:")), md, 0644)
-	idx, _ := json.Marshal(struct {
+	if err := os.MkdirAll(filepath.Join(src, "blobs", "sha256"), 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(src, "blobs", "sha256", strings.TrimPrefix(ld, "sha256:")), layerData, 0644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(src, "blobs", "sha256", strings.TrimPrefix(mDigest, "sha256:")), md, 0644); err != nil {
+		t.Fatal(err)
+	}
+	idx, err := json.Marshal(struct {
 		Manifests []struct {
 			Digest      string            `json:"digest"`
 			Annotations map[string]string `json:"annotations,omitempty"`
@@ -448,7 +458,12 @@ func TestExtractFromOCIStore_Symlink(t *testing.T) {
 			Annotations map[string]string `json:"annotations,omitempty"`
 		}{{Digest: mDigest, Annotations: map[string]string{"org.opencontainers.image.ref.name": "latest"}}},
 	})
-	os.WriteFile(filepath.Join(src, "index.json"), idx, 0644)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(src, "index.json"), idx, 0644); err != nil {
+		t.Fatal(err)
+	}
 
 	err := extractFromOCIStore(src, "latest", dst)
 	if err == nil || !strings.Contains(err.Error(), "symlink") {
@@ -473,16 +488,25 @@ func TestExtractFromOCIStore_InvalidLayerDigest(t *testing.T) {
 		return d, fmt.Sprintf("sha256:%s", hex.EncodeToString(hm[:]))
 	}()
 
-	os.MkdirAll(filepath.Join(src, "blobs", "sha256"), 0755)
-	os.WriteFile(filepath.Join(src, "blobs", "sha256", strings.TrimPrefix(mDigest, "sha256:")), md, 0644)
-	idx, _ := json.Marshal(struct {
+	if err := os.MkdirAll(filepath.Join(src, "blobs", "sha256"), 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(src, "blobs", "sha256", strings.TrimPrefix(mDigest, "sha256:")), md, 0644); err != nil {
+		t.Fatal(err)
+	}
+	idx, err := json.Marshal(struct {
 		Manifests []struct {
 			Digest string `json:"digest"`
 		} `json:"manifests"`
 	}{Manifests: []struct {
 		Digest string `json:"digest"`
 	}{{Digest: mDigest}}})
-	os.WriteFile(filepath.Join(src, "index.json"), idx, 0644)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(src, "index.json"), idx, 0644); err != nil {
+		t.Fatal(err)
+	}
 
 	err := extractFromOCIStore(src, "latest", dst)
 	if err == nil || !strings.Contains(err.Error(), "invalid layer digest") {

--- a/server/handlers/component_handler_test.go
+++ b/server/handlers/component_handler_test.go
@@ -217,6 +217,41 @@ func TestValidateOCIRegistryDestination_RejectsUnspecifiedWithPort(t *testing.T)
 	}
 }
 
+func TestValidateOCIRegistryDestination_RejectsSchemeWithPath(t *testing.T) {
+	err := validateOCIRegistryDestination("https://reg.example.com/some/path", "repo")
+	if err == nil || !strings.Contains(err.Error(), "path, query, or fragment") {
+		t.Fatal("expected path rejection error, got:", err)
+	}
+}
+
+func TestValidateOCIRegistryDestination_RejectsSchemeWithQuery(t *testing.T) {
+	err := validateOCIRegistryDestination("https://reg.example.com?query=val", "repo")
+	if err == nil || !strings.Contains(err.Error(), "path, query, or fragment") {
+		t.Fatal("expected query rejection error, got:", err)
+	}
+}
+
+func TestValidateOCIRegistryDestination_RejectsSchemeWithFragment(t *testing.T) {
+	err := validateOCIRegistryDestination("https://reg.example.com#frag", "repo")
+	if err == nil || !strings.Contains(err.Error(), "path, query, or fragment") {
+		t.Fatal("expected fragment rejection error, got:", err)
+	}
+}
+
+func TestValidateOCIRegistryDestination_AcceptsSchemeHost(t *testing.T) {
+	err := validateOCIRegistryDestination("https://reg.example.com", "repo")
+	if err != nil {
+		t.Fatal("unexpected error:", err)
+	}
+}
+
+func TestValidateOCIRegistryDestination_AcceptsSchemeHostPort(t *testing.T) {
+	err := validateOCIRegistryDestination("http://reg.example.com:5000", "repo")
+	if err != nil {
+		t.Fatal("unexpected error:", err)
+	}
+}
+
 // ---- resolveCredentials ----
 
 func TestResolveCredentials_Inline(t *testing.T) {
@@ -603,7 +638,9 @@ func TestExtractFromOCIStore_InvalidLayerDigest(t *testing.T) {
 func TestExtractFromOCIStore_NoManifests(t *testing.T) {
 	src := t.TempDir()
 	dst := t.TempDir()
-	os.WriteFile(filepath.Join(src, "index.json"), []byte(`{"manifests":[]}`), 0644)
+	if err := os.WriteFile(filepath.Join(src, "index.json"), []byte(`{"manifests":[]}`), 0644); err != nil {
+		t.Fatal(err)
+	}
 
 	err := extractFromOCIStore(src, "latest", dst)
 	if err == nil || !strings.Contains(err.Error(), "no manifests") {
@@ -637,7 +674,7 @@ func TestPushModel_InvalidJSON(t *testing.T) {
 	h.PushModel(rec, req, nil, nil, prov)
 
 	resp := rec.Result()
-	defer resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }()
 	if resp.StatusCode != http.StatusBadRequest {
 		t.Errorf("expected 400, got %d", resp.StatusCode)
 	}
@@ -658,7 +695,7 @@ func TestPushModel_MissingModelId(t *testing.T) {
 	h.PushModel(rec, req, nil, nil, prov)
 
 	resp := rec.Result()
-	defer resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }()
 	if resp.StatusCode != http.StatusBadRequest {
 		t.Errorf("expected 400, got %d", resp.StatusCode)
 	}
@@ -675,7 +712,7 @@ func TestPullModel_InvalidJSON(t *testing.T) {
 	h.PullModel(rec, req, nil, nil, prov)
 
 	resp := rec.Result()
-	defer resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }()
 	if resp.StatusCode != http.StatusBadRequest {
 		t.Errorf("expected 400, got %d", resp.StatusCode)
 	}
@@ -692,8 +729,12 @@ func TestExtractFromOCIStore_NoLayers(t *testing.T) {
 	hm := sha256.Sum256(md)
 	mDigest := fmt.Sprintf("sha256:%s", hex.EncodeToString(hm[:]))
 
-	os.MkdirAll(filepath.Join(src, "blobs", "sha256"), 0755)
-	os.WriteFile(filepath.Join(src, "blobs", "sha256", strings.TrimPrefix(mDigest, "sha256:")), md, 0644)
+	if err := os.MkdirAll(filepath.Join(src, "blobs", "sha256"), 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(src, "blobs", "sha256", strings.TrimPrefix(mDigest, "sha256:")), md, 0644); err != nil {
+		t.Fatal(err)
+	}
 	idx, _ := json.Marshal(struct {
 		Manifests []struct {
 			Digest string `json:"digest"`
@@ -701,7 +742,9 @@ func TestExtractFromOCIStore_NoLayers(t *testing.T) {
 	}{Manifests: []struct {
 		Digest string `json:"digest"`
 	}{{Digest: mDigest}}})
-	os.WriteFile(filepath.Join(src, "index.json"), idx, 0644)
+	if err := os.WriteFile(filepath.Join(src, "index.json"), idx, 0644); err != nil {
+		t.Fatal(err)
+	}
 
 	err := extractFromOCIStore(src, "latest", dst)
 	if err == nil || !strings.Contains(err.Error(), "no layers") {

--- a/server/handlers/component_handler_test.go
+++ b/server/handlers/component_handler_test.go
@@ -405,6 +405,92 @@ func TestExtractFromOCIStore_PathTraversal(t *testing.T) {
 	}
 }
 
+func TestExtractFromOCIStore_AbsolutePath(t *testing.T) {
+	src := t.TempDir()
+	dst := t.TempDir()
+	writeOCIStore(t, src, "latest", map[string]string{"/etc/passwd": "x"})
+
+	err := extractFromOCIStore(src, "latest", dst)
+	if err == nil || !strings.Contains(err.Error(), "path traversal") {
+		t.Fatal("expected path traversal error for absolute path, got:", err)
+	}
+}
+
+func TestExtractFromOCIStore_RootDirEntry(t *testing.T) {
+	src := t.TempDir()
+	dst := t.TempDir()
+
+	// Build a layer with a root-directory header followed by regular files.
+	var buf bytes.Buffer
+	gz := gzip.NewWriter(&buf)
+	tw := tar.NewWriter(gz)
+	if err := tw.WriteHeader(&tar.Header{Name: ".", Typeflag: tar.TypeDir, Mode: 0755}); err != nil {
+		t.Fatal(err)
+	}
+	if err := tw.WriteHeader(&tar.Header{Name: "a.txt", Size: int64(len("ok")), Mode: 0644}); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := io.WriteString(tw, "ok"); err != nil {
+		t.Fatal(err)
+	}
+	if err := tw.Close(); err != nil {
+		t.Fatal(err)
+	}
+	if err := gz.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	h := sha256.Sum256(buf.Bytes())
+	ld := fmt.Sprintf("sha256:%s", hex.EncodeToString(h[:]))
+	layerData := buf.Bytes()
+	md, mDigest := func() ([]byte, string) {
+		m := struct {
+			Layers []struct {
+				Digest string `json:"digest"`
+			} `json:"layers"`
+		}{Layers: []struct {
+			Digest string `json:"digest"`
+		}{{Digest: ld}}}
+		d, _ := json.Marshal(m)
+		hm := sha256.Sum256(d)
+		return d, fmt.Sprintf("sha256:%s", hex.EncodeToString(hm[:]))
+	}()
+
+	if err := os.MkdirAll(filepath.Join(src, "blobs", "sha256"), 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(src, "blobs", "sha256", strings.TrimPrefix(ld, "sha256:")), layerData, 0644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(src, "blobs", "sha256", strings.TrimPrefix(mDigest, "sha256:")), md, 0644); err != nil {
+		t.Fatal(err)
+	}
+	idx, err := json.Marshal(struct {
+		Manifests []struct {
+			Digest      string            `json:"digest"`
+			Annotations map[string]string `json:"annotations,omitempty"`
+		} `json:"manifests"`
+	}{
+		Manifests: []struct {
+			Digest      string            `json:"digest"`
+			Annotations map[string]string `json:"annotations,omitempty"`
+		}{{Digest: mDigest, Annotations: map[string]string{"org.opencontainers.image.ref.name": "latest"}}},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(src, "index.json"), idx, 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := extractFromOCIStore(src, "latest", dst); err != nil {
+		t.Fatal("root dir entry should be accepted:", err)
+	}
+	if _, err := os.Stat(filepath.Join(dst, "a.txt")); err != nil {
+		t.Error("a.txt not extracted:", err)
+	}
+}
+
 func TestExtractFromOCIStore_Symlink(t *testing.T) {
 	src := t.TempDir()
 	dst := t.TempDir()
@@ -465,7 +551,7 @@ func TestExtractFromOCIStore_Symlink(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	err := extractFromOCIStore(src, "latest", dst)
+	err = extractFromOCIStore(src, "latest", dst)
 	if err == nil || !strings.Contains(err.Error(), "symlink") {
 		t.Fatal("expected symlink error, got:", err)
 	}
@@ -508,7 +594,7 @@ func TestExtractFromOCIStore_InvalidLayerDigest(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	err := extractFromOCIStore(src, "latest", dst)
+	err = extractFromOCIStore(src, "latest", dst)
 	if err == nil || !strings.Contains(err.Error(), "invalid layer digest") {
 		t.Fatal("expected invalid layer digest error, got:", err)
 	}

--- a/server/handlers/error.go
+++ b/server/handlers/error.go
@@ -214,6 +214,8 @@ const (
 	ErrTelemetryGrafanaDatasourceCode      = "meshery-server-1433"
 	ErrTelemetryGrafanaAuthCode            = "meshery-server-1434"
 	ErrTelemetryPrometheusAuthCode         = "meshery-server-1435"
+	ErrPushModelCode                       = "meshery-server-1436"
+	ErrPullModelCode                       = "meshery-server-1437"
 )
 
 var (
@@ -1085,4 +1087,14 @@ func ErrInitializeMachine(err error) error {
 // caller input.
 func ErrSendMachineEvent(err error) error {
 	return errors.New(ErrSendMachineEventCode, errors.Alert, []string{"Failed to advance connection state machine"}, []string{err.Error()}, []string{"The requested event is not valid from the connection's current state.", "A side-effect action attached to the transition (e.g. provisioning, discovery) returned an error."}, []string{"Inspect the connection's current status before retrying. If the failure originates from a side-effect action, address the underlying cause (e.g. cluster reachability, credential validity) and retry."})
+}
+
+// ErrPushModel wraps failures pushing a model to an OCI registry.
+func ErrPushModel(err error, stage string) error {
+	return errors.New(ErrPushModelCode, errors.Alert, []string{fmt.Sprintf("Failed to push model to OCI registry during %s", stage)}, []string{err.Error()}, []string{"OCI registry is unreachable or rejected credentials.", "Model directory could not be prepared.", "Network error during push."}, []string{"Verify the OCI registry URL and credentials are correct and the registry is reachable from the Meshery server."})
+}
+
+// ErrPullModel wraps failures pulling a model from an OCI registry.
+func ErrPullModel(err error, stage string) error {
+	return errors.New(ErrPullModelCode, errors.Alert, []string{fmt.Sprintf("Failed to pull model from OCI registry during %s", stage)}, []string{err.Error()}, []string{"OCI registry is unreachable or rejected credentials.", "Pulled artifact is malformed or missing expected content.", "Model directory could not be extracted or registered."}, []string{"Verify the OCI registry URL and credentials are correct and the registry is reachable from the Meshery server."})
 }

--- a/server/handlers/error.go
+++ b/server/handlers/error.go
@@ -214,8 +214,8 @@ const (
 	ErrTelemetryGrafanaDatasourceCode      = "meshery-server-1433"
 	ErrTelemetryGrafanaAuthCode            = "meshery-server-1434"
 	ErrTelemetryPrometheusAuthCode         = "meshery-server-1435"
-	ErrPushModelCode                       = "meshery-server-1436"
-	ErrPullModelCode                       = "meshery-server-1437"
+	ErrPushModelCode                       = "meshery-server-1438"
+	ErrPullModelCode                       = "meshery-server-1439"
 )
 
 var (

--- a/server/helpers/component_info.json
+++ b/server/helpers/component_info.json
@@ -1,5 +1,5 @@
 {
   "name": "meshery-server",
   "type": "component",
-  "next_error_code": 1437
+  "next_error_code": 1440
 }

--- a/server/models/handlers.go
+++ b/server/models/handlers.go
@@ -215,6 +215,8 @@ type HandlerInterface interface {
 	ProcessConnectionRegistration(w http.ResponseWriter, req *http.Request, prefObj *Preference, user *User, provider Provider)
 
 	ExportModel(w http.ResponseWriter, req *http.Request)
+	PushModel(w http.ResponseWriter, req *http.Request, prefObj *Preference, user *User, provider Provider)
+	PullModel(w http.ResponseWriter, req *http.Request, prefObj *Preference, user *User, provider Provider)
 
 	GetEnvironments(w http.ResponseWriter, req *http.Request, prefObj *Preference, user *User, provider Provider)
 	GetEnvironmentByIDHandler(w http.ResponseWriter, req *http.Request, prefObj *Preference, user *User, provider Provider)

--- a/server/router/server.go
+++ b/server/router/server.go
@@ -131,6 +131,8 @@ func NewRouter(_ context.Context, h models.HandlerInterface, port int, g http.Ha
 	gMux.Handle("/api/system/availableAdapters", http.HandlerFunc(h.AvailableAdaptersHandler)).
 		Methods("GET")
 	gMux.Handle("/api/meshmodels/export", h.ProviderMiddleware(h.AuthMiddleware(http.HandlerFunc(h.ExportModel), models.NoAuth))).Methods("GET")
+	gMux.Handle("/api/meshmodels/push", h.ProviderMiddleware(h.AuthMiddleware(h.SessionInjectorMiddleware(h.PushModel), models.ProviderAuth))).Methods("POST")
+	gMux.Handle("/api/meshmodels/pull", h.ProviderMiddleware(h.AuthMiddleware(h.SessionInjectorMiddleware(h.PullModel), models.ProviderAuth))).Methods("POST")
 
 	gMux.Handle("/api/system/events", h.ProviderMiddleware(h.AuthMiddleware(h.SessionInjectorMiddleware(h.ClientEventHandler), models.ProviderAuth))).
 		Methods("POST")


### PR DESCRIPTION
**Notes for Reviewers**

- This PR fixes #19093
- Implements server-side push/pull operations for distributing Meshery Models via OCI-compliant registries
- Depends on meshkit v1.0.19 (PushToOCIRegistry / PullFromOCIRegistry) (both functions verified present in pinned dependency)

**[Signed commits](https://github.com/meshery/meshery/blob/master/CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [ ] Yes, I signed my commits.

---

## Implementation Summary

This PR adds two authenticated POST endpoints for OCI model distribution:

### Endpoints
- `POST /api/meshmodels/push` - Packs and pushes a Meshery Model to an OCI-compliant registry
- `POST /api/meshmodels/pull` - Pulls and registers a Meshery Model from an OCI-compliant registry

### Architecture
- Uses existing `github.com/meshery/meshkit/models/oci` (meshkit v1.0.19) for ORAS-based push/pull transport
- Custom `extractFromOCIStore` function for streaming OCI layer decompression and extraction (meshkit's `UnCompressOCIArtifact` is incompatible with ORAS file store output)
- `validateOCIRegistryDestination` provides SSRF protection (rejects loopback/private/link-local/unspecified addresses via DNS resolution; DNS-rebinding TOCTOU documented as upstream meshkit limitation)
- `resolveCredentials` supports both stored credentials (via `provider.GetCredentialByID`) and inline username/password

### Security
- SSRF protection with hostname resolution and IP range checks
- Path traversal prevention in artifact extraction
- Symlink/hardlink rejection in tar streams
- OCI digest validation before reading blobs
- Resource limits: 500 MiB total decompressed, 100 MiB per file, 10,000 files
- Credential lifetime minimized (cleared from request struct after resolution)

### Error Handling
- Structured MeshKit error codes: ErrPushModelCode (meshery-server-1436), ErrPullModelCode (meshery-server-1437)
- Registration failure detection (empty PkgUnits)
- Safe type assertions for model components/relationships

### Files Changed
| File | Change |
|------|--------|
| server/handlers/component_handler.go | +550/-28 - PushModel, PullModel, extractFromOCIStore, validateOCIDigest, resolveCredentials, validateOCIRegistryDestination |
| server/handlers/error.go | +12 - ErrPushModelCode, ErrPullModelCode + constructors |
| server/models/handlers.go | +2 - PushModel/PullModel in HandlerInterface |
| server/router/server.go | +2 - Route registrations with ProviderAuth + SessionInjectorMiddleware |
| server/handlers/component_handler_test.go | +600 - 26 test functions |

### Test Coverage (26 tests, all passing)
- validateOCIDigest: 7 cases
- validateOCIRegistryDestination: 7 cases (empty, loopback, path, traversal, bad scheme, unspecified)
- resolveCredentials: 8 cases (inline, fallback, invalid UUID, lookup, provider error, nil, missing username, missing token)
- extractFromOCIStore: 7 cases (valid, path traversal, symlink, invalid digest, no manifests, missing index, no layers)
- Handler-level: 3 cases (PushModel invalid JSON, PushModel missing modelId, PullModel invalid JSON)