### PR TITLE
Aws observability misc relationships v2

### DIFF
--- a/models/aws-cloudwatchlogs-controller/v1.3.2/v1.0.0/relationships/edge-non-binding-reference-loggroup-key.json
+++ b/models/aws-cloudwatchlogs-controller/v1.3.2/v1.0.0/relationships/edge-non-binding-reference-loggroup-key.json
@@ -1,0 +1,99 @@
+{
+  "id": "00000000-0000-0000-0000-000000000000",
+  "evaluationQuery": "",
+  "kind": "edge",
+  "metadata": {
+    "description": "References a KMS Key from a CloudWatchLogs LogGroup via spec.kmsKeyID.",
+    "isAnnotation": false,
+    "styles": {
+      "primaryColor": "",
+      "svgColor": "",
+      "svgWhite": ""
+    }
+  },
+  "model": {
+    "displayName": "",
+    "id": "00000000-0000-0000-0000-000000000000",
+    "model": {
+      "version": "v1.3.2"
+    },
+    "name": "aws-cloudwatchlogs-controller",
+    "registrant": {
+      "kind": ""
+    },
+    "version": ""
+  },
+  "schemaVersion": "relationships.meshery.io/v1beta2",
+  "selectors": [
+    {
+      "allow": {
+        "from": [
+          {
+            "id": null,
+            "kind": "Key",
+            "match": {},
+            "match_strategy_matrix": null,
+            "model": {
+              "displayName": "",
+              "id": "00000000-0000-0000-0000-000000000000",
+              "model": {
+                "version": ""
+              },
+              "name": "aws-kms-controller",
+              "registrant": {
+                "kind": "github"
+              },
+              "version": ""
+            },
+            "patch": {
+              "patchStrategy": "replace",
+              "mutatorRef": [
+                [
+                  "displayName"
+                ]
+              ]
+            }
+          }
+        ],
+        "to": [
+          {
+            "id": null,
+            "kind": "LogGroup",
+            "match": {},
+            "match_strategy_matrix": null,
+            "model": {
+              "displayName": "",
+              "id": "00000000-0000-0000-0000-000000000000",
+              "model": {
+                "version": ""
+              },
+              "name": "aws-cloudwatchlogs-controller",
+              "registrant": {
+                "kind": "github"
+              },
+              "version": ""
+            },
+            "patch": {
+              "patchStrategy": "replace",
+              "mutatedRef": [
+                [
+                  "configuration",
+                  "spec",
+                  "kmsKeyID"
+                ]
+              ]
+            }
+          }
+        ]
+      },
+      "deny": {
+        "from": [],
+        "to": []
+      }
+    }
+  ],
+  "subType": "reference",
+  "status": "enabled",
+  "type": "non-binding",
+  "version": "v1.0.0"
+}

--- a/models/aws-cloudwatchlogs-controller/v1.3.2/v1.0.0/relationships/edge-non-binding-reference-loggroup-key.json
+++ b/models/aws-cloudwatchlogs-controller/v1.3.2/v1.0.0/relationships/edge-non-binding-reference-loggroup-key.json
@@ -23,7 +23,7 @@
     },
     "version": ""
   },
