### PR TITLE
fix: Navigator toggle button should work in mobile view

### DIFF
--- a/ui/components/layout/Navigator/Navigator.tsx
+++ b/ui/components/layout/Navigator/Navigator.tsx
@@ -206,7 +206,6 @@ const resolveNavigatorComponents = ({
 const NavigatorWrapper = () => {
   const isMobile = useMediaQuery('(max-width:599px)');
   const dispatch = useDispatch();
-  const { isDrawerCollapsed } = useSelector((state) => state.ui);
 
   useEffect(() => {
     if (isMobile) {

--- a/ui/components/layout/Navigator/Navigator.tsx
+++ b/ui/components/layout/Navigator/Navigator.tsx
@@ -209,10 +209,10 @@ const NavigatorWrapper = () => {
   const { isDrawerCollapsed } = useSelector((state) => state.ui);
 
   useEffect(() => {
-    if (isMobile && !isDrawerCollapsed) {
+    if (isMobile) {
       dispatch(toggleDrawer({ isDrawerCollapsed: true }));
     }
-  }, [dispatch, isDrawerCollapsed, isMobile]);
+  }, [dispatch, isMobile]);
 
   return <NavigatorContent />;
 };


### PR DESCRIPTION
## What this fixes
Fixes #20529 — Sidebar cannot be expanded after switching to 
mobile viewport.

## What I changed
Removed `isDrawerCollapsed` from the dependency array and 
the `!isDrawerCollapsed` guard condition. The effect now 
only fires when `isMobile` changes, not when drawer state changes.

##ScreenShot:

https://github.com/user-attachments/assets/6b347769-db1c-42d8-9874-06d737eeb600




## Signed commits
- [x] Yes, I signed my commits.