### PR TITLE
[Server] Normalize YAML designs to JSON so component dependsOn metadata survives parsing

### DIFF
--- a/server/models/pattern/core/pattern.go
+++ b/server/models/pattern/core/pattern.go
@@ -23,6 +23,7 @@ import (
 	pattern "github.com/meshery/schemas/models/v1beta3/design"
 	cytoscapejs "gonum.org/v1/gonum/graph/formats/cytoscapejs"
 	"gopkg.in/yaml.v2"
+	yamlv3 "gopkg.in/yaml.v3"
 )
 
 type prettifier bool
@@ -147,7 +148,7 @@ type DryRunFailureCause struct {
 
 // NewPatternFile takes in raw yaml and encodes it into a construct
 func NewPatternFile(yml []byte) (patternFile pattern.PatternFile, err error) {
-	err = encoding.Unmarshal(yml, &patternFile)
+	err = encoding.Unmarshal(normalizeToJSON(yml), &patternFile)
 	if err != nil {
 		return patternFile, err
 	}
@@ -166,6 +167,31 @@ func NewPatternFile(yml []byte) (patternFile pattern.PatternFile, err error) {
 	}
 
 	return
+}
+
+// normalizeToJSON converts YAML input to JSON before unmarshaling. The schema
+// types only capture unknown metadata keys (such as a component's
+// "dependsOn") through their custom JSON unmarshalers; the YAML path drops
+// them because AdditionalProperties is tagged `yaml:"-"`. Converting keeps
+// both wire formats carrying the same fields. Input that is already JSON, or
+// that fails conversion, is returned unchanged so error behavior stays with
+// the regular unmarshal path.
+func normalizeToJSON(data []byte) []byte {
+	if json.Valid(data) {
+		return data
+	}
+
+	var doc interface{}
+	if err := yamlv3.Unmarshal(data, &doc); err != nil {
+		return data
+	}
+
+	converted, err := json.Marshal(doc)
+	if err != nil {
+		return data
+	}
+
+	return converted
 }
 
 // ToCytoscapeJS converts pattern file into cytoscape object

--- a/server/models/pattern/core/pattern.go
+++ b/server/models/pattern/core/pattern.go
@@ -182,7 +182,9 @@ func normalizeToJSON(data []byte) []byte {
 	}
 
 	var doc interface{}
-	if err := yamlv3.Unmarshal(data, &doc); err != nil {
+	if err := yamlv3.Unmarshal(data, &doc); err != nil || doc == nil {
+		// Empty / comment-only YAML unmarshals to nil; leave the input alone
+		// so the regular unmarshal path keeps its existing error behavior.
 		return data
 	}
 

--- a/server/models/pattern/core/pattern_test.go
+++ b/server/models/pattern/core/pattern_test.go
@@ -146,4 +146,13 @@ components:
 	if len(plan.Edges) == 0 {
 		t.Fatal("expected the design's dependsOn to produce at least one ordering edge")
 	}
+
+	// Traversal dereferences edge endpoints; make sure a YAML-parsed
+	// dependsOn does not panic when the plan is evaluated.
+	defer func() {
+		if r := recover(); r != nil {
+			t.Fatalf("Plan.IsFeasible panicked on YAML-parsed dependsOn: %v", r)
+		}
+	}()
+	_ = plan.IsFeasible()
 }

--- a/server/models/pattern/core/pattern_test.go
+++ b/server/models/pattern/core/pattern_test.go
@@ -2,6 +2,8 @@ package core
 
 import (
 	"testing"
+
+	"github.com/meshery/meshery/server/models/pattern/planner"
 )
 
 func TestDesignNameFromFileName(t *testing.T) {
@@ -89,5 +91,59 @@ func TestDesignNameFromFileName(t *testing.T) {
 				t.Errorf("expected %q, got %q", tt.expectedName, result)
 			}
 		})
+	}
+}
+
+// The UI serializes designs to YAML for deploy/undeploy/validate, and the
+// schema types only capture unknown metadata keys (such as a component's
+// "dependsOn") through their custom JSON unmarshalers. Without normalizing
+// YAML input to JSON, those keys were silently dropped and the provision
+// planner saw no ordering edges.
+func TestNewPatternFileKeepsDependsOnFromYAML(t *testing.T) {
+	yml := []byte(`
+name: dependson-design
+components:
+  - id: 22222222-2222-2222-2222-222222222222
+    displayName: guestbook
+    metadata:
+      isNamespaced: true
+  - id: 11111111-1111-1111-1111-111111111111
+    displayName: frontend
+    metadata:
+      isNamespaced: true
+      dependsOn:
+        - guestbook
+`)
+
+	pf, err := NewPatternFile(yml)
+	if err != nil {
+		t.Fatalf("NewPatternFile returned an error: %v", err)
+	}
+	if len(pf.Components) != 2 {
+		t.Fatalf("expected 2 components, got %d", len(pf.Components))
+	}
+
+	var frontendDeps interface{}
+	var found bool
+	for _, comp := range pf.Components {
+		if comp.DisplayName == "frontend" {
+			frontendDeps, found = comp.Metadata.AdditionalProperties["dependsOn"]
+			if !comp.Metadata.IsNamespaced {
+				t.Fatal("typed metadata (isNamespaced) was lost while parsing the YAML design")
+			}
+		}
+	}
+	if !found {
+		t.Fatalf("dependsOn was dropped while parsing the YAML design: %v", frontendDeps)
+	}
+
+	// The planner must be able to consume the wire-decoded shape
+	// ([]interface{}) and produce an ordering edge from it.
+	plan, err := planner.CreatePlan(pf, false)
+	if err != nil {
+		t.Fatalf("CreatePlan rejected the parsed design: %v", err)
+	}
+	if len(plan.Edges) == 0 {
+		t.Fatal("expected the design's dependsOn to produce at least one ordering edge")
 	}
 }

