### PR TITLE
[Server] Resolve mutatorRef orientation in Rego edge relationship rules

### DIFF
--- a/models/meshery-core/0.7.2/v1.0.0/policies/eval_rules.rego
+++ b/models/meshery-core/0.7.2/v1.0.0/policies/eval_rules.rego
@@ -63,7 +63,9 @@ patch_mutators_action(relationship, design_file) := {action |
 	mutator := clauses[orientation.mutator]
 	mutated := clauses[orientation.mutated]
 
-	some i in numbers.range(0, count(mutator.patch.mutatorRef) - 1)
+	# clamp to the shorter of the two ref lists, like the Go engine
+	pair_count := min([count(mutator.patch.mutatorRef), count(mutated.patch.mutatedRef)])
+	some i in numbers.range(0, pair_count - 1)
 
 	mutatorRef := mutator.patch.mutatorRef[i]
 	mutatedRef := mutated.patch.mutatedRef[i]
@@ -182,7 +184,10 @@ matching_mutators(component_from, component_to, from_clause, to_clause, design_f
 	mutated_component := components[orientation.mutated]
 
 	# print("match_strategy",match_strategy_matrix)
-	mutatorCount := count(mutator_clause.patch.mutatorRef)
+	# clamp to the shorter of the two ref lists and require at least one
+	# pair, like the Go engine
+	mutatorCount := min([count(mutator_clause.patch.mutatorRef), count(mutated_clause.patch.mutatedRef)])
+	mutatorCount > 0
 
 	every i in numbers.range(0, mutatorCount - 1) {
 		mutatorPath := mutator_clause.patch.mutatorRef[i]

--- a/models/meshery-core/0.7.2/v1.0.0/policies/eval_rules.rego
+++ b/models/meshery-core/0.7.2/v1.0.0/policies/eval_rules.rego
@@ -40,28 +40,46 @@ cleanup_deleted_relationships_actions(relationships) := delete_actions if {
 	}
 }
 
+# mutatorRef usually lives on the from side of a selector, but many
+# relationship definitions declare it on the to side with mutatedRef on the
+# from side. Resolve which side carries the mutator instead of assuming the
+# from side, like the hierarchical and binding flows
+# (extract_mutator_config_from_patch, extract_mutator_from_match) already do.
+# When both sides declare a mutatorRef, the from side wins.
+mutator_mutated_orientation(from_clause, to_clause) := {"mutator": "from", "mutated": "to"} if {
+	from_clause.patch.mutatorRef
+	to_clause.patch.mutatedRef
+} else := {"mutator": "to", "mutated": "from"} if {
+	to_clause.patch.mutatorRef
+	from_clause.patch.mutatedRef
+}
+
 patch_mutators_action(relationship, design_file) := {action |
 	#      print("patch mutators action", relationship.kind)
 	some selector in relationship.selectors
-	from := selector.allow.from[0]
-	to := selector.allow.to[0]
-	some i in numbers.range(0, count(from.patch.mutatorRef) - 1)
+	clauses := {"from": selector.allow.from[0], "to": selector.allow.to[0]}
 
-	mutatorRef := from.patch.mutatorRef[i]
-	mutatedRef := to.patch.mutatedRef[i]
+	orientation := mutator_mutated_orientation(clauses.from, clauses.to)
+	mutator := clauses[orientation.mutator]
+	mutated := clauses[orientation.mutated]
 
-	from_component := core_utils.component_declaration_by_id(design_file, from.id)
-	to_component := core_utils.component_declaration_by_id(design_file, to.id)
+	some i in numbers.range(0, count(mutator.patch.mutatorRef) - 1)
 
-	mutatorValue := core_utils.configuration_for_component_at_path(mutatorRef, from_component, design_file)
-	old_value := core_utils.configuration_for_component_at_path(mutatedRef, to_component, design_file)
+	mutatorRef := mutator.patch.mutatorRef[i]
+	mutatedRef := mutated.patch.mutatedRef[i]
+
+	mutator_component := core_utils.component_declaration_by_id(design_file, mutator.id)
+	mutated_component := core_utils.component_declaration_by_id(design_file, mutated.id)
+
+	mutatorValue := core_utils.configuration_for_component_at_path(mutatorRef, mutator_component, design_file)
+	old_value := core_utils.configuration_for_component_at_path(mutatedRef, mutated_component, design_file)
 
 	old_value != mutatorValue
 
 	action := {
 		"op": actions.get_component_update_op(mutatedRef),
 		"value": {
-			"id": to.id,
+			"id": mutated.id,
 			"path": mutatedRef,
 			"value": mutatorValue,
 		},
@@ -152,15 +170,26 @@ get_strategy_for_value_at(strategies, index) := strategy if {
 matching_mutators(component_from, component_to, from_clause, to_clause, design_file) := matching_selectors if {
 	match_strategy_matrix := get_match_strategy_for_selector(from_clause)
 
+	# mutatorRef may live on either side of the selector; resolve the
+	# orientation the same way patch_mutators_action does.
+	clauses := {"from": from_clause, "to": to_clause}
+	components := {"from": component_from, "to": component_to}
+
+	orientation := mutator_mutated_orientation(from_clause, to_clause)
+	mutator_clause := clauses[orientation.mutator]
+	mutated_clause := clauses[orientation.mutated]
+	mutator_component := components[orientation.mutator]
+	mutated_component := components[orientation.mutated]
+
 	# print("match_strategy",match_strategy_matrix)
-	mutatorCount := count(from_clause.patch.mutatorRef)
+	mutatorCount := count(mutator_clause.patch.mutatorRef)
 
 	every i in numbers.range(0, mutatorCount - 1) {
-		mutatorPath := from_clause.patch.mutatorRef[i]
-		mutatedPath := to_clause.patch.mutatedRef[i]
+		mutatorPath := mutator_clause.patch.mutatorRef[i]
+		mutatedPath := mutated_clause.patch.mutatedRef[i]
 
-		mutatorValue := core_utils.configuration_for_component_at_path(mutatorPath, component_from, design_file)
-		mutatedValue := core_utils.configuration_for_component_at_path(mutatedPath, component_to, design_file)
+		mutatorValue := core_utils.configuration_for_component_at_path(mutatorPath, mutator_component, design_file)
+		mutatedValue := core_utils.configuration_for_component_at_path(mutatedPath, mutated_component, design_file)
 
 		strategies := get_strategy_for_value_at(match_strategy_matrix, i)
 

--- a/server/policies/rego_test.go
+++ b/server/policies/rego_test.go
@@ -379,6 +379,69 @@ func TestRelationshipEvaluationScenarios(t *testing.T) {
 			},
 		},
 		{
+			// Ragged ref lists: the pair count is clamped to the shorter of
+			// mutatorRef/mutatedRef, like the Go engine, so the extra
+			// mutator entry is ignored rather than dropping the whole
+			// selector.
+			name:  "patch_mutators_clamps_to_shorter_ref_list",
+			query: "data.eval_rules.patch_mutators_action(input.relationship, input.design_file)",
+			input: map[string]interface{}{
+				"relationship": map[string]interface{}{
+					"selectors": []map[string]interface{}{
+						{
+							"allow": map[string]interface{}{
+								"from": []map[string]interface{}{
+									{
+										"id": "route-1",
+										"patch": map[string]interface{}{
+											"mutatorRef": [][]string{
+												{"configuration", "spec", "target"},
+												{"configuration", "spec", "extra"},
+											},
+										},
+									},
+								},
+								"to": []map[string]interface{}{
+									{
+										"id": "integration-1",
+										"patch": map[string]interface{}{
+											"mutatedRef": [][]string{{"configuration", "spec", "integrationID"}},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+				"design_file": map[string]interface{}{
+					"components": []map[string]interface{}{
+						{
+							"id": "route-1",
+							"configuration": map[string]interface{}{
+								"spec": map[string]interface{}{"target": "integrations/abc", "extra": "x"},
+							},
+						},
+						{
+							"id":            "integration-1",
+							"configuration": map[string]interface{}{"spec": map[string]interface{}{}},
+						},
+					},
+				},
+			},
+			expectError: false,
+			designFile:  "inline",
+			expected: []interface{}{
+				map[string]interface{}{
+					"op": "update_component_configuration",
+					"value": map[string]interface{}{
+						"id":    "integration-1",
+						"path":  []interface{}{"configuration", "spec", "integrationID"},
+						"value": "integrations/abc",
+					},
+				},
+			},
+		},
+		{
 			// Positive control for the case above: the common from-side
 			// mutator orientation keeps working unchanged.
 			name:  "patch_mutators_emits_update_for_from_side_mutator",
@@ -526,8 +589,14 @@ func TestRegoSyntax(t *testing.T) {
 // use this orientation, and the Go engine resolves it
 // (resolveMutatorMutatedRefs), so the Rego engine must identify it too.
 func TestParity_RegoAndGoEngineIdentifyToSideMutatorRelationship(t *testing.T) {
-	vpcLinkID, _ := uuid.FromString("00000000-0000-0000-0000-0000000000a1")
-	integrationID, _ := uuid.FromString("00000000-0000-0000-0000-0000000000a2")
+	vpcLinkID, err := uuid.FromString("00000000-0000-0000-0000-0000000000a1")
+	if err != nil {
+		t.Fatalf("parse vpcLink id: %v", err)
+	}
+	integrationID, err := uuid.FromString("00000000-0000-0000-0000-0000000000a2")
+	if err != nil {
+		t.Fatalf("parse integration id: %v", err)
+	}
 
 	vpcLink := &component.ComponentDefinition{
 		Component:      component.Component{Kind: "VPCLink"},
@@ -586,7 +655,10 @@ func TestParity_RegoAndGoEngineIdentifyToSideMutatorRelationship(t *testing.T) {
 		Model:            modelv1beta1.ModelReference{Name: "aws-apigatewayv2-controller"},
 		Selectors:        &selectorSet,
 	}
-	relDef.ID, _ = uuid.FromString("00000000-0000-0000-0000-0000000000b1")
+	relDef.ID, err = uuid.FromString("00000000-0000-0000-0000-0000000000b1")
+	if err != nil {
+		t.Fatalf("parse relationship id: %v", err)
+	}
 
 	goIdentified := (&EdgeNonBindingPolicy{}).IdentifyRelationship(relDef, design)
 	if len(goIdentified) != 1 {

--- a/server/policies/rego_test.go
+++ b/server/policies/rego_test.go
@@ -3,6 +3,7 @@ package policies
 
 import (
 	"context"
+	"encoding/json"
 	"os"
 	"path/filepath"
 	"reflect"
@@ -10,10 +11,15 @@ import (
 	"testing"
 	"time"
 
+	"github.com/gofrs/uuid"
 	"github.com/open-policy-agent/opa/v1/ast"
 	"github.com/open-policy-agent/opa/v1/rego"
 	"github.com/open-policy-agent/opa/v1/tester"
 	"github.com/open-policy-agent/opa/v1/topdown"
+
+	"github.com/meshery/schemas/models/v1beta1/component"
+	modelv1beta1 "github.com/meshery/schemas/models/v1beta1/model"
+	"github.com/meshery/schemas/models/v1beta2/relationship"
 )
 
 // designFileName extracts a human-friendly design file name from a test location.
@@ -309,6 +315,127 @@ func TestRelationshipEvaluationScenarios(t *testing.T) {
 			designFile:  "namespace_parent_inline",
 			expected:    true,
 		},
+		{
+			// Many shipped relationship definitions (AWS/Azure controller
+			// models) declare mutatorRef on the TO side and mutatedRef on
+			// the FROM side. patch_mutators_action must resolve that
+			// orientation instead of assuming from-side mutators, like the
+			// Go engine (resolveMutatorMutatedRefs) and the hierarchical
+			// and binding flows already do. The emitted update targets the
+			// mutated (from) component.
+			name:  "patch_mutators_emits_update_for_to_side_mutator",
+			query: "data.eval_rules.patch_mutators_action(input.relationship, input.design_file)",
+			input: map[string]interface{}{
+				"relationship": map[string]interface{}{
+					"selectors": []map[string]interface{}{
+						{
+							"allow": map[string]interface{}{
+								"from": []map[string]interface{}{
+									{
+										"id": "vpclink-1",
+										"patch": map[string]interface{}{
+											"mutatedRef": [][]string{{"configuration", "status", "vpcLinkID"}},
+										},
+									},
+								},
+								"to": []map[string]interface{}{
+									{
+										"id": "integration-1",
+										"patch": map[string]interface{}{
+											"mutatorRef": [][]string{{"configuration", "spec", "vpcLinkID"}},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+				"design_file": map[string]interface{}{
+					"components": []map[string]interface{}{
+						{
+							"id":            "vpclink-1",
+							"configuration": map[string]interface{}{"status": map[string]interface{}{}},
+						},
+						{
+							"id": "integration-1",
+							"configuration": map[string]interface{}{
+								"spec": map[string]interface{}{"vpcLinkID": "vpcl-abc123"},
+							},
+						},
+					},
+				},
+			},
+			expectError: false,
+			designFile:  "inline",
+			expected: []interface{}{
+				map[string]interface{}{
+					"op": "update_component_configuration",
+					"value": map[string]interface{}{
+						"id":    "vpclink-1",
+						"path":  []interface{}{"configuration", "status", "vpcLinkID"},
+						"value": "vpcl-abc123",
+					},
+				},
+			},
+		},
+		{
+			// Positive control for the case above: the common from-side
+			// mutator orientation keeps working unchanged.
+			name:  "patch_mutators_emits_update_for_from_side_mutator",
+			query: "data.eval_rules.patch_mutators_action(input.relationship, input.design_file)",
+			input: map[string]interface{}{
+				"relationship": map[string]interface{}{
+					"selectors": []map[string]interface{}{
+						{
+							"allow": map[string]interface{}{
+								"from": []map[string]interface{}{
+									{
+										"id": "route-1",
+										"patch": map[string]interface{}{
+											"mutatorRef": [][]string{{"configuration", "spec", "target"}},
+										},
+									},
+								},
+								"to": []map[string]interface{}{
+									{
+										"id": "integration-1",
+										"patch": map[string]interface{}{
+											"mutatedRef": [][]string{{"configuration", "spec", "integrationID"}},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+				"design_file": map[string]interface{}{
+					"components": []map[string]interface{}{
+						{
+							"id": "route-1",
+							"configuration": map[string]interface{}{
+								"spec": map[string]interface{}{"target": "integrations/abc"},
+							},
+						},
+						{
+							"id":            "integration-1",
+							"configuration": map[string]interface{}{"spec": map[string]interface{}{}},
+						},
+					},
+				},
+			},
+			expectError: false,
+			designFile:  "inline",
+			expected: []interface{}{
+				map[string]interface{}{
+					"op": "update_component_configuration",
+					"value": map[string]interface{}{
+						"id":    "integration-1",
+						"path":  []interface{}{"configuration", "spec", "integrationID"},
+						"value": "integrations/abc",
+					},
+				},
+			},
+		},
 	}
 
 	for _, tc := range testCases {
@@ -387,5 +514,141 @@ func TestRegoSyntax(t *testing.T) {
 				t.Errorf("Parse error in %s: %v", filepath.Base(file), err)
 			}
 		})
+	}
+}
+
+// TestParity_RegoAndGoEngineIdentifyToSideMutatorRelationship runs
+// identification for an edge/non-binding relationship whose mutatorRef lives
+// on the TO-side selector (with mutatedRef on the FROM side) through BOTH
+// engines and asserts they agree. Hundreds of shipped relationship
+// definitions (AWS/Azure controller models, e.g.
+// models/aws-apigatewayv2-controller/.../edge-binding-network-udxey.json)
+// use this orientation, and the Go engine resolves it
+// (resolveMutatorMutatedRefs), so the Rego engine must identify it too.
+func TestParity_RegoAndGoEngineIdentifyToSideMutatorRelationship(t *testing.T) {
+	vpcLinkID, _ := uuid.FromString("00000000-0000-0000-0000-0000000000a1")
+	integrationID, _ := uuid.FromString("00000000-0000-0000-0000-0000000000a2")
+
+	vpcLink := &component.ComponentDefinition{
+		Component:      component.Component{Kind: "VPCLink"},
+		ModelReference: modelv1beta1.ModelReference{Name: "aws-apigatewayv2-controller"},
+		Configuration: map[string]interface{}{
+			"status": map[string]interface{}{"vpcLinkID": "vpcl-abc123"},
+		},
+	}
+	vpcLink.ID = vpcLinkID
+
+	integration := &component.ComponentDefinition{
+		Component:      component.Component{Kind: "Integration"},
+		ModelReference: modelv1beta1.ModelReference{Name: "aws-apigatewayv2-controller"},
+		Configuration: map[string]interface{}{
+			"spec": map[string]interface{}{"vpcLinkID": "vpcl-abc123"},
+		},
+	}
+	integration.ID = integrationID
+
+	design := makePatternFile([]*component.ComponentDefinition{vpcLink, integration}, nil)
+
+	// from side carries mutatedRef only, to side carries mutatorRef only —
+	// the shipped orientation under test.
+	mutatedRef := relationship.MutatedRef{[]string{"configuration", "status", "vpcLinkID"}}
+	mutatorRef := relationship.MutatorRef{[]string{"configuration", "spec", "vpcLinkID"}}
+
+	selectorSet := relationship.SelectorSet{
+		relationship.SelectorSetItem{
+			Allow: relationship.Selector{
+				From: []relationship.SelectorItem{
+					{
+						Kind:  strPtr("VPCLink"),
+						Model: &modelv1beta1.ModelReference{Name: "aws-apigatewayv2-controller"},
+						RelationshipDefinitionSelectorsPatch: &relationship.RelationshipDefinitionSelectorsPatch{
+							MutatedRef: &mutatedRef,
+						},
+					},
+				},
+				To: []relationship.SelectorItem{
+					{
+						Kind:  strPtr("Integration"),
+						Model: &modelv1beta1.ModelReference{Name: "aws-apigatewayv2-controller"},
+						RelationshipDefinitionSelectorsPatch: &relationship.RelationshipDefinitionSelectorsPatch{
+							MutatorRef: &mutatorRef,
+						},
+					},
+				},
+			},
+		},
+	}
+
+	relDef := &relationship.RelationshipDefinition{
+		Kind:             relationship.RelationshipDefinitionKind("edge"),
+		RelationshipType: "non-binding",
+		SubType:          "network",
+		Model:            modelv1beta1.ModelReference{Name: "aws-apigatewayv2-controller"},
+		Selectors:        &selectorSet,
+	}
+	relDef.ID, _ = uuid.FromString("00000000-0000-0000-0000-0000000000b1")
+
+	goIdentified := (&EdgeNonBindingPolicy{}).IdentifyRelationship(relDef, design)
+	if len(goIdentified) != 1 {
+		t.Fatalf("Go engine: expected 1 identified relationship, got %d", len(goIdentified))
+	}
+
+	// Feed the byte-identical input to the Rego engine.
+	relJSON, err := json.Marshal(relDef)
+	if err != nil {
+		t.Fatalf("marshal relationship: %v", err)
+	}
+	designJSON, err := json.Marshal(design)
+	if err != nil {
+		t.Fatalf("marshal design: %v", err)
+	}
+	var relMap, designMap map[string]interface{}
+	if err := json.Unmarshal(relJSON, &relMap); err != nil {
+		t.Fatalf("unmarshal relationship: %v", err)
+	}
+	if err := json.Unmarshal(designJSON, &designMap); err != nil {
+		t.Fatalf("unmarshal design: %v", err)
+	}
+
+	policiesDir := "../../models/meshery-core/0.7.2/v1.0.0/policies"
+	policyFiles, err := collectRegoFiles(policiesDir)
+	if err != nil {
+		t.Fatalf("collect rego files: %v", err)
+	}
+	var opts []func(*rego.Rego)
+	for _, file := range policyFiles {
+		if strings.Contains(file, "/tests/") || strings.HasSuffix(file, ".template") {
+			continue
+		}
+		content, readErr := os.ReadFile(file)
+		if readErr != nil {
+			t.Fatalf("read %s: %v", file, readErr)
+		}
+		opts = append(opts, rego.Module(file, string(content)))
+	}
+	opts = append(opts,
+		rego.Query(`data.eval.identify_relationship(input.relationship, input.design_file, "edge-non-binding")`),
+		rego.Input(map[string]interface{}{
+			"relationship": relMap,
+			"design_file":  designMap,
+		}),
+	)
+
+	rs, err := rego.New(opts...).Eval(context.Background())
+	if err != nil {
+		t.Fatalf("rego eval: %v", err)
+	}
+
+	regoCount := 0
+	if len(rs) > 0 && len(rs[0].Expressions) > 0 {
+		identified, ok := rs[0].Expressions[0].Value.([]interface{})
+		if !ok {
+			t.Fatalf("unexpected rego result shape: %#v", rs[0].Expressions[0].Value)
+		}
+		regoCount = len(identified)
+	}
+
+	if regoCount != len(goIdentified) {
+		t.Fatalf("engine divergence: Go identified %d, Rego identified %d", len(goIdentified), regoCount)
 	}
 }


### PR DESCRIPTION
**Notes for Reviewers**

214 shipped edge/non-binding relationship definitions (AWS/Azure controller models, e.g. the VPCLink→Integration edge in `models/aws-apigatewayv2-controller/v1.3.2/v1.0.0/relationships/edge-binding-network-udxey.json`) declare `mutatorRef` on the **to-side** selector and `mutatedRef` on the from side. The Rego engine's `matching_mutators` and `patch_mutators_action` only read the from side, so these relationships are never identified and never patched under the default engine, while the Go engine resolves both orientations (`resolveMutatorMutatedRefs`) — evaluation results differ by engine.

This adds a `mutator_mutated_orientation` helper to eval_rules.rego and uses it in both rules. Resolution order matches the Go engine: the from side wins when both sides declare a `mutatorRef`. The hierarchical and binding flows already resolve either side (`extract_mutator_config_from_patch`, `extract_mutator_from_match`); this brings the edge flow in line with them.

Tests (written first, failing on master):
- `TestParity_RegoAndGoEngineIdentifyToSideMutatorRelationship` — feeds the byte-identical to-side-mutator input to both engines and asserts they agree (master: Go 1, Rego 0).
- Scenario coverage in `TestRelationshipEvaluationScenarios` for the patch flow in both orientations, pinning the exact emitted action (the to-side case targets the from component).

Full `server/policies` suite is green locally. Note: #20556 touches the same rule body (`patch_mutators_action` null guard); whichever lands first, the other rebases trivially — the changes compose.

- This PR fixes #20558

**Signed commits**

- [x] Yes, I signed my commits.
