### PR TITLE
[Server] Fix ProviderTracker.Publish send on closed channel panic ,snapshot ordering

### DIFF
--- a/server/handlers/provider_handler.go
+++ b/server/handlers/provider_handler.go
@@ -104,7 +104,7 @@ func (h *Handler) ProvidersStreamHandler(w http.ResponseWriter, r *http.Request)
 	flusher.Flush()
 
 	ctx := r.Context()
-	events, unsubscribe := h.config.ProviderTracker.Subscribe(ctx)
+	events, unsubscribe := h.config.ProviderTracker.Subscribe()
 	defer unsubscribe()
 
 	// Refresh status on subscribe so a freshly-opened chooser shows live

--- a/server/models/provider_tracker.go
+++ b/server/models/provider_tracker.go
@@ -84,34 +84,36 @@ func (t *ProviderTracker) Snapshot() map[string]ProviderStatusEvent {
 }
 
 // Subscribe registers a new listener for status transitions. The returned
-// channel receives the current snapshot first (one event per provider)
-// followed by every future Publish. The returned unsubscribe must be called
-// when the listener is done; calling it twice is safe.
+// channel is pre-loaded with the current snapshot (one event per provider)
+// before it is registered for live updates, so the subscriber is guaranteed
+// to observe the snapshot ahead of any concurrent Publish. The subscription
+// lifetime is governed by the returned unsubscribe, which is safe to call
+// more than once.
 //
 // Sends to a subscriber that is not draining its channel are dropped
 // (logged at debug) rather than blocking the publisher. A slow SSE client
 // will simply miss intermediate updates and pick up state on its next
 // reconnection.
