### PR TITLE
[UI] Point Notification Center connection links at the search param the table actually reads

### DIFF
--- a/ui/components/layout/NotificationCenter/formatters/meshsync_events.test.tsx
+++ b/ui/components/layout/NotificationCenter/formatters/meshsync_events.test.tsx
@@ -58,7 +58,7 @@ describe('ConnectionFieldFormatter', () => {
     expect(chip).toHaveTextContent('my-conn id');
     expect(chip).toHaveAttribute(
       'href',
-      `/management/connections?tab=connections&searchText=${encodeURIComponent('my-conn id')}`,
+      `/management/connections?tab=connections&con_q=${encodeURIComponent('my-conn id')}`,
     );
     expect(chip).toHaveAttribute('data-clickable', 'true');
     expect(chip).toHaveAttribute('data-component', 'a');

--- a/ui/components/layout/NotificationCenter/formatters/meshsync_events.tsx
+++ b/ui/components/layout/NotificationCenter/formatters/meshsync_events.tsx
@@ -37,7 +37,7 @@ export const ConnectionFieldFormatter = ({ value, fieldName }) => {
           label={value}
           clickable
           component="a"
-          href={`/management/connections?tab=connections&searchText=${encodeURIComponent(value)}`}
+          href={`/management/connections?tab=connections&con_q=${encodeURIComponent(value)}`}
           target="_self"
           style={{
             marginBlock: '0.25rem',

--- a/ui/components/layout/NotificationCenter/metadata.test.tsx
+++ b/ui/components/layout/NotificationCenter/metadata.test.tsx
@@ -161,7 +161,7 @@ describe('PropertyFormatters', () => {
     const chip = screen.getByTestId('chip-wrapper');
     expect(chip).toHaveAttribute(
       'href',
-      `/management/connections?tab=connections&searchText=${encodeURIComponent('my-conn name')}`,
+      `/management/connections?tab=connections&con_q=${encodeURIComponent('my-conn name')}`,
     );
     expect(chip).toHaveTextContent('my-conn name');
   });

--- a/ui/components/layout/NotificationCenter/metadata.tsx
+++ b/ui/components/layout/NotificationCenter/metadata.tsx
@@ -54,7 +54,7 @@ export const PropertyFormatters = {
         label={value}
         clickable
         component="a"
-        href={`/management/connections?tab=connections&searchText=${encodeURIComponent(value)}`}
+        href={`/management/connections?tab=connections&con_q=${encodeURIComponent(value)}`}
         target="_self"
       />
     );


### PR DESCRIPTION
**Notes for Reviewers**

- This PR fixes #20574

The connections table hydrates its search box from `con_q` (via `useTableUrlState({ tableKey: 'con' })`), but the Notification Center's connection chips still emit `searchText`, which nothing reads anymore. Clicking a connection name in a notification landed on the unfiltered table.

Two formatters updated to emit `con_q` instead (`metadata.tsx` `connectionName` chip and `formatters/meshsync_events.tsx`), and their paired unit tests updated to lock the new param. The Registry deeplink in `model_registration.tsx` is intentionally untouched since the Registry page still reads `searchText`.

**[Signed commits](https://github.com/meshery/meshery/blob/master/CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [x] Yes, I signed my commits.
