### PR TITLE
feat(relationships): add AWS EKS cluster relationship definitions

### DIFF
--- a/models/aws-eks-controller/v1.15.1/v1.0.0/relationships/edge-binding-firewall-cluster-securitygroup.json
+++ b/models/aws-eks-controller/v1.15.1/v1.0.0/relationships/edge-binding-firewall-cluster-securitygroup.json
@@ -1,0 +1,103 @@
+{
+  "id": "00000000-0000-0000-0000-000000000000",
+  "evaluationQuery": "",
+  "kind": "edge",
+  "metadata": {
+    "description": "Binds an EKS Cluster to an EC2 SecurityGroup for control plane security. The Cluster's resourcesVPCConfig.securityGroupRefs[0].from.name field is populated with the SecurityGroup name to control traffic to the Kubernetes API server endpoint.",
+    "isAnnotation": false,
+    "styles": {
+      "primaryColor": "",
+      "svgColor": "",
+      "svgWhite": ""
+    }
+  },
+  "model": {
+    "displayName": "",
+    "id": "00000000-0000-0000-0000-000000000000",
+    "model": {
+      "version": "v1.15.1"
+    },
+    "name": "aws-eks-controller",
+    "registrant": {
+      "kind": ""
+    },
+    "version": ""
+  },
+  "schemaVersion": "relationships.meshery.io/v1beta2",
+  "selectors": [
+    {
+      "allow": {
+        "from": [
+          {
+            "id": null,
+            "kind": "Cluster",
+            "match": {},
+            "match_strategy_matrix": null,
+            "model": {
+              "displayName": "",
+              "id": "00000000-0000-0000-0000-000000000000",
+              "model": {
+                "version": ""
+              },
+              "name": "aws-eks-controller",
+              "registrant": {
+                "kind": "github"
+              },
+              "version": ""
+            },
+            "patch": {
+              "patchStrategy": "replace",
+              "mutatedRef": [
+                [
+                  "configuration",
+                  "spec",
+                  "resourcesVPCConfig",
+                  "securityGroupRefs",
+                  "0",
+                  "from",
+                  "name"
+                ]
+              ]
+            }
+          }
+        ],
+        "to": [
+          {
+            "id": null,
+            "kind": "SecurityGroup",
+            "match": {},
+            "match_strategy_matrix": null,
+            "model": {
+              "displayName": "",
+              "id": "00000000-0000-0000-0000-000000000000",
+              "model": {
+                "version": ""
+              },
+              "name": "aws-ec2-controller",
+              "registrant": {
+                "kind": "github"
+              },
+              "version": ""
+            },
+            "patch": {
+              "patchStrategy": "replace",
+              "mutatorRef": [
+                [
+                  "displayName"
+                ]
+              ]
+            }
+          }
+        ]
+      },
+      "deny": {
+        "from": [],
+        "to": []
+      }
+    }
+  ],
+  "subType": "firewall",
+  "status": "enabled",
+  "type": "binding",
+  "version": "v1.0.0"
+}

--- a/models/aws-eks-controller/v1.15.1/v1.0.0/relationships/edge-binding-network-cluster-subnet.json
+++ b/models/aws-eks-controller/v1.15.1/v1.0.0/relationships/edge-binding-network-cluster-subnet.json
@@ -1,0 +1,103 @@
+{
+  "id": "00000000-0000-0000-0000-000000000000",
+  "evaluationQuery": "",
+  "kind": "edge",
+  "metadata": {
+    "description": "Binds an AWS EKS Cluster to a VPC Subnet to define the network subnets for Kubernetes control plane and node communication. The Cluster's resourcesVPCConfig.subnetIDs[0] field is populated with the Subnet id.",
+    "isAnnotation": false,
+    "styles": {
+      "primaryColor": "",
+      "svgColor": "",
+      "svgWhite": ""
+    }
+  },
+  "model": {
+    "displayName": "",
+    "id": "00000000-0000-0000-0000-000000000000",
+    "model": {
+      "version": "v1.15.1"
+    },
+    "name": "aws-eks-controller",
+    "registrant": {
+      "kind": ""
+    },
+    "version": ""
+  },
+  "schemaVersion": "relationships.meshery.io/v1beta2",
+  "selectors": [
+    {
+      "allow": {
+        "from": [
+          {
+            "id": null,
+            "kind": "Cluster",
+            "match": {},
+            "match_strategy_matrix": null,
+            "model": {
+              "displayName": "",
+              "id": "00000000-0000-0000-0000-000000000000",
+              "model": {
+                "version": ""
+              },
+              "name": "aws-eks-controller",
+              "registrant": {
+                "kind": "github"
+              },
+              "version": ""
+            },
+            "patch": {
+              "patchStrategy": "replace",
+              "mutatedRef": [
+                [
+                  "configuration",
+                  "spec",
+                  "resourcesVPCConfig",
+                  "subnetIDs",
+                  "0"
+                ]
+              ]
+            }
+          }
+        ],
+        "to": [
+          {
+            "id": null,
+            "kind": "Subnet",
+            "match": {},
+            "match_strategy_matrix": null,
+            "model": {
+              "displayName": "",
+              "id": "00000000-0000-0000-0000-000000000000",
+              "model": {
+                "version": ""
+              },
+              "name": "aws-ec2-controller",
+              "registrant": {
+                "kind": "github"
+              },
+              "version": ""
+            },
+            "patch": {
+              "patchStrategy": "replace",
+              "mutatorRef": [
+                [
+                  "configuration",
+                  "status",
+                  "id"
+                ]
+              ]
+            }
+          }
+        ]
+      },
+      "deny": {
+        "from": [],
+        "to": []
+      }
+    }
+  ],
+  "subType": "network",
+  "status": "enabled",
+  "type": "binding",
+  "version": "v1.0.0"
+}

--- a/models/aws-eks-controller/v1.15.1/v1.0.0/relationships/edge-binding-network-nodegroup-cluster.json
+++ b/models/aws-eks-controller/v1.15.1/v1.0.0/relationships/edge-binding-network-nodegroup-cluster.json
@@ -1,0 +1,103 @@
+{
+  "id": "00000000-0000-0000-0000-000000000000",
+  "evaluationQuery": "",
+  "kind": "edge",
+  "metadata": {
+    "description": "EKS Nodegroup to Cluster network binding. A Nodegroup references its parent Cluster via the clusterName field. This relationship represents the first link in the EKS compute stack: the cluster defines the control plane, and nodegroups provision the worker nodes within it.",
+    "isAnnotation": false,
+    "styles": {
+      "primaryColor": "",
+      "svgColor": "",
+      "svgWhite": ""
+    }
+  },
+  "model": {
+    "displayName": "",
+    "id": "00000000-0000-0000-0000-000000000000",
+    "model": {
+      "version": "v1.15.1"
+    },
+    "name": "aws-eks-controller",
+    "registrant": {
+      "kind": ""
+    },
+    "version": ""
+  },
+  "schemaVersion": "relationships.meshery.io/v1beta2",
+  "selectors": [
+    {
+      "allow": {
+        "from": [
+          {
+            "id": null,
+            "kind": "Nodegroup",
+            "match": {},
+            "match_strategy_matrix": null,
+            "model": {
+              "displayName": "",
+              "id": "00000000-0000-0000-0000-000000000000",
+              "model": {
+                "version": ""
+              },
+              "name": "aws-eks-controller",
+              "registrant": {
+                "kind": "github"
+              },
+              "version": ""
+            },
+            "patch": {
+              "patchStrategy": "replace",
+              "mutatedRef": [
+                [
+                  "configuration",
+                  "spec",
+                  "clusterRef",
+                  "from",
+                  "name"
+                ]
+              ]
+            }
+          }
+        ],
+        "to": [
+          {
+            "id": null,
+            "kind": "Cluster",
+            "match": {},
+            "match_strategy_matrix": null,
+            "model": {
+              "displayName": "",
+              "id": "00000000-0000-0000-0000-000000000000",
+              "model": {
+                "version": ""
+              },
+              "name": "aws-eks-controller",
+              "registrant": {
+                "kind": "github"
+              },
+              "version": ""
+            },
+            "patch": {
+              "patchStrategy": "replace",
+              "mutatorRef": [
+                [
+                  "configuration",
+                  "metadata",
+                  "name"
+                ]
+              ]
+            }
+          }
+        ]
+      },
+      "deny": {
+        "from": [],
+        "to": []
+      }
+    }
+  ],
+  "subType": "network",
+  "status": "enabled",
+  "type": "binding",
+  "version": "v1.0.0"
+}

