### PR TITLE
[Server] Dedupe Go policy engine's inventory-parent additions by content

### DIFF
--- a/server/policies/policy_inventory.go
+++ b/server/policies/policy_inventory.go
@@ -63,7 +63,7 @@ func identifyInventoryAdditionsForRel(
 		return nil
 	}
 	var out []PolicyAction
-	emittedIDs := map[string]bool{}
+	emittedKeys := map[string]bool{}
 
 	for _, ss := range *rel.Selectors {
 		mutatedSels, mutatorSels := partitionByPatchRole(ss)
@@ -87,6 +87,18 @@ func identifyInventoryAdditionsForRel(
 					if existsMatchingMutatorComponent(design, mutatorSel, mutatorRefs, values) {
 						continue
 					}
+					// De-duplicate on content before a candidate gets its (always
+					// unique) random component ID assigned below. Without this,
+					// several mutated components that imply the same missing
+					// parent (e.g. multiple Pods in the same missing namespace)
+					// each produce their own candidate with a different random
+					// ID, so an ID-keyed dedup can never collapse them. The rego
+					// engine avoids this because its candidate id is derived from
+					// the candidate's content, not randomly generated.
+					key := inventoryCandidateKey(mutatorSel, values)
+					if emittedKeys[key] {
+						continue
+					}
 					candidate := buildInventoryParentCandidate(mutatorSel, mutatorRefs, values)
 					if candidate == nil {
 						continue
@@ -98,10 +110,7 @@ func identifyInventoryAdditionsForRel(
 					if feasibleRelationshipSelectorBetween(mutatedComp, candidate, rel) == nil {
 						continue
 					}
-					if emittedIDs[candidate.ID.String()] {
-						continue
-					}
-					emittedIDs[candidate.ID.String()] = true
+					emittedKeys[key] = true
 					out = append(out, newAddComponentAction(candidate))
 				}
 			}
@@ -157,6 +166,22 @@ func extractValuesAtPaths(
 		values = append(values, v)
 	}
 	return values, true
+}
+
+// inventoryCandidateKey derives a stable de-duplication key for a
+// not-yet-created inventory parent candidate, from the same inputs
+// buildInventoryParentCandidate uses to construct it. Two candidates with
+// the same kind, model, and resolved mutator values represent the same
+// logical addition (e.g. "a Namespace named default") and must collapse to
+// one add_component action even though each gets its own random component
+// ID once built.
+func inventoryCandidateKey(mutatorSel relationship.SelectorItem, values []interface{}) string {
+	modelName := ""
+	if mutatorSel.Model != nil {
+		modelName = mutatorSel.Model.Name
+	}
+	valuesJSON, _ := json.Marshal(values)
+	return selectorItemKind(mutatorSel) + "|" + modelName + "|" + string(valuesJSON)
 }
 
 // existsMatchingMutatorComponent answers "is there already a parent in the

--- a/server/policies/policy_inventory.go
+++ b/server/policies/policy_inventory.go
@@ -180,7 +180,14 @@ func inventoryCandidateKey(mutatorSel relationship.SelectorItem, values []interf
 	if mutatorSel.Model != nil {
 		modelName = mutatorSel.Model.Name
 	}
-	valuesJSON, _ := json.Marshal(values)
+	valuesJSON, err := json.Marshal(values)
+	if err != nil {
+		// Fall back to a unique identifier so that unmarshalable candidates
+		// are never incorrectly collapsed into the same dedup bucket.
+		if u, uuidErr := uuid.NewV4(); uuidErr == nil {
+			return selectorItemKind(mutatorSel) + "|" + modelName + "|" + u.String()
+		}
+	}
 	return selectorItemKind(mutatorSel) + "|" + modelName + "|" + string(valuesJSON)
 }
 

--- a/server/policies/policy_inventory.go
+++ b/server/policies/policy_inventory.go
@@ -2,6 +2,7 @@ package policies
 
 import (
 	"encoding/json"
+	"fmt"
 	"strings"
 
 	"github.com/gofrs/uuid"
@@ -87,20 +88,20 @@ func identifyInventoryAdditionsForRel(
 					if existsMatchingMutatorComponent(design, mutatorSel, mutatorRefs, values) {
 						continue
 					}
-					// De-duplicate on content before a candidate gets its (always
-					// unique) random component ID assigned below. Without this,
-					// several mutated components that imply the same missing
+					candidate := buildInventoryParentCandidate(mutatorSel, mutatorRefs, values)
+					if candidate == nil {
+						continue
+					}
+					// De-duplicate on the candidate's content, ignoring the (always
+					// unique) random component ID it was just assigned. Without
+					// this, several mutated components that imply the same missing
 					// parent (e.g. multiple Pods in the same missing namespace)
 					// each produce their own candidate with a different random
 					// ID, so an ID-keyed dedup can never collapse them. The rego
 					// engine avoids this because its candidate id is derived from
 					// the candidate's content, not randomly generated.
-					key := inventoryCandidateKey(mutatorSel, values)
+					key := inventoryCandidateKey(candidate)
 					if emittedKeys[key] {
-						continue
-					}
-					candidate := buildInventoryParentCandidate(mutatorSel, mutatorRefs, values)
-					if candidate == nil {
 						continue
 					}
 					// The rego runs feasibility against the relationship-as-a-whole;
@@ -168,29 +169,36 @@ func extractValuesAtPaths(
 	return values, true
 }
 
-// inventoryCandidateKey derives a stable de-duplication key for a
-// not-yet-created inventory parent candidate, from the same inputs
-// buildInventoryParentCandidate uses to construct it. Two candidates with
-// the same kind, model, and resolved mutator values represent the same
-// logical addition (e.g. "a Namespace named default") and must collapse to
-// one add_component action even though each gets its own random component
-// ID once built.
-func inventoryCandidateKey(mutatorSel relationship.SelectorItem, values []interface{}) string {
-	modelName := ""
-	modelVersion := ""
-	if mutatorSel.Model != nil {
-		modelName = mutatorSel.Model.Name
-		modelVersion = mutatorSel.Model.Version
+// inventoryCandidateKey derives a de-duplication key from a built
+// candidate's content, ignoring its random component ID. Two candidates
+// that would add the same logical component (same kind, model, displayName
+// and configuration) represent the same addition (e.g. "a Namespace named
+// default") and must collapse to one add_component action. Keying on the
+// built candidate rather than the selector inputs also captures the effect
+// of the mutatorRef paths, which decide where the mutated values land on
+// the candidate.
+func inventoryCandidateKey(candidate *component.ComponentDefinition) string {
+	content := struct {
+		Kind          string                      `json:"kind"`
+		Model         modelv1beta1.ModelReference `json:"model"`
+		DisplayName   string                      `json:"displayName"`
+		Configuration map[string]interface{}      `json:"configuration"`
+	}{
+		Kind:          candidate.Component.Kind,
+		Model:         candidate.ModelReference,
+		DisplayName:   candidate.DisplayName,
+		Configuration: candidate.Configuration,
 	}
-	valuesJSON, err := json.Marshal(values)
+	key, err := json.Marshal(content)
 	if err != nil {
-		// Fall back to a unique identifier so that unmarshalable candidates
-		// are never incorrectly collapsed into the same dedup bucket.
-		if u, uuidErr := uuid.NewV4(); uuidErr == nil {
-			return selectorItemKind(mutatorSel) + "|" + modelName + "|" + modelVersion + "|" + u.String()
-		}
+		// Configuration values come from JSON-decoded design content, so
+		// marshaling only fails on values JSON cannot represent (e.g. NaN).
+		// Fall back to fmt's textual form, which is also deterministic (map
+		// keys print in sorted order), so distinct candidates keep distinct
+		// keys and identical ones still collapse.
+		return fmt.Sprintf("%v|%v|%v|%#v", candidate.Component.Kind, candidate.ModelReference, candidate.DisplayName, candidate.Configuration)
 	}
-	return selectorItemKind(mutatorSel) + "|" + modelName + "|" + modelVersion + "|" + string(valuesJSON)
+	return string(key)
 }
 
 // existsMatchingMutatorComponent answers "is there already a parent in the

--- a/server/policies/policy_inventory.go
+++ b/server/policies/policy_inventory.go
@@ -177,18 +177,20 @@ func extractValuesAtPaths(
 // ID once built.
 func inventoryCandidateKey(mutatorSel relationship.SelectorItem, values []interface{}) string {
 	modelName := ""
+	modelVersion := ""
 	if mutatorSel.Model != nil {
 		modelName = mutatorSel.Model.Name
+		modelVersion = mutatorSel.Model.Version
 	}
 	valuesJSON, err := json.Marshal(values)
 	if err != nil {
 		// Fall back to a unique identifier so that unmarshalable candidates
 		// are never incorrectly collapsed into the same dedup bucket.
 		if u, uuidErr := uuid.NewV4(); uuidErr == nil {
-			return selectorItemKind(mutatorSel) + "|" + modelName + "|" + u.String()
+			return selectorItemKind(mutatorSel) + "|" + modelName + "|" + modelVersion + "|" + u.String()
 		}
 	}
-	return selectorItemKind(mutatorSel) + "|" + modelName + "|" + string(valuesJSON)
+	return selectorItemKind(mutatorSel) + "|" + modelName + "|" + modelVersion + "|" + string(valuesJSON)
 }
 
 // existsMatchingMutatorComponent answers "is there already a parent in the

--- a/server/policies/policy_inventory_test.go
+++ b/server/policies/policy_inventory_test.go
@@ -164,6 +164,25 @@ func TestIdentifyInventoryAdditions_SkipsWhenParentAlreadyPresent(t *testing.T) 
 	assert.Empty(t, actions, "must not emit add_component when a matching parent already exists in the design")
 }
 
+// Two Pods that reference the SAME missing namespace must produce exactly
+// one add_component action, not one per referencing Pod. buildInventoryParentCandidate
+// assigns each candidate a fresh random component ID, so an ID-keyed dedup
+// (what this used to do) can never collapse two candidates that describe the
+// same logical addition; the rego engine avoids this because its candidate
+// id is derived from the candidate's own content instead of being random.
+func TestIdentifyInventoryAdditions_DedupesSharedMissingParent(t *testing.T) {
+	t.Parallel()
+	_, pod1 := makePodWithNamespace(t, "default")
+	_, pod2 := makePodWithNamespace(t, "default")
+	design := makePatternFile([]*component.ComponentDefinition{pod1, pod2}, nil)
+
+	actions := identifyInventoryAdditions(design, []*relationship.RelationshipDefinition{kubernetesInventoryRelationship()})
+
+	require.Len(t, actions, 1, "two Pods referencing the same missing namespace must produce exactly one add_component action")
+	assert.Equal(t, "Namespace", actions[0].Component.Component.Kind)
+	assert.Equal(t, "default", string(actions[0].Component.DisplayName))
+}
+
 // Cross-model regression: if the relationship has a different model on the
 // to-side than the from-side (e.g. azure-event-grid EventSubscription →
 // azure-storage StorageAccount), the auto-added parent must inherit the

--- a/server/policies/policy_inventory_test.go
+++ b/server/policies/policy_inventory_test.go
@@ -3,6 +3,7 @@ package policies
 import (
 	"context"
 	"encoding/json"
+	"math"
 	"os"
 	"strings"
 	"testing"
@@ -179,8 +180,53 @@ func TestIdentifyInventoryAdditions_DedupesSharedMissingParent(t *testing.T) {
 	actions := identifyInventoryAdditions(design, []*relationship.RelationshipDefinition{kubernetesInventoryRelationship()})
 
 	require.Len(t, actions, 1, "two Pods referencing the same missing namespace must produce exactly one add_component action")
+	assert.Equal(t, AddComponentOp, actions[0].Op)
+	require.NotNil(t, actions[0].Component)
 	assert.Equal(t, "Namespace", actions[0].Component.Component.Kind)
 	assert.Equal(t, "default", string(actions[0].Component.DisplayName))
+}
+
+// The inverse guard for the content dedup: two Pods referencing DIFFERENT
+// missing namespaces must still produce one add_component action each.
+func TestIdentifyInventoryAdditions_DistinctMissingParentsStayDistinct(t *testing.T) {
+	t.Parallel()
+	_, pod1 := makePodWithNamespace(t, "default")
+	_, pod2 := makePodWithNamespace(t, "production")
+	design := makePatternFile([]*component.ComponentDefinition{pod1, pod2}, nil)
+
+	actions := identifyInventoryAdditions(design, []*relationship.RelationshipDefinition{kubernetesInventoryRelationship()})
+
+	require.Len(t, actions, 2, "different missing namespaces must not be collapsed by the content dedup")
+	names := make([]string, 0, len(actions))
+	for _, a := range actions {
+		assert.Equal(t, AddComponentOp, a.Op)
+		require.NotNil(t, a.Component)
+		assert.Equal(t, "Namespace", a.Component.Component.Kind)
+		names = append(names, string(a.Component.DisplayName))
+	}
+	assert.ElementsMatch(t, []string{"default", "production"}, names)
+}
+
+// json.Marshal rejects NaN, forcing inventoryCandidateKey onto its textual
+// fallback. The fallback must stay deterministic (same candidate, same key)
+// while still keeping distinct candidates distinct.
+func TestInventoryCandidateKey_MarshalFailureFallback(t *testing.T) {
+	t.Parallel()
+	build := func(name string) *component.ComponentDefinition {
+		return &component.ComponentDefinition{
+			Component:      component.Component{Kind: "Namespace"},
+			ModelReference: modelv1beta1.ModelReference{Name: "kubernetes"},
+			DisplayName:    name,
+			Configuration: map[string]interface{}{
+				"limit": math.NaN(),
+			},
+		}
+	}
+
+	assert.Equal(t, inventoryCandidateKey(build("default")), inventoryCandidateKey(build("default")),
+		"fallback key must be deterministic for identical candidates")
+	assert.NotEqual(t, inventoryCandidateKey(build("default")), inventoryCandidateKey(build("production")),
+		"fallback key must not collapse distinct candidates")
 }
 
 // Cross-model regression: if the relationship has a different model on the

--- a/ui/tests/e2e/performance.spec.ts
+++ b/ui/tests/e2e/performance.spec.ts
@@ -1,6 +1,35 @@
 import { expect, test, Page } from '@playwright/test';
 import { DashboardPage } from './pages/DashboardPage';
 
+/**
+ * Waits for the performance dashboard to be visible, retrying via page reload
+ * if the non-reactive CAN() permission gate renders <DefaultError/> before
+ * capabilities have loaded.
+ *
+ * Known flake (meshery/meshery#20504): "performance-dashboard" only renders
+ * when CAN(VIEW_PERFORMANCE_PROFILES) is true, and CAN() (ui/utils/can.ts)
+ * reads a non-reactive module-level casl ability singleton. If the user's
+ * capabilities load after the component mounts, it renders <DefaultError/>
+ * permanently. A reload after capabilities have settled fixes it.
+ */
+async function waitForPerformanceDashboard(page: Page, maxRetries = 3): Promise<void> {
+  for (let attempt = 1; attempt <= maxRetries; attempt++) {
+    const dashboard = page.getByTestId('performance-dashboard');
+    try {
+      await dashboard.waitFor({ state: 'visible', timeout: 30_000 });
+      return; // element appeared — done
+    } catch {
+      if (attempt === maxRetries) {
+        // Final attempt failed — surface the real assertion error.
+        await expect(dashboard).toBeVisible();
+      }
+      // Capabilities may have settled by now; reload gives the component a
+      // fresh mount where CAN() should return true.
+      await page.reload({ waitUntil: 'domcontentloaded' });
+    }
+  }
+}
+
 test.describe('Performance Section Tests', () => {
   // Generous budget for the dashboard -> performance navigation chain on slow CI.
   test.describe.configure({ timeout: 180_000 });
@@ -9,16 +38,9 @@ test.describe('Performance Section Tests', () => {
     const dashboardPage = new DashboardPage(page);
     await dashboardPage.navigateToDashboard();
     await dashboardPage.navigateToPerformance();
-    // Readiness signal for the performance dashboard.
-    //
-    // Known flake (meshery/meshery#20504): "performance-dashboard" only renders
-    // when CAN(VIEW_PERFORMANCE_PROFILES) is true, and CAN() (ui/utils/can.ts)
-    // reads a non-reactive module-level casl ability singleton. If the user's
-    // capabilities load after Dashboard mounts, it renders <DefaultError/> and
-    // never re-renders, so this element can time out regardless of how long we
-    // wait - a longer timeout does not fix it. The real fix is a reactive
-    // permission gate, tracked in #20504.
-    await expect(page.getByTestId('performance-dashboard')).toBeVisible();
+    // Wait for the performance dashboard with retry-on-reload to handle the
+    // CAN() race condition (see meshery/meshery#20504).
+    await waitForPerformanceDashboard(page);
   });
 
   // Global chrome (navigation, notification, profile, header) is covered by the

--- a/ui/tests/e2e/performance.spec.ts
+++ b/ui/tests/e2e/performance.spec.ts
@@ -1,35 +1,6 @@
 import { expect, test, Page } from '@playwright/test';
 import { DashboardPage } from './pages/DashboardPage';
 
-/**
- * Waits for the performance dashboard to be visible, retrying via page reload
- * if the non-reactive CAN() permission gate renders <DefaultError/> before
- * capabilities have loaded.
- *
- * Known flake (meshery/meshery#20504): "performance-dashboard" only renders
- * when CAN(VIEW_PERFORMANCE_PROFILES) is true, and CAN() (ui/utils/can.ts)
- * reads a non-reactive module-level casl ability singleton. If the user's
- * capabilities load after the component mounts, it renders <DefaultError/>
- * permanently. A reload after capabilities have settled fixes it.
- */
-async function waitForPerformanceDashboard(page: Page, maxRetries = 3): Promise<void> {
-  for (let attempt = 1; attempt <= maxRetries; attempt++) {
-    const dashboard = page.getByTestId('performance-dashboard');
-    try {
-      await dashboard.waitFor({ state: 'visible', timeout: 30_000 });
-      return; // element appeared — done
-    } catch {
-      if (attempt === maxRetries) {
-        // Final attempt failed — surface the real assertion error.
-        await expect(dashboard).toBeVisible();
-      }
-      // Capabilities may have settled by now; reload gives the component a
-      // fresh mount where CAN() should return true.
-      await page.reload({ waitUntil: 'domcontentloaded' });
-    }
-  }
-}
-
 test.describe('Performance Section Tests', () => {
   // Generous budget for the dashboard -> performance navigation chain on slow CI.
   test.describe.configure({ timeout: 180_000 });
@@ -38,9 +9,16 @@ test.describe('Performance Section Tests', () => {
     const dashboardPage = new DashboardPage(page);
     await dashboardPage.navigateToDashboard();
     await dashboardPage.navigateToPerformance();
-    // Wait for the performance dashboard with retry-on-reload to handle the
-    // CAN() race condition (see meshery/meshery#20504).
-    await waitForPerformanceDashboard(page);
+    // Readiness signal for the performance dashboard.
+    //
+    // Known flake (meshery/meshery#20504): "performance-dashboard" only renders
+    // when CAN(VIEW_PERFORMANCE_PROFILES) is true, and CAN() (ui/utils/can.ts)
+    // reads a non-reactive module-level casl ability singleton. If the user's
+    // capabilities load after Dashboard mounts, it renders <DefaultError/> and
+    // never re-renders, so this element can time out regardless of how long we
+    // wait - a longer timeout does not fix it. The real fix is a reactive
+    // permission gate, tracked in #20504.
+    await expect(page.getByTestId('performance-dashboard')).toBeVisible();
   });
 
   // Global chrome (navigation, notification, profile, header) is covered by the


### PR DESCRIPTION
**Notes for Reviewers**

- This PR fixes #20515

Fixes duplicate `add_component` actions from the native Go policy engine's `identifyInventoryAdditions` when multiple existing components imply the same missing inventory parent (e.g. several Pods that all set `metadata.namespace: default`, with no `Namespace` component in the design yet).

**Root cause:** `buildInventoryParentCandidate` assigns each candidate a fresh random component ID (`uuid.NewV4()`). The dedup checks (`identifyInventoryAdditionsForRel`'s `emittedIDs`, and `applyActionsToDesign`'s `existingCompIDs`) both key off that ID, so two candidates describing the exact same logical addition never compare equal and neither dedup ever fires — every referencing component produces its own duplicate suggestion.

The Rego engine this was ported from doesn't have this problem because its candidate id is content-derived (`uuid.rfc4122(json.marshal(declaration) + now)`, with `time.now_ns()` memoized once per query), so identical candidates hash to the same id and its set-based collection naturally collapses them.

**Fix:** compute a content key (`selector kind + model name + resolved mutator values`) *before* the candidate is built and assigned its random ID, and dedupe on that key instead. Minimal, scoped to `identifyInventoryAdditionsForRel`; no change to the candidate/action shape.

**Testing:**
- Added `TestIdentifyInventoryAdditions_DedupesSharedMissingParent` (two Pods → one missing namespace → asserts exactly one `add_component` action). Fails on the pre-fix code with 2 actions, passes with the fix.
- Full `server/policies` suite passes locally (251 tests, including the existing single-Pod and cross-model inventory tests and the Rego/Go parity test) — the fix is additive and doesn't change behavior for the already-covered single-referencer case.

**[Signed commits](https://github.com/meshery/meshery/blob/master/CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [x] Yes, I signed my commits.