-func (t *ProviderTracker) Subscribe(ctx context.Context) (<-chan ProviderStatusEvent, func()) {
+func (t *ProviderTracker) Subscribe() (<-chan ProviderStatusEvent, func()) {
 	ch := make(chan ProviderStatusEvent, 32)
 
 	t.mu.Lock()
-	t.subs[ch] = struct{}{}
-	snapshot := make([]ProviderStatusEvent, 0, len(t.statuses))
+	// Seed the snapshot into the buffer *before* ch is registered in t.subs.
+	// Because no Publish can observe ch until it is registered, the snapshot
+	// always precedes live events in the channel's FIFO order — this is what
+	// delivers the "snapshot first, then updates" contract without a separate
+	// replay goroutine that could race Publish. Sends are non-blocking; the
+	// 32-slot buffer comfortably holds one event per registered provider, and
+	// any entry dropped on a (pathologically) full buffer is re-published by
+	// the VerifyAll the handler kicks off on connect.
 	for _, evt := range t.statuses {
-		snapshot = append(snapshot, evt)
-	}
-	t.mu.Unlock()
-
-	go func() {
-		for _, evt := range snapshot {
-			select {
-			case ch <- evt:
-			case <-ctx.Done():
-				return
-			}
+		select {
+		case ch <- evt:
+		default:
 		}
-	}()
+	}
+	t.subs[ch] = struct{}{}
+	t.mu.Unlock()
 
 	var once sync.Once
 	unsubscribe := func() {
@@ -128,19 +130,20 @@ func (t *ProviderTracker) Subscribe(ctx context.Context) (<-chan ProviderStatusE
 }
 
 // Publish records the new event in the status map and broadcasts it to every
-// subscriber. Sends are non-blocking; a subscriber whose channel is full is
-// skipped for this event so a single stalled SSE writer cannot stall the
-// tracker for everyone else.
+// subscriber.
+//
+// The tracker mutex is held across the entire fan-out. Because unsubscribe
+// closes a subscriber channel only while holding the same lock, no channel can
+// be closed mid-send, so Publish can never panic with "send on closed channel"
+// during a concurrent unsubscribe/client-disconnect. The sends are
+// non-blocking (a subscriber whose buffer is full is skipped for this event),
+// so holding the lock across the fan-out never blocks the tracker on a single
+// stalled SSE writer.
 func (t *ProviderTracker) Publish(evt ProviderStatusEvent) {
 	t.mu.Lock()
+	defer t.mu.Unlock()
 	t.statuses[evt.Key] = evt
-	subs := make([]chan ProviderStatusEvent, 0, len(t.subs))
 	for ch := range t.subs {
-		subs = append(subs, ch)
-	}
-	t.mu.Unlock()
-
-	for _, ch := range subs {
 		select {
 		case ch <- evt:
 		default:

--- a/server/models/provider_tracker_test.go
+++ b/server/models/provider_tracker_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"net/http"
 	"net/http/httptest"
+	"sync"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -110,9 +111,7 @@ func TestProviderTracker_SubscriberReceivesSnapshotAndUpdates(t *testing.T) {
 	providers := map[string]Provider{LocalProviderName: lp}
 	tracker := NewProviderTracker(providers, lp.Log)
 
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
-	events, unsubscribe := tracker.Subscribe(ctx)
+	events, unsubscribe := tracker.Subscribe()
 	defer unsubscribe()
 
 	// First event: snapshot replay for the local provider.
@@ -148,6 +147,79 @@ func TestProviderTracker_SubscriberReceivesSnapshotAndUpdates(t *testing.T) {
 		}
 	case <-time.After(2 * time.Second):
 		t.Fatal("did not receive published event within 2s")
+	}
+}
+
+// TestProviderTracker_ConcurrentPublishUnsubscribeNoPanic drives publishers
+// concurrently with subscribers that immediately unsubscribe (closing their
+// channels), which is the exact interleaving that previously panicked with
+// "send on closed channel" and crashed the server. Publish now holds the
+// tracker mutex across the whole fan-out (the same lock unsubscribe closes
+// under), so no channel can be closed mid-send. Run with -race.
+func TestProviderTracker_ConcurrentPublishUnsubscribeNoPanic(t *testing.T) {
+	tracker := NewProviderTracker(map[string]Provider{}, newTestLogger(t))
+
+	stop := make(chan struct{})
+	var wg sync.WaitGroup
+
+	// Publishers hammer Publish for the whole test.
+	for i := 0; i < 4; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for {
+				select {
+				case <-stop:
+					return
+				default:
+					tracker.Publish(ProviderStatusEvent{Key: "remote", Status: ProviderStatusOnline})
+				}
+			}
+		}()
+	}
+
+	// Subscribers churn: each subscribe is immediately torn down so the
+	// close(ch) in unsubscribe races the concurrent Publish fan-outs.
+	for i := 0; i < 500; i++ {
+		_, unsubscribe := tracker.Subscribe()
+		unsubscribe()
+	}
+
+	close(stop)
+	wg.Wait()
+}
+
+// TestProviderTracker_SnapshotPrecedesLiveUpdates asserts the documented
+// ordering contract: a subscriber always receives the current snapshot before
+// any live Publish, even when the live event is published before the
+// subscriber starts reading. The snapshot is seeded into the channel buffer
+// under the lock before the channel is registered, so FIFO ordering holds.
+func TestProviderTracker_SnapshotPrecedesLiveUpdates(t *testing.T) {
+	lp := newTestLocalProviderForTracker(t)
+	tracker := NewProviderTracker(map[string]Provider{LocalProviderName: lp}, lp.Log)
+
+	events, unsubscribe := tracker.Subscribe()
+	defer unsubscribe()
+
+	// Publish a live update immediately, before draining the snapshot.
+	tracker.Publish(ProviderStatusEvent{Key: "live", Status: ProviderStatusOffline})
+
+	select {
+	case first := <-events:
+		if first.Key != LocalProviderName {
+			t.Fatalf("first event Key = %q, want snapshot %q ahead of the live update", first.Key, LocalProviderName)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("did not receive snapshot event within 2s")
+	}
+
+	select {
+	case second := <-events:
+		if second.Key != "live" {
+			t.Fatalf("second event Key = %q, want live update %q", second.Key, "live")
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("did not receive live event within 2s")
 	}
 }
 

--- a/server/models/provider_tracker_test.go
+++ b/server/models/provider_tracker_test.go
@@ -160,6 +160,7 @@ func TestProviderTracker_ConcurrentPublishUnsubscribeNoPanic(t *testing.T) {
 	tracker := NewProviderTracker(map[string]Provider{}, newTestLogger(t))
 
 	stop := make(chan struct{})
+	start := make(chan struct{})
 	var wg sync.WaitGroup
 
 	// Publishers hammer Publish for the whole test.
@@ -167,6 +168,7 @@ func TestProviderTracker_ConcurrentPublishUnsubscribeNoPanic(t *testing.T) {
 		wg.Add(1)
 		go func() {
 			defer wg.Done()
+			<-start
 			for {
 				select {
 				case <-stop:
@@ -177,6 +179,8 @@ func TestProviderTracker_ConcurrentPublishUnsubscribeNoPanic(t *testing.T) {
 			}
 		}()
 	}
+
+	close(start)
 
 	// Subscribers churn: each subscribe is immediately torn down so the
 	// close(ch) in unsubscribe races the concurrent Publish fan-outs.


### PR DESCRIPTION


**Notes for Reviewers**

- This PR fixes #20470 

**[Signed commits](https://github.com/meshery/meshery/blob/master/CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [x] Yes, I signed my commits.

<!--
Thank you for contributing to Meshery! 

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. Sign your commits.
4. Include before and after screenshots/terminal output.

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.
-->