--- a/models/aws-eks-controller/v1.15.1/v1.0.0/relationships/edge-binding-network-nodegroup-launchtemplate.json
+++ b/models/aws-eks-controller/v1.15.1/v1.0.0/relationships/edge-binding-network-nodegroup-launchtemplate.json
@@ -1,0 +1,102 @@
+{
+  "id": "00000000-0000-0000-0000-000000000000",
+  "evaluationQuery": "",
+  "kind": "edge",
+  "metadata": {
+    "description": "LaunchTemplate to EKS Nodegroup network binding. A Nodegroup references a LaunchTemplate by name to define the EC2 instance configuration (AMI, instance type, user data) for its worker nodes. This relationship represents the second link in the EKS compute stack.",
+    "isAnnotation": false,
+    "styles": {
+      "primaryColor": "",
+      "svgColor": "",
+      "svgWhite": ""
+    }
+  },
+  "model": {
+    "displayName": "",
+    "id": "00000000-0000-0000-0000-000000000000",
+    "model": {
+      "version": "v1.15.1"
+    },
+    "name": "aws-eks-controller",
+    "registrant": {
+      "kind": ""
+    },
+    "version": ""
+  },
+  "schemaVersion": "relationships.meshery.io/v1beta2",
+  "selectors": [
+    {
+      "allow": {
+        "from": [
+          {
+            "id": null,
+            "kind": "Nodegroup",
+            "match": {},
+            "match_strategy_matrix": null,
+            "model": {
+              "displayName": "",
+              "id": "00000000-0000-0000-0000-000000000000",
+              "model": {
+                "version": ""
+              },
+              "name": "aws-eks-controller",
+              "registrant": {
+                "kind": "github"
+              },
+              "version": ""
+            },
+            "patch": {
+              "patchStrategy": "replace",
+              "mutatedRef": [
+                [
+                  "configuration",
+                  "spec",
+                  "launchTemplate",
+                  "name"
+                ]
+              ]
+            }
+          }
+        ],
+        "to": [
+          {
+            "id": null,
+            "kind": "LaunchTemplate",
+            "match": {},
+            "match_strategy_matrix": null,
+            "model": {
+              "displayName": "",
+              "id": "00000000-0000-0000-0000-000000000000",
+              "model": {
+                "version": ""
+              },
+              "name": "aws-ec2-controller",
+              "registrant": {
+                "kind": "github"
+              },
+              "version": ""
+            },
+            "patch": {
+              "patchStrategy": "replace",
+              "mutatorRef": [
+                [
+                  "configuration",
+                  "metadata",
+                  "name"
+                ]
+              ]
+            }
+          }
+        ]
+      },
+      "deny": {
+        "from": [],
+        "to": []
+      }
+    }
+  ],
+  "subType": "network",
+  "status": "enabled",
+  "type": "binding",
+  "version": "v1.0.0"
+}

--- a/models/aws-eks-controller/v1.15.1/v1.0.0/relationships/edge-binding-network-nodegroup-subnet.json
+++ b/models/aws-eks-controller/v1.15.1/v1.0.0/relationships/edge-binding-network-nodegroup-subnet.json
@@ -1,0 +1,102 @@
+{
+  "id": "00000000-0000-0000-0000-000000000000",
+  "evaluationQuery": "",
+  "kind": "edge",
+  "metadata": {
+    "description": "Binds an EKS Nodegroup to a VPC Subnet for worker node placement. The Nodegroup's subnetRefs[0].from.name field is populated with the Subnet name to determine which AZs worker nodes are launched in.",
+    "isAnnotation": false,
+    "styles": {
+      "primaryColor": "",
+      "svgColor": "",
+      "svgWhite": ""
+    }
+  },
+  "model": {
+    "displayName": "",
+    "id": "00000000-0000-0000-0000-000000000000",
+    "model": {
+      "version": "v1.15.1"
+    },
+    "name": "aws-eks-controller",
+    "registrant": {
+      "kind": ""
+    },
+    "version": ""
+  },
+  "schemaVersion": "relationships.meshery.io/v1beta2",
+  "selectors": [
+    {
+      "allow": {
+        "from": [
+          {
+            "id": null,
+            "kind": "Nodegroup",
+            "match": {},
+            "match_strategy_matrix": null,
+            "model": {
+              "displayName": "",
+              "id": "00000000-0000-0000-0000-000000000000",
+              "model": {
+                "version": ""
+              },
+              "name": "aws-eks-controller",
+              "registrant": {
+                "kind": "github"
+              },
+              "version": ""
+            },
+            "patch": {
+              "patchStrategy": "replace",
+              "mutatedRef": [
+                [
+                  "configuration",
+                  "spec",
+                  "subnetRefs",
+                  "0",
+                  "from",
+                  "name"
+                ]
+              ]
+            }
+          }
+        ],
+        "to": [
+          {
+            "id": null,
+            "kind": "Subnet",
+            "match": {},
+            "match_strategy_matrix": null,
+            "model": {
+              "displayName": "",
+              "id": "00000000-0000-0000-0000-000000000000",
+              "model": {
+                "version": ""
+              },
+              "name": "aws-ec2-controller",
+              "registrant": {
+                "kind": "github"
+              },
+              "version": ""
+            },
+            "patch": {
+              "patchStrategy": "replace",
+              "mutatorRef": [
+                [
+                  "displayName"
+                ]
+              ]
+            }
+          }
+        ]
+      },
+      "deny": {
+        "from": [],
+        "to": []
+      }
+    }
+  ],
+  "subType": "network",
+  "status": "enabled",
+  "type": "binding",
+  "version": "v1.0.0"
+}

--- a/models/aws-eks-controller/v1.15.1/v1.0.0/relationships/edge-binding-permission-eks-sa-iam-role.json
+++ b/models/aws-eks-controller/v1.15.1/v1.0.0/relationships/edge-binding-permission-eks-sa-iam-role.json
@@ -1,0 +1,103 @@
+{
+  "id": "00000000-0000-0000-0000-000000000000",
+  "evaluationQuery": "",
+  "kind": "edge",
+  "metadata": {
+    "description": "Binds a Kubernetes ServiceAccount to an AWS IAM Role for AWS permissions.",
+    "isAnnotation": false,
+    "styles": {
+      "primaryColor": "",
+      "svgColor": "",
+      "svgWhite": ""
+    }
+  },
+  "model": {
+    "displayName": "",
+    "id": "00000000-0000-0000-0000-000000000000",
+    "model": {
+      "version": "v1.15.1"
+    },
+    "name": "aws-eks-controller",
+    "registrant": {
+      "kind": ""
+    },
+    "version": ""
+  },
+  "schemaVersion": "relationships.meshery.io/v1beta2",
+  "selectors": [
+    {
+      "allow": {
+        "from": [
+          {
+            "id": null,
+            "kind": "ServiceAccount",
+            "match": {},
+            "match_strategy_matrix": null,
+            "model": {
+              "displayName": "",
+              "id": "00000000-0000-0000-0000-000000000000",
+              "model": {
+                "version": ""
+              },
+              "name": "kubernetes",
+              "registrant": {
+                "kind": "github"
+              },
+              "version": ""
+            },
+            "patch": {
+              "patchStrategy": "replace",
+              "mutatedRef": [
+                [
+                  "configuration",
+                  "metadata",
+                  "annotations",
+                  "eks.amazonaws.com/role-arn"
+                ]
+              ]
+            }
+          }
+        ],
+        "to": [
+          {
+            "id": null,
+            "kind": "Role",
+            "match": {},
+            "match_strategy_matrix": null,
+            "model": {
+              "displayName": "",
+              "id": "00000000-0000-0000-0000-000000000000",
+              "model": {
+                "version": ""
+              },
+              "name": "aws-iam-controller",
+              "registrant": {
+                "kind": "github"
+              },
+              "version": ""
+            },
+            "patch": {
+              "patchStrategy": "replace",
+              "mutatorRef": [
+                [
+                  "configuration",
+                  "status",
+                  "ackResourceMetadata",
+                  "arn"
+                ]
+              ]
+            }
+          }
+        ]
+      },
+      "deny": {
+        "from": [],
+        "to": []
+      }
+    }
+  ],
+  "subType": "permission",
+  "status": "enabled",
+  "type": "binding",
+  "version": "v1.0.0"
+}

