### PR TITLE
fix: guard empty page param and clean up orphaned connection mappings on environment delete

### DIFF
--- a/server/models/environment_persister.go
+++ b/server/models/environment_persister.go
@@ -125,8 +125,8 @@ func (ep *EnvironmentPersister) SaveEnvironment(environment *environment.Environ
 	return envJSON, nil
 }
 
-func (ep *EnvironmentPersister) DeleteEnvironment(environment *environment.Environment) ([]byte, error) {
-	err := ep.DB.Model(&environment).Find(&environment).Error
+func (ep *EnvironmentPersister) DeleteEnvironment(env *environment.Environment) ([]byte, error) {
+	err := ep.DB.Model(&env).Find(&env).Error
 	if err != nil {
 		if err == gorm.ErrRecordNotFound {
 			return nil, ErrResultNotFound(err)
@@ -136,18 +136,22 @@ func (ep *EnvironmentPersister) DeleteEnvironment(environment *environment.Envir
 	// Clean up connection mappings for this environment before deleting it,
 	// to avoid orphaned rows in environment_connection_mappings that would
 	// otherwise cause deleted environments to still appear (as blank tags)
-	// against connections that were assigned to them.
-	if err := ep.DB.Exec("DELETE FROM environment_connection_mappings WHERE environment_id = ?", environment.ID).Error; err != nil {
-		return nil, ErrDBDelete(err, ep.fetchUserDetails().ID.String())
-	}
-
-	err = ep.DB.Delete(environment).Error
+	// against connections that were assigned to them. Both deletes run in
+	// a single transaction so a failed environment delete cannot leave
+	// mappings already removed.
+	err = ep.DB.Transaction(func(tx *gorm.DB) error {
+		if err := tx.Where("environment_id = ?", env.ID).
+			Delete(&environment.EnvironmentConnectionMapping{}).Error; err != nil {
+			return err
+		}
+		return tx.Delete(env).Error
+	})
 	if err != nil {
 		return nil, ErrDBDelete(err, ep.fetchUserDetails().ID.String())
 	}
 
 	// Marshal the environment to JSON
-	envJSON, err := json.Marshal(environment)
+	envJSON, err := json.Marshal(env)
 	if err != nil {
 		return nil, err
 	}

--- a/server/models/environment_persister.go
+++ b/server/models/environment_persister.go
@@ -132,6 +132,15 @@ func (ep *EnvironmentPersister) DeleteEnvironment(environment *environment.Envir
 			return nil, ErrResultNotFound(err)
 		}
 	}
+
+	// Clean up connection mappings for this environment before deleting it,
+	// to avoid orphaned rows in environment_connection_mappings that would
+	// otherwise cause deleted environments to still appear (as blank tags)
+	// against connections that were assigned to them.
+	if err := ep.DB.Exec("DELETE FROM environment_connection_mappings WHERE environment_id = ?", environment.ID).Error; err != nil {
+		return nil, ErrDBDelete(err, ep.fetchUserDetails().ID.String())
+	}
+
 	err = ep.DB.Delete(environment).Error
 	if err != nil {
 		return nil, ErrDBDelete(err, ep.fetchUserDetails().ID.String())
@@ -284,6 +293,13 @@ func (ep *EnvironmentPersister) GetEnvironmentConnections(environmentID core.Uui
 
 	count := int64(0)
 	query.Count(&count)
+
+	if page == "" {
+		page = "0"
+	}
+	if pageSize == "" {
+		pageSize = "10"
+	}
 
 	var connectionsFetched []*connections.Connection
 	pageUint, err := strconv.ParseUint(page, 10, 32)


### PR DESCRIPTION
## Description

Two related backend issues found while testing the Environments feature — surfaced while verifying the fix in meshery/schemas#1045, which corrects the Environment card's "Assigned Connections" count so it refetches correctly after a connection is assigned or removed.

With that frontend fix in place, the Environment card began correctly triggering a refetch of connection data — which is what exposed these two backend issues that were previously masked by the stale-cache bug.

### Bug 1 — 500 error on empty `page` param

`GetEnvironmentConnections` in `server/models/environment_persister.go` calls `strconv.ParseUint(page, ...)` without first checking for an empty string, causing a 500 error whenever the endpoint is called without an explicit `page` parameter (which happens naturally from the frontend's Environment card count query). This meant that even with the frontend cache fix in place, the Environment card's count still failed to update — it just failed with a 500 instead of silently going stale.

### Bug 2 — Orphaned connection mappings after environment delete

`DeleteEnvironment` only deletes the environment row itself — it never cleans up matching rows in `environment_connection_mappings`. These orphaned rows continue to reference the now-deleted environment, causing the UI to render a blank, unlabeled tag chip against connections that were previously assigned to that environment.

Fixes #20628

## Fix

- Default `page`/`pageSize` to `"0"`/`"10"` when empty, matching the existing guard already used elsewhere in this file (`GetEnvironments`)
- Delete matching `environment_connection_mappings` rows before deleting the environment row in `DeleteEnvironment`

## Result

With this fix combined with meshery/schemas#1045, the full Environments assignment flow now works correctly end-to-end:
- Assigning a connection to an environment updates the "Assigned Connections" count immediately, with no manual refresh needed
- Deleting an environment cleanly removes its tag from previously assigned connections, with no orphaned blank chips left behind

### Before

[environment.webm](https://github.com/user-attachments/assets/1375157e-3add-4b6f-9a73-d7e088627145)


### After

[environment_sol.webm](https://github.com/user-attachments/assets/f9da48d2-3b51-4f97-b541-bfb6777e1b9e)


## Testing

Tested locally against a linked build of meshery/schemas#1045. Confirmed:
- `GetEnvironmentConnections` no longer 500s on an empty `page` param
- Assigning a connection to an environment now correctly updates the card's count in real time
- Deleting an environment now cleanly removes its tag from previously assigned connections, with no orphaned blank chips remaining

## Related

- meshery/schemas#1045

## Notes for Reviewers

This PR fixes #20628

## Signed commits

- [x] Yes, I signed my commits.