### PR TITLE
[server] Fix Meshsyn->Meshsync typo in controller helper symbols

### DIFF
--- a/server/handlers/connections_handlers.go
+++ b/server/handlers/connections_handlers.go
@@ -671,7 +671,7 @@ func (h *Handler) handleMeshSyncDeploymentModeChange(
 				SetMeshsyncDeploymentMode(newMeshSyncMode).
 				UpdateOperatorsStatusMap(machineCtx.OperatorTracker).
 				DeployUndeployedOperators(machineCtx.OperatorTracker).
-				AddMeshsynDataHandlers(ctx, machineCtx.K8sContext, userID, mesheryInstanceID, provider)
+				AddMeshsyncDataHandlers(ctx, machineCtx.K8sContext, userID, mesheryInstanceID, provider)
 		}
 
 	}

--- a/server/handlers/controllers_config_handlers.go
+++ b/server/handlers/controllers_config_handlers.go
@@ -363,7 +363,7 @@ func (h *Handler) applyControllersConfigToConnection(
 		// watch-list are re-read.
 		contextID := machineCtx.K8sContext.ID
 		ctrlHelper.RemoveMeshSyncDataHandler(ctx, contextID)
-		ctrlHelper.AddMeshsynDataHandlers(ctx, machineCtx.K8sContext, userID, *h.SystemID, provider)
+		ctrlHelper.AddMeshsyncDataHandlers(ctx, machineCtx.K8sContext, userID, *h.SystemID, provider)
 		h.emitControllersConfigApplyEvent(eventBuilder, provider, token, userID, events.Informational, "Controllers configuration applied: embedded MeshSync restarted with the updated configuration.", map[string]interface{}{"connectionId": connectionID})
 	case connections.MeshsyncDeploymentModeOperator:
 		kubeClient, err := machineCtx.K8sContext.GenerateKubeHandler()

--- a/server/machines/kubernetes/connect.go
+++ b/server/machines/kubernetes/connect.go
@@ -103,7 +103,7 @@ func (ca *ConnectAction) Execute(ctx context.Context, machineCtx interface{}, da
 			SetControllersConfig(mergedControllersConfig).
 			UpdateOperatorsStatusMap(machinectx.OperatorTracker).
 			DeployUndeployedOperators(machinectx.OperatorTracker)
-		ctrlHelper.AddMeshsynDataHandlers(ctx, machinectx.K8sContext, userUUID, *sysID, provider)
+		ctrlHelper.AddMeshsyncDataHandlers(ctx, machinectx.K8sContext, userUUID, *sysID, provider)
 
 		// Operator mode: best-effort apply of the explicitly-set
 		// configuration onto the cluster's MeshSync/Broker custom resources

--- a/server/models/meshery_controllers.go
+++ b/server/models/meshery_controllers.go
@@ -156,8 +156,8 @@ func (mch *MesheryControllersHelper) ResolveControllersConfigForConnection(metad
 // initialized yet. Apart from updating the map, it also runs the handler after
 // updating the map. The presence of a handler for a context in a map indicate that
 // the meshsync data for that context is properly being handled
-func (mch *MesheryControllersHelper) AddMeshsynDataHandlers(ctx context.Context, k8scontext K8sContext, userID, mesheryInstanceID core.Uuid, provider Provider) *MesheryControllersHelper {
-	// only checking those contexts whose MesheryConrollers are active
+func (mch *MesheryControllersHelper) AddMeshsyncDataHandlers(ctx context.Context, k8scontext K8sContext, userID, mesheryInstanceID core.Uuid, provider Provider) *MesheryControllersHelper {
+	// only checking those contexts whose MesheryControllers are active
 	// go func(mch *MesheryControllersHelper) {
 
 	ctxID := k8scontext.ID
@@ -167,13 +167,13 @@ func (mch *MesheryControllersHelper) AddMeshsynDataHandlers(ctx context.Context,
 
 		switch mch.meshsyncDeploymentMode {
 		case connections.MeshsyncDeploymentModeOperator:
-			brokerHandler = mch.meshsynDataHandlersNatsBroker(k8scontext, userID)
+			brokerHandler = mch.meshsyncDataHandlersNatsBroker(k8scontext, userID)
 		case connections.MeshsyncDeploymentModeEmbedded:
 			brokerHandler = channelBroker.NewChannelBrokerHandler()
 			// use a standalone context here context.Background(), as
 			// meshsync run must be stopped only when meshsync data handler is deregistered
 			// and ctx which is passed from above, could be closed earlier
-			stop, err := mch.meshsynDataHandlersStartLibMeshsyncRun(context.Background(), brokerHandler, k8scontext, userID)
+			stop, err := mch.meshsyncDataHandlersStartLibMeshsyncRun(context.Background(), brokerHandler, k8scontext, userID)
 			if err != nil {
 				mch.log.Error(err)
 				mch.emitErrorEvent("Failed to start MeshSync library run", err, map[string]any{
@@ -200,7 +200,7 @@ func (mch *MesheryControllersHelper) AddMeshsynDataHandlers(ctx context.Context,
 		}
 
 		if brokerHandler == nil {
-			mch.log.Warnf("MesheryControllersHelper::AddMeshsynDataHandlers brokerHandler is nil")
+			mch.log.Warnf("MesheryControllersHelper::AddMeshsyncDataHandlers brokerHandler is nil")
 			mch.emitWarningEvent("MeshSync data handler broker is nil", nil, map[string]any{
 				"k8sContextID":   ctxID,
 				"k8sContextName": k8scontext.Name,
@@ -249,7 +249,7 @@ func (mch *MesheryControllersHelper) AddMeshsynDataHandlers(ctx context.Context,
 	return mch
 }
 
-func (mch *MesheryControllersHelper) meshsynDataHandlersNatsBroker(
+func (mch *MesheryControllersHelper) meshsyncDataHandlersNatsBroker(
 	k8scontext K8sContext,
 	userID core.Uuid,
 ) broker.Handler {
@@ -303,9 +303,9 @@ func (mch *MesheryControllersHelper) meshsynDataHandlersNatsBroker(
 	return brokerHandler
 }
 
-// meshsynDataHandlersStartLibMeshsyncRun starts the libmeshsync run for the given context.
+// meshsyncDataHandlersStartLibMeshsyncRun starts the libmeshsync run for the given context.
 // returns stop function to stop goroutine
-func (mch *MesheryControllersHelper) meshsynDataHandlersStartLibMeshsyncRun(
+func (mch *MesheryControllersHelper) meshsyncDataHandlersStartLibMeshsyncRun(
 	ctx context.Context,
 	brokerHandler broker.Handler,
 	k8sContext K8sContext,
@@ -313,7 +313,7 @@ func (mch *MesheryControllersHelper) meshsynDataHandlersStartLibMeshsyncRun(
 ) (func(), error) {
 	kubeConfig, err := k8sContext.GenerateKubeConfig()
 	if err != nil {
-		return nil, fmt.Errorf("MesheryControllersHelper::meshsynDataHandlersStartLibMeshsyncRun error generating kubeconfig from context: %v", err)
+		return nil, fmt.Errorf("MesheryControllersHelper::meshsyncDataHandlersStartLibMeshsyncRun error generating kubeconfig from context: %v", err)
 	}
 
 	cancelCtx, stopFunc := context.WithCancel(ctx)
@@ -344,7 +344,7 @@ func (mch *MesheryControllersHelper) meshsynDataHandlersStartLibMeshsyncRun(
 			mch.log,
 			runOptions...,
 		); err != nil {
-			meshsyncErr := fmt.Errorf("MesheryControllersHelper::meshsynDataHandlersStartLibMeshsyncRun error running meshsync lib: %v", err)
+			meshsyncErr := fmt.Errorf("MesheryControllersHelper::meshsyncDataHandlersStartLibMeshsyncRun error running meshsync lib: %v", err)
 			mch.log.Error(meshsyncErr)
 			mch.emitErrorEvent("Error running MeshSync library", meshsyncErr, map[string]any{
 				"k8sContextID":           k8sContext.ID,


### PR DESCRIPTION
## Summary

`server/models/meshery_controllers.go` defined `AddMeshsynDataHandlers` and two related private helpers with "Meshsyn" missing the trailing "c" in "Meshsync". This misspelling family has confused code search and tripped up automated review bots that flagged a correctly-spelled doc reference as a typo.

- Renamed `AddMeshsynDataHandlers` -> `AddMeshsyncDataHandlers`
- Renamed `meshsynDataHandlersNatsBroker` -> `meshsyncDataHandlersNatsBroker`
- Renamed `meshsynDataHandlersStartLibMeshsyncRun` -> `meshsyncDataHandlersStartLibMeshsyncRun` (found via a repo-wide case-sensitive grep for `Meshsyn[^c]`, not named in the original ask but part of the same misspelling family)
- Updated all call sites: `server/machines/kubernetes/connect.go` (`ConnectAction.Execute`) and `server/handlers/connections_handlers.go` (`handleMeshSyncDeploymentModeChange`)
- Updated log strings, error strings, and comments referencing the old names

Pure rename, no behavior change.

### External callers

Searched GitHub across the `meshery` org and broader public code for `AddMeshsynDataHandlers` usage outside this repo. All hits were forks of `meshery/meshery` itself (same file/line) - no genuine external consumer imports this symbol as a package API, so no deprecated alias is kept.

### Follow-up (separate repo, separate PR)

`meshery/meshsync`'s `docs/design/fd6-non-kubernetes-discovery.md` references `AddMeshsynDataHandlers` with a "sic" note. That note should be removed and the reference updated to `AddMeshsyncDataHandlers` in a coordinated PR once this merges - not included here since it lives in a different repo.

## Test plan

- [x] `go build ./models/... ./machines/... ./handlers/...` in `server/`
- [x] `go test ./models/... ./machines/...` in `server/` - all passing
- [ ] `make golangci` - could not run; installed `golangci-lint` (v2.12.2) in this environment is incompatible with the repo's `.golangci.yml` config version (pre-existing environment issue, unrelated to this change)