### PR TITLE
[mesheryctl] Fix design undeploy to undeploy instead of deleting or sending an invalid body

### DIFF
--- a/mesheryctl/internal/cli/root/design/fixtures/undeploy.byname.patterns.response.golden
+++ b/mesheryctl/internal/cli/root/design/fixtures/undeploy.byname.patterns.response.golden
@@ -1,0 +1,1 @@
+{"page":0,"pageSize":10,"totalCount":1,"patterns":[{"id":"aaaaaaaa-bbbb-4ccc-8ddd-eeeeeeeeeeee","name":"TestDesign","patternFile":"name: TestDesign\n"}]}

--- a/mesheryctl/internal/cli/root/design/undeploy.go
+++ b/mesheryctl/internal/cli/root/design/undeploy.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"net/url"
 	"os"
 
 	"github.com/asaskevich/govalidator"
@@ -29,7 +30,6 @@ import (
 	"github.com/meshery/meshery/server/models"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
-	"gopkg.in/yaml.v2"
 )
 
 var designUndeployCmd = &cobra.Command{
@@ -37,14 +37,17 @@ var designUndeployCmd = &cobra.Command{
 	Short: "Undeploy design",
 	Long:  `Undeploy design will trigger undeploy of design`,
 	Example: `
-// Undeploy design by providing file path
+// Undeploy a deployed design by its name or ID
+mesheryctl design undeploy [design name | ID]
+
+// Undeploy a design by providing a design file path
 mesheryctl design undeploy -f [filepath]
 	`,
 
 	Args: func(cmd *cobra.Command, args []string) error {
 		if len(args) == 0 && file == "" {
 			return ErrUndeployDesign(
-				fmt.Errorf("provide either a design ID or -f [filepath]"),
+				fmt.Errorf("provide either a design name/ID or -f [filepath]"),
 			)
 		}
 
@@ -56,103 +59,139 @@ mesheryctl design undeploy -f [filepath]
 		return nil
 	},
 	RunE: func(cmd *cobra.Command, args []string) error {
-		var req *http.Request
-		var err error
 		mctlCfg, err := config.GetMesheryCtl(viper.GetViper())
 		if err != nil {
 			return err
 		}
 
-		design := ""
-		isID := false
-		if len(args) > 0 {
-			design, isID, err = utils.ValidId(mctlCfg.GetBaseMesheryURL(), args[0], "pattern")
-			if err != nil {
-				return err
-			}
-		}
-
-		// Delete the design using the id
-		if isID {
-			err := utils.DeleteConfiguration(mctlCfg.GetBaseMesheryURL(), design, "pattern")
-			if err != nil {
-				return ErrDeleteDesign(err, args[0])
-			}
-			utils.Log.Infof("design %s deleted", args[0])
-			return nil
-		}
-
-		designURLPath := "api/pattern"
-
 		deployURL := mctlCfg.GetBaseMesheryURL() + "/api/pattern/deploy"
 
-		if !govalidator.IsURL(file) {
-			content, err := os.ReadFile(file)
-			if err != nil {
-				return utils.ErrFileRead(err)
-			}
-			designFile = string(content)
+		// Resolve the design file content to undeploy. A design can be referenced
+		// either by its name/ID (a previously saved design) or by a design file
+		// path. In every case the design is undeployed; the saved design record
+		// is never deleted.
+		var patternFileContent string
+		if len(args) > 0 {
+			patternFileContent, err = getUndeployPatternFileByNameOrID(mctlCfg.GetBaseMesheryURL(), args[0])
 		} else {
-			utils.Log.Info("URLs are not currently supported")
+			patternFileContent, err = getUndeployPatternFileFromFile(file)
 		}
-
-		jsonValues, _ := json.Marshal(map[string]interface{}{
-			"K8sManifest": designFile,
-		})
-
-		resp, err := api.Add(designURLPath, bytes.NewBuffer(jsonValues), nil)
-		if err != nil {
-			return err
-		}
-		defer func() { _ = resp.Body.Close() }()
-
-		var response []*models.MesheryPattern
-
-		body, err := io.ReadAll(resp.Body)
-		if err != nil {
-			return utils.ErrReadFromBody(err)
-		}
-
-		err = json.Unmarshal(body, &response)
-		if err != nil {
-			return utils.ErrUnmarshal(err)
-		}
-
-		if len(response) == 0 {
-			return ErrDesignNotFound(file)
-		}
-
-		utils.Log.Debug("design file converted to design")
-
-		patternFile := response[0].PatternFile
-		patternFileByt, err := yaml.Marshal(patternFile)
-		if err != nil {
-			return models.ErrMarshallingDesignIntoYAML(err)
-		}
-
-		req, err = utils.NewRequest("DELETE", deployURL, bytes.NewBuffer(patternFileByt))
 		if err != nil {
 			return err
 		}
 
-		res, err := utils.MakeRequest(req)
-		if err != nil {
-			return err
-		}
-
-		defer func() { _ = res.Body.Close() }()
-		body, err = io.ReadAll(res.Body)
-		if err != nil {
-			return utils.ErrReadFromBody(err)
-		}
-
-		if res.StatusCode == 200 {
-			utils.Log.Info("design undeployed")
-		}
-		utils.Log.Info(string(body))
-
-		return nil
+		return undeployPatternFile(deployURL, patternFileContent)
 	},
+}
+
+// getUndeployPatternFileByNameOrID resolves a saved design, referenced by name
+// or ID, to its design file content. It only reads the design; it must never
+// delete it.
+func getUndeployPatternFileByNameOrID(baseMesheryURL, arg string) (string, error) {
+	design, isID, err := utils.ValidId(baseMesheryURL, arg, "pattern")
+	if err != nil {
+		return "", err
+	}
+
+	if isID {
+		resp, err := api.Fetch[models.MesheryPattern](fmt.Sprintf("api/pattern/%s", url.PathEscape(design)))
+		if err != nil {
+			return "", err
+		}
+		if resp.PatternFile == "" {
+			return "", ErrDesignNotFound(arg)
+		}
+		return resp.PatternFile, nil
+	}
+
+	queryParams := url.Values{}
+	queryParams.Set("populate", "pattern_file")
+	queryParams.Set("search", design)
+	urlPath := fmt.Sprintf("api/pattern?%s", queryParams.Encode())
+
+	resp, err := api.Fetch[models.PatternsAPIResponse](urlPath)
+	if err != nil {
+		return "", err
+	}
+	if len(resp.Patterns) == 0 {
+		return "", ErrDesignNotFound(design)
+	}
+	return resp.Patterns[0].PatternFile, nil
+}
+
+// getUndeployPatternFileFromFile imports the given design file into a saved
+// design and returns the resulting design file content.
+func getUndeployPatternFileFromFile(filePath string) (string, error) {
+	if govalidator.IsURL(filePath) {
+		return "", ErrUndeployDesign(fmt.Errorf("URLs are not currently supported"))
+	}
+
+	content, err := os.ReadFile(filePath)
+	if err != nil {
+		return "", utils.ErrFileRead(err)
+	}
+
+	jsonValues, _ := json.Marshal(map[string]interface{}{
+		"K8sManifest": string(content),
+	})
+
+	resp, err := api.Add("api/pattern", bytes.NewBuffer(jsonValues), nil)
+	if err != nil {
+		return "", err
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return "", utils.ErrReadFromBody(err)
+	}
+
+	var response []*models.MesheryPattern
+	if err := json.Unmarshal(body, &response); err != nil {
+		return "", utils.ErrUnmarshal(err)
+	}
+	if len(response) == 0 {
+		return "", ErrDesignNotFound(filePath)
+	}
+
+	utils.Log.Debug("design file converted to design")
+	return response[0].PatternFile, nil
+}
+
+// undeployPatternFile sends the resolved design file to the server's undeploy
+// endpoint using the same request contract as `design deploy`: a JSON-encoded
+// models.MesheryPatternFileDeployPayload sent to DELETE /api/pattern/deploy.
+func undeployPatternFile(deployURL, patternFileContent string) error {
+	payload := models.MesheryPatternFileDeployPayload{
+		PatternFile: patternFileContent,
+	}
+	payloadBytes, err := json.Marshal(payload)
+	if err != nil {
+		return utils.ErrMarshal(err)
+	}
+
+	req, err := utils.NewRequest("DELETE", deployURL, bytes.NewBuffer(payloadBytes))
+	if err != nil {
+		return err
+	}
+
+	res, err := utils.MakeRequest(req)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = res.Body.Close() }()
+
+	body, err := io.ReadAll(res.Body)
+	if err != nil {
+		return utils.ErrReadFromBody(err)
+	}
+
+	if res.StatusCode == http.StatusOK {
+		utils.Log.Info("design undeployed")
+	}
+	utils.Log.Info(string(body))
+
+	return nil
 }
 
 func init() {

--- a/mesheryctl/internal/cli/root/design/undeploy_test.go
+++ b/mesheryctl/internal/cli/root/design/undeploy_test.go
@@ -44,6 +44,31 @@ func TestUndeployCmd(t *testing.T) {
 			ExpectError: false,
 		},
 		{
+			// Referencing a saved design by name must undeploy it (DELETE
+			// /api/pattern/deploy), never delete the saved design record
+			// (DELETE /api/pattern/{id}). The delete endpoint is deliberately
+			// not mocked, so if the command tried to delete the design the
+			// request would fail with no matching responder.
+			Name:             "given a design name when design undeploy then design is undeployed not deleted",
+			Args:             []string{"undeploy", "TestDesign"},
+			ExpectedResponse: "undeploy.output.golden",
+			URLs: []utils.MockURL{
+				{
+					Method:       "GET",
+					URL:          "/api/pattern",
+					Response:     "undeploy.byname.patterns.response.golden",
+					ResponseCode: 200,
+				},
+				{
+					Method:       "DELETE",
+					URL:          "/api/pattern/deploy",
+					Response:     "undeploy.response.golden",
+					ResponseCode: 200,
+				},
+			},
+			ExpectError: false,
+		},
+		{
 			Name:             "given invalid file path when design undeploy then error is thrown",
 			Args:             []string{"undeploy", "-f", invalidFilePath},
 			ExpectedResponse: "",


### PR DESCRIPTION
## Notes for Reviewers

`mesheryctl design undeploy` was broken in both supported modes (details in #20603):

- **By ID** it called `DeleteConfiguration` → `DELETE /api/pattern/{id}`, **deleting the saved design** instead of undeploying, orphaning the running workloads.
- **By file** it `yaml.Marshal`-ed the design file string and sent the raw bytes to `DELETE /api/pattern/deploy`, which expects a JSON-encoded `models.MesheryPatternFileDeployPayload`, so the body failed to decode.

This PR resolves the referenced design to its file content in every case:

- **name/ID** → a read-only fetch (`GET /api/pattern/{id}` for an ID, or the `populate=pattern_file` search for a name), never a delete;
- **file** → import the provided file, as before;

and undeploys it through a single helper that uses the **same JSON payload contract as `design deploy`**. The saved design is never deleted.

The positional argument now behaves as the inverse of `design deploy` (name or ID). I kept ID resolution via `ValidId`. Happy to adjust if maintainers prefer name-only, to match `deploy`.

### Testing

- `go test --short ./internal/cli/root/design/...` green.
- Added a behavioral test: undeploy-by-name hits `DELETE /api/pattern/deploy` and **not** `DELETE /api/pattern/{id}` (the delete endpoint is deliberately unmocked, so a regression to the destructive path would fail with no responder).

This PR fixes #20603

---

- [x] I have read the [contribution guidelines](https://github.com/meshery/meshery/blob/master/CONTRIBUTING.md).
- [x] I have signed off all my commits as required by [DCO](https://github.com/meshery/meshery/blob/master/CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin).
