### PR TITLE
[Docs] Update Font Awesome to v7.3.0 and remove duplicate loads

### DIFF
--- a/docs/assets/scss/_tabbed-menu.scss
+++ b/docs/assets/scss/_tabbed-menu.scss
@@ -1,6 +1,5 @@
 /* Essential font imports */
 @import url("https://fonts.googleapis.com/css?family=Open+Sans:400,600,700");
-@import url("https://netdna.bootstrapcdn.com/font-awesome/4.1.0/css/font-awesome.css");
 
 /* Tab container - this will apply to any container with tabs */
 [class*="tab-container"] {

--- a/docs/layouts/_default/baseof.html
+++ b/docs/layouts/_default/baseof.html
@@ -4,7 +4,6 @@
     {{ partial "head.html" (dict "Title" .Title "Description" .Params.abstract "Kind" .Kind "Permalink" .Permalink "Site" .Site) }}
     {{ partialCached "header.html" . .RelPermalink }}
     <script src="https://cdn.jsdelivr.net/npm/clipboard@1/dist/clipboard.min.js"></script>
-    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.0/css/all.min.css">
 
     <script src="{{ "js/error-code-handler.js" | relURL }}"></script>
     

--- a/docs/layouts/partials/head.html
+++ b/docs/layouts/partials/head.html
@@ -117,7 +117,7 @@
   {{- end -}}
   <link
     rel="stylesheet"
-    href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/5.11.2/css/all.css"
+    href="https://cdn.jsdelivr.net/npm/@fortawesome/fontawesome-free@7.3.0/css/all.min.css"
   />
   <link
     rel="stylesheet"

--- a/docs/layouts/partials/head.html
+++ b/docs/layouts/partials/head.html
@@ -118,6 +118,8 @@
   <link
     rel="stylesheet"
     href="https://cdn.jsdelivr.net/npm/@fortawesome/fontawesome-free@7.3.0/css/all.min.css"
+    integrity="sha384-sTlsophtwz/I4myskS3OIJf5VvEojkXKZyBTWZm0YD/K1pN7C5wpBPLyrsbr1SU2" 
+    crossorigin="anonymous" 
   />
   <link
     rel="stylesheet"


### PR DESCRIPTION
**Notes for Reviewers**

- This PR fixes #17156

The docs were loading **three separate Font Awesome versions** on every page:

| File | Version loaded |
|---|---|
| `docs/layouts/partials/head.html` | 5.11.2 (cdnjs) |
| `docs/layouts/_default/baseof.html` | 6.5.0 (cdnjs) — a duplicate, since this template also includes `head.html` |
| `docs/assets/scss/_tabbed-menu.scss` | 4.1.0 (via the deprecated netdna.bootstrapcdn.com CDN) |

This PR consolidates them into a single load of the latest stable release, **7.3.0**, in `head.html` and removes the other two.

**Why jsDelivr instead of cdnjs:** cdnjs currently only hosts FA up to 7.0.1 (their update request has been open since February), while jsDelivr mirrors the official npm package at 7.3.0 and is already used in `baseof.html` for clipboard.js. Happy to switch to cdnjs 7.0.1 if maintainers prefer a single CDN.

**Verification:**
- Confirmed all 14 icon classes used across the docs render under 7.3.0, including the legacy `fa` / `fas` / `fab` prefixes used in the quick-start tabs — v7 retains these as aliases, so removing the old 4.x/5.x loads is safe.
- Icon verification matrix (exact class strings from docs source, single 7.3.0 stylesheet):

<img width="1188" height="838" alt="image" src="https://github.com/user-attachments/assets/b7448459-39f1-44a6-8d0a-3d33bca0fb75" />

- Deploy Preview pages checked: quick-start tabs, community (brands font), search, pagination + edit-page icons.
- `docs/static/v0.9/` (archived snapshot) and the inline footer SVG were intentionally left untouched.

**[Signed commits](https://github.com/meshery/meshery/blob/master/CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [x] Yes, I signed my commits.