### PR TITLE
[UI] Fix Telemetry sidebar icon visibility in light mode

### DIFF
--- a/ui/components/layout/Navigator/navigatorComponents.tsx
+++ b/ui/components/layout/Navigator/navigatorComponents.tsx
@@ -183,9 +183,9 @@ export const getNavigatorComponents = (
   },
   {
     id: TELEMETRY,
-    icon: <InsertChartIcon style={{ ...drawerIconsStyle }} fill={theme.palette.icon.default} />,
+    icon: <InsertChartIcon style={{ ...drawerIconsStyle }} />,
     hovericon: (
-      <InsertChartIcon style={{ ...drawerIconsStyle }} fill={theme.palette.icon.default} />
+      <InsertChartIcon style={{ ...drawerIconsStyle }} />
     ),
     href: '/telemetry',
     title: 'Telemetry',
@@ -195,7 +195,7 @@ export const getNavigatorComponents = (
     children: [
       {
         id: GRAFANA,
-        icon: <InsertChartIcon style={{ ...drawerIconsStyle }} fill={theme.palette.icon.default} />,
+        icon: <InsertChartIcon style={{ ...drawerIconsStyle }} />,
         href: '/telemetry/charts',
         title: 'Charts',
         show: providerUiAccessControl.isNavigatorComponentEnabled([TELEMETRY, GRAFANA]),
@@ -203,7 +203,7 @@ export const getNavigatorComponents = (
       },
       {
         id: PROMETHEUS,
-        icon: <TachographDigitalIcon fill={theme.palette.icon.default} style={drawerIconsStyle} />,
+        icon: <TachographDigitalIcon style={drawerIconsStyle} />,
         href: '/telemetry/metrics',
         title: 'Metrics',
         show: providerUiAccessControl.isNavigatorComponentEnabled([TELEMETRY, PROMETHEUS]),
@@ -223,7 +223,7 @@ export const getNavigatorComponents = (
     children: [
       {
         id: PROFILES,
-        icon: <TachographDigitalIcon fill={theme.palette.icon.default} />,
+        icon: <TachographDigitalIcon />,
         href: '/performance/profiles',
         title: 'Profiles',
         show: providerUiAccessControl.isNavigatorComponentEnabled([PERFORMANCE, PROFILES]),


### PR DESCRIPTION
**Description**

Fixes #20378

The Telemetry icon and its children (Charts/Grafana, Metrics/Prometheus) explicitly set `fill={theme.palette.icon.default}`, overriding the parent sidebar's white fill. In light mode, `theme.palette.icon.default` resolves to a dark color, making the Telemetry icon appear significantly darker than all other navigation icons.

**Change**

Removed the explicit `fill` override from:
- Telemetry parent icon and hovericon
- Charts (Grafana) child icon
- Metrics (Prometheus) child icon

The icons now inherit color from the parent sidebar context (`SideBarListItem` / `MainListIcon`), consistent with Dashboard, Lifecycle, Configuration, Performance, and Extensions.

---

**Release Notes**

```release-note
Fix Telemetry sidebar icon color in light mode by removing explicit fill override.

---