--- a/models/aws-eks-controller/v1.15.1/v1.0.0/relationships/edge-binding-permission-nodegroup-role.json
+++ b/models/aws-eks-controller/v1.15.1/v1.0.0/relationships/edge-binding-permission-nodegroup-role.json
@@ -1,0 +1,101 @@
+{
+  "id": "00000000-0000-0000-0000-000000000000",
+  "evaluationQuery": "",
+  "kind": "edge",
+  "metadata": {
+    "description": "Binds an EKS Nodegroup to an IAM Role for node instance permissions. The Nodegroup's nodeRoleRef.from.name field is populated with the IAM Role name to grant worker nodes permission to make AWS API calls via the node instance profile.",
+    "isAnnotation": false,
+    "styles": {
+      "primaryColor": "",
+      "svgColor": "",
+      "svgWhite": ""
+    }
+  },
+  "model": {
+    "displayName": "",
+    "id": "00000000-0000-0000-0000-000000000000",
+    "model": {
+      "version": "v1.15.1"
+    },
+    "name": "aws-eks-controller",
+    "registrant": {
+      "kind": ""
+    },
+    "version": ""
+  },
+  "schemaVersion": "relationships.meshery.io/v1beta2",
+  "selectors": [
+    {
+      "allow": {
+        "from": [
+          {
+            "id": null,
+            "kind": "Nodegroup",
+            "match": {},
+            "match_strategy_matrix": null,
+            "model": {
+              "displayName": "",
+              "id": "00000000-0000-0000-0000-000000000000",
+              "model": {
+                "version": ""
+              },
+              "name": "aws-eks-controller",
+              "registrant": {
+                "kind": "github"
+              },
+              "version": ""
+            },
+            "patch": {
+              "patchStrategy": "replace",
+              "mutatedRef": [
+                [
+                  "configuration",
+                  "spec",
+                  "nodeRoleRef",
+                  "from",
+                  "name"
+                ]
+              ]
+            }
+          }
+        ],
+        "to": [
+          {
+            "id": null,
+            "kind": "Role",
+            "match": {},
+            "match_strategy_matrix": null,
+            "model": {
+              "displayName": "",
+              "id": "00000000-0000-0000-0000-000000000000",
+              "model": {
+                "version": ""
+              },
+              "name": "aws-iam-controller",
+              "registrant": {
+                "kind": "github"
+              },
+              "version": ""
+            },
+            "patch": {
+              "patchStrategy": "replace",
+              "mutatorRef": [
+                [
+                  "displayName"
+                ]
+              ]
+            }
+          }
+        ]
+      },
+      "deny": {
+        "from": [],
+        "to": []
+      }
+    }
+  ],
+  "subType": "permission",
+  "status": "enabled",
+  "type": "binding",
+  "version": "v1.0.0"
+}

--- a/models/aws-eks-controller/v1.15.1/v1.0.0/relationships/edge-binding-permission-sdhny.json
+++ b/models/aws-eks-controller/v1.15.1/v1.0.0/relationships/edge-binding-permission-sdhny.json
@@ -1,0 +1,101 @@
+{
+  "id": "00000000-0000-0000-0000-000000000000",
+  "evaluationQuery": "",
+  "kind": "edge",
+  "metadata": {
+    "description": "Binds EFS FileSystem replication role to IAM Role.",
+    "isAnnotation": false,
+    "styles": {
+      "primaryColor": "",
+      "svgColor": "",
+      "svgWhite": ""
+    }
+  },
+  "model": {
+    "displayName": "",
+    "id": "00000000-0000-0000-0000-000000000000",
+    "model": {
+      "version": "v1.15.1"
+    },
+    "name": "aws-eks-controller",
+    "registrant": {
+      "kind": ""
+    },
+    "version": ""
+  },
+  "schemaVersion": "relationships.meshery.io/v1beta2",
+  "selectors": [
+    {
+      "allow": {
+        "from": [
+          {
+            "id": null,
+            "kind": "FileSystem",
+            "match": {},
+            "match_strategy_matrix": null,
+            "model": {
+              "displayName": "",
+              "id": "00000000-0000-0000-0000-000000000000",
+              "model": {
+                "version": ""
+              },
+              "name": "aws-efs-controller",
+              "registrant": {
+                "kind": "github"
+              },
+              "version": ""
+            },
+            "patch": {
+              "patchStrategy": "replace",
+              "mutatedRef": [
+                [
+                  "configuration",
+                  "spec",
+                  "roleRef",
+                  "from",
+                  "name"
+                ]
+              ]
+            }
+          }
+        ],
+        "to": [
+          {
+            "id": null,
+            "kind": "Role",
+            "match": {},
+            "match_strategy_matrix": null,
+            "model": {
+              "displayName": "",
+              "id": "00000000-0000-0000-0000-000000000000",
+              "model": {
+                "version": ""
+              },
+              "name": "aws-iam-controller",
+              "registrant": {
+                "kind": "github"
+              },
+              "version": ""
+            },
+            "patch": {
+              "patchStrategy": "replace",
+              "mutatorRef": [
+                [
+                  "displayName"
+                ]
+              ]
+            }
+          }
+        ]
+      },
+      "deny": {
+        "from": [],
+        "to": []
+      }
+    }
+  ],
+  "subType": "permission",
+  "status": "enabled",
+  "type": "binding",
+  "version": "v1.0.0"
+}

--- a/models/aws-eks-controller/v1.15.1/v1.0.0/relationships/edge-non-binding-firewall-cluster-securitygroup.json
+++ b/models/aws-eks-controller/v1.15.1/v1.0.0/relationships/edge-non-binding-firewall-cluster-securitygroup.json
@@ -23,7 +23,7 @@
     },
     "version": ""
   },
-  "schemaVersion": "relationships.meshery.io/v1beta2",
+  "schemaVersion": "relationships.meshery.io/v1beta3",
   "selectors": [
     {
       "allow": {

--- a/models/aws-eks-controller/v1.15.1/v1.0.0/relationships/edge-non-binding-firewall-cluster-securitygroup.json
+++ b/models/aws-eks-controller/v1.15.1/v1.0.0/relationships/edge-non-binding-firewall-cluster-securitygroup.json
@@ -98,6 +98,6 @@
   ],
   "subType": "firewall",
   "status": "enabled",
-  "type": "binding",
+  "type": "non-binding",
   "version": "v1.0.0"
 }

--- a/models/aws-eks-controller/v1.15.1/v1.0.0/relationships/edge-non-binding-network-cluster-subnet.json
+++ b/models/aws-eks-controller/v1.15.1/v1.0.0/relationships/edge-non-binding-network-cluster-subnet.json
@@ -23,7 +23,7 @@
     },
     "version": ""
   },
