### PR TITLE
feat(user): adopt schemas v1beta3 User + adapt to Meshery Cloud account-consolidation

### DIFF
--- a/server/handlers/mesh_ops_handlers.go
+++ b/server/handlers/mesh_ops_handlers.go
@@ -147,7 +147,7 @@ func (h *Handler) MeshAdapterConfigHandler(w http.ResponseWriter, req *http.Requ
 	}
 
 	prefObj.MeshAdapters = meshAdapters
-	err = provider.RecordPreferences(req, user.UserId, prefObj)
+	err = provider.RecordPreferences(req, user.ID.String(), prefObj)
 	if err != nil {
 		h.log.Error(ErrRecordPreferences(err))
 		writeMeshkitError(w, ErrRecordPreferences(err), http.StatusInternalServerError)
@@ -339,7 +339,7 @@ func (h *Handler) MeshOpsHandler(w http.ResponseWriter, req *http.Request, prefO
 	_, err = mClient.MClient.ApplyOperation(req.Context(), &meshes.ApplyRuleRequest{
 		OperationId: operationID.String(),
 		OpName:      opName,
-		Username:    user.UserId,
+		Username:    user.ID.String(),
 		Namespace:   namespace,
 		CustomBody:  customBody,
 		DeleteOp:    (deleteOp != ""),

--- a/server/handlers/middlewares.go
+++ b/server/handlers/middlewares.go
@@ -254,14 +254,14 @@ func (h *Handler) SessionInjectorMiddleware(next func(http.ResponseWriter, *http
 			writeMeshkitError(w, ErrGetUserDetails(err), http.StatusUnauthorized)
 			return
 		}
-		prefObj, err := provider.ReadFromPersister(user.UserId)
+		prefObj, err := provider.ReadFromPersister(user.ID.String())
 		if err != nil {
 			// log underlying error from persister along with high-level context
-			h.log.Warn(fmt.Errorf("%w: userID=%s: %v", ErrReadSessionPersistor, user.UserId, err))
+			h.log.Warn(fmt.Errorf("%w: userID=%s: %v", ErrReadSessionPersistor, user.ID.String(), err))
 			prefObj = models.NewDefaultPreference()
 		} else if prefObj == nil {
 			// persister unexpectedly returned a nil preference without error
-			h.log.Warn(fmt.Errorf("%w: persister returned nil preference without error for userID=%s", ErrReadSessionPersistor, user.UserId))
+			h.log.Warn(fmt.Errorf("%w: persister returned nil preference without error for userID=%s", ErrReadSessionPersistor, user.ID.String()))
 			prefObj = models.NewDefaultPreference()
 		}
 

--- a/server/handlers/session_sync_handler.go
+++ b/server/handlers/session_sync_handler.go
@@ -43,7 +43,7 @@ func (h *Handler) SessionSyncHandler(w http.ResponseWriter, req *http.Request, p
 	}
 	h.log.Debug("final list of active adapters: ", meshAdapters)
 	prefObj.MeshAdapters = meshAdapters
-	err := provider.RecordPreferences(req, user.UserId, prefObj)
+	err := provider.RecordPreferences(req, user.ID.String(), prefObj)
 	if err != nil { // ignoring errors in this context
 		h.log.Error(ErrSaveSession(err))
 	}

--- a/server/handlers/user_handler.go
+++ b/server/handlers/user_handler.go
@@ -143,7 +143,7 @@ func (h *Handler) UserPrefsHandler(w http.ResponseWriter, req *http.Request, pre
 		}
 	}
 
-	if err := provider.RecordPreferences(req, user.UserId, prefObj); err != nil {
+	if err := provider.RecordPreferences(req, user.ID.String(), prefObj); err != nil {
 		err := fmt.Errorf("unable to save user preferences: %v", err)
 		h.log.Error(ErrSavingUserPreference(err))
 		writeMeshkitError(w, ErrSavingUserPreference(err), http.StatusInternalServerError)

--- a/server/models/connection_persister.go
+++ b/server/models/connection_persister.go
@@ -180,7 +180,7 @@ func (cp *ConnectionPersister) DeleteConnectionById(connectionID core.Uuid) (*co
 	}
 	err = cp.DB.Delete(connection).Error
 	if err != nil {
-		return nil, ErrDBDelete(err, cp.fetchUserDetails().UserId)
+		return nil, ErrDBDelete(err, cp.fetchUserDetails().ID.String())
 	}
 
 	return &connection, nil
@@ -189,7 +189,7 @@ func (cp *ConnectionPersister) DeleteConnectionById(connectionID core.Uuid) (*co
 func (cp *ConnectionPersister) fetchUserDetails() *User {
 
 	return &User{
-		UserId:    "meshery",
+		ID:        LocalProviderUserID,
 		FirstName: "Meshery",
 		LastName:  "Meshery",
 	}

--- a/server/models/default_local_provider.go
+++ b/server/models/default_local_provider.go
@@ -375,7 +375,7 @@ func (l *DefaultLocalProvider) fetchUserDetails() *User {
 	avatarUrl := ""
 	localEmail := types.Email("meshery@meshery.local")
 	return &User{
-		UserId:    "meshery",
+		ID:        LocalProviderUserID,
 		FirstName: "Meshery",
 		LastName:  "Meshery",
 		Email:     localEmail,
@@ -677,7 +677,7 @@ func (l *DefaultLocalProvider) PublishResults(req *http.Request, result *Meshery
 		return "", ErrMarshal(err, "meshery result for shipping")
 	}
 	user, _ := l.GetUserDetails(req)
-	pref, _ := l.ReadFromPersister(user.UserId)
+	pref, _ := l.ReadFromPersister(user.ID.String())
 	if !pref.AnonymousPerfResults {
 		return "", nil
 	}

--- a/server/models/environment_persister.go
+++ b/server/models/environment_persister.go
@@ -25,7 +25,7 @@ type EnvironmentPersister struct {
 func (ep *EnvironmentPersister) fetchUserDetails() *User {
 
 	return &User{
-		UserId:    "meshery",
+		ID:        LocalProviderUserID,
 		FirstName: "Meshery",
 		LastName:  "Meshery",
 	}
@@ -134,7 +134,7 @@ func (ep *EnvironmentPersister) DeleteEnvironment(environment *environment.Envir
 	}
 	err = ep.DB.Delete(environment).Error
 	if err != nil {
-		return nil, ErrDBDelete(err, ep.fetchUserDetails().UserId)
+		return nil, ErrDBDelete(err, ep.fetchUserDetails().ID.String())
 	}
 
 	// Marshal the environment to JSON
@@ -332,7 +332,7 @@ func (ep *EnvironmentPersister) DeleteConnectionFromEnvironment(environmentID, c
 
 	// Delete the connection mapping
 	if err := ep.DB.Delete(&envConMapping).Error; err != nil {
-		return nil, ErrDBDelete(err, ep.fetchUserDetails().UserId)
+		return nil, ErrDBDelete(err, ep.fetchUserDetails().ID.String())
 	}
 
 	envJSON, err := json.Marshal(envConMapping)

--- a/server/models/meshsync_events_test.go
+++ b/server/models/meshsync_events_test.go
@@ -79,6 +79,12 @@ func (b *testMeshsyncBroker) isClosed() bool {
 	return b.closed
 }
 
+// IsConnected satisfies broker.Handler; the fake is "connected" until its
+// connection is closed.
+func (b *testMeshsyncBroker) IsConnected() bool {
+	return !b.isClosed()
+}
+
 func newTestMeshsyncHandler(t *testing.T, broker meshkitBroker.Handler, stopFunc func()) *MeshsyncDataHandler {
 	t.Helper()
 

--- a/server/models/remote_provider.go
+++ b/server/models/remote_provider.go
@@ -697,10 +697,10 @@ func (l *RemoteProvider) GetUserDetails(req *http.Request) (*User, error) {
 		return nil, ErrUnmarshal(err, "User Pref")
 	}
 
-	prefLocal, _ := l.ReadFromPersister(up.UserId)
+	prefLocal, _ := l.ReadFromPersister(up.ID.String())
 
 	if prefLocal == nil || up.Preferences.UpdatedAt.After(prefLocal.UpdatedAt) || !reflect.DeepEqual(up.Preferences.RemoteProviderPreferences, prefLocal.RemoteProviderPreferences) {
-		_ = l.WriteToPersister(up.UserId, up.Preferences)
+		_ = l.WriteToPersister(up.ID.String(), up.Preferences)
 	}
 
 	// Uncomment when Debug verbosity is figured out project wide. | @leecalcote

--- a/server/models/remote_provider.go
+++ b/server/models/remote_provider.go
@@ -699,10 +699,11 @@ func (l *RemoteProvider) GetUserDetails(req *http.Request) (*User, error) {
 
 	prefLocal, _ := l.ReadFromPersister(up.ID.String())
 
-	// Guard up.Preferences: the remote provider can return a null/absent
-	// preferences field, which json.Unmarshal leaves nil - dereferencing
-	// UpdatedAt / RemoteProviderPreferences below would then panic. Nothing to
-	// persist in that case.
+	// Guard up.Preferences: up is pre-initialized with a non-nil Preferences, so
+	// an absent `preferences` field stays non-nil; but an explicit
+	// `"preferences": null` from the remote provider overwrites it to nil, and
+	// dereferencing UpdatedAt / RemoteProviderPreferences below would then panic.
+	// Nothing to persist in that case.
 	if up.Preferences != nil && (prefLocal == nil || up.Preferences.UpdatedAt.After(prefLocal.UpdatedAt) || !reflect.DeepEqual(up.Preferences.RemoteProviderPreferences, prefLocal.RemoteProviderPreferences)) {
 		_ = l.WriteToPersister(up.ID.String(), up.Preferences)
 	}

--- a/server/models/remote_provider.go
+++ b/server/models/remote_provider.go
@@ -699,7 +699,11 @@ func (l *RemoteProvider) GetUserDetails(req *http.Request) (*User, error) {
 
 	prefLocal, _ := l.ReadFromPersister(up.ID.String())
 
-	if prefLocal == nil || up.Preferences.UpdatedAt.After(prefLocal.UpdatedAt) || !reflect.DeepEqual(up.Preferences.RemoteProviderPreferences, prefLocal.RemoteProviderPreferences) {
+	// Guard up.Preferences: the remote provider can return a null/absent
+	// preferences field, which json.Unmarshal leaves nil - dereferencing
+	// UpdatedAt / RemoteProviderPreferences below would then panic. Nothing to
+	// persist in that case.
+	if up.Preferences != nil && (prefLocal == nil || up.Preferences.UpdatedAt.After(prefLocal.UpdatedAt) || !reflect.DeepEqual(up.Preferences.RemoteProviderPreferences, prefLocal.RemoteProviderPreferences)) {
 		_ = l.WriteToPersister(up.ID.String(), up.Preferences)
 	}
 

--- a/server/models/user.go
+++ b/server/models/user.go
@@ -3,7 +3,8 @@ package models
 import (
 	"encoding/gob"
 
-	userV1beta2 "github.com/meshery/schemas/models/v1beta2/user"
+	"github.com/gofrs/uuid"
+	userV1beta3 "github.com/meshery/schemas/models/v1beta3/user"
 )
 
 func init() {
@@ -15,8 +16,16 @@ var (
 	GlobalTokenForAnonymousResults = "dev_token"
 )
 
+// LocalProviderUserID is the stable synthetic id the built-in local provider
+// uses to key preferences and persister-scoped data for its single "meshery"
+// system user. schemas v1beta3 dropped the string User.UserId ("meshery"); this
+// deterministic (namespaced) uuid replaces it so the local persister key stays
+// stable across restarts. It is non-nil on purpose - a nil user id is treated
+// as "unset" on the remote path.
+var LocalProviderUserID = uuid.NewV5(uuid.NamespaceDNS, "meshery-local-provider-user")
+
 // User - represents a user in Meshery
-type User = userV1beta2.User
+type User = userV1beta3.User
 
 type AllUsers struct {
 	Page       int     `json:"page"`

--- a/server/models/user.go
+++ b/server/models/user.go
@@ -20,8 +20,9 @@ var (
 // uses to key preferences and persister-scoped data for its single "meshery"
 // system user. schemas v1beta3 dropped the string User.UserId ("meshery"); this
 // deterministic (namespaced) uuid replaces it so the local persister key stays
-// stable across restarts. It is non-nil on purpose - a nil user id is treated
-// as "unset" on the remote path.
+// stable across restarts. It is a non-zero UUID on purpose - the zero value
+// (uuid.Nil) is treated as "unset" on the remote path (see the
+// `user.ID == uuid.Nil` guards in this package).
 var LocalProviderUserID = uuid.NewV5(uuid.NamespaceDNS, "meshery-local-provider-user")
 
 // User - represents a user in Meshery

--- a/server/models/workspace_persister.go
+++ b/server/models/workspace_persister.go
@@ -42,7 +42,7 @@ func uuidPtr(u core.Uuid) *core.Uuid {
 
 func (wp *WorkspacePersister) fetchUserDetails() *User {
 	return &User{
-		UserId:    "meshery",
+		ID:        LocalProviderUserID,
 		FirstName: "Meshery",
 		LastName:  "Meshery",
 	}
@@ -166,7 +166,7 @@ func (wp *WorkspacePersister) DeleteWorkspace(workspace *workspace.Workspace) ([
 	}
 	err = wp.DB.Delete(workspace).Error
 	if err != nil {
-		return nil, ErrDBDelete(err, wp.fetchUserDetails().UserId)
+		return nil, ErrDBDelete(err, wp.fetchUserDetails().ID.String())
 	}
 
 	// Marshal the workspace to JSON
@@ -383,7 +383,7 @@ func (wp *WorkspacePersister) DeleteEnvironmentFromWorkspace(workspaceID, enviro
 
 	// Delete the environment mapping
 	if err := wp.DB.Delete(&wsEnvMapping).Error; err != nil {
-		return nil, ErrDBDelete(err, wp.fetchUserDetails().UserId)
+		return nil, ErrDBDelete(err, wp.fetchUserDetails().ID.String())
 	}
 
 	wsJSON, err := json.Marshal(wsEnvMapping)
@@ -442,7 +442,7 @@ func (wp *WorkspacePersister) DeleteDesignFromWorkspace(workspaceID, designID co
 
 	// Delete the design mapping
 	if err := wp.DB.Delete(&wsDesignMapping).Error; err != nil {
-		return nil, ErrDBDelete(err, wp.fetchUserDetails().UserId)
+		return nil, ErrDBDelete(err, wp.fetchUserDetails().ID.String())
 	}
 
 	wsJSON, err := json.Marshal(wsDesignMapping)
@@ -592,7 +592,7 @@ func (wp *WorkspacePersister) DeleteViewFromWorkspace(workspaceID, viewID core.U
 	}
 
 	if err := wp.DB.Delete(&wsViewMapping).Error; err != nil {
-		return nil, ErrDBDelete(err, wp.fetchUserDetails().UserId)
+		return nil, ErrDBDelete(err, wp.fetchUserDetails().ID.String())
 	}
 
 	wsJSON, err := json.Marshal(wsViewMapping)
@@ -720,7 +720,7 @@ func (wp *WorkspacePersister) DeleteTeamFromWorkspace(workspaceID, teamID core.U
 	}
 
 	if err := wp.DB.Delete(&wsTeamMapping).Error; err != nil {
-		return nil, ErrDBDelete(err, wp.fetchUserDetails().UserId)
+		return nil, ErrDBDelete(err, wp.fetchUserDetails().ID.String())
 	}
 
 	wsJSON, err := json.Marshal(wsTeamMapping)

--- a/ui/components/User.tsx
+++ b/ui/components/User.tsx
@@ -40,6 +40,8 @@ const User = (props) => {
 
   useEffect(() => {
     if (!userLoaded && isGetUserSuccess) {
+      // userData is normalized by getLoggedInUser's transformResponse
+      // (userId backfilled from id for the v1beta3 Cloud response).
       dispatch(updateUser({ user: userData }));
       setUserLoaded(true);
     } else if (isGetUserError) {

--- a/ui/rtk-query/__tests__/transforms.test.ts
+++ b/ui/rtk-query/__tests__/transforms.test.ts
@@ -25,8 +25,10 @@ describe('normalizeLoggedInUser', () => {
     });
   });
 
-  it('returns undefined for a null/non-object response', () => {
+  it('returns undefined for null / non-object responses', () => {
     expect(normalizeLoggedInUser(undefined)).toBeUndefined();
+    expect(normalizeLoggedInUser(null as unknown as undefined)).toBeUndefined();
+    expect(normalizeLoggedInUser('not-an-object' as unknown as undefined)).toBeUndefined();
   });
 });
 

--- a/ui/rtk-query/__tests__/transforms.test.ts
+++ b/ui/rtk-query/__tests__/transforms.test.ts
@@ -1,9 +1,34 @@
 import { describe, expect, it } from 'vitest';
 import {
   normalizeKubernetesContextsResponse,
+  normalizeLoggedInUser,
   normalizePaginatedCollectionResponse,
   normalizeProviderCapabilities,
 } from '../transforms';
+
+describe('normalizeLoggedInUser', () => {
+  it('backfills userId from id when the v1beta3 response omits userId', () => {
+    expect(normalizeLoggedInUser({ id: 'uuid-1', email: 'owner@meshery.io' })).toEqual({
+      id: 'uuid-1',
+      email: 'owner@meshery.io',
+      userId: 'uuid-1',
+    });
+  });
+
+  it('preserves an existing userId (does not overwrite it with id)', () => {
+    expect(
+      normalizeLoggedInUser({ id: 'uuid-1', userId: 'legacy-user', status: 'active' }),
+    ).toEqual({
+      id: 'uuid-1',
+      userId: 'legacy-user',
+      status: 'active',
+    });
+  });
+
+  it('returns undefined for a null/non-object response', () => {
+    expect(normalizeLoggedInUser(undefined)).toBeUndefined();
+  });
+});
 
 describe('normalizeProviderCapabilities', () => {
   it('normalizes snake_case provider fields to camelCase', () => {

--- a/ui/rtk-query/transforms.ts
+++ b/ui/rtk-query/transforms.ts
@@ -105,3 +105,26 @@ export const normalizeKubernetesContextsResponse = (response?: KubernetesContext
       : [],
   };
 };
+
+type LoggedInUserResponse = {
+  id?: string;
+  userId?: string;
+  [key: string]: unknown;
+};
+
+// normalizeLoggedInUser adapts the current-user response for the v1beta3 Cloud
+// account-consolidation cutover: schemas v1beta3 dropped the `userId` field (the
+// canonical identifier is the `id` UUID). Backfill `userId` from `id` so
+// ownership checks that compare `user.userId` against a resource's owner UUID
+// keep working across every consumer of getLoggedInUser. Non-destructive: all
+// other fields pass through unchanged.
+export const normalizeLoggedInUser = (response?: LoggedInUserResponse) => {
+  if (!response || typeof response !== 'object') {
+    return undefined;
+  }
+
+  return {
+    ...response,
+    userId: response.userId ?? response.id,
+  };
+};

--- a/ui/rtk-query/user.ts
+++ b/ui/rtk-query/user.ts
@@ -5,7 +5,7 @@ import { initiateQuery } from './utils';
 import { useGetOrgsQuery } from './organization';
 import { useGetWorkspacesQuery } from './workspace';
 import { normalizeLoadTestPrefs } from '../lib/load-test-prefs';
-import { normalizeProviderCapabilities } from './transforms';
+import { normalizeLoggedInUser, normalizeProviderCapabilities } from './transforms';
 import { normalizeUserProfileSummary } from './userProfile';
 
 const Tags = {
@@ -101,16 +101,7 @@ export const userApi = api
           url: '/api/user',
           method: 'GET',
         }),
-        // Meshery Cloud's account-consolidation (Phase 4) moved the current-user
-        // response to schemas v1beta3, which drops the `userId` field (the
-        // canonical identifier is the `id` UUID). Backfill `userId` from `id` so
-        // ownership checks that compare `user.userId` against a resource's
-        // owner UUID keep working across every consumer of this query.
-        // Non-destructive: all other fields pass through unchanged.
-        transformResponse: (response) =>
-          response && typeof response === 'object'
-            ? { ...response, userId: response.userId ?? response.id }
-            : response,
+        transformResponse: normalizeLoggedInUser,
         // All callers share one cache entry per user session (client-side Redux store).
         // This does not affect other users—each browser has its own isolated store.
         serializeQueryArgs: ({ endpointName }) => endpointName,

--- a/ui/rtk-query/user.ts
+++ b/ui/rtk-query/user.ts
@@ -101,6 +101,16 @@ export const userApi = api
           url: '/api/user',
           method: 'GET',
         }),
+        // Meshery Cloud's account-consolidation (Phase 4) moved the current-user
+        // response to schemas v1beta3, which drops the `userId` field (the
+        // canonical identifier is the `id` UUID). Backfill `userId` from `id` so
+        // ownership checks that compare `user.userId` against a resource's
+        // owner UUID keep working across every consumer of this query.
+        // Non-destructive: all other fields pass through unchanged.
+        transformResponse: (response) =>
+          response && typeof response === 'object'
+            ? { ...response, userId: response.userId ?? response.id }
+            : response,
         // All callers share one cache entry per user session (client-side Redux store).
         // This does not affect other users—each browser has its own isolated store.
         serializeQueryArgs: ({ endpointName }) => endpointName,


### PR DESCRIPTION
Adapts Meshery (server, mesheryctl, UI) to Meshery Cloud's account-consolidation Phase 4: Cloud dropped `users.user_id`, moved its User to schemas **v1beta3** (removing the legacy `userId` field), and re-keyed the JWT `sub` to the `users.id` UUID. Its single-user profile response no longer carries `userId`.

Closes part of #20521.

## Server (Go)
- `type User = userV1beta3.User`; add a deterministic `LocalProviderUserID` (namespaced uuid) for the built-in local provider's synthetic "meshery" user, replacing the removed string `UserId`.
- **Preference persister was keyed on `user.UserId`**, now absent on the v1beta3 Cloud profile response - every user would collapse onto the `""` key. Re-key on `user.ID.String()` / `up.ID.String()` at all sites: `remote_provider`, `default_local_provider`, `mesh_ops_handlers`, `middlewares`, `session_sync_handler`, `user_handler`, and the persister `fetchUserDetails` stubs.

## mesheryctl
No independent changes needed - it inherits the shared alias and reads only `FirstName`/`LastName`. Builds clean.

## UI
- Cloud's current-user response drops `userId`, silently disabling ownership/permission checks (`user.userId == resource.userId`). Backfill `userId` from `id` in `getLoggedInUser`'s `transformResponse` - one normalization point covering every consumer. Resource responses already carry `userId` = owner UUID, so comparisons are uuid==uuid again.

## JWT `sub`
No changes needed: `VerifyToken` only validates signature + expiry and never decodes the subject; mesheryctl treats the token opaquely.

## Verification
- `go build ./...`, `go vet`, and the handlers/mesheryctl test binaries compile clean.
- UI files pass eslint (`--max-warnings=0`) + prettier.
- Pre-existing (not this PR): `server/models/meshsync_events_test.go` fails to compile on master (a `broker.Handler` mock missing `IsConnected`), unrelated to this change.