### PR TITLE
Fix MeshSync invalid image rollout

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -486,11 +486,14 @@ wasm-engine: dep-check-go
 	@echo "Patching wasm_exec.js to add process.env polyfill..."
 	@tmp=server/policies/wasm/wasm_exec.js.tmp && \
 		awk '{ \
-			print; \
-			if (index($$0, "chdir() { throw enosys(); },") > 0) { \
+			if (index($$0, "chdir() { throw enosys(); }") > 0) { \
+				sub(/},?$$/, "},"); \
+				print; \
 				print "\t\t\tenv: {},"; \
 				found = 1; \
+				next; \
 			} \
+			print; \
 		} END { exit(found ? 0 : 1) }' server/policies/wasm/wasm_exec.js > "$$tmp" && \
 		mv "$$tmp" server/policies/wasm/wasm_exec.js || { \
 			rm -f "$$tmp"; \

--- a/install/docker/Dockerfile
+++ b/install/docker/Dockerfile
@@ -24,7 +24,7 @@ RUN mkdir -p /wasm-dist && cd server/policies/wasm && \
     GOOS=js GOARCH=wasm GOPROXY=https://proxy.golang.org GOSUMDB=off \
         go build -trimpath -ldflags="-w -s" -o /wasm-dist/policy_engine.wasm . && \
     cp "$(go env GOROOT)/lib/wasm/wasm_exec.js" /wasm-dist/wasm_exec.js && \
-    awk '{ print; if (index($0, "chdir() { throw enosys(); },") > 0) { print "\t\t\tenv: {},"; found=1 } } END { exit(found ? 0 : 1) }' \
+    awk '{ if (index($0, "chdir() { throw enosys(); }") > 0) { sub(/},?$/, "},"); print; print "\t\t\tenv: {},"; found=1; next } print } END { exit(found ? 0 : 1) }' \
         /wasm-dist/wasm_exec.js > /wasm-dist/wasm_exec.js.tmp && \
     mv /wasm-dist/wasm_exec.js.tmp /wasm-dist/wasm_exec.js
 


### PR DESCRIPTION
## Description

This PR fixes the intermittent MeshSync invalid-image rollout captured in #20494 by updating Meshery Server's embedded MeshSync dependency from `github.com/meshery/meshsync v1.0.0` to `v1.0.2`.

The diagnostic dump added by #20492 captured the bad state:

- Deployment / ReplicaSet image: `meshery/meshsync:Not Set`
- MeshSync CR: `spec.version: Not Set`
- `managedFields` writer for `spec.version`: `Go-http-client`

The root cause matches the embedded MeshSync library path used by Meshery Server integration runs:

- Meshery Server was pinned to MeshSync `v1.0.0`.
- MeshSync `v1.0.0` defaults `Options.Version` to `Not Set`.
- MeshSync `v1.0.0` calls `PatchCRVersion(...)`, which patches the MeshSync CR with `spec.version = Server["version"]`.
- The operator maps `spec.version` into the MeshSync Deployment image tag, producing the invalid image reference `meshery/meshsync:Not Set`.

MeshSync `v1.0.2` removes that CR self-write. The running embedded MeshSync instance no longer writes its own build/version placeholder into the desired-state CR, so it cannot overwrite the operator-managed image tag with `Not Set`.

## Additional fixes

- Keeps the root Kubernetes module set consistent on `v0.35.3`, including `k8s.io/apiextensions-apiserver` and `k8s.io/apiserver`.
- Aligns the nested `server/policies/wasm` module with the same MeshSync/MeshKit/Kubernetes dependency graph so the Docker WASM stage builds against the same dependency set.
- Makes the Docker WASM `wasm_exec.js` patch tolerate Go 1.26's current `chdir() { throw enosys(); }` line, which no longer includes a trailing comma.

## Validation

- `go list -m github.com/meshery/meshsync github.com/meshery/meshkit k8s.io/api k8s.io/apimachinery k8s.io/client-go k8s.io/apiextensions-apiserver k8s.io/apiserver k8s.io/kms`
- Verified MeshSync `v1.0.0` contains `Version: "Not Set"` and `PatchCRVersion(...)`.
- Verified MeshSync `v1.0.2` no longer contains `PatchCRVersion(...)` and documents that MeshSync must not write its running version into `spec.version`.
- `go mod tidy`
- `go mod verify`
- `cd server/policies/wasm && go mod verify`
- `go test ./server/models/... -count=1`
- `go test ./server/machines/... ./server/handlers ./server/helpers/... -count=1`
- `go test github.com/meshery/meshsync/pkg/lib/meshsync -run '^$' -count=1`
- `go test ./... -run '^$' -count=1`
- `cd server/policies/wasm && GOOS=js GOARCH=wasm GOPROXY=https://proxy.golang.org go build -trimpath -ldflags='-w -s' -o /tmp/policy_engine.wasm .`
- Containerized reproduction of the Docker WASM stage using `golang:1.26.4`, including `policy_engine.wasm` build and patched `wasm_exec.js` containing `env: {},`.
- `git diff --check`

Fixes #20494
