### PR TITLE
[Server] Guard patch_mutators_action against null mutator values

### DIFF
--- a/models/meshery-core/0.7.2/v1.0.0/policies/eval_rules.rego
+++ b/models/meshery-core/0.7.2/v1.0.0/policies/eval_rules.rego
@@ -56,6 +56,11 @@ patch_mutators_action(relationship, design_file) := {action |
 	mutatorValue := core_utils.configuration_for_component_at_path(mutatorRef, from_component, design_file)
 	old_value := core_utils.configuration_for_component_at_path(mutatedRef, to_component, design_file)
 
+	# A missing mutator path resolves to null; without this guard the action
+	# below writes null over the mutated field. The hierarchical patch path
+	# already guards this (patch_helper_rules.rego `update_value != null`).
+	mutatorValue != null
+
 	old_value != mutatorValue
 
 	action := {

--- a/server/policies/rego_test.go
+++ b/server/policies/rego_test.go
@@ -309,6 +309,123 @@ func TestRelationshipEvaluationScenarios(t *testing.T) {
 			designFile:  "namespace_parent_inline",
 			expected:    true,
 		},
+		{
+			// A missing mutator path resolves to null (utils.rego
+			// configuration_for_component_at_path defaults to null), and
+			// patch_mutators_action must not emit an update that writes
+			// null over the mutated field. The hierarchical patch path
+			// already guards this (patch_helper_rules.rego
+			// `update_value != null`); this pins the same behavior for the
+			// edge flow, matching the Go engine, which skips nil mutator
+			// values.
+			name:  "patch_mutators_skips_missing_mutator_value",
+			query: "data.eval_rules.patch_mutators_action(input.relationship, input.design_file)",
+			input: map[string]interface{}{
+				"relationship": map[string]interface{}{
+					"selectors": []map[string]interface{}{
+						{
+							"allow": map[string]interface{}{
+								"from": []map[string]interface{}{
+									{
+										"id": "from-1",
+										"patch": map[string]interface{}{
+											"mutatorRef": [][]string{{"configuration", "metadata", "name"}},
+										},
+									},
+								},
+								"to": []map[string]interface{}{
+									{
+										"id": "to-1",
+										"patch": map[string]interface{}{
+											"mutatedRef": [][]string{{"configuration", "metadata", "namespace"}},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+				"design_file": map[string]interface{}{
+					"components": []map[string]interface{}{
+						{
+							"id": "from-1",
+							// metadata exists but "name" is missing, so the
+							// mutator path resolves to null.
+							"configuration": map[string]interface{}{"metadata": map[string]interface{}{}},
+						},
+						{
+							"id": "to-1",
+							"configuration": map[string]interface{}{
+								"metadata": map[string]interface{}{"namespace": "default"},
+							},
+						},
+					},
+				},
+			},
+			expectError: false,
+			designFile:  "inline",
+			expected:    []interface{}{},
+		},
+		{
+			// Positive control for the case above: when the mutator path
+			// resolves to a real value, the update action is emitted.
+			name:  "patch_mutators_emits_update_for_present_mutator_value",
+			query: "data.eval_rules.patch_mutators_action(input.relationship, input.design_file)",
+			input: map[string]interface{}{
+				"relationship": map[string]interface{}{
+					"selectors": []map[string]interface{}{
+						{
+							"allow": map[string]interface{}{
+								"from": []map[string]interface{}{
+									{
+										"id": "from-1",
+										"patch": map[string]interface{}{
+											"mutatorRef": [][]string{{"configuration", "metadata", "name"}},
+										},
+									},
+								},
+								"to": []map[string]interface{}{
+									{
+										"id": "to-1",
+										"patch": map[string]interface{}{
+											"mutatedRef": [][]string{{"configuration", "metadata", "namespace"}},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+				"design_file": map[string]interface{}{
+					"components": []map[string]interface{}{
+						{
+							"id": "from-1",
+							"configuration": map[string]interface{}{
+								"metadata": map[string]interface{}{"name": "prod"},
+							},
+						},
+						{
+							"id": "to-1",
+							"configuration": map[string]interface{}{
+								"metadata": map[string]interface{}{"namespace": "default"},
+							},
+						},
+					},
+				},
+			},
+			expectError: false,
+			designFile:  "inline",
+			expected: []interface{}{
+				map[string]interface{}{
+					"op": "update_component_configuration",
+					"value": map[string]interface{}{
+						"id":    "to-1",
+						"path":  []interface{}{"configuration", "metadata", "namespace"},
+						"value": "prod",
+					},
+				},
+			},
+		},
 	}
 
 	for _, tc := range testCases {


### PR DESCRIPTION
**Notes for Reviewers**

- This PR fixes #20555

When an edge relationship's mutatorRef path does not resolve on the from-component, `configuration_for_component_at_path` returns null and `patch_mutators_action`'s only guard was `old_value != mutatorValue`. The Rego engine therefore emitted an `update_component_configuration` action writing null over the mutated field, while the Go engine (`patchMutatorsAction`) skips nil mutator values. Same design, different result depending on which engine is enabled, and the Rego side destroys an existing value.

The fix adds the same `mutatorValue != null` guard that the hierarchical patch path already has in `patch_helper_rules.rego` (`update_value != null`), so all three patch flows (hierarchical Rego, edge Rego, Go) now agree.

Regression coverage added to `TestRelationshipEvaluationScenarios`: the missing-mutator case (fails on master with the null-write action, passes with the guard) and a present-mutator positive control. Full `server/policies` suite passes locally, including the Rego/Go parity tests.

**Signed commits**

- [x] Yes, I signed my commits.
