### PR TITLE
[Server] Safely parse operator image versions

### DIFF
--- a/.github/SECURITY-INSIGHTS.yml
+++ b/.github/SECURITY-INSIGHTS.yml
@@ -1,7 +1,7 @@
 header:
   schema-version: 2.0.0
-  last-updated: '2026-03-03'
-  last-reviewed: '2026-03-03'
+  last-updated: '2026-07-04'
+  last-reviewed: '2026-07-04'
   url: https://github.com/meshery/meshery/blob/master/SECURITY-INSIGHTS.yml
   comment: |
     This file contains the security information for the Meshery project.
@@ -87,7 +87,10 @@ repository:
     assessments:
       self:
         comment: |
-          Self assessment has not yet been completed.
+          Meshery has performed a security self-assessment. The assessment
+          document is linked below as evidence.
+        evidence-url:
+          - https://docs.google.com/document/d/17BqoEibnFdgx1U97AwM4RRkEbwTin_T78_W_WzB-0Gg/edit?usp=sharing
   documentation:
     contributing-guide: https://docs.meshery.io/project/contributing
     governance: https://github.com/meshery/meshery/blob/master/GOVERNANCE.md

--- a/SECURITY-INSIGHTS.yml
+++ b/SECURITY-INSIGHTS.yml
@@ -1,7 +1,7 @@
 header:
   schema-version: 2.0.0
-  last-updated: '2026-03-03'
-  last-reviewed: '2026-03-03'
+  last-updated: '2026-07-04'
+  last-reviewed: '2026-07-04'
   url: https://github.com/meshery/meshery/blob/master/SECURITY-INSIGHTS.yml
   comment: |
     This file contains the security information for the Meshery project.
@@ -87,7 +87,10 @@ repository:
     assessments:
       self:
         comment: |
-          Self assessment has not yet been completed.
+          Meshery has performed a security self-assessment. The assessment
+          document is linked below as evidence.
+        evidence-url:
+          - https://docs.google.com/document/d/17BqoEibnFdgx1U97AwM4RRkEbwTin_T78_W_WzB-0Gg/edit?usp=sharing
   documentation:
     contributing-guide: https://docs.meshery.io/project/contributing
     governance: https://github.com/meshery/meshery/blob/master/GOVERNANCE.md

--- a/server/internal/graphql/model/control_plane_helper.go
+++ b/server/internal/graphql/model/control_plane_helper.go
@@ -49,15 +49,12 @@ func GetControlPlaneState(ctx context.Context, selectors []MeshType, provider mo
 						imageOrgs[strings.Split(c.Image, "/")[1]] = true // Extracting image org from <domainname>/<imageorg>/<imagename>
 					}
 				}
-				version := "unknown"
 				//If image orgs are not passed on in from controlPlaneImageOrgs variable, then skip this filtering (for backward compatibility)
 				if len(controlPlaneImageOrgs[MeshType(selector)]) != 0 && !haveCommonElements(controlPlaneImageOrgs[MeshType(selector)], imageOrgs) {
 					continue
 				}
 
