### PR TITLE
 [mesheryctl] Fix nil map panic in registry publish commands

### DIFF
--- a/mesheryctl/internal/cli/root/registry/publish.go
+++ b/mesheryctl/internal/cli/root/registry/publish.go
@@ -197,10 +197,16 @@ func remoteProviderSystem() error {
 	modelDir := filepath.Join(outputPath)
 	totalModelsPublished := 0
 	for _, model := range models {
-		comps, ok := components[model.Registrant][model.Model]
+		registrantComps, ok := components[model.Registrant]
 		if !ok {
 			utils.Log.Debug("no components found for ", model.Model)
 			comps = []meshkitRegistryUtils.ComponentCSV{}
+		} else {
+			comps, ok = registrantComps[model.Model]
+			if !ok {
+				utils.Log.Debug("no components found for ", model.Model)
+				comps = []meshkitRegistryUtils.ComponentCSV{}
+			}
 		}
 
 		err := utils.GenerateIcons(model, comps, imgsOutputPath)
@@ -228,10 +234,16 @@ func websiteSystem() error {
 	}
 	docsJSON := "const data = ["
 	for _, model := range models {
-		comps, ok := components[model.Registrant][model.Model]
+		registrantComps, ok := components[model.Registrant]
 		if !ok {
 			utils.Log.Debug("no components found for ", model.Model)
 			comps = []meshkitRegistryUtils.ComponentCSV{}
+		} else {
+			comps, ok = registrantComps[model.Model]
+			if !ok {
+				utils.Log.Debug("no components found for ", model.Model)
+				comps = []meshkitRegistryUtils.ComponentCSV{}
+			}
 		}
 
 		relnships, ok := relationshipMap[model.Model]


### PR DESCRIPTION
**Description**

`mesheryctl registry publish` crashes with a runtime panic when a model's `Registrant` column contains a value that does not exist as a key in the pre-built `components` map. The crash originates from an unchecked nested map access pattern used in both `remoteProviderSystem()` and `websiteSystem()`.

**Root Cause**

The expression `components[model.Registrant][model.Model]` performs two map lookups in a single statement. In Go, when the outer key is absent, the first lookup returns a nil map, and the subsequent index expression on that nil map triggers a panic — the `ok` variable never gets a chance to catch it because the panic occurs during evaluation of the right-hand side.

Affected code at `mesheryctl/internal/cli/root/registry/publish.go`:

```go
// Before: panics when model.Registrant is not in components
comps, ok := components[model.Registrant][model.Model]
if !ok {
    comps = []meshkitRegistryUtils.ComponentCSV{}
}
Fix
Guard the outer map access separately before attempting the inner lookup:
// After: safe access with nil map guard
registrantComps, ok := components[model.Registrant]
if !ok {
    comps = []meshkitRegistryUtils.ComponentCSV{}
} else {
    comps, ok = registrantComps[model.Model]
    if !ok {
        comps = []meshkitRegistryUtils.ComponentCSV{}
    }
}
```
This ensures that a missing registrant key produces an empty component slice and a debug log message instead of a stack trace. Applied to both remoteProviderSystem() and websiteSystem().
Verification
- go vet ./mesheryctl/... — clean
- go build ./mesheryctl/... — succeeds
- Before fix: running mesheryctl registry publish with a sheet containing an unknown registrant key panics with a traceback to publish.go
- After fix: same input logs "no components found for <model>" and continues gracefully
Related issue
Fixes #20206
