### PR TITLE
 [Docs] Improve mobile sidebar interaction behavior

### DIFF
--- a/docs/layouts/partials/sidebar.html
+++ b/docs/layouts/partials/sidebar.html
@@ -153,14 +153,21 @@
     });
 
     document.addEventListener("click", function(event) {
+      if (!window.matchMedia("(max-width: 37.5em)").matches) return;
+
+      const targetLink = event.target.closest("#td-sidebar-menu a.td-sidebar-link");
+      const clickedInsideSidebar = event.target.closest("#td-sidebar-menu, .sidebar-container, .sidebar-container-wrapper");
+      const clickedToggle = event.target.closest("#toggleBtnSidebarNav");
+
       if (
-        window.matchMedia("(max-width: 37.5em)").matches &&
         document.querySelector(".left-container.left-container--active") &&
-        (event.target.closest("#td-sidebar-menu a") || event.target.closest("#td-sidebar-menu button"))
+        !clickedToggle &&
+        (targetLink || !clickedInsideSidebar)
       ) {
         const toggle = document.getElementById("toggleBtnSidebarNav");
         if (toggle) toggle.click();
       }
     });
+
   });
 </script>

--- a/docs/layouts/partials/sidebar.html
+++ b/docs/layouts/partials/sidebar.html
@@ -173,14 +173,14 @@
     document.addEventListener("click", function(event) {
       if (!window.matchMedia("(max-width: 37.5em)").matches) return;
 
-      const targetLink = event.target.closest("#td-sidebar-menu a.td-sidebar-link");
-      const clickedInsideSidebar = event.target.closest("#td-sidebar-menu, .sidebar-container, .sidebar-container-wrapper");
-      const clickedToggle = event.target.closest("#toggleBtnSidebarNav");
+      const isLinkClicked = event.target.closest("#td-sidebar-menu a.td-sidebar-link");
+      const isClickInsideSidebar = event.target.closest("#td-sidebar-menu, .sidebar-container, .sidebar-container-wrapper");
+      const isToggleClicked = event.target.closest("#toggleBtnSidebarNav");
 
       if (
         document.querySelector(".left-container.left-container--active") &&
-        !clickedToggle &&
-        (targetLink || !clickedInsideSidebar)
+        !isToggleClicked &&
+        (isLinkClicked || !isClickInsideSidebar)
       ) {
         const toggle = document.getElementById("toggleBtnSidebarNav");
         if (toggle) toggle.click();

--- a/docs/layouts/partials/sidebar.html
+++ b/docs/layouts/partials/sidebar.html
@@ -28,6 +28,36 @@
 {{- end }}
 <script>
   (function() {
+    function setSectionExpanded(li, expanded) {
+      var ul = li.querySelector(":scope > ul");
+      if (!ul) return;
+
+      ul.hidden = !expanded;
+      li.classList.toggle("active-path", expanded);
+
+      if (expanded) {
+        ul.querySelectorAll(":scope > li").forEach(function(childLi) {
+          childLi.classList.add("show");
+        });
+      } else {
+        li.querySelectorAll("li").forEach(function(descendantLi) {
+          descendantLi.classList.remove("active-path");
+          descendantLi.classList.remove("show");
+        });
+      }
+    }
+
+    function collapseSiblingSections(li) {
+      var parentUl = li.parentElement;
+      if (!parentUl) return;
+
+      Array.from(parentUl.children).forEach(function(siblingLi) {
+        if (siblingLi !== li && siblingLi.classList.contains("with-child")) {
+          setSectionExpanded(siblingLi, false);
+        }
+      });
+    }
+
     function injectToggleButton(li, icon, position, extraClass) {
       // Only process sections that actually have children (ul exists)
       var ul = li.querySelector(":scope > ul");
@@ -42,28 +72,14 @@
       btn.innerHTML = icon;
       btn.onclick = function(e) {
         e.preventDefault();
-        
-        var $ul = $(ul);
-        var childLis = ul.querySelectorAll(":scope > li");
-        var isClosed = childLis.length > 0 && !childLis[0].classList.contains("show");
-        
-        if (isClosed) {
-          $ul.hide();
-          childLis.forEach(function(childLi) {
-            childLi.classList.add("show");
-          });
-        }
-        
-        $ul.slideToggle(400, function() {
-          if ($ul.css("display") === "none") {
-            childLis.forEach(function(childLi) {
-              childLi.classList.remove("show");
-            });
-            $ul.css("display", "");
-          }
-        });
 
-        li.classList.toggle("active-path");
+        if (li.classList.contains("active-path")) {
+          setSectionExpanded(li, false);
+          return;
+        }
+
+        collapseSiblingSections(li);
+        setSectionExpanded(li, true);
       };
       
       var wrapper = document.createElement("div");
@@ -85,11 +101,13 @@
     var rootLis = document.querySelectorAll(".td-sidebar-nav .ul-1 > li.with-child");
     rootLis.forEach(function(li) {
       injectToggleButton(li, caretIcon, "before", "");
+      setSectionExpanded(li, li.classList.contains("active-path"));
     });
 
     var childLis = document.querySelectorAll(".td-sidebar-nav .ul-1 ul li.with-child");
     childLis.forEach(function(li) {
       injectToggleButton(li, caretIcon, "before", "child-toggle");
+      setSectionExpanded(li, li.classList.contains("active-path"));
     });
   })();
 </script>

--- a/docs/layouts/partials/sidebar.html
+++ b/docs/layouts/partials/sidebar.html
@@ -97,18 +97,24 @@
     }
 
     var caretIcon = '<svg class="caret-icon" viewBox="0 0 16 16" width="1em" height="1em" aria-hidden="true" focusable="false"><path d="M6 4l4 4-4 4" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/></svg>';
+    function initSidebarSectionToggles() {
+      var rootLis = document.querySelectorAll(".td-sidebar-nav .ul-1 > li.with-child");
+      rootLis.forEach(function(li) {
+        injectToggleButton(li, caretIcon, "before", "");
+        setSectionExpanded(li, li.classList.contains("active-path"));
+      });
 
-    var rootLis = document.querySelectorAll(".td-sidebar-nav .ul-1 > li.with-child");
-    rootLis.forEach(function(li) {
-      injectToggleButton(li, caretIcon, "before", "");
-      setSectionExpanded(li, li.classList.contains("active-path"));
-    });
-
-    var childLis = document.querySelectorAll(".td-sidebar-nav .ul-1 ul li.with-child");
-    childLis.forEach(function(li) {
-      injectToggleButton(li, caretIcon, "before", "child-toggle");
-      setSectionExpanded(li, li.classList.contains("active-path"));
-    });
+      var childLis = document.querySelectorAll(".td-sidebar-nav .ul-1 ul li.with-child");
+      childLis.forEach(function(li) {
+        injectToggleButton(li, caretIcon, "before", "child-toggle");
+        setSectionExpanded(li, li.classList.contains("active-path"));
+      });
+    }
+    if (document.readyState === "loading") {
+      document.addEventListener("DOMContentLoaded", initSidebarSectionToggles);
+    } else {
+      initSidebarSectionToggles();
+    }
   })();
 </script>
 

--- a/docs/layouts/partials/sidebar.html
+++ b/docs/layouts/partials/sidebar.html
@@ -40,6 +40,9 @@
           childLi.classList.add("show");
         });
       } else {
+        li.querySelectorAll("ul").forEach(function(descendantUl) {
+           descendantUl.hidden = true;
+         });
         li.querySelectorAll("li").forEach(function(descendantLi) {
           descendantLi.classList.remove("active-path");
           descendantLi.classList.remove("show");


### PR DESCRIPTION
**Notes for Reviewers**

This PR updates the mobile docs sidebar behavior to make interactions more intuitive.

**What changed**
- The sidebar now closes when a user clicks a real sidebar navigation link on small screens.
- The sidebar no longer closes when clicking the expand/collapse controls rather, it only expands or collapse the targeted section.
- The sidebar also closes when the user clicks outside the sidebar or its wrapper.

**Why**
This improves the mobile navigation experience by preventing the sidebar from closing during normal section expansion interactions and by allowing it to dismiss cleanly when the user interacts with the rest of the page.

### Before
https://mesheryio.slack.com/files/U0A474KR6L8/F0BGAPKC8LT/screen_recording_2026-07-10_at_14.29.44.mov

### After
https://mesheryio.slack.com/files/U0A474KR6L8/F0BGF1G6LP8/screen_recording_2026-07-10_at_14.32.48.mov

- This PR fixes #20591

**[Signed commits](https://github.com/meshery/meshery/blob/master/CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [x] Yes, I signed my commits.

<!--
Thank you for contributing to Meshery! 

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. Sign your commits.
4. Include before and after screenshots/terminal output.

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved sidebar section expansion and collapsing behavior using consistent visibility states.
  * Preserved the correct expanded section when navigating between pages.
  * Ensured closing a section also resets expanded nested items.
  * Improved initial sidebar state handling when pages load.
  * Enhanced mobile sidebar closing when selecting links or clicking outside the sidebar.
  * Prevented toggle-button interactions from unintentionally closing the mobile sidebar.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->