--- a/server/models/pattern/planner/planner.go
+++ b/server/models/pattern/planner/planner.go
@@ -41,7 +41,7 @@ func CreatePlan(pattern pattern.PatternFile, invert bool) (*Plan, error) {
 			continue
 		}
 
-		dependsOn, err := utils.Cast[[]string](_dependsOn)
+		dependsOn, err := castStringSlice(_dependsOn)
 		if err != nil {
 			err = errors.Wrapf(err, "Failed to cast 'dependsOn' to []string for component %s", component.DisplayName)
 			return nil, err
@@ -60,4 +60,30 @@ func CreatePlan(pattern pattern.PatternFile, invert bool) (*Plan, error) {
 	}
 
 	return &Plan{pattern, g}, nil
+}
+
+// castStringSlice accepts both []string (in-process callers) and
+// []interface{}: the schema's JSON unmarshaler stores unknown metadata keys
+// such as "dependsOn" as []interface{}, so wire-decoded designs never carry
+// a typed []string.
+func castStringSlice(val interface{}) ([]string, error) {
+	if strs, err := utils.Cast[[]string](val); err == nil {
+		return strs, nil
+	}
+
+	items, err := utils.Cast[[]interface{}](val)
+	if err != nil {
+		return nil, err
+	}
+
+	strs := make([]string, 0, len(items))
+	for _, item := range items {
+		s, err := utils.Cast[string](item)
+		if err != nil {
+			return nil, err
+		}
+		strs = append(strs, s)
+	}
+
+	return strs, nil
 }

--- a/server/models/pattern/planner/planner.go
+++ b/server/models/pattern/planner/planner.go
@@ -67,23 +67,20 @@ func CreatePlan(pattern pattern.PatternFile, invert bool) (*Plan, error) {
 // such as "dependsOn" as []interface{}, so wire-decoded designs never carry
 // a typed []string.
 func castStringSlice(val interface{}) ([]string, error) {
-	if strs, err := utils.Cast[[]string](val); err == nil {
-		return strs, nil
-	}
-
-	items, err := utils.Cast[[]interface{}](val)
-	if err != nil {
-		return nil, err
-	}
-
-	strs := make([]string, 0, len(items))
-	for _, item := range items {
-		s, err := utils.Cast[string](item)
-		if err != nil {
-			return nil, err
+	switch v := val.(type) {
+	case []string:
+		return v, nil
+	case []interface{}:
+		strs := make([]string, 0, len(v))
+		for _, item := range v {
+			s, err := utils.Cast[string](item)
+			if err != nil {
+				return nil, err
+			}
+			strs = append(strs, s)
 		}
-		strs = append(strs, s)
+		return strs, nil
+	default:
+		return utils.Cast[[]string](val)
 	}
-
-	return strs, nil
 }


### PR DESCRIPTION
## Notes for Reviewers

Designs deployed/undeployed/validated from the UI are serialized to **YAML** (`encodeDesignFile`), but the schema only captures unknown metadata keys — chiefly a component's `dependsOn` — through its custom JSON unmarshaler. `ComponentDefinition_Metadata.AdditionalProperties` is tagged `yaml:"-"`, so the YAML path drops `dependsOn` and the provisioning planner never receives the ordering edges. The design still deploys, silently, in undefined order.

This fixes that on the parsing boundary:

1. **`server/models/pattern/core/pattern.go`** — new `normalizeToJSON` converts YAML input to JSON before `encoding.Unmarshal`, so the schema's `UnmarshalJSON` (which populates `AdditionalProperties`) always runs. Already-JSON input, and any input that fails conversion, is returned unchanged so error behavior on malformed designs is unaffected.
2. **`server/models/pattern/planner/planner.go`** — new `castStringSlice` accepts both `[]string` (in-process callers) and `[]interface{}`. A JSON-normalized `dependsOn` decodes as `[]interface{}`, so `CreatePlan` needs to handle both shapes.
3. **`server/models/pattern/core/pattern_test.go`** — end-to-end regression: a full YAML design → `NewPatternFile` → asserts `dependsOn` survives in `AdditionalProperties`, typed metadata still works, and `planner.CreatePlan` produces ordering edges.

This is **orthogonal to #20572/#20573**: those fix the planner's DisplayName-vs-ID keying *when* the edges are present; this fixes the edges never arriving on the YAML wire path. Both are needed.

```
$ go test ./server/models/pattern/core/... ./server/models/pattern/planner/... -run TestNewPatternFileKeepsDependsOnFromYAML -v
=== RUN   TestNewPatternFileKeepsDependsOnFromYAML
--- PASS: TestNewPatternFileKeepsDependsOnFromYAML (0.00s)
PASS
ok  	github.com/meshery/meshery/server/models/pattern/core
```

- This PR fixes #20582

- [x] I have signed off my commits with `git commit --signoff`