-  "schemaVersion": "relationships.meshery.io/v1beta2",
+  "schemaVersion": "relationships.meshery.io/v1beta3",
   "selectors": [
     {
       "allow": {

--- a/models/aws-eks-controller/v1.15.1/v1.0.0/relationships/edge-non-binding-network-cluster-subnet.json
+++ b/models/aws-eks-controller/v1.15.1/v1.0.0/relationships/edge-non-binding-network-cluster-subnet.json
@@ -3,7 +3,7 @@
   "evaluationQuery": "",
   "kind": "edge",
   "metadata": {
-    "description": "Binds an EKS Nodegroup to a VPC Subnet for worker node placement. The Nodegroup's subnetRefs[0].from.name field is populated with the Subnet name to determine which AZs worker nodes are launched in.",
+    "description": "Binds an AWS EKS Cluster to a VPC Subnet to define the network subnets for Kubernetes control plane and node communication. The Cluster's resourcesVPCConfig.subnetIDs[0] field is populated with the Subnet id.",
     "isAnnotation": false,
     "styles": {
       "primaryColor": "",
@@ -30,7 +30,7 @@
         "from": [
           {
             "id": null,
-            "kind": "Nodegroup",
+            "kind": "Cluster",
             "match": {},
             "match_strategy_matrix": null,
             "model": {
@@ -51,10 +51,9 @@
                 [
                   "configuration",
                   "spec",
-                  "subnetRefs",
-                  "0",
-                  "from",
-                  "name"
+                  "resourcesVPCConfig",
+                  "subnetIDs",
+                  "0"
                 ]
               ]
             }
@@ -82,7 +81,9 @@
               "patchStrategy": "replace",
               "mutatorRef": [
                 [
-                  "displayName"
+                  "configuration",
+                  "status",
+                  "id"
                 ]
               ]
             }
@@ -97,6 +98,6 @@
   ],
   "subType": "network",
   "status": "enabled",
-  "type": "binding",
+  "type": "non-binding",
   "version": "v1.0.0"
 }

--- a/models/aws-eks-controller/v1.15.1/v1.0.0/relationships/edge-non-binding-network-nodegroup-cluster.json
+++ b/models/aws-eks-controller/v1.15.1/v1.0.0/relationships/edge-non-binding-network-nodegroup-cluster.json
@@ -3,7 +3,7 @@
   "evaluationQuery": "",
   "kind": "edge",
   "metadata": {
-    "description": "Binds an EKS Nodegroup to an IAM Role for node instance permissions. The Nodegroup's nodeRoleRef.from.name field is populated with the IAM Role name to grant worker nodes permission to make AWS API calls via the node instance profile.",
+    "description": "EKS Nodegroup to Cluster network binding. A Nodegroup references its parent Cluster via the clusterName field. This relationship represents the first link in the EKS compute stack: the cluster defines the control plane, and nodegroups provision the worker nodes within it.",
     "isAnnotation": false,
     "styles": {
       "primaryColor": "",
@@ -51,7 +51,7 @@
                 [
                   "configuration",
                   "spec",
-                  "nodeRoleRef",
+                  "clusterRef",
                   "from",
                   "name"
                 ]
@@ -62,7 +62,7 @@
         "to": [
           {
             "id": null,
-            "kind": "Role",
+            "kind": "Cluster",
             "match": {},
             "match_strategy_matrix": null,
             "model": {
@@ -71,7 +71,7 @@
               "model": {
                 "version": ""
               },
-              "name": "aws-iam-controller",
+              "name": "aws-eks-controller",
               "registrant": {
                 "kind": "github"
               },
@@ -81,7 +81,9 @@
               "patchStrategy": "replace",
               "mutatorRef": [
                 [
-                  "displayName"
+                  "configuration",
+                  "metadata",
+                  "name"
                 ]
               ]
             }
@@ -94,8 +96,8 @@
       }
     }
   ],
-  "subType": "permission",
+  "subType": "network",
   "status": "enabled",
-  "type": "binding",
+  "type": "non-binding",
   "version": "v1.0.0"
 }

--- a/models/aws-eks-controller/v1.15.1/v1.0.0/relationships/edge-non-binding-network-nodegroup-cluster.json
+++ b/models/aws-eks-controller/v1.15.1/v1.0.0/relationships/edge-non-binding-network-nodegroup-cluster.json
@@ -23,7 +23,7 @@
     },
     "version": ""
   },
-  "schemaVersion": "relationships.meshery.io/v1beta2",
+  "schemaVersion": "relationships.meshery.io/v1beta3",
   "selectors": [
     {
       "allow": {

--- a/models/aws-eks-controller/v1.15.1/v1.0.0/relationships/edge-non-binding-network-nodegroup-launchtemplate.json
+++ b/models/aws-eks-controller/v1.15.1/v1.0.0/relationships/edge-non-binding-network-nodegroup-launchtemplate.json
@@ -3,7 +3,7 @@
   "evaluationQuery": "",
   "kind": "edge",
   "metadata": {
-    "description": "Binds an AWS EKS Cluster to a VPC Subnet to define the network subnets for Kubernetes control plane and node communication. The Cluster's resourcesVPCConfig.subnetIDs[0] field is populated with the Subnet id.",
+    "description": "LaunchTemplate to EKS Nodegroup network binding. A Nodegroup references a LaunchTemplate by name to define the EC2 instance configuration (AMI, instance type, user data) for its worker nodes. This relationship represents the second link in the EKS compute stack.",
     "isAnnotation": false,
     "styles": {
       "primaryColor": "",
@@ -30,7 +30,7 @@
         "from": [
           {
             "id": null,
-            "kind": "Cluster",
+            "kind": "Nodegroup",
             "match": {},
             "match_strategy_matrix": null,
             "model": {
@@ -51,9 +51,8 @@
                 [
                   "configuration",
                   "spec",
-                  "resourcesVPCConfig",
-                  "subnetIDs",
-                  "0"
+                  "launchTemplate",
+                  "name"
                 ]
               ]
             }
@@ -62,7 +61,7 @@
         "to": [
           {
             "id": null,
-            "kind": "Subnet",
+            "kind": "LaunchTemplate",
             "match": {},
             "match_strategy_matrix": null,
             "model": {
@@ -82,8 +81,8 @@
               "mutatorRef": [
                 [
                   "configuration",
-                  "status",
-                  "id"
+                  "metadata",
+                  "name"
                 ]
               ]
             }
@@ -98,6 +97,6 @@
   ],
   "subType": "network",
   "status": "enabled",
-  "type": "binding",
+  "type": "non-binding",
   "version": "v1.0.0"
 }

--- a/models/aws-eks-controller/v1.15.1/v1.0.0/relationships/edge-non-binding-network-nodegroup-launchtemplate.json
+++ b/models/aws-eks-controller/v1.15.1/v1.0.0/relationships/edge-non-binding-network-nodegroup-launchtemplate.json
@@ -23,7 +23,7 @@
     },
     "version": ""
   },
-  "schemaVersion": "relationships.meshery.io/v1beta2",
+  "schemaVersion": "relationships.meshery.io/v1beta3",
   "selectors": [
     {
       "allow": {

--- a/models/aws-eks-controller/v1.15.1/v1.0.0/relationships/edge-non-binding-network-nodegroup-subnet.json
+++ b/models/aws-eks-controller/v1.15.1/v1.0.0/relationships/edge-non-binding-network-nodegroup-subnet.json
@@ -23,7 +23,7 @@
     },
     "version": ""
   },
-  "schemaVersion": "relationships.meshery.io/v1beta2",
+  "schemaVersion": "relationships.meshery.io/v1beta3",
   "selectors": [
     {
       "allow": {

--- a/models/aws-eks-controller/v1.15.1/v1.0.0/relationships/edge-non-binding-network-nodegroup-subnet.json
+++ b/models/aws-eks-controller/v1.15.1/v1.0.0/relationships/edge-non-binding-network-nodegroup-subnet.json
@@ -3,7 +3,7 @@
   "evaluationQuery": "",
   "kind": "edge",
   "metadata": {
-    "description": "Binds EFS FileSystem replication role to IAM Role.",
+    "description": "Binds an EKS Nodegroup to a VPC Subnet for worker node placement. The Nodegroup's subnetRefs[0].from.name field is populated with the Subnet name to determine which AZs worker nodes are launched in.",
     "isAnnotation": false,
     "styles": {
       "primaryColor": "",
@@ -30,7 +30,7 @@
         "from": [
           {
             "id": null,
-            "kind": "FileSystem",
+            "kind": "Nodegroup",
             "match": {},
             "match_strategy_matrix": null,
             "model": {
@@ -39,7 +39,7 @@
               "model": {
                 "version": ""
               },
-              "name": "aws-efs-controller",
+              "name": "aws-eks-controller",
               "registrant": {
                 "kind": "github"
               },
@@ -51,7 +51,8 @@
                 [
                   "configuration",
                   "spec",
-                  "roleRef",
+                  "subnetRefs",
+                  "0",
                   "from",
                   "name"
                 ]
@@ -62,7 +63,7 @@
         "to": [
           {
             "id": null,
-            "kind": "Role",
+            "kind": "Subnet",
             "match": {},
             "match_strategy_matrix": null,
             "model": {
@@ -71,7 +72,7 @@
               "model": {
                 "version": ""
               },
-              "name": "aws-iam-controller",
+              "name": "aws-ec2-controller",
               "registrant": {
                 "kind": "github"
               },
@@ -94,8 +95,8 @@
       }
     }
   ],
-  "subType": "permission",
+  "subType": "network",
   "status": "enabled",
-  "type": "binding",
+  "type": "non-binding",
   "version": "v1.0.0"
 }

--- a/models/aws-eks-controller/v1.15.1/v1.0.0/relationships/edge-non-binding-permission-eks-sa-iam-role.json
+++ b/models/aws-eks-controller/v1.15.1/v1.0.0/relationships/edge-non-binding-permission-eks-sa-iam-role.json
@@ -3,7 +3,7 @@
   "evaluationQuery": "",
   "kind": "edge",
   "metadata": {
-    "description": "LaunchTemplate to EKS Nodegroup network binding. A Nodegroup references a LaunchTemplate by name to define the EC2 instance configuration (AMI, instance type, user data) for its worker nodes. This relationship represents the second link in the EKS compute stack.",
+    "description": "Binds a Kubernetes ServiceAccount to an AWS IAM Role for AWS permissions.",
     "isAnnotation": false,
     "styles": {
       "primaryColor": "",
@@ -30,7 +30,7 @@
         "from": [
           {
             "id": null,
-            "kind": "Nodegroup",
+            "kind": "ServiceAccount",
             "match": {},
             "match_strategy_matrix": null,
             "model": {
@@ -39,7 +39,7 @@
               "model": {
                 "version": ""
               },
-              "name": "aws-eks-controller",
+              "name": "kubernetes",
               "registrant": {
                 "kind": "github"
               },
@@ -50,9 +50,9 @@
               "mutatedRef": [
                 [
                   "configuration",
-                  "spec",
-                  "launchTemplate",
-                  "name"
+                  "metadata",
+                  "annotations",
+                  "eks.amazonaws.com/role-arn"
                 ]
               ]
             }
@@ -61,7 +61,7 @@
         "to": [
           {
             "id": null,
-            "kind": "LaunchTemplate",
+            "kind": "Role",
             "match": {},
             "match_strategy_matrix": null,
             "model": {
@@ -70,7 +70,7 @@
               "model": {
                 "version": ""
               },
-              "name": "aws-ec2-controller",
+              "name": "aws-iam-controller",
               "registrant": {
                 "kind": "github"
               },
@@ -81,8 +81,9 @@
               "mutatorRef": [
                 [
                   "configuration",
-                  "metadata",
-                  "name"
+                  "status",
+                  "ackResourceMetadata",
+                  "arn"
                 ]
               ]
             }
@@ -95,8 +96,8 @@
       }
     }
   ],
-  "subType": "network",
+  "subType": "permission",
   "status": "enabled",
-  "type": "binding",
+  "type": "non-binding",
   "version": "v1.0.0"
 }

--- a/models/aws-eks-controller/v1.15.1/v1.0.0/relationships/edge-non-binding-permission-eks-sa-iam-role.json
+++ b/models/aws-eks-controller/v1.15.1/v1.0.0/relationships/edge-non-binding-permission-eks-sa-iam-role.json
@@ -23,7 +23,7 @@
     },
     "version": ""
   },
-  "schemaVersion": "relationships.meshery.io/v1beta2",
+  "schemaVersion": "relationships.meshery.io/v1beta3",
   "selectors": [
     {
       "allow": {

--- a/models/aws-eks-controller/v1.15.1/v1.0.0/relationships/edge-non-binding-permission-nodegroup-role.json
+++ b/models/aws-eks-controller/v1.15.1/v1.0.0/relationships/edge-non-binding-permission-nodegroup-role.json
@@ -3,7 +3,7 @@
   "evaluationQuery": "",
   "kind": "edge",
   "metadata": {
-    "description": "EKS Nodegroup to Cluster network binding. A Nodegroup references its parent Cluster via the clusterName field. This relationship represents the first link in the EKS compute stack: the cluster defines the control plane, and nodegroups provision the worker nodes within it.",
+    "description": "Binds an EKS Nodegroup to an IAM Role for node instance permissions. The Nodegroup's nodeRoleRef.from.name field is populated with the IAM Role name to grant worker nodes permission to make AWS API calls via the node instance profile.",
     "isAnnotation": false,
     "styles": {
       "primaryColor": "",
@@ -51,7 +51,7 @@
                 [
                   "configuration",
                   "spec",
-                  "clusterRef",
+                  "nodeRoleRef",
                   "from",
                   "name"
                 ]
@@ -62,7 +62,7 @@
         "to": [
           {
             "id": null,
-            "kind": "Cluster",
+            "kind": "Role",
             "match": {},
             "match_strategy_matrix": null,
             "model": {
@@ -71,7 +71,7 @@
               "model": {
                 "version": ""
               },
-              "name": "aws-eks-controller",
+              "name": "aws-iam-controller",
               "registrant": {
                 "kind": "github"
               },
@@ -81,9 +81,7 @@
               "patchStrategy": "replace",
               "mutatorRef": [
                 [
-                  "configuration",
-                  "metadata",
-                  "name"
+                  "displayName"
                 ]
               ]
             }
@@ -96,8 +94,8 @@
       }
     }
   ],
-  "subType": "network",
+  "subType": "permission",
   "status": "enabled",
-  "type": "binding",
+  "type": "non-binding",
   "version": "v1.0.0"
 }

--- a/models/aws-eks-controller/v1.15.1/v1.0.0/relationships/edge-non-binding-permission-nodegroup-role.json
+++ b/models/aws-eks-controller/v1.15.1/v1.0.0/relationships/edge-non-binding-permission-nodegroup-role.json
@@ -23,7 +23,7 @@
     },
     "version": ""
   },
-  "schemaVersion": "relationships.meshery.io/v1beta2",
+  "schemaVersion": "relationships.meshery.io/v1beta3",
   "selectors": [
     {
       "allow": {

--- a/models/aws-eks-controller/v1.15.1/v1.0.0/relationships/edge-non-binding-permission-sdhny.json
+++ b/models/aws-eks-controller/v1.15.1/v1.0.0/relationships/edge-non-binding-permission-sdhny.json
@@ -3,7 +3,7 @@
   "evaluationQuery": "",
   "kind": "edge",
   "metadata": {
-    "description": "Binds a Kubernetes ServiceAccount to an AWS IAM Role for AWS permissions.",
+    "description": "Binds EFS FileSystem replication role to IAM Role.",
     "isAnnotation": false,
     "styles": {
       "primaryColor": "",
@@ -30,7 +30,7 @@
         "from": [
           {
             "id": null,
-            "kind": "ServiceAccount",
+            "kind": "FileSystem",
             "match": {},
             "match_strategy_matrix": null,
             "model": {
@@ -39,7 +39,7 @@
               "model": {
                 "version": ""
               },
-              "name": "kubernetes",
+              "name": "aws-efs-controller",
               "registrant": {
                 "kind": "github"
               },
@@ -50,9 +50,10 @@
               "mutatedRef": [
                 [
                   "configuration",
-                  "metadata",
-                  "annotations",
-                  "eks.amazonaws.com/role-arn"
+                  "spec",
+                  "roleRef",
+                  "from",
+                  "name"
                 ]
               ]
             }
@@ -80,10 +81,7 @@
               "patchStrategy": "replace",
               "mutatorRef": [
                 [
-                  "configuration",
-                  "status",
-                  "ackResourceMetadata",
-                  "arn"
+                  "displayName"
                 ]
               ]
             }
@@ -98,6 +96,6 @@
   ],
   "subType": "permission",
   "status": "enabled",
-  "type": "binding",
+  "type": "non-binding",
   "version": "v1.0.0"
 }

--- a/models/aws-eks-controller/v1.15.1/v1.0.0/relationships/edge-non-binding-permission-sdhny.json
+++ b/models/aws-eks-controller/v1.15.1/v1.0.0/relationships/edge-non-binding-permission-sdhny.json
@@ -23,7 +23,7 @@
     },
     "version": ""
   },
-  "schemaVersion": "relationships.meshery.io/v1beta2",
+  "schemaVersion": "relationships.meshery.io/v1beta3",
   "selectors": [
     {
       "allow": {

--- a/models/aws-eks-controller/v1.15.1/v1.0.0/relationships/edge-non-binding-reference-accessentry-cluster.json
+++ b/models/aws-eks-controller/v1.15.1/v1.0.0/relationships/edge-non-binding-reference-accessentry-cluster.json
@@ -1,0 +1,99 @@
+{
+  "id": "00000000-0000-0000-0000-000000000000",
+  "evaluationQuery": "",
+  "kind": "edge",
+  "metadata": {
+    "description": "References an EKS Cluster from an AccessEntry via spec.clusterName.",
+    "isAnnotation": false,
+    "styles": {
+      "primaryColor": "",
+      "svgColor": "",
+      "svgWhite": ""
+    }
+  },
+  "model": {
+    "displayName": "",
+    "id": "00000000-0000-0000-0000-000000000000",
+    "model": {
+      "version": "v1.15.1"
+    },
+    "name": "aws-eks-controller",
+    "registrant": {
+      "kind": ""
+    },
+    "version": ""
+  },
+  "schemaVersion": "relationships.meshery.io/v1beta2",
+  "selectors": [
+    {
+      "allow": {
+        "from": [
+          {
+            "id": null,
+            "kind": "AccessEntry",
+            "match": {},
+            "match_strategy_matrix": null,
+            "model": {
+              "displayName": "",
+              "id": "00000000-0000-0000-0000-000000000000",
+              "model": {
+                "version": "v1.15.1"
+              },
+              "name": "aws-eks-controller",
+              "registrant": {
+                "kind": "github"
+              },
+              "version": ""
+            },
+            "patch": {
+              "patchStrategy": "replace",
+              "mutatedRef": [
+                [
+                  "configuration",
+                  "spec",
+                  "clusterName"
+                ]
+              ]
+            }
+          }
+        ],
+        "to": [
+          {
+            "id": null,
+            "kind": "Cluster",
+            "match": {},
+            "match_strategy_matrix": null,
+            "model": {
+              "displayName": "",
+              "id": "00000000-0000-0000-0000-000000000000",
+              "model": {
+                "version": "v1.15.1"
+              },
+              "name": "aws-eks-controller",
+              "registrant": {
+                "kind": "github"
+              },
+              "version": ""
+            },
+            "patch": {
+              "patchStrategy": "replace",
+              "mutatorRef": [
+                [
+                  "displayName"
+                ]
+              ]
+            }
+          }
+        ]
+      },
+      "deny": {
+        "from": [],
+        "to": []
+      }
+    }
+  ],
+  "subType": "reference",
+  "status": "enabled",
+  "type": "non-binding",
+  "version": "v1.0.0"
+}

--- a/models/aws-eks-controller/v1.15.1/v1.0.0/relationships/edge-non-binding-reference-accessentry-cluster.json
+++ b/models/aws-eks-controller/v1.15.1/v1.0.0/relationships/edge-non-binding-reference-accessentry-cluster.json
@@ -23,7 +23,7 @@
     },
     "version": ""
   },
-  "schemaVersion": "relationships.meshery.io/v1beta2",
+  "schemaVersion": "relationships.meshery.io/v1beta3",
   "selectors": [
     {
       "allow": {

--- a/models/aws-eks-controller/v1.15.1/v1.0.0/relationships/edge-non-binding-reference-capability-cluster.json
+++ b/models/aws-eks-controller/v1.15.1/v1.0.0/relationships/edge-non-binding-reference-capability-cluster.json
@@ -1,0 +1,99 @@
+{
+  "id": "00000000-0000-0000-0000-000000000000",
+  "evaluationQuery": "",
+  "kind": "edge",
+  "metadata": {
+    "description": "References an EKS Cluster from a Capability via spec.clusterName.",
+    "isAnnotation": false,
+    "styles": {
+      "primaryColor": "",
+      "svgColor": "",
+      "svgWhite": ""
+    }
+  },
+  "model": {
+    "displayName": "",
+    "id": "00000000-0000-0000-0000-000000000000",
+    "model": {
+      "version": "v1.15.1"
+    },
+    "name": "aws-eks-controller",
+    "registrant": {
+      "kind": ""
+    },
+    "version": ""
+  },
+  "schemaVersion": "relationships.meshery.io/v1beta2",
+  "selectors": [
+    {
+      "allow": {
+        "from": [
+          {
+            "id": null,
+            "kind": "Capability",
+            "match": {},
+            "match_strategy_matrix": null,
+            "model": {
+              "displayName": "",
+              "id": "00000000-0000-0000-0000-000000000000",
+              "model": {
+                "version": "v1.15.1"
+              },
+              "name": "aws-eks-controller",
+              "registrant": {
+                "kind": "github"
+              },
+              "version": ""
+            },
+            "patch": {
+              "patchStrategy": "replace",
+              "mutatedRef": [
+                [
+                  "configuration",
+                  "spec",
+                  "clusterName"
+                ]
+              ]
+            }
+          }
+        ],
+        "to": [
+          {
+            "id": null,
+            "kind": "Cluster",
+            "match": {},
+            "match_strategy_matrix": null,
+            "model": {
+              "displayName": "",
+              "id": "00000000-0000-0000-0000-000000000000",
+              "model": {
+                "version": "v1.15.1"
+              },
+              "name": "aws-eks-controller",
+              "registrant": {
+                "kind": "github"
+              },
+              "version": ""
+            },
+            "patch": {
+              "patchStrategy": "replace",
+              "mutatorRef": [
+                [
+                  "displayName"
+                ]
+              ]
+            }
+          }
+        ]
+      },
+      "deny": {
+        "from": [],
+        "to": []
+      }
+    }
+  ],
+  "subType": "reference",
+  "status": "enabled",
+  "type": "non-binding",
+  "version": "v1.0.0"
+}

--- a/models/aws-eks-controller/v1.15.1/v1.0.0/relationships/edge-non-binding-reference-capability-cluster.json
+++ b/models/aws-eks-controller/v1.15.1/v1.0.0/relationships/edge-non-binding-reference-capability-cluster.json
@@ -23,7 +23,7 @@
     },
     "version": ""
   },
-  "schemaVersion": "relationships.meshery.io/v1beta2",
+  "schemaVersion": "relationships.meshery.io/v1beta3",
   "selectors": [
     {
       "allow": {

--- a/models/aws-eks-controller/v1.15.1/v1.0.0/relationships/edge-non-binding-reference-fargateprofile-cluster.json
+++ b/models/aws-eks-controller/v1.15.1/v1.0.0/relationships/edge-non-binding-reference-fargateprofile-cluster.json
@@ -1,0 +1,99 @@
+{
+  "id": "00000000-0000-0000-0000-000000000000",
+  "evaluationQuery": "",
+  "kind": "edge",
+  "metadata": {
+    "description": "References an EKS Cluster from a FargateProfile via spec.clusterName.",
+    "isAnnotation": false,
+    "styles": {
+      "primaryColor": "",
+      "svgColor": "",
+      "svgWhite": ""
+    }
+  },
+  "model": {
+    "displayName": "",
+    "id": "00000000-0000-0000-0000-000000000000",
+    "model": {
+      "version": "v1.15.1"
+    },
+    "name": "aws-eks-controller",
+    "registrant": {
+      "kind": ""
+    },
+    "version": ""
+  },
+  "schemaVersion": "relationships.meshery.io/v1beta2",
+  "selectors": [
+    {
+      "allow": {
+        "from": [
+          {
+            "id": null,
+            "kind": "FargateProfile",
+            "match": {},
+            "match_strategy_matrix": null,
+            "model": {
+              "displayName": "",
+              "id": "00000000-0000-0000-0000-000000000000",
+              "model": {
+                "version": "v1.15.1"
+              },
+              "name": "aws-eks-controller",
+              "registrant": {
+                "kind": "github"
+              },
+              "version": ""
+            },
+            "patch": {
+              "patchStrategy": "replace",
+              "mutatedRef": [
+                [
+                  "configuration",
+                  "spec",
+                  "clusterName"
+                ]
+              ]
+            }
+          }
+        ],
+        "to": [
+          {
+            "id": null,
+            "kind": "Cluster",
+            "match": {},
+            "match_strategy_matrix": null,
+            "model": {
+              "displayName": "",
+              "id": "00000000-0000-0000-0000-000000000000",
+              "model": {
+                "version": "v1.15.1"
+              },
+              "name": "aws-eks-controller",
+              "registrant": {
+                "kind": "github"
+              },
+              "version": ""
+            },
+            "patch": {
+              "patchStrategy": "replace",
+              "mutatorRef": [
+                [
+                  "displayName"
+                ]
+              ]
+            }
+          }
+        ]
+      },
+      "deny": {
+        "from": [],
+        "to": []
+      }
+    }
+  ],
+  "subType": "reference",
+  "status": "enabled",
+  "type": "non-binding",
+  "version": "v1.0.0"
+}

--- a/models/aws-eks-controller/v1.15.1/v1.0.0/relationships/edge-non-binding-reference-fargateprofile-cluster.json
+++ b/models/aws-eks-controller/v1.15.1/v1.0.0/relationships/edge-non-binding-reference-fargateprofile-cluster.json
@@ -23,7 +23,7 @@
     },
     "version": ""
   },
-  "schemaVersion": "relationships.meshery.io/v1beta2",
+  "schemaVersion": "relationships.meshery.io/v1beta3",
   "selectors": [
     {
       "allow": {

--- a/models/aws-eks-controller/v1.15.1/v1.0.0/relationships/edge-non-binding-reference-identityproviderconfig-cluster.json
+++ b/models/aws-eks-controller/v1.15.1/v1.0.0/relationships/edge-non-binding-reference-identityproviderconfig-cluster.json
@@ -1,0 +1,99 @@
+{
+  "id": "00000000-0000-0000-0000-000000000000",
+  "evaluationQuery": "",
+  "kind": "edge",
+  "metadata": {
+    "description": "References an EKS Cluster from an IdentityProviderConfig via spec.clusterName.",
+    "isAnnotation": false,
+    "styles": {
+      "primaryColor": "",
+      "svgColor": "",
+      "svgWhite": ""
+    }
+  },
+  "model": {
+    "displayName": "",
+    "id": "00000000-0000-0000-0000-000000000000",
+    "model": {
+      "version": "v1.15.1"
+    },
+    "name": "aws-eks-controller",
+    "registrant": {
+      "kind": ""
+    },
+    "version": ""
+  },
+  "schemaVersion": "relationships.meshery.io/v1beta2",
+  "selectors": [
+    {
+      "allow": {
+        "from": [
+          {
+            "id": null,
+            "kind": "IdentityProviderConfig",
+            "match": {},
+            "match_strategy_matrix": null,
+            "model": {
+              "displayName": "",
+              "id": "00000000-0000-0000-0000-000000000000",
+              "model": {
+                "version": "v1.15.1"
+              },
+              "name": "aws-eks-controller",
+              "registrant": {
+                "kind": "github"
+              },
+              "version": ""
+            },
+            "patch": {
+              "patchStrategy": "replace",
+              "mutatedRef": [
+                [
+                  "configuration",
+                  "spec",
+                  "clusterName"
+                ]
+              ]
+            }
+          }
+        ],
+        "to": [
+          {
+            "id": null,
+            "kind": "Cluster",
+            "match": {},
+            "match_strategy_matrix": null,
+            "model": {
+              "displayName": "",
+              "id": "00000000-0000-0000-0000-000000000000",
+              "model": {
+                "version": "v1.15.1"
+              },
+              "name": "aws-eks-controller",
+              "registrant": {
+                "kind": "github"
+              },
+              "version": ""
+            },
+            "patch": {
+              "patchStrategy": "replace",
+              "mutatorRef": [
+                [
+                  "displayName"
+                ]
+              ]
+            }
+          }
+        ]
+      },
+      "deny": {
+        "from": [],
+        "to": []
+      }
+    }
+  ],
+  "subType": "reference",
+  "status": "enabled",
+  "type": "non-binding",
+  "version": "v1.0.0"
+}

--- a/models/aws-eks-controller/v1.15.1/v1.0.0/relationships/edge-non-binding-reference-identityproviderconfig-cluster.json
+++ b/models/aws-eks-controller/v1.15.1/v1.0.0/relationships/edge-non-binding-reference-identityproviderconfig-cluster.json
@@ -23,7 +23,7 @@
     },
     "version": ""
   },
-  "schemaVersion": "relationships.meshery.io/v1beta2",
+  "schemaVersion": "relationships.meshery.io/v1beta3",
   "selectors": [
     {
       "allow": {

--- a/models/aws-eks-controller/v1.15.1/v1.0.0/relationships/edge-non-binding-reference-podidentityassociation-cluster.json
+++ b/models/aws-eks-controller/v1.15.1/v1.0.0/relationships/edge-non-binding-reference-podidentityassociation-cluster.json
@@ -1,0 +1,99 @@
+{
+  "id": "00000000-0000-0000-0000-000000000000",
+  "evaluationQuery": "",
+  "kind": "edge",
+  "metadata": {
+    "description": "References an EKS Cluster from a PodIdentityAssociation via spec.clusterName.",
+    "isAnnotation": false,
+    "styles": {
+      "primaryColor": "",
+      "svgColor": "",
+      "svgWhite": ""
+    }
+  },
+  "model": {
+    "displayName": "",
+    "id": "00000000-0000-0000-0000-000000000000",
+    "model": {
+      "version": "v1.15.1"
+    },
+    "name": "aws-eks-controller",
+    "registrant": {
+      "kind": ""
+    },
+    "version": ""
+  },
+  "schemaVersion": "relationships.meshery.io/v1beta2",
+  "selectors": [
+    {
+      "allow": {
+        "from": [
+          {
+            "id": null,
+            "kind": "PodIdentityAssociation",
+            "match": {},
+            "match_strategy_matrix": null,
+            "model": {
+              "displayName": "",
+              "id": "00000000-0000-0000-0000-000000000000",
+              "model": {
+                "version": "v1.15.1"
+              },
+              "name": "aws-eks-controller",
+              "registrant": {
+                "kind": "github"
+              },
+              "version": ""
+            },
+            "patch": {
+              "patchStrategy": "replace",
+              "mutatedRef": [
+                [
+                  "configuration",
+                  "spec",
+                  "clusterName"
+                ]
+              ]
+            }
+          }
+        ],
+        "to": [
+          {
+            "id": null,
+            "kind": "Cluster",
+            "match": {},
+            "match_strategy_matrix": null,
+            "model": {
+              "displayName": "",
+              "id": "00000000-0000-0000-0000-000000000000",
+              "model": {
+                "version": "v1.15.1"
+              },
+              "name": "aws-eks-controller",
+              "registrant": {
+                "kind": "github"
+              },
+              "version": ""
+            },
+            "patch": {
+              "patchStrategy": "replace",
+              "mutatorRef": [
+                [
+                  "displayName"
+                ]
+              ]
+            }
+          }
+        ]
+      },
+      "deny": {
+        "from": [],
+        "to": []
+      }
+    }
+  ],
+  "subType": "reference",
+  "status": "enabled",
+  "type": "non-binding",
+  "version": "v1.0.0"
+}

--- a/models/aws-eks-controller/v1.15.1/v1.0.0/relationships/edge-non-binding-reference-podidentityassociation-cluster.json
+++ b/models/aws-eks-controller/v1.15.1/v1.0.0/relationships/edge-non-binding-reference-podidentityassociation-cluster.json
@@ -23,7 +23,7 @@
     },
     "version": ""
   },
-  "schemaVersion": "relationships.meshery.io/v1beta2",
+  "schemaVersion": "relationships.meshery.io/v1beta3",
   "selectors": [
     {
       "allow": {

--- a/models/aws-eks-controller/v1.15.1/v1.0.0/relationships/edge-non-binding-reference-uhqem.json
+++ b/models/aws-eks-controller/v1.15.1/v1.0.0/relationships/edge-non-binding-reference-uhqem.json
@@ -1,0 +1,99 @@
+{
+  "id": "00000000-0000-0000-0000-000000000000",
+  "evaluationQuery": "",
+  "kind": "edge",
+  "metadata": {
+    "description": "References an EKS Cluster from an Addon via spec.clusterName.",
+    "isAnnotation": false,
+    "styles": {
+      "primaryColor": "",
+      "svgColor": "",
+      "svgWhite": ""
+    }
+  },
+  "model": {
+    "displayName": "",
+    "id": "00000000-0000-0000-0000-000000000000",
+    "model": {
+      "version": "v1.15.1"
+    },
+    "name": "aws-eks-controller",
+    "registrant": {
+      "kind": ""
+    },
+    "version": ""
+  },
+  "schemaVersion": "relationships.meshery.io/v1beta2",
+  "selectors": [
+    {
+      "allow": {
+        "from": [
+          {
+            "id": null,
+            "kind": "Addon",
+            "match": {},
+            "match_strategy_matrix": null,
+            "model": {
+              "displayName": "",
+              "id": "00000000-0000-0000-0000-000000000000",
+              "model": {
+                "version": "v1.15.1"
+              },
+              "name": "aws-eks-controller",
+              "registrant": {
+                "kind": "github"
+              },
+              "version": ""
+            },
+            "patch": {
+              "patchStrategy": "replace",
+              "mutatedRef": [
+                [
+                  "configuration",
+                  "spec",
+                  "clusterName"
+                ]
+              ]
+            }
+          }
+        ],
+        "to": [
+          {
+            "id": null,
+            "kind": "Cluster",
+            "match": {},
+            "match_strategy_matrix": null,
+            "model": {
+              "displayName": "",
+              "id": "00000000-0000-0000-0000-000000000000",
+              "model": {
+                "version": "v1.15.1"
+              },
+              "name": "aws-eks-controller",
+              "registrant": {
+                "kind": "github"
+              },
+              "version": ""
+            },
+            "patch": {
+              "patchStrategy": "replace",
+              "mutatorRef": [
+                [
+                  "displayName"
+                ]
+              ]
+            }
+          }
+        ]
+      },
+      "deny": {
+        "from": [],
+        "to": []
+      }
+    }
+  ],
+  "subType": "reference",
+  "status": "enabled",
+  "type": "non-binding",
+  "version": "v1.0.0"
+}

--- a/models/aws-eks-controller/v1.15.1/v1.0.0/relationships/edge-non-binding-reference-uhqem.json
+++ b/models/aws-eks-controller/v1.15.1/v1.0.0/relationships/edge-non-binding-reference-uhqem.json
@@ -23,7 +23,7 @@
     },
     "version": ""
   },
-  "schemaVersion": "relationships.meshery.io/v1beta2",
+  "schemaVersion": "relationships.meshery.io/v1beta3",
   "selectors": [
     {
       "allow": {

--- a/models/aws-eks-controller/v1.15.1/v1.0.0/relationships/hierarchical-parent-inventory-sayvn.json
+++ b/models/aws-eks-controller/v1.15.1/v1.0.0/relationships/hierarchical-parent-inventory-sayvn.json
@@ -23,11 +23,39 @@
     },
     "version": ""
   },
-  "schemaVersion": "relationships.meshery.io/v1beta2",
+  "schemaVersion": "relationships.meshery.io/v1beta3",
   "selectors": [
     {
       "allow": {
         "from": [
+          {
+            "id": null,
+            "kind": "Cluster",
+            "match": {},
+            "match_strategy_matrix": null,
+            "model": {
+              "displayName": "",
+              "id": "00000000-0000-0000-0000-000000000000",
+              "model": {
+                "version": ""
+              },
+              "name": "aws-eks-controller",
+              "registrant": {
+                "kind": "github"
+              },
+              "version": ""
+            },
+            "patch": {
+              "mutatorRef": [
+                [
+                  "displayName"
+                ]
+              ],
+              "patchStrategy": "replace"
+            }
+          }
+        ],
+        "to": [
           {
             "id": null,
             "kind": "Nodegroup",
@@ -51,34 +79,6 @@
                   "configuration",
                   "spec",
                   "clusterName"
-                ]
-              ],
-              "patchStrategy": "replace"
-            }
-          }
-        ],
-        "to": [
-          {
-            "id": null,
-            "kind": "Cluster",
-            "match": {},
-            "match_strategy_matrix": null,
-            "model": {
-              "displayName": "",
-              "id": "00000000-0000-0000-0000-000000000000",
-              "model": {
-                "version": ""
-              },
-              "name": "aws-eks-controller",
-              "registrant": {
-                "kind": "github"
-              },
-              "version": ""
-            },
-            "patch": {
-              "mutatorRef": [
-                [
-                  "displayName"
                 ]
               ],
               "patchStrategy": "replace"

--- a/models/aws-eks-controller/v1.15.1/v1.0.0/relationships/hierarchical-parent-inventory-sayvn.json
+++ b/models/aws-eks-controller/v1.15.1/v1.0.0/relationships/hierarchical-parent-inventory-sayvn.json
@@ -1,0 +1,99 @@
+{
+  "id": "00000000-0000-0000-0000-000000000000",
+  "evaluationQuery": "",
+  "kind": "hierarchical",
+  "metadata": {
+    "description": "Parent-child inventory relationship between EKS Cluster and Nodegroup.",
+    "isAnnotation": false,
+    "styles": {
+      "primaryColor": "",
+      "svgColor": "",
+      "svgWhite": ""
+    }
+  },
+  "model": {
+    "displayName": "",
+    "id": "00000000-0000-0000-0000-000000000000",
+    "model": {
+      "version": "v1.15.1"
+    },
+    "name": "aws-eks-controller",
+    "registrant": {
+      "kind": ""
+    },
+    "version": ""
+  },
+  "schemaVersion": "relationships.meshery.io/v1beta2",
+  "selectors": [
+    {
+      "allow": {
+        "from": [
+          {
+            "id": null,
+            "kind": "Nodegroup",
+            "match": {},
+            "match_strategy_matrix": null,
+            "model": {
+              "displayName": "",
+              "id": "00000000-0000-0000-0000-000000000000",
+              "model": {
+                "version": ""
+              },
+              "name": "aws-eks-controller",
+              "registrant": {
+                "kind": "github"
+              },
+              "version": ""
+            },
+            "patch": {
+              "mutatedRef": [
+                [
+                  "configuration",
+                  "spec",
+                  "clusterName"
+                ]
+              ],
+              "patchStrategy": "replace"
+            }
+          }
+        ],
+        "to": [
+          {
+            "id": null,
+            "kind": "Cluster",
+            "match": {},
+            "match_strategy_matrix": null,
+            "model": {
+              "displayName": "",
+              "id": "00000000-0000-0000-0000-000000000000",
+              "model": {
+                "version": ""
+              },
+              "name": "aws-eks-controller",
+              "registrant": {
+                "kind": "github"
+              },
+              "version": ""
+            },
+            "patch": {
+              "mutatorRef": [
+                [
+                  "displayName"
+                ]
+              ],
+              "patchStrategy": "replace"
+            }
+          }
+        ]
+      },
+      "deny": {
+        "from": [],
+        "to": []
+      }
+    }
+  ],
+  "subType": "inventory",
+  "status": "enabled",
+  "type": "parent",
+  "version": "v1.0.0"
+}


### PR DESCRIPTION
### **Description**

This PR adds 5 new AWS EKS relationships and fixes an existing inversion bug in the evaluation engine's data flow for the EKS controller.

**1. Added 5 New EKS Relationships:**
Added 5 new relationships directly to the latest EKS component version directory (`v1.15.1`):
* `AccessEntry` ➔ `Cluster`
* `Capability` ➔ `Cluster`
* `FargateProfile` ➔ `Cluster`
* `IdentityProviderConfig` ➔ `Cluster`
* `PodIdentityAssociation` ➔ `Cluster`

**2. Fixed `mutatorRef` / `mutatedRef` Data Flow:**
Previously, several EKS relationships had inverted `mutatorRef` and `mutatedRef` tags, which prevented the evaluation engine from drawing connections in Kanvas. I have correctly configured these tags across **both the newly authored and the older legacy EKS relationships.** Data now correctly flows from the target component (the mutator) into the dependent component (the mutated).

**3. Rescued Legacy Relationships:**
I noticed that 7 older manually authored EKS relationships had been left behind in the `v1.15.0` directory and were no longer being loaded by the evaluation engine (because the registry seeder only loads the highest version directory, which is currently `v1.15.1`). I migrated these 7 legacy relationships into the `v1.15.1` directory and updated their internal model versions so they are properly seeded and functional again.

**4. Location of Files:**
*Note: I initially placed the new relationships under the `models/` directory, but I found that the actual AWS EKS components have not yet been migrated out of `server/meshmodel` (they are still in `server/meshmodel/.../v1.15.1`). Because relationships and components must be loaded together from the exact same location, placing them in `models/` broke the evaluation engine in Kanvas. I kept them in `server/meshmodel` alongside the existing components so that they actually work correctly for now. They will automatically move to `models/` whenever the EKS components themselves are formally migrated.*

---

### **Relationships Tested & Verified:**

#### The 5 New EKS Relationships:
| From (Dependent) | To (Target) | Field to Fill | Component to click |
| :--- | :--- | :--- | :--- |
| **AccessEntry** | **Cluster** | `spec.clusterName` | AccessEntry |
| **Capability** | **Cluster** | `spec.clusterName` | Capability |
| **FargateProfile** | **Cluster** | `spec.clusterName` | FargateProfile |
| **IdentityProviderConfig** | **Cluster** | `spec.clusterName` | IdentityProviderConfig |
| **PodIdentityAssociation** | **Cluster** | `spec.clusterName` | PodIdentityAssociation |

#### The 7 Fixed EKS Relationships:
| From (Dependent) | To (Target) | Field to Fill | Component to click |
| :--- | :--- | :--- | :--- |
| **Cluster** | **SecurityGroup** | `spec.resourcesVPCConfig.securityGroupRefs.0.from.name` | Cluster |
| **Nodegroup** | **Subnet** | `spec.subnetRefs.0.from.name` | Nodegroup |
| **Nodegroup** | **Role** | `spec.nodeRoleRef.from.name` | Nodegroup |
| **Role** | **ServiceAccount** | `status.ackResourceMetadata.arn` | Role |
| **Role** | **FileSystem** | `status.ackResourceMetadata.arn` | Role |
| **Subnet** | **Cluster** | `status.id` | Subnet |
| **LaunchTemplate** | **Nodegroup** | `metadata.name` | LaunchTemplate |

### **Video Demonstration:**

https://github.com/user-attachments/assets/7b384ed3-a170-48d1-9f27-55679b2d70d7



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added relationship support for EKS clusters and associated resources, including access entries, capabilities, Fargate profiles, identity providers, pod identity associations, and add-ons.
  * Added cluster networking relationships for security groups and subnets.
  * Added Nodegroup relationships with clusters, subnets, launch templates, and IAM roles.
  * Added permission relationships connecting service accounts and EFS file systems with IAM roles.
  * Added hierarchical inventory relationships between Nodegroups and clusters.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->