### PR TITLE
[mesheryctl] Fix `design deploy` double-encoding the search param (spaces in design name)

### DIFF
--- a/mesheryctl/internal/cli/root/design/deploy.go
+++ b/mesheryctl/internal/cli/root/design/deploy.go
@@ -107,7 +107,11 @@ mesheryctl design deploy -f [filepath] -s [source type]
 
 			queryParams := url.Values{}
 			queryParams.Set("populate", "pattern_file")
-			queryParams.Set("search", url.QueryEscape(patternName))
+			// url.Values.Encode() already percent-encodes each value, so the
+			// name must be set raw here; pre-escaping with url.QueryEscape would
+			// double-encode it (e.g. "My Design" -> "search=My%2BDesign") and the
+			// server would never match the design.
+			queryParams.Set("search", patternName)
 			urlPath := fmt.Sprintf("%s?%s", patternURLPath, queryParams.Encode())
 			// search and fetch patterns with pattern-name
 			utils.Log.Debug("Fetching designs")

--- a/mesheryctl/internal/cli/root/design/deploy_test.go
+++ b/mesheryctl/internal/cli/root/design/deploy_test.go
@@ -127,6 +127,31 @@ func TestDeployCmd(t *testing.T) {
 			IsOutputGolden: false,
 			ExpectedError:  ErrDesignNotFound("nonexistent-design"),
 		},
+		{
+			// Regression for the double-encoded search param: a multi-word name
+			// must be sent as `search=multi+word+design`, not double-encoded to
+			// `search=multi%2Bword%2Bdesign`, otherwise the server never matches.
+			Name:             "given a design name with spaces when design deploy then the search param is single-encoded",
+			Args:             []string{"deploy", "multi", "word", "design"},
+			ExpectedResponse: "",
+			URLs: []utils.MockURL{
+				{
+					Method:       "GET",
+					URL:          testContext.BaseURL + "/api/pattern/types",
+					Response:     "view.designTypes.response.golden",
+					ResponseCode: 200,
+				},
+				{
+					Method:       "GET",
+					URL:          testContext.BaseURL + "/api/pattern?populate=pattern_file&search=multi+word+design",
+					Response:     "pattern.empty.response.golden",
+					ResponseCode: 200,
+				},
+			},
+			ExpectError:    true,
+			IsOutputGolden: false,
+			ExpectedError:  ErrDesignNotFound("multi word design"),
+		},
 	}
 
 	// Run tests


### PR DESCRIPTION
**Notes for Reviewers**

`mesheryctl design deploy <name>` double-encodes the `search` query parameter, so any design whose name contains a space (or other percent-encoded character) is never matched and the command exits with a misleading "design not found".

In `mesheryctl/internal/cli/root/design/deploy.go` the name was passed through `url.QueryEscape` **and then** `url.Values.Encode()`. `Encode()` already percent-encodes each value, so pre-escaping encodes it twice:

- `url.QueryEscape("My Design")` → `My+Design`
- `queryParams.Encode()` then escapes the `+` → `search=My%2BDesign`
- the server decodes this once and searches for the literal `My+Design`, which never matches `My Design`, so the lookup returns 0 patterns and hits `ErrDesignNotFound`.

Single-token names were unaffected (nothing to double-encode), which is why this went unnoticed.

The sibling commands already single-encode correctly and were used as the reference: `design/view.go` (`queryParams.Add("search", design)` + `Encode()`) and `design/export.go` (`url.QueryEscape` into a raw string, not re-`Encode()`d). Only `deploy.go` applied both.

**Fix:** drop the redundant `url.QueryEscape` and let `url.Values.Encode()` do the single, correct encoding. Added a `TestDeployCmd` case for a multi-word design name asserting the request is `search=multi+word+design` (fails on the old double-encoded path, passes now).

- This PR fixes #20588

**[Signed commits](https://github.com/meshery/meshery/blob/master/CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [x] Yes, I signed my commits.
