### PR TITLE
fix Category and Subcategory dropdown menus in Create Model wizard

### DIFF
--- a/ui/components/registry/CreateModelModal.tsx
+++ b/ui/components/registry/CreateModelModal.tsx
@@ -30,7 +30,7 @@ const CreateModelModal: FC<CreateModelModalProps> = ({
       title="Create Model"
       size="sm"
       disableBodyWrap
-      sx={{ zIndex: 1600 }}
+      sx={{ zIndex: 1500 }}
     >
       <UrlStepper handleClose={handleClose} />
     </Modal>


### PR DESCRIPTION
**Notes for Reviewers**

- This PR fixes #20580

This change updates the z-index configuration so that the dropdown menus render above the modal and remain fully accessible.

**Screenshots** :

Before:
<img width="897" height="560" alt="image" src="https://github.com/user-attachments/assets/30f1cc03-a00b-4d74-9612-9d370843bc5c" />

After:
<img width="1276" height="720" alt="image" src="https://github.com/user-attachments/assets/ef60228b-b13b-41c2-af95-862f4ef29010" />


**[Signed commits](https://github.com/meshery/meshery/blob/master/CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**

- [x] Yes, I signed my commits.
