### PR TITLE
[Server] Ignore stale publishes from abandoned evaluations in the eval tracker

### DIFF
--- a/server/handlers/evaluation_tracker.go
+++ b/server/handlers/evaluation_tracker.go
@@ -15,41 +15,58 @@ type evalResult struct {
 // the first caller runs the evaluation, the rest wait for its result.
 type evaluationTracker struct {
 	mu       sync.Mutex
-	inFlight map[string][]chan evalResult
+	lastGen  uint64
+	inFlight map[string]*evalSlot
+}
+
+// evalSlot tracks one in-flight evaluation. The generation ties publishes to
+// the acquire that started them: an evaluation abandoned on timeout/cancel
+// can complete late, and without the generation check its publish would
+// deliver a stale result to the waiters of a newer evaluation of the same
+// design and drop that evaluation's real result.
+type evalSlot struct {
+	gen     uint64
+	waiters []chan evalResult
 }
 
 func newEvaluationTracker() *evaluationTracker {
 	return &evaluationTracker{
-		inFlight: make(map[string][]chan evalResult),
+		inFlight: make(map[string]*evalSlot),
 	}
 }
 
-// acquire returns (leader=true, nil) for the first caller per designID;
-// subsequent callers get (false, waitCh) and must read one value from waitCh.
-func (t *evaluationTracker) acquire(designID string) (leader bool, wait <-chan evalResult) {
+// acquire returns (leader=true, gen, nil) for the first caller per designID;
+// subsequent callers get (false, gen, waitCh) and must read one value from
+// waitCh. The leader must pass gen back to publish.
+func (t *evaluationTracker) acquire(designID string) (leader bool, gen uint64, wait <-chan evalResult) {
 	t.mu.Lock()
 	defer t.mu.Unlock()
 
-	if _, exists := t.inFlight[designID]; exists {
+	if slot, exists := t.inFlight[designID]; exists {
 		ch := make(chan evalResult, 1)
-		t.inFlight[designID] = append(t.inFlight[designID], ch)
-		return false, ch
+		slot.waiters = append(slot.waiters, ch)
+		return false, slot.gen, ch
 	}
-	t.inFlight[designID] = nil
-	return true, nil
+
+	t.lastGen++
+	t.inFlight[designID] = &evalSlot{gen: t.lastGen}
+	return true, t.lastGen, nil
 }
 
-// publish broadcasts the result to all waiters. Idempotent: subsequent
-// calls for the same designID after the entry is cleared are no-ops.
-func (t *evaluationTracker) publish(designID string, result evalResult) {
+// publish broadcasts the result to the waiters of the evaluation started by
+// the acquire that returned gen. Publishes for a cleared or superseded
+// generation are no-ops.
+func (t *evaluationTracker) publish(designID string, gen uint64, result evalResult) {
 	t.mu.Lock()
-	waiters, ok := t.inFlight[designID]
-	if ok {
-		delete(t.inFlight, designID)
+	slot, ok := t.inFlight[designID]
+	if !ok || slot.gen != gen {
+		t.mu.Unlock()
+		return
 	}
+	delete(t.inFlight, designID)
 	t.mu.Unlock()
 
-	for _, ch := range waiters {
+	for _, ch := range slot.waiters {
 		ch <- result
 	}
 }

--- a/server/handlers/evaluation_tracker_test.go
+++ b/server/handlers/evaluation_tracker_test.go
@@ -11,7 +11,7 @@ import (
 func TestEvaluationTracker_SingleLeader(t *testing.T) {
 	tr := newEvaluationTracker()
 
-	leader, wait := tr.acquire("d1")
+	leader, gen, wait := tr.acquire("d1")
 	if !leader {
 		t.Fatal("first caller should be the leader")
 	}
@@ -20,10 +20,10 @@ func TestEvaluationTracker_SingleLeader(t *testing.T) {
 	}
 
 	// publish with no followers should not panic or block
-	tr.publish("d1", evalResult{})
+	tr.publish("d1", gen, evalResult{})
 
 	// after publish, the next caller should again be a leader
-	leader2, _ := tr.acquire("d1")
+	leader2, _, _ := tr.acquire("d1")
 	if !leader2 {
 		t.Fatal("after publish, next caller should be a new leader")
 	}
@@ -33,7 +33,7 @@ func TestEvaluationTracker_CoalescesConcurrent(t *testing.T) {
 	tr := newEvaluationTracker()
 
 	// Leader acquires first and does not publish yet.
-	leader, _ := tr.acquire("d1")
+	leader, gen, _ := tr.acquire("d1")
 	if !leader {
 		t.Fatal("first caller should be the leader")
 	}
@@ -41,7 +41,7 @@ func TestEvaluationTracker_CoalescesConcurrent(t *testing.T) {
 	const followers = 50
 	waits := make([]<-chan evalResult, 0, followers)
 	for range followers {
-		isLeader, w := tr.acquire("d1")
+		isLeader, _, w := tr.acquire("d1")
 		if isLeader {
 			t.Fatal("subsequent callers should be followers")
 		}
@@ -50,7 +50,7 @@ func TestEvaluationTracker_CoalescesConcurrent(t *testing.T) {
 
 	// Leader finishes and publishes once. All followers must receive the same result.
 	sentinelErr := errors.New("boom")
-	tr.publish("d1", evalResult{err: sentinelErr})
+	tr.publish("d1", gen, evalResult{err: sentinelErr})
 
 	var wg sync.WaitGroup
 	var received int32
@@ -78,19 +78,65 @@ func TestEvaluationTracker_CoalescesConcurrent(t *testing.T) {
 
 func TestEvaluationTracker_PublishIsIdempotent(t *testing.T) {
 	tr := newEvaluationTracker()
-	_, _ = tr.acquire("d1")
+	_, gen, _ := tr.acquire("d1")
 
-	tr.publish("d1", evalResult{})
+	tr.publish("d1", gen, evalResult{})
 	// second publish must be a no-op (in particular, no panic).
-	tr.publish("d1", evalResult{})
+	tr.publish("d1", gen, evalResult{})
 }
 
 func TestEvaluationTracker_DistinctDesignsAreIndependent(t *testing.T) {
 	tr := newEvaluationTracker()
 
-	leader1, _ := tr.acquire("d1")
-	leader2, _ := tr.acquire("d2")
+	leader1, _, _ := tr.acquire("d1")
+	leader2, _, _ := tr.acquire("d2")
 	if !leader1 || !leader2 {
 		t.Fatal("different designs should each get their own leader")
+	}
+}
+
+// A publish carrying the generation of an abandoned evaluation must not
+// deliver into a newer evaluation of the same design. Sequence mirrors the
+// handler's timeout path: leader A times out and clears the slot, leader B
+// starts a fresh evaluation with follower C, then A's goroutine finishes
+// late.
+func TestEvaluationTracker_StaleGenerationPublishIsIgnored(t *testing.T) {
+	tr := newEvaluationTracker()
+
+	// A leads, then its HTTP side times out and clears the slot.
+	leaderA, genA, _ := tr.acquire("d1")
+	if !leaderA {
+		t.Fatal("A should be the leader")
+	}
+	tr.publish("d1", genA, evalResult{err: errors.New("timeout")})
+
+	// B starts a new evaluation of the same design; C coalesces onto it.
+	leaderB, genB, _ := tr.acquire("d1")
+	if !leaderB {
+		t.Fatal("B should lead the new evaluation")
+	}
+	_, _, waitC := tr.acquire("d1")
+
+	// A's abandoned goroutine finishes late. C must not see its result.
+	staleErr := errors.New("stale result from A")
+	tr.publish("d1", genA, evalResult{err: staleErr})
+
+	select {
+	case r := <-waitC:
+		t.Fatalf("follower received a result from the abandoned evaluation: %v", r.err)
+	default:
+	}
+
+	// B's real result must still reach C.
+	realErr := errors.New("real result from B")
+	tr.publish("d1", genB, evalResult{err: realErr})
+
+	select {
+	case r := <-waitC:
+		if !errors.Is(r.err, realErr) {
+			t.Fatalf("follower got %v, want the current leader's result", r.err)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("follower timed out waiting for the current leader's result")
 	}
 }

--- a/server/handlers/policy_relationship_handler.go
+++ b/server/handlers/policy_relationship_handler.go
@@ -701,6 +701,7 @@ func runRelationshipEvaluation(
 	log logger.Handler,
 	tracker *evaluationTracker,
 	designKey string,
+	gen uint64,
 	eval func() (pattern.EvaluationResponse, error),
 	respCh chan<- pattern.EvaluationResponse,
 	errCh chan<- error,
@@ -716,7 +717,7 @@ func runRelationshipEvaluation(
 		// propagates to errCh / coalesced followers / the response body.
 		panicErr := fmt.Errorf("panic during relationship evaluation: %v", r)
 		log.Error(fmt.Errorf("%s\n%s", panicErr.Error(), debug.Stack()))
-		tracker.publish(designKey, evalResult{err: panicErr})
+		tracker.publish(designKey, gen, evalResult{err: panicErr})
 		// Non-blocking send: if the leader's select already returned
 		// via ctx.Done() the receiver is gone and a blocking send
 		// would leak this goroutine forever.
@@ -727,17 +728,17 @@ func runRelationshipEvaluation(
 	}()
 
 	if ctx.Err() != nil {
-		tracker.publish(designKey, evalResult{err: ctx.Err()})
+		tracker.publish(designKey, gen, evalResult{err: ctx.Err()})
 		return
 	}
 
 	resp, err := eval()
 	if err != nil {
-		tracker.publish(designKey, evalResult{err: err})
+		tracker.publish(designKey, gen, evalResult{err: err})
 		errCh <- err
 		return
 	}
-	tracker.publish(designKey, evalResult{resp: resp})
+	tracker.publish(designKey, gen, evalResult{resp: resp})
 	respCh <- resp
 }
 
@@ -783,7 +784,7 @@ func (h *Handler) EvaluateRelationshipPolicy(
 
 	// Coalesce concurrent evaluations of the same design (rage-click guard).
 	designKey := patternUUID.String()
-	leader, waitCh := h.evalTracker.acquire(designKey)
+	leader, evalGen, waitCh := h.evalTracker.acquire(designKey)
 
 	if !leader {
 		h.log.Debug("coalescing relationship evaluation request for design ", designKey)
@@ -805,6 +806,7 @@ func (h *Handler) EvaluateRelationshipPolicy(
 		h.log,
 		h.evalTracker,
 		designKey,
+		evalGen,
 		func() (pattern.EvaluationResponse, error) {
 			return h.EvaluateDesign(relationshipPolicyEvalPayload, MAX_RE_EVALUATION_DEPTH)
 		},
@@ -833,7 +835,7 @@ func (h *Handler) EvaluateRelationshipPolicy(
 		h.writeEvaluationResult(rw, evalResult{resp: evaluationResponse})
 	case <-evalCtx.Done():
 		// Unblock any followers waiting on this designID.
-		h.evalTracker.publish(designKey, evalResult{err: errEvalTimeout})
+		h.evalTracker.publish(designKey, evalGen, evalResult{err: errEvalTimeout})
 		h.writeEvalCtxError(rw, evalCtx)
 		return
 	}

--- a/server/handlers/policy_relationship_handler_test.go
+++ b/server/handlers/policy_relationship_handler_test.go
@@ -40,12 +40,12 @@ func TestRunRelationshipEvaluation_RecoversPanic(t *testing.T) {
 	// 120 ECONNREFUSEDs. Verify the panic is converted to an error sent
 	// to the requesting client AND broadcast to coalesced followers.
 	tracker := newEvaluationTracker()
-	leader, _ := tracker.acquire("design-1")
+	leader, gen1, _ := tracker.acquire("design-1")
 	if !leader {
 		t.Fatalf("expected leader on first acquire")
 	}
 	// A follower joins before the leader publishes.
-	_, waitCh := tracker.acquire("design-1")
+	_, _, waitCh := tracker.acquire("design-1")
 
 	respCh := make(chan pattern.EvaluationResponse, 1)
 	errCh := make(chan error, 1)
@@ -58,6 +58,7 @@ func TestRunRelationshipEvaluation_RecoversPanic(t *testing.T) {
 			newTestLogger(t),
 			tracker,
 			"design-1",
+			gen1,
 			func() (pattern.EvaluationResponse, error) {
 				panic("synthetic engine explosion")
 			},
@@ -107,7 +108,7 @@ func TestRunRelationshipEvaluation_PanicDoesNotDeadlock(t *testing.T) {
 	// short-circuits before eval() is called and exercises a different
 	// path).
 	tracker := newEvaluationTracker()
-	tracker.acquire("design-2")
+	_, gen2, _ := tracker.acquire("design-2")
 
 	respCh := make(chan pattern.EvaluationResponse)
 	errCh := make(chan error)
@@ -120,6 +121,7 @@ func TestRunRelationshipEvaluation_PanicDoesNotDeadlock(t *testing.T) {
 			newTestLogger(t),
 			tracker,
 			"design-2",
+			gen2,
 			func() (pattern.EvaluationResponse, error) {
 				panic("synthetic engine explosion with no receiver")
 			},
@@ -139,7 +141,7 @@ func TestRunRelationshipEvaluation_PassesThroughEvalError(t *testing.T) {
 	// Non-panic eval errors must still flow through the same channels so
 	// the existing happy-error path is unchanged by the recovery wrapper.
 	tracker := newEvaluationTracker()
-	tracker.acquire("design-3")
+	_, gen3, _ := tracker.acquire("design-3")
 
 	respCh := make(chan pattern.EvaluationResponse, 1)
 	errCh := make(chan error, 1)
@@ -151,6 +153,7 @@ func TestRunRelationshipEvaluation_PassesThroughEvalError(t *testing.T) {
 		newTestLogger(t),
 		tracker,
 		"design-3",
+		gen3,
 		func() (pattern.EvaluationResponse, error) {
 			return pattern.EvaluationResponse{}, sentinel
 		},


### PR DESCRIPTION
**Notes for Reviewers**

- This PR fixes #20576

`evaluationTracker.publish` cleared the in-flight slot for whoever holds it now, with nothing tying a publish to the evaluation that started it. So an evaluation abandoned on timeout/cancel could finish late and hand its result to the followers of the *next* evaluation of the same design, while that evaluation's real result became a no-op.

The fix gives each slot a generation: `acquire` returns it to the leader, and `publish` ignores anything that doesn't carry the current generation. Late publishes from abandoned evaluations die quietly.

Changes:

- `evaluation_tracker.go`: slot struct with a generation, `acquire`/`publish` signatures extended.
- `policy_relationship_handler.go`: the generation flows from `acquire` through `runRelationshipEvaluation` and the timeout path. No behavior change on the happy path.
- Tests: existing four tracker tests updated to the new signatures, plus `TestEvaluationTracker_StaleGenerationPublishIsIgnored`, which replays the exact failing sequence (A times out → B leads a new eval → C coalesces → A's goroutine publishes late) and asserts C only ever sees B's result. The `runRelationshipEvaluation` panic-path tests are untouched semantically.

```
$ go test ./server/handlers/ -run 'TestEvaluationTracker|TestRunRelationshipEvaluation' -count=1
ok      github.com/meshery/meshery/server/handlers 2.439s
$ go build ./server/...   # clean
```

**[Signed commits](https://github.com/meshery/meshery/blob/master/CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [x] Yes, I signed my commits.
