### PR TITLE
fix: resolve Kubernetes connection delete failures

### DIFF
--- a/server/router/server.go
+++ b/server/router/server.go
@@ -106,7 +106,7 @@ func NewRouter(_ context.Context, h models.HandlerInterface, port int, g http.Ha
 		Methods("GET")
 	gMux.Handle("/api/system/kubernetes/contexts/{id}", h.ProviderMiddleware(h.AuthMiddleware(h.SessionInjectorMiddleware(h.GetContext), models.ProviderAuth))).
 		Methods("GET")
-	gMux.Handle("/api/system/kubernetes/contexts/{id}", h.ProviderMiddleware(h.AuthMiddleware(h.SessionInjectorMiddleware(h.DeleteContext), models.ProviderAuth))).
+	gMux.Handle("/api/system/kubernetes/contexts/{id}", h.ProviderMiddleware(h.AuthMiddleware(h.SessionInjectorMiddleware(h.KubernetesMiddleware(h.DeleteContext)), models.ProviderAuth))).
 		Methods("DELETE")
 
 	gMux.Handle("/api/perf/profile", h.ProviderMiddleware(h.AuthMiddleware(h.SessionInjectorMiddleware(h.LoadTestHandler), models.ProviderAuth))).

--- a/ui/components/connections/ConnectionTable.hooks.ts
+++ b/ui/components/connections/ConnectionTable.hooks.ts
@@ -5,6 +5,7 @@ import {
   useSaveEnvironmentMutation,
 } from '../../rtk-query/environments';
 import { useUpdateConnectionByIdMutation } from '@/rtk-query/connection';
+import { useDeleteKubernetesContextMutation } from '@/rtk-query/system';
 import { useNotification } from '../../utils/hooks/useNotification';
 import { EVENT_TYPES } from '../../lib/event-types';
 import { ACTION_TYPES, getErrorMessage } from './ConnectionTable.constants';
@@ -16,6 +17,7 @@ type UseConnectionActionsArgs = {
 export const useConnectionActions = ({ organizationId }: UseConnectionActionsArgs) => {
   const { notify } = useNotification();
   const [updateConnectionByIdMutator] = useUpdateConnectionByIdMutation();
+  const [deleteKubernetesContextMutator] = useDeleteKubernetesContextMutation();
   const [addConnectionToEnvironmentMutator] = useAddConnectionToEnvironmentMutation();
   const [removeConnectionFromEnvMutator] = useRemoveConnectionFromEnvironmentMutation();
   const [saveEnvironmentMutator] = useSaveEnvironmentMutation();
@@ -118,6 +120,26 @@ export const useConnectionActions = ({ organizationId }: UseConnectionActionsArg
     [notify, updateConnectionByIdMutator],
   );
 
+  const deleteConnection = useCallback(
+    async (connectionId: string) => {
+      try {
+        await deleteKubernetesContextMutator({ connectionId }).unwrap();
+
+        notify({
+          message: `Connection status updated`,
+          event_type: EVENT_TYPES.SUCCESS,
+        });
+      } catch (error) {
+        notify({
+          message: `${ACTION_TYPES.UPDATE_CONNECTION.error_msg}: ${getErrorMessage(error)}`,
+          event_type: EVENT_TYPES.ERROR,
+          details: String(error),
+        });
+      }
+    },
+    [deleteKubernetesContextMutator, notify],
+  );
+
   return {
     notify,
     updateConnectionByIdMutator,
@@ -125,5 +147,6 @@ export const useConnectionActions = ({ organizationId }: UseConnectionActionsArg
     removeConnectionFromEnvironment,
     saveEnvironment,
     updateConnectionStatus,
+    deleteConnection,
   };
 };

--- a/ui/components/connections/ConnectionTable.test.tsx
+++ b/ui/components/connections/ConnectionTable.test.tsx
@@ -10,6 +10,7 @@ const ping = vi.fn();
 const pingGrafana = vi.fn();
 const modalShow = vi.fn();
 const updateConnectionByIdMutator = vi.fn();
+const deleteKubernetesContextMutator = vi.fn();
 const addConnectionToEnvironmentMutator = vi.fn();
 const removeConnectionFromEnvironmentMutator = vi.fn();
 const saveEnvironmentMutator = vi.fn();
@@ -193,6 +194,10 @@ vi.mock('@/rtk-query/connection', () => ({
   useUpdateConnectionByIdMutation: () => [updateConnectionByIdMutator],
 }));
 
+vi.mock('@/rtk-query/system', () => ({
+  useDeleteKubernetesContextMutation: () => [deleteKubernetesContextMutator],
+}));
+
 vi.mock('../../assets/icons/disconnect', () => ({
   default: () => <svg />,
 }));
@@ -254,6 +259,7 @@ describe('ConnectionTable', () => {
     refetchConnections.mockReset();
 
     updateConnectionByIdMutator.mockReset();
+    deleteKubernetesContextMutator.mockReset();
     addConnectionToEnvironmentMutator.mockReset();
     removeConnectionFromEnvironmentMutator.mockReset();
     saveEnvironmentMutator.mockReset();
@@ -275,6 +281,9 @@ describe('ConnectionTable', () => {
 
     updateConnectionByIdMutator.mockImplementation(({ connectionId, body }) => ({
       unwrap: () => Promise.resolve({ connectionId, body }),
+    }));
+    deleteKubernetesContextMutator.mockImplementation(({ connectionId }) => ({
+      unwrap: () => Promise.resolve({ connectionId }),
     }));
     addConnectionToEnvironmentMutator.mockImplementation(() => ({
       unwrap: () => Promise.resolve({}),
@@ -378,16 +387,14 @@ describe('ConnectionTable', () => {
 
     await waitFor(() => {
       expect(modalShow).toHaveBeenCalled();
-      expect(updateConnectionByIdMutator).toHaveBeenCalledTimes(2);
+      expect(deleteKubernetesContextMutator).toHaveBeenCalledTimes(2);
     });
 
-    expect(updateConnectionByIdMutator).toHaveBeenNthCalledWith(1, {
+    expect(deleteKubernetesContextMutator).toHaveBeenNthCalledWith(1, {
       connectionId: 'connection-1',
-      body: { status: 'deleted' },
     });
-    expect(updateConnectionByIdMutator).toHaveBeenNthCalledWith(2, {
+    expect(deleteKubernetesContextMutator).toHaveBeenNthCalledWith(2, {
       connectionId: 'connection-2',
-      body: { status: 'deleted' },
     });
   });
 

--- a/ui/components/connections/ConnectionTable.tsx
+++ b/ui/components/connections/ConnectionTable.tsx
@@ -5,7 +5,7 @@ import { EVENT_TYPES } from '../../lib/event-types';
 import _PromptComponent from '../PromptComponent';
 import resetDatabase from '@/graphql/queries/ResetDatabaseQuery';
 
-import { CONNECTION_KINDS, CONNECTION_STATES } from '../../utils/Enum';
+import { CONNECTION_KINDS } from '../../utils/Enum';
 import useKubernetesHook from '@/utils/hooks/useKubernetesHook';
 import useGrafanaPingHook from '@/utils/hooks/useGrafanaPingHook';
 import { getResponsiveColumnVisibility } from '../../utils/responsive-column';
@@ -132,6 +132,7 @@ const ConnectionTable = ({
     removeConnectionFromEnvironment,
     saveEnvironment,
     updateConnectionStatus,
+    deleteConnection,
   } = useConnectionActions({ organizationId: organization?.id });
   const [anchorEl, setAnchorEl] = useState<HTMLElement | null>(null);
   const [deploymentModeAnchorEl, setDeploymentModeAnchorEl] = useState<HTMLElement | null>(null);
@@ -326,10 +327,10 @@ const ConnectionTable = ({
       });
 
       if (response === 'DELETE') {
-        await updateConnectionStatus(connectionId, CONNECTION_STATES.DELETED);
+        await deleteConnection(connectionId);
       }
     },
-    [updateConnectionStatus],
+    [deleteConnection],
   );
 
   const handleDeleteConnections = useCallback(
@@ -360,14 +361,10 @@ const ConnectionTable = ({
       });
 
       if (response === 'DELETE') {
-        await Promise.all(
-          ids.map((connectionId) =>
-            updateConnectionStatus(connectionId, CONNECTION_STATES.DELETED),
-          ),
-        );
+        await Promise.all(ids.map((connectionId) => deleteConnection(connectionId)));
       }
     },
-    [filteredConnections, updateConnectionStatus],
+    [deleteConnection, filteredConnections],
   );
 
   const handleError = useCallback(

--- a/ui/components/layout/Header/Header.test.tsx
+++ b/ui/components/layout/Header/Header.test.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { fireEvent, render, screen } from '@testing-library/react';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 const pingKubernetes = vi.fn();
@@ -7,7 +7,8 @@ const getControllerStatesByConnectionID = vi.fn();
 const dispatchMock = vi.fn();
 const notifyMock = vi.fn();
 const fetchSystemSyncMock = vi.fn(() => ({ unwrap: () => Promise.resolve({ k8sConfig: [] }) }));
-const updateConnectionStatusMock = vi.fn(() => ({ unwrap: () => Promise.resolve({}) }));
+const deleteKubernetesContextMock = vi.fn(() => ({ unwrap: () => Promise.resolve({}) }));
+const promptShowMock = vi.fn(() => Promise.resolve('CANCEL'));
 const useGetConnectionsQueryMock = vi.fn(() => ({ data: { connections: [] } }));
 const useGetProviderCapabilitiesQueryMock = vi.fn(() => ({
   data: { providerUrl: 'https://x', extensions: {} },
@@ -37,7 +38,12 @@ vi.mock('../../User', () => ({
 }));
 
 vi.mock('../../../utils/helpers/common', () => ({
-  successHandlerGenerator: () => () => {},
+  successHandlerGenerator:
+    (_notify: any, _message: string, callback?: () => Promise<void>) => async () => {
+      if (callback) {
+        await callback();
+      }
+    },
   errorHandlerGenerator: () => () => {},
 }));
 
@@ -58,15 +64,10 @@ vi.mock('../../connections/ConnectionChip', () => ({
 
 vi.mock('../../../rtk-query/system', () => ({
   useLazyGetSystemSyncQuery: () => [fetchSystemSyncMock],
-}));
-
-vi.mock('../../../rtk-query/connection', () => ({
-  useUpdateConnectionStatusMutation: () => [updateConnectionStatusMock],
-  useGetConnectionsQuery: () => useGetConnectionsQueryMock(),
+  useDeleteKubernetesContextMutation: () => [deleteKubernetesContextMock],
 }));
 
 vi.mock('@/rtk-query/connection', () => ({
-  useUpdateConnectionStatusMutation: () => [updateConnectionStatusMock],
   useGetConnectionsQuery: () => useGetConnectionsQueryMock(),
 }));
 
@@ -78,7 +79,7 @@ vi.mock('../../../utils/Enum', () => ({
 vi.mock('../../PromptComponent', () => ({
   default: React.forwardRef((_props: any, ref: any) => {
     if (ref) {
-      ref.current = { show: vi.fn(() => Promise.resolve('CANCEL')) };
+      ref.current = { show: promptShowMock };
     }
     return <div data-testid="prompt-component" />;
   }),
@@ -407,5 +408,33 @@ describe('Header (default export)', () => {
       />,
     );
     expect(screen.getByTestId('cbadge')).toHaveTextContent('3');
+  });
+
+  it('refreshes the header contexts after deleting a kubernetes connection', async () => {
+    promptShowMock.mockResolvedValueOnce('CONFIRM');
+    const searchContextsMock = vi.fn(() => Promise.resolve());
+
+    render(
+      <Header
+        onDrawerToggle={vi.fn()}
+        contexts={{
+          totalCount: 1,
+          contexts: [
+            { id: 'ctx-1', name: 'cluster-a', server: 'https://a', connectionId: 'conn-1' },
+          ],
+        }}
+        activeContexts={[]}
+        setActiveContexts={vi.fn()}
+        searchContexts={searchContextsMock}
+      />,
+    );
+
+    fireEvent.click(screen.getByTestId('chip-delete'));
+
+    await waitFor(() => {
+      expect(deleteKubernetesContextMock).toHaveBeenCalledWith({ connectionId: 'conn-1' });
+      expect(fetchSystemSyncMock).toHaveBeenCalled();
+      expect(searchContextsMock).toHaveBeenCalledWith('');
+    });
   });
 });

--- a/ui/components/layout/Header/Header.tsx
+++ b/ui/components/layout/Header/Header.tsx
@@ -6,8 +6,7 @@ import { successHandlerGenerator, errorHandlerGenerator } from '../../../utils/h
 import { ConnectionChip } from '../../connections/ConnectionChip';
 import { normalizeStaticImagePath } from '../../../utils/fallback';
 import { useLazyGetSystemSyncQuery } from '../../../rtk-query/system';
-import { useUpdateConnectionStatusMutation } from '../../../rtk-query/connection';
-import { CONNECTION_KINDS, CONNECTION_STATES } from '../../../utils/Enum';
+import { CONNECTION_KINDS } from '../../../utils/Enum';
 import _PromptComponent from '../../PromptComponent';
 import { iconMedium, iconSmall } from '../../../css/icons.styles';
 import { createPathForRemoteComponent } from '../../ExtensionSandbox';
@@ -62,6 +61,7 @@ import {
   useGetProviderCapabilitiesQuery,
 } from '@/rtk-query/user';
 import { useGetConnectionsQuery } from '@/rtk-query/connection';
+import { useDeleteKubernetesContextMutation } from '@/rtk-query/system';
 import { EVENT_TYPES } from 'lib/event-types';
 import { useDispatch, useSelector } from 'react-redux';
 import { updateK8SConfig } from '@/store/slices/mesheryUi';
@@ -151,7 +151,7 @@ function K8sContextMenu({
   const deleteCtxtRef = React.createRef();
   const { notify } = useNotification();
   const [fetchSystemSync] = useLazyGetSystemSyncQuery();
-  const [updateConnectionStatus] = useUpdateConnectionStatusMutation();
+  const [deleteKubernetesContext] = useDeleteKubernetesContextMutation();
   const { controllerState: meshsyncControllerState, connectionMetadataState } = useSelector(
     (state) => state.ui,
   );
@@ -227,15 +227,13 @@ function K8sContextMenu({
           if (Array.isArray(res?.k8sConfig)) {
             dispatch(updateK8SConfig({ k8sConfig: res.k8sConfig }));
           }
+          await searchContexts('');
         } catch (e) {
           console.error('An error occurred while loading k8sconfig', e);
         }
       };
       try {
-        await updateConnectionStatus({
-          kind: CONNECTION_KINDS.KUBERNETES,
-          body: { [connectionID]: CONNECTION_STATES.DELETED },
-        }).unwrap();
+        await deleteKubernetesContext({ connectionId: connectionID }).unwrap();
         successHandlerGenerator(
           notify,
           `Kubernetes connection "${name}" removed`,

--- a/ui/rtk-query/__tests__/system.test.ts
+++ b/ui/rtk-query/__tests__/system.test.ts
@@ -52,6 +52,7 @@ describe('system endpoints', () => {
     expect(mod.useLazyGetSystemSyncQuery).toBeTypeOf('function');
     expect(mod.useGetKubernetesContextsQuery).toBeTypeOf('function');
     expect(mod.useLazyGetKubernetesContextsQuery).toBeTypeOf('function');
+    expect(mod.useDeleteKubernetesContextMutation).toBeTypeOf('function');
     expect(mod.useAdapterOperationMutation).toBeTypeOf('function');
     expect(mod.useLazyGetSmiResultsQuery).toBeTypeOf('function');
   });
@@ -156,6 +157,17 @@ describe('system endpoints', () => {
     expect(req.url).toContain('pagesize=10');
     // Empty search string should still be encoded in the params
     expect(req.url).toMatch(/search=&?/);
+  });
+
+  it('deleteKubernetesContext issues DELETE on /api/system/kubernetes/contexts/{id}', async () => {
+    const { api, store } = await setupStore();
+    await store.dispatch(
+      api.endpoints.deleteKubernetesContext.initiate({ connectionId: 'conn-1' }),
+    );
+    const req = fetchMock.mock.calls[0][0] as Request;
+    expect(req.method).toBe('DELETE');
+    expect(req.url).toContain('/api/system/kubernetes/contexts/conn-1');
+    expect(req.credentials).toBe('include');
   });
 
   it('adapterOperation issues POST with form-encoded body and custom url override', async () => {

--- a/ui/rtk-query/system.ts
+++ b/ui/rtk-query/system.ts
@@ -5,6 +5,7 @@ const TAGS = {
   SYSTEM: 'system',
   ADAPTERS: 'adapters',
   SYNC: 'sync',
+  CONNECTIONS: 'Connection_API_Connections',
 };
 
 const systemApi = api.injectEndpoints({
@@ -70,6 +71,15 @@ const systemApi = api.injectEndpoints({
       providesTags: [TAGS.SYSTEM],
     }),
 
+    deleteKubernetesContext: builder.mutation({
+      query: (queryArg) => ({
+        url: mesheryApiPath(`system/kubernetes/contexts/${queryArg.connectionId}`),
+        method: 'DELETE',
+        credentials: 'include',
+      }),
+      invalidatesTags: [TAGS.CONNECTIONS],
+    }),
+
     adapterOperation: builder.mutation({
       query: (queryArg) => ({
         url: mesheryApiPath(queryArg.url || 'system/adapter/operation'),
@@ -128,6 +138,7 @@ export const {
   useLazyGetSystemSyncQuery,
   useGetKubernetesContextsQuery,
   useLazyGetKubernetesContextsQuery,
+  useDeleteKubernetesContextMutation,
   useAdapterOperationMutation,
   useLazyGetSmiResultsQuery,
 } = systemApi;


### PR DESCRIPTION
## Summary

This PR fixes a 500 Internal Server Error that occurs when deleting a Kubernetes connection. It continues the effort started in #20186, addressing the root cause identified by @chaitanyamedidar during review of that PR.


## After

https://github.com/user-attachments/assets/64ad1643-d5be-41b8-971b-99972d50fc3d

## Changes

- **Switch connection delete flow from partial PUT to dedicated DELETE endpoint**: The delete/disconnect flow was calling `updateConnectionById` (PUT) with partial data (`{id, status, metadata}`), which overwrote `Name`, `Kind`, `Type`, and `SubType` fields via GORM's `.Save()` method. Switched to the dedicated `DELETE /api/system/kubernetes/contexts/{id}` endpoint instead.

- **Add missing `KubernetesMiddleware` to the DELETE route**: The DELETE route wasn't wrapped in `KubernetesMiddleware`, so the request-scoped `AllKubeClusterKey` was never populated in the request context. This caused the MeshSync flush step to fail with "No Kubernetes context specified, please choose a context from context switcher." Added the middleware, following the same pattern already used by `/api/system/sync`.

- **Refresh header's Kubernetes context list after delete**: The header's cluster dropdown wasn't updating after a successful delete without a full page reload — it reads from a separate `contexts` state in `_app.tsx`, not the connections cache. Added a `searchContexts('')` call after successful delete so the dropdown updates immediately.

Continues work from [#20186](https://github.com/meshery/meshery/pull/20186) ([UI] Remove K8s context chip on connection delete, #5078), per discussion with [@chaitanyamedidar](https://github.com/chaitanyamedidar). Credit to [@udita-0707](https://github.com/udita-0707) for identifying the original issue and starting the fix.

## Notes for Reviewers

- All backend tests pass (`go test ./...`).
- Frontend changes are covered by the existing RTK Query and component test suites (`ConnectionTable.test.tsx`, `Header.test.tsx`, `system.test.ts`).
- Per discussion with @chaitanyamedidar , the Context Switcher dropdown (top right) still shows deleted connections — this is a known, separate concern that needs UX discussion before addressing, and is intentionally out of scope for this PR.

This PR fixes #5078