-  "schemaVersion": "relationships.meshery.io/v1beta2",
+  "schemaVersion": "relationships.meshery.io/v1beta3",
   "selectors": [
     {
       "allow": {

--- a/models/aws-dynamodb-controller/v1.9.2/v1.0.0/relationships/edge-non-binding-reference-table-key.json
+++ b/models/aws-dynamodb-controller/v1.9.2/v1.0.0/relationships/edge-non-binding-reference-table-key.json
@@ -23,7 +23,7 @@
     },
     "version": ""
   },
-  "schemaVersion": "relationships.meshery.io/v1beta2",
+  "schemaVersion": "relationships.meshery.io/v1beta3",
   "selectors": [
     {
       "allow": {

--- a/models/aws-dynamodb-controller/v1.9.2/v1.0.0/relationships/edge-non-binding-reference-table-key.json
+++ b/models/aws-dynamodb-controller/v1.9.2/v1.0.0/relationships/edge-non-binding-reference-table-key.json
@@ -1,0 +1,100 @@
+{
+  "id": "00000000-0000-0000-0000-000000000000",
+  "evaluationQuery": "",
+  "kind": "edge",
+  "metadata": {
+    "description": "References a KMS Key from a DynamoDB Table via spec.sseSpecification.kmsMasterKeyID.",
+    "isAnnotation": false,
+    "styles": {
+      "primaryColor": "",
+      "svgColor": "",
+      "svgWhite": ""
+    }
+  },
+  "model": {
+    "displayName": "",
+    "id": "00000000-0000-0000-0000-000000000000",
+    "model": {
+      "version": "v1.9.2"
+    },
+    "name": "aws-dynamodb-controller",
+    "registrant": {
+      "kind": ""
+    },
+    "version": ""
+  },
+  "schemaVersion": "relationships.meshery.io/v1beta2",
+  "selectors": [
+    {
+      "allow": {
+        "from": [
+          {
+            "id": null,
+            "kind": "Key",
+            "match": {},
+            "match_strategy_matrix": null,
+            "model": {
+              "displayName": "",
+              "id": "00000000-0000-0000-0000-000000000000",
+              "model": {
+                "version": ""
+              },
+              "name": "aws-kms-controller",
+              "registrant": {
+                "kind": "github"
+              },
+              "version": ""
+            },
+            "patch": {
+              "patchStrategy": "replace",
+              "mutatorRef": [
+                [
+                  "displayName"
+                ]
+              ]
+            }
+          }
+        ],
+        "to": [
+          {
+            "id": null,
+            "kind": "Table",
+            "match": {},
+            "match_strategy_matrix": null,
+            "model": {
+              "displayName": "",
+              "id": "00000000-0000-0000-0000-000000000000",
+              "model": {
+                "version": ""
+              },
+              "name": "aws-dynamodb-controller",
+              "registrant": {
+                "kind": "github"
+              },
+              "version": ""
+            },
+            "patch": {
+              "patchStrategy": "replace",
+              "mutatedRef": [
+                [
+                  "configuration",
+                  "spec",
+                  "sseSpecification",
+                  "kmsMasterKeyID"
+                ]
+              ]
+            }
+          }
+        ]
+      },
+      "deny": {
+        "from": [],
+        "to": []
+      }
+    }
+  ],
+  "subType": "reference",
+  "status": "enabled",
+  "type": "non-binding",
+  "version": "v1.0.0"
+}

--- a/models/aws-prometheusservice-controller/v1.5.2/v1.0.0/relationships/edge-non-binding-reference-alertmanagerdefinition-workspace.json
+++ b/models/aws-prometheusservice-controller/v1.5.2/v1.0.0/relationships/edge-non-binding-reference-alertmanagerdefinition-workspace.json
@@ -1,0 +1,99 @@
+{
+  "id": "00000000-0000-0000-0000-000000000000",
+  "evaluationQuery": "",
+  "kind": "edge",
+  "metadata": {
+    "description": "References a PrometheusService Workspace from an AlertManagerDefinition via spec.workspaceID.",
+    "isAnnotation": false,
+    "styles": {
+      "primaryColor": "",
+      "svgColor": "",
+      "svgWhite": ""
+    }
+  },
+  "model": {
+    "displayName": "",
+    "id": "00000000-0000-0000-0000-000000000000",
+    "model": {
+      "version": "v1.5.2"
+    },
+    "name": "aws-prometheusservice-controller",
+    "registrant": {
+      "kind": ""
+    },
+    "version": ""
+  },
+  "schemaVersion": "relationships.meshery.io/v1beta2",
+  "selectors": [
+    {
+      "allow": {
+        "from": [
+          {
+            "id": null,
+            "kind": "Workspace",
+            "match": {},
+            "match_strategy_matrix": null,
+            "model": {
+              "displayName": "",
+              "id": "00000000-0000-0000-0000-000000000000",
+              "model": {
+                "version": ""
+              },
+              "name": "aws-prometheusservice-controller",
+              "registrant": {
+                "kind": "github"
+              },
+              "version": ""
+            },
+            "patch": {
+              "patchStrategy": "replace",
+              "mutatorRef": [
+                [
+                  "displayName"
+                ]
+              ]
+            }
+          }
+        ],
+        "to": [
+          {
+            "id": null,
+            "kind": "AlertManagerDefinition",
+            "match": {},
+            "match_strategy_matrix": null,
+            "model": {
+              "displayName": "",
+              "id": "00000000-0000-0000-0000-000000000000",
+              "model": {
+                "version": ""
+              },
+              "name": "aws-prometheusservice-controller",
+              "registrant": {
+                "kind": "github"
+              },
+              "version": ""
+            },
+            "patch": {
+              "patchStrategy": "replace",
+              "mutatedRef": [
+                [
+                  "configuration",
+                  "spec",
+                  "workspaceID"
+                ]
+              ]
+            }
+          }
+        ]
+      },
+      "deny": {
+        "from": [],
+        "to": []
+      }
+    }
+  ],
+  "subType": "reference",
+  "status": "enabled",
+  "type": "non-binding",
+  "version": "v1.0.0"
+}

--- a/models/aws-prometheusservice-controller/v1.5.2/v1.0.0/relationships/edge-non-binding-reference-alertmanagerdefinition-workspace.json
+++ b/models/aws-prometheusservice-controller/v1.5.2/v1.0.0/relationships/edge-non-binding-reference-alertmanagerdefinition-workspace.json
@@ -23,7 +23,7 @@
     },
     "version": ""
   },
-  "schemaVersion": "relationships.meshery.io/v1beta2",
+  "schemaVersion": "relationships.meshery.io/v1beta3",
   "selectors": [
     {
       "allow": {


### PR DESCRIPTION


## fix(relationships): add AWS observability and misc relationship definitions

Adds new relationship definitions for AWS observability and miscellaneous controllers. All `mutatorRef`/`mutatedRef` directions and field paths have been verified against the actual ACK controller CRD specs.

### Changes

| File | From | To | Field Path | Status |
|------|------|----|------------|--------|
| `edge-non-binding-reference-alertmanagerdefinition-workspace.json` | AlertManagerDefinition | Workspace | `spec.workspaceID` | Tested in Kanvas |
| `edge-non-binding-reference-loggroup-key.json` | LogGroup | Key | `spec.kmsKeyID` | Tested in Kanvas |
| `edge-non-binding-reference-table-key.json` | Table | Key | `spec.sseSpecification.kmsMasterKeyID` | Tested in Kanvas |

## Testing

* **AlertManagerDefinition - Workspace** was tested and validated in Kanvas. Dragging `AlertManagerDefinition` and `Workspace` from `aws-prometheusservice-controller` and connecting them correctly auto-populates `spec.workspaceID`.
* **LogGroup - Key** and **Table - Key** were successfully validated in Kanvas since `aws-kms-controller` is present in the `models/` directory on this branch. Connecting them auto-populates `spec.kmsKeyID` and `spec.sseSpecification.kmsMasterKeyID` respectively.

## Related Issue

Addresses https://github.com/meshery/meshery/issues/17096

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added reference relationships connecting AWS KMS keys with CloudWatch Logs log groups.
  * Added reference relationships connecting AWS KMS keys with DynamoDB tables.
  * Added reference relationships connecting Prometheus workspaces with AlertManager definitions.
  * Enabled automatic propagation of referenced resource identifiers and display names across these integrations.
  * Improved configuration consistency when linking encryption keys, logging resources, monitoring workspaces, and alert-management settings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->