### PR TITLE
[Docs] Fix make clean to remove build output and cache

### DIFF
--- a/docs/Makefile
+++ b/docs/Makefile
@@ -48,9 +48,10 @@ build-production: check-deps
 		npm run build:production -- --gc; \
 	fi
 
-## Empty build cache and run docs.meshery.io on your local machine.
-clean: check-deps
-	npm run dev:clean
+## Empty the build cache, reinstall dependencies, and run the site locally.
+clean:
+	npm run clean
+	$(MAKE) setup
 	$(MAKE) site
 
 ## Validate Go is installed by delegating to the root Makefile check.

--- a/docs/package.json
+++ b/docs/package.json
@@ -21,7 +21,6 @@
     "check:links": "npm run _check:links",
     "clean": "rm -Rf public/* resources",
     "dev:build": "npm run _hugo-dev",
-    "dev:clean": "npm run _hugo",
     "dev:serve": "npm run _hugo-dev -- server --watch=false",
     "dev:site": "npm run _hugo-dev -- server",
     "make:public": "git init -b main public",


### PR DESCRIPTION
**Notes for Reviewers**

- This PR fixes #20546

`make clean` previously delegated to `npm run dev:clean` (`hugo --cleanDestinationDir` - a full
site build) and then launched the dev server, while `resources/` (Hugo's build cache) was never
removed and the correct `clean` script in `package.json` was never invoked.

This PR:
- Rewires `clean` to `npm run clean` → `$(MAKE) setup` → `$(MAKE) site`, matching the
  standardized target already merged across the Academy repos
  (layer5io/layer5-academy#240, meshery-extensions/digitalocean-academy#79)
- Drops the `check-deps` prerequisite from `clean` - cleaning is often the recovery step when
  dependencies are broken; `$(MAKE) setup` reinstalls them and `site` still runs
  `check-deps check-go`
- Removes the now-orphaned `dev:clean` script (referenced only by the old target)


*Before:* `make clean`'s delegate starts a full Hugo build and `resources/` survives:

<img width="1127" height="666" alt="Screenshot 2026-07-09 023027" src="https://github.com/user-attachments/assets/20074b55-86e1-422c-a130-063c6351bc2b" />



*After:* same entry point removes `public/*` and `resources/` instantly:

<img width="1122" height="513" alt="image" src="https://github.com/user-attachments/assets/26e350a7-731a-4312-8419-844c568a28ce" />



**[Signed commits](https://github.com/meshery/meshery/blob/master/CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [x] Yes, I signed my commits.

<!--
Thank you for contributing to Meshery! 

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. Sign your commits.
4. Include before and after screenshots/terminal output.

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.
-->
