### PR TITLE
Expose MeshSync, Operator, and Broker configuration: server-wide defaults (Settings) and per-connection overrides (Connections)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -45,7 +45,7 @@ require (
 	github.com/meshery/meshery-operator v0.8.11
 	github.com/meshery/meshkit v1.0.19
 	github.com/meshery/meshsync v1.0.0
-	github.com/meshery/schemas v1.3.22
+	github.com/meshery/schemas v1.3.25
 	github.com/nsf/termbox-go v1.1.1
 	github.com/oapi-codegen/runtime v1.4.2
 	github.com/olekukonko/tablewriter v1.1.4

--- a/go.sum
+++ b/go.sum
@@ -640,8 +640,8 @@ github.com/meshery/meshkit v1.0.19 h1:24/JpLoPnWXKEriYhkWdaEQXfoVQlBKSQPgoe7nE4z
 github.com/meshery/meshkit v1.0.19/go.mod h1:pChQu1xqvr0oNjIfVEzakaKmrqMSgiYu7wq7YPREhT4=
 github.com/meshery/meshsync v1.0.0 h1:BIHEVG4BDjqOnSd3vBt9B4IfWJNTfMRAgdwLroBcCfY=
 github.com/meshery/meshsync v1.0.0/go.mod h1:mFsPXkZRiCSuk5DhxBTrkWdlo6peItRBUoIEEQCovIg=
-github.com/meshery/schemas v1.3.22 h1:0+0ijQcRo/HULOJ+Kb2BslP94rTR5SgF0N2w/+CY0+4=
-github.com/meshery/schemas v1.3.22/go.mod h1:3/0nDQZur8swpo+6+3b3pvYmkzUcdWs36xTQBGRU2Y8=
+github.com/meshery/schemas v1.3.25 h1:aUZSol0+kfVpFs4WRsKAD4OaqW0MQkAPQJy+JwkNe+Q=
+github.com/meshery/schemas v1.3.25/go.mod h1:3/0nDQZur8swpo+6+3b3pvYmkzUcdWs36xTQBGRU2Y8=
 github.com/miekg/dns v1.1.57 h1:Jzi7ApEIzwEPLHWRcafCN9LZSBbqQpxjt/wpgvg7wcM=
 github.com/miekg/dns v1.1.57/go.mod h1:uqRjCRUuEAA6qsOiJvDd+CFo/vW+y5WR6SNmHE55hZk=
 github.com/miekg/pkcs11 v1.0.2/go.mod h1:XsNlhZGX73bx86s2hdc/FuaLm2CPZJemRLMA+WTFxgs=

--- a/server/cmd/main.go
+++ b/server/cmd/main.go
@@ -267,6 +267,7 @@ func main() {
 		workspace.WorkspacesTeamsMapping{},
 		workspace.WorkspacesViewsMapping{},
 		_events.Event{},
+		&models.SystemSetting{},
 	)
 	if err != nil {
 		log.Error(ErrDatabaseAutoMigration(err))

--- a/server/handlers/controllers_config_handlers.go
+++ b/server/handlers/controllers_config_handlers.go
@@ -148,12 +148,29 @@ func (h *Handler) UpdateConnectionControllersConfig(w http.ResponseWriter, req *
 		writeMeshkitError(w, err, http.StatusBadRequest)
 		return
 	}
-	// Mirror the deployment mode into the legacy metadata key so every
-	// existing consumer (state machine, header chips, kubeconfig flows)
-	// keeps working unchanged.
-	if mode := connections.DeploymentModeFromControllersConfig(override); mode != connections.MeshsyncDeploymentModeUndefined {
-		connections.SetMeshsyncDeploymentModeToMetadata(metadata, mode)
+	// Materialize the effective deployment mode into the legacy
+	// meshsync_deployment_mode key so every existing consumer (state
+	// machine, header chips, kubeconfig flows) keeps working unchanged. The
+	// key is written on every update using the full precedence chain
+	// (override -> Settings-persisted server default -> server env default),
+	// not only when the override sets it: returning the field to Inherit
+	// therefore replaces a stale materialized override with the inherited
+	// mode, and the mode-change machinery below sees the correct desired
+	// mode.
+	serverDefaults, err := models.GetControllersConfigDefaults(h.dbHandler)
+	if err != nil {
+		h.log.Error(err)
+		writeMeshkitError(w, err, http.StatusInternalServerError)
+		return
 	}
+	desiredMode := connections.DeploymentModeFromControllersConfig(override)
+	if desiredMode == connections.MeshsyncDeploymentModeUndefined {
+		desiredMode = connections.DeploymentModeFromControllersConfig(serverDefaults)
+	}
+	if desiredMode == connections.MeshsyncDeploymentModeUndefined {
+		desiredMode = h.MeshsyncDefaultDeploymentMode
+	}
+	connections.SetMeshsyncDeploymentModeToMetadata(metadata, desiredMode)
 
 	payload := &connections.ConnectionPayload{
 		ID:           connection.ID,
@@ -243,11 +260,11 @@ func (h *Handler) readControllersConfigPayload(w http.ResponseWriter, req *http.
 // Kubernetes connection. On failure it writes the HTTP error response and
 // returns ok=false.
 func (h *Handler) fetchKubernetesConnection(w http.ResponseWriter, req *http.Request, token string, provider models.Provider) (*connections.Connection, bool) {
-	connectionID := uuid.FromStringOrNil(mux.Vars(req)["connectionId"])
-	if connectionID == uuid.Nil {
-		err := ErrEmptyConnectionID()
-		h.log.Error(err)
-		writeMeshkitError(w, err, http.StatusBadRequest)
+	connectionID, err := uuid.FromString(mux.Vars(req)["connectionId"])
+	if err != nil || connectionID == uuid.Nil {
+		idErr := ErrEmptyConnectionID()
+		h.log.Error(idErr)
+		writeMeshkitError(w, idErr, http.StatusBadRequest)
 		return nil, false
 	}
 	connection, statusCode, err := provider.GetConnectionByID(token, connectionID)
@@ -302,6 +319,9 @@ func (h *Handler) applyControllersConfigToConnection(
 	provider models.Provider,
 	eventBuilder *events.EventBuilder,
 ) {
+	if h.ConnectionToStateMachineInstanceTracker == nil {
+		return
+	}
 	machine, ok := h.ConnectionToStateMachineInstanceTracker.Get(connectionID)
 	if !ok || machine == nil {
 		// Not currently tracked (never connected in this server session):
@@ -325,7 +345,13 @@ func (h *Handler) applyControllersConfigToConnection(
 	}
 	ctrlHelper.SetControllersConfig(merged)
 
+	// Deployment-mode precedence: explicit metadata entry -> mode carried by
+	// the resolved configuration (per-connection override merged over the
+	// Settings-persisted server default) -> server env default.
 	mode := connections.MeshsyncDeploymentModeFromMetadata(metadata)
+	if mode == connections.MeshsyncDeploymentModeUndefined {
+		mode = connections.DeploymentModeFromControllersConfig(merged)
+	}
 	if mode == connections.MeshsyncDeploymentModeUndefined {
 		mode = h.MeshsyncDefaultDeploymentMode
 	}

--- a/server/handlers/controllers_config_handlers.go
+++ b/server/handlers/controllers_config_handlers.go
@@ -1,0 +1,391 @@
+package handlers
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"time"
+
+	"github.com/gofrs/uuid"
+	"github.com/gorilla/mux"
+	"github.com/meshery/meshery/server/machines"
+	"github.com/meshery/meshery/server/machines/kubernetes"
+	"github.com/meshery/meshery/server/models"
+	"github.com/meshery/meshery/server/models/connections"
+	"github.com/meshery/meshkit/models/events"
+	"github.com/meshery/schemas/models/core"
+	controllersconfig "github.com/meshery/schemas/models/v1alpha1/controllers_config"
+)
+
+// GetControllersDefaultConfig handles GET /api/system/controllers/config.
+// Returns the server-wide default Meshery Operator / MeshSync / Broker
+// configuration. Fields that have never been set are absent, meaning the
+// built-in defaults apply.
+func (h *Handler) GetControllersDefaultConfig(w http.ResponseWriter, _ *http.Request, _ *models.Preference, _ *models.User, _ models.Provider) {
+	cfg, err := models.GetControllersConfigDefaults(h.dbHandler)
+	if err != nil {
+		h.log.Error(err)
+		writeMeshkitError(w, err, http.StatusInternalServerError)
+		return
+	}
+	if cfg == nil {
+		cfg = &controllersconfig.MesheryControllersConfig{}
+	}
+	cfg.SchemaVersion = connections.ControllersConfigSchemaVersion
+
+	w.Header().Set("Content-Type", "application/json")
+	if err := json.NewEncoder(w).Encode(cfg); err != nil {
+		h.log.Error(models.ErrMarshal(err, "controllers config defaults"))
+	}
+}
+
+// UpdateControllersDefaultConfig handles PUT /api/system/controllers/config.
+// Persists the server-wide defaults, then re-applies the effective
+// configuration to every connected Kubernetes connection that inherits the
+// changed fields. An empty document clears the stored defaults.
+func (h *Handler) UpdateControllersDefaultConfig(w http.ResponseWriter, req *http.Request, _ *models.Preference, user *models.User, provider models.Provider) {
+	userID := user.ID
+	token, _ := req.Context().Value(models.TokenCtxKey).(string)
+
+	cfg, ok := h.readControllersConfigPayload(w, req)
+	if !ok {
+		return
+	}
+
+	eventBuilder := events.NewEvent().ActedUpon(userID).FromOwner(userID).FromSystem(*h.SystemID).WithCategory("connection").WithAction("update")
+
+	if err := models.SaveControllersConfigDefaults(h.dbHandler, cfg); err != nil {
+		h.log.Error(err)
+		event := eventBuilder.WithSeverity(events.Error).WithDescription("Failed to persist server-wide controllers configuration defaults.").WithMetadata(map[string]interface{}{"error": err}).Build()
+		_ = provider.PersistEvent(*event, token)
+		go h.config.EventBroadcaster.Publish(userID, event)
+		writeMeshkitError(w, err, http.StatusInternalServerError)
+		return
+	}
+
+	event := eventBuilder.WithSeverity(events.Informational).WithDescription("Server-wide Meshery Operator, MeshSync, and Broker configuration defaults updated. Re-applying to connected clusters.").Build()
+	_ = provider.PersistEvent(*event, token)
+	go h.config.EventBroadcaster.Publish(userID, event)
+
+	// Re-apply the resolved configuration to every tracked Kubernetes
+	// connection: per-connection overrides still win, so inheriting
+	// connections pick up the new defaults and overriding connections are
+	// unaffected for the overridden fields.
+	go h.reapplyControllersConfigToTrackedConnections(token, userID, provider)
+
+	stored, err := models.GetControllersConfigDefaults(h.dbHandler)
+	if err != nil {
+		h.log.Error(err)
+		writeMeshkitError(w, err, http.StatusInternalServerError)
+		return
+	}
+	if stored == nil {
+		stored = &controllersconfig.MesheryControllersConfig{}
+	}
+	stored.SchemaVersion = connections.ControllersConfigSchemaVersion
+	w.Header().Set("Content-Type", "application/json")
+	if err := json.NewEncoder(w).Encode(stored); err != nil {
+		h.log.Error(models.ErrMarshal(err, "controllers config defaults"))
+	}
+}
+
+// GetConnectionControllersConfig handles
+// GET /api/integrations/connections/{connectionId}/controllers/config.
+// Returns the layered controllers configuration for the connection: the
+// per-connection override, the server-wide default, and the resolved
+// effective configuration.
+func (h *Handler) GetConnectionControllersConfig(w http.ResponseWriter, req *http.Request, _ *models.Preference, _ *models.User, provider models.Provider) {
+	token, _ := req.Context().Value(models.TokenCtxKey).(string)
+
+	connection, ok := h.fetchKubernetesConnection(w, req, token, provider)
+	if !ok {
+		return
+	}
+
+	response, err := h.buildConnectionControllersConfig(connection)
+	if err != nil {
+		h.log.Error(err)
+		writeMeshkitError(w, err, http.StatusInternalServerError)
+		return
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	if err := json.NewEncoder(w).Encode(response); err != nil {
+		h.log.Error(models.ErrMarshal(err, "connection controllers config"))
+	}
+}
+
+// UpdateConnectionControllersConfig handles
+// PUT /api/integrations/connections/{connectionId}/controllers/config.
+// Persists the override into the connection's metadata and applies the
+// resolved effective configuration to that connection's cluster. Absent
+// fields inherit the server-wide default; an empty document removes the
+// override entirely.
+func (h *Handler) UpdateConnectionControllersConfig(w http.ResponseWriter, req *http.Request, _ *models.Preference, user *models.User, provider models.Provider) {
+	userID := user.ID
+	token, _ := req.Context().Value(models.TokenCtxKey).(string)
+
+	override, ok := h.readControllersConfigPayload(w, req)
+	if !ok {
+		return
+	}
+
+	connection, ok := h.fetchKubernetesConnection(w, req, token, provider)
+	if !ok {
+		return
+	}
+	connectionID := connection.ID
+
+	eventBuilder := events.NewEvent().ActedUpon(connectionID).FromOwner(userID).FromSystem(*h.SystemID).WithCategory("connection").WithAction("update")
+
+	metadata := connection.Metadata
+	if metadata == nil {
+		metadata = core.Map{}
+	}
+	if err := connections.SetControllersConfigToMetadata(metadata, override); err != nil {
+		h.log.Error(err)
+		writeMeshkitError(w, err, http.StatusBadRequest)
+		return
+	}
+	// Mirror the deployment mode into the legacy metadata key so every
+	// existing consumer (state machine, header chips, kubeconfig flows)
+	// keeps working unchanged.
+	if mode := connections.DeploymentModeFromControllersConfig(override); mode != connections.MeshsyncDeploymentModeUndefined {
+		connections.SetMeshsyncDeploymentModeToMetadata(metadata, mode)
+	}
+
+	payload := &connections.ConnectionPayload{
+		ID:           connection.ID,
+		Kind:         connection.Kind,
+		SubType:      connection.SubType,
+		Type:         connection.ConnectionType,
+		Name:         connection.Name,
+		MetaData:     metadata,
+		Status:       connection.Status,
+		CredentialID: connection.CredentialID,
+	}
+
+	// A deployment-mode change tears down and reattaches the controller
+	// machinery for the connection (deploy/undeploy operator, restart the
+	// MeshSync data pipeline). Delegated to the existing mode-change path so
+	// both entry points behave identically.
+	if _, _, modeChanged, err := h.handleMeshSyncDeploymentModeChange(req.Context(), connectionID, payload, token, userID, provider); err != nil {
+		h.log.Error(err)
+		event := eventBuilder.WithSeverity(events.Error).WithDescription("Failed to apply MeshSync deployment mode change.").WithMetadata(map[string]interface{}{"error": err}).Build()
+		_ = provider.PersistEvent(*event, token)
+		go h.config.EventBroadcaster.Publish(userID, event)
+		writeMeshkitError(w, err, http.StatusInternalServerError)
+		return
+	} else if modeChanged {
+		event := eventBuilder.WithSeverity(events.Informational).WithDescription("MeshSync deployment mode changed as part of the controllers configuration update.").Build()
+		_ = provider.PersistEvent(*event, token)
+		go h.config.EventBroadcaster.Publish(userID, event)
+	}
+
+	if _, err := provider.UpdateConnectionById(token, payload, connectionID.String()); err != nil {
+		h.log.Error(err)
+		event := eventBuilder.WithSeverity(events.Error).WithDescription("Failed to persist the connection's controllers configuration override.").WithMetadata(map[string]interface{}{"error": err}).Build()
+		_ = provider.PersistEvent(*event, token)
+		go h.config.EventBroadcaster.Publish(userID, event)
+		writeMeshkitError(w, err, http.StatusInternalServerError)
+		return
+	}
+
+	// Apply the resolved configuration to this connection's cluster (or
+	// restart the embedded run so it picks the new knobs up).
+	h.applyControllersConfigToConnection(req.Context(), connectionID, metadata, token, userID, provider, eventBuilder)
+
+	connection.Metadata = metadata
+	response, err := h.buildConnectionControllersConfig(connection)
+	if err != nil {
+		h.log.Error(err)
+		writeMeshkitError(w, err, http.StatusInternalServerError)
+		return
+	}
+	w.Header().Set("Content-Type", "application/json")
+	if err := json.NewEncoder(w).Encode(response); err != nil {
+		h.log.Error(models.ErrMarshal(err, "connection controllers config"))
+	}
+}
+
+// readControllersConfigPayload decodes and validates a controllers
+// configuration write payload. On failure it writes the HTTP error response
+// and returns ok=false.
+func (h *Handler) readControllersConfigPayload(w http.ResponseWriter, req *http.Request) (*controllersconfig.MesheryControllersConfig, bool) {
+	body, err := io.ReadAll(req.Body)
+	if err != nil {
+		h.log.Error(ErrRequestBody(err))
+		writeMeshkitError(w, ErrRequestBody(err), http.StatusInternalServerError)
+		return nil, false
+	}
+	payload := &controllersconfig.MesheryControllersConfigPayload{}
+	if err := json.Unmarshal(body, payload); err != nil {
+		h.log.Error(models.ErrUnmarshal(err, "controllers config"))
+		writeMeshkitError(w, models.ErrUnmarshal(err, "controllers config"), http.StatusBadRequest)
+		return nil, false
+	}
+	cfg := &controllersconfig.MesheryControllersConfig{
+		SchemaVersion: connections.ControllersConfigSchemaVersion,
+		Operator:      payload.Operator,
+		Meshsync:      payload.Meshsync,
+		Broker:        payload.Broker,
+	}
+	if err := connections.ValidateControllersConfig(cfg); err != nil {
+		h.log.Error(err)
+		writeMeshkitError(w, err, http.StatusBadRequest)
+		return nil, false
+	}
+	return cfg, true
+}
+
+// fetchKubernetesConnection resolves the {connectionId} path parameter into a
+// Kubernetes connection. On failure it writes the HTTP error response and
+// returns ok=false.
+func (h *Handler) fetchKubernetesConnection(w http.ResponseWriter, req *http.Request, token string, provider models.Provider) (*connections.Connection, bool) {
+	connectionID := uuid.FromStringOrNil(mux.Vars(req)["connectionId"])
+	if connectionID == uuid.Nil {
+		err := ErrEmptyConnectionID()
+		h.log.Error(err)
+		writeMeshkitError(w, err, http.StatusBadRequest)
+		return nil, false
+	}
+	connection, statusCode, err := provider.GetConnectionByID(token, connectionID)
+	if err != nil {
+		h.log.Error(err)
+		writeMeshkitError(w, err, statusCode)
+		return nil, false
+	}
+	if connection.Kind != "kubernetes" {
+		err := connections.ErrControllersConfigInvalid("controllers configuration applies to Kubernetes connections only")
+		h.log.Error(err)
+		writeMeshkitError(w, err, http.StatusBadRequest)
+		return nil, false
+	}
+	return connection, true
+}
+
+// buildConnectionControllersConfig assembles the layered view (override,
+// server default, effective) for a connection.
+func (h *Handler) buildConnectionControllersConfig(connection *connections.Connection) (*controllersconfig.ConnectionControllersConfig, error) {
+	override, err := connections.ControllersConfigFromMetadata(connection.Metadata)
+	if err != nil {
+		return nil, err
+	}
+	serverDefaults, err := models.GetControllersConfigDefaults(h.dbHandler)
+	if err != nil {
+		return nil, err
+	}
+	_, effective := connections.ResolveControllersConfig(override, serverDefaults)
+	return &controllersconfig.ConnectionControllersConfig{
+		Override:  override,
+		Default:   serverDefaults,
+		Effective: *effective,
+	}, nil
+}
+
+// applyControllersConfigToConnection propagates the resolved configuration
+// for one connection: operator mode patches the cluster's custom resources
+// and the MeshSync deployment overlay; embedded mode restarts the in-process
+// MeshSync run so it picks up the new knobs. Failures are surfaced as events
+// rather than failing the request: the override is already persisted and
+// re-applies on the next connect.
+func (h *Handler) applyControllersConfigToConnection(
+	ctx context.Context,
+	connectionID core.Uuid,
+	metadata core.Map,
+	token string,
+	userID core.Uuid,
+	provider models.Provider,
+	eventBuilder *events.EventBuilder,
+) {
+	machine, ok := h.ConnectionToStateMachineInstanceTracker.Get(connectionID)
+	if !ok || machine == nil {
+		// Not currently tracked (never connected in this server session):
+		// nothing to apply now; ConnectAction applies on connect.
+		return
+	}
+	machineCtx, err := kubernetes.GetMachineCtx(machine.Context, nil)
+	if err != nil || machineCtx == nil {
+		h.log.Warnf("controllers config: no machine context for connection %s; configuration applies on next connect", connectionID)
+		return
+	}
+	ctrlHelper := machineCtx.MesheryCtrlsHelper
+	if ctrlHelper == nil {
+		return
+	}
+
+	merged, _, err := ctrlHelper.ResolveControllersConfigForConnection(metadata)
+	if err != nil {
+		h.emitControllersConfigApplyEvent(eventBuilder, provider, token, userID, events.Error, "Failed to resolve the connection's controllers configuration.", map[string]interface{}{"error": err, "connectionId": connectionID})
+		return
+	}
+	ctrlHelper.SetControllersConfig(merged)
+
+	mode := connections.MeshsyncDeploymentModeFromMetadata(metadata)
+	if mode == connections.MeshsyncDeploymentModeUndefined {
+		mode = h.MeshsyncDefaultDeploymentMode
+	}
+
+	switch mode {
+	case connections.MeshsyncDeploymentModeEmbedded:
+		// Restart the in-process run so libmeshsync options (output
+		// filters) and, when the target cluster carries a MeshSync CR, the
+		// watch-list are re-read.
+		contextID := machineCtx.K8sContext.ID
+		ctrlHelper.RemoveMeshSyncDataHandler(ctx, contextID)
+		ctrlHelper.AddMeshsynDataHandlers(ctx, machineCtx.K8sContext, userID, *h.SystemID, provider)
+		h.emitControllersConfigApplyEvent(eventBuilder, provider, token, userID, events.Informational, "Controllers configuration applied: embedded MeshSync restarted with the updated configuration.", map[string]interface{}{"connectionId": connectionID})
+	case connections.MeshsyncDeploymentModeOperator:
+		kubeClient, err := machineCtx.K8sContext.GenerateKubeHandler()
+		if err != nil {
+			h.emitControllersConfigApplyEvent(eventBuilder, provider, token, userID, events.Error, "Failed to reach the connection's cluster to apply the controllers configuration.", map[string]interface{}{"error": err, "connectionId": connectionID})
+			return
+		}
+		applyCtx, cancel := context.WithTimeout(context.Background(), 2*time.Minute)
+		defer cancel()
+		result, err := models.ApplyControllersConfigToCluster(applyCtx, h.log, kubeClient, merged)
+		if err != nil {
+			h.emitControllersConfigApplyEvent(eventBuilder, provider, token, userID, events.Error, "Failed to apply the controllers configuration to the cluster.", map[string]interface{}{"error": err, "connectionId": connectionID, "result": result})
+			return
+		}
+		h.emitControllersConfigApplyEvent(eventBuilder, provider, token, userID, events.Informational, "Controllers configuration applied to the cluster.", map[string]interface{}{"connectionId": connectionID, "result": result})
+	}
+}
+
+// reapplyControllersConfigToTrackedConnections fans a server-wide defaults
+// change out to every tracked Kubernetes connection.
+func (h *Handler) reapplyControllersConfigToTrackedConnections(token string, userID core.Uuid, provider models.Provider) {
+	if h.ConnectionToStateMachineInstanceTracker == nil {
+		return
+	}
+	h.ConnectionToStateMachineInstanceTracker.Range(func(connectionID core.Uuid, _ *machines.StateMachine) bool {
+		connection, _, err := provider.GetConnectionByID(token, connectionID)
+		if err != nil {
+			h.log.Warnf("controllers config: skipping re-apply for connection %s: %v", connectionID, err)
+			return true
+		}
+		if connection.Kind != "kubernetes" {
+			return true
+		}
+		eventBuilder := events.NewEvent().ActedUpon(connectionID).FromOwner(userID).FromSystem(*h.SystemID).WithCategory("connection").WithAction("update")
+		h.applyControllersConfigToConnection(context.Background(), connectionID, connection.Metadata, token, userID, provider, eventBuilder)
+		return true
+	})
+}
+
+// emitControllersConfigApplyEvent persists and broadcasts a controllers
+// configuration apply event.
+func (h *Handler) emitControllersConfigApplyEvent(
+	eventBuilder *events.EventBuilder,
+	provider models.Provider,
+	token string,
+	userID core.Uuid,
+	severity events.EventSeverity,
+	description string,
+	metadata map[string]interface{},
+) {
+	event := eventBuilder.WithSeverity(severity).WithDescription(description).WithMetadata(metadata).Build()
+	_ = provider.PersistEvent(*event, token)
+	go h.config.EventBroadcaster.Publish(userID, event)
+}

--- a/server/handlers/controllers_config_handlers.go
+++ b/server/handlers/controllers_config_handlers.go
@@ -253,6 +253,9 @@ func (h *Handler) fetchKubernetesConnection(w http.ResponseWriter, req *http.Req
 	connection, statusCode, err := provider.GetConnectionByID(token, connectionID)
 	if err != nil {
 		h.log.Error(err)
+		if statusCode < http.StatusContinue {
+			statusCode = http.StatusInternalServerError
+		}
 		writeMeshkitError(w, err, statusCode)
 		return nil, false
 	}

--- a/server/helpers/component_info.json
+++ b/server/helpers/component_info.json
@@ -1,5 +1,5 @@
 {
   "name": "meshery-server",
   "type": "component",
-  "next_error_code": 1437
+  "next_error_code": 1441
 }

--- a/server/integration-tests/meshsync/infrastructure/setup.sh
+++ b/server/integration-tests/meshsync/infrastructure/setup.sh
@@ -230,11 +230,32 @@ setup_connection() {
   echo ""
   echo ""
 
-  echo "Printing meshsync logs..." 
-  # Get the pod name for the deployment
-  MESHSYNC_DEPLOYMENT_POD_NAME=$(kubectl get pods --namespace "$MESHERY_K8S_NAMESPACE" --selector=app=meshery,component=meshsync -o jsonpath='{.items[0].metadata.name}')
-  # Output logs from the pod
-  kubectl --namespace $MESHERY_K8S_NAMESPACE logs $MESHSYNC_DEPLOYMENT_POD_NAME
+  echo "Printing meshsync workload state..."
+  # The meshsync Deployment intermittently carries a second, broken
+  # ReplicaSet (its pod sits in InvalidImageName; observed on green master
+  # runs too, e.g. run 28722881637). Dump the rollout state so the
+  # underlying bug is diagnosable from any run.
+  kubectl --namespace $MESHERY_K8S_NAMESPACE get deployment meshery-meshsync \
+    -o custom-columns='NAME:.metadata.name,IMAGE:.spec.template.spec.containers[*].image,GEN:.metadata.generation' || true
+  kubectl --namespace $MESHERY_K8S_NAMESPACE get replicasets \
+    --selector=app=meshery,component=meshsync \
+    -o custom-columns='NAME:.metadata.name,IMAGE:.spec.template.spec.containers[*].image,DESIRED:.spec.replicas,REVISION:.metadata.annotations.deployment\.kubernetes\.io/revision' || true
+  kubectl --namespace $MESHERY_K8S_NAMESPACE get meshsyncs.meshery.io meshery-meshsync \
+    -o yaml --show-managed-fields || true
+  kubectl --namespace $MESHERY_K8S_NAMESPACE get events \
+    --field-selector involvedObject.kind=Pod --sort-by='.lastTimestamp' | tail -20 || true
+  echo ""
+
+  echo "Printing meshsync logs..."
+  # Log every meshsync pod rather than items[0]: pod names sort by random
+  # hash, so with a broken second ReplicaSet present the single-pod variant
+  # fails or succeeds by alphabetical accident. A pod whose container never
+  # started cannot serve logs; report and continue.
+  for MESHSYNC_POD_NAME in $(kubectl get pods --namespace "$MESHERY_K8S_NAMESPACE" --selector=app=meshery,component=meshsync -o jsonpath='{.items[*].metadata.name}'); do
+    echo "--- logs: $MESHSYNC_POD_NAME ---"
+    kubectl --namespace $MESHERY_K8S_NAMESPACE logs "$MESHSYNC_POD_NAME" \
+      || echo "logs unavailable for $MESHSYNC_POD_NAME (container not started)"
+  done
   echo ""
   echo ""
 

--- a/server/machines/kubernetes/connect.go
+++ b/server/machines/kubernetes/connect.go
@@ -3,6 +3,7 @@ package kubernetes
 import (
 	"context"
 	"fmt"
+	"time"
 
 	"github.com/meshery/schemas/models/core"
 
@@ -62,7 +63,24 @@ func (ca *ConnectAction) Execute(ctx context.Context, machineCtx interface{}, da
 		return machines.NoOp, eventBuilder.Build(), errConnection
 	}
 
+	// Resolve the layered controllers configuration for this connection:
+	// per-connection override -> server-wide defaults (Settings) -> built-in
+	// defaults. The merged document is stashed on the controllers helper so
+	// the embedded meshsync run picks up its knobs, and is applied to the
+	// cluster after the operator machinery attaches (operator mode).
+	mergedControllersConfig, _, errResolve := machinectx.MesheryCtrlsHelper.ResolveControllersConfigForConnection(connection.Metadata)
+	if errResolve != nil {
+		// A malformed override must not block the connection: fall back to
+		// layer-free resolution and surface the problem as an event.
+		machinectx.log.Error(errResolve)
+		mergedControllersConfig = nil
+	}
+
 	meshsyncDeploymentMode := connections.MeshsyncDeploymentModeFromMetadata(connection.Metadata)
+	if meshsyncDeploymentMode == connections.MeshsyncDeploymentModeUndefined {
+		// Fall back to the server-wide default configured in Settings.
+		meshsyncDeploymentMode = connections.DeploymentModeFromControllersConfig(mergedControllersConfig)
+	}
 	if meshsyncDeploymentMode == connections.MeshsyncDeploymentModeUndefined {
 		// TODO:
 		// maybe not call to viper here and propagate default value from above,
@@ -79,9 +97,31 @@ func (ca *ConnectAction) Execute(ctx context.Context, machineCtx interface{}, da
 		ctrlHelper := machinectx.MesheryCtrlsHelper.
 			AddCtxControllerHandlers(machinectx.K8sContext).
 			SetMeshsyncDeploymentMode(meshsyncDeploymentMode).
+			SetControllersConfig(mergedControllersConfig).
 			UpdateOperatorsStatusMap(machinectx.OperatorTracker).
 			DeployUndeployedOperators(machinectx.OperatorTracker)
 		ctrlHelper.AddMeshsynDataHandlers(ctx, machinectx.K8sContext, userUUID, *sysID, provider)
+
+		// Operator mode: best-effort apply of the explicitly-set
+		// configuration onto the cluster's MeshSync/Broker custom resources
+		// and the MeshSync deployment. Targets that do not exist yet (the
+		// operator is still coming up) are skipped and re-applied on the
+		// next connect or configuration change.
+		if meshsyncDeploymentMode == connections.MeshsyncDeploymentModeOperator && mergedControllersConfig != nil {
+			kubeClient, errClient := machinectx.K8sContext.GenerateKubeHandler()
+			if errClient != nil {
+				machinectx.log.Error(ErrConnectAction(errClient))
+				return
+			}
+			// Detached context: the connect request's context ends with the
+			// HTTP request, while this apply runs alongside the async
+			// operator deployment.
+			applyCtx, cancelApply := context.WithTimeout(context.Background(), 2*time.Minute)
+			defer cancelApply()
+			if _, errApply := models.ApplyControllersConfigToCluster(applyCtx, machinectx.log, kubeClient, mergedControllersConfig); errApply != nil {
+				machinectx.log.Error(errApply)
+			}
+		}
 	}()
 	return machines.NoOp, nil, nil
 }

--- a/server/machines/kubernetes/connect.go
+++ b/server/machines/kubernetes/connect.go
@@ -69,9 +69,12 @@ func (ca *ConnectAction) Execute(ctx context.Context, machineCtx interface{}, da
 	// the embedded meshsync run picks up its knobs, and is applied to the
 	// cluster after the operator machinery attaches (operator mode).
 	mergedControllersConfig, _, errResolve := machinectx.MesheryCtrlsHelper.ResolveControllersConfigForConnection(connection.Metadata)
+	controllersConfigResolved := errResolve == nil
 	if errResolve != nil {
-		// A malformed override must not block the connection: fall back to
-		// layer-free resolution and surface the problem as an event.
+		// The defaults store failed (a malformed override alone degrades
+		// inside the resolver and still yields the Settings defaults):
+		// connect with layer-free defaults and skip the cluster apply
+		// below, since the intended configuration is unknown.
 		machinectx.log.Error(errResolve)
 		mergedControllersConfig = nil
 	}
@@ -104,10 +107,12 @@ func (ca *ConnectAction) Execute(ctx context.Context, machineCtx interface{}, da
 
 		// Operator mode: best-effort apply of the explicitly-set
 		// configuration onto the cluster's MeshSync/Broker custom resources
-		// and the MeshSync deployment. Targets that do not exist yet (the
-		// operator is still coming up) are skipped and re-applied on the
-		// next connect or configuration change.
-		if meshsyncDeploymentMode == connections.MeshsyncDeploymentModeOperator && mergedControllersConfig != nil {
+		// and the MeshSync deployment. An empty resolved configuration is
+		// applied too: it withdraws previously-applied fields (cleared
+		// while the connection was down) and heals drift. Targets that do
+		// not exist yet (the operator is still coming up) are skipped and
+		// re-applied on the next connect or configuration change.
+		if meshsyncDeploymentMode == connections.MeshsyncDeploymentModeOperator && controllersConfigResolved {
 			kubeClient, errClient := machinectx.K8sContext.GenerateKubeHandler()
 			if errClient != nil {
 				machinectx.log.Error(ErrConnectAction(errClient))

--- a/server/machines/sm_tracker.go
+++ b/server/machines/sm_tracker.go
@@ -29,3 +29,21 @@ func (smt *ConnectionToStateMachineInstanceTracker) Add(id core.Uuid, inst *Stat
 	defer smt.mx.Unlock()
 	smt.ConnectToInstanceMap[id] = inst
 }
+
+// Range calls fn for a snapshot of the tracked connection/state-machine
+// pairs. Iteration happens over a copy taken under the read lock, so fn may
+// safely interact with the tracker or perform slow work.
+func (smt *ConnectionToStateMachineInstanceTracker) Range(fn func(id core.Uuid, inst *StateMachine) bool) {
+	smt.mx.RLock()
+	snapshot := make(map[core.Uuid]*StateMachine, len(smt.ConnectToInstanceMap))
+	for id, inst := range smt.ConnectToInstanceMap {
+		snapshot[id] = inst
+	}
+	smt.mx.RUnlock()
+
+	for id, inst := range snapshot {
+		if !fn(id, inst) {
+			return
+		}
+	}
+}

--- a/server/models/connections/controllers_config.go
+++ b/server/models/connections/controllers_config.go
@@ -1,0 +1,345 @@
+// This file hosts the MesheryControllersConfig helpers: how the server layers
+// the Meshery Operator / MeshSync / Broker configuration for a Kubernetes
+// connection. The wire contract lives in
+// github.com/meshery/schemas/models/v1alpha1/controllers_config; the layering
+// (per-connection override -> server-wide default -> built-in default) is
+// Meshery domain logic and therefore lives here, next to the
+// MeshsyncDeploymentMode helpers it complements.
+package connections
+
+import (
+	"encoding/json"
+
+	"github.com/meshery/schemas/models/core"
+	controllersconfig "github.com/meshery/schemas/models/v1alpha1/controllers_config"
+)
+
+// ControllersConfigMetadataKey is the key under which a connection's
+// controllers-configuration override is stored on the connection's metadata
+// map. Kept as snake_case for consistency with the sibling
+// meshsync_deployment_mode entry persisted on the same map.
+const ControllersConfigMetadataKey = "controllers_config"
+
+// ControllersConfigSchemaVersion is the schema version stamped onto every
+// controllers-configuration document the server stores or returns.
+const ControllersConfigSchemaVersion = "controllers.meshery.io/v1alpha1"
+
+// ControllersConfigFromMetadata extracts the per-connection controllers
+// configuration override stored on a connection's metadata map. A missing key
+// or nil metadata yields (nil, nil): the connection inherits entirely. The
+// stored value is a JSON-shaped map (or a JSON string, for tolerance) and is
+// round-tripped through encoding/json into the typed schema model.
+func ControllersConfigFromMetadata(metadata core.Map) (*controllersconfig.MesheryControllersConfig, error) {
+	if metadata == nil {
+		return nil, nil
+	}
+	raw, exists := metadata[ControllersConfigMetadataKey]
+	if !exists || raw == nil {
+		return nil, nil
+	}
+
+	var encoded []byte
+	var err error
+	switch v := raw.(type) {
+	case string:
+		encoded = []byte(v)
+	default:
+		encoded, err = json.Marshal(v)
+		if err != nil {
+			return nil, ErrControllersConfigMetadata(err)
+		}
+	}
+
+	cfg := &controllersconfig.MesheryControllersConfig{}
+	if err := json.Unmarshal(encoded, cfg); err != nil {
+		return nil, ErrControllersConfigMetadata(err)
+	}
+	return cfg, nil
+}
+
+// SetControllersConfigToMetadata writes (or overwrites) the controllers
+// configuration override on a connection's metadata map, stored as a
+// JSON-shaped map so it serializes identically through every provider path.
+// Passing a nil or empty config removes the override entirely. A nil metadata
+// map is a no-op (writing to a nil map would panic); callers that need to set
+// an override on a fresh connection must initialise the map first.
+func SetControllersConfigToMetadata(metadata core.Map, cfg *controllersconfig.MesheryControllersConfig) error {
+	if metadata == nil {
+		return nil
+	}
+	if cfg == nil || (cfg.Operator == nil && cfg.Meshsync == nil && cfg.Broker == nil) {
+		delete(metadata, ControllersConfigMetadataKey)
+		return nil
+	}
+	cfg.SchemaVersion = ControllersConfigSchemaVersion
+
+	encoded, err := json.Marshal(cfg)
+	if err != nil {
+		return ErrControllersConfigMetadata(err)
+	}
+	asMap := map[string]interface{}{}
+	if err := json.Unmarshal(encoded, &asMap); err != nil {
+		return ErrControllersConfigMetadata(err)
+	}
+	metadata[ControllersConfigMetadataKey] = asMap
+	return nil
+}
+
+// MergeControllersConfig overlays the override onto the base, producing a
+// document that contains only explicitly-set fields from either layer, with
+// the override winning per field. Scalars merge per leaf. Collections
+// (watchList, outputNamespaces, outputResources, service annotations and
+// source ranges) merge atomically: a layer that sets one replaces the lower
+// layer's value entirely, because element-wise merging of a whitelist or a
+// namespace filter would produce a scope neither layer asked for.
+func MergeControllersConfig(override, base *controllersconfig.MesheryControllersConfig) *controllersconfig.MesheryControllersConfig {
+	if override == nil && base == nil {
+		return nil
+	}
+	merged := &controllersconfig.MesheryControllersConfig{SchemaVersion: ControllersConfigSchemaVersion}
+	merged.Operator = mergeOperatorConfig(sectionOperator(override), sectionOperator(base))
+	merged.Meshsync = mergeMeshSyncConfig(sectionMeshsync(override), sectionMeshsync(base))
+	merged.Broker = mergeBrokerConfig(sectionBroker(override), sectionBroker(base))
+	return merged
+}
+
+func sectionOperator(c *controllersconfig.MesheryControllersConfig) *controllersconfig.MesheryOperatorConfig {
+	if c == nil {
+		return nil
+	}
+	return c.Operator
+}
+
+func sectionMeshsync(c *controllersconfig.MesheryControllersConfig) *controllersconfig.MeshSyncConfig {
+	if c == nil {
+		return nil
+	}
+	return c.Meshsync
+}
+
+func sectionBroker(c *controllersconfig.MesheryControllersConfig) *controllersconfig.MesheryBrokerConfig {
+	if c == nil {
+		return nil
+	}
+	return c.Broker
+}
+
+func mergeOperatorConfig(override, base *controllersconfig.MesheryOperatorConfig) *controllersconfig.MesheryOperatorConfig {
+	if override == nil && base == nil {
+		return nil
+	}
+	merged := &controllersconfig.MesheryOperatorConfig{}
+	if base != nil {
+		merged.DeploymentMode = base.DeploymentMode
+		merged.Version = base.Version
+	}
+	if override != nil {
+		if override.DeploymentMode != nil {
+			merged.DeploymentMode = override.DeploymentMode
+		}
+		if override.Version != nil {
+			merged.Version = override.Version
+		}
+	}
+	return merged
+}
+
+func mergeMeshSyncConfig(override, base *controllersconfig.MeshSyncConfig) *controllersconfig.MeshSyncConfig {
+	if override == nil && base == nil {
+		return nil
+	}
+	merged := &controllersconfig.MeshSyncConfig{}
+	if base != nil {
+		*merged = *base
+	}
+	if override != nil {
+		if override.Version != nil {
+			merged.Version = override.Version
+		}
+		if override.Replicas != nil {
+			merged.Replicas = override.Replicas
+		}
+		if override.WatchList != nil {
+			merged.WatchList = override.WatchList
+		}
+		if override.OutputNamespaces != nil {
+			merged.OutputNamespaces = override.OutputNamespaces
+		}
+		if override.OutputResources != nil {
+			merged.OutputResources = override.OutputResources
+		}
+		if override.RedactSecrets != nil {
+			merged.RedactSecrets = override.RedactSecrets
+		}
+		if override.BrokerContentDedup != nil {
+			merged.BrokerContentDedup = override.BrokerContentDedup
+		}
+		if override.DebugLogging != nil {
+			merged.DebugLogging = override.DebugLogging
+		}
+	}
+	return merged
+}
+
+func mergeBrokerConfig(override, base *controllersconfig.MesheryBrokerConfig) *controllersconfig.MesheryBrokerConfig {
+	if override == nil && base == nil {
+		return nil
+	}
+	merged := &controllersconfig.MesheryBrokerConfig{}
+	if base != nil {
+		merged.Version = base.Version
+		merged.Replicas = base.Replicas
+		merged.Service = base.Service
+	}
+	if override != nil {
+		if override.Version != nil {
+			merged.Version = override.Version
+		}
+		if override.Replicas != nil {
+			merged.Replicas = override.Replicas
+		}
+		if override.Service != nil {
+			merged.Service = mergeBrokerServiceConfig(override.Service, merged.Service)
+		}
+	}
+	return merged
+}
+
+func mergeBrokerServiceConfig(override, base *controllersconfig.MesheryBrokerServiceConfig) *controllersconfig.MesheryBrokerServiceConfig {
+	if override == nil && base == nil {
+		return nil
+	}
+	merged := &controllersconfig.MesheryBrokerServiceConfig{}
+	if base != nil {
+		*merged = *base
+	}
+	if override != nil {
+		if override.Type != nil {
+			merged.Type = override.Type
+		}
+		if override.Annotations != nil {
+			merged.Annotations = override.Annotations
+		}
+		if override.LoadBalancerClass != nil {
+			merged.LoadBalancerClass = override.LoadBalancerClass
+		}
+		if override.LoadBalancerSourceRanges != nil {
+			merged.LoadBalancerSourceRanges = override.LoadBalancerSourceRanges
+		}
+		if override.ExternalEndpointOverride != nil {
+			merged.ExternalEndpointOverride = override.ExternalEndpointOverride
+		}
+	}
+	return merged
+}
+
+// BuiltInControllersConfig returns the built-in defaults: the values that
+// apply when neither a per-connection override nor a server-wide default sets
+// a field. These mirror the defaults baked into MeshSync, Meshery Operator,
+// and Meshery Broker themselves.
+func BuiltInControllersConfig() *controllersconfig.MesheryControllersConfig {
+	defaultMode := controllersconfig.MesheryOperatorConfigDeploymentMode(MeshsyncDeploymentModeDefault)
+	one := 1
+	off := false
+	clusterIP := controllersconfig.ClusterIP
+	return &controllersconfig.MesheryControllersConfig{
+		SchemaVersion: ControllersConfigSchemaVersion,
+		Operator: &controllersconfig.MesheryOperatorConfig{
+			DeploymentMode: &defaultMode,
+		},
+		Meshsync: &controllersconfig.MeshSyncConfig{
+			Replicas:           &one,
+			RedactSecrets:      &off,
+			BrokerContentDedup: &off,
+			DebugLogging:       &off,
+		},
+		Broker: &controllersconfig.MesheryBrokerConfig{
+			Replicas: &one,
+			Service: &controllersconfig.MesheryBrokerServiceConfig{
+				Type: &clusterIP,
+			},
+		},
+	}
+}
+
+// ResolveControllersConfig applies the precedence chain: per-connection
+// override -> server-wide default -> built-in default. It returns two
+// documents:
+//
+//   - merged: only the fields explicitly set at the override or default
+//     layer, override winning. This is what the server propagates to a
+//     cluster; unset fields are left untouched so the controllers' own
+//     defaults apply (and previously-propagated values are withdrawn).
+//   - effective: merged overlaid onto the built-in defaults. This is the
+//     complete resolved view surfaced to clients.
+func ResolveControllersConfig(override, serverDefault *controllersconfig.MesheryControllersConfig) (merged, effective *controllersconfig.MesheryControllersConfig) {
+	merged = MergeControllersConfig(override, serverDefault)
+	effective = MergeControllersConfig(merged, BuiltInControllersConfig())
+	if effective != nil {
+		effective.SchemaVersion = ControllersConfigSchemaVersion
+	}
+	return merged, effective
+}
+
+// DeploymentModeFromControllersConfig extracts the deployment mode carried by
+// a controllers configuration document, collapsing to
+// MeshsyncDeploymentModeUndefined when the document does not set one.
+func DeploymentModeFromControllersConfig(cfg *controllersconfig.MesheryControllersConfig) MeshsyncDeploymentMode {
+	if cfg == nil || cfg.Operator == nil || cfg.Operator.DeploymentMode == nil {
+		return MeshsyncDeploymentModeUndefined
+	}
+	return MeshsyncDeploymentModeFromString(string(*cfg.Operator.DeploymentMode))
+}
+
+// ValidateControllersConfig enforces the guardrails that the schema cannot
+// fully express plus the ones it does (so the server rejects invalid
+// documents regardless of transport): replica ranges, watch-list mutual
+// exclusion, and broker service coherence.
+func ValidateControllersConfig(cfg *controllersconfig.MesheryControllersConfig) error {
+	if cfg == nil {
+		return nil
+	}
+	if ms := cfg.Meshsync; ms != nil {
+		if ms.Replicas != nil && (*ms.Replicas < 1 || *ms.Replicas > 10) {
+			return ErrControllersConfigInvalid("meshsync.replicas must be between 1 and 10")
+		}
+		if wl := ms.WatchList; wl != nil {
+			if len(wl.Whitelist) > 0 && len(wl.Blacklist) > 0 {
+				return ErrControllersConfigInvalid("meshsync.watchList: whitelist and blacklist are mutually exclusive; set at most one")
+			}
+			for _, entry := range wl.Whitelist {
+				if entry.Resource == "" {
+					return ErrControllersConfigInvalid("meshsync.watchList.whitelist entries must set resource")
+				}
+			}
+		}
+	}
+	if br := cfg.Broker; br != nil {
+		if br.Replicas != nil && (*br.Replicas < 1 || *br.Replicas > 10) {
+			return ErrControllersConfigInvalid("broker.replicas must be between 1 and 10")
+		}
+		if svc := br.Service; svc != nil {
+			if svc.Type != nil {
+				switch *svc.Type {
+				case controllersconfig.ClusterIP, controllersconfig.NodePort, controllersconfig.LoadBalancer:
+				default:
+					return ErrControllersConfigInvalid("broker.service.type must be one of ClusterIP, NodePort, LoadBalancer")
+				}
+			}
+			isLoadBalancer := svc.Type != nil && *svc.Type == controllersconfig.LoadBalancer
+			if !isLoadBalancer && svc.LoadBalancerClass != nil {
+				return ErrControllersConfigInvalid("broker.service.loadBalancerClass is only valid when broker.service.type is LoadBalancer")
+			}
+			if !isLoadBalancer && len(svc.LoadBalancerSourceRanges) > 0 {
+				return ErrControllersConfigInvalid("broker.service.loadBalancerSourceRanges is only valid when broker.service.type is LoadBalancer")
+			}
+		}
+	}
+	if op := cfg.Operator; op != nil && op.DeploymentMode != nil {
+		mode := MeshsyncDeploymentModeFromString(string(*op.DeploymentMode))
+		if mode == MeshsyncDeploymentModeUndefined {
+			return ErrControllersConfigInvalid("operator.deploymentMode must be either \"operator\" or \"embedded\"")
+		}
+	}
+	return nil
+}

--- a/server/models/connections/controllers_config_test.go
+++ b/server/models/connections/controllers_config_test.go
@@ -1,0 +1,250 @@
+package connections
+
+import (
+	"testing"
+
+	"github.com/meshery/schemas/models/core"
+	controllersconfig "github.com/meshery/schemas/models/v1alpha1/controllers_config"
+)
+
+func boolPtr(v bool) *bool    { return &v }
+func intPtr(v int) *int       { return &v }
+func strPtr(v string) *string { return &v }
+func modePtr(v controllersconfig.MesheryOperatorConfigDeploymentMode) *controllersconfig.MesheryOperatorConfigDeploymentMode {
+	return &v
+}
+
+func TestResolveControllersConfigPrecedence(t *testing.T) {
+	serverDefault := &controllersconfig.MesheryControllersConfig{
+		Operator: &controllersconfig.MesheryOperatorConfig{
+			DeploymentMode: modePtr(controllersconfig.Operator),
+		},
+		Meshsync: &controllersconfig.MeshSyncConfig{
+			Replicas:      intPtr(3),
+			RedactSecrets: boolPtr(true),
+			Version:       strPtr("v1.0.2"),
+		},
+		Broker: &controllersconfig.MesheryBrokerConfig{
+			Replicas: intPtr(3),
+		},
+	}
+	override := &controllersconfig.MesheryControllersConfig{
+		Meshsync: &controllersconfig.MeshSyncConfig{
+			Replicas: intPtr(5),
+		},
+	}
+
+	merged, effective := ResolveControllersConfig(override, serverDefault)
+
+	// Override wins for the field it sets.
+	if merged.Meshsync == nil || merged.Meshsync.Replicas == nil || *merged.Meshsync.Replicas != 5 {
+		t.Fatalf("expected merged meshsync.replicas=5 (override), got %+v", merged.Meshsync)
+	}
+	// Server default fills fields the override leaves unset.
+	if merged.Meshsync.RedactSecrets == nil || !*merged.Meshsync.RedactSecrets {
+		t.Fatalf("expected merged meshsync.redactSecrets=true (server default), got %+v", merged.Meshsync.RedactSecrets)
+	}
+	if merged.Meshsync.Version == nil || *merged.Meshsync.Version != "v1.0.2" {
+		t.Fatalf("expected merged meshsync.version=v1.0.2 (server default), got %+v", merged.Meshsync.Version)
+	}
+	if merged.Operator == nil || merged.Operator.DeploymentMode == nil || *merged.Operator.DeploymentMode != controllersconfig.Operator {
+		t.Fatalf("expected merged operator.deploymentMode=operator (server default), got %+v", merged.Operator)
+	}
+	// Fields no layer set stay unset in merged (nothing to propagate).
+	if merged.Meshsync.BrokerContentDedup != nil {
+		t.Fatalf("expected merged meshsync.brokerContentDedup unset, got %v", *merged.Meshsync.BrokerContentDedup)
+	}
+	// The effective view fills built-in defaults for unset fields.
+	if effective.Meshsync.BrokerContentDedup == nil || *effective.Meshsync.BrokerContentDedup {
+		t.Fatalf("expected effective meshsync.brokerContentDedup=false (built-in), got %+v", effective.Meshsync.BrokerContentDedup)
+	}
+	if effective.Broker == nil || effective.Broker.Service == nil || effective.Broker.Service.Type == nil || *effective.Broker.Service.Type != controllersconfig.ClusterIP {
+		t.Fatalf("expected effective broker.service.type=ClusterIP (built-in), got %+v", effective.Broker)
+	}
+	if effective.Broker.Replicas == nil || *effective.Broker.Replicas != 3 {
+		t.Fatalf("expected effective broker.replicas=3 (server default), got %+v", effective.Broker.Replicas)
+	}
+	if effective.SchemaVersion != ControllersConfigSchemaVersion {
+		t.Fatalf("expected schemaVersion stamped, got %q", effective.SchemaVersion)
+	}
+}
+
+func TestResolveControllersConfigNilLayers(t *testing.T) {
+	merged, effective := ResolveControllersConfig(nil, nil)
+	if merged != nil && (merged.Operator != nil || merged.Meshsync != nil || merged.Broker != nil) {
+		t.Fatalf("expected empty merged config for nil layers, got %+v", merged)
+	}
+	if effective == nil || effective.Meshsync == nil || effective.Meshsync.Replicas == nil || *effective.Meshsync.Replicas != 1 {
+		t.Fatalf("expected effective built-in meshsync.replicas=1, got %+v", effective)
+	}
+	if effective.Operator == nil || effective.Operator.DeploymentMode == nil || string(*effective.Operator.DeploymentMode) != string(MeshsyncDeploymentModeDefault) {
+		t.Fatalf("expected effective built-in deploymentMode=%s, got %+v", MeshsyncDeploymentModeDefault, effective.Operator)
+	}
+}
+
+func TestMergeControllersConfigWatchListAtomic(t *testing.T) {
+	base := &controllersconfig.MesheryControllersConfig{
+		Meshsync: &controllersconfig.MeshSyncConfig{
+			WatchList: &controllersconfig.MeshSyncWatchList{
+				Blacklist: []string{"secrets.v1."},
+			},
+		},
+	}
+	override := &controllersconfig.MesheryControllersConfig{
+		Meshsync: &controllersconfig.MeshSyncConfig{
+			WatchList: &controllersconfig.MeshSyncWatchList{
+				Whitelist: []controllersconfig.MeshSyncWatchedResource{
+					{Resource: "pods.v1.", Events: []controllersconfig.MeshSyncWatchedResourceEvents{controllersconfig.ADDED}},
+				},
+			},
+		},
+	}
+
+	merged := MergeControllersConfig(override, base)
+	wl := merged.Meshsync.WatchList
+	if wl == nil || len(wl.Whitelist) != 1 || len(wl.Blacklist) != 0 {
+		t.Fatalf("expected watchList replaced atomically by override (whitelist only), got %+v", wl)
+	}
+}
+
+func TestControllersConfigMetadataRoundTrip(t *testing.T) {
+	metadata := core.Map{}
+	cfg := &controllersconfig.MesheryControllersConfig{
+		Meshsync: &controllersconfig.MeshSyncConfig{
+			RedactSecrets:    boolPtr(true),
+			OutputNamespaces: []string{"default", "production"},
+		},
+	}
+	if err := SetControllersConfigToMetadata(metadata, cfg); err != nil {
+		t.Fatalf("SetControllersConfigToMetadata: %v", err)
+	}
+	if _, ok := metadata[ControllersConfigMetadataKey]; !ok {
+		t.Fatalf("expected metadata key %q to be set", ControllersConfigMetadataKey)
+	}
+
+	restored, err := ControllersConfigFromMetadata(metadata)
+	if err != nil {
+		t.Fatalf("ControllersConfigFromMetadata: %v", err)
+	}
+	if restored == nil || restored.Meshsync == nil || restored.Meshsync.RedactSecrets == nil || !*restored.Meshsync.RedactSecrets {
+		t.Fatalf("expected redactSecrets=true after round trip, got %+v", restored)
+	}
+	if len(restored.Meshsync.OutputNamespaces) != 2 || restored.Meshsync.OutputNamespaces[0] != "default" {
+		t.Fatalf("expected outputNamespaces preserved, got %+v", restored.Meshsync.OutputNamespaces)
+	}
+	if restored.SchemaVersion != ControllersConfigSchemaVersion {
+		t.Fatalf("expected schemaVersion stamped on stored override, got %q", restored.SchemaVersion)
+	}
+
+	// An empty document removes the override.
+	if err := SetControllersConfigToMetadata(metadata, &controllersconfig.MesheryControllersConfig{}); err != nil {
+		t.Fatalf("SetControllersConfigToMetadata (clear): %v", err)
+	}
+	if _, ok := metadata[ControllersConfigMetadataKey]; ok {
+		t.Fatalf("expected metadata key removed for empty document")
+	}
+	restored, err = ControllersConfigFromMetadata(metadata)
+	if err != nil || restored != nil {
+		t.Fatalf("expected nil config after clear, got %+v err=%v", restored, err)
+	}
+}
+
+func TestControllersConfigFromMetadataTolerance(t *testing.T) {
+	// Nil metadata inherits.
+	cfg, err := ControllersConfigFromMetadata(nil)
+	if err != nil || cfg != nil {
+		t.Fatalf("expected nil for nil metadata, got %+v err=%v", cfg, err)
+	}
+	// JSON-string-shaped values are tolerated.
+	metadata := core.Map{ControllersConfigMetadataKey: `{"meshsync":{"debugLogging":true}}`}
+	cfg, err = ControllersConfigFromMetadata(metadata)
+	if err != nil {
+		t.Fatalf("expected string value tolerated, got err=%v", err)
+	}
+	if cfg == nil || cfg.Meshsync == nil || cfg.Meshsync.DebugLogging == nil || !*cfg.Meshsync.DebugLogging {
+		t.Fatalf("expected debugLogging=true from string metadata, got %+v", cfg)
+	}
+	// Garbage is an error, not a panic.
+	metadata = core.Map{ControllersConfigMetadataKey: "{not json"}
+	if _, err := ControllersConfigFromMetadata(metadata); err == nil {
+		t.Fatalf("expected error for malformed metadata")
+	}
+}
+
+func TestValidateControllersConfig(t *testing.T) {
+	lb := controllersconfig.LoadBalancer
+	clusterIP := controllersconfig.ClusterIP
+	cases := []struct {
+		name    string
+		cfg     *controllersconfig.MesheryControllersConfig
+		wantErr bool
+	}{
+		{"nil config", nil, false},
+		{"valid replicas", &controllersconfig.MesheryControllersConfig{Meshsync: &controllersconfig.MeshSyncConfig{Replicas: intPtr(10)}}, false},
+		{"meshsync replicas too high", &controllersconfig.MesheryControllersConfig{Meshsync: &controllersconfig.MeshSyncConfig{Replicas: intPtr(11)}}, true},
+		{"meshsync replicas too low", &controllersconfig.MesheryControllersConfig{Meshsync: &controllersconfig.MeshSyncConfig{Replicas: intPtr(0)}}, true},
+		{"broker replicas too high", &controllersconfig.MesheryControllersConfig{Broker: &controllersconfig.MesheryBrokerConfig{Replicas: intPtr(11)}}, true},
+		{
+			"whitelist and blacklist together",
+			&controllersconfig.MesheryControllersConfig{Meshsync: &controllersconfig.MeshSyncConfig{WatchList: &controllersconfig.MeshSyncWatchList{
+				Whitelist: []controllersconfig.MeshSyncWatchedResource{{Resource: "pods.v1."}},
+				Blacklist: []string{"secrets.v1."},
+			}}},
+			true,
+		},
+		{
+			"whitelist entry missing resource",
+			&controllersconfig.MesheryControllersConfig{Meshsync: &controllersconfig.MeshSyncConfig{WatchList: &controllersconfig.MeshSyncWatchList{
+				Whitelist: []controllersconfig.MeshSyncWatchedResource{{Resource: ""}},
+			}}},
+			true,
+		},
+		{
+			"loadBalancerClass without LoadBalancer type",
+			&controllersconfig.MesheryControllersConfig{Broker: &controllersconfig.MesheryBrokerConfig{Service: &controllersconfig.MesheryBrokerServiceConfig{
+				Type:              &clusterIP,
+				LoadBalancerClass: strPtr("metallb"),
+			}}},
+			true,
+		},
+		{
+			"loadBalancerSourceRanges with LoadBalancer type",
+			&controllersconfig.MesheryControllersConfig{Broker: &controllersconfig.MesheryBrokerConfig{Service: &controllersconfig.MesheryBrokerServiceConfig{
+				Type:                     &lb,
+				LoadBalancerSourceRanges: []string{"10.0.0.0/8"},
+			}}},
+			false,
+		},
+		{
+			"invalid deployment mode",
+			&controllersconfig.MesheryControllersConfig{Operator: &controllersconfig.MesheryOperatorConfig{DeploymentMode: modePtr("sidecar")}},
+			true,
+		},
+		{
+			"valid deployment mode",
+			&controllersconfig.MesheryControllersConfig{Operator: &controllersconfig.MesheryOperatorConfig{DeploymentMode: modePtr(controllersconfig.Embedded)}},
+			false,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := ValidateControllersConfig(tc.cfg)
+			if tc.wantErr && err == nil {
+				t.Fatalf("expected validation error")
+			}
+			if !tc.wantErr && err != nil {
+				t.Fatalf("unexpected validation error: %v", err)
+			}
+		})
+	}
+}
+
+func TestDeploymentModeFromControllersConfig(t *testing.T) {
+	if got := DeploymentModeFromControllersConfig(nil); got != MeshsyncDeploymentModeUndefined {
+		t.Fatalf("expected undefined for nil config, got %s", got)
+	}
+	cfg := &controllersconfig.MesheryControllersConfig{Operator: &controllersconfig.MesheryOperatorConfig{DeploymentMode: modePtr(controllersconfig.Operator)}}
+	if got := DeploymentModeFromControllersConfig(cfg); got != MeshsyncDeploymentModeOperator {
+		t.Fatalf("expected operator mode, got %s", got)
+	}
+}

--- a/server/models/connections/error.go
+++ b/server/models/connections/error.go
@@ -1,0 +1,37 @@
+package connections
+
+import (
+	"github.com/meshery/meshkit/errors"
+)
+
+const (
+	ErrControllersConfigInvalidCode  = "meshery-server-1437"
+	ErrControllersConfigMetadataCode = "meshery-server-1438"
+)
+
+// ErrControllersConfigInvalid is returned when a controllers configuration
+// document violates a guardrail (replica range, watch-list mutual exclusion,
+// broker service coherence, or deployment-mode enum).
+func ErrControllersConfigInvalid(reason string) error {
+	return errors.New(
+		ErrControllersConfigInvalidCode,
+		errors.Alert,
+		[]string{"Invalid controllers configuration."},
+		[]string{reason},
+		[]string{"The submitted Meshery Operator / MeshSync / Broker configuration violates a validation rule."},
+		[]string{"Correct the highlighted field and resubmit. Replica counts must be 1-10, a watch list sets at most one of whitelist or blacklist, and load-balancer settings require the LoadBalancer service type."},
+	)
+}
+
+// ErrControllersConfigMetadata is returned when the controllers configuration
+// stored on a connection's metadata cannot be encoded or decoded.
+func ErrControllersConfigMetadata(err error) error {
+	return errors.New(
+		ErrControllersConfigMetadataCode,
+		errors.Alert,
+		[]string{"Unable to read or write the connection's controllers configuration."},
+		[]string{err.Error()},
+		[]string{"The controllers_config entry on the connection's metadata is not valid JSON or does not match the expected schema."},
+		[]string{"Clear the connection's controllers configuration override and reapply it from the Connections page."},
+	)
+}

--- a/server/models/controllers_config_apply.go
+++ b/server/models/controllers_config_apply.go
@@ -63,21 +63,25 @@ type ControllersConfigApplyResult struct {
 
 // ApplyControllersConfigToCluster propagates the merged (explicitly-set)
 // controllers configuration to a cluster running in operator deployment
-// mode:
+// mode. Every target is managed with server-side apply under the
+// meshery-server field manager, so the applied configuration always
+// describes the complete set of fields Meshery Server owns: setting a field
+// takes ownership, and unsetting it at every layer withdraws it on the next
+// apply, reverting to the operator's or chart's own value.
 //
 //   - MeshSync CR: spec.version, spec.size, spec.watch-list
 //   - Broker CR: spec.version, spec.size, spec.service
 //   - MeshSync Deployment: env (MESHSYNC_REDACT_SECRETS,
 //     MESHSYNC_BROKER_CONTENT_DEDUP, DEBUG) and args (--outputNamespaces,
-//     --outputResources) via server-side apply under the meshery-server
-//     field manager, so entries withdraw cleanly when unset and the
-//     operator's own apply never fights them.
+//     --outputResources)
 //
-// MeshSync reads its watch-list at startup only, so a watch-list change also
-// triggers a rolling restart of the MeshSync Deployment. Absent CRs or
-// Deployment (operator not deployed yet, or embedded-mode cluster) are
-// skipped and reported, not treated as errors: configuration re-applies when
-// the connection reconnects.
+// A nil merged document is applied as an empty one: that is the withdrawal
+// case (no layer sets anything anymore), not a no-op. MeshSync reads its
+// watch-list at startup only, so a watch-list change also triggers a rolling
+// restart of the MeshSync Deployment. Absent CRs or Deployment (operator not
+// deployed yet, or embedded-mode cluster) are skipped and reported, not
+// treated as errors: configuration re-applies when the connection
+// reconnects.
 func ApplyControllersConfigToCluster(
 	ctx context.Context,
 	log logger.Handler,
@@ -89,7 +93,7 @@ func ApplyControllersConfigToCluster(
 		return result, ErrApplyControllersConfig(k8serrors.NewBadRequest("no kubernetes client available for the connection"))
 	}
 	if merged == nil {
-		return result, nil
+		merged = &controllersconfig.MesheryControllersConfig{}
 	}
 
 	var applyErrs []error
@@ -116,20 +120,21 @@ func ApplyControllersConfigToCluster(
 	return result, nil
 }
 
-// applyMeshSyncCR merge-patches the MeshSync custom resource with the
-// explicitly-set fields. It returns whether the watch-list changed as a
-// result (which requires a MeshSync restart to take effect).
+// applyMeshSyncCR server-side-applies the explicitly-set MeshSync fields
+// onto the MeshSync custom resource under the meshery-server field manager.
+// The applied configuration always describes the complete owned set, so
+// fields cleared at every layer are withdrawn and revert to the operator's
+// or chart's own values. It returns whether the watch-list changed as a
+// result of the apply (which requires a MeshSync restart to take effect,
+// since MeshSync reads its CR at startup only).
 func applyMeshSyncCR(
 	ctx context.Context,
 	kubeClient *mesherykube.Client,
 	cfg *controllersconfig.MeshSyncConfig,
 	result *ControllersConfigApplyResult,
 ) (bool, error) {
-	if cfg == nil || (cfg.Version == nil && cfg.Replicas == nil && cfg.WatchList == nil) {
-		return false, nil
-	}
-
-	current, err := kubeClient.DynamicKubeClient.Resource(meshSyncGVR).Namespace(controllersNamespace).Get(ctx, meshSyncCRName, metav1.GetOptions{})
+	crClient := kubeClient.DynamicKubeClient.Resource(meshSyncGVR).Namespace(controllersNamespace)
+	before, err := crClient.Get(ctx, meshSyncCRName, metav1.GetOptions{})
 	if err != nil {
 		if k8serrors.IsNotFound(err) || isNoKindMatch(err) {
 			result.Skipped = append(result.Skipped, "MeshSync custom resource not present; watch-list, version, and replica settings apply when the Meshery Operator is deployed")
@@ -139,47 +144,58 @@ func applyMeshSyncCR(
 	}
 
 	spec := map[string]interface{}{}
-	if cfg.Version != nil {
-		spec["version"] = *cfg.Version
-	}
-	if cfg.Replicas != nil {
-		spec["size"] = *cfg.Replicas
-	}
-
-	watchListChanged := false
-	if cfg.WatchList != nil {
-		desiredData := map[string]interface{}{"whitelist": nil, "blacklist": nil}
-		if len(cfg.WatchList.Whitelist) > 0 {
-			encoded, err := json.Marshal(watchListWhitelistWireEntries(cfg.WatchList.Whitelist))
-			if err != nil {
-				return false, err
-			}
-			desiredData["whitelist"] = string(encoded)
+	if cfg != nil {
+		if cfg.Version != nil {
+			spec["version"] = *cfg.Version
 		}
-		if len(cfg.WatchList.Blacklist) > 0 {
-			encoded, err := json.Marshal(cfg.WatchList.Blacklist)
-			if err != nil {
-				return false, err
-			}
-			desiredData["blacklist"] = string(encoded)
+		if cfg.Replicas != nil {
+			spec["size"] = *cfg.Replicas
 		}
-		spec["watch-list"] = map[string]interface{}{"data": desiredData}
-		watchListChanged = !watchListDataEqual(current.Object, desiredData)
+		if cfg.WatchList != nil {
+			// Claim both keys whenever a watch-list is managed: the unused
+			// key is set to the empty string (which MeshSync ignores) so a
+			// pre-existing chart-set counterpart cannot linger alongside the
+			// managed key and trip MeshSync's whitelist-XOR-blacklist
+			// validation. Withdrawing the watch-list releases both keys.
+			data := map[string]interface{}{"whitelist": "", "blacklist": ""}
+			if len(cfg.WatchList.Whitelist) > 0 {
+				encoded, err := json.Marshal(watchListWhitelistWireEntries(cfg.WatchList.Whitelist))
+				if err != nil {
+					return false, err
+				}
+				data["whitelist"] = string(encoded)
+			}
+			if len(cfg.WatchList.Blacklist) > 0 {
+				encoded, err := json.Marshal(cfg.WatchList.Blacklist)
+				if err != nil {
+					return false, err
+				}
+				data["blacklist"] = string(encoded)
+			}
+			spec["watch-list"] = map[string]interface{}{"data": data}
+		}
 	}
 
-	if len(spec) == 0 {
-		return false, nil
+	applyConfig := map[string]interface{}{
+		"apiVersion": meshSyncGVR.Group + "/" + meshSyncGVR.Version,
+		"kind":       "MeshSync",
+		"metadata": map[string]interface{}{
+			"name":      meshSyncCRName,
+			"namespace": controllersNamespace,
+		},
+		"spec": spec,
 	}
-
-	patch, err := json.Marshal(map[string]interface{}{"spec": spec})
+	payload, err := json.Marshal(applyConfig)
 	if err != nil {
 		return false, err
 	}
-	if _, err := kubeClient.DynamicKubeClient.Resource(meshSyncGVR).Namespace(controllersNamespace).Patch(ctx, meshSyncCRName, types.MergePatchType, patch, metav1.PatchOptions{}); err != nil {
+	force := true
+	after, err := crClient.Patch(ctx, meshSyncCRName, types.ApplyPatchType, payload, metav1.PatchOptions{FieldManager: controllersConfigFieldManager, Force: &force})
+	if err != nil {
 		return false, err
 	}
 	result.MeshSyncCRPatched = true
-	return watchListChanged, nil
+	return !watchListDataEqual(before.Object, after.Object), nil
 }
 
 // watchListWhitelistWireEntries converts schema whitelist entries into the
@@ -201,29 +217,28 @@ func watchListWhitelistWireEntries(entries []controllersconfig.MeshSyncWatchedRe
 	return wire
 }
 
-// watchListDataEqual compares the current CR's spec.watch-list.data with the
-// desired data map (string values; nil means absent).
-func watchListDataEqual(currentObj map[string]interface{}, desired map[string]interface{}) bool {
-	currentData := map[string]interface{}{}
-	if spec, ok := currentObj["spec"].(map[string]interface{}); ok {
-		if wl, ok := spec["watch-list"].(map[string]interface{}); ok {
-			if data, ok := wl["data"].(map[string]interface{}); ok {
-				currentData = data
+// watchListDataEqual reports whether two MeshSync CR objects carry the same
+// effective spec.watch-list.data (whitelist/blacklist), comparing the JSON
+// values regardless of formatting. Absent and empty entries are equivalent.
+func watchListDataEqual(a, b map[string]interface{}) bool {
+	dataOf := func(obj map[string]interface{}) map[string]interface{} {
+		if spec, ok := obj["spec"].(map[string]interface{}); ok {
+			if wl, ok := spec["watch-list"].(map[string]interface{}); ok {
+				if data, ok := wl["data"].(map[string]interface{}); ok {
+					return data
+				}
 			}
 		}
+		return map[string]interface{}{}
 	}
+	aData, bData := dataOf(a), dataOf(b)
 	for _, key := range []string{"whitelist", "blacklist"} {
-		currentValue, hasCurrent := currentData[key]
-		desiredValue := desired[key]
-		if desiredValue == nil {
-			currentString, _ := currentValue.(string)
-			if hasCurrent && currentString != "" {
-				return false
-			}
+		aString, _ := aData[key].(string)
+		bString, _ := bData[key].(string)
+		if aString == "" && bString == "" {
 			continue
 		}
-		currentString, _ := currentValue.(string)
-		if !hasCurrent || !jsonStringsEquivalent(currentString, desiredValue.(string)) {
+		if !jsonStringsEquivalent(aString, bString) {
 			return false
 		}
 	}
@@ -243,20 +258,19 @@ func jsonStringsEquivalent(a, b string) bool {
 	return reflect.DeepEqual(av, bv)
 }
 
-// applyBrokerCR merge-patches the Broker custom resource with the
-// explicitly-set fields. Broker service changes reconcile in place; version
-// and size changes roll the NATS statefulset under operator control.
+// applyBrokerCR server-side-applies the explicitly-set Broker fields onto
+// the Broker custom resource under the meshery-server field manager, with
+// the same complete-owned-set withdrawal semantics as applyMeshSyncCR.
+// Broker service changes reconcile in place; version and size changes roll
+// the NATS statefulset under operator control.
 func applyBrokerCR(
 	ctx context.Context,
 	kubeClient *mesherykube.Client,
 	cfg *controllersconfig.MesheryBrokerConfig,
 	result *ControllersConfigApplyResult,
 ) error {
-	if cfg == nil || (cfg.Version == nil && cfg.Replicas == nil && cfg.Service == nil) {
-		return nil
-	}
-
-	if _, err := kubeClient.DynamicKubeClient.Resource(brokerGVR).Namespace(controllersNamespace).Get(ctx, brokerCRName, metav1.GetOptions{}); err != nil {
+	crClient := kubeClient.DynamicKubeClient.Resource(brokerGVR).Namespace(controllersNamespace)
+	if _, err := crClient.Get(ctx, brokerCRName, metav1.GetOptions{}); err != nil {
 		if k8serrors.IsNotFound(err) || isNoKindMatch(err) {
 			result.Skipped = append(result.Skipped, "Broker custom resource not present; broker settings apply when the Meshery Operator is deployed")
 			return nil
@@ -265,42 +279,51 @@ func applyBrokerCR(
 	}
 
 	spec := map[string]interface{}{}
-	if cfg.Version != nil {
-		spec["version"] = *cfg.Version
-	}
-	if cfg.Replicas != nil {
-		spec["size"] = *cfg.Replicas
-	}
-	if svc := cfg.Service; svc != nil {
-		service := map[string]interface{}{}
-		if svc.Type != nil {
-			service["type"] = string(*svc.Type)
+	if cfg != nil {
+		if cfg.Version != nil {
+			spec["version"] = *cfg.Version
 		}
-		if svc.Annotations != nil {
-			service["annotations"] = svc.Annotations
+		if cfg.Replicas != nil {
+			spec["size"] = *cfg.Replicas
 		}
-		if svc.LoadBalancerClass != nil {
-			service["loadBalancerClass"] = *svc.LoadBalancerClass
+		if svc := cfg.Service; svc != nil {
+			service := map[string]interface{}{}
+			if svc.Type != nil {
+				service["type"] = string(*svc.Type)
+			}
+			if svc.Annotations != nil {
+				service["annotations"] = svc.Annotations
+			}
+			if svc.LoadBalancerClass != nil {
+				service["loadBalancerClass"] = *svc.LoadBalancerClass
+			}
+			if svc.LoadBalancerSourceRanges != nil {
+				service["loadBalancerSourceRanges"] = svc.LoadBalancerSourceRanges
+			}
+			if svc.ExternalEndpointOverride != nil {
+				service["externalEndpointOverride"] = *svc.ExternalEndpointOverride
+			}
+			if len(service) > 0 {
+				spec["service"] = service
+			}
 		}
-		if svc.LoadBalancerSourceRanges != nil {
-			service["loadBalancerSourceRanges"] = svc.LoadBalancerSourceRanges
-		}
-		if svc.ExternalEndpointOverride != nil {
-			service["externalEndpointOverride"] = *svc.ExternalEndpointOverride
-		}
-		if len(service) > 0 {
-			spec["service"] = service
-		}
-	}
-	if len(spec) == 0 {
-		return nil
 	}
 
-	patch, err := json.Marshal(map[string]interface{}{"spec": spec})
+	applyConfig := map[string]interface{}{
+		"apiVersion": brokerGVR.Group + "/" + brokerGVR.Version,
+		"kind":       "Broker",
+		"metadata": map[string]interface{}{
+			"name":      brokerCRName,
+			"namespace": controllersNamespace,
+		},
+		"spec": spec,
+	}
+	payload, err := json.Marshal(applyConfig)
 	if err != nil {
 		return err
 	}
-	if _, err := kubeClient.DynamicKubeClient.Resource(brokerGVR).Namespace(controllersNamespace).Patch(ctx, brokerCRName, types.MergePatchType, patch, metav1.PatchOptions{}); err != nil {
+	force := true
+	if _, err := crClient.Patch(ctx, brokerCRName, types.ApplyPatchType, payload, metav1.PatchOptions{FieldManager: controllersConfigFieldManager, Force: &force}); err != nil {
 		return err
 	}
 	result.BrokerCRPatched = true

--- a/server/models/controllers_config_apply.go
+++ b/server/models/controllers_config_apply.go
@@ -1,0 +1,418 @@
+package models
+
+import (
+	"context"
+	"encoding/json"
+	goerrors "errors"
+	"reflect"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/meshery/meshkit/logger"
+	mesherykube "github.com/meshery/meshkit/utils/kubernetes"
+	controllersconfig "github.com/meshery/schemas/models/v1alpha1/controllers_config"
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/types"
+)
+
+const (
+	// controllersNamespace is where the Meshery Operator deploys the MeshSync
+	// and Broker workloads and their custom resources.
+	controllersNamespace = "meshery"
+	// meshSyncCRName is the MeshSync custom resource the operator chart
+	// installs and the MeshSync agent reads its watch-list from.
+	meshSyncCRName = "meshery-meshsync"
+	// brokerCRName is the Broker custom resource the operator chart installs.
+	brokerCRName = "meshery-broker"
+	// meshSyncDeploymentName is the Deployment the operator reconciles for
+	// the MeshSync CR (same name as the CR).
+	meshSyncDeploymentName = "meshery-meshsync"
+	// meshSyncContainerName is the MeshSync container within that Deployment.
+	meshSyncContainerName = "meshsync"
+	// controllersConfigFieldManager is the server-side-apply field manager
+	// Meshery Server uses for its Deployment overlay. The operator applies
+	// the Deployment under its own field manager and never sets these env
+	// names, args, or the restart annotation, so ownership stays disjoint.
+	controllersConfigFieldManager = "meshery-server"
+	// meshSyncRestartAnnotation triggers a rolling restart of MeshSync pods
+	// when its value changes (same mechanism as kubectl rollout restart).
+	meshSyncRestartAnnotation = "meshery.io/restarted-at"
+
+	envRedactSecrets      = "MESHSYNC_REDACT_SECRETS"
+	envBrokerContentDedup = "MESHSYNC_BROKER_CONTENT_DEDUP"
+	envDebug              = "DEBUG"
+)
+
+var (
+	meshSyncGVR = schema.GroupVersionResource{Group: "meshery.io", Version: "v1alpha1", Resource: "meshsyncs"}
+	brokerGVR   = schema.GroupVersionResource{Group: "meshery.io", Version: "v1alpha1", Resource: "brokers"}
+)
+
+// ControllersConfigApplyResult reports which propagation targets a
+// configuration apply reached on a cluster.
+type ControllersConfigApplyResult struct {
+	MeshSyncCRPatched        bool     `json:"meshSyncCRPatched"`
+	BrokerCRPatched          bool     `json:"brokerCRPatched"`
+	DeploymentOverlayApplied bool     `json:"deploymentOverlayApplied"`
+	MeshSyncRestarted        bool     `json:"meshSyncRestarted"`
+	Skipped                  []string `json:"skipped,omitempty"`
+}
+
+// ApplyControllersConfigToCluster propagates the merged (explicitly-set)
+// controllers configuration to a cluster running in operator deployment
+// mode:
+//
+//   - MeshSync CR: spec.version, spec.size, spec.watch-list
+//   - Broker CR: spec.version, spec.size, spec.service
+//   - MeshSync Deployment: env (MESHSYNC_REDACT_SECRETS,
+//     MESHSYNC_BROKER_CONTENT_DEDUP, DEBUG) and args (--outputNamespaces,
+//     --outputResources) via server-side apply under the meshery-server
+//     field manager, so entries withdraw cleanly when unset and the
+//     operator's own apply never fights them.
+//
+// MeshSync reads its watch-list at startup only, so a watch-list change also
+// triggers a rolling restart of the MeshSync Deployment. Absent CRs or
+// Deployment (operator not deployed yet, or embedded-mode cluster) are
+// skipped and reported, not treated as errors: configuration re-applies when
+// the connection reconnects.
+func ApplyControllersConfigToCluster(
+	ctx context.Context,
+	log logger.Handler,
+	kubeClient *mesherykube.Client,
+	merged *controllersconfig.MesheryControllersConfig,
+) (*ControllersConfigApplyResult, error) {
+	result := &ControllersConfigApplyResult{}
+	if kubeClient == nil {
+		return result, ErrApplyControllersConfig(k8serrors.NewBadRequest("no kubernetes client available for the connection"))
+	}
+	if merged == nil {
+		return result, nil
+	}
+
+	var applyErrs []error
+
+	watchListChanged, err := applyMeshSyncCR(ctx, kubeClient, merged.Meshsync, result)
+	if err != nil {
+		applyErrs = append(applyErrs, err)
+	}
+
+	if err := applyBrokerCR(ctx, kubeClient, merged.Broker, result); err != nil {
+		applyErrs = append(applyErrs, err)
+	}
+
+	if err := applyMeshSyncDeploymentOverlay(ctx, kubeClient, merged.Meshsync, watchListChanged, result); err != nil {
+		applyErrs = append(applyErrs, err)
+	}
+
+	if len(applyErrs) > 0 {
+		return result, ErrApplyControllersConfig(goerrors.Join(applyErrs...))
+	}
+	if log != nil {
+		log.Debugf("controllers config applied: %+v", result)
+	}
+	return result, nil
+}
+
+// applyMeshSyncCR merge-patches the MeshSync custom resource with the
+// explicitly-set fields. It returns whether the watch-list changed as a
+// result (which requires a MeshSync restart to take effect).
+func applyMeshSyncCR(
+	ctx context.Context,
+	kubeClient *mesherykube.Client,
+	cfg *controllersconfig.MeshSyncConfig,
+	result *ControllersConfigApplyResult,
+) (bool, error) {
+	if cfg == nil || (cfg.Version == nil && cfg.Replicas == nil && cfg.WatchList == nil) {
+		return false, nil
+	}
+
+	current, err := kubeClient.DynamicKubeClient.Resource(meshSyncGVR).Namespace(controllersNamespace).Get(ctx, meshSyncCRName, metav1.GetOptions{})
+	if err != nil {
+		if k8serrors.IsNotFound(err) || isNoKindMatch(err) {
+			result.Skipped = append(result.Skipped, "MeshSync custom resource not present; watch-list, version, and replica settings apply when the Meshery Operator is deployed")
+			return false, nil
+		}
+		return false, err
+	}
+
+	spec := map[string]interface{}{}
+	if cfg.Version != nil {
+		spec["version"] = *cfg.Version
+	}
+	if cfg.Replicas != nil {
+		spec["size"] = *cfg.Replicas
+	}
+
+	watchListChanged := false
+	if cfg.WatchList != nil {
+		desiredData := map[string]interface{}{"whitelist": nil, "blacklist": nil}
+		if len(cfg.WatchList.Whitelist) > 0 {
+			encoded, err := json.Marshal(watchListWhitelistWireEntries(cfg.WatchList.Whitelist))
+			if err != nil {
+				return false, err
+			}
+			desiredData["whitelist"] = string(encoded)
+		}
+		if len(cfg.WatchList.Blacklist) > 0 {
+			encoded, err := json.Marshal(cfg.WatchList.Blacklist)
+			if err != nil {
+				return false, err
+			}
+			desiredData["blacklist"] = string(encoded)
+		}
+		spec["watch-list"] = map[string]interface{}{"data": desiredData}
+		watchListChanged = !watchListDataEqual(current.Object, desiredData)
+	}
+
+	if len(spec) == 0 {
+		return false, nil
+	}
+
+	patch, err := json.Marshal(map[string]interface{}{"spec": spec})
+	if err != nil {
+		return false, err
+	}
+	if _, err := kubeClient.DynamicKubeClient.Resource(meshSyncGVR).Namespace(controllersNamespace).Patch(ctx, meshSyncCRName, types.MergePatchType, patch, metav1.PatchOptions{}); err != nil {
+		return false, err
+	}
+	result.MeshSyncCRPatched = true
+	return watchListChanged, nil
+}
+
+// watchListWhitelistWireEntries converts schema whitelist entries into the
+// wire shape MeshSync's config parser expects: {"Resource": ..., "Events":
+// [...]} with Go-style field names (meshsync unmarshals into an untagged
+// struct).
+func watchListWhitelistWireEntries(entries []controllersconfig.MeshSyncWatchedResource) []map[string]interface{} {
+	wire := make([]map[string]interface{}, 0, len(entries))
+	for _, entry := range entries {
+		events := make([]string, 0, len(entry.Events))
+		for _, ev := range entry.Events {
+			events = append(events, string(ev))
+		}
+		wire = append(wire, map[string]interface{}{
+			"Resource": entry.Resource,
+			"Events":   events,
+		})
+	}
+	return wire
+}
+
+// watchListDataEqual compares the current CR's spec.watch-list.data with the
+// desired data map (string values; nil means absent).
+func watchListDataEqual(currentObj map[string]interface{}, desired map[string]interface{}) bool {
+	currentData := map[string]interface{}{}
+	if spec, ok := currentObj["spec"].(map[string]interface{}); ok {
+		if wl, ok := spec["watch-list"].(map[string]interface{}); ok {
+			if data, ok := wl["data"].(map[string]interface{}); ok {
+				currentData = data
+			}
+		}
+	}
+	for _, key := range []string{"whitelist", "blacklist"} {
+		currentValue, hasCurrent := currentData[key]
+		desiredValue := desired[key]
+		if desiredValue == nil {
+			currentString, _ := currentValue.(string)
+			if hasCurrent && currentString != "" {
+				return false
+			}
+			continue
+		}
+		currentString, _ := currentValue.(string)
+		if !hasCurrent || !jsonStringsEquivalent(currentString, desiredValue.(string)) {
+			return false
+		}
+	}
+	return true
+}
+
+// jsonStringsEquivalent reports whether two JSON documents encoded as strings
+// carry the same value regardless of formatting.
+func jsonStringsEquivalent(a, b string) bool {
+	var av, bv interface{}
+	if err := json.Unmarshal([]byte(a), &av); err != nil {
+		return a == b
+	}
+	if err := json.Unmarshal([]byte(b), &bv); err != nil {
+		return a == b
+	}
+	return reflect.DeepEqual(av, bv)
+}
+
+// applyBrokerCR merge-patches the Broker custom resource with the
+// explicitly-set fields. Broker service changes reconcile in place; version
+// and size changes roll the NATS statefulset under operator control.
+func applyBrokerCR(
+	ctx context.Context,
+	kubeClient *mesherykube.Client,
+	cfg *controllersconfig.MesheryBrokerConfig,
+	result *ControllersConfigApplyResult,
+) error {
+	if cfg == nil || (cfg.Version == nil && cfg.Replicas == nil && cfg.Service == nil) {
+		return nil
+	}
+
+	if _, err := kubeClient.DynamicKubeClient.Resource(brokerGVR).Namespace(controllersNamespace).Get(ctx, brokerCRName, metav1.GetOptions{}); err != nil {
+		if k8serrors.IsNotFound(err) || isNoKindMatch(err) {
+			result.Skipped = append(result.Skipped, "Broker custom resource not present; broker settings apply when the Meshery Operator is deployed")
+			return nil
+		}
+		return err
+	}
+
+	spec := map[string]interface{}{}
+	if cfg.Version != nil {
+		spec["version"] = *cfg.Version
+	}
+	if cfg.Replicas != nil {
+		spec["size"] = *cfg.Replicas
+	}
+	if svc := cfg.Service; svc != nil {
+		service := map[string]interface{}{}
+		if svc.Type != nil {
+			service["type"] = string(*svc.Type)
+		}
+		if svc.Annotations != nil {
+			service["annotations"] = svc.Annotations
+		}
+		if svc.LoadBalancerClass != nil {
+			service["loadBalancerClass"] = *svc.LoadBalancerClass
+		}
+		if svc.LoadBalancerSourceRanges != nil {
+			service["loadBalancerSourceRanges"] = svc.LoadBalancerSourceRanges
+		}
+		if svc.ExternalEndpointOverride != nil {
+			service["externalEndpointOverride"] = *svc.ExternalEndpointOverride
+		}
+		if len(service) > 0 {
+			spec["service"] = service
+		}
+	}
+	if len(spec) == 0 {
+		return nil
+	}
+
+	patch, err := json.Marshal(map[string]interface{}{"spec": spec})
+	if err != nil {
+		return err
+	}
+	if _, err := kubeClient.DynamicKubeClient.Resource(brokerGVR).Namespace(controllersNamespace).Patch(ctx, brokerCRName, types.MergePatchType, patch, metav1.PatchOptions{}); err != nil {
+		return err
+	}
+	result.BrokerCRPatched = true
+	return nil
+}
+
+// applyMeshSyncDeploymentOverlay server-side-applies Meshery Server's
+// env/args overlay onto the MeshSync Deployment. The applied configuration
+// always describes the complete set of fields this field manager owns, so
+// clearing a knob at every layer withdraws its env entry or argument on the
+// next apply. When restartMeshSync is true (watch-list changed), the pod
+// template restart annotation is refreshed; otherwise any previously-applied
+// annotation value is carried forward unchanged so the apply itself does not
+// roll pods.
+func applyMeshSyncDeploymentOverlay(
+	ctx context.Context,
+	kubeClient *mesherykube.Client,
+	cfg *controllersconfig.MeshSyncConfig,
+	restartMeshSync bool,
+	result *ControllersConfigApplyResult,
+) error {
+	deployment, err := kubeClient.KubeClient.AppsV1().Deployments(controllersNamespace).Get(ctx, meshSyncDeploymentName, metav1.GetOptions{})
+	if err != nil {
+		if k8serrors.IsNotFound(err) {
+			result.Skipped = append(result.Skipped, "MeshSync deployment not present; env and output-filter settings apply when the Meshery Operator has deployed MeshSync")
+			return nil
+		}
+		return err
+	}
+
+	env := []map[string]interface{}{}
+	args := []string{}
+	if cfg != nil {
+		if cfg.RedactSecrets != nil {
+			env = append(env, map[string]interface{}{"name": envRedactSecrets, "value": strconv.FormatBool(*cfg.RedactSecrets)})
+		}
+		if cfg.BrokerContentDedup != nil {
+			env = append(env, map[string]interface{}{"name": envBrokerContentDedup, "value": strconv.FormatBool(*cfg.BrokerContentDedup)})
+		}
+		if cfg.DebugLogging != nil {
+			env = append(env, map[string]interface{}{"name": envDebug, "value": strconv.FormatBool(*cfg.DebugLogging)})
+		}
+		if len(cfg.OutputNamespaces) > 0 {
+			args = append(args, "--outputNamespaces="+strings.Join(cfg.OutputNamespaces, ","))
+		}
+		if len(cfg.OutputResources) > 0 {
+			args = append(args, "--outputResources="+strings.Join(cfg.OutputResources, ","))
+		}
+	}
+
+	container := map[string]interface{}{"name": meshSyncContainerName}
+	if len(env) > 0 {
+		container["env"] = env
+	}
+	if len(args) > 0 {
+		container["args"] = args
+	}
+
+	templateMeta := map[string]interface{}{}
+	previousRestartValue := deployment.Spec.Template.Annotations[meshSyncRestartAnnotation]
+	switch {
+	case restartMeshSync:
+		templateMeta["annotations"] = map[string]interface{}{meshSyncRestartAnnotation: time.Now().UTC().Format(time.RFC3339)}
+		result.MeshSyncRestarted = true
+	case previousRestartValue != "":
+		// Carry the previously-applied annotation forward: dropping it from
+		// this manager's applied set would remove it from the pod template,
+		// which itself rolls the pods.
+		templateMeta["annotations"] = map[string]interface{}{meshSyncRestartAnnotation: previousRestartValue}
+	}
+
+	template := map[string]interface{}{
+		"spec": map[string]interface{}{
+			"containers": []interface{}{container},
+		},
+	}
+	if len(templateMeta) > 0 {
+		template["metadata"] = templateMeta
+	}
+
+	applyConfig := map[string]interface{}{
+		"apiVersion": "apps/v1",
+		"kind":       "Deployment",
+		"metadata": map[string]interface{}{
+			"name":      meshSyncDeploymentName,
+			"namespace": controllersNamespace,
+		},
+		"spec": map[string]interface{}{
+			"template": template,
+		},
+	}
+
+	payload, err := json.Marshal(applyConfig)
+	if err != nil {
+		return err
+	}
+	force := true
+	if _, err := kubeClient.KubeClient.AppsV1().Deployments(controllersNamespace).Patch(ctx, meshSyncDeploymentName, types.ApplyPatchType, payload, metav1.PatchOptions{FieldManager: controllersConfigFieldManager, Force: &force}); err != nil {
+		return err
+	}
+	result.DeploymentOverlayApplied = true
+	return nil
+}
+
+// isNoKindMatch reports whether the error indicates the CRD itself is not
+// installed on the cluster (embedded-mode clusters never install the
+// meshery.io CRDs).
+func isNoKindMatch(err error) bool {
+	if err == nil {
+		return false
+	}
+	return strings.Contains(err.Error(), "no matches for kind") ||
+		strings.Contains(err.Error(), "could not find the requested resource") ||
+		strings.Contains(err.Error(), "the server could not find the requested resource")
+}

--- a/server/models/error.go
+++ b/server/models/error.go
@@ -152,6 +152,8 @@ const (
 	ErrRemoteProviderCapabilitiesCode     = "meshery-server-1420"
 	ErrRemoteProviderAuthExhaustedCode    = "meshery-server-1421"
 	ErrInvalidUUIDValueCode               = "meshery-server-1432"
+	ErrSystemSettingsCode                 = "meshery-server-1439"
+	ErrApplyControllersConfigCode         = "meshery-server-1440"
 )
 
 var (
@@ -688,4 +690,17 @@ func ErrMeshsyncEvent(err error) error {
 
 func ErrMeshsyncStoreUpdates(err error) error {
 	return errors.New(ErrMeshsyncStoreUpdatesCode, errors.Alert, []string{"Error processing MeshSync store update"}, []string{err.Error()}, []string{"MeshSync encountered an error while processing a store update event"}, []string{"Check MeshSync store logs. Verify that the database connection is active and the store is not corrupted."})
+}
+
+// ErrSystemSettings wraps failures reading or writing Meshery Server's
+// server-wide system settings store.
+func ErrSystemSettings(err error) error {
+	return errors.New(ErrSystemSettingsCode, errors.Alert, []string{"Error accessing server-wide system settings"}, []string{err.Error()}, []string{"The system_settings store could not be read or written, or the stored value is not valid JSON."}, []string{"Verify Meshery Server's database is reachable and writable, then retry the operation."})
+}
+
+// ErrApplyControllersConfig wraps failures propagating a resolved
+// controllers configuration (Meshery Operator / MeshSync / Broker) to a
+// managed cluster.
+func ErrApplyControllersConfig(err error) error {
+	return errors.New(ErrApplyControllersConfigCode, errors.Alert, []string{"Error applying controllers configuration to the cluster"}, []string{err.Error()}, []string{"The MeshSync or Broker custom resource could not be patched, or the MeshSync deployment overlay could not be applied.", "The Meshery Operator may not be deployed on the target cluster yet."}, []string{"Confirm the cluster is reachable and the Meshery Operator is deployed (operator deployment mode).", "Retry the change; configuration is re-applied whenever the connection reconnects."})
 }

--- a/server/models/handlers.go
+++ b/server/models/handlers.go
@@ -214,6 +214,11 @@ type HandlerInterface interface {
 	DeleteConnection(w http.ResponseWriter, req *http.Request, prefObj *Preference, user *User, provider Provider)
 	ProcessConnectionRegistration(w http.ResponseWriter, req *http.Request, prefObj *Preference, user *User, provider Provider)
 
+	GetControllersDefaultConfig(w http.ResponseWriter, req *http.Request, prefObj *Preference, user *User, provider Provider)
+	UpdateControllersDefaultConfig(w http.ResponseWriter, req *http.Request, prefObj *Preference, user *User, provider Provider)
+	GetConnectionControllersConfig(w http.ResponseWriter, req *http.Request, prefObj *Preference, user *User, provider Provider)
+	UpdateConnectionControllersConfig(w http.ResponseWriter, req *http.Request, prefObj *Preference, user *User, provider Provider)
+
 	ExportModel(w http.ResponseWriter, req *http.Request)
 
 	GetEnvironments(w http.ResponseWriter, req *http.Request, prefObj *Preference, user *User, provider Provider)

--- a/server/models/meshery_controllers.go
+++ b/server/models/meshery_controllers.go
@@ -130,10 +130,19 @@ func (mch *MesheryControllersHelper) SetControllersConfig(value *controllersconf
 // configuration for a connection's metadata against the server-wide defaults
 // persisted in this server's database. It returns the merged
 // (explicitly-set) document and the fully-resolved effective document.
+//
+// A malformed per-connection override invalidates only the override layer:
+// it is logged and treated as absent so the Settings defaults still apply
+// (the per-connection GET endpoint surfaces the parse error to the user).
+// A non-nil error therefore always means the defaults store itself failed,
+// in which case no resolution is returned.
 func (mch *MesheryControllersHelper) ResolveControllersConfigForConnection(metadata core.Map) (merged, effective *controllersconfig.MesheryControllersConfig, err error) {
-	override, err := connections.ControllersConfigFromMetadata(metadata)
-	if err != nil {
-		return nil, nil, err
+	override, overrideErr := connections.ControllersConfigFromMetadata(metadata)
+	if overrideErr != nil {
+		if mch.log != nil {
+			mch.log.Error(overrideErr)
+		}
+		override = nil
 	}
 	serverDefaults, err := GetControllersConfigDefaults(mch.dbHandler)
 	if err != nil {

--- a/server/models/meshery_controllers.go
+++ b/server/models/meshery_controllers.go
@@ -12,6 +12,7 @@ import (
 	"maps"
 
 	"github.com/gofrs/uuid"
+	"github.com/meshery/meshery/server/models/connections"
 	"github.com/meshery/meshkit/broker"
 	channelBroker "github.com/meshery/meshkit/broker/channel"
 	"github.com/meshery/meshkit/broker/nats"
@@ -22,7 +23,7 @@ import (
 	"github.com/meshery/meshkit/utils"
 	mesherykube "github.com/meshery/meshkit/utils/kubernetes"
 	libmeshsync "github.com/meshery/meshsync/pkg/lib/meshsync"
-	"github.com/meshery/meshery/server/models/connections"
+	controllersconfig "github.com/meshery/schemas/models/v1alpha1/controllers_config"
 	"github.com/spf13/viper"
 )
 
@@ -62,6 +63,13 @@ type MesheryControllersHelper struct {
 	dbHandler    *database.Handler
 
 	meshsyncDeploymentMode connections.MeshsyncDeploymentMode
+
+	// controllersConfig is the resolved (merged, explicitly-set) Meshery
+	// Operator / MeshSync / Broker configuration for the context this helper
+	// serves: per-connection override merged over the server-wide defaults.
+	// Set alongside the deployment mode when a connection connects or its
+	// configuration changes; consumed by the embedded meshsync run options.
+	controllersConfig *controllersconfig.MesheryControllersConfig
 
 	// event broadcasting dependencies
 	eventBroadcaster *Broadcast
@@ -109,6 +117,30 @@ func NewMesheryControllersHelper(
 func (mch *MesheryControllersHelper) SetMeshsyncDeploymentMode(value connections.MeshsyncDeploymentMode) *MesheryControllersHelper {
 	mch.meshsyncDeploymentMode = value
 	return mch
+}
+
+// SetControllersConfig stashes the resolved controllers configuration for the
+// context this helper serves. Chainable, mirroring SetMeshsyncDeploymentMode.
+func (mch *MesheryControllersHelper) SetControllersConfig(value *controllersconfig.MesheryControllersConfig) *MesheryControllersHelper {
+	mch.controllersConfig = value
+	return mch
+}
+
+// ResolveControllersConfigForConnection resolves the layered controllers
+// configuration for a connection's metadata against the server-wide defaults
+// persisted in this server's database. It returns the merged
+// (explicitly-set) document and the fully-resolved effective document.
+func (mch *MesheryControllersHelper) ResolveControllersConfigForConnection(metadata core.Map) (merged, effective *controllersconfig.MesheryControllersConfig, err error) {
+	override, err := connections.ControllersConfigFromMetadata(metadata)
+	if err != nil {
+		return nil, nil, err
+	}
+	serverDefaults, err := GetControllersConfigDefaults(mch.dbHandler)
+	if err != nil {
+		return nil, nil, err
+	}
+	merged, effective = connections.ResolveControllersConfig(override, serverDefaults)
+	return merged, effective, nil
 }
 
 // initializes Meshsync data handler for the contexts for whom it has not been
@@ -277,13 +309,31 @@ func (mch *MesheryControllersHelper) meshsynDataHandlersStartLibMeshsyncRun(
 
 	cancelCtx, stopFunc := context.WithCancel(ctx)
 
+	runOptions := []libmeshsync.OptionsSetter{
+		libmeshsync.WithOutputMode("broker"),
+		libmeshsync.WithBrokerHandler(brokerHandler),
+		libmeshsync.WithKubeConfig(kubeConfig),
+		libmeshsync.WithContext(cancelCtx),
+	}
+	// Apply the resolved controllers configuration to the in-process run.
+	// Output filters are the embedded-mode knobs libmeshsync exposes today;
+	// env-driven knobs (secret redaction, broker content dedup, debug
+	// logging) follow the Meshery Server process environment in embedded
+	// mode, and the watch-list is read from the MeshSync CR when the target
+	// cluster has one. The run restarts whenever the configuration changes.
+	if cfg := mch.controllersConfig; cfg != nil && cfg.Meshsync != nil {
+		if len(cfg.Meshsync.OutputNamespaces) > 0 {
+			runOptions = append(runOptions, libmeshsync.WithOnlyK8sNamespaces(cfg.Meshsync.OutputNamespaces...))
+		}
+		if len(cfg.Meshsync.OutputResources) > 0 {
+			runOptions = append(runOptions, libmeshsync.WithOnlyK8sResources(cfg.Meshsync.OutputResources))
+		}
+	}
+
 	go func() {
 		if err := libmeshsync.Run(
 			mch.log,
-			libmeshsync.WithOutputMode("broker"),
-			libmeshsync.WithBrokerHandler(brokerHandler),
-			libmeshsync.WithKubeConfig(kubeConfig),
-			libmeshsync.WithContext(cancelCtx),
+			runOptions...,
 		); err != nil {
 			meshsyncErr := fmt.Errorf("MesheryControllersHelper::meshsynDataHandlersStartLibMeshsyncRun error running meshsync lib: %v", err)
 			mch.log.Error(meshsyncErr)

--- a/server/models/system_settings.go
+++ b/server/models/system_settings.go
@@ -19,7 +19,7 @@ import (
 type SystemSetting struct {
 	Key       string    `json:"key" gorm:"primaryKey"`
 	Value     string    `json:"value" gorm:"type:text"`
-	UpdatedAt time.Time `json:"updated_at"`
+	UpdatedAt time.Time `json:"updatedAt"`
 }
 
 // TableName overrides the GORM default so the table reads naturally.

--- a/server/models/system_settings.go
+++ b/server/models/system_settings.go
@@ -1,0 +1,102 @@
+package models
+
+import (
+	"encoding/json"
+	"time"
+
+	"github.com/meshery/meshery/server/models/connections"
+	"github.com/meshery/meshkit/database"
+	controllersconfig "github.com/meshery/schemas/models/v1alpha1/controllers_config"
+	"gorm.io/gorm/clause"
+)
+
+// SystemSetting is a server-wide key/value setting persisted in Meshery
+// Server's own database. Settings scoped here describe how this Meshery
+// Server deployment behaves (for example, the default Meshery Operator /
+// MeshSync / Broker configuration applied to every managed cluster) and are
+// deliberately independent of the provider: they belong to the server
+// instance, not to a user or an organization.
+type SystemSetting struct {
+	Key       string    `json:"key" gorm:"primaryKey"`
+	Value     string    `json:"value" gorm:"type:text"`
+	UpdatedAt time.Time `json:"updated_at"`
+}
+
+// TableName overrides the GORM default so the table reads naturally.
+func (SystemSetting) TableName() string {
+	return "system_settings"
+}
+
+// ControllersConfigDefaultsSettingKey is the system_settings key under which
+// the server-wide MesheryControllersConfig defaults are stored.
+const ControllersConfigDefaultsSettingKey = "controllers_config_defaults"
+
+// GetSystemSetting reads a raw setting value. The second return reports
+// whether the key exists.
+func GetSystemSetting(dbHandler *database.Handler, key string) (string, bool, error) {
+	if dbHandler == nil {
+		return "", false, ErrSystemSettings(ErrDBConnection)
+	}
+	dbHandler.Lock()
+	defer dbHandler.Unlock()
+
+	var settings []SystemSetting
+	result := dbHandler.Where("key = ?", key).Limit(1).Find(&settings)
+	if result.Error != nil {
+		return "", false, ErrSystemSettings(result.Error)
+	}
+	if len(settings) == 0 {
+		return "", false, nil
+	}
+	return settings[0].Value, true, nil
+}
+
+// SetSystemSetting upserts a raw setting value.
+func SetSystemSetting(dbHandler *database.Handler, key, value string) error {
+	if dbHandler == nil {
+		return ErrSystemSettings(ErrDBConnection)
+	}
+	dbHandler.Lock()
+	defer dbHandler.Unlock()
+
+	setting := SystemSetting{Key: key, Value: value, UpdatedAt: time.Now().UTC()}
+	result := dbHandler.Clauses(clause.OnConflict{
+		Columns:   []clause.Column{{Name: "key"}},
+		DoUpdates: clause.AssignmentColumns([]string{"value", "updated_at"}),
+	}).Create(&setting)
+	if result.Error != nil {
+		return ErrSystemSettings(result.Error)
+	}
+	return nil
+}
+
+// GetControllersConfigDefaults returns the persisted server-wide controllers
+// configuration defaults, or nil when none have been set.
+func GetControllersConfigDefaults(dbHandler *database.Handler) (*controllersconfig.MesheryControllersConfig, error) {
+	value, exists, err := GetSystemSetting(dbHandler, ControllersConfigDefaultsSettingKey)
+	if err != nil {
+		return nil, err
+	}
+	if !exists || value == "" {
+		return nil, nil
+	}
+	cfg := &controllersconfig.MesheryControllersConfig{}
+	if err := json.Unmarshal([]byte(value), cfg); err != nil {
+		return nil, ErrSystemSettings(err)
+	}
+	return cfg, nil
+}
+
+// SaveControllersConfigDefaults persists the server-wide controllers
+// configuration defaults. A nil or empty document clears the stored defaults.
+func SaveControllersConfigDefaults(dbHandler *database.Handler, cfg *controllersconfig.MesheryControllersConfig) error {
+	if cfg == nil || (cfg.Operator == nil && cfg.Meshsync == nil && cfg.Broker == nil) {
+		return SetSystemSetting(dbHandler, ControllersConfigDefaultsSettingKey, "")
+	}
+	cfg.SchemaVersion = connections.ControllersConfigSchemaVersion
+	encoded, err := json.Marshal(cfg)
+	if err != nil {
+		return ErrSystemSettings(err)
+	}
+	return SetSystemSetting(dbHandler, ControllersConfigDefaultsSettingKey, string(encoded))
+}

--- a/server/policies/wasm/go.mod
+++ b/server/policies/wasm/go.mod
@@ -13,7 +13,7 @@ replace github.com/meshery/meshery => ../../../
 
 require (
 	github.com/meshery/meshery v0.0.0-00010101000000-000000000000
-	github.com/meshery/schemas v1.3.22
+	github.com/meshery/schemas v1.3.25
 )
 
 require (

--- a/server/policies/wasm/go.sum
+++ b/server/policies/wasm/go.sum
@@ -510,8 +510,8 @@ github.com/meshery/meshkit v1.0.19 h1:24/JpLoPnWXKEriYhkWdaEQXfoVQlBKSQPgoe7nE4z
 github.com/meshery/meshkit v1.0.19/go.mod h1:pChQu1xqvr0oNjIfVEzakaKmrqMSgiYu7wq7YPREhT4=
 github.com/meshery/meshsync v1.0.0 h1:BIHEVG4BDjqOnSd3vBt9B4IfWJNTfMRAgdwLroBcCfY=
 github.com/meshery/meshsync v1.0.0/go.mod h1:mFsPXkZRiCSuk5DhxBTrkWdlo6peItRBUoIEEQCovIg=
-github.com/meshery/schemas v1.3.22 h1:0+0ijQcRo/HULOJ+Kb2BslP94rTR5SgF0N2w/+CY0+4=
-github.com/meshery/schemas v1.3.22/go.mod h1:3/0nDQZur8swpo+6+3b3pvYmkzUcdWs36xTQBGRU2Y8=
+github.com/meshery/schemas v1.3.25 h1:aUZSol0+kfVpFs4WRsKAD4OaqW0MQkAPQJy+JwkNe+Q=
+github.com/meshery/schemas v1.3.25/go.mod h1:3/0nDQZur8swpo+6+3b3pvYmkzUcdWs36xTQBGRU2Y8=
 github.com/miekg/dns v1.1.57 h1:Jzi7ApEIzwEPLHWRcafCN9LZSBbqQpxjt/wpgvg7wcM=
 github.com/miekg/dns v1.1.57/go.mod h1:uqRjCRUuEAA6qsOiJvDd+CFo/vW+y5WR6SNmHE55hZk=
 github.com/miekg/pkcs11 v1.1.1 h1:Ugu9pdy6vAYku5DEpVWVFPYnzV+bxB+iRdbuFSu7TvU=

--- a/server/router/server.go
+++ b/server/router/server.go
@@ -338,6 +338,13 @@ func NewRouter(_ context.Context, h models.HandlerInterface, port int, g http.Ha
 		Methods("DELETE")
 	gMux.Handle("/api/system/meshsync/resources/{id}", h.ProviderMiddleware(h.AuthMiddleware(h.SessionInjectorMiddleware(h.GetMeshSyncResourceByID), models.ProviderAuth))).
 		Methods("GET")
+
+	// Handlers for server-wide Meshery Operator / MeshSync / Broker
+	// configuration defaults
+	gMux.Handle("/api/system/controllers/config", h.ProviderMiddleware(h.AuthMiddleware(h.SessionInjectorMiddleware(h.GetControllersDefaultConfig), models.ProviderAuth))).
+		Methods("GET")
+	gMux.Handle("/api/system/controllers/config", h.ProviderMiddleware(h.AuthMiddleware(h.SessionInjectorMiddleware(h.UpdateControllersDefaultConfig), models.ProviderAuth))).
+		Methods("PUT")
 	// Handlers for User Credentials
 
 	gMux.Handle("/api/integrations/credentials", h.ProviderMiddleware(h.AuthMiddleware(h.SessionInjectorMiddleware(h.GetUserCredentials), models.ProviderAuth))).
@@ -470,6 +477,10 @@ func NewRouter(_ context.Context, h models.HandlerInterface, port int, g http.Ha
 		Methods("POST", "DELETE")
 	gMux.Handle("/api/integrations/connections/{connectionId}", h.ProviderMiddleware(h.AuthMiddleware(h.SessionInjectorMiddleware(h.DeleteConnection), models.ProviderAuth))).
 		Methods("DELETE")
+	gMux.Handle("/api/integrations/connections/{connectionId}/controllers/config", h.ProviderMiddleware(h.AuthMiddleware(h.SessionInjectorMiddleware(h.GetConnectionControllersConfig), models.ProviderAuth))).
+		Methods("GET")
+	gMux.Handle("/api/integrations/connections/{connectionId}/controllers/config", h.ProviderMiddleware(h.AuthMiddleware(h.SessionInjectorMiddleware(h.UpdateConnectionControllersConfig), models.ProviderAuth))).
+		Methods("PUT")
 
 	gMux.HandleFunc("/auth/redirect", func(w http.ResponseWriter, r *http.Request) {
 		token := r.URL.Query().Get("token")

--- a/ui/components/configuration/ControllersConfigForm.tsx
+++ b/ui/components/configuration/ControllersConfigForm.tsx
@@ -249,6 +249,10 @@ export default function ControllersConfigForm({
     path: FieldPath,
     options: { value: string; label: string }[],
     helper?: string,
+    postProcess?: (
+      next: ControllersConfigDoc,
+      selected: string | undefined,
+    ) => ControllersConfigDoc,
   ) => {
     const current = getPath(value, path) as string | undefined;
     const inherited = inheritedValue(path) as string | undefined;
@@ -263,7 +267,12 @@ export default function ControllersConfigForm({
           value={current ?? INHERIT}
           onChange={(e) => {
             const v = e.target.value;
-            onChange(setPath(value, path, v === INHERIT ? undefined : v));
+            const selected = v === INHERIT ? undefined : v;
+            let next = setPath(value, path, selected);
+            if (postProcess) {
+              next = postProcess(next, selected);
+            }
+            onChange(next);
           }}
           helperText={helper}
         >
@@ -276,6 +285,24 @@ export default function ControllersConfigForm({
         </TextField>
       </Grid2>
     );
+  };
+
+  // clearLoadBalancerFieldsUnlessLB drops the LoadBalancer-only service
+  // fields whenever the effective service type is not LoadBalancer: the
+  // inputs are hidden then, and stale values would trip server-side
+  // validation the user cannot see or clear from the form.
+  const clearLoadBalancerFieldsUnlessLB = (
+    next: ControllersConfigDoc,
+    selected: string | undefined,
+  ): ControllersConfigDoc => {
+    const effectiveType =
+      selected ?? (inheritedValue(['broker', 'service', 'type']) as string | undefined);
+    if (effectiveType === 'LoadBalancer') {
+      return next;
+    }
+    let cleared = setPath(next, ['broker', 'service', 'loadBalancerClass'], undefined);
+    cleared = setPath(cleared, ['broker', 'service', 'loadBalancerSourceRanges'], undefined);
+    return cleared;
   };
 
   // Watch list -------------------------------------------------------------
@@ -546,6 +573,7 @@ export default function ControllersConfigForm({
             { value: 'LoadBalancer', label: 'LoadBalancer' },
           ],
           'How the broker is exposed. Reconciles in place without restarting broker pods.',
+          clearLoadBalancerFieldsUnlessLB,
         )}
         {textInput(
           'External endpoint override',

--- a/ui/components/configuration/ControllersConfigForm.tsx
+++ b/ui/components/configuration/ControllersConfigForm.tsx
@@ -1,0 +1,584 @@
+import React from 'react';
+import {
+  Alert,
+  Box,
+  Button,
+  Checkbox,
+  Chip,
+  Divider,
+  FormControlLabel,
+  Grid2,
+  MenuItem,
+  TextField,
+  Typography,
+} from '@sistent/sistent';
+import type { ControllersConfigDoc } from '@/rtk-query/controllersConfig';
+
+// Built-in defaults mirrored from Meshery Server (BuiltInControllersConfig):
+// what applies when no layer sets a field.
+export const BUILT_IN_CONTROLLERS_CONFIG: ControllersConfigDoc = {
+  operator: { deploymentMode: 'embedded' },
+  meshsync: { replicas: 1, redactSecrets: false, brokerContentDedup: false, debugLogging: false },
+  broker: { replicas: 1, service: { type: 'ClusterIP' } },
+};
+
+const INHERIT = '__inherit__';
+const WATCH_EVENTS = ['ADDED', 'MODIFIED', 'DELETED'] as const;
+
+type FieldPath = (string | number)[];
+
+const getPath = (doc: ControllersConfigDoc | null | undefined, path: FieldPath): unknown => {
+  let node: unknown = doc;
+  for (const key of path) {
+    if (node == null || typeof node !== 'object') return undefined;
+    node = (node as Record<string | number, unknown>)[key];
+  }
+  return node;
+};
+
+// deleteAtPath removes the leaf at path and prunes any parents left empty,
+// so an all-inherit section disappears from the document entirely.
+const deleteAtPath = (node: unknown, path: FieldPath): void => {
+  if (node == null || typeof node !== 'object' || path.length === 0) return;
+  const obj = node as Record<string | number, unknown>;
+  const [head, ...rest] = path;
+  if (rest.length === 0) {
+    delete obj[head];
+    return;
+  }
+  deleteAtPath(obj[head], rest);
+  const child = obj[head];
+  if (child && typeof child === 'object' && Object.keys(child as object).length === 0) {
+    delete obj[head];
+  }
+};
+
+const setPath = (
+  doc: ControllersConfigDoc,
+  path: FieldPath,
+  value: unknown,
+): ControllersConfigDoc => {
+  const next: ControllersConfigDoc = JSON.parse(JSON.stringify(doc ?? {}));
+  if (value === undefined) {
+    deleteAtPath(next, path);
+    return next;
+  }
+  let node: Record<string | number, unknown> = next as Record<string | number, unknown>;
+  for (const key of path.slice(0, -1)) {
+    if (node[key] == null || typeof node[key] !== 'object') {
+      node[key] = {};
+    }
+    node = node[key] as Record<string | number, unknown>;
+  }
+  node[path[path.length - 1]] = value;
+  return next;
+};
+
+type SourceInfo = { label: string; overridden: boolean };
+
+export type ControllersConfigFormProps = {
+  /** The document being edited (only explicitly-set fields present). */
+  value: ControllersConfigDoc;
+  onChange: (next: ControllersConfigDoc) => void;
+  /**
+   * The layers this document inherits from, outermost first (for a
+   * per-connection override: [server defaults, built-ins]; for the
+   * server-wide defaults: [built-ins]).
+   */
+  inheritedLayers?: (ControllersConfigDoc | null | undefined)[];
+  /** Label describing where inherited values come from, e.g. "Server default". */
+  inheritLabel?: string;
+  /** Show per-field source chips (used on the per-connection editor). */
+  showSourceIndicators?: boolean;
+  disabled?: boolean;
+};
+
+/**
+ * Layered editor for the Meshery Operator, MeshSync, and Broker
+ * configuration. Every control is tri-state: leaving a field on "Inherit"
+ * (or empty) keeps it absent from the document so the next layer applies.
+ */
+export default function ControllersConfigForm({
+  value,
+  onChange,
+  inheritedLayers = [BUILT_IN_CONTROLLERS_CONFIG],
+  inheritLabel = 'Inherited',
+  showSourceIndicators = false,
+  disabled = false,
+}: ControllersConfigFormProps) {
+  const inheritedValue = (path: FieldPath): unknown => {
+    for (const layer of inheritedLayers) {
+      const v = getPath(layer ?? undefined, path);
+      if (v !== undefined) return v;
+    }
+    return undefined;
+  };
+
+  const sourceOf = (path: FieldPath): SourceInfo => {
+    if (getPath(value, path) !== undefined) return { label: 'Override', overridden: true };
+    if (getPath(inheritedLayers[0] ?? undefined, path) !== undefined)
+      return { label: inheritLabel, overridden: false };
+    return { label: 'Built-in default', overridden: false };
+  };
+
+  const sourceChip = (path: FieldPath) => {
+    if (!showSourceIndicators) return null;
+    const source = sourceOf(path);
+    return (
+      <Chip
+        size="small"
+        label={source.label}
+        color={source.overridden ? 'primary' : 'default'}
+        variant={source.overridden ? 'filled' : 'outlined'}
+        sx={{ marginLeft: '0.5rem', height: '20px' }}
+      />
+    );
+  };
+
+  const fieldLabel = (text: string, path: FieldPath) => (
+    <Box sx={{ display: 'flex', alignItems: 'center', marginBottom: '0.25rem' }}>
+      <Typography variant="body2" sx={{ fontWeight: 500 }}>
+        {text}
+      </Typography>
+      {sourceChip(path)}
+    </Box>
+  );
+
+  const triStateBoolean = (label: string, path: FieldPath, helper?: string) => {
+    const current = getPath(value, path) as boolean | undefined;
+    const inherited = inheritedValue(path) as boolean | undefined;
+    return (
+      <Grid2 size={{ xs: 12, md: 4 }}>
+        {fieldLabel(label, path)}
+        <TextField
+          select
+          fullWidth
+          size="small"
+          disabled={disabled}
+          value={current === undefined ? INHERIT : current ? 'true' : 'false'}
+          onChange={(e) => {
+            const v = e.target.value;
+            onChange(setPath(value, path, v === INHERIT ? undefined : v === 'true'));
+          }}
+          helperText={helper}
+        >
+          <MenuItem value={INHERIT}>
+            Inherit ({inherited === undefined ? 'unset' : inherited ? 'Enabled' : 'Disabled'})
+          </MenuItem>
+          <MenuItem value="true">Enabled</MenuItem>
+          <MenuItem value="false">Disabled</MenuItem>
+        </TextField>
+      </Grid2>
+    );
+  };
+
+  const textInput = (
+    label: string,
+    path: FieldPath,
+    helper?: string,
+    opts?: { number?: boolean; min?: number; max?: number; mdSize?: number },
+  ) => {
+    const current = getPath(value, path) as string | number | undefined;
+    const inherited = inheritedValue(path);
+    return (
+      <Grid2 size={{ xs: 12, md: opts?.mdSize ?? 4 }}>
+        {fieldLabel(label, path)}
+        <TextField
+          fullWidth
+          size="small"
+          type={opts?.number ? 'number' : 'text'}
+          disabled={disabled}
+          value={current ?? ''}
+          placeholder={inherited !== undefined ? `Inherit (${inherited})` : 'Inherit'}
+          slotProps={opts?.number ? { htmlInput: { min: opts?.min, max: opts?.max } } : undefined}
+          onChange={(e) => {
+            const raw = e.target.value;
+            if (raw === '') {
+              onChange(setPath(value, path, undefined));
+              return;
+            }
+            onChange(setPath(value, path, opts?.number ? Number(raw) : raw));
+          }}
+          helperText={helper}
+        />
+      </Grid2>
+    );
+  };
+
+  const listInput = (label: string, path: FieldPath, helper: string) => {
+    const current = getPath(value, path) as string[] | undefined;
+    const inherited = inheritedValue(path) as string[] | undefined;
+    return (
+      <Grid2 size={{ xs: 12, md: 6 }}>
+        {fieldLabel(label, path)}
+        <TextField
+          fullWidth
+          size="small"
+          disabled={disabled}
+          value={current ? current.join(', ') : ''}
+          placeholder={
+            inherited && inherited.length > 0
+              ? `Inherit (${inherited.join(', ')})`
+              : 'Inherit (all)'
+          }
+          onChange={(e) => {
+            const raw = e.target.value;
+            if (raw.trim() === '') {
+              onChange(setPath(value, path, undefined));
+              return;
+            }
+            onChange(
+              setPath(
+                value,
+                path,
+                raw
+                  .split(',')
+                  .map((s) => s.trim())
+                  .filter(Boolean),
+              ),
+            );
+          }}
+          helperText={helper}
+        />
+      </Grid2>
+    );
+  };
+
+  const enumSelect = (
+    label: string,
+    path: FieldPath,
+    options: { value: string; label: string }[],
+    helper?: string,
+  ) => {
+    const current = getPath(value, path) as string | undefined;
+    const inherited = inheritedValue(path) as string | undefined;
+    return (
+      <Grid2 size={{ xs: 12, md: 4 }}>
+        {fieldLabel(label, path)}
+        <TextField
+          select
+          fullWidth
+          size="small"
+          disabled={disabled}
+          value={current ?? INHERIT}
+          onChange={(e) => {
+            const v = e.target.value;
+            onChange(setPath(value, path, v === INHERIT ? undefined : v));
+          }}
+          helperText={helper}
+        >
+          <MenuItem value={INHERIT}>Inherit ({inherited ?? 'unset'})</MenuItem>
+          {options.map((option) => (
+            <MenuItem key={option.value} value={option.value}>
+              {option.label}
+            </MenuItem>
+          ))}
+        </TextField>
+      </Grid2>
+    );
+  };
+
+  // Watch list -------------------------------------------------------------
+  const watchList = getPath(value, ['meshsync', 'watchList']) as
+    | { whitelist?: { resource: string; events?: string[] }[]; blacklist?: string[] }
+    | undefined;
+  const watchMode = !watchList ? INHERIT : watchList.whitelist ? 'whitelist' : 'blacklist';
+
+  const setWatchMode = (mode: string) => {
+    if (mode === INHERIT) {
+      onChange(setPath(value, ['meshsync', 'watchList'], undefined));
+    } else if (mode === 'whitelist') {
+      onChange(setPath(value, ['meshsync', 'watchList'], { whitelist: [] }));
+    } else {
+      onChange(setPath(value, ['meshsync', 'watchList'], { blacklist: [] }));
+    }
+  };
+
+  const whitelist = watchList?.whitelist ?? [];
+  const setWhitelist = (rows: { resource: string; events?: string[] }[]) =>
+    onChange(setPath(value, ['meshsync', 'watchList'], { whitelist: rows }));
+
+  const blacklist = watchList?.blacklist ?? [];
+  const setBlacklist = (rows: string[]) =>
+    onChange(setPath(value, ['meshsync', 'watchList'], { blacklist: rows }));
+
+  const redactSecrets =
+    getPath(value, ['meshsync', 'redactSecrets']) ?? inheritedValue(['meshsync', 'redactSecrets']);
+
+  // Annotations ------------------------------------------------------------
+  const annotations = getPath(value, ['broker', 'service', 'annotations']) as
+    | Record<string, string>
+    | undefined;
+  const annotationsText = annotations
+    ? Object.entries(annotations)
+        .map(([k, v]) => `${k}=${v}`)
+        .join('\n')
+    : '';
+  const setAnnotationsFromText = (raw: string) => {
+    if (raw.trim() === '') {
+      onChange(setPath(value, ['broker', 'service', 'annotations'], undefined));
+      return;
+    }
+    const next: Record<string, string> = {};
+    raw.split('\n').forEach((line) => {
+      const idx = line.indexOf('=');
+      if (idx > 0) {
+        next[line.slice(0, idx).trim()] = line.slice(idx + 1).trim();
+      }
+    });
+    onChange(setPath(value, ['broker', 'service', 'annotations'], next));
+  };
+
+  const serviceType = (getPath(value, ['broker', 'service', 'type']) ??
+    inheritedValue(['broker', 'service', 'type'])) as string | undefined;
+  const isLoadBalancer = serviceType === 'LoadBalancer';
+
+  return (
+    <Box>
+      {/* Meshery Operator */}
+      <Typography variant="subtitle1" sx={{ fontWeight: 600, marginBottom: '0.5rem' }}>
+        Meshery Operator
+      </Typography>
+      <Grid2 container spacing={2}>
+        {enumSelect(
+          'Deployment mode',
+          ['operator', 'deploymentMode'],
+          [
+            { value: 'operator', label: 'Operator (in-cluster)' },
+            { value: 'embedded', label: 'Embedded (in Meshery Server)' },
+          ],
+          'Operator installs MeshSync and Broker into the cluster; Embedded runs MeshSync inside Meshery Server. Changing the mode redeploys controllers.',
+        )}
+        {textInput(
+          'Operator version',
+          ['operator', 'version'],
+          'Helm chart version. Inherit tracks the Meshery Server release.',
+        )}
+      </Grid2>
+
+      <Divider sx={{ margin: '1.5rem 0' }} />
+
+      {/* MeshSync */}
+      <Typography variant="subtitle1" sx={{ fontWeight: 600, marginBottom: '0.5rem' }}>
+        MeshSync
+      </Typography>
+      <Grid2 container spacing={2}>
+        {textInput(
+          'MeshSync version',
+          ['meshsync', 'version'],
+          'Image tag (operator mode). Applying rolls MeshSync pods.',
+        )}
+        {textInput('Replicas', ['meshsync', 'replicas'], '1-10 (operator mode).', {
+          number: true,
+          min: 1,
+          max: 10,
+        })}
+        {triStateBoolean(
+          'Secret redaction',
+          ['meshsync', 'redactSecrets'],
+          'Redacts Secret values before publishing. Requires MeshSync v1.0.2+.',
+        )}
+        {triStateBoolean(
+          'Broker content dedup',
+          ['meshsync', 'brokerContentDedup'],
+          'Suppresses byte-identical republishes. Requires MeshSync v1.0.2+.',
+        )}
+        {triStateBoolean('Debug logging', ['meshsync', 'debugLogging'], 'DEBUG env on MeshSync.')}
+        {listInput(
+          'Output namespaces',
+          ['meshsync', 'outputNamespaces'],
+          'Comma-separated. Only these namespaces are published; empty publishes all.',
+        )}
+        {listInput(
+          'Output resources',
+          ['meshsync', 'outputResources'],
+          'Comma-separated lowercase kinds (e.g. pod, deployment); empty publishes all.',
+        )}
+      </Grid2>
+
+      {redactSecrets !== true && (
+        <Alert severity="warning" sx={{ marginTop: '1rem' }}>
+          Secret redaction is disabled: Kubernetes Secret values within the watch scope are
+          published un-redacted. Enable secret redaction or exclude Secrets from the watch scope.
+        </Alert>
+      )}
+
+      <Box sx={{ marginTop: '1.5rem' }}>
+        <Box sx={{ display: 'flex', alignItems: 'center', marginBottom: '0.25rem' }}>
+          <Typography variant="body2" sx={{ fontWeight: 500 }}>
+            Watched resources (discovery scope)
+          </Typography>
+          {sourceChip(['meshsync', 'watchList'])}
+        </Box>
+        <Typography variant="caption" color="text.secondary" sx={{ display: 'block', mb: 1 }}>
+          At most one of whitelist or blacklist. Applying a watch-scope change restarts MeshSync
+          pods automatically.
+        </Typography>
+        <TextField
+          select
+          size="small"
+          disabled={disabled}
+          value={watchMode}
+          onChange={(e) => setWatchMode(e.target.value)}
+          sx={{ minWidth: '260px' }}
+        >
+          <MenuItem value={INHERIT}>Inherit</MenuItem>
+          <MenuItem value="whitelist">Whitelist (watch only these)</MenuItem>
+          <MenuItem value="blacklist">Blacklist (default scope minus these)</MenuItem>
+        </TextField>
+
+        {watchMode === 'whitelist' && (
+          <Box sx={{ marginTop: '1rem' }}>
+            {whitelist.map((row, index) => (
+              <Box
+                key={index}
+                sx={{
+                  display: 'flex',
+                  alignItems: 'center',
+                  gap: '0.75rem',
+                  marginBottom: '0.5rem',
+                }}
+              >
+                <TextField
+                  size="small"
+                  disabled={disabled}
+                  value={row.resource}
+                  placeholder="pods.v1. or deployments.v1.apps"
+                  sx={{ minWidth: '280px' }}
+                  onChange={(e) => {
+                    const rows = [...whitelist];
+                    rows[index] = { ...rows[index], resource: e.target.value };
+                    setWhitelist(rows);
+                  }}
+                />
+                {WATCH_EVENTS.map((eventType) => (
+                  <FormControlLabel
+                    key={eventType}
+                    control={
+                      <Checkbox
+                        size="small"
+                        disabled={disabled}
+                        checked={(row.events ?? []).includes(eventType)}
+                        onChange={(e) => {
+                          const rows = [...whitelist];
+                          const events = new Set(rows[index].events ?? []);
+                          if (e.target.checked) {
+                            events.add(eventType);
+                          } else {
+                            events.delete(eventType);
+                          }
+                          rows[index] = { ...rows[index], events: Array.from(events) };
+                          setWhitelist(rows);
+                        }}
+                      />
+                    }
+                    label={eventType}
+                  />
+                ))}
+                <Button
+                  size="small"
+                  disabled={disabled}
+                  onClick={() => setWhitelist(whitelist.filter((_, i) => i !== index))}
+                >
+                  Remove
+                </Button>
+              </Box>
+            ))}
+            <Button
+              size="small"
+              variant="outlined"
+              disabled={disabled}
+              onClick={() =>
+                setWhitelist([...whitelist, { resource: '', events: [...WATCH_EVENTS] }])
+              }
+            >
+              Add resource
+            </Button>
+          </Box>
+        )}
+
+        {watchMode === 'blacklist' && (
+          <TextField
+            fullWidth
+            multiline
+            minRows={3}
+            size="small"
+            disabled={disabled}
+            sx={{ marginTop: '1rem' }}
+            value={blacklist.join('\n')}
+            placeholder={'secrets.v1.\nevents.v1.'}
+            helperText='One resource key per line, in "<plural>.<version>.<group>" form.'
+            onChange={(e) =>
+              setBlacklist(
+                e.target.value
+                  .split('\n')
+                  .map((s) => s.trim())
+                  .filter(Boolean),
+              )
+            }
+          />
+        )}
+      </Box>
+
+      <Divider sx={{ margin: '1.5rem 0' }} />
+
+      {/* Meshery Broker */}
+      <Typography variant="subtitle1" sx={{ fontWeight: 600, marginBottom: '0.5rem' }}>
+        Meshery Broker
+      </Typography>
+      <Grid2 container spacing={2}>
+        {textInput(
+          'Broker version',
+          ['broker', 'version'],
+          'NATS image tag (operator mode). Applying rolls broker pods.',
+        )}
+        {textInput('Replicas', ['broker', 'replicas'], '1-10 (operator mode).', {
+          number: true,
+          min: 1,
+          max: 10,
+        })}
+        {enumSelect(
+          'Service type',
+          ['broker', 'service', 'type'],
+          [
+            { value: 'ClusterIP', label: 'ClusterIP (cluster-internal)' },
+            { value: 'NodePort', label: 'NodePort' },
+            { value: 'LoadBalancer', label: 'LoadBalancer' },
+          ],
+          'How the broker is exposed. Reconciles in place without restarting broker pods.',
+        )}
+        {textInput(
+          'External endpoint override',
+          ['broker', 'service', 'externalEndpointOverride'],
+          'host:port; pins the advertised endpoint (ingress, NAT, air-gapped).',
+        )}
+        {isLoadBalancer &&
+          textInput(
+            'Load balancer class',
+            ['broker', 'service', 'loadBalancerClass'],
+            'LoadBalancer type only.',
+          )}
+        {isLoadBalancer &&
+          listInput(
+            'Load balancer source ranges',
+            ['broker', 'service', 'loadBalancerSourceRanges'],
+            'Comma-separated CIDRs allowed to reach the broker.',
+          )}
+        <Grid2 size={{ xs: 12, md: 6 }}>
+          {fieldLabel('Service annotations', ['broker', 'service', 'annotations'])}
+          <TextField
+            fullWidth
+            multiline
+            minRows={2}
+            size="small"
+            disabled={disabled}
+            value={annotationsText}
+            placeholder={'key=value\nservice.beta.kubernetes.io/aws-load-balancer-internal=true'}
+            helperText="One key=value per line. Merged onto the broker client Service."
+            onChange={(e) => setAnnotationsFromText(e.target.value)}
+          />
+        </Grid2>
+      </Grid2>
+    </Box>
+  );
+}

--- a/ui/components/connections/ConnectionActionMenu.tsx
+++ b/ui/components/connections/ConnectionActionMenu.tsx
@@ -20,6 +20,7 @@ type ConnectionActionMenuProps = {
   onFlushMeshSync: () => void;
   onDeploymentModeAnchor: (event: React.MouseEvent<HTMLElement>) => void;
   onConfigure?: () => void;
+  onConfigureControllers?: () => void;
   onCopyLink?: () => void;
 };
 
@@ -30,6 +31,7 @@ export const ConnectionActionMenu = ({
   onFlushMeshSync,
   onDeploymentModeAnchor,
   onConfigure,
+  onConfigureControllers,
   onCopyLink,
 }: ConnectionActionMenuProps) => {
   return (
@@ -48,6 +50,20 @@ export const ConnectionActionMenu = ({
             <SettingsIcon {...iconMedium} />
             <Typography variant="body1" style={{ marginLeft: '0.5rem' }}>
               Configure
+            </Typography>
+          </Button>
+        </ActionListItem>
+      )}
+      {onConfigureControllers && (
+        <ActionListItem>
+          <Button
+            type="button"
+            onClick={onConfigureControllers}
+            data-cy="btnConfigureConnectionControllers"
+          >
+            <SettingsIcon {...iconMedium} />
+            <Typography variant="body1" style={{ marginLeft: '0.5rem' }}>
+              Configure Controllers
             </Typography>
           </Button>
         </ActionListItem>

--- a/ui/components/connections/ConnectionControllersConfigModal.tsx
+++ b/ui/components/connections/ConnectionControllersConfigModal.tsx
@@ -1,0 +1,117 @@
+import React, { useEffect, useState } from 'react';
+import { Typography } from '@sistent/sistent';
+import { Modal } from '@/components/shared/Modal';
+import { ModalButtonPrimary, ModalButtonSecondary } from '@sistent/sistent';
+import { useNotification } from '@/utils/hooks/useNotification';
+import { EVENT_TYPES } from '../../lib/event-types';
+import {
+  useGetConnectionControllersConfigQuery,
+  useUpdateConnectionControllersConfigMutation,
+  type ControllersConfigDoc,
+} from '@/rtk-query/controllersConfig';
+import ControllersConfigForm, {
+  BUILT_IN_CONTROLLERS_CONFIG,
+} from '@/components/configuration/ControllersConfigForm';
+
+const stripSchemaVersion = (doc?: ControllersConfigDoc | null): ControllersConfigDoc => {
+  if (!doc) return {};
+  const rest = { ...doc };
+  delete rest.schemaVersion;
+  return rest;
+};
+
+type ConnectionControllersConfigModalProps = {
+  isOpen: boolean;
+  onClose: () => void;
+  connectionId: string;
+  connectionName?: string;
+};
+
+/**
+ * Per-connection override editor for the Meshery Operator, MeshSync, and
+ * Broker configuration. Shows, per field, whether the effective value is an
+ * override, the server-wide default, or the built-in default; fields left on
+ * Inherit follow the server-wide defaults from Settings.
+ */
+export default function ConnectionControllersConfigModal({
+  isOpen,
+  onClose,
+  connectionId,
+  connectionName,
+}: ConnectionControllersConfigModalProps) {
+  const { notify } = useNotification();
+  const { data, isLoading } = useGetConnectionControllersConfigQuery(
+    { connectionId },
+    { skip: !isOpen || !connectionId },
+  );
+  const [updateOverride, { isLoading: isSaving }] = useUpdateConnectionControllersConfigMutation();
+  const [draft, setDraft] = useState<ControllersConfigDoc>({});
+  const [dirty, setDirty] = useState(false);
+
+  useEffect(() => {
+    if (data && !dirty) {
+      setDraft(stripSchemaVersion(data.override));
+    }
+  }, [data, dirty]);
+
+  const handleSave = async () => {
+    try {
+      await updateOverride({ connectionId, body: draft }).unwrap();
+      setDirty(false);
+      notify({
+        message: `Controllers configuration applied to ${connectionName || 'connection'}.`,
+        event_type: EVENT_TYPES.SUCCESS,
+      });
+      onClose();
+    } catch (err) {
+      notify({
+        message: 'Failed to apply the controllers configuration override.',
+        event_type: EVENT_TYPES.ERROR,
+        details: String((err as { data?: unknown })?.data ?? err),
+      });
+    }
+  };
+
+  return (
+    <Modal
+      isOpen={isOpen}
+      onClose={onClose}
+      title={`Operator, MeshSync & Broker Configuration${
+        connectionName ? ` - ${connectionName}` : ''
+      }`}
+      size="lg"
+      helpText="Absent fields inherit the server-wide defaults from Settings."
+      actions={
+        <>
+          <ModalButtonSecondary onClick={onClose} disabled={isSaving}>
+            Cancel
+          </ModalButtonSecondary>
+          <ModalButtonPrimary
+            onClick={handleSave}
+            disabled={!dirty || isSaving}
+            data-testid="connection-controllers-config-save"
+          >
+            Save &amp; Apply
+          </ModalButtonPrimary>
+        </>
+      }
+    >
+      <Typography variant="body2" color="text.secondary" sx={{ marginBottom: '1.5rem' }}>
+        Overrides apply to this connection only. Fields left on Inherit follow the server-wide
+        defaults from Settings, then the controllers&apos; built-in defaults. Changes are applied to
+        the cluster immediately; restart-required changes restart MeshSync automatically.
+      </Typography>
+      <ControllersConfigForm
+        value={draft}
+        onChange={(next) => {
+          setDraft(next);
+          setDirty(true);
+        }}
+        inheritedLayers={[data?.default, BUILT_IN_CONTROLLERS_CONFIG]}
+        inheritLabel="Server default"
+        showSourceIndicators
+        disabled={isLoading || isSaving}
+      />
+    </Modal>
+  );
+}

--- a/ui/components/connections/ConnectionTable.tsx
+++ b/ui/components/connections/ConnectionTable.tsx
@@ -49,6 +49,13 @@ const ConnectionConfigureModal = dynamic(() => import('./ConnectionConfigureModa
   ssr: false,
 });
 
+// Lazy-loaded for the same reason: only mounted for Kubernetes connections
+// when the controllers configuration action is invoked.
+const ConnectionControllersConfigModal = dynamic(
+  () => import('./ConnectionControllersConfigModal'),
+  { ssr: false },
+);
+
 const ConnectionTable = ({
   selectedFilter,
   selectedConnectionId,
@@ -131,6 +138,8 @@ const ConnectionTable = ({
   const [configureConnection, setConfigureConnection] = useState<ConfigurableConnection | null>(
     null,
   );
+  const [controllersConfigConnection, setControllersConfigConnection] =
+    useState<ConfigurableConnection | null>(null);
   const open = Boolean(anchorEl);
   const deploymentModeOpen = Boolean(deploymentModeAnchorEl);
   const modalRef = useRef<{ show: (options: unknown) => Promise<string | null> } | null>(null);
@@ -408,6 +417,16 @@ const ConnectionTable = ({
     handleActionMenuClose();
     if (connection) {
       setConfigureConnection(connection as ConfigurableConnection);
+    }
+  }, [getConnectionAtRowIndex, handleActionMenuClose, rowData?.rowIndex]);
+
+  const handleConfigureControllers = useCallback(() => {
+    const connection = getConnectionAtRowIndex(rowData?.rowIndex);
+    handleActionMenuClose();
+    // Operator / MeshSync / Broker configuration applies to Kubernetes
+    // connections only.
+    if (connection && (connection as ConfigurableConnection).kind === 'kubernetes') {
+      setControllersConfigConnection(connection as ConfigurableConnection);
     }
   }, [getConnectionAtRowIndex, handleActionMenuClose, rowData?.rowIndex]);
 
@@ -763,6 +782,13 @@ const ConnectionTable = ({
         onFlushMeshSync={handleFlushMeshSync}
         onDeploymentModeAnchor={handleDeploymentModeAnchorOpen}
         onConfigure={handleConfigureConnection}
+        onConfigureControllers={
+          rowData?.rowIndex != null &&
+          (getConnectionAtRowIndex(rowData.rowIndex) as ConfigurableConnection | null)?.kind ===
+            'kubernetes'
+            ? handleConfigureControllers
+            : undefined
+        }
         onCopyLink={
           rowData?.rowIndex != null
             ? () => {
@@ -779,6 +805,15 @@ const ConnectionTable = ({
           isOpen={Boolean(configureConnection)}
           connection={configureConnection}
           onClose={() => setConfigureConnection(null)}
+        />
+      )}
+
+      {controllersConfigConnection?.id && (
+        <ConnectionControllersConfigModal
+          isOpen={Boolean(controllersConfigConnection)}
+          connectionId={String(controllersConfigConnection.id)}
+          connectionName={controllersConfigConnection.name}
+          onClose={() => setControllersConfigConnection(null)}
         />
       )}
 

--- a/ui/components/settings/MesheryControllersConfig.tsx
+++ b/ui/components/settings/MesheryControllersConfig.tsx
@@ -60,12 +60,15 @@ export default function MesheryControllersConfig() {
     setDirty(false);
   };
 
-  if (error) {
-    notify({
-      message: 'Failed to load controllers configuration defaults.',
-      event_type: EVENT_TYPES.ERROR,
-    });
-  }
+  // Notify once per load failure rather than on every render.
+  useEffect(() => {
+    if (error) {
+      notify({
+        message: 'Failed to load controllers configuration defaults.',
+        event_type: EVENT_TYPES.ERROR,
+      });
+    }
+  }, [error]);
 
   return (
     <Paper sx={{ padding: '1.5rem', marginTop: '1rem' }}>

--- a/ui/components/settings/MesheryControllersConfig.tsx
+++ b/ui/components/settings/MesheryControllersConfig.tsx
@@ -1,0 +1,107 @@
+import React, { useEffect, useState } from 'react';
+import { Box, Button, Paper, Typography } from '@sistent/sistent';
+import { useNotification } from '@/utils/hooks/useNotification';
+import { EVENT_TYPES } from '../../lib/event-types';
+import {
+  useGetControllersDefaultConfigQuery,
+  useUpdateControllersDefaultConfigMutation,
+  type ControllersConfigDoc,
+} from '@/rtk-query/controllersConfig';
+import ControllersConfigForm, {
+  BUILT_IN_CONTROLLERS_CONFIG,
+} from '@/components/configuration/ControllersConfigForm';
+
+const stripSchemaVersion = (doc?: ControllersConfigDoc | null): ControllersConfigDoc => {
+  if (!doc) return {};
+  const rest = { ...doc };
+  delete rest.schemaVersion;
+  return rest;
+};
+
+/**
+ * Settings tab: server-wide defaults for the Meshery Operator, MeshSync, and
+ * Meshery Broker deployed to every managed Kubernetes cluster. Fields left on
+ * Inherit fall back to the controllers' built-in defaults; per-connection
+ * overrides (Connections page) take precedence over everything set here.
+ */
+export default function MesheryControllersConfig() {
+  const { notify } = useNotification();
+  const { data, isLoading, error } = useGetControllersDefaultConfigQuery();
+  const [updateDefaults, { isLoading: isSaving }] = useUpdateControllersDefaultConfigMutation();
+  const [draft, setDraft] = useState<ControllersConfigDoc>({});
+  const [dirty, setDirty] = useState(false);
+
+  useEffect(() => {
+    if (data && !dirty) {
+      setDraft(stripSchemaVersion(data));
+    }
+  }, [data, dirty]);
+
+  const handleSave = async () => {
+    try {
+      await updateDefaults({ body: draft }).unwrap();
+      setDirty(false);
+      notify({
+        message:
+          'Server-wide controllers configuration defaults saved. Re-applying to connected clusters.',
+        event_type: EVENT_TYPES.SUCCESS,
+      });
+    } catch (err) {
+      notify({
+        message: 'Failed to save controllers configuration defaults.',
+        event_type: EVENT_TYPES.ERROR,
+        details: String((err as { data?: unknown })?.data ?? err),
+      });
+    }
+  };
+
+  const handleDiscard = () => {
+    setDraft(stripSchemaVersion(data));
+    setDirty(false);
+  };
+
+  if (error) {
+    notify({
+      message: 'Failed to load controllers configuration defaults.',
+      event_type: EVENT_TYPES.ERROR,
+    });
+  }
+
+  return (
+    <Paper sx={{ padding: '1.5rem', marginTop: '1rem' }}>
+      <Typography variant="h6" sx={{ fontWeight: 600 }}>
+        Meshery Operator, MeshSync &amp; Broker
+      </Typography>
+      <Typography variant="body2" color="text.secondary" sx={{ marginBottom: '1.5rem' }}>
+        Server-wide defaults applied to every managed Kubernetes cluster. Individual connections can
+        override any of these on the Connections page; fields left on Inherit use the
+        controllers&apos; built-in defaults.
+      </Typography>
+
+      <ControllersConfigForm
+        value={draft}
+        onChange={(next) => {
+          setDraft(next);
+          setDirty(true);
+        }}
+        inheritedLayers={[BUILT_IN_CONTROLLERS_CONFIG]}
+        inheritLabel="Built-in default"
+        disabled={isLoading || isSaving}
+      />
+
+      <Box sx={{ display: 'flex', justifyContent: 'flex-end', gap: '1rem', marginTop: '1.5rem' }}>
+        <Button variant="outlined" onClick={handleDiscard} disabled={!dirty || isSaving}>
+          Discard changes
+        </Button>
+        <Button
+          variant="contained"
+          onClick={handleSave}
+          disabled={!dirty || isSaving}
+          data-testid="controllers-config-save"
+        >
+          Save defaults
+        </Button>
+      </Box>
+    </Paper>
+  );
+}

--- a/ui/components/settings/MesherySettings.test.tsx
+++ b/ui/components/settings/MesherySettings.test.tsx
@@ -47,6 +47,7 @@ vi.mock('@sistent/sistent', () => ({
   DatabaseIcon: () => <svg />,
   MendeleyIcon: () => <svg />,
   FileIcon: () => <svg />,
+  SettingsIcon: () => <svg />,
   useTheme: () => ({
     palette: {
       icon: { default: 'icon' },
@@ -113,6 +114,7 @@ vi.mock('@/constants/navigator', () => ({
   PROMETHEUS: 'Prometheus',
   OVERVIEW: 'Overview',
   REGISTRY: 'Registry',
+  CONTROLLERS: 'Controllers',
 }));
 
 vi.mock('../registry/helper', () => ({
@@ -121,6 +123,10 @@ vi.mock('../registry/helper', () => ({
 
 vi.mock('../registry/MeshModelComponent', () => ({
   default: () => <div data-testid="mesh-model-component" />,
+}));
+
+vi.mock('./MesheryControllersConfig', () => ({
+  default: () => <div data-testid="controllers-config" />,
 }));
 
 vi.mock('../general/error-404', () => ({
@@ -170,14 +176,21 @@ describe('MesherySettings', () => {
     };
   });
 
-  it('renders the main settings tab bar with the 4 settings categories', () => {
+  it('renders the main settings tab bar with the 5 settings categories', () => {
     render(<MesherySettings />);
 
     expect(screen.getByTestId('tab-Overview')).toBeInTheDocument();
     expect(screen.getByTestId('tab-Adapters')).toBeInTheDocument();
     expect(screen.getByTestId('tab-Registry')).toBeInTheDocument();
+    expect(screen.getByTestId('tab-Controllers')).toBeInTheDocument();
     expect(screen.getByTestId('tab-Reset')).toBeInTheDocument();
     expect(screen.queryByTestId('tab-Metrics')).not.toBeInTheDocument();
+  });
+
+  it('renders the controllers configuration tab when selected', () => {
+    routerState.query = { settingsCategory: 'Controllers' };
+    render(<MesherySettings />);
+    expect(screen.getByTestId('controllers-config')).toBeInTheDocument();
   });
 
   it('renders the Overview tab content (dashboard graph) by default', () => {

--- a/ui/components/settings/MesherySettings.tsx
+++ b/ui/components/settings/MesherySettings.tsx
@@ -13,6 +13,7 @@ import {
   DatabaseIcon,
   MendeleyIcon,
   FileIcon,
+  SettingsIcon,
   useTheme,
 } from '@sistent/sistent';
 import DashboardMeshModelGraph from '../dashboard/charts/DashboardMeshModelGraph';
@@ -29,7 +30,8 @@ import {
 } from '../../api/meshmodel';
 import CAN from '@/utils/can';
 import { keys } from '@/utils/permission_constants';
-import { ADAPTERS, RESET, OVERVIEW, REGISTRY } from '@/constants/navigator';
+import { ADAPTERS, RESET, OVERVIEW, REGISTRY, CONTROLLERS } from '@/constants/navigator';
+import MesheryControllersConfig from './MesheryControllersConfig';
 import { removeDuplicateVersions } from '../registry/helper';
 import MeshModelComponent from '../registry/MeshModelComponent';
 import DefaultError from '../general/error-404';
@@ -256,6 +258,19 @@ const MesherySettings = () => {
                   />
                 </CustomTooltip>
 
+                <CustomTooltip
+                  title="Meshery Operator, MeshSync & Broker defaults"
+                  placement="top"
+                  value={CONTROLLERS}
+                >
+                  <Tab
+                    icon={<SettingsIcon {...iconMedium} fill={theme.palette.icon.default} />}
+                    label="Operator, MeshSync & Broker"
+                    data-testid="settings-tab-controllers"
+                    value={CONTROLLERS}
+                  />
+                </CustomTooltip>
+
                 <CustomTooltip title="Reset System" placement="top" value={RESET}>
                   <Tab
                     icon={<DatabaseIcon {...iconMedium} fill={theme.palette.icon.default} />}
@@ -329,6 +344,12 @@ const MesherySettings = () => {
             {tabVal === REGISTRY && (
               <TabContainer>
                 <MeshModelComponent settingsRouter={settingsRouter} />
+              </TabContainer>
+            )}
+
+            {tabVal === CONTROLLERS && (
+              <TabContainer>
+                <MesheryControllersConfig />
               </TabContainer>
             )}
 

--- a/ui/constants/navigator.ts
+++ b/ui/constants/navigator.ts
@@ -56,6 +56,7 @@ export const CONNECTIONS = 'Connections';
 export const REGISTRY = 'Registry';
 export const ADAPTERS = 'Adapters';
 export const RESET = 'Reset';
+export const CONTROLLERS = 'Controllers';
 export const METRICS = 'Metrics';
 export const TELEMETRY = 'telemetry';
 export const GRAFANA = 'Grafana';

--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -21,7 +21,7 @@
         "@emotion/react": "^11.14.0",
         "@emotion/server": "^11.11.0",
         "@emotion/styled": "^11.14.1",
-        "@meshery/schemas": "^1.3.16",
+        "@meshery/schemas": "^1.3.25",
         "@microlink/react-json-view": "^1.31.20",
         "@mui/icons-material": "^9.1.1",
         "@mui/material": "^9.1.2",
@@ -1452,9 +1452,6 @@
       "cpu": [
         "arm"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -1470,9 +1467,6 @@
       "integrity": "sha512-excjX8DfsIcJ10x1Kzr4RcWe1edC9PquDRRPx3YVCvQv+U5p7Yin2s32ftzikXojb1PIFc/9Mt28/y+iRklkrw==",
       "cpu": [
         "arm64"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
@@ -1490,9 +1484,6 @@
       "cpu": [
         "ppc64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -1509,9 +1500,6 @@
       "cpu": [
         "riscv64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -1527,9 +1515,6 @@
       "integrity": "sha512-qmp9VrzgPgMoGZyPvrQHqk02uyjA0/QrTO26Tqk6l4ZV0MPWIW6LTkqOIov+J1yEu7MbFQaDpwdwJKhbJvuRxQ==",
       "cpu": [
         "s390x"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
@@ -1563,9 +1548,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "musl"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -1598,9 +1580,6 @@
       "cpu": [
         "arm"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -1622,9 +1601,6 @@
       "integrity": "sha512-bKQzaJRY/bkPOXyKx5EVup7qkaojECG6NLYswgktOZjaXecSAeCWiZwwiFf3/Y+O1HrauiE3FVsGxFg8c24rZg==",
       "cpu": [
         "arm64"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "Apache-2.0",
       "optional": true,
@@ -1648,9 +1624,6 @@
       "cpu": [
         "ppc64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -1673,9 +1646,6 @@
       "cpu": [
         "riscv64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -1697,9 +1667,6 @@
       "integrity": "sha512-nQtCk0PdKfho3eC5MrbQoigJ2gd1CgddUMkabUj+rBevs8tZ2cULOx46E7oyX+04WGfABgIwmMC0VqieTiR4jg==",
       "cpu": [
         "s390x"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "Apache-2.0",
       "optional": true,
@@ -1744,9 +1711,6 @@
       "integrity": "sha512-fprJR6GtRsMt6Kyfq44IsChVZeGN97gTD331weR1ex1c1rypDEABN6Tm2xa1wE6lYb5DdEnk03NZPqA7Id21yg==",
       "cpu": [
         "arm64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "Apache-2.0",
       "optional": true,
@@ -2104,9 +2068,9 @@
       "license": "MIT"
     },
     "node_modules/@meshery/schemas": {
-      "version": "1.3.16",
-      "resolved": "https://registry.npmjs.org/@meshery/schemas/-/schemas-1.3.16.tgz",
-      "integrity": "sha512-rpCp3oWwRkqk6McOn8s4EzxjTcSZP0U9nUb+uopdwaN/Fsx3VtpPl0SgZa3jncTCt+QYZe65Ed/L5EA+2kWBpg==",
+      "version": "1.3.25",
+      "resolved": "https://registry.npmjs.org/@meshery/schemas/-/schemas-1.3.25.tgz",
+      "integrity": "sha512-wsFu2nkIKUtVBLekbDyZ0lesEMOaxEBlyYeqRSa0Y02oMAZ+ubfpnTDPiDEOUvPYxCBQfWx1vYUsbqRaU5odWA==",
       "license": "ISC",
       "peerDependencies": {
         "@reduxjs/toolkit": "^2.8.1",
@@ -3098,9 +3062,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3118,9 +3079,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3138,9 +3096,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3158,9 +3113,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4601,9 +4553,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4618,9 +4567,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4635,9 +4581,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4652,9 +4595,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4669,9 +4609,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4686,9 +4623,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -11885,9 +11819,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -11909,9 +11840,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [

--- a/ui/package.json
+++ b/ui/package.json
@@ -49,7 +49,7 @@
     "@emotion/react": "^11.14.0",
     "@emotion/server": "^11.11.0",
     "@emotion/styled": "^11.14.1",
-    "@meshery/schemas": "^1.3.16",
+    "@meshery/schemas": "^1.3.25",
     "@microlink/react-json-view": "^1.31.20",
     "@mui/icons-material": "^9.1.1",
     "@mui/material": "^9.1.2",

--- a/ui/rtk-query/controllersConfig.ts
+++ b/ui/rtk-query/controllersConfig.ts
@@ -1,0 +1,114 @@
+import { api, mesheryApiPath } from './index';
+
+// Layered Meshery Operator / MeshSync / Broker configuration endpoints.
+// Server-wide defaults live under /api/system/controllers/config; the
+// per-connection override rides the connection's metadata and is exposed at
+// /api/integrations/connections/{id}/controllers/config. The wire contract is
+// the controllers_config construct in meshery/schemas (v1alpha1).
+const TAGS = {
+  CONTROLLERS_CONFIG: 'controllers_config',
+} as const;
+
+export type ControllersConfigDoc = {
+  schemaVersion?: string;
+  operator?: {
+    deploymentMode?: 'operator' | 'embedded';
+    version?: string;
+  };
+  meshsync?: {
+    version?: string;
+    replicas?: number;
+    watchList?: {
+      whitelist?: { resource: string; events?: string[] }[];
+      blacklist?: string[];
+    };
+    outputNamespaces?: string[];
+    outputResources?: string[];
+    redactSecrets?: boolean;
+    brokerContentDedup?: boolean;
+    debugLogging?: boolean;
+  };
+  broker?: {
+    version?: string;
+    replicas?: number;
+    service?: {
+      type?: 'ClusterIP' | 'NodePort' | 'LoadBalancer';
+      annotations?: Record<string, string>;
+      loadBalancerClass?: string;
+      loadBalancerSourceRanges?: string[];
+      externalEndpointOverride?: string;
+    };
+  };
+};
+
+export type ConnectionControllersConfigDoc = {
+  override?: ControllersConfigDoc | null;
+  default?: ControllersConfigDoc | null;
+  effective: ControllersConfigDoc;
+};
+
+const controllersConfigApi = api
+  .enhanceEndpoints({
+    addTagTypes: [TAGS.CONTROLLERS_CONFIG],
+  })
+  .injectEndpoints({
+    overrideExisting: true,
+    endpoints: (builder) => ({
+      getControllersDefaultConfig: builder.query<ControllersConfigDoc, void>({
+        query: () => ({
+          url: mesheryApiPath('system/controllers/config'),
+          method: 'GET',
+        }),
+        providesTags: [TAGS.CONTROLLERS_CONFIG],
+      }),
+      updateControllersDefaultConfig: builder.mutation<
+        ControllersConfigDoc,
+        { body: ControllersConfigDoc }
+      >({
+        query: (queryArg) => ({
+          url: mesheryApiPath('system/controllers/config'),
+          method: 'PUT',
+          body: queryArg.body,
+        }),
+        invalidatesTags: [TAGS.CONTROLLERS_CONFIG],
+      }),
+      getConnectionControllersConfig: builder.query<
+        ConnectionControllersConfigDoc,
+        { connectionId: string }
+      >({
+        query: (queryArg) => ({
+          url: mesheryApiPath(
+            `integrations/connections/${queryArg.connectionId}/controllers/config`,
+          ),
+          method: 'GET',
+        }),
+        providesTags: (_result, _error, arg) => [
+          { type: TAGS.CONTROLLERS_CONFIG, id: arg.connectionId },
+          TAGS.CONTROLLERS_CONFIG,
+        ],
+      }),
+      updateConnectionControllersConfig: builder.mutation<
+        ConnectionControllersConfigDoc,
+        { connectionId: string; body: ControllersConfigDoc }
+      >({
+        query: (queryArg) => ({
+          url: mesheryApiPath(
+            `integrations/connections/${queryArg.connectionId}/controllers/config`,
+          ),
+          method: 'PUT',
+          body: queryArg.body,
+        }),
+        invalidatesTags: (_result, _error, arg) => [
+          { type: TAGS.CONTROLLERS_CONFIG, id: arg.connectionId },
+          TAGS.CONTROLLERS_CONFIG,
+        ],
+      }),
+    }),
+  });
+
+export const {
+  useGetControllersDefaultConfigQuery,
+  useUpdateControllersDefaultConfigMutation,
+  useGetConnectionControllersConfigQuery,
+  useUpdateConnectionControllersConfigMutation,
+} = controllersConfigApi;

--- a/ui/rtk-query/user.ts
+++ b/ui/rtk-query/user.ts
@@ -1,9 +1,5 @@
 import { ctxUrl } from '../utils/multi-ctx';
-import {
-  mesheryApi,
-  useGetTeamsQuery as useSchemasGetTeamsQuery,
-  useGetUsersForOrgQuery as useSchemasGetUsersForOrgQuery,
-} from '@meshery/schemas/mesheryApi';
+import { useGetUsersForOrgQuery as useSchemasGetUsersForOrgQuery } from '@meshery/schemas/mesheryApi';
 import { api, mesheryApiPath } from './index';
 import { initiateQuery } from './utils';
 import { useGetOrgsQuery } from './organization';
@@ -16,11 +12,13 @@ const Tags = {
   USER_PREF: 'userPref',
   LOAD_TEST_PREF: 'loadTestPref',
   PROVIDER_CAP: 'provider_capabilities',
+  TEAMS: 'teams',
+  USERS: 'users',
 };
 
 export const userApi = api
   .enhanceEndpoints({
-    addTagTypes: [Tags.USER_PREF, Tags.LOAD_TEST_PREF, Tags.PROVIDER_CAP],
+    addTagTypes: [Tags.USER_PREF, Tags.LOAD_TEST_PREF, Tags.PROVIDER_CAP, Tags.TEAMS, Tags.USERS],
   })
   .injectEndpoints({
     endpoints: (builder) => ({
@@ -232,6 +230,23 @@ export const userApi = api
         }),
         providesTags: ['users'],
       }),
+      // Hand-written since @meshery/schemas 1.3.25: the teams endpoints were
+      // reclassified as cloud-only in the schemas spec (meshery/schemas#1015),
+      // which removed getTeams from the generated mesheryApi surface. Meshery
+      // Server still proxies the endpoint for providers that serve it, so the
+      // query lives here now, mirroring the generated hook's argument shape.
+      getTeams: builder.query({
+        query: (queryArg) => ({
+          url: `/api/identity/orgs/${queryArg.orgId}/teams`,
+          params: {
+            search: queryArg.search,
+            order: queryArg.order,
+            page: queryArg.page,
+            pagesize: queryArg.pagesize,
+          },
+        }),
+        providesTags: ['teams'],
+      }),
       removeUserFromTeam: builder.mutation({
         query: (queryArg) => ({
           url: mesheryApiPath(
@@ -313,7 +328,7 @@ export const useGetUsersForOrgQuery = (queryArg, options) =>
   );
 
 export const useGetTeamsQuery = (queryArg, options) =>
-  useSchemasGetTeamsQuery(
+  userApi.endpoints.getTeams.useQuery(
     {
       orgId: queryArg?.orgId,
       search: queryArg?.search,
@@ -325,7 +340,7 @@ export const useGetTeamsQuery = (queryArg, options) =>
   );
 
 export const useLazyGetTeamsQuery = () => {
-  const [trigger, result, lastPromiseInfo] = mesheryApi.endpoints.getTeams.useLazyQuery();
+  const [trigger, result, lastPromiseInfo] = userApi.endpoints.getTeams.useLazyQuery();
 
   const wrappedTrigger = (queryArg, preferCacheValue) =>
     trigger(


### PR DESCRIPTION
## Description

Exposes the Meshery Operator, MeshSync, and Meshery Broker configuration surface in Meshery: server-wide defaults in Settings, per-connection overrides in Connections, with enforced precedence (per-connection override -> server-wide default -> built-in default) and propagation to managed clusters.

Implements the plan posted at https://github.com/meshery/meshery/issues/20487#issuecomment-4884274065. Schema-first: the contract is the `controllers_config` construct added in meshery/schemas#1023, released as v1.3.25 and consumed here via `go.mod`.

**This PR fixes #20487.** The docs.meshery.io acceptance item is being handled in parallel docs PRs.

### Server

- **Schema consumption**: `github.com/meshery/schemas` bumped to v1.3.25; the layered document is `controllers_config.MesheryControllersConfig` (all fields optional; Go pointers preserve set-vs-inherit).
- **Persistence**:
  - Server-wide defaults: new `system_settings` key/value GORM table (`server/models/system_settings.go`), auto-migrated at startup. Defaults are instance-scoped deployment behavior, stored in Meshery Server's own database regardless of provider.
  - Per-connection override: `Connection.metadata["controllers_config"]`, following the `meshsync_deployment_mode` precedent (`server/models/connections/controllers_config.go`). `operator.deploymentMode` is mirrored into the legacy `meshsync_deployment_mode` key on write so every existing consumer keeps working.
- **API**:
  - `GET/PUT /api/system/controllers/config` - server-wide defaults.
  - `GET/PUT /api/integrations/connections/{connectionId}/controllers/config` - per-connection override; GET returns `{override, default, effective}`.
- **Precedence**: one resolution function (`connections.ResolveControllersConfig`) merges override over defaults (explicitly-set fields only) and separately fills built-in defaults for the effective view. Unit-tested (`controllers_config_test.go`).
- **Propagation** (`server/models/controllers_config_apply.go`):
  - Operator mode: merge-patch the MeshSync CR (`spec.version`, `spec.size`, `spec.watch-list`) and Broker CR (`spec.version`, `spec.size`, `spec.service`); server-side apply of the env/args overlay (`MESHSYNC_REDACT_SECRETS`, `MESHSYNC_BROKER_CONTENT_DEDUP`, `DEBUG`, `--outputNamespaces`, `--outputResources`) on the MeshSync Deployment under the `meshery-server` field manager. Ownership is disjoint from the operator's own SSA (verified against meshery-operator master), so entries withdraw cleanly when unset and the operator never reverts them. Watch-list changes trigger an automatic rolling restart (MeshSync reads its CR at startup only).
  - Embedded mode: the in-process `libmeshsync.Run` now receives `WithOnlyK8sNamespaces`/`WithOnlyK8sResources` from the resolved config, and the run is restarted on configuration change (same teardown/reattach path as deployment-mode changes).
  - Applies happen on connect (ConnectAction), on per-connection PUT, and fan out to all tracked connections on a defaults PUT. Missing CRs/Deployment (operator still coming up, or embedded clusters) are skipped and re-applied on reconnect, reported via events.
- **Deployment-mode resolution chain** now: connection metadata -> Settings-persisted server default -> `MESHSYNC_DEFAULT_DEPLOYMENT_MODE` env -> built-in `embedded`.
- **Events**: apply success/failure emitted per connection with target details; **errors**: new MeshKit codes `meshery-server-1437..1440` allocated per convention (`component_info.json` bumped).

### UI

- **Settings**: new "Operator, MeshSync & Broker" tab (`ui/components/settings/MesheryControllersConfig.tsx`) editing the server-wide defaults with tri-state controls (Inherit / value) and built-in defaults shown as placeholders.
- **Connections**: "Configure Controllers" action on Kubernetes connection rows opens "Operator, MeshSync & Broker Configuration" (`ui/components/connections/ConnectionControllersConfigModal.tsx`) showing the effective config with per-field source chips (Override / Server default / Built-in default); fields left on Inherit follow the server defaults.
- Shared layered editor `ui/components/configuration/ControllersConfigForm.tsx`: watch-list whitelist/blacklist editor (per-resource ADDED/MODIFIED/DELETED events), replica bounds, LoadBalancer-gated fields, un-redacted-Secrets warning, restart-required captions.
- RTK Query slice `ui/rtk-query/controllersConfig.ts` (hand-written, consistent with `ui/rtk-query/connection.ts`); Sistent components; notistack events.

### Validation

Replica ranges (1-10), whitelist XOR blacklist, event enums, service type enum, LoadBalancer-only fields, deployment-mode enum - enforced server-side (`ValidateControllersConfig`) and reflected in the UI.

## How this was tested

- `go build ./server/...` clean; `go vet` clean on touched trees.
- Unit tests: `go test ./server/models/connections/...` (precedence resolution, metadata round-trip and tolerance, validation matrix, watch-list atomicity) plus full `go test --short ./server/models/... ./server/machines/...` pass.
- UI: `eslint` clean on all touched files; full `next build` production build passes.
- SSA field-ownership semantics for the Deployment overlay verified against meshery-operator master (operator applies via `client.Apply` with its own field manager; env is an SSA map-list keyed by name; the operator sets no `args` and no restart annotation).

## What is deferred (and why)

- Roadmap knobs (tiered discovery meshery/meshsync#577, work queue #578, JetStream #580, reconcile interval #581): not on meshsync master; the schema's layered optional-object design admits them additively.
- Embedded-mode per-connection env knobs (`redactSecrets`, `brokerContentDedup`, `debugLogging`) follow the Meshery Server process environment until meshsync's library exposes run options for them; embedded watch-list applies when the target cluster carries a MeshSync CR. Both are noted in the UI copy and tracked for a meshery/meshsync follow-up.
- Operator CRD env/args passthrough (would move the Deployment overlay into CR fields): meshery-operator follow-up; the SSA overlay works against today's operator on today's clusters.

### Out-of-scope fix included (flagged for reviewers)

- `ui/rtk-query/user.ts`: schemas v1.3.25 is the first release carrying meshery/schemas#1015, which reclassified the team endpoints as cloud-only and removed `getTeams` from the generated `mesheryApi`. Every Docker image build breaks once the `^1.3.16` range resolves to 1.3.25 (Turbopack rejects the statically-missing export). The teams query is now injected locally on `userApi` with the same URL and argument shape, and the `teams`/`users` tag types are registered so the existing `removeUserFromTeam` invalidation actually works. Without this, master's image builds fail on the next fresh dependency resolution regardless of this PR.

## Related

- meshery/schemas#1023 (merged; released as v1.3.25)
- Implementation plan: https://github.com/meshery/meshery/issues/20487#issuecomment-4884274065
