### PR TITLE
[UI] Clear useWindowDimensions debounce on unmount

### DIFF
--- a/ui/utils/__tests__/dimension.test.tsx
+++ b/ui/utils/__tests__/dimension.test.tsx
@@ -132,4 +132,33 @@ describe('useWindowDimensions', () => {
     expect(removeListenerSpy.mock.calls.some(([eventName]) => eventName === 'resize')).toBe(true);
     removeListenerSpy.mockRestore();
   });
+
+  it('clears the pending debounce timeout on unmount', () => {
+    const onRender = vi.fn();
+    const { unmount } = render(<Probe onRender={onRender} />);
+    onRender.mockClear();
+
+    Object.defineProperty(window, 'innerWidth', {
+      configurable: true,
+      writable: true,
+      value: 1200,
+    });
+    Object.defineProperty(window, 'innerHeight', {
+      configurable: true,
+      writable: true,
+      value: 900,
+    });
+
+    act(() => {
+      window.dispatchEvent(new Event('resize'));
+    });
+
+    unmount();
+
+    act(() => {
+      vi.advanceTimersByTime(500);
+    });
+
+    expect(onRender).not.toHaveBeenCalled();
+  });
 });

--- a/ui/utils/dimension.ts
+++ b/ui/utils/dimension.ts
@@ -45,7 +45,12 @@ export function useWindowDimensions() {
     }
 
     window.addEventListener('resize', handleResize);
-    return () => window.removeEventListener('resize', handleResize);
+    return () => {
+      window.removeEventListener('resize', handleResize);
+      if (searchTimeout) {
+        clearTimeout(searchTimeout);
+      }
+    };
   }, []);
 
   return windowDimensions;

--- a/ui/utils/dimension.ts
+++ b/ui/utils/dimension.ts
@@ -33,13 +33,13 @@ export function useWindowDimensions() {
   const [windowDimensions, setWindowDimensions] = useState(getWindowDimensions());
 
   useEffect(() => {
-    let searchTimeout;
+    let resizeDebounceTimeout: ReturnType<typeof window.setTimeout> | undefined;
 
     function handleResize() {
-      if (searchTimeout) {
-        clearTimeout(searchTimeout);
+      if (resizeDebounceTimeout !== undefined) {
+        clearTimeout(resizeDebounceTimeout);
       }
-      searchTimeout = setTimeout(() => {
+      resizeDebounceTimeout = window.setTimeout(() => {
         setWindowDimensions(getWindowDimensions());
       }, 500);
     }
@@ -47,8 +47,8 @@ export function useWindowDimensions() {
     window.addEventListener('resize', handleResize);
     return () => {
       window.removeEventListener('resize', handleResize);
-      if (searchTimeout) {
-        clearTimeout(searchTimeout);
+      if (resizeDebounceTimeout !== undefined) {
+        clearTimeout(resizeDebounceTimeout);
       }
     };
   }, []);


### PR DESCRIPTION
## Summary

- Clear the pending debounce timeout in `useWindowDimensions` when the hook unmounts.
- Add a regression test to ensure no state updates fire after unmount.

Fixes #20327.

**Notes for Reviewers**

- This PR fixes #20327.
- Scope is limited to `ui/utils/dimension.ts` and `ui/utils/__tests__/dimension.test.tsx`.

**[Signed commits](https://github.com/meshery/meshery/blob/master/CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [x] Yes, I signed my commits.

<!--
Thank you for contributing to Meshery! 

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. Sign your commits.
4. Include before and after screenshots/terminal output.

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.
-->