### PR TITLE
[Server] Fix file descriptor leaks in DownloadMesheryPatternHandler OCI export path

### DIFF
--- a/server/handlers/meshery_pattern_handler.go
+++ b/server/handlers/meshery_pattern_handler.go
@@ -1128,6 +1128,10 @@ func (h *Handler) DownloadMesheryPatternHandler(
 			return
 		}
 
+		if err := file.Close(); err != nil {
+			h.log.Error(err)
+		}
+
 		file, err = os.OpenFile(tmpOCITarFilePath, os.O_RDONLY, 0444)
 		if err != nil {
 			h.log.Error(ErrOpenFile(tmpOCITarFilePath))

--- a/server/handlers/meshery_pattern_handler.go
+++ b/server/handlers/meshery_pattern_handler.go
@@ -1044,7 +1044,9 @@ func (h *Handler) DownloadMesheryPatternHandler(
 			event := eb.WithSeverity(events.Error).WithDescription(fmt.Sprintf("Unable to create artifacthub pkg for the design \"%s\"", pattern.Name)).WithMetadata(map[string]interface{}{"error": err}).Build()
 			_ = provider.PersistEvent(*event, token)
 			go h.config.EventBroadcaster.Publish(userID, event)
+			return
 		}
+		defer artifactHubPkgFile.Close()
 
 		data, err := createArtifactHubPkg(pattern, strings.Trim(fmt.Sprintf("%s %s", user.FirstName, user.LastName), " "))
 		if err != nil {

--- a/server/handlers/meshery_pattern_handler.go
+++ b/server/handlers/meshery_pattern_handler.go
@@ -1046,7 +1046,11 @@ func (h *Handler) DownloadMesheryPatternHandler(
 			go h.config.EventBroadcaster.Publish(userID, event)
 			return
 		}
-		defer artifactHubPkgFile.Close()
+		defer func() {
+			if err := artifactHubPkgFile.Close(); err != nil {
+				h.log.Error(err)
+			}
+		}()
 
 		data, err := createArtifactHubPkg(pattern, strings.Trim(fmt.Sprintf("%s %s", user.FirstName, user.LastName), " "))
 		if err != nil {


### PR DESCRIPTION
## Description

This PR fixes #20540

`DownloadMesheryPatternHandler` in `server/handlers/meshery_pattern_handler.go` had three resource-handling bugs on the OCI export path (the `if ociFormat { ... }` block). This PR fixes all three.

**1. design.yml file descriptor leak (the reported issue #20540)**

The `file` variable is first assigned by `os.Create(tmpDesignFile)` to create `design.yml`, and is written to further down. Later in the same block it is reassigned with `=` by `os.OpenFile(tmpOCITarFilePath, ...)` to read the OCI tar. The deferred `file.Close()` captures the variable *by reference*, so on return it closes the OCI tar handle — the original `design.yml` descriptor is never closed and leaks. Fixed by closing the `design.yml` handle before the variable is reused.

**2. artifactHubPkgFile never closed**

`artifactHubPkgFile`, created by `os.Create(artifactHubPkgFilePath)`, is written to but never closed anywhere in the function — leaking a descriptor on every OCI download. Fixed with a deferred close.

**3. Missing early-return on os.Create failure**

When `os.Create(artifactHubPkgFilePath)` failed, the handler logged the error and an event but continued to `createArtifactHubPkg` and `artifactHubPkgFile.Write(data)` with a nil file handle instead of returning. Fixed by returning after the failure.

Under sustained load these leaks can exhaust the process file descriptor limit (`RLIMIT_NOFILE`), causing subsequent syscalls to fail with `EMFILE` ("too many open files"). All changes are confined to the `if ociFormat { ... }` block; there is no behavioral change on the success path or on non-OCI export paths.

**Notes for Reviewers**

- This PR fixes #20540

**[Signed commits](https://github.com/meshery/meshery/blob/master/CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [x] Yes, I signed my commits.