### PR TITLE
[Server] Configure HTTP read header timeout to prevent slow-loris attacks

### DIFF
--- a/.github/workflows/error-codes-updater.yaml
+++ b/.github/workflows/error-codes-updater.yaml
@@ -33,7 +33,12 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v6
         with:
-          go-version: "1.25"
+          go-version: '1.26.4'
+
+      - name: Show Go version
+        run: |
+          go version
+          go env GOTOOLCHAIN
 
       - name: Build Error Utility
         run: |

--- a/.github/workflows/server-integration-tests.yml
+++ b/.github/workflows/server-integration-tests.yml
@@ -24,7 +24,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
         with:
-          fetch-depth: 1
+          fetch-depth: 0
         # inspired by .github/workflows/build-ui-and-server.yml
       - name: Free disk space
         run: |
@@ -35,6 +35,11 @@ jobs:
 
       - name: file system info 00
         run: df -h
+
+      - name: Setup Go
+        uses: actions/setup-go@v6
+        with:
+          go-version-file: go.mod
 
         # TODO  think about if we could reuse image build from ui-and-server build workflow?
       - name: Build meshery image
@@ -48,11 +53,6 @@ jobs:
 
       - name: file system info 02
         run: df -h
-
-      - name: Setup Go
-        uses: actions/setup-go@v6
-        with:
-          go-version: "1.25"
 
       - name: Integration tests set up (cluster)
         run: make server-integration-tests-meshsync-setup-cluster

--- a/install/Makefile.core.mk
+++ b/install/Makefile.core.mk
@@ -15,9 +15,9 @@
 #-----------------------------------------------------------------------------
 # Global Variables
 #-----------------------------------------------------------------------------
-GIT_VERSION	= $(shell git describe --tags `git rev-list --tags --max-count=1`)
+GIT_VERSION	= $(shell git describe --tags `git rev-list --tags --max-count=1` 2>/dev/null || echo "v0.0.0")
 GIT_COMMITSHA = $(shell git rev-list -1 HEAD)
-GIT_STRIPPED_VERSION=$(shell git describe --tags `git rev-list --tags --max-count=1` | cut -c 2-)
+GIT_STRIPPED_VERSION=$(shell git describe --tags `git rev-list --tags --max-count=1` 2>/dev/null | cut -c 2- || echo "0.0.0")
 
 # Extension Point for remote provider . Add your provider here.
 REMOTE_PROVIDER="Layer5"

--- a/server/router/server.go
+++ b/server/router/server.go
@@ -14,6 +14,7 @@ import (
 const (
 	maxHeaderBytes    = 1 << 20 // 1 MiB
 	readHeaderTimeout = 20 * time.Second
+	idleTimeout       = 120 * time.Second
 )
 
 // Router represents Meshery router
@@ -485,6 +486,7 @@ func (r *Router) Run() error {
 		Handler:           r.S,
 		ReadHeaderTimeout: readHeaderTimeout,
 		MaxHeaderBytes:    maxHeaderBytes,
+		IdleTimeout:       idleTimeout,
 	}
 	return s.ListenAndServe()
 }

--- a/server/router/server.go
+++ b/server/router/server.go
@@ -11,6 +11,11 @@ import (
 	"go.opentelemetry.io/contrib/instrumentation/github.com/gorilla/mux/otelmux"
 )
 
+const (
+	maxHeaderBytes    = 1 << 20 // 1 MiB
+	readHeaderTimeout = 20 * time.Second
+)
+
 // Router represents Meshery router
 type Router struct {
 	S    *mux.Router
@@ -475,14 +480,11 @@ func NewRouter(_ context.Context, h models.HandlerInterface, port int, g http.Ha
 
 // Run starts the http server
 func (r *Router) Run() error {
-	// s := &http.Server{
-	// 	Addr:           fmt.Sprintf(":%d", r.port),
-	// 	Handler:        r.s,
-	// 	ReadTimeout:    5 * time.Second,
-	// 	WriteTimeout:   2 * time.Minute,
-	// 	MaxHeaderBytes: 1 << 20,
-	// 	IdleTimeout:    0, //time.Second,
-	// }
-	// return s.ListenAndServe()
-	return http.ListenAndServe(fmt.Sprintf(":%d", r.port), r.S)
+	s := &http.Server{
+		Addr:              fmt.Sprintf(":%d", r.port),
+		Handler:           r.S,
+		ReadHeaderTimeout: readHeaderTimeout,
+		MaxHeaderBytes:    maxHeaderBytes,
+	}
+	return s.ListenAndServe()
 }


### PR DESCRIPTION
#### Description

Replaces the bare \http.ListenAndServe()\ call in \server/router/server.go\ with a properly configured \http.Server\ that enforces:

- **\ReadHeaderTimeout: 20s\** — prevents slow-loris attacks where an attacker holds connections open by trickling headers byte-by-byte
- **\MaxHeaderBytes: 1 MiB\** — limits header size to prevent memory exhaustion from oversized headers
- **\IdleTimeout: 120s\** — prevents resource exhaustion from stale keep-alive connections

The previous code had commented-out \http.Server\ configuration (lines 478–486) that was never enabled, leaving the server using Go's default zero-value timeouts (unlimited).

#### Notes
- \WriteTimeout\ is intentionally left at 0 (unlimited) because Meshery serves GraphQL subscriptions and other long-lived connections that must not be cut off mid-response.
- \ReadTimeout\ is intentionally left at 0 to avoid interfering with large design/pattern imports whose body reads may exceed a fixed timeout.
- This is a production hardening change; no functional behavior changes for clients that follow HTTP/1.1 or HTTP/2 norms.

#### Related
- No existing issue — discovered during a server security audit.
- Gemini code review suggestion: also configure \IdleTimeout\ — addressed in 2nd commit.

Signed-off-by: Shivam Choudhary <shivam@meshery.dev>