### PR TITLE
[Server] Resolve dependsOn display names to component IDs in the provision planner

### DIFF
--- a/server/models/pattern/planner/graph.go
+++ b/server/models/pattern/planner/graph.go
@@ -137,7 +137,12 @@ func (g *Graph) Order() int {
 func (g *Graph) Visit(fn VisitFn) {
 	for node := range g.Nodes {
 		for _, edgeNode := range g.Edges[node] {
-			fn(edgeNode, g.Nodes[edgeNode].Data)
+			n, ok := g.Nodes[edgeNode]
+			if !ok {
+				continue
+			}
+
+			fn(edgeNode, n.Data)
 		}
 	}
 }

--- a/server/models/pattern/planner/graph.go
+++ b/server/models/pattern/planner/graph.go
@@ -138,7 +138,7 @@ func (g *Graph) Visit(fn VisitFn) {
 	for node := range g.Nodes {
 		for _, edgeNode := range g.Edges[node] {
 			n, ok := g.Nodes[edgeNode]
-			if !ok {
+			if !ok || n == nil {
 				continue
 			}
 

--- a/server/models/pattern/planner/parallel_process.go
+++ b/server/models/pattern/planner/parallel_process.go
@@ -47,11 +47,21 @@ func NewParallelProcessGraph(g *Graph) *ParallelProcessGraph {
 		}
 	}
 
-	// Copy the edges data
+	// Copy the edges data, skipping endpoints that do not map to a known
+	// node: an unknown destination would nil-panic the DepCount bookkeeping
+	// and an unknown source would leave its dependents waiting on a signal
+	// that never arrives.
 	for node, adjacentNodes := range g.Edges {
-		pg.Edges[node] = adjacentNodes
+		if _, ok := pg.ParallelProcessGraphNodeMap[node]; !ok {
+			continue
+		}
 
 		for _, aNode := range adjacentNodes {
+			if _, ok := pg.ParallelProcessGraphNodeMap[aNode]; !ok {
+				continue
+			}
+
+			pg.Edges[node] = append(pg.Edges[node], aNode)
 			pg.ParallelProcessGraphNodeMap[aNode].DepCount++
 		}
 	}

--- a/server/models/pattern/planner/planner.go
+++ b/server/models/pattern/planner/planner.go
@@ -35,6 +35,16 @@ func CreatePlan(pattern pattern.PatternFile, invert bool) (*Plan, error) {
 		g.AddNode(component.ID.String(), *component)
 	}
 
+	// "dependsOn" entries reference sibling components by display name while
+	// graph nodes are keyed by component ID; resolve the names so that edges
+	// land on real nodes.
+	idByDisplayName := make(map[string]string, len(pattern.Components))
+	for _, component := range pattern.Components {
+		if _, ok := idByDisplayName[string(component.DisplayName)]; !ok {
+			idByDisplayName[string(component.DisplayName)] = component.ID.String()
+		}
+	}
+
 	for _, component := range pattern.Components {
 		_dependsOn, ok := component.Metadata.AdditionalProperties["dependsOn"]
 		if !ok {
@@ -47,12 +57,21 @@ func CreatePlan(pattern pattern.PatternFile, invert bool) (*Plan, error) {
 			return nil, err
 		}
 		for _, dep := range dependsOn {
-			from := dep
-			to := component.DisplayName
+			depID, ok := idByDisplayName[dep]
+			if !ok {
+				if _, isID := g.Nodes[dep]; isID {
+					// The entry already carries a component ID.
+					depID = dep
+				} else {
+					return nil, errors.Errorf("component %s dependsOn %q, which does not match any component in the design", component.DisplayName, dep)
+				}
+			}
+
+			from := depID
+			to := component.ID.String()
 
 			if invert {
-				from = component.DisplayName
-				to = dep
+				from, to = to, from
 			}
 
 			g.AddEdge(from, to)

--- a/server/models/pattern/planner/planner.go
+++ b/server/models/pattern/planner/planner.go
@@ -38,11 +38,10 @@ func CreatePlan(pattern pattern.PatternFile, invert bool) (*Plan, error) {
 	// "dependsOn" entries reference sibling components by display name while
 	// graph nodes are keyed by component ID; resolve the names so that edges
 	// land on real nodes.
-	idByDisplayName := make(map[string]string, len(pattern.Components))
+	idsByDisplayName := make(map[string][]string, len(pattern.Components))
 	for _, component := range pattern.Components {
-		if _, ok := idByDisplayName[string(component.DisplayName)]; !ok {
-			idByDisplayName[string(component.DisplayName)] = component.ID.String()
-		}
+		name := string(component.DisplayName)
+		idsByDisplayName[name] = append(idsByDisplayName[name], component.ID.String())
 	}
 
 	for _, component := range pattern.Components {
@@ -57,14 +56,18 @@ func CreatePlan(pattern pattern.PatternFile, invert bool) (*Plan, error) {
 			return nil, err
 		}
 		for _, dep := range dependsOn {
-			depID, ok := idByDisplayName[dep]
-			if !ok {
-				if _, isID := g.Nodes[dep]; isID {
-					// The entry already carries a component ID.
-					depID = dep
-				} else {
+			var depID string
+			switch ids := idsByDisplayName[dep]; len(ids) {
+			case 1:
+				depID = ids[0]
+			case 0:
+				if _, isID := g.Nodes[dep]; !isID {
 					return nil, errors.Errorf("component %s dependsOn %q, which does not match any component in the design", component.DisplayName, dep)
 				}
+				// The entry already carries a component ID.
+				depID = dep
+			default:
+				return nil, errors.Errorf("component %s dependsOn %q, which matches %d components in the design; give them distinct display names or reference the component ID", component.DisplayName, dep, len(ids))
 			}
 
 			from := depID

--- a/server/models/pattern/planner/planner_test.go
+++ b/server/models/pattern/planner/planner_test.go
@@ -1,0 +1,150 @@
+package planner
+
+import (
+	"sync"
+	"testing"
+
+	"github.com/gofrs/uuid"
+	"github.com/meshery/meshkit/logger"
+	"github.com/meshery/schemas/models/v1beta2/component"
+	pattern "github.com/meshery/schemas/models/v1beta3/design"
+)
+
+func testComponent(t *testing.T, displayName string, dependsOn ...string) *component.ComponentDefinition {
+	t.Helper()
+
+	id, err := uuid.NewV4()
+	if err != nil {
+		t.Fatalf("failed to generate component id: %v", err)
+	}
+
+	comp := &component.ComponentDefinition{
+		ID:          id,
+		DisplayName: displayName,
+	}
+	if len(dependsOn) > 0 {
+		comp.Metadata.AdditionalProperties = map[string]interface{}{
+			"dependsOn": dependsOn,
+		}
+	}
+
+	return comp
+}
+
+func testLogger(t *testing.T) logger.Handler {
+	t.Helper()
+
+	log, err := logger.New("planner-test", logger.Options{
+		Format: logger.SyslogLogFormat,
+	})
+	if err != nil {
+		t.Fatalf("failed to initialize logger: %v", err)
+	}
+
+	return log
+}
+
+// executionOrder runs the plan and returns component display names in the
+// order the visit callback was invoked.
+func executionOrder(t *testing.T, plan *Plan) []string {
+	t.Helper()
+
+	var mu sync.Mutex
+	order := []string{}
+
+	err := plan.Execute(func(_ string, comp component.ComponentDefinition) bool {
+		mu.Lock()
+		defer mu.Unlock()
+		order = append(order, string(comp.DisplayName))
+		return true
+	}, testLogger(t))
+	if err != nil {
+		t.Fatalf("plan execution failed: %v", err)
+	}
+
+	return order
+}
+
+func indexOf(items []string, target string) int {
+	for i, item := range items {
+		if item == target {
+			return i
+		}
+	}
+	return -1
+}
+
+func TestCreatePlanDependsOnByDisplayName(t *testing.T) {
+	db := testComponent(t, "db")
+	app := testComponent(t, "app", "db")
+
+	plan, err := CreatePlan(pattern.PatternFile{Components: []*component.ComponentDefinition{app, db}}, false)
+	if err != nil {
+		t.Fatalf("CreatePlan returned an error: %v", err)
+	}
+
+	if !plan.IsFeasible() {
+		t.Fatal("expected an acyclic plan to be feasible")
+	}
+
+	order := executionOrder(t, plan)
+	if len(order) != 2 {
+		t.Fatalf("expected 2 components to be visited, got %d: %v", len(order), order)
+	}
+	if indexOf(order, "db") > indexOf(order, "app") {
+		t.Fatalf("expected db to be provisioned before its dependent app, got order %v", order)
+	}
+}
+
+func TestCreatePlanInvertReversesOrder(t *testing.T) {
+	db := testComponent(t, "db")
+	app := testComponent(t, "app", "db")
+
+	plan, err := CreatePlan(pattern.PatternFile{Components: []*component.ComponentDefinition{app, db}}, true)
+	if err != nil {
+		t.Fatalf("CreatePlan returned an error: %v", err)
+	}
+
+	order := executionOrder(t, plan)
+	if indexOf(order, "app") > indexOf(order, "db") {
+		t.Fatalf("expected app to be removed before its dependency db on inverted plan, got order %v", order)
+	}
+}
+
+func TestCreatePlanDetectsDisplayNameCycle(t *testing.T) {
+	a := testComponent(t, "a", "b")
+	b := testComponent(t, "b", "a")
+
+	plan, err := CreatePlan(pattern.PatternFile{Components: []*component.ComponentDefinition{a, b}}, false)
+	if err != nil {
+		t.Fatalf("CreatePlan returned an error: %v", err)
+	}
+
+	if plan.IsFeasible() {
+		t.Fatal("expected a cyclic dependsOn chain to be reported as infeasible")
+	}
+}
+
+func TestCreatePlanDependsOnByComponentID(t *testing.T) {
+	db := testComponent(t, "db")
+	app := testComponent(t, "app", db.ID.String())
+
+	plan, err := CreatePlan(pattern.PatternFile{Components: []*component.ComponentDefinition{app, db}}, false)
+	if err != nil {
+		t.Fatalf("CreatePlan returned an error: %v", err)
+	}
+
+	order := executionOrder(t, plan)
+	if indexOf(order, "db") > indexOf(order, "app") {
+		t.Fatalf("expected db to be provisioned before its dependent app, got order %v", order)
+	}
+}
+
+func TestCreatePlanUnknownDependencyErrors(t *testing.T) {
+	app := testComponent(t, "app", "ghost")
+
+	_, err := CreatePlan(pattern.PatternFile{Components: []*component.ComponentDefinition{app}}, false)
+	if err == nil {
+		t.Fatal("expected an error for a dependsOn entry that matches no component")
+	}
+}

--- a/server/models/pattern/planner/planner_test.go
+++ b/server/models/pattern/planner/planner_test.go
@@ -140,6 +140,17 @@ func TestCreatePlanDependsOnByComponentID(t *testing.T) {
 	}
 }
 
+func TestCreatePlanAmbiguousDependencyErrors(t *testing.T) {
+	db1 := testComponent(t, "db")
+	db2 := testComponent(t, "db")
+	app := testComponent(t, "app", "db")
+
+	_, err := CreatePlan(pattern.PatternFile{Components: []*component.ComponentDefinition{app, db1, db2}}, false)
+	if err == nil {
+		t.Fatal("expected an error when a dependsOn entry matches multiple components")
+	}
+}
+
 func TestCreatePlanUnknownDependencyErrors(t *testing.T) {
 	app := testComponent(t, "app", "ghost")
 


### PR DESCRIPTION
**Notes for Reviewers**

- This PR fixes #20572

The provision planner keyed its graph nodes by component ID but built edges out of `dependsOn` display names, so the two never met: cycle detection silently skipped every edge, and `NewParallelProcessGraph` nil-panicked on the first `dependsOn`-bearing design it saw (a 500 on the deploy request).

What changed:

- `CreatePlan` now resolves each `dependsOn` entry to the matching component's ID before adding the edge (entries that already carry a component ID pass through). An entry that matches nothing in the design returns a descriptive error instead of panicking later.
- `NewParallelProcessGraph` and `Graph.Visit` skip edge endpoints that don't map to a known node, so no graph shape can panic the handler again. Skipping unknown sources also matters: a dependent counted against a source that has no process goroutine would wait forever on a signal that never comes.
- Regression tests: `dependsOn` by display name executes dependency-first (panicked before this change), inverted plans reverse the order, a display-name cycle is now reported as infeasible (`IsFeasible` returned true before), `dependsOn` by ID still works, and an unknown dependency errors cleanly.

One behavior note: if two components share a display name, the first one wins the resolution. Happy to error on ambiguity instead if you'd rather have that.

Terminal output:

```
$ go test ./server/models/pattern/... -count=1
ok      github.com/meshery/meshery/server/models/pattern/planner   4.797s
ok      github.com/meshery/meshery/server/models/pattern/stages    7.754s
ok      github.com/meshery/meshery/server/models/pattern/utils     6.332s
```

**[Signed commits](https://github.com/meshery/meshery/blob/master/CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [x] Yes, I signed my commits.
