### PR TITLE
[Docs] Link security self-assessment in SECURITY-INSIGHTS.yml

### DIFF
--- a/.github/SECURITY-INSIGHTS.yml
+++ b/.github/SECURITY-INSIGHTS.yml
@@ -90,7 +90,7 @@ repository:
           Meshery has performed a security self-assessment. The assessment
           document is linked below as evidence.
         evidence-url:
-          - https://docs.google.com/document/d/17BqoEibnFdgx1U97AwM4RRkEbwTin_T78_W_WzB-0Gg/edit?usp=sharing
+          - https://docs.google.com/document/d/17BqoEibnFdgx1U97AwM4RRkEbwTin_T78_W_WzB-0Gg
   documentation:
     contributing-guide: https://docs.meshery.io/project/contributing
     governance: https://github.com/meshery/meshery/blob/master/GOVERNANCE.md

--- a/.github/SECURITY-INSIGHTS.yml
+++ b/.github/SECURITY-INSIGHTS.yml
@@ -1,7 +1,7 @@
 header:
   schema-version: 2.0.0
-  last-updated: '2026-03-03'
-  last-reviewed: '2026-03-03'
+  last-updated: '2026-07-04'
+  last-reviewed: '2026-07-04'
   url: https://github.com/meshery/meshery/blob/master/SECURITY-INSIGHTS.yml
   comment: |
     This file contains the security information for the Meshery project.
@@ -87,7 +87,10 @@ repository:
     assessments:
       self:
         comment: |
-          Self assessment has not yet been completed.
+          Meshery has performed a security self-assessment. The assessment
+          document is linked below as evidence.
+        evidence-url:
+          - https://docs.google.com/document/d/17BqoEibnFdgx1U97AwM4RRkEbwTin_T78_W_WzB-0Gg/edit?usp=sharing
   documentation:
     contributing-guide: https://docs.meshery.io/project/contributing
     governance: https://github.com/meshery/meshery/blob/master/GOVERNANCE.md

--- a/SECURITY-INSIGHTS.yml
+++ b/SECURITY-INSIGHTS.yml
@@ -90,7 +90,7 @@ repository:
           Meshery has performed a security self-assessment. The assessment
           document is linked below as evidence.
         evidence-url:
-          - https://docs.google.com/document/d/17BqoEibnFdgx1U97AwM4RRkEbwTin_T78_W_WzB-0Gg/edit?usp=sharing
+          - https://docs.google.com/document/d/17BqoEibnFdgx1U97AwM4RRkEbwTin_T78_W_WzB-0Gg
   documentation:
     contributing-guide: https://docs.meshery.io/project/contributing
     governance: https://github.com/meshery/meshery/blob/master/GOVERNANCE.md

--- a/SECURITY-INSIGHTS.yml
+++ b/SECURITY-INSIGHTS.yml
@@ -1,7 +1,7 @@
 header:
   schema-version: 2.0.0
-  last-updated: '2026-03-03'
-  last-reviewed: '2026-03-03'
+  last-updated: '2026-07-04'
+  last-reviewed: '2026-07-04'
   url: https://github.com/meshery/meshery/blob/master/SECURITY-INSIGHTS.yml
   comment: |
     This file contains the security information for the Meshery project.
@@ -87,7 +87,10 @@ repository:
     assessments:
       self:
         comment: |
-          Self assessment has not yet been completed.
+          Meshery has performed a security self-assessment. The assessment
+          document is linked below as evidence.
+        evidence-url:
+          - https://docs.google.com/document/d/17BqoEibnFdgx1U97AwM4RRkEbwTin_T78_W_WzB-0Gg/edit?usp=sharing
   documentation:
     contributing-guide: https://docs.meshery.io/project/contributing
     governance: https://github.com/meshery/meshery/blob/master/GOVERNANCE.md


### PR DESCRIPTION
**Notes for Reviewers**

Closes #20477.

The `repository.security.assessments.self` block in `SECURITY-INSIGHTS.yml` was still the placeholder from when the file was first created (`schema-version 2.0.0`):

```yaml
security:
  assessments:
    self:
      comment: |
        Self assessment has not yet been completed.
```

This PR populates it with the project's security self-assessment, linked as `evidence-url` per the OSSF Security Insights v2.0.0 schema, and refreshes `header.last-updated` / `last-reviewed`:

```yaml
security:
  assessments:
    self:
      comment: |
        Meshery has performed a security self-assessment. The assessment
        document is linked below as evidence.
      evidence-url:
        - https://docs.google.com/document/d/17BqoEibnFdgx1U97AwM4RRkEbwTin_T78_W_WzB-0Gg/edit?usp=sharing
```

Applied to **both** the root `SECURITY-INSIGHTS.yml` and the `.github/SECURITY-INSIGHTS.yml` copy so the two stay in sync (a prior sync gap was already fixed once in #17995).

On the issue's second bullet — the OpenSSF Best Practices badge (project [3564](https://www.bestpractices.dev/en/projects/3564/passing)) is already at the passing level (`badge_percentage_0: 100`), so no change was needed there; it's noted here for completeness.

If you'd prefer the self-assessment to live as an in-repo markdown doc (rather than the Google Doc link) and be referenced from there, I'm happy to follow up with that — this PR keeps the change minimal and reversible.

Both files were validated to parse as YAML.

**Signed commits**
- [x] Yes, I signed my commits.