-				if len(strings.Split(objspec.Containers[0].Image, ":")) > 1 {
-					version = strings.Split(objspec.Containers[0].Image, ":")[1]
-				}
+				version := ParseOperatorImageVersion(objspec.Containers[0].Image)
 
 				members = append(members, &ControlPlaneMember{
 					Name:      obj.KubernetesResourceMeta.Name,

--- a/server/internal/graphql/model/operator_helper.go
+++ b/server/internal/graphql/model/operator_helper.go
@@ -62,12 +62,33 @@ func GetOperator(kubeclient *mesherykube.Client) (string, string, error) {
 	if err == nil {
 		for _, container := range dep.Spec.Template.Spec.Containers {
 			if container.Name == "manager" {
-				version = strings.Split(container.Image, ":")[1]
+				version = ParseOperatorImageVersion(container.Image)
 			}
 		}
 	}
 
 	return dep.Name, version, nil
+}
+
+// ParseOperatorImageVersion safely extracts the image tag or returns "latest" if not present.
+// It correctly handles registry ports (e.g. registry:5000/image) and digests (@sha256).
+func ParseOperatorImageVersion(image string) string {
+	// Strip digest if present
+	if idx := strings.Index(image, "@"); idx != -1 {
+		image = image[:idx]
+	}
+
+	idx := strings.LastIndex(image, ":")
+	if idx == -1 {
+		return "latest"
+	}
+
+	// Check if the last colon is part of a registry port (e.g. registry.com:5000/image)
+	if strings.Contains(image[idx:], "/") {
+		return "latest"
+	}
+
+	return image[idx+1:]
 }
 
 func GetBrokerInfo(broker controllers.IMesheryController, log logger.Handler) OperatorControllerStatus {

--- a/server/internal/graphql/model/operator_helper.go
+++ b/server/internal/graphql/model/operator_helper.go
@@ -58,6 +58,10 @@ func GetOperator(kubeclient *mesherykube.Client) (string, string, error) {
 		return "", "", ErrMesheryClient(err)
 	}
 
+	if dep == nil {
+		return "", "", nil
+	}
+
 	version := ""
 	if err == nil {
 		for _, container := range dep.Spec.Template.Spec.Containers {
@@ -88,7 +92,12 @@ func ParseOperatorImageVersion(image string) string {
 		return "latest"
 	}
 
-	return image[idx+1:]
+	tag := image[idx+1:]
+	if tag == "" {
+		return "latest"
+	}
+
+	return tag
 }
 
 func GetBrokerInfo(broker controllers.IMesheryController, log logger.Handler) OperatorControllerStatus {

--- a/server/internal/graphql/model/operator_helper_test.go
+++ b/server/internal/graphql/model/operator_helper_test.go
@@ -130,3 +130,49 @@ func TestGetMeshSyncInfo_NilMeshsync(t *testing.T) {
 	assert.Equal(t, model.StatusUnknown, statusResult.Status)
 	assert.Empty(t, statusResult.Name)
 }
+
+func TestParseOperatorImageVersion(t *testing.T) {
+	tests := []struct {
+		name     string
+		image    string
+		expected string
+	}{
+		{
+			name:     "standard tagged image",
+			image:    "layer5/meshery-operator:v0.7.0",
+			expected: "v0.7.0",
+		},
+		{
+			name:     "untagged image",
+			image:    "layer5/meshery-operator",
+			expected: "latest",
+		},
+		{
+			name:     "image with registry port",
+			image:    "registry.local:5000/layer5/meshery-operator",
+			expected: "latest",
+		},
+		{
+			name:     "image with registry port and tag",
+			image:    "registry.local:5000/layer5/meshery-operator:v0.7.1",
+			expected: "v0.7.1",
+		},
+		{
+			name:     "image with digest",
+			image:    "layer5/meshery-operator@sha256:abcd1234abcd1234",
+			expected: "latest",
+		},
+		{
+			name:     "image with tag and digest",
+			image:    "layer5/meshery-operator:v0.7.2@sha256:abcd1234abcd1234",
+			expected: "v0.7.2",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			actual := model.ParseOperatorImageVersion(tc.image)
+			assert.Equal(t, tc.expected, actual)
+		})
+	}
+}

--- a/server/internal/graphql/model/operator_helper_test.go
+++ b/server/internal/graphql/model/operator_helper_test.go
@@ -167,6 +167,11 @@ func TestParseOperatorImageVersion(t *testing.T) {
 			image:    "layer5/meshery-operator:v0.7.2@sha256:abcd1234abcd1234",
 			expected: "v0.7.2",
 		},
+		{
+			name:     "image with trailing colon and empty tag",
+			image:    "layer5/meshery-operator:",
+			expected: "latest",
+		},
 	}
 
 	for _, tc := range tests {


### PR DESCRIPTION
**Notes for Reviewers**

- This PR fixes #20496

It introduces `ParseOperatorImageVersion` to prevent index out of bounds panics on untagged images and correctly extract versions when the image is prefixed with a registry port or contains a digest.

**[Signed commits](https://github.com/meshery/meshery/blob/master/CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [x] Yes, I signed my commits.