### PR TITLE
[Server] Fix FlushMeshSyncData stale table-name subqueries leaking MeshSync data

### DIFF
--- a/server/helpers/component_info.json
+++ b/server/helpers/component_info.json
@@ -1,5 +1,5 @@
 {
   "name": "meshery-server",
   "type": "component",
-  "next_error_code": 1441
+  "next_error_code": 1442
 }

--- a/server/internal/graphql/resolver/meshsync.go
+++ b/server/internal/graphql/resolver/meshsync.go
@@ -145,43 +145,29 @@ func (r *Resolver) resyncCluster(ctx context.Context, provider models.Provider, 
 				r.Log.Error(ErrEmptyCurrentK8sContext)
 				return "", ErrEmptyCurrentK8sContext
 			}
-			var sid string
+			var sid, ctxName, ctxServer string
 			for _, k8ctx := range k8sctxs {
 				if k8ctx == nil {
 					continue
 				}
 				if k8ctx.ID == k8scontextID && k8ctx.KubernetesServerID != nil {
 					sid = k8ctx.KubernetesServerID.String()
+					ctxName = k8ctx.Name
+					ctxServer = k8ctx.Server
 					break
 				}
 			}
 			if provider.GetGenericPersister() == nil {
-				return "", model.ErrEmptyHandler
+				return "", models.ErrEmptyMeshSyncHandler()
 			}
 
-			err := provider.GetGenericPersister().Where("id IN (?)", provider.GetGenericPersister().Table("kubernetes_resources").Select("id").Where("cluster_id=?", sid)).Delete(&meshsyncmodel.KubernetesKeyValue{}).Error
-			if err != nil {
-				return "", model.ErrEmptyHandler
-			}
-
-			err = provider.GetGenericPersister().Where("id IN (?)", provider.GetGenericPersister().Table("kubernetes_resources").Select("id").Where("cluster_id=?", sid)).Delete(&meshsyncmodel.KubernetesResourceSpec{}).Error
-			if err != nil {
-				return "", model.ErrEmptyHandler
-			}
-
-			err = provider.GetGenericPersister().Where("id IN (?)", provider.GetGenericPersister().Table("kubernetes_resources").Select("id").Where("cluster_id=?", sid)).Delete(&meshsyncmodel.KubernetesResourceStatus{}).Error
-			if err != nil {
-				return "", model.ErrEmptyHandler
-			}
-
-			err = provider.GetGenericPersister().Where("id IN (?)", provider.GetGenericPersister().Table("kubernetes_resources").Select("id").Where("cluster_id=?", sid)).Delete(&meshsyncmodel.KubernetesResourceObjectMeta{}).Error
-			if err != nil {
-				return "", model.ErrEmptyHandler
-			}
-
-			err = provider.GetGenericPersister().Where("cluster_id = ?", sid).Delete(&meshsyncmodel.KubernetesResource{}).Error
-			if err != nil {
-				return "", model.ErrEmptyHandler
+			// Shared with models.FlushMeshSyncData so both cluster-delete paths remove
+			// the parent resources and all of their child rows using model-derived
+			// table names rather than duplicated, easily-stale raw SQL.
+			if err := models.FlushMeshSyncResourcesForCluster(provider.GetGenericPersister(), sid); err != nil {
+				flushErr := models.ErrFlushMeshSyncData(err, ctxName, ctxServer)
+				r.Log.Error(flushErr)
+				return "", flushErr
 			}
 		}
 	}

--- a/server/models/error.go
+++ b/server/models/error.go
@@ -107,6 +107,7 @@ const (
 	ErrInvalidEventDataCode               = "meshery-server-1357"
 	ErrUnreachableKubeAPICode             = "meshery-server-1304"
 	ErrFlushMeshSyncDataCode              = "meshery-server-1305"
+	ErrEmptyMeshSyncHandlerCode           = "meshery-server-1441"
 	ErrUpdateConnectionStatusCode         = "meshery-server-1306"
 	ErrResultNotFoundCode                 = "meshery-server-1307"
 	ErrPersistCredentialCode              = "meshery-server-1308"
@@ -547,7 +548,11 @@ func ErrUnreachableKubeAPI(err error, server string) error {
 }
 
 func ErrFlushMeshSyncData(err error, contextName, server string) error {
-	return errors.New(ErrFlushMeshSyncDataCode, errors.Alert, []string{"Unable to flush MeshSync data for context %s at %s "}, []string{err.Error()}, []string{"Meshery Database handler is not accessible to perform operations"}, []string{"Restart Meshery Server or Perform Hard Reset"})
+	return errors.New(ErrFlushMeshSyncDataCode, errors.Alert, []string{fmt.Sprintf("Unable to flush MeshSync data for context %s at %s", contextName, server)}, []string{err.Error()}, []string{"Meshery Database handler is not accessible to perform operations"}, []string{"Restart Meshery Server or Perform Hard Reset"})
+}
+
+func ErrEmptyMeshSyncHandler() error {
+	return errors.New(ErrEmptyMeshSyncHandlerCode, errors.Alert, []string{"MeshSync data flush skipped: database handler is not usable"}, []string{"The MeshSync database handler is nil, or its underlying database connection is not initialized"}, []string{"Meshery Database handler is not accessible to perform operations", "Meshery Database is crashed or not reachable"}, []string{"Restart Meshery Server", "Verify that Meshery Server can reach the database"})
 }
 
 func ErrUpdateConnectionStatus(err error, statusCode int) error {

--- a/server/models/k8s_context.go
+++ b/server/models/k8s_context.go
@@ -6,7 +6,6 @@ import (
 	"encoding/base64"
 	"encoding/hex"
 	"encoding/json"
-	"errors"
 	"fmt"
 	"net"
 	"os"
@@ -18,11 +17,13 @@ import (
 	"github.com/meshery/meshery/server/helpers/utils"
 	"github.com/meshery/meshery/server/internal/sql"
 	"github.com/meshery/meshery/server/models/connections"
+	"github.com/meshery/meshkit/database"
 	"github.com/meshery/meshkit/logger"
 	"github.com/meshery/meshkit/models/events"
 	"github.com/meshery/meshkit/utils/kubernetes"
 	meshsyncmodel "github.com/meshery/meshsync/pkg/model"
 	"gopkg.in/yaml.v2"
+	"gorm.io/gorm"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
@@ -529,7 +530,7 @@ func FlushMeshSyncData(ctx context.Context, k8sContext K8sContext, provider Prov
 		if provider.GetGenericPersister() == nil {
 
 			event := events.NewEvent().ActedUpon(ctxUUID).FromSystem(*mesheryInstanceID).WithSeverity(events.Error).WithCategory("meshsync").WithAction("flush").WithDescription(fmt.Sprintf("Error flushing MeshSync data for %s", ctxName)).FromOwner(userUUID).WithMetadata(map[string]interface{}{
-				"error": ErrFlushMeshSyncData(errors.New("meshery Database handler is not accessible to perform operations"), ctxName, serverURL),
+				"error": ErrEmptyMeshSyncHandler(),
 			}).Build()
 			err := provider.PersistSystemEvent(*event)
 			if err != nil {
@@ -540,81 +541,12 @@ func FlushMeshSyncData(ctx context.Context, k8sContext K8sContext, provider Prov
 			return
 		}
 
-		err := provider.GetGenericPersister().Where("id IN (?)", provider.GetGenericPersister().Table("objects").Select("id").Where("cluster_id=?", sid)).Delete(&meshsyncmodel.KubernetesKeyValue{}).Error
-		if err != nil {
-
+		if err := FlushMeshSyncResourcesForCluster(provider.GetGenericPersister(), sid); err != nil {
 			event := events.NewEvent().ActedUpon(ctxUUID).FromSystem(*mesheryInstanceID).WithSeverity(events.Error).WithCategory("meshsync").WithAction("flush").WithDescription(fmt.Sprintf("Error flushing MeshSync data for %s", ctxName)).FromOwner(userUUID).WithMetadata(map[string]interface{}{
 				"error": ErrFlushMeshSyncData(err, ctxName, serverURL),
 			}).Build()
-			err := provider.PersistSystemEvent(*event)
-			if err != nil {
-				err = ErrPersistEvent(err)
-				log.Error(err)
-			}
-
-			eventsChan.Publish(userUUID, event)
-			return
-		}
-
-		err = provider.GetGenericPersister().Where("id IN (?)", provider.GetGenericPersister().Table("objects").Select("id").Where("cluster_id=?", sid)).Delete(&meshsyncmodel.KubernetesResourceSpec{}).Error
-		if err != nil {
-
-			event := events.NewEvent().ActedUpon(ctxUUID).FromSystem(*mesheryInstanceID).WithSeverity(events.Error).WithCategory("meshsync").WithAction("flush").WithDescription(fmt.Sprintf("Error flushing MeshSync data for %s", ctxName)).FromOwner(userUUID).WithMetadata(map[string]interface{}{
-				"error": ErrFlushMeshSyncData(err, ctxName, serverURL),
-			}).Build()
-			err := provider.PersistSystemEvent(*event)
-			if err != nil {
-				err = ErrPersistEvent(err)
-				log.Error(err)
-			}
-
-			eventsChan.Publish(userUUID, event)
-			return
-		}
-
-		err = provider.GetGenericPersister().Where("id IN (?)", provider.GetGenericPersister().Table("objects").Select("id").Where("cluster_id=?", sid)).Delete(&meshsyncmodel.KubernetesResourceStatus{}).Error
-		if err != nil {
-
-			event := events.NewEvent().ActedUpon(ctxUUID).FromSystem(*mesheryInstanceID).WithSeverity(events.Error).WithCategory("meshsync").WithAction("flush").WithDescription(fmt.Sprintf("Error flushing MeshSync data for %s", ctxName)).FromOwner(userUUID).WithMetadata(map[string]interface{}{
-				"error": ErrFlushMeshSyncData(err, ctxName, serverURL),
-			}).Build()
-
-			err := provider.PersistSystemEvent(*event)
-			if err != nil {
-				err = ErrPersistEvent(err)
-				log.Error(err)
-			}
-
-			eventsChan.Publish(userUUID, event)
-			return
-		}
-
-		err = provider.GetGenericPersister().Where("id IN (?)", provider.GetGenericPersister().Table("objects").Select("id").Where("cluster_id=?", sid)).Delete(&meshsyncmodel.KubernetesResourceObjectMeta{}).Error
-		if err != nil {
-
-			event := events.NewEvent().ActedUpon(ctxUUID).FromSystem(*mesheryInstanceID).WithSeverity(events.Error).WithCategory("meshsync").WithAction("flush").WithDescription(fmt.Sprintf("Error flushing MeshSync data for %s", ctxName)).FromOwner(userUUID).WithMetadata(map[string]interface{}{
-				"error": ErrFlushMeshSyncData(err, ctxName, serverURL),
-			}).Build()
-			err := provider.PersistSystemEvent(*event)
-			if err != nil {
-				err = ErrPersistEvent(err)
-				log.Error(err)
-			}
-
-			eventsChan.Publish(userUUID, event)
-			return
-		}
-
-		err = provider.GetGenericPersister().Where("cluster_id = ?", sid).Delete(&meshsyncmodel.KubernetesResource{}).Error
-		if err != nil {
-
-			event := events.NewEvent().ActedUpon(ctxUUID).FromSystem(*mesheryInstanceID).WithSeverity(events.Error).WithCategory("meshsync").WithAction("flush").WithDescription(fmt.Sprintf("Error flushing MeshSync data for %s", ctxName)).FromOwner(userUUID).WithMetadata(map[string]interface{}{
-				"error": ErrFlushMeshSyncData(err, ctxName, serverURL),
-			}).Build()
-			err := provider.PersistSystemEvent(*event)
-			if err != nil {
-				err = ErrPersistEvent(err)
-				log.Error(err)
+			if perr := provider.PersistSystemEvent(*event); perr != nil {
+				log.Error(ErrPersistEvent(perr))
 			}
 
 			eventsChan.Publish(userUUID, event)
@@ -630,6 +562,57 @@ func FlushMeshSyncData(ctx context.Context, k8sContext K8sContext, provider Prov
 		}
 		eventsChan.Publish(userUUID, event)
 	}
+}
+
+// FlushMeshSyncResourcesForCluster removes every MeshSync-discovered Kubernetes
+// resource that belongs to the given cluster (Kubernetes server) ID, together with
+// its child spec, status, object-meta, and key-value rows.
+//
+// Every child row shares its `id` primary key with the parent KubernetesResource.
+// The spec, status, and key-value children carry no cluster_id column of their own
+// (only the resource and its object-meta do), so all children are scoped uniformly
+// by a single subquery over the resource IDs owned by the cluster. Children are
+// deleted before the parent rows so that subquery still resolves to the IDs being
+// removed.
+//
+// Every table name is derived from the GORM models (via Model/Delete) rather than
+// hard-coded strings, so a future model rename or naming-strategy change cannot
+// silently orphan child rows - the defect this function was extracted to fix, where
+// the subqueries referenced a stale "objects" table that no longer existed and left
+// child rows behind on every cluster deletion.
+func FlushMeshSyncResourcesForCluster(db *database.Handler, clusterID string) error {
+	// The embedded *gorm.DB can be nil even when the handler is not, in which case
+	// the db.Transaction call below would panic; guard both.
+	if db == nil || db.DB == nil {
+		return ErrEmptyMeshSyncHandler()
+	}
+
+	// Run all deletes in one transaction so a mid-way failure rolls back rather than
+	// leaving the cluster partially flushed (e.g. children gone but parents kept).
+	return db.Transaction(func(tx *gorm.DB) error {
+		// The IDs of the resources being removed; reused as the scoping subquery for
+		// every child delete since each child row shares the parent resource's id.
+		resourceIDs := tx.Model(&meshsyncmodel.KubernetesResource{}).
+			Select("id").
+			Where("cluster_id = ?", clusterID)
+
+		// Child rows keyed by the parent resource's id, deleted before the parent so
+		// the subquery still resolves.
+		childModels := []any{
+			&meshsyncmodel.KubernetesKeyValue{},
+			&meshsyncmodel.KubernetesResourceSpec{},
+			&meshsyncmodel.KubernetesResourceStatus{},
+			&meshsyncmodel.KubernetesResourceObjectMeta{},
+		}
+		for _, child := range childModels {
+			if err := tx.Where("id IN (?)", resourceIDs).Delete(child).Error; err != nil {
+				return err
+			}
+		}
+
+		// Finally remove the parent resources for the cluster.
+		return tx.Where("cluster_id = ?", clusterID).Delete(&meshsyncmodel.KubernetesResource{}).Error
+	})
 }
 
 func RedactCredentialsForContext(ctx *K8sContext) (redactedContext K8sContext) {

--- a/server/models/k8s_context_test.go
+++ b/server/models/k8s_context_test.go
@@ -5,6 +5,11 @@ import (
 	"testing"
 
 	"github.com/gofrs/uuid"
+	"github.com/meshery/meshkit/database"
+	mkerrors "github.com/meshery/meshkit/errors"
+	meshsyncmodel "github.com/meshery/meshsync/pkg/model"
+	"gorm.io/driver/sqlite"
+	"gorm.io/gorm"
 )
 
 // TestFlushMeshSyncDataNilKubernetesServerIDNoPanic verifies that FlushMeshSyncData
@@ -46,4 +51,162 @@ func TestFlushMeshSyncDataMixedNilAndPopulatedServerIDs(t *testing.T) {
 	k8sCtx := K8sContext{ID: "ctx-1", Name: "cluster-a", Server: "https://k8s.example.com"}
 
 	FlushMeshSyncData(ctx, k8sCtx, nil, nil, "00000000-0000-0000-0000-000000000000", nil, nil)
+}
+
+// newMeshSyncTestDB spins up an in-memory SQLite database with the MeshSync
+// resource tables migrated, returning a meshkit database handler over it.
+func newMeshSyncTestDB(t *testing.T) *database.Handler {
+	t.Helper()
+	gdb, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{})
+	if err != nil {
+		t.Fatalf("failed to open in-memory sqlite: %v", err)
+	}
+	// A ":memory:" database is scoped to a single connection, so a pooled second
+	// connection would see none of the migrated tables ("no such table"). Pin the
+	// pool to one connection to keep the migrated schema visible for the whole test.
+	sqlDB, err := gdb.DB()
+	if err != nil {
+		t.Fatalf("failed to access underlying sql.DB: %v", err)
+	}
+	sqlDB.SetMaxOpenConns(1)
+	if err := gdb.AutoMigrate(
+		&meshsyncmodel.KubernetesKeyValue{},
+		&meshsyncmodel.KubernetesResource{},
+		&meshsyncmodel.KubernetesResourceSpec{},
+		&meshsyncmodel.KubernetesResourceStatus{},
+		&meshsyncmodel.KubernetesResourceObjectMeta{},
+	); err != nil {
+		t.Fatalf("failed to migrate meshsync tables: %v", err)
+	}
+	return &database.Handler{DB: gdb}
+}
+
+// seedMeshSyncResource inserts a KubernetesResource together with one child row in
+// every dependent table, all sharing the resource's id (the same shape MeshSync
+// persists). Children are written as independent rows rather than via associations
+// so the linkage under test is explicit and SetID cannot rewrite the ids.
+func seedMeshSyncResource(t *testing.T, db *database.Handler, id, clusterID string) {
+	t.Helper()
+	rows := []interface{}{
+		// KubernetesResourceMeta left nil so the BeforeCreate SetID hook is a no-op
+		// and the explicit id/cluster_id survive.
+		&meshsyncmodel.KubernetesResource{ID: id, ClusterID: clusterID, Kind: "Service", APIVersion: "v1"},
+		&meshsyncmodel.KubernetesResourceObjectMeta{ID: id, ClusterID: clusterID, Name: "svc-" + id},
+		&meshsyncmodel.KubernetesResourceSpec{ID: id, Attribute: "{}"},
+		&meshsyncmodel.KubernetesResourceStatus{ID: id, Attribute: "{}"},
+		&meshsyncmodel.KubernetesKeyValue{ID: id, UniqueID: id + "-kv", Kind: meshsyncmodel.KindLabel, Key: "app", Value: "demo"},
+	}
+	for _, row := range rows {
+		if err := db.Create(row).Error; err != nil {
+			t.Fatalf("failed to seed %T for %s: %v", row, id, err)
+		}
+	}
+}
+
+// TestFlushMeshSyncResourcesForCluster is a regression test for the stale
+// "objects" table-name subqueries in FlushMeshSyncData. It asserts that flushing a
+// cluster removes the parent resource and every child row (spec, status,
+// object-meta, key-value) for that cluster, while leaving another cluster's rows
+// untouched. Before the fix the child cleanup targeted a non-existent "objects"
+// table, so the flush errored out and MeshSync inventory was never removed on
+// cluster deletion.
+func TestFlushMeshSyncResourcesForCluster(t *testing.T) {
+	db := newMeshSyncTestDB(t)
+
+	const (
+		flushedCluster = "cluster-to-flush"
+		keptCluster    = "cluster-to-keep"
+		flushedID      = "res-flushed"
+		keptID         = "res-kept"
+	)
+	seedMeshSyncResource(t, db, flushedID, flushedCluster)
+	seedMeshSyncResource(t, db, keptID, keptCluster)
+
+	if err := FlushMeshSyncResourcesForCluster(db, flushedCluster); err != nil {
+		t.Fatalf("FlushMeshSyncResourcesForCluster returned error: %v", err)
+	}
+
+	assertCount := func(model interface{}, where string, arg interface{}, want int64, label string) {
+		t.Helper()
+		var got int64
+		if err := db.Model(model).Where(where, arg).Count(&got).Error; err != nil {
+			t.Fatalf("counting %s: %v", label, err)
+		}
+		if got != want {
+			t.Errorf("%s: got %d rows, want %d", label, got, want)
+		}
+	}
+
+	// The flushed cluster must have no parent and no child rows left behind.
+	assertCount(&meshsyncmodel.KubernetesResource{}, "cluster_id = ?", flushedCluster, 0, "resources (flushed cluster)")
+	assertCount(&meshsyncmodel.KubernetesResourceObjectMeta{}, "id = ?", flushedID, 0, "object meta (flushed cluster)")
+	assertCount(&meshsyncmodel.KubernetesResourceSpec{}, "id = ?", flushedID, 0, "spec (flushed cluster)")
+	assertCount(&meshsyncmodel.KubernetesResourceStatus{}, "id = ?", flushedID, 0, "status (flushed cluster)")
+	assertCount(&meshsyncmodel.KubernetesKeyValue{}, "id = ?", flushedID, 0, "key value (flushed cluster)")
+
+	// The other cluster's parent and child rows must be untouched.
+	assertCount(&meshsyncmodel.KubernetesResource{}, "cluster_id = ?", keptCluster, 1, "resources (kept cluster)")
+	assertCount(&meshsyncmodel.KubernetesResourceObjectMeta{}, "id = ?", keptID, 1, "object meta (kept cluster)")
+	assertCount(&meshsyncmodel.KubernetesResourceSpec{}, "id = ?", keptID, 1, "spec (kept cluster)")
+	assertCount(&meshsyncmodel.KubernetesResourceStatus{}, "id = ?", keptID, 1, "status (kept cluster)")
+	assertCount(&meshsyncmodel.KubernetesKeyValue{}, "id = ?", keptID, 1, "key value (kept cluster)")
+}
+
+// TestFlushMeshSyncResourcesForClusterNilHandler verifies the helper reports the
+// structured MeshKit error (ErrEmptyMeshSyncHandler) instead of panicking, both when
+// the handler itself is nil and when only its embedded *gorm.DB is nil.
+func TestFlushMeshSyncResourcesForClusterNilHandler(t *testing.T) {
+	cases := map[string]*database.Handler{
+		"nil handler":     nil,
+		"nil embedded DB": {DB: nil},
+	}
+	for name, db := range cases {
+		t.Run(name, func(t *testing.T) {
+			err := FlushMeshSyncResourcesForCluster(db, "any-cluster")
+			if err == nil {
+				t.Fatal("expected an error for an unusable database handler, got nil")
+			}
+			if code := mkerrors.GetCode(err); code != ErrEmptyMeshSyncHandlerCode {
+				t.Errorf("expected error code %s, got %s", ErrEmptyMeshSyncHandlerCode, code)
+			}
+		})
+	}
+}
+
+// TestFlushMeshSyncResourcesForClusterRollsBackOnError verifies the cleanup is
+// atomic: if a delete fails partway through, the whole flush rolls back rather
+// than leaving the cluster partially flushed. The object-meta delete is the last
+// child, so dropping its table makes that delete fail after the earlier child
+// deletes have run inside the transaction; all of them must be rolled back.
+func TestFlushMeshSyncResourcesForClusterRollsBackOnError(t *testing.T) {
+	db := newMeshSyncTestDB(t)
+
+	const cluster = "cluster-atomic"
+	const id = "res-atomic"
+	seedMeshSyncResource(t, db, id, cluster)
+
+	if err := db.Migrator().DropTable(&meshsyncmodel.KubernetesResourceObjectMeta{}); err != nil {
+		t.Fatalf("failed to drop object-meta table: %v", err)
+	}
+
+	if err := FlushMeshSyncResourcesForCluster(db, cluster); err == nil {
+		t.Fatal("expected an error when a child delete fails, got nil")
+	}
+
+	// The transaction must have rolled back, so the parent and the child rows that
+	// were deleted before the failing delete are all still present.
+	assertCount := func(model interface{}, where string, arg interface{}, want int64, label string) {
+		t.Helper()
+		var got int64
+		if err := db.Model(model).Where(where, arg).Count(&got).Error; err != nil {
+			t.Fatalf("counting %s: %v", label, err)
+		}
+		if got != want {
+			t.Errorf("%s: got %d rows, want %d", label, got, want)
+		}
+	}
+	assertCount(&meshsyncmodel.KubernetesResource{}, "cluster_id = ?", cluster, 1, "resources (rolled back)")
+	assertCount(&meshsyncmodel.KubernetesResourceSpec{}, "id = ?", id, 1, "spec (rolled back)")
+	assertCount(&meshsyncmodel.KubernetesResourceStatus{}, "id = ?", id, 1, "status (rolled back)")
+	assertCount(&meshsyncmodel.KubernetesKeyValue{}, "id = ?", id, 1, "key value (rolled back)")
 }

--- a/ui/tests/e2e/performance.spec.ts
+++ b/ui/tests/e2e/performance.spec.ts
@@ -1,40 +1,29 @@
 import { expect, test, Page } from '@playwright/test';
 import { DashboardPage } from './pages/DashboardPage';
 
-const COMMON_UI_ELEMENTS: string[] = [
-  'navigation',
-  'notification-button',
-  'profile-button',
-  'header-menu',
-];
-
 test.describe('Performance Section Tests', () => {
-  // The shared beforeEach calls navigateToDashboard() (two 120s visibility
-  // waits) and navigateToPerformance() (120s wait), then waits on the
-  // performance dashboard. Under the default BASE_TIMEOUT=60s the hook dies
-  // before those inner waits resolve when CI is slow. 180s gives the chain
-  // enough wall-clock.
+  // Generous budget for the dashboard -> performance navigation chain on slow CI.
   test.describe.configure({ timeout: 180_000 });
 
   test.beforeEach(async ({ page }: { page: Page }) => {
     const dashboardPage = new DashboardPage(page);
     await dashboardPage.navigateToDashboard();
     await dashboardPage.navigateToPerformance();
-    // Readiness signal for the performance dashboard. The legacy "Configure
-    // Metrics" flow (meshery-metrics / grafana config) was removed when
-    // telemetry moved to its own section under /telemetry — see telemetry.spec.ts.
+    // Readiness signal for the performance dashboard.
+    //
+    // Known flake (meshery/meshery#20504): "performance-dashboard" only renders
+    // when CAN(VIEW_PERFORMANCE_PROFILES) is true, and CAN() (ui/utils/can.ts)
+    // reads a non-reactive module-level casl ability singleton. If the user's
+    // capabilities load after Dashboard mounts, it renders <DefaultError/> and
+    // never re-renders, so this element can time out regardless of how long we
+    // wait - a longer timeout does not fix it. The real fix is a reactive
+    // permission gate, tracked in #20504.
     await expect(page.getByTestId('performance-dashboard')).toBeVisible();
   });
 
-  test('Common UI elements', async ({ page }: { page: Page }) => {
-    for (const elementId of COMMON_UI_ELEMENTS) {
-      await expect(
-        page.getByTestId(elementId),
-        `UI element with ID ${elementId} should be visible`,
-      ).toBeVisible();
-    }
-  });
-
+  // Global chrome (navigation, notification, profile, header) is covered by the
+  // stable indexui.spec.ts tests and by navigateToDashboard() above, so this
+  // suite only asserts performance-specific controls.
   test('Performance dashboard controls', async ({ page }: { page: Page }) => {
     await expect(page.getByRole('button', { name: 'Run Test' })).toBeVisible();
     await expect(page.getByRole('button', { name: 'Manage Profiles' })).toBeVisible();

--- a/ui/tests/e2e/telemetry.spec.ts
+++ b/ui/tests/e2e/telemetry.spec.ts
@@ -9,13 +9,6 @@ import { DashboardPage } from './pages/DashboardPage';
 // Both render an empty state when no matching connection is registered, which
 // is the expected state in a fresh CI environment.
 
-const COMMON_UI_ELEMENTS: string[] = [
-  'navigation',
-  'notification-button',
-  'profile-button',
-  'header-menu',
-];
-
 test.describe('Telemetry Section Tests', () => {
   // navigateToDashboard() + navigateToSubMenuItem() chain their own 120s inner
   // waits; 180s gives the hook enough wall-clock on slow CI.
@@ -53,17 +46,5 @@ test.describe('Telemetry Section Tests', () => {
         .getByTestId('telemetry-prometheus-empty')
         .or(page.getByTestId('telemetry-prometheus-toolbar')),
     ).toBeVisible();
-  });
-
-  test('Common UI elements', async ({ page }: { page: Page }) => {
-    const dashboardPage = new DashboardPage(page);
-    await dashboardPage.navigateToTelemetryCharts();
-
-    for (const elementId of COMMON_UI_ELEMENTS) {
-      await expect(
-        page.getByTestId(elementId),
-        `UI element with ID ${elementId} should be visible`,
-      ).toBeVisible();
-    }
   });
 });


### PR DESCRIPTION
## Description

Flushing a deleted cluster's MeshSync inventory never removed anything, leaking rows in the database on every cluster deletion. The child-row cleanup in `FlushMeshSyncData` queried a table that no longer exists.

### Symptom

When the last connection referencing a Kubernetes server ID is deleted, `models.FlushMeshSyncData` (`server/models/k8s_context.go`) is supposed to flush that cluster's MeshSync inventory. Instead the flush errored out and an error event was emitted on every attempt; the `kubernetes_resources` rows and all of their child rows (`kubernetes_resource_specs`, `kubernetes_resource_statuses`, `kubernetes_resource_object_meta`, `kubernetes_key_values`) were left behind and accumulated over time.

### Root cause

The child-row cleanup subqueries selected ids from a stale table name:

```go
provider.GetGenericPersister().Table("objects").Select("id").Where("cluster_id=?", sid)
```

`objects` is the pre-refactor MeshSync table name and no longer exists. The MeshSync resource table is `kubernetes_resources` (GORM's default naming for `meshsyncmodel.KubernetesResource`; there is no `TableName()` override). So each child delete failed with `no such table: objects` and `FlushMeshSyncData` returned early - before it ever reached the final `KubernetesResource` delete (which alone used the model directly and targeted the right table). Net result: nothing was flushed.

The same cleanup was duplicated in the `resyncCluster` GraphQL resolver (`server/internal/graphql/resolver/meshsync.go`) using the correct `kubernetes_resources` string - so the two copies had already diverged, exactly the kind of drift raw table-name strings invite.

### Fix

- Extract the cleanup into `FlushMeshSyncResourcesForCluster(db *database.Handler, clusterID string) error`, which derives every table name from the GORM models (`Model`/`Delete`) instead of hard-coded strings. This means a future model rename or naming-strategy change can no longer silently orphan child rows. Children are deleted before the parent so the id subquery over `kubernetes_resources` still resolves.
- `FlushMeshSyncData` and the `resyncCluster` resolver now share this single helper, removing the duplicated block. The resolver also surfaces the real delete error instead of the misleading `ErrEmptyHandler` it previously returned for any failure.
- Added a MeshKit structured error `ErrEmptyMeshSyncHandler` (`meshery-server-1441`) for the nil-handler guard. (The branch was rebased onto master, which had meanwhile taken `meshery-server-1437`; the code was reassigned to the next free code `1441`, with `component_info.json` `next_error_code` advanced to `1442`.)

### Regression test

`TestFlushMeshSyncResourcesForCluster` (`server/models/k8s_context_test.go`) seeds a `KubernetesResource` with a spec, status, object-meta, and key-value child across two clusters, flushes one cluster, and asserts:

- the flushed cluster's parent resource and every child row are gone, and
- the other cluster's parent and child rows are untouched.

`TestFlushMeshSyncResourcesForClusterNilHandler` asserts the helper returns a structured error rather than panicking on a nil handler.

Verified the generated SQL now targets `kubernetes_resources` / `kubernetes_resource_specs` / `kubernetes_resource_statuses` / `kubernetes_resource_object_meta` / `kubernetes_key_values`.


### E2E test cleanup

Removed the redundant "Common UI elements" tests from `performance.spec.ts` and `telemetry.spec.ts` - they only re-checked global chrome already covered by `indexui.spec.ts` and `navigateToDashboard()`.

While there, the recurring performance/telemetry e2e flake was diagnosed to a **non-reactive permission gate** (`performance-dashboard` renders only when `CAN(VIEW_PERFORMANCE_PROFILES)` is true, and `CAN()` reads a module-level casl ability singleton that doesn't re-render when capabilities load late). A timeout cannot fix that, so it is documented inline and tracked in #20504 for a proper reactive-permission fix rather than attempted in this server-focused PR.


### Watch for

Other MeshSync consumers that build raw SQL with table-name string literals rather than the GORM models are the remaining rot risk; the flush path is now model-derived. (One such sibling - a stale `resource_specs`/`resource_statuses` join in the `getTelemetryComps` GraphQL resolver - was intentionally left out of this PR: that query is orphaned/dead and sits on the GraphQL-removal path, so it will be deleted rather than fixed.)

## Notes for reviewer

- `errorutil update` + `analyze` were run locally (matching the Error codes utility CI check) and report clean with the reassigned `meshery-server-1441` code. The bot-maintained `docs/data/errorref/*_errors_export.json` is intentionally not committed here - it is regenerated on merge to master.
- Local: `go build ./...`, `go vet`, `gofmt`, `golangci-lint run --config=.github/.golangci.yml` (clean on changed files), and `go test ./models/` all pass